### PR TITLE
backupccl: actually enable stats at end of download job

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1941,6 +1941,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 
 	r.restoreStats = resTotal
+	if err := r.maybeWriteDownloadJob(ctx, p.ExecCfg(), preData, mainData); err != nil {
+		return err
+	}
 
 	// Emit an event now that the restore job has completed.
 	emitRestoreJobEvent(ctx, p, jobs.StatusSucceeded, r.job)
@@ -2250,7 +2253,7 @@ func (r *restoreResumer) publishDescriptors(
 	for i := range details.TableDescs {
 		mutTable := all.LookupDescriptor(details.TableDescs[i].GetID()).(*tabledesc.Mutable)
 
-		if details.ExperimentalOnline {
+		if details.ExperimentalOnline && mutTable.IsTable() {
 			// We disable automatic stats refresh on all restored tables until the
 			// download job finishes.
 			boolean := false

--- a/pkg/ccl/backupccl/testdata/backup-restore/online-restore-auto-stats
+++ b/pkg/ccl/backupccl/testdata/backup-restore/online-restore-auto-stats
@@ -1,0 +1,65 @@
+# This test ensures that online restore restores the backed up auto stats
+# settings
+
+reset test-nodelocal
+----
+
+new-cluster name=s1 disable-tenant
+----
+
+exec-sql
+USE data;
+CREATE TABLE reg (i INT PRIMARY KEY, s STRING);
+INSERT INTO reg VALUES (1, 'x'),(2,'y'),(3,'z');
+CREATE TABLE stats (i INT PRIMARY KEY, s STRING);
+CREATE TABLE nostats (i INT PRIMARY KEY, s STRING);
+ALTER TABLE stats SET (sql_stats_automatic_collection_enabled = true);
+ALTER TABLE nostats SET (sql_stats_automatic_collection_enabled = false);
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
+----
+
+
+exec-sql
+RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY;
+----
+
+# Wait for download job to complete
+
+query-sql retry
+SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' and status='succeeded';
+----
+2
+
+query-sql
+SHOW CREATE TABLE data.reg
+----
+data.public.reg CREATE TABLE public.reg (
+	i INT8 NOT NULL,
+	s STRING NULL,
+	CONSTRAINT reg_pkey PRIMARY KEY (i ASC)
+)
+
+query-sql
+SHOW CREATE TABLE data.stats
+----
+data.public.stats CREATE TABLE public.stats (
+	i INT8 NOT NULL,
+	s STRING NULL,
+	CONSTRAINT stats_pkey PRIMARY KEY (i ASC)
+) WITH (sql_stats_automatic_collection_enabled = true)
+
+query-sql
+SHOW CREATE TABLE data.nostats
+----
+data.public.nostats CREATE TABLE public.nostats (
+	i INT8 NOT NULL,
+	s STRING NULL,
+	CONSTRAINT nostats_pkey PRIMARY KEY (i ASC)
+) WITH (sql_stats_automatic_collection_enabled = false)

--- a/pkg/ccl/backupccl/testdata/backup-restore/online-restore-cluster
+++ b/pkg/ccl/backupccl/testdata/backup-restore/online-restore-cluster
@@ -1,0 +1,37 @@
+# This test ensures that cluster online restore publishes only one download job. 
+
+reset test-nodelocal
+----
+
+new-cluster name=s1 disable-tenant
+----
+
+exec-sql
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
+----
+
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY;
+----
+
+query-sql
+SELECT count(*) FROM [SHOW JOBS] WHERE description LIKE '%Background Data Download%';
+----
+1
+
+
+
+

--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -36,6 +36,7 @@ proto_library(
         "//pkg/kv/kvpb:kvpb_proto",
         "//pkg/multitenant/mtinfopb:mtinfopb_proto",
         "//pkg/roachpb:roachpb_proto",
+        "//pkg/sql/catalog/catpb:catpb_proto",
         "//pkg/sql/catalog/descpb:descpb_proto",
         "//pkg/sql/sessiondatapb:sessiondatapb_proto",
         "//pkg/util/hlc:hlc_proto",

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -19,6 +19,7 @@ import "roachpb/data.proto";
 import "roachpb/metadata.proto";
 import "roachpb/io-formats.proto";
 import "sql/catalog/descpb/structured.proto";
+import "sql/catalog/catpb/catalog.proto";
 import "multitenant/mtinfopb/info.proto";
 import "sql/sessiondatapb/session_data.proto";
 import "util/hlc/timestamp.proto";
@@ -504,8 +505,13 @@ message RestoreDetails {
   // UnsafeRestoreIncompatibleVersion allows restoring a backup older than the min compatible
   // version.
   bool unsafe_restore_incompatible_version = 34;
+ 
+  // PostDownloadTableAutoStatsSettings contains the backed up auto stats
+  // settings for online restored tables. These setting will be restored at the
+  // end of the download job. 
+  map<uint32,cockroach.sql.catalog.catpb.AutoStatsSettings> post_download_table_auto_stats_settings = 35;
 
-  // NEXT ID: 34.
+  // NEXT ID: 36.
 }
 
 


### PR DESCRIPTION
PR https://github.com/cockroachdb/cockroach/pull/116977 didn't re-enable auto stats collection for online restored tables
after the download job. This patch fixes this bug.

Fixes https://github.com/cockroachdb/cockroach/issues/119935

Release note: none