### PR TITLE
kv: allow DeleteRangeRequests to be pipelined 

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -2228,6 +2228,9 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 		},
 		{
 			name: "forwarded timestamp with delete range",
+			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
+				return db.Put(ctx, "a", "put") // ensure DeleteRange is not a no-op
+			},
 			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
 				_, err := db.Get(ctx, "a") // read key to set ts cache
 				return err
@@ -2552,6 +2555,9 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			name: "forwarded timestamp with too many refreshes in batch commit " +
 				"with refresh",
 			refreshSpansCondenseFilter: disableCondensingRefreshSpans,
+			beforeTxnStart: func(ctx context.Context, db *kv.DB) error {
+				return db.Put(ctx, "a", "put") // ensure DeleteRange is not a no-op
+			},
 			afterTxnStart: func(ctx context.Context, db *kv.DB) error {
 				_, err := db.Get(ctx, "a") // set ts cache
 				return err

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1166,14 +1166,19 @@ func TestTxnCoordSenderNoDuplicateLockSpans(t *testing.T) {
 	b.GetForUpdate(roachpb.Key("n"), kvpb.GuaranteedDurability)
 	b.ReverseScanForShare(roachpb.Key("v"), roachpb.Key("z"), kvpb.GuaranteedDurability)
 
-	// The expected locks are a-b, c, m, n, and u-z.
+	// The expected locks are a-b, c, m, n, and v-z.
+	//
+	// A note about the v-z span -- because the DeleteRange request did not
+	// actually delete any keys, we'll not track anything for it in the lock
+	// footprint for this transaction. The v-z range comes from the
+	// ReverseScanForShare request in the final batch.
 	expectedLockSpans = []roachpb.Span{
 		{Key: roachpb.Key("a"), EndKey: roachpb.Key("b").Next()},
 		{Key: roachpb.Key("c"), EndKey: nil},
 		{Key: roachpb.Key("d"), EndKey: nil},
 		{Key: roachpb.Key("m"), EndKey: nil},
 		{Key: roachpb.Key("n"), EndKey: nil},
-		{Key: roachpb.Key("u"), EndKey: roachpb.Key("z")},
+		{Key: roachpb.Key("v"), EndKey: roachpb.Key("z")},
 	}
 
 	pErr = txn.CommitInBatch(ctx, b)
@@ -1986,6 +1991,15 @@ func TestCommitMutatingTransaction(t *testing.T) {
 		if !bytes.Equal(ba.Txn.Key, roachpb.Key("a")) {
 			t.Errorf("expected transaction key to be \"a\"; got %s", ba.Txn.Key)
 		}
+
+		if _, ok := ba.GetArg(kvpb.DeleteRange); ok {
+			// Simulate deleting a single key for DeleteRange requests. Unlike other
+			// point writes, pipelined DeleteRange writes are tracked by looking at
+			// the batch response.
+			resp := br.Responses[0].GetInner()
+			resp.(*kvpb.DeleteRangeResponse).Keys = []roachpb.Key{roachpb.Key("a")}
+		}
+
 		if et, ok := ba.GetArg(kvpb.EndTxn); ok {
 			if !et.(*kvpb.EndTxnRequest).Commit {
 				t.Errorf("expected commit to be true")
@@ -2009,61 +2023,178 @@ func TestCommitMutatingTransaction(t *testing.T) {
 	testArgs := []struct {
 		f         func(ctx context.Context, txn *kv.Txn) error
 		expMethod kvpb.Method
-		// pointWrite is set if the method is a "point write", which means that it
-		// will be pipelined and we should expect a QueryIntent request at commit
-		// time.
-		pointWrite bool
+		// All retryable functions below involve writing to exactly one key. The
+		// write will be pipelined if it's not in the same batch as the
+		// EndTxnRequest, in which case we expect a single QueryIntent request to be
+		// added when trying to commit the transaction.
+		expQueryIntent bool
 	}{
 		{
-			f:          func(ctx context.Context, txn *kv.Txn) error { return txn.Put(ctx, "a", "b") },
-			expMethod:  kvpb.Put,
-			pointWrite: true,
+			f:              func(ctx context.Context, txn *kv.Txn) error { return txn.Put(ctx, "a", "b") },
+			expMethod:      kvpb.Put,
+			expQueryIntent: true,
 		},
 		{
-			f:          func(ctx context.Context, txn *kv.Txn) error { return txn.CPut(ctx, "a", "b", nil) },
-			expMethod:  kvpb.ConditionalPut,
-			pointWrite: true,
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Put("a", "b")
+				return txn.CommitInBatch(ctx, b)
+			},
+			expMethod: kvpb.Put,
+		},
+		{
+			f:              func(ctx context.Context, txn *kv.Txn) error { return txn.CPut(ctx, "a", "b", nil) },
+			expMethod:      kvpb.ConditionalPut,
+			expQueryIntent: true,
+		},
+		{
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.CPut("a", "b", nil)
+				return txn.CommitInBatch(ctx, b)
+			},
+			expMethod: kvpb.ConditionalPut,
 		},
 		{
 			f: func(ctx context.Context, txn *kv.Txn) error {
 				_, err := txn.Inc(ctx, "a", 1)
 				return err
 			},
-			expMethod:  kvpb.Increment,
-			pointWrite: true,
+			expMethod:      kvpb.Increment,
+			expQueryIntent: true,
+		},
+		{
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Inc("a", 1)
+				return txn.CommitInBatch(ctx, b)
+			},
+			expMethod: kvpb.Increment,
 		},
 		{
 			f: func(ctx context.Context, txn *kv.Txn) error {
 				_, err := txn.Del(ctx, "a")
 				return err
 			},
-			expMethod:  kvpb.Delete,
-			pointWrite: true,
+			expMethod:      kvpb.Delete,
+			expQueryIntent: true,
+		},
+		{
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.Del("a")
+				return txn.CommitInBatch(ctx, b)
+			},
+			expMethod: kvpb.Delete,
 		},
 		{
 			f: func(ctx context.Context, txn *kv.Txn) error {
 				_, err := txn.DelRange(ctx, "a", "b", false /* returnKeys */)
 				return err
 			},
-			expMethod:  kvpb.DeleteRange,
-			pointWrite: false,
+			expMethod:      kvpb.DeleteRange,
+			expQueryIntent: true,
+		},
+		{
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.DelRange("a", "b", false /* returnKeys */)
+				return txn.CommitInBatch(ctx, b)
+			},
+			expMethod:      kvpb.DeleteRange,
+			expQueryIntent: false,
 		},
 	}
-	for i, test := range testArgs {
+	for _, test := range testArgs {
 		t.Run(test.expMethod.String(), func(t *testing.T) {
 			calls = nil
 			db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
-			if err := db.Txn(ctx, test.f); err != nil {
-				t.Fatalf("%d: unexpected error on commit: %s", i, err)
-			}
+			require.NoError(t, db.Txn(ctx, test.f))
 			expectedCalls := []kvpb.Method{test.expMethod}
-			if test.pointWrite {
+			if test.expQueryIntent {
 				expectedCalls = append(expectedCalls, kvpb.QueryIntent)
 			}
 			expectedCalls = append(expectedCalls, kvpb.EndTxn)
-			if !reflect.DeepEqual(expectedCalls, calls) {
-				t.Fatalf("%d: expected %s, got %s", i, expectedCalls, calls)
+			require.Equal(t, expectedCalls, calls)
+		})
+	}
+}
+
+// TestCommitNoopDeleteRangeTransaction ensures that committing a no-op
+// DeleteRange transaction works correctly. In particular, the EndTxn request is
+// elided, if possible.
+func TestCommitNoopDeleteRangeTransaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	clock := hlc.NewClockForTesting(nil)
+	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	sender := &mockSender{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	var calls []kvpb.Method
+	sender.match(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		br := ba.CreateReply()
+		br.Txn = ba.Txn.Clone()
+
+		calls = append(calls, ba.Methods()...)
+		if !bytes.Equal(ba.Txn.Key, roachpb.Key("a")) {
+			t.Errorf("expected transaction key to be \"a\"; got %s", ba.Txn.Key)
+		}
+		if et, ok := ba.GetArg(kvpb.EndTxn); ok {
+			if !et.(*kvpb.EndTxnRequest).Commit {
+				t.Errorf("expected commit to be true")
 			}
+			br.Txn.Status = roachpb.COMMITTED
+		}
+
+		// Don't return any keys in the DeleteRange response, which simulates what a
+		// no-op DeleteRange looks like from the client's perspective.
+		return br, nil
+	})
+
+	factory := kvcoord.NewTxnCoordSenderFactory(
+		kvcoord.TxnCoordSenderFactoryConfig{
+			AmbientCtx: ambient,
+			Clock:      clock,
+			Stopper:    stopper,
+			Settings:   cluster.MakeTestingClusterSettings(),
+		},
+		sender,
+	)
+
+	testCases := []struct {
+		f           func(ctx context.Context, txn *kv.Txn) error
+		elideEndTxn bool
+	}{
+		{
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				_, err := txn.DelRange(ctx, "a", "d", true /* returnKeys */)
+				return err
+			},
+			elideEndTxn: true,
+		},
+		{
+			f: func(ctx context.Context, txn *kv.Txn) error {
+				b := txn.NewBatch()
+				b.DelRange("a", "b", true /* returnKeys */)
+				return txn.CommitInBatch(ctx, b)
+			},
+			elideEndTxn: false,
+		},
+	}
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			calls = nil
+			db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
+			require.NoError(t, db.Txn(ctx, test.f))
+			expectedCalls := []kvpb.Method{kvpb.DeleteRange}
+			if !test.elideEndTxn {
+				expectedCalls = append(expectedCalls, kvpb.EndTxn)
+			}
+			require.Equal(t, expectedCalls, calls)
 		})
 	}
 }

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
@@ -52,6 +52,7 @@ func TestTxnCommitterElideEndTxn(t *testing.T) {
 
 	txn := makeTxnProto()
 	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
 
 	// Test with both commits and rollbacks.
 	testutils.RunTrueAndFalse(t, "commit", func(t *testing.T, commit bool) {
@@ -65,7 +66,7 @@ func TestTxnCommitterElideEndTxn(t *testing.T) {
 		ba := &kvpb.BatchRequest{}
 		ba.Header = kvpb.Header{Txn: &txn}
 		ba.Add(&kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
-		ba.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
+		ba.Add(&kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyA, EndKey: keyB}})
 		ba.Add(&kvpb.EndTxnRequest{Commit: commit, LockSpans: nil})
 
 		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
@@ -72,7 +72,7 @@ func TestTxnCommitterElideEndTxn(t *testing.T) {
 		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 			require.Len(t, ba.Requests, 2)
 			require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
-			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[1].GetInner())
+			require.IsType(t, &kvpb.ScanRequest{}, ba.Requests[1].GetInner())
 
 			br := ba.CreateReply()
 			br.Txn = ba.Txn

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -75,15 +75,19 @@ const (
 	canSkipLocked                                             // commands which can evaluate under the SkipLocked wait policy
 	bypassesReplicaCircuitBreaker                             // commands which bypass the replica circuit breaker, i.e. opt out of fail-fast
 	requiresClosedTSOlderThanStorageSnapshot                  // commands which read a replica's closed timestamp that is older than the state of the storage engine
+	canPipeline                                               // commands which can be pipelined
+	canParallelCommit                                         // commands which can be part of a parallel commit batch
 )
 
 // flagDependencies specifies flag dependencies, asserted by TestFlagCombinations.
 var flagDependencies = map[flag][]flag{
-	isAdmin:         {isAlone},
-	isLocking:       {isTxn},
-	isIntentWrite:   {isWrite, isLocking},
-	appliesTSCache:  {isWrite},
-	skipsLeaseCheck: {isAlone},
+	isAdmin:           {isAlone},
+	isLocking:         {isTxn},
+	isIntentWrite:     {isWrite, isLocking},
+	canPipeline:       {isIntentWrite},
+	canParallelCommit: {canPipeline},
+	appliesTSCache:    {isWrite},
+	skipsLeaseCheck:   {isAlone},
 }
 
 // flagExclusions specifies flag incompatibilities, asserted by TestFlagCombinations.
@@ -178,6 +182,17 @@ func CanSkipLocked(args Request) bool {
 // addressed to an unavailable range (instead of failing fast).
 func BypassesReplicaCircuitBreaker(args Request) bool {
 	return (args.flags() & bypassesReplicaCircuitBreaker) != 0
+}
+
+// CanPipeline returns true iff the command can be pipelined.
+func CanPipeline(args Request) bool {
+	return (args.flags() & canPipeline) != 0
+}
+
+// CanParallelCommit returns true iff the command can be part of a batch that is
+// committed in parallel.
+func CanParallelCommit(args Request) bool {
+	return (args.flags() & canParallelCommit) != 0
 }
 
 // Request is an interface for RPC requests.
@@ -1578,7 +1593,8 @@ func (gr *GetRequest) flags() flag {
 }
 
 func (*PutRequest) flags() flag {
-	return isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure
+	return isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure |
+		canPipeline | canParallelCommit
 }
 
 // ConditionalPut effectively reads without writing if it hits a
@@ -1588,7 +1604,8 @@ func (*PutRequest) flags() flag {
 // transaction to be retried at end transaction.
 func (*ConditionalPutRequest) flags() flag {
 	return isRead | isWrite | isTxn | isLocking | isIntentWrite |
-		appliesTSCache | updatesTSCache | updatesTSCacheOnErr | canBackpressure
+		appliesTSCache | updatesTSCache | updatesTSCacheOnErr | canBackpressure | canPipeline |
+		canParallelCommit
 }
 
 // InitPut, like ConditionalPut, effectively reads without writing if it hits a
@@ -1598,7 +1615,8 @@ func (*ConditionalPutRequest) flags() flag {
 // to be retried at end transaction.
 func (*InitPutRequest) flags() flag {
 	return isRead | isWrite | isTxn | isLocking | isIntentWrite |
-		appliesTSCache | updatesTSCache | updatesTSCacheOnErr | canBackpressure
+		appliesTSCache | updatesTSCache | updatesTSCacheOnErr | canBackpressure |
+		canPipeline | canParallelCommit
 }
 
 // Increment reads the existing value, but always leaves an intent so
@@ -1607,7 +1625,8 @@ func (*InitPutRequest) flags() flag {
 // error immediately instead of continuing a serializable transaction
 // to be retried at end transaction.
 func (*IncrementRequest) flags() flag {
-	return isRead | isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure
+	return isRead | isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure |
+		canPipeline | canParallelCommit
 }
 
 func (*DeleteRequest) flags() flag {
@@ -1615,7 +1634,8 @@ func (*DeleteRequest) flags() flag {
 	// an existing key was deleted at the read timestamp. isIntentWrite allows
 	// omitting needsRefresh. For background, see:
 	// https://github.com/cockroachdb/cockroach/pull/89375
-	return isRead | isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure
+	return isRead | isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure |
+		canPipeline | canParallelCommit
 }
 
 func (drr *DeleteRangeRequest) flags() flag {
@@ -1631,6 +1651,10 @@ func (drr *DeleteRangeRequest) flags() flag {
 	// transaction by TxnCoordSender, which can occur if the command spans
 	// multiple ranges.
 	//
+	// As inline deletes cannot be part of a transaction, and don't go through the
+	// TxnCoordSender stack, there's no pipelining to speak of. As such, they
+	// don't set the canPipeline flag as well.
+	//
 	// TODO(mrtracy): The behavior of DeleteRangeRequest with "inline" set has
 	// likely diverged enough that it should be promoted into its own command.
 	// However, it is complicated to plumb a new command through the system,
@@ -1640,6 +1664,22 @@ func (drr *DeleteRangeRequest) flags() flag {
 	if drr.Inline {
 		return isRead | isWrite | isRange | isAlone
 	}
+
+	maybeCanPipeline := flag(0)
+	// DeleteRange requests operate over a range of keys. As such, we only
+	// know the actual keys that were deleted on the response path, not on the
+	// request path. This prevents them from being part of a batch that can be
+	// committed using parallel commits -- that's because for parallel commit
+	// recovery we need the entire in-flight write set to plop on the txn record,
+	// and we don't have that on the request path if the batch contains a
+	// DeleteRange request.
+	//
+	// We'll only know the actual keys that were deleted on the response path if
+	// they're returned to us. This is contingent on the ReturnKeys flag being set
+	// on the request.
+	if drr.ReturnKeys {
+		maybeCanPipeline = canPipeline
+	}
 	// DeleteRange updates the timestamp cache as it doesn't leave intents or
 	// tombstones for keys which don't yet exist or keys that already have
 	// tombstones on them, but still wants to prevent anybody from writing under
@@ -1647,7 +1687,7 @@ func (drr *DeleteRangeRequest) flags() flag {
 	// that exist would not be lost (since the DeleteRange leaves intents on
 	// those keys), but deletes of "empty space" would.
 	return isRead | isWrite | isTxn | isLocking | isIntentWrite | isRange |
-		appliesTSCache | updatesTSCache | needsRefresh | canBackpressure
+		appliesTSCache | updatesTSCache | needsRefresh | canBackpressure | maybeCanPipeline
 }
 
 // Note that ClearRange commands cannot be part of a transaction as

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -78,8 +78,8 @@ func maybeStripInFlightWrites(ba *kvpb.BatchRequest) (*kvpb.BatchRequest, error)
 		for _, ru := range otherReqs {
 			req := ru.GetInner()
 			switch {
-			case kvpb.IsIntentWrite(req) && !kvpb.IsRange(req):
-				// Concurrent point write.
+			case kvpb.CanParallelCommit(req):
+				// Concurrent point write being committed in parallel.
 				writes++
 			case req.Method() == kvpb.QueryIntent:
 				// Earlier pipelined point write that hasn't been proven yet.
@@ -109,8 +109,8 @@ func maybeStripInFlightWrites(ba *kvpb.BatchRequest) (*kvpb.BatchRequest, error)
 		req := ru.GetInner()
 		seq := req.Header().Sequence
 		switch {
-		case kvpb.IsIntentWrite(req) && !kvpb.IsRange(req):
-			// Concurrent point write.
+		case kvpb.CanParallelCommit(req):
+			// Concurrent point write being committed in parallel.
 		case req.Method() == kvpb.QueryIntent:
 			// Earlier pipelined point write that hasn't been proven yet. We
 			// could remove from the in-flight writes set when we see these,


### PR DESCRIPTION
Previously, ranged requests could not be pipelined. However, there is no
good reason to not allow them to be pipeliend -- we just have to take
extra care to correctly update in-flight writes tracking on the response
path. We do so now.

As part of this patch, we introduce two new flags -- canPipeline and
canParallelCommit. We use these flags to determine whether batches can
be pipelined or committed using parallel commits. This is in contrast to
before, where we derived this information from other flags
(isIntentWrite, !isRange). This wasn't strictly necessary for this
change, but helps clean up the concepts.

As a consequence of this change, we now have a distinction between
requests that can be pipelined and requests that can be part of a batch
that can be committed in parallel. Notably, this applies to
DeleteRangeRequests -- they can be pipeliend, but not be committed in
parallel. That's because we need to have the entire write set upfront
when performing a parallel commit, lest we need to perform recovery --
we don't have this for DeleteRange requests.

In the future, we'll extend the concept of canPipeline
(and !canParallelCommit) to other locking ranged requests as well. In
particular, (replicated) locking {,Reverse}ScanRequests who want to
pipeline their lock acquisitions.

Closes https://github.com/cockroachdb/cockroach/issues/64723
Informs https://github.com/cockroachdb/cockroach/issues/117978

Release note: None