### PR TITLE
roachtest: escape url in debug zip

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1365,9 +1365,8 @@ func (c *clusterImpl) FetchDebugZip(
 			cmd := roachtestutil.NewCommand("%s debug zip", test.DefaultCockroachPath).
 				Option("include-range-info").
 				Flag("exclude-files", fmt.Sprintf("'%s'", excludeFiles)).
-				Flag("url", nodePgUrl[0]).
+				Flag("url", fmt.Sprintf("'%s'", nodePgUrl[0])).
 				MaybeFlag(c.IsSecure(), "certs-dir", install.CockroachNodeCertsDir).
-				MaybeFlag(c.IsSecure(), "certs-dir", "certs").
 				Arg(zipName).
 				String()
 			if err = c.RunE(ctx, option.WithNodes(c.Node(node)), cmd); err != nil {


### PR DESCRIPTION
Also removed erroneous extra certs flag. 

Release note: none
Epic: none
Fixes: none