### PR TITLE
[wip] rangefeed: improve memory accounting for event queue

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "budget.go",
         "catchup_scan.go",
+        "event_size.go",
         "filter.go",
         "metrics.go",
         "processor.go",
@@ -56,6 +57,7 @@ go_test(
         "budget_test.go",
         "catchup_scan_bench_test.go",
         "catchup_scan_test.go",
+        "event_size_test.go",
         "processor_test.go",
         "registry_test.go",
         "resolved_timestamp_test.go",
@@ -76,6 +78,7 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/skip",
+        "//pkg/testutils/storageutils",
         "//pkg/util",
         "//pkg/util/encoding",
         "//pkg/util/future",

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -148,6 +148,7 @@ func NewFeedBudget(budget *mon.BoundAccount, limit int64, settings *settings.Val
 		stopC:      make(chan interface{}),
 		limit:      limit,
 		settings:   settings,
+		// add more fields to cache span size here
 	}
 	f.mu.memBudget = budget
 	return f

--- a/pkg/kv/kvserver/rangefeed/event_size.go
+++ b/pkg/kv/kvserver/rangefeed/event_size.go
@@ -1,0 +1,130 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+)
+
+const (
+	mvccLogicalOp      = int64(unsafe.Sizeof(enginepb.MVCCLogicalOp{}))
+	mvccWriteValueOp   = int64(unsafe.Sizeof(enginepb.MVCCWriteValueOp{}))
+	mvccDeleteRangeOp  = int64(unsafe.Sizeof(enginepb.MVCCDeleteRangeOp{}))
+	mvccWriteIntentOp  = int64(unsafe.Sizeof(enginepb.MVCCWriteIntentOp{}))
+	mvccUpdateIntentOp = int64(unsafe.Sizeof(enginepb.MVCCUpdateIntentOp{}))
+	mvccCommitIntentOp = int64(unsafe.Sizeof(enginepb.MVCCCommitIntentOp{}))
+	mvccAbortIntentOp  = int64(unsafe.Sizeof(enginepb.MVCCAbortIntentOp{}))
+	mvccAbortTxnOp     = int64(unsafe.Sizeof(enginepb.MVCCAbortTxnOp{}))
+)
+
+const (
+	eventOverhead = int64(unsafe.Sizeof(&event{})) + int64(unsafe.Sizeof(event{}))
+)
+
+const (
+	sharedEventPtrOverhead  = int64(unsafe.Sizeof(&sharedEvent{}))
+	sharedEventOverhead     = int64(unsafe.Sizeof(sharedEvent{}))
+	rangeFeedEventOverhead  = int64(unsafe.Sizeof(kvpb.RangeFeedEvent{}))
+	allocEventOverhead      = int64(unsafe.Sizeof(SharedBudgetAllocation{}))
+	feedBudgetOverhead      = int64(unsafe.Sizeof(FeedBudget{}))
+	futureEventBaseOverhead = sharedEventPtrOverhead + sharedEventOverhead + rangeFeedEventOverhead + allocEventOverhead + feedBudgetOverhead
+)
+
+const (
+	rangefeedValueOverhead       = int64(unsafe.Sizeof(kvpb.RangeFeedValue{}))
+	rangefeedDeleteRangeOverhead = int64(unsafe.Sizeof(kvpb.RangeFeedDeleteRange{}))
+	rangefeedCheckpointOverhead  = int64(unsafe.Sizeof(kvpb.RangeFeedCheckpoint{}))
+	rangefeedSSTTableOverhead    = int64(unsafe.Sizeof(kvpb.RangeFeedSSTable{}))
+)
+
+const (
+	sstEventOverhead  = int64(unsafe.Sizeof(sstEvent{}))
+	syncEventOverhead = int64(unsafe.Sizeof(syncEvent{}))
+)
+
+func estimateCheckpointEventMemUsage() (futureMemUsage int64) {
+	// eventOverhead should have included the overhead of the ctEvent{} already.
+	// account for checkpoint event: it is possible that new checkpoint event is needed to be published, but we overaccount for now and release later on.
+	return futureEventBaseOverhead + rangefeedCheckpointOverhead
+}
+
+func estimateSSTEventMemUsage() (currMemUsage, futureMemUsage int64) {
+	currMemUsage += sstEventOverhead
+	futureMemUsage += futureEventBaseOverhead + rangefeedSSTTableOverhead
+	return currMemUsage, futureMemUsage
+}
+
+func estimateSyncEventMemUsage() (currMemUsage int64) {
+	return syncEventOverhead
+}
+
+// can free more once we finish current
+func estimateOpsMemUsage(ops opsEvent, spanSize int64) (currMemUsage, futureMemUsage int64) {
+	// ops: []enginepb.MVCCLogicalOp
+	currMemUsage += mvccLogicalOp * int64(cap(ops))
+	// For each op, some probability to publish checkpoint
+	// TODO(wenyihu6): this memory is over-held if no checkpoint events and they
+	// should be separated out fromn the other events budget
+	futureMemUsage += estimateCheckpointEventMemUsage() * int64(len(ops))
+	for _, op := range ops {
+		// May publish checkpoint (add a probability) and adjust the budget
+		switch op.GetValue().(type) {
+		case *enginepb.MVCCWriteValueOp:
+			currMemUsage += mvccWriteValueOp + int64(op.Size())
+			futureMemUsage += futureEventBaseOverhead + rangefeedValueOverhead + int64(op.Size())
+		case *enginepb.MVCCDeleteRangeOp:
+			currMemUsage += mvccDeleteRangeOp + int64(op.Size())
+			futureMemUsage += futureEventBaseOverhead + rangefeedDeleteRangeOverhead + int64(op.Size())
+		case *enginepb.MVCCWriteIntentOp:
+			currMemUsage += mvccWriteIntentOp + int64(op.Size())
+			// No updates to publish.
+		case *enginepb.MVCCUpdateIntentOp:
+			currMemUsage += mvccUpdateIntentOp + int64(op.Size())
+			// No updates to publish.
+		case *enginepb.MVCCCommitIntentOp:
+			currMemUsage += mvccCommitIntentOp + int64(op.Size())
+			futureMemUsage += futureEventBaseOverhead + rangefeedValueOverhead + int64(op.Size())
+		case *enginepb.MVCCAbortIntentOp:
+			currMemUsage += mvccAbortIntentOp + int64(op.Size())
+			// No updates to publish.
+		case *enginepb.MVCCAbortTxnOp:
+			currMemUsage += mvccAbortTxnOp + int64(op.Size())
+			// No updates to publish.
+		}
+	}
+	return currMemUsage, futureMemUsage
+}
+
+func estimateEventMemUsage(e event, spanSize int64) int64 {
+	currMemUsage, futureMemUsage := int64(0), int64(0)
+	switch {
+	case e.ops != nil:
+		currMemUsage, futureMemUsage = estimateOpsMemUsage(e.ops, spanSize)
+	case !e.ct.IsEmpty():
+		// no current extra memory usage
+		futureMemUsage = estimateCheckpointEventMemUsage() + spanSize
+	case bool(e.initRTS):
+		// no current extra memory usage
+		// may publish checkpoint but we overaccount for now and release later on right after we know we dont need it.
+		futureMemUsage = estimateCheckpointEventMemUsage() + spanSize
+	case e.sst != nil:
+		underlyingDataSize := int64(len(e.sst.data)) + spanSize
+		currMemUsage, futureMemUsage = estimateSSTEventMemUsage()
+		currMemUsage += underlyingDataSize
+		futureMemUsage += underlyingDataSize
+	case e.sync != nil:
+		currMemUsage = estimateSyncEventMemUsage()
+	}
+	return max(currMemUsage+eventOverhead, futureMemUsage)
+}

--- a/pkg/kv/kvserver/rangefeed/event_size_test.go
+++ b/pkg/kv/kvserver/rangefeed/event_size_test.go
@@ -1,0 +1,386 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type kvs = storageutils.KVs
+
+var (
+	pointKV = storageutils.PointKV
+	rangeKV = storageutils.RangeKV
+)
+var (
+	testKey            = roachpb.Key("/db1")
+	testTxnID          = uuid.MakeV4()
+	testIsolationLevel = isolation.Serializable
+	testTxnTS          = hlc.Timestamp{Logical: 1}
+	testNewClosedTs    = hlc.Timestamp{WallTime: 10, Logical: 2}
+	testMinTs          = hlc.Timestamp{}
+	testRSpan          = roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
+	testSpan           = roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("z")}
+	testTs             = hlc.Timestamp{WallTime: 1}
+	testStartKey       = roachpb.Key("a")
+	testEndKey         = roachpb.Key("z")
+	testValue          = []byte("1")
+	sstKVs             = kvs{
+		pointKV("a", 1, "1"),
+		pointKV("b", 1, "2"),
+		pointKV("c", 1, "3"),
+		rangeKV("d", "e", 1, ""),
+	}
+)
+
+func writeValueOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCWriteValueOp{
+		Key:       testKey,
+		Timestamp: testTxnTS,
+	})
+	var futureEvent kvpb.RangeFeedEvent
+	futureEvent.MustSetValue(&kvpb.RangeFeedValue{
+		Key: testKey,
+		Value: roachpb.Value{
+			Timestamp: testTxnTS,
+		},
+	})
+	expectedMemUsage += mvccLogicalOp + mvccWriteValueOp + int64(op.Size())
+	expectedFutureMemUsage += futureEventBaseOverhead + rangefeedValueOverhead + int64(futureEvent.Size())
+	return op, expectedMemUsage, expectedFutureMemUsage
+}
+
+func deleteRangeOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCDeleteRangeOp{
+		StartKey:  testStartKey,
+		EndKey:    testEndKey,
+		Timestamp: testTs,
+	})
+	var futureEvent kvpb.RangeFeedEvent
+	futureEvent.MustSetValue(&kvpb.RangeFeedDeleteRange{
+		Span:      roachpb.Span{Key: testStartKey, EndKey: testEndKey},
+		Timestamp: testTs,
+	})
+	expectedMemUsage += mvccLogicalOp + mvccDeleteRangeOp + int64(op.Size())
+	expectedFutureMemUsage += futureEventBaseOverhead + rangefeedDeleteRangeOverhead + int64(futureEvent.Size())
+	return op, expectedMemUsage, expectedFutureMemUsage
+}
+
+func writeIntentOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCWriteIntentOp{
+		TxnID:           testTxnID,
+		TxnKey:          testKey,
+		TxnIsoLevel:     testIsolationLevel,
+		TxnMinTimestamp: testMinTs,
+		Timestamp:       testTxnTS,
+	})
+	expectedMemUsage += mvccLogicalOp + mvccWriteIntentOp + int64(op.Size())
+	// no future event to publish
+	return op, expectedMemUsage, 0
+}
+
+func updateIntentOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCUpdateIntentOp{
+		TxnID:     testTxnID,
+		Timestamp: hlc.Timestamp{Logical: 3},
+	})
+	expectedMemUsage += mvccLogicalOp + mvccUpdateIntentOp + int64(op.Size())
+	// no future event to publish
+	return op, expectedMemUsage, 0
+}
+
+func commitIntentOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCCommitIntentOp{
+		Key:       testKey,
+		Timestamp: hlc.Timestamp{Logical: 4},
+		PrevValue: testValue,
+	})
+
+	var prevVal roachpb.Value
+	if op.CommitIntent.PrevValue != nil {
+		prevVal.RawBytes = op.CommitIntent.PrevValue
+	}
+	var futureEvent kvpb.RangeFeedEvent
+	futureEvent.MustSetValue(&kvpb.RangeFeedValue{
+		Key: testKey,
+		Value: roachpb.Value{
+			Timestamp: op.CommitIntent.Timestamp,
+		},
+		PrevValue: prevVal,
+	})
+
+	expectedMemUsage += mvccLogicalOp + mvccCommitIntentOp + int64(op.Size())
+	expectedFutureMemUsage += futureEventBaseOverhead + rangefeedValueOverhead + int64(futureEvent.Size())
+	return op, expectedMemUsage, expectedFutureMemUsage
+}
+
+func abortIntentOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCAbortIntentOp{
+		TxnID: testTxnID,
+	})
+	expectedMemUsage += mvccLogicalOp + mvccAbortIntentOp + int64(op.Size())
+	// no future event to publish
+	return op, expectedMemUsage, 0
+}
+
+func abortTxnOpEvent() (
+	op enginepb.MVCCLogicalOp,
+	expectedMemUsage int64,
+	expectedFutureMemUsage int64,
+) {
+	op = makeLogicalOp(&enginepb.MVCCAbortTxnOp{
+		TxnID: testTxnID,
+	})
+	expectedMemUsage += mvccLogicalOp + mvccAbortTxnOp + int64(op.Size())
+	// no future event to publish
+	return op, expectedMemUsage, 0
+}
+
+func generateLogicalOpEvent(
+	typesOfOps string, span roachpb.RSpan, rts resolvedTimestamp,
+) (ev event, expectedMemUsage int64, expectedFutureMemUsage int64) {
+	var op enginepb.MVCCLogicalOp
+	var mem, futureMem int64
+	switch typesOfOps {
+	case "write_value":
+		op, mem, futureMem = writeValueOpEvent()
+	case "delete_range":
+		op, mem, futureMem = deleteRangeOpEvent()
+	case "write_intent":
+		op, mem, futureMem = writeIntentOpEvent()
+	case "update_intent":
+		op, mem, futureMem = updateIntentOpEvent()
+	case "commit_intent":
+		op, mem, futureMem = commitIntentOpEvent()
+	case "abort_intent":
+		op, mem, futureMem = abortIntentOpEvent()
+	case "abort_txn":
+		op, mem, futureMem = abortTxnOpEvent()
+	}
+
+	ev = event{
+		ops: []enginepb.MVCCLogicalOp{op},
+	}
+	expectedMemUsage += eventOverhead + mem
+	expectedFutureMemUsage += futureMem
+	if rts.ConsumeLogicalOp(context.Background(), op) {
+		ce := checkpointEvent(span, rts)
+		expectedFutureMemUsage += futureEventBaseOverhead + rangefeedCheckpointOverhead + int64(ce.Size())
+	}
+	return
+}
+
+func checkpointEvent(span roachpb.RSpan, rts resolvedTimestamp) kvpb.RangeFeedEvent {
+	var event kvpb.RangeFeedEvent
+	event.MustSetValue(&kvpb.RangeFeedCheckpoint{
+		Span:       span.AsRawSpanWithNoLocals(),
+		ResolvedTS: rts.Get(),
+	})
+	return event
+}
+
+func generateCtEvent(
+	span roachpb.RSpan, rts resolvedTimestamp,
+) (ev event, expectedMemUsage int64, expectedFutureMemUsage int64) {
+	ev = event{
+		ct: ctEvent{
+			Timestamp: testNewClosedTs,
+		},
+	}
+	expectedMemUsage += eventOverhead
+	if rts.ForwardClosedTS(context.Background(), testNewClosedTs) {
+		ce := checkpointEvent(span, rts)
+		expectedFutureMemUsage += futureEventBaseOverhead + rangefeedCheckpointOverhead + int64(ce.Size())
+	}
+	return
+}
+
+func generateInitRTSEvent(
+	span roachpb.RSpan, rts resolvedTimestamp,
+) (ev event, expectedMemUsage int64, expectedFutureMemUsage int64) {
+	ev = event{
+		initRTS: true,
+	}
+	expectedMemUsage += eventOverhead
+	if rts.Init(context.Background()) {
+		ce := checkpointEvent(span, rts)
+		expectedFutureMemUsage += futureEventBaseOverhead + rangefeedCheckpointOverhead + int64(ce.Size())
+	}
+	return
+}
+
+func generateSSTEvent(
+	data []byte,
+) (ev event, expectedMemUsage int64, expectedFutureMemUsage int64) {
+	ev = event{
+		sst: &sstEvent{
+			data: data,
+			span: testSpan,
+			ts:   testTs,
+		},
+	}
+
+	var futureEvent kvpb.RangeFeedEvent
+	futureEvent.MustSetValue(&kvpb.RangeFeedSSTable{
+		Data:    data,
+		Span:    testSpan,
+		WriteTS: testTs,
+	})
+	expectedMemUsage += eventOverhead + sstEventOverhead + int64(cap(data)+cap(testSpan.Key)+cap(testSpan.EndKey))
+	expectedFutureMemUsage += futureEventBaseOverhead + rangefeedSSTTableOverhead + int64(futureEvent.Size())
+	return
+}
+
+func generateSyncEvent() (ev event, expectedMemUsage int64, expectedFutureMemUsage int64) {
+	ev = event{
+		sync: &syncEvent{c: make(chan struct{})},
+	}
+	expectedMemUsage += eventOverhead + syncEventOverhead
+	return
+}
+
+func TestEventSizeCalculation(t *testing.T) {
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	t.Run("empty_event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev := event{}
+		require.Equal(t, eventOverhead, ev.MemUsage())
+		require.Equal(t, int64(0), ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("write_value event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("write_value", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("delete_range event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("delete_range", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("write_intent event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("write_intent", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("update_intent event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("update_intent", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("commit_intent event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("commit_intent", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("abort_intent event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("abort_intent", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("abort_txn event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateLogicalOpEvent("abort_txn", testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("ct event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateCtEvent(testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("initRTS event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		generateLogicalOpEvent("write_intent", testRSpan, rts)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateInitRTSEvent(testRSpan, rts)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("sst event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		sst, _, _ := storageutils.MakeSST(t, st, sstKVs)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateSSTEvent(sst)
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+
+	t.Run("sync event", func(t *testing.T) {
+		rts := makeResolvedTimestamp(st)
+		rts.Init(ctx)
+		ev, expectedMemUsage, expectedFutureMemUsage := generateSyncEvent()
+		require.Equal(t, expectedMemUsage, ev.MemUsage())
+		require.Equal(t, expectedFutureMemUsage, ev.FutureMemUsage(ctx, testRSpan, rts))
+	})
+}

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -291,19 +291,3 @@ type syncEvent struct {
 // should be called from underneath a stopper task to ensure that the
 // engine has not been closed.
 type IntentScannerConstructor func() IntentScanner
-
-// calculateDateEventSize returns estimated size of the event that contain actual
-// data. We only account for logical ops and sst's. Those events come from raft
-// and are budgeted. Other events come from processor jobs and update timestamps
-// we don't take them into account as they are supposed to be small and to avoid
-// complexity of having multiple producers getting from budget.
-func calculateDateEventSize(e event) int64 {
-	var size int64
-	for _, op := range e.ops {
-		size += int64(op.Size())
-	}
-	if e.sst != nil {
-		size += int64(len(e.sst.data))
-	}
-	return size
-}

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -128,7 +128,7 @@ func (p *ScheduledProcessor) Start(
 			return err
 		}
 	} else {
-		p.initResolvedTS(p.taskCtx)
+		p.initResolvedTS(p.taskCtx, nil)
 	}
 
 	p.Metrics.RangeFeedProcessorsScheduler.Inc(1)
@@ -448,7 +448,8 @@ func (p *ScheduledProcessor) enqueueEventInternal(
 	// inserting value into channel.
 	var alloc *SharedBudgetAllocation
 	if p.MemBudget != nil {
-		size := calculateDateEventSize(e)
+		span := p.Span.AsRawSpanWithNoLocals()
+		size := estimateEventMemUsage(e, int64(len(span.Key)+len(span.EndKey)))
 		if size > 0 {
 			var err error
 			// First we will try non-blocking fast path to allocate memory budget.
@@ -638,9 +639,9 @@ func (p *ScheduledProcessor) consumeEvent(ctx context.Context, e *event) {
 	case e.ops != nil:
 		p.consumeLogicalOps(ctx, e.ops, e.alloc)
 	case !e.ct.IsEmpty():
-		p.forwardClosedTS(ctx, e.ct.Timestamp)
+		p.forwardClosedTS(ctx, e.ct.Timestamp, e.alloc)
 	case bool(e.initRTS):
-		p.initResolvedTS(ctx)
+		p.initResolvedTS(ctx, e.alloc)
 	case e.sst != nil:
 		p.consumeSSTable(ctx, e.sst.data, e.sst.span, e.sst.ts, e.alloc)
 	case e.sync != nil:
@@ -699,7 +700,8 @@ func (p *ScheduledProcessor) consumeLogicalOps(
 		// Determine whether the operation caused the resolved timestamp to
 		// move forward. If so, publish a RangeFeedCheckpoint notification.
 		if p.rts.ConsumeLogicalOp(ctx, op) {
-			p.publishCheckpoint(ctx)
+			// May publish checkpoint we are over accounting here -> we should have a separate token for publishcheckpoint maybe
+			p.publishCheckpoint(ctx, alloc)
 		}
 	}
 }
@@ -714,15 +716,17 @@ func (p *ScheduledProcessor) consumeSSTable(
 	p.publishSSTable(ctx, sst, sstSpan, sstWTS, alloc)
 }
 
-func (p *ScheduledProcessor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) {
+func (p *ScheduledProcessor) forwardClosedTS(
+	ctx context.Context, newClosedTS hlc.Timestamp, alloc *SharedBudgetAllocation,
+) {
 	if p.rts.ForwardClosedTS(ctx, newClosedTS) {
-		p.publishCheckpoint(ctx)
+		p.publishCheckpoint(ctx, alloc)
 	}
 }
 
-func (p *ScheduledProcessor) initResolvedTS(ctx context.Context) {
+func (p *ScheduledProcessor) initResolvedTS(ctx context.Context, alloc *SharedBudgetAllocation) {
 	if p.rts.Init(ctx) {
-		p.publishCheckpoint(ctx)
+		p.publishCheckpoint(ctx, alloc)
 	}
 }
 
@@ -795,12 +799,12 @@ func (p *ScheduledProcessor) publishSSTable(
 	}, false /* omitInRangefeeds */, alloc)
 }
 
-func (p *ScheduledProcessor) publishCheckpoint(ctx context.Context) {
+func (p *ScheduledProcessor) publishCheckpoint(ctx context.Context, alloc *SharedBudgetAllocation) {
 	// TODO(nvanbenschoten): persist resolvedTimestamp. Give Processor a client.DB.
 	// TODO(nvanbenschoten): rate limit these? send them periodically?
 
 	event := p.newCheckpointEvent()
-	p.reg.PublishToOverlapping(ctx, all, event, false /* omitInRangefeeds */, nil)
+	p.reg.PublishToOverlapping(ctx, all, event, false /* omitInRangefeeds */, alloc)
 }
 
 func (p *ScheduledProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -790,13 +790,13 @@ func (p *ScheduledProcessor) publishSSTable(
 	if sstWTS.IsEmpty() {
 		log.Fatalf(ctx, "received SSTable without write timestamp")
 	}
-	p.reg.PublishToOverlapping(ctx, sstSpan, &kvpb.RangeFeedEvent{
-		SST: &kvpb.RangeFeedSSTable{
-			Data:    sst,
-			Span:    sstSpan,
-			WriteTS: sstWTS,
-		},
-	}, false /* omitInRangefeeds */, alloc)
+	var event kvpb.RangeFeedEvent
+	event.MustSetValue(&kvpb.RangeFeedSSTable{
+		Data:    sst,
+		Span:    sstSpan,
+		WriteTS: sstWTS,
+	})
+	p.reg.PublishToOverlapping(ctx, sstSpan, &event, false /* omitInRangefeeds */, alloc)
 }
 
 func (p *ScheduledProcessor) publishCheckpoint(ctx context.Context, alloc *SharedBudgetAllocation) {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -448,8 +448,7 @@ func (p *ScheduledProcessor) enqueueEventInternal(
 	// inserting value into channel.
 	var alloc *SharedBudgetAllocation
 	if p.MemBudget != nil {
-		span := p.Span.AsRawSpanWithNoLocals()
-		size := estimateEventMemUsage(e, int64(len(span.Key)+len(span.EndKey)))
+		size := max(e.MemUsage(), e.FutureMemUsage(ctx, p.Span, p.rts))
 		if size > 0 {
 			var err error
 			// First we will try non-blocking fast path to allocate memory budget.


### PR DESCRIPTION
We can use the processor's resolved timestamp to predict if a checkpoint event will happen. But calling p.rts.ConsumeLogicalOp for memory accounting can change internal field unresolvedIntentQueue. To resolve this, we could make a deep copy of rts, but this is on a hot path and could introduce significant overhead. 

Related: https://github.com/cockroachdb/cockroach/issues/73616
Resolves: https://github.com/cockroachdb/cockroach/issues/114190