### PR TITLE
stmtdiagnostics: reduce row count in a test

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -483,7 +483,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 		runner.Exec(t, "ANALYZE small;")
 		runner.Exec(t, "CREATE TABLE large (v INT, INDEX (v));")
 		runner.Exec(t, "INSERT INTO large VALUES (1);")
-		runner.Exec(t, "INSERT INTO large SELECT 2 FROM generate_series(1, 10000);")
+		runner.Exec(t, "INSERT INTO large SELECT 2 FROM generate_series(1, 100);")
 		runner.Exec(t, "ANALYZE large;")
 
 		// query1 results in scan + lookup join whereas query2 does two scans +


### PR DESCRIPTION
We can go from 10k to 100 for the large table while still getting the desired plans.

Informs: #119945

Epic: None

Release note: None