### PR TITLE
tests: move some heavyweight tests to heavier pools

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
@@ -6,6 +6,10 @@ go_test(
         "main_test.go",
         "tenant_upgrade_test.go",
     ],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     shard_count = 4,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -183,7 +183,9 @@ func (t *testdir) dump() error {
 		if cfg.Name == "3node-tenant" || strings.HasPrefix(cfg.Name, "multiregion-") {
 			tplCfg.SkipCclUnderRace = true
 		}
-		if strings.Contains(cfg.Name, "5node") || strings.Contains(cfg.Name, "fakedist") {
+		if strings.Contains(cfg.Name, "5node") ||
+			strings.Contains(cfg.Name, "fakedist") ||
+			(strings.HasPrefix(cfg.Name, "local-") && !tplCfg.Ccl) {
 			tplCfg.UseHeavyPool = true
 		}
 		subdir := filepath.Join(t.dir, cfg.Name)

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -111,7 +111,7 @@ go_test(
     ],
     embed = [":jobs"],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "default"},
     }),
     shard_count = 16,

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -156,6 +156,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvcoord"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     shard_count = 16,
     deps = [
         "//build/bazelutil:noop",

--- a/pkg/kv/kvserver/rangelog/BUILD.bazel
+++ b/pkg/kv/kvserver/rangelog/BUILD.bazel
@@ -28,6 +28,10 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":rangelog"],
     embedsrcs = ["testdata/rangelog.bin"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/kv",

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-mixed-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-23.1/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-read-committed/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-read-committed/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.1/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.1/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-read-committed/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-read-committed/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 1,
     tags = [
         "cpu:1",

--- a/pkg/sql/pgwire/pgwirecancel/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirecancel/BUILD.bazel
@@ -16,6 +16,10 @@ go_test(
         "main_test.go",
     ],
     embed = [":pgwirecancel"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/security/securityassets",

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -145,6 +145,10 @@ go_test(
         "zigzagjoiner_test.go",
     ],
     embed = [":rowexec"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/gossip",

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-mixed-23.1/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-mixed-23.1/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-mixed-23.2/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-read-committed/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-read-committed/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -85,6 +85,10 @@ go_test(
         "stats_test.go",
     ],
     embed = [":stats"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     shard_count = 8,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
All of these had flakes in yesterday's nightly runs.

Epic: CRDB-8308
Release note: None