### PR TITLE
roachtest: add operations to add column, indexes 

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -2,8 +2,20 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "operations",
-    srcs = ["register.go"],
+    srcs = [
+        "add_column.go",
+        "add_index.go",
+        "register.go",
+        "utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/cmd/roachtest/registry"],
+    deps = [
+        "//pkg/cmd/roachtest/cluster",
+        "//pkg/cmd/roachtest/operation",
+        "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/registry",
+        "//pkg/cmd/roachtest/roachtestflags",
+        "//pkg/util/randutil",
+    ],
 )

--- a/pkg/cmd/roachtest/operations/add_column.go
+++ b/pkg/cmd/roachtest/operations/add_column.go
@@ -1,0 +1,78 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+type cleanupAddedColumn struct {
+	db, table, column string
+}
+
+func (cl *cleanupAddedColumn) Cleanup(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	o.Status(fmt.Sprintf("dropping column %s", cl.column))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DROP COLUMN %s CASCADE", cl.db, cl.table, cl.column))
+	if err != nil {
+		o.Fatal(err)
+	}
+}
+
+func runAddColumn(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	rng, _ := randutil.NewPseudoRand()
+	dbName := pickRandomDB(ctx, o, conn, systemDBs)
+	tableName := pickRandomTable(ctx, o, conn, dbName)
+
+	colName := fmt.Sprintf("add_column_op_%d", rng.Uint32())
+	o.Status(fmt.Sprintf("adding column %s to table %s.%s", colName, dbName, tableName))
+	addColStmt := fmt.Sprintf("ALTER TABLE %s.%s ADD COLUMN %s VARCHAR DEFAULT 'default'", dbName, tableName, colName)
+	_, err := conn.ExecContext(ctx, addColStmt)
+	if err != nil {
+		o.Fatal(err)
+	}
+
+	o.Status(fmt.Sprintf("column %s created", colName))
+	return &cleanupAddedColumn{
+		db:     dbName,
+		table:  tableName,
+		column: colName,
+	}
+}
+
+func registerAddColumn(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "add-column",
+		Owner:            registry.OwnerSQLFoundations,
+		Timeout:          24 * time.Hour,
+		CompatibleClouds: registry.AllClouds,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:              runAddColumn,
+	})
+}

--- a/pkg/cmd/roachtest/operations/add_index.go
+++ b/pkg/cmd/roachtest/operations/add_index.go
@@ -1,0 +1,91 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+type cleanupAddedIndex struct {
+	db, table, index string
+}
+
+func (cl *cleanupAddedIndex) Cleanup(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	o.Status(fmt.Sprintf("dropping index %s", cl.index))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP INDEX %s.%s@%s", cl.db, cl.table, cl.index))
+	if err != nil {
+		o.Fatal(err)
+	}
+}
+
+func runAddIndex(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	rng, _ := randutil.NewPseudoRand()
+	dbName := pickRandomDB(ctx, o, conn, systemDBs)
+	tableName := pickRandomTable(ctx, o, conn, dbName)
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT column_name FROM [SHOW COLUMNS FROM %s.%s]", dbName, tableName))
+	if err != nil {
+		o.Fatal(err)
+	}
+	rows.Next()
+	if !rows.Next() {
+		o.Status("found a table with only one column, skipping")
+		return nil
+	}
+	var colName string
+	if err := rows.Scan(&colName); err != nil {
+		o.Fatal(err)
+	}
+
+	indexName := fmt.Sprintf("add_index_op_%d", rng.Uint32())
+	o.Status(fmt.Sprintf("adding index to column %s in table %s.%s", colName, dbName, tableName))
+	createIndexStmt := fmt.Sprintf("CREATE INDEX %s ON %s.%s (%s)", indexName, dbName, tableName, colName)
+	_, err = conn.ExecContext(ctx, createIndexStmt)
+	if err != nil {
+		o.Fatal(err)
+	}
+
+	o.Status(fmt.Sprintf("index %s created", indexName))
+	return &cleanupAddedIndex{
+		db:    dbName,
+		table: tableName,
+		index: indexName,
+	}
+}
+
+func registerAddIndex(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "add-index",
+		Owner:            registry.OwnerSQLFoundations,
+		Timeout:          24 * time.Hour,
+		CompatibleClouds: registry.AllClouds,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:              runAddIndex,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -14,4 +14,6 @@ import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 
 // RegisterOperations registers all operations to the Registry. This powers `roachtest run-operations`.
 func RegisterOperations(r registry.Registry) {
+	registerAddColumn(r)
+	registerAddIndex(r)
 }

--- a/pkg/cmd/roachtest/operations/utils.go
+++ b/pkg/cmd/roachtest/operations/utils.go
@@ -1,0 +1,95 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// systemDBs lists dbs created by default on a new cockroachdb cluster. These
+// may not be mutable and should be excluded by most operations.
+var systemDBs = []string{"system", "information_schema", "crdb_internal", "defaultdb", "postgres"}
+
+// pickRandomDB picks a random DB that isn't one of `excludeDBs` on the
+// target cluster connected to by `conn`.
+func pickRandomDB(
+	ctx context.Context, o operation.Operation, conn *gosql.DB, excludeDBs []string,
+) string {
+	rng, _ := randutil.NewPseudoRand()
+
+	// Pick a random table.
+	dbs, err := conn.QueryContext(ctx, "SELECT database_name FROM [SHOW DATABASES]")
+	if err != nil {
+		o.Fatal(err)
+		return ""
+	}
+	var dbNames []string
+	for dbs.Next() {
+		var dbName string
+		if err := dbs.Scan(&dbName); err != nil {
+			o.Fatal(err)
+			return ""
+		}
+		isExcluded := false
+		for i := range excludeDBs {
+			if excludeDBs[i] == dbName {
+				isExcluded = true
+				break
+			}
+		}
+		if isExcluded {
+			continue
+		}
+		dbNames = append(dbNames, dbName)
+	}
+	if len(dbNames) == 0 {
+		o.Fatalf("unexpected zero active dbs found in cluster")
+		return ""
+	}
+	return dbNames[rng.Intn(len(dbNames))]
+}
+
+func pickRandomTable(
+	ctx context.Context, o operation.Operation, conn *gosql.DB, dbName string,
+) string {
+	rng, _ := randutil.NewPseudoRand()
+
+	// Pick a random table.
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", dbName)); err != nil {
+		o.Fatal(err)
+		return ""
+	}
+
+	tables, err := conn.QueryContext(ctx, "SELECT table_name FROM [SHOW TABLES]")
+	if err != nil {
+		o.Fatal(err)
+		return ""
+	}
+	var tableNames []string
+	for tables.Next() {
+		var tableName string
+		if err := tables.Scan(&tableName); err != nil {
+			o.Fatal(err)
+			return ""
+		}
+		tableNames = append(tableNames, tableName)
+	}
+	if len(tableNames) == 0 {
+		o.Fatalf("unexpected zero active tables found in db %s", dbName)
+		return ""
+	}
+	return tableNames[rng.Intn(len(tableNames))]
+}


### PR DESCRIPTION
NB: the first two changes are in #119796 and #120023 respectively. Review those first.

This change builds on the operation framework added in
previous changes to add new operations that randomly add
columns and indexes to an existing cluster.

Epic: none

Release note: None