### PR TITLE
kvserver: add proxySender variable to node

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -413,6 +413,7 @@ type Node struct {
 		encodedVersion string
 		updateCh       chan struct{}
 	}
+	proxySender kv.Sender
 }
 
 var _ kvpb.InternalServer = &Node{}
@@ -565,6 +566,7 @@ func NewNode(
 	tenantInfoWatcher *tenantcapabilitieswatcher.Watcher,
 	spanConfigAccessor spanconfig.KVAccessor,
 	spanConfigReporter spanconfig.Reporter,
+	proxySender kv.Sender,
 ) *Node {
 	n := &Node{
 		storeCfg:              cfg,
@@ -582,6 +584,7 @@ func NewNode(
 		spanConfigReporter:    spanConfigReporter,
 		testingErrorEvent:     cfg.TestingKnobs.TestingResponseErrorEvent,
 		spanStatsCollector:    spanstatscollector.New(cfg.Settings),
+		proxySender:           proxySender,
 	}
 	n.versionUpdateMu.updateCh = make(chan struct{})
 	n.perReplicaServer = kvserver.MakeServer(&n.Descriptor, n.stores)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -923,6 +923,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		tenantCapabilitiesWatcher,
 		spanConfig.kvAccessor,
 		spanConfig.reporter,
+		distSender,
 	)
 	kvpb.RegisterInternalServer(grpcServer.Server, node)
 	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)


### PR DESCRIPTION
The node object has an indirect reference to DistSender through the `storeCfg.DB`. This PR directly injects the proxySender variable for use for proxying requests.

Epic: none

Release note: None