### PR TITLE
workflows: for roachtest, print summary to `GITHUB_STEP_SUMMARY` file

### DIFF
--- a/build/github/local-roachtest.sh
+++ b/build/github/local-roachtest.sh
@@ -40,5 +40,5 @@ $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance \
   --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
   --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
   --artifacts $PWD/artifacts \
-  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
+  --github
 

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -282,6 +282,12 @@ var (
 		Usage: `Include teamcity-specific markers in output`,
 	})
 
+	GitHubActions bool
+	_             = registerRunFlag(&GitHubActions, FlagInfo{
+		Name:  "github",
+		Usage: `Add GitHub-specific markers to the output where possible, and optionally populate GITHUB_STEP_SUMMARY with a summary of all tests`,
+	})
+
 	DisableIssue bool
 	_            = registerRunFlag(&DisableIssue, FlagInfo{
 		Name:  "disable-issue",


### PR DESCRIPTION
Also, group log lines on a per-test basis.

Part of: DEVINF-1031
Epic: CRDB-8308
Release note: None