### PR TITLE
logictest: unskip upgrade tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_procedure
@@ -33,19 +33,20 @@ CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'
 
 # Upgrade all nodes.
 
-# TODO(#112621): Unskip these tests. It is currently skipped because the cluster
-# does not reliably complete the upgrade in CI.
-# upgrade 1
-#
-# upgrade 2
-#
-# # Makes sure the upgrade job has finished, and the cluster version gate is
-# # passed.
-# query B retry
-# SELECT crdb_internal.is_at_least_version('23.2')
-# ----
-# true
-#
-# # Creating a procedure should now be possible.
-# statement ok
-# CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'
+upgrade 1
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+# Makes sure the upgrade job has finished, and the cluster version gate is
+# passed.
+query B
+SELECT crdb_internal.is_at_least_version('23.2')
+----
+true
+
+# Creating a procedure should now be possible.
+statement ok
+CREATE PROCEDURE p() LANGUAGE SQL AS 'SELECT 1'

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_execute_privileges
@@ -71,33 +71,37 @@ SELECT crdb_internal.release_series(crdb_internal.node_executable_version())
 
 # Makes sure the upgrade job has finished, and the cluster version gate is
 # passed.
-# TODO(#112621): Unskip these tests. It is currently skipped because the cluster
-# does not reliably complete the upgrade in CI.
-# query B retry
-# SELECT crdb_internal.is_at_least_version('23.2')
-# ----
-# true
-#
-# query TTTTTTB colnames
-# SELECT * FROM [SHOW GRANTS ON FUNCTION f] ORDER BY grantee
-# ----
-# database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
-# test           public       100106      f()                admin    ALL             true
-# test           public       100106      f()                public   EXECUTE         false
-# test           public       100106      f()                root     ALL             true
-#
-# user testuser1 nodeidx=1
-#
-# # Makes sure the user can execute f on node 1.
-# query I
-# SELECT f()
-# ----
-# 1
-#
-# user testuser1 nodeidx=2
-#
-# # Makes sure the user can execute f on node 2.
-# query I
-# SELECT f()
-# ----
-# 1
+
+user root
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+query B
+SELECT crdb_internal.is_at_least_version('23.2')
+----
+true
+
+query TTTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON FUNCTION f] ORDER BY grantee
+----
+database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
+test           public       100106      f()                admin    ALL             true
+test           public       100106      f()                public   EXECUTE         false
+test           public       100106      f()                root     ALL             true
+
+user testuser1 nodeidx=1
+
+# Makes sure the user can execute f on node 1.
+query I
+SELECT f()
+----
+1
+
+user testuser1 nodeidx=2
+
+# Makes sure the user can execute f on node 2.
+query I
+SELECT f()
+----
+1

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations
@@ -83,28 +83,29 @@ $$ LANGUAGE SQL;
 # Upgrade all nodes and test that creating UDFs with mutations succeeds.
 # ----------------------------------------------------------------------
 
-# TODO(#112621): Unskip these tests. It is currently skipped because the cluster
-# does not reliably complete the upgrade in CI.
-# upgrade 1
-#
-# upgrade 2
-#
-# query B retry
-# SELECT crdb_internal.is_at_least_version('23.2')
-# ----
-# true
-#
-# statement ok
-# CREATE FUNCTION f_insert() RETURNS VOID AS $$
-#   INSERT INTO t VALUES (1,1);
-# $$ LANGUAGE SQL;
-#
-# statement ok
-# CREATE FUNCTION f_delete() RETURNS VOID AS $$
-#   DELETE FROM t WHERE a = 1;
-# $$ LANGUAGE SQL;
-#
-# statement ok
-# CREATE FUNCTION f_update() RETURNS VOID AS $$
-#   UPDATE t SET b = 1 WHERE a = 1;
-# $$ LANGUAGE SQL;
+upgrade 1
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
+
+query B retry
+SELECT crdb_internal.is_at_least_version('23.2')
+----
+true
+
+statement ok
+CREATE FUNCTION f_insert() RETURNS VOID AS $$
+  INSERT INTO t VALUES (1,1);
+$$ LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_delete() RETURNS VOID AS $$
+  DELETE FROM t WHERE a = 1;
+$$ LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION f_update() RETURNS VOID AS $$
+  UPDATE t SET b = 1 WHERE a = 1;
+$$ LANGUAGE SQL;

--- a/pkg/sql/logictest/testdata/logic_test/upgrade_skip_version
+++ b/pkg/sql/logictest/testdata/logic_test/upgrade_skip_version
@@ -7,12 +7,11 @@ select crdb_internal.active_version()
 
 upgrade all
 
-# We have seen that upgrades can take a long time in CI. Give some extra time
-# for the upgrade to complete.
-retry_duration 10m
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
 
 # Verify that the cluster is upgrading to 24.1.
-query T retry
+query T
 SELECT crdb_internal.release_series(version) FROM [SHOW CLUSTER SETTING version]
 ----
 24.1


### PR DESCRIPTION
These tests were skipped since we previously thought there was no way to force the upgrade to complete. Turns out there is, actually.

fixes https://github.com/cockroachdb/cockroach/issues/112621
Release note: None