### PR TITLE
sql: enhance error messages on validation of rows in virtual tables

### DIFF
--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const virtualSchemaNotImplementedMessage = "virtual schema table not implemented: %s.%s"
@@ -566,15 +567,18 @@ func (e *virtualDefEntry) validateRow(datums tree.Datums, columns colinfo.Result
 	}
 	for i := range columns {
 		col := &columns[i]
+		// Names of virtual tables and columns in them don't contain any PII, so
+		// we can always mark them safe for redaction.
+		colName := redact.SafeString(col.Name)
 		datum := datums[i]
 		if datum == tree.DNull {
 			if !e.desc.PublicColumns()[i].IsNullable() {
 				return errors.AssertionFailedf("column %s.%s not nullable, but found NULL value",
-					e.desc.GetName(), col.Name)
+					redact.SafeString(e.desc.GetName()), colName)
 			}
 		} else if !datum.ResolvedType().Equivalent(col.Typ) {
 			return errors.AssertionFailedf("datum column %q expected to be type %s; found type %s",
-				col.Name, col.Typ, datum.ResolvedType())
+				colName, col.Typ.SQLStringForError(), datum.ResolvedType().SQLStringForError())
 		}
 	}
 	return nil


### PR DESCRIPTION
We just saw an internal error when populating `crdb_internal.cluster_locks` virtual table that was missing important bits (the column name) to understand what happens. Since names of virtual tables and columns in them don't contain PII, they are safe for redaction.

Epic: None

Release note: None