### PR TITLE
kvclient: add a utility method to RangeCache

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -540,6 +540,14 @@ func (et *EvictionToken) evictAndReplaceLocked(ctx context.Context, newDescs ...
 	et.clear()
 }
 
+// RangeInfo extracts the RangeInfo from this token.
+func (et *EvictionToken) RangeInfo() roachpb.RangeInfo {
+	if !et.Valid() {
+		return roachpb.RangeInfo{}
+	}
+	return et.entry.toRangeInfo()
+}
+
 // LookupWithEvictionToken attempts to locate a descriptor, and possibly also a
 // lease) for the range containing the given key. This is done by first trying
 // the cache, and then querying the two-level lookup table of range descriptors

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1514,6 +1514,10 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	require.Equal(t, desc1, *tok.Desc())
 	require.Nil(t, tok.Leaseholder())
 	requireTokenDoesNotHaveClosedTimestampPolicy(t, tok)
+	tokRI := tok.RangeInfo()
+	require.Equal(t, desc1, tokRI.Desc)
+	require.Equal(t, roachpb.Lease{}, tokRI.Lease)
+	require.Equal(t, UnknownClosedTimestampPolicy, tokRI.ClosedTimestampPolicy)
 
 	// EvictAndReplace() with a new descriptor.
 	ri.Desc = desc2
@@ -1525,6 +1529,10 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	require.Nil(t, tok.Leaseholder())
 	// Note that we now have a definitive closed timestamp policy.
 	require.Equal(t, lag, tok.ClosedTimestampPolicy(lead))
+	tokRI = tok.RangeInfo()
+	require.Equal(t, desc2, tokRI.Desc)
+	require.Equal(t, roachpb.Lease{}, tokRI.Lease)
+	require.Equal(t, lag, tokRI.ClosedTimestampPolicy)
 
 	// EvictAndReplace() with a new lease.
 	ri.Lease = roachpb.Lease{
@@ -1539,6 +1547,10 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	require.Equal(t, rep1, *tok.Leaseholder())
 	require.Equal(t, roachpb.LeaseSequence(1), tok.LeaseSeq())
 	require.Equal(t, lag, tok.ClosedTimestampPolicy(lead))
+	tokRI = tok.RangeInfo()
+	require.Equal(t, desc2, tokRI.Desc)
+	require.Equal(t, ri.Lease, tokRI.Lease)
+	require.Equal(t, lag, tokRI.ClosedTimestampPolicy)
 
 	// EvictAndReplace() with a new closed timestamp policy.
 	ri.ClosedTimestampPolicy = lead


### PR DESCRIPTION
The fields within the RangeCache are all independent today, but it often interacts with a RangeInfo. Being able to directly convert to one is useful.

Epic: none

Release note: None