### PR TITLE
catalog: remove maybeSetCheckConstraintColumnIDs

### DIFF
--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -108,10 +108,6 @@ const (
 	// descriptor did not have its version set.
 	SetSystemDatabaseDescriptorVersion
 
-	// SetCheckConstraintColumnIDs indicates that a table's check constraint's
-	// ColumnIDs slice hadn't been set yet, and was set to a non-empty slice.
-	SetCheckConstraintColumnIDs
-
 	// UpgradedDeclarativeSchemaChangerState indicates the declarative schema changer
 	// state was modified.
 	UpgradedDeclarativeSchemaChangerState

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -400,7 +400,6 @@ func maybeFillInDescriptor(
 	}
 	set(catalog.UpgradedPrivileges, fixedPrivileges)
 	set(catalog.RemovedDuplicateIDsInRefs, maybeRemoveDuplicateIDsInRefs(desc))
-	set(catalog.SetCheckConstraintColumnIDs, maybeSetCheckConstraintColumnIDs(desc))
 	set(catalog.StrippedDanglingSelfBackReferences, maybeStripDanglingSelfBackReferences(desc))
 	set(catalog.FixSecondaryIndexEncodingType, maybeFixSecondaryIndexEncodingType(desc))
 	return changes, nil
@@ -927,60 +926,6 @@ func cleanedIDs(input []descpb.ID) []descpb.ID {
 		return nil
 	}
 	return s
-}
-
-// maybeSetCheckConstraintColumnIDs ensures that all check constraints have a
-// ColumnIDs slice which is populated if it should be.
-func maybeSetCheckConstraintColumnIDs(desc *descpb.TableDescriptor) (hasChanged bool) {
-	// Collect valid column names.
-	nonDropColumnIDs := make(map[string]descpb.ColumnID, len(desc.Columns))
-	for i := range desc.Columns {
-		nonDropColumnIDs[desc.Columns[i].Name] = desc.Columns[i].ID
-	}
-	for _, m := range desc.Mutations {
-		if col := m.GetColumn(); col != nil && m.Direction != descpb.DescriptorMutation_DROP {
-			nonDropColumnIDs[col.Name] = col.ID
-		}
-	}
-	var colIDsUsed catalog.TableColSet
-	visitFn := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-		if vBase, ok := expr.(tree.VarName); ok {
-			v, err := vBase.NormalizeVarName()
-			if err != nil {
-				return false, nil, err
-			}
-			if c, ok := v.(*tree.ColumnItem); ok {
-				colID, found := nonDropColumnIDs[string(c.ColumnName)]
-				if !found {
-					return false, nil, errors.New("column not found")
-				}
-				colIDsUsed.Add(colID)
-			}
-			return false, v, nil
-		}
-		return true, expr, nil
-	}
-
-	for _, ck := range desc.Checks {
-		if len(ck.ColumnIDs) > 0 {
-			continue
-		}
-		parsed, err := parser.ParseExpr(ck.Expr)
-		if err != nil {
-			// We do this on a best-effort basis.
-			continue
-		}
-		colIDsUsed = catalog.TableColSet{}
-		if _, err := tree.SimpleVisit(parsed, visitFn); err != nil {
-			// We do this on a best-effort basis.
-			continue
-		}
-		if !colIDsUsed.Empty() {
-			ck.ColumnIDs = colIDsUsed.Ordered()
-			hasChanged = true
-		}
-	}
-	return hasChanged
 }
 
 // maybeStripDanglingSelfBackReferences removes any references to things

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -760,6 +760,7 @@ func maybeCreateAndAddShardCol(
 	shardCheckConstraint := &scpb.CheckConstraint{
 		TableID:      tbl.TableID,
 		ConstraintID: shardColCkConstraintID,
+		ColumnIDs:    []catid.ColumnID{shardColID},
 		Expression: scpb.Expression{
 			Expr:                catpb.Expression(checkConstraintBucketValues.String()),
 			ReferencedColumnIDs: []catid.ColumnID{shardColID},

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -113,7 +113,7 @@ CREATE INDEX id4
 - [[ColumnNotNull:{DescID: 104, ColumnID: 4, IndexID: 1}, PUBLIC], ABSENT]
   {columnId: 4, indexIdForValidation: 1, tableId: 104}
 - [[CheckConstraint:{DescID: 104, IndexID: 1, ConstraintID: 2, ReferencedColumnIDs: [4]}, PUBLIC], ABSENT]
-  {constraintId: 2, expr: '"crdb_internal_id_name_shard_8" IN (0,1,2,3,4,5,6,7)', fromHashShardedColumn: true, indexIdForValidation: 1, referencedColumnIds: [4], tableId: 104}
+  {columnIds: [4], constraintId: 2, expr: '"crdb_internal_id_name_shard_8" IN (0,1,2,3,4,5,6,7)', fromHashShardedColumn: true, indexIdForValidation: 1, referencedColumnIds: [4], tableId: 104}
 - [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_id_name_shard_8, ConstraintID: 2}, PUBLIC], ABSENT]
   {constraintId: 2, name: check_crdb_internal_id_name_shard_8, tableId: 104}
 - [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC], ABSENT]

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
@@ -791,7 +791,9 @@ upsert descriptor #104
    table:
   -  checks: []
   +  checks:
-  +  - constraintId: 2
+  +  - columnIds:
+  +    - 3
+  +    constraintId: 2
   +    expr: '"crdb_internal_j_shard_3" IN (0,1,2)'
   +    fromHashShardedColumn: true
   +    name: check_crdb_internal_j_shard_3
@@ -878,6 +880,8 @@ upsert descriptor #104
   +    state: DELETE_ONLY
   +  - constraint:
   +      check:
+  +        columnIds:
+  +        - 3
   +        constraintId: 2
   +        expr: '"crdb_internal_j_shard_3" IN (0,1,2)'
   +        fromHashShardedColumn: true
@@ -998,6 +1002,8 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   -  - constraint:
   -      check:
+  -        columnIds:
+  -        - 3
   -        constraintId: 2
   -        expr: '"crdb_internal_j_shard_3" IN (0,1,2)'
   -        fromHashShardedColumn: true


### PR DESCRIPTION
This post-deserialization change is no longer needed, since it was
applied to all descriptors during the last major version upgrade.

Removing it revealed a bug in the new schema changer - the code was not
setting the column IDs for CHECK constraints that are created for
hash-sharded indexes.

Epic: None
Release note: None