### PR TITLE
opt: normalize greatest and least functions into separate comparison clauses

### DIFF
--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -281,3 +281,25 @@ $left
 (Ne $left:* (False))
 =>
 $left
+
+# NormalizeCmpGreatest normalizes the comparison condition into nested AND clauses
+# such that certain the query has the potential of leveraging indicies, while
+# allowing other normalizations to further optimize the condition clauses.
+[NormalizeCmpGreatest, Normalize]
+(Le | Lt
+    (Function $args:* $private:(FunctionPrivate "greatest"))
+    $right:(Const)
+)
+=>
+(NormalizeCmpGreatest (OpName) $args $right)
+
+# NormalizeCmpLeast normalizes the comparison condition into nested OR clauses
+# such that certain the query has the potential of leveraging indicies, while
+# allowing other normalizations to further optimize the condition clauses.
+[NormalizeCmpLeast, Normalize]
+(Le | Lt
+    (Function $args:* $private:(FunctionPrivate "least"))
+    $right:(Const)
+)
+=>
+(NormalizeCmpLeast (OpName) $args $right)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1033,3 +1033,86 @@ project
  │    └── columns: b:2
  └── projections
       └── b:2 [as="?column?":5, outer=(2)]
+
+# --------------------------------------------------
+# NormalizeCmpGreatest, NormalizeCmpLeast
+# --------------------------------------------------
+exec-ddl
+CREATE TABLE alphabet (a INT PRIMARY KEY, b INT, c INT)
+----
+
+norm expect=NormalizeCmpGreatest
+SELECT * FROM alphabet WHERE greatest(a, b, c) < 42 
+----
+select
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan alphabet
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      ├── (a:1 < 42) OR (a:1 IS NULL) [outer=(1), constraints=(/1: [/NULL - /41]; tight)]
+      ├── (b:2 < 42) OR (b:2 IS NULL) [outer=(2), constraints=(/2: [/NULL - /41]; tight)]
+      ├── (c:3 < 42) OR (c:3 IS NULL) [outer=(3), constraints=(/3: [/NULL - /41]; tight)]
+      └── ((a:1 IS NOT NULL) OR (b:2 IS NOT NULL)) OR (c:3 IS NOT NULL) [outer=(1-3)]
+
+norm expect=NormalizeCmpGreatest
+SELECT * FROM alphabet WHERE greatest(a, 3) < 42 
+----
+select
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan alphabet
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── (a:1 < 42) OR (a:1 IS NULL) [outer=(1), constraints=(/1: [/NULL - /41]; tight)]
+
+norm expect=NormalizeCmpGreatest
+SELECT * FROM alphabet WHERE greatest(a, b, c, 43) < 42 
+----
+values
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-3)
+
+norm expect=NormalizeCmpLeast
+SELECT * FROM alphabet WHERE least(a, b, c) < 42 
+----
+select
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan alphabet
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── ((((a:1 < 42) AND (a:1 IS NOT NULL)) OR ((b:2 < 42) AND (b:2 IS NOT NULL))) OR ((c:3 < 42) AND (c:3 IS NOT NULL))) OR ((((a:1 IS NULL) AND (b:2 IS NULL)) AND (c:3 IS NULL)) AND NULL) [outer=(1-3)]
+
+norm expect=NormalizeCmpLeast
+SELECT * FROM alphabet WHERE least(a, 43) < 42 
+----
+select
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan alphabet
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── a:1 < 42 [outer=(1), constraints=(/1: (/NULL - /41]; tight)]
+
+norm expect=NormalizeCmpLeast
+SELECT * FROM alphabet WHERE least(a, b, c, 1) < 42 
+----
+scan alphabet
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ └── fd: (1)-->(2,3)


### PR DESCRIPTION
As raised in the issue #119831 it does make sense to normalize the `greatest` and `least` functions such that the index can be leveraged during the query. 

Before the change,

```sql
root@127.0.0.1:26257/defaultdb> EXPLAIN select * from alphabet where least(b) < 30; 

---------------------------------------------------------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • filter
  │ estimated row count: 0
  │ filter: least(b) < 30
  │
  └── • scan
        estimated row count: 1 (100% of the table; stats collected 16 seconds ago; using stats forecast for 44 seconds in the future)
        table: alphabet@alphabet_pkey
        spans: FULL SCAN
```

after

```sql
root@127.0.0.1:26257/defaultdb> EXPLAIN select * from alphabet where least(b) < 30; 

  • index join
  │ estimated row count: 1
  │ table: alphabet@alphabet_pkey
  │
  └── • scan
        estimated row count: 1 (100% of the table; stats collected 52 minutes ago; using stats forecast for 51 minutes ago)
        table: alphabet@alphabet_b_idx
        spans: (/NULL - /29]
```

Also, the normalization allows further optimizations by other opt rules. For example, 

```sql
SELECT * FROM xxx WHERE greatest(x, 3) < 42
```

is essentially equivalent to 

```sql
SELECT * FROM xxx WHERE x < 42
```

I have added test cases for the OPT rules, and it seems the normalization flow is able to optimize away the redundent clause.

Epic: none

Release note: None