### PR TITLE
kvnemesis: run test on `large` pool

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvnemesis"],
+    exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None