### PR TITLE
sql: fix mixed version test for node-level sequence caching

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_sequence_per_node_cache
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_sequence_per_node_cache
@@ -47,6 +47,9 @@ upgrade 1
 
 upgrade 2
 
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version();
+
 query T nodeidx=1
 SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 ----


### PR DESCRIPTION
Fix mixed version test for node-level sequence caching by making it wait for upgrade to complete.

Epic: none
Fixes: #119978

Release note: None