### PR TITLE
jobs: deflake TestRetriesWithExponentialBackoff

### DIFF
--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -992,7 +992,6 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 		bti.clock.AdvanceTo(lastRun)
 		<-bti.resumeCh
 		pauseOrCancelJob(t, ctx, bti.idb, bti.registry, jobID, cancel)
-		bti.errCh <- nil
 		<-bti.failOrCancelCh
 		bti.errCh <- MarkAsRetryJobError(errors.New("injecting error in reverting state"))
 		expectedResumed := bti.resumed.Count()


### PR DESCRIPTION
This is my best guess at what is happening here. The next person to touch this test should consider deleting this test case, or the whole test, or the whole feature.

Fixes #115552

Release note: None