### PR TITLE
[CLOUDOPS-8255] kvprober: enabling default values for kvprober reads and writes

### DIFF
--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -33,7 +33,7 @@ var readEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.prober.read.enabled",
 	"whether the KV read prober is enabled",
-	false)
+	true)
 
 // TODO(josh): Another option is for the cluster setting to be a QPS target
 // for the cluster as a whole.
@@ -62,7 +62,7 @@ var writeEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.prober.write.enabled",
 	"whether the KV write prober is enabled",
-	false)
+	true)
 
 var writeInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,


### PR DESCRIPTION
Previously, if a variable is removed from the registry but not from the desired state, it will not be able to apply the intended changes to the cluster.

In this particular case, since the read and writes are disabled by default, kv prober will not function in the cluster and SREs will be paged for it.

This change enables the kv prober by default.