### PR TITLE
release-23.2: sql: set locality for all tables on MR system database

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/testutilsccl",
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/upgrade/upgrades/create_task_system_tables.go
+++ b/pkg/upgrade/upgrades/create_task_system_tables.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 
@@ -32,8 +33,8 @@ func createTaskSystemTables(
 	}
 
 	for _, table := range tables {
-		err := createSystemTable(ctx, d.DB.KV(), d.Settings, keys.SystemSQLCodec,
-			table)
+		err := createSystemTable(ctx, d.DB, d.Settings, keys.SystemSQLCodec,
+			table, tree.LocalityLevelTable)
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/descriptor_utils.go
+++ b/pkg/upgrade/upgrades/descriptor_utils.go
@@ -20,20 +20,49 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 // createSystemTable is a function to inject a new system table. If the table
-// already exists, ths function is a no-op.
+// already exists, ths function is a no-op. If the setGlobalLocality flag is
+// true this system table will be setup as a global table on multi-region clusters,
+// otherwise the locality needs to be configured by the caller.
 func createSystemTable(
 	ctx context.Context,
-	db *kv.DB,
+	db descs.DB,
 	settings *cluster.Settings,
 	codec keys.SQLCodec,
 	desc catalog.TableDescriptor,
+	tableLocality tree.LocalityLevel,
 ) error {
-	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		_, _, err := CreateSystemTableInTxn(ctx, settings, txn, codec, desc)
+	return db.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		dbDesc, err := txn.Descriptors().ByID(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
+		if err != nil {
+			return err
+		}
+		// For locality by row extra work is needed, and we will leave it to the caller.
+		if tableLocality == tree.LocalityLevelRow {
+			return errors.AssertionFailedf("only global and by region are implemented.")
+		}
+		if dbDesc.IsMultiRegion() {
+			primaryRegion, err := dbDesc.PrimaryRegionName()
+			if err != nil {
+				return err
+			}
+			tableDescBuilder := tabledesc.NewBuilder(desc.TableDesc())
+			mutableDesc := tableDescBuilder.BuildExistingMutableTable()
+			if tableLocality == tree.LocalityLevelGlobal {
+				mutableDesc.SetTableLocalityGlobal()
+			} else {
+				// Locality by table.
+				mutableDesc.SetTableLocalityRegionalByTable(tree.Name(primaryRegion))
+			}
+			desc = mutableDesc
+		}
+		_, _, err = CreateSystemTableInTxn(ctx, settings, txn.KV(), codec, desc)
 		return err
 	})
 }

--- a/pkg/upgrade/upgrades/descriptor_utils_test.go
+++ b/pkg/upgrade/upgrades/descriptor_utils_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -90,8 +92,9 @@ SELECT *
 			table.GetParentID(), table.GetParentSchemaID(), table.GetName())
 	}
 	require.Len(t, checkEntries(t), 0)
+	descDB := tc.Server(0).InternalDB().(descs.DB)
 	require.NoError(t, upgrades.CreateSystemTable(
-		ctx, tc.Server(0).DB(), tc.Server(0).ClusterSettings(), keys.SystemSQLCodec, table,
+		ctx, descDB, tc.Server(0).ClusterSettings(), keys.SystemSQLCodec, table, tree.LocalityLevelGlobal,
 	))
 	require.Len(t, checkEntries(t), 1)
 	sqlDB.CheckQueryResults(t,
@@ -100,7 +103,7 @@ SELECT *
 
 	// Make sure it's idempotent.
 	require.NoError(t, upgrades.CreateSystemTable(
-		ctx, tc.Server(0).DB(), tc.Server(0).ClusterSettings(), keys.SystemSQLCodec, table,
+		ctx, descDB, tc.Server(0).ClusterSettings(), keys.SystemSQLCodec, table, tree.LocalityLevelGlobal,
 	))
 	require.Len(t, checkEntries(t), 1)
 

--- a/pkg/upgrade/upgrades/key_visualizer_migration.go
+++ b/pkg/upgrade/upgrades/key_visualizer_migration.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
@@ -41,8 +42,9 @@ func keyVisualizerTablesMigration(
 	}
 
 	for _, table := range tables {
-		err := createSystemTable(ctx, d.DB.KV(), d.Settings, keys.SystemSQLCodec,
-			table)
+		err := createSystemTable(ctx, d.DB, d.Settings, keys.SystemSQLCodec,
+			table,
+			tree.LocalityLevelTable)
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/mvcc_statistics_migration.go
+++ b/pkg/upgrade/upgrades/mvcc_statistics_migration.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 
@@ -36,10 +37,11 @@ func createMVCCStatisticsTableAndJobMigration(
 	// Create the table.
 	err := createSystemTable(
 		ctx,
-		d.DB.KV(),
+		d.DB,
 		d.Settings,
 		d.Codec,
 		systemschema.SystemMVCCStatisticsTable,
+		tree.LocalityLevelTable,
 	)
 	if err != nil {
 		return err

--- a/pkg/upgrade/upgrades/system_exec_insights.go
+++ b/pkg/upgrade/upgrades/system_exec_insights.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 
@@ -22,10 +23,10 @@ import (
 func systemExecInsightsTableMigration(
 	ctx context.Context, _ clusterversion.ClusterVersion, d upgrade.TenantDeps,
 ) error {
-	if err := createSystemTable(ctx, d.DB.KV(), d.Settings, d.Codec, systemschema.TransactionExecInsightsTable); err != nil {
+	if err := createSystemTable(ctx, d.DB, d.Settings, d.Codec, systemschema.TransactionExecInsightsTable, tree.LocalityLevelTable); err != nil {
 		return err
 	}
-	if err := createSystemTable(ctx, d.DB.KV(), d.Settings, d.Codec, systemschema.StatementExecInsightsTable); err != nil {
+	if err := createSystemTable(ctx, d.DB, d.Settings, d.Codec, systemschema.StatementExecInsightsTable, tree.LocalityLevelTable); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/upgrade/upgrades/system_job_info.go
+++ b/pkg/upgrade/upgrades/system_job_info.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
@@ -27,7 +28,7 @@ func systemJobInfoTableMigration(
 ) error {
 	// Create the job_info table proper.
 	if err := createSystemTable(
-		ctx, d.DB.KV(), d.Settings, d.Codec, systemschema.SystemJobInfoTable,
+		ctx, d.DB, d.Settings, d.Codec, systemschema.SystemJobInfoTable, tree.LocalityLevelTable,
 	); err != nil {
 		return err
 	}

--- a/pkg/upgrade/upgrades/system_statistics_activity.go
+++ b/pkg/upgrade/upgrades/system_statistics_activity.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 
@@ -31,8 +32,8 @@ func systemStatisticsActivityTableMigration(
 	}
 
 	for _, table := range tables {
-		err := createSystemTable(ctx, d.DB.KV(), d.Settings, d.Codec,
-			table)
+		err := createSystemTable(ctx, d.DB, d.Settings, d.Codec,
+			table, tree.LocalityLevelTable)
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/tenant_id_sequence_for_system_tenant.go
+++ b/pkg/upgrade/upgrades/tenant_id_sequence_for_system_tenant.go
@@ -16,11 +16,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 
 func tenantIDSequenceForSystemTenant(
 	ctx context.Context, _ clusterversion.ClusterVersion, d upgrade.SystemDeps,
 ) error {
-	return createSystemTable(ctx, d.DB.KV(), d.Settings, keys.SystemSQLCodec, systemschema.TenantIDSequence)
+	return createSystemTable(ctx, d.DB, d.Settings, keys.SystemSQLCodec, systemschema.TenantIDSequence, tree.LocalityLevelTable)
 }


### PR DESCRIPTION
Previously, table locality was set for only a subset of system tables, and the upgrade logic lacked the ability to set locality for newly created tables. This caused upgrades to version 24.1 on multi-region (MR) clusters to fail due to new tables lacking locality settings. To address this, the upgrade logic now consistently sets locality when creating system tables. Additionally, the optimization logic for system databases sets global locality as the default for new tables.

Epic: CC-24173
Fixes: #119948
Release note: None

Release justification: This bug impact all multi-region serverless updates to 23.2 and makes it impossible to upgrade. The fix itself is low risk and only impacts serverless.