### PR TITLE
release-23.1: kvserver: record QPS stats on successful batch request only

### DIFF
--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -137,9 +137,6 @@ func (r *Replica) SendWithWriteBytes(
 	// recorded regardless of errors that are encountered.
 	startCPU := grunning.Time()
 	defer r.MeasureReqCPUNanos(startCPU)
-	// Record summary throughput information about the batch request for
-	// accounting.
-	r.recordBatchRequestLoad(ctx, ba)
 
 	// If the internal Raft group is not initialized, create it and wake the leader.
 	r.maybeInitializeRaftGroup(ctx)
@@ -212,6 +209,9 @@ func (r *Replica) SendWithWriteBytes(
 		r.recordBatchForLoadBasedSplitting(ctx, ba, br, int(grunning.Difference(startCPU, grunning.Time())))
 	}
 
+	// Record summary throughput information about the batch request for
+	// accounting.
+	r.recordBatchRequestLoad(ctx, ba)
 	r.recordRequestWriteBytes(writeBytes)
 	r.recordImpactOnRateLimiter(ctx, br, isReadOnly)
 	return br, writeBytes, pErr


### PR DESCRIPTION
Backport 1/1 commits from #119723 on behalf of @koorosh.

/cc @cockroachdb/release

----

Before, QPS stats for batch request were recorded before request executed,
and it could lead to cases when request failed but calculated QPS is recorded.
This behavior looks inconsistent comparing to other replica stats (ie Write Keys,
or Write Bytes) that recorded only after successful batch request.

This patch changes the order of accounting QPS stats that now recorded after
request completes.
In addition, it calculates QPS on the final batch request (after possible
mutation of it by `maybeStripInFlightWrites` function).

Release note: None

Related issue: https://github.com/cockroachdb/cockroach/issues/119388
Related issue: https://github.com/cockroachdb/cockroach/issues/119206

Epic: None

----

Release justification: low risk, high benefit changes to existing functionality