### PR TITLE
sql: crdb_internal.leases should be placed behind VIEWCLUSTERMETADATA

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -877,6 +877,9 @@ CREATE TABLE crdb_internal.leases (
 	populate: func(
 		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
 	) error {
+		if err := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERMETADATA); err != nil {
+			return err
+		}
 		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 		var leaseEntries []crdbInternalLeasesTableEntry
 		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, takenOffline bool, _ int, expiration tree.DTimestamp) (wantMore bool) {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -795,6 +795,9 @@ select * from crdb_internal.gossip_alerts
 query error user testuser does not have VIEWCLUSTERMETADATA system privilege
 select * from crdb_internal.node_inflight_trace_spans
 
+query error user testuser does not have VIEWCLUSTERMETADATA system privilege
+select * from crdb_internal.leases;
+
 query error user testuser does not have REPAIRCLUSTERMETADATA system privilege
 SELECT * FROM crdb_internal.check_consistency(true, b'\x02', b'\x04')
 
@@ -1655,6 +1658,11 @@ subtest end
 # test validates that this is no longer the case.
 subtest allow_role_memberships_to_change_during_transaction
 
+user root
+
+statement ok
+GRANT SYSTEM VIEWCLUSTERMETADATA TO testuser
+
 user testuser
 
 statement ok
@@ -1662,5 +1670,10 @@ set allow_role_memberships_to_change_during_transaction=true
 
 statement ok
 SELECT  * FROM crdb_internal.leases;
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWCLUSTERMETADATA FROM testuser
 
 subtest end


### PR DESCRIPTION
Previously, all users could access the internal table crdb_internal.leases. This was unnecessary, as the table's intensive locking requirements can potentially cause heavy overhead. Limiting user access to the VIEWCLUSTERMETADATA privilege is a more sensible approach. This patch will place crdb_internal.leases behind the VIEWCLUSTERMETADATA privilege, which would also help mitigate previous issues (#119253).

Fixes: #119440
Release note (sql change): crdb_internal.leases is now behind the VIEWCLUSTERMETADATA privilege.