### PR TITLE
release-23.2: sql: introduce `crdb_internal.execute_internally` builtin

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -91,6 +91,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -124,6 +125,21 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
+
+func init() {
+	builtins.ExecuteQueryViaJobExecContext = func(
+		evalCtx *eval.Context,
+		ctx context.Context,
+		opName string,
+		txn *kv.Txn,
+		override sessiondata.InternalExecutorOverride,
+		stmt string,
+		qargs ...interface{},
+	) (eval.InternalRows, error) {
+		ie := evalCtx.JobExecContext.(JobExecContext).ExecCfg().InternalDB.Executor()
+		return ie.QueryIteratorEx(ctx, opName, txn, override, stmt, qargs...)
+	}
+}
 
 // ClusterOrganization is the organization name.
 var ClusterOrganization = settings.RegisterStringSetting(

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -858,6 +858,17 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.OptimizerUseHistograms {
 		sd.OptimizerUseHistograms = true
 	}
+
+	if o.MultiOverride != "" {
+		overrides := strings.Split(o.MultiOverride, ",")
+		for _, override := range overrides {
+			parts := strings.Split(override, "=")
+			if len(parts) == 2 {
+				sd.Update(parts[0], parts[1])
+			}
+		}
+	}
+	// Add any new overrides above the MultiOverride.
 }
 
 func (ie *InternalExecutor) maybeRootSessionDataOverride(

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -1,0 +1,170 @@
+# LogicTest: local
+
+# Note that even though this file contains some queries that actually get
+# executed, we choose to keep it in the execbuilder tests because it also has
+# EXPLAIN output.
+
+statement ok
+CREATE TABLE t (k PRIMARY KEY) AS VALUES (1), (3), (5);
+
+# When the internal executor is not session bound, it doesn't have Database
+# session variable set, so we must specify the fully-qualified table name.
+query T rowsort
+SELECT crdb_internal.execute_internally('SELECT k FROM test.public.t;');
+----
+1
+3
+5
+
+# When the internal executor is session bound that is not needed.
+query T rowsort
+SELECT crdb_internal.execute_internally('SELECT k FROM t;', true);
+----
+1
+3
+5
+
+# Set the database via the override.
+query T rowsort
+SELECT crdb_internal.execute_internally('EXPLAIN SELECT k FROM t;', 'Database=test');
+----
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: FULL SCAN
+
+# Same query as above, but with vectorized engine disabled.
+query T rowsort
+SELECT crdb_internal.execute_internally('EXPLAIN SELECT k FROM t;', 'Database=test,VectorizeMode=off');
+----
+distribution: local
+vectorized: false
+·
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: FULL SCAN
+
+# optimizer_use_histograms is the only variable that differs from the default
+# right now (except when the internal executor is session-bound, #102954).
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', false);
+----
+off
+
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', true);
+----
+on
+
+# Ensure that we can override it.
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', false, 'OptimizerUseHistograms=true');
+----
+on
+
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', true, 'OptimizerUseHistograms=false');
+----
+off
+
+# Some sanity checks around error handling.
+statement error unknown signature
+SELECT crdb_internal.execute_internally(1);
+
+statement error unknown signature
+SELECT crdb_internal.execute_internally('SELECT 1;', false, true);
+
+statement error when session bound internal executor is used, it always uses the session txn - omit the last argument
+SELECT crdb_internal.execute_internally('SELECT 1;', true, '', true);
+
+query error internally-executed-query-builtin: relation "foo" does not exist
+SELECT crdb_internal.execute_internally('SELECT col FROM foo;');
+
+statement error syntax error
+SELECT crdb_internal.execute_internally('SELECT col FROM;');
+
+statement error only one statement is supported, 2 were given
+SELECT crdb_internal.execute_internally('SELECT col FROM foo; SELECT 1;');
+
+statement error only one statement is supported, 0 were given
+SELECT crdb_internal.execute_internally('');
+
+statement error this statement is disallowed
+SELECT crdb_internal.execute_internally('BEGIN;');
+
+statement error this statement is disallowed
+SELECT crdb_internal.execute_internally('COMMIT;', 'Database=test', true);
+
+# Check transactionality.
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY);
+
+# When running in a separate txn, we cannot see the newly created table.
+query error internally-executed-query-builtin: relation "t2" does not exist
+SELECT crdb_internal.execute_internally('SELECT k FROM t2;', 'Database=test', false);
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY);
+
+# But using the session's txn with non-session-bound executor should work.
+statement ok
+SELECT crdb_internal.execute_internally('SELECT k FROM t2;', 'Database=test', true);
+
+statement ok
+SELECT crdb_internal.execute_internally('INSERT INTO t2 VALUES (1);', 'Database=test', true);
+
+query T
+SELECT crdb_internal.execute_internally('SELECT * FROM t2;', 'Database=test', true);
+----
+1
+
+statement ok
+COMMIT;
+
+user testuser
+
+statement error crdb_internal.execute_internally\(\) requires admin privilege
+SELECT crdb_internal.execute_internally('SELECT session_user;');
+
+user root
+
+statement ok
+GRANT admin TO testuser
+
+user testuser
+
+# Ensure that changing the user via the override isn't possible.
+query T
+SELECT crdb_internal.execute_internally('SELECT session_user;');
+----
+testuser
+
+query T
+SELECT crdb_internal.execute_internally('SELECT session_user;', 'User=root');
+----
+testuser
+
+user root
+
+query T
+SELECT crdb_internal.execute_internally('SELECT session_user;');
+----
+root
+
+query T
+SELECT crdb_internal.execute_internally('SELECT session_user;', 'User=testuser');
+----
+root

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -174,6 +174,13 @@ func TestExecBuild_enums(
 	runExecBuildLogicTest(t, "enums")
 }
 
+func TestExecBuild_execute_internally_builtin(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "execute_internally_builtin")
+}
+
 func TestExecBuild_explain(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2507,6 +2507,12 @@ var builtinOidsArray = []string{
 	2536: `percentile_disc_impl(arg1: float, arg2: refcursor) -> refcursor`,
 	2537: `percentile_disc_impl(arg1: float[], arg2: refcursor) -> refcursor[]`,
 	2543: `crdb_internal.fips_ready() -> bool`,
+	2599: `crdb_internal.execute_internally(query: string) -> string`,
+	2600: `crdb_internal.execute_internally(query: string, session_bound: bool) -> string`,
+	2601: `crdb_internal.execute_internally(query: string, overrides: string) -> string`,
+	2602: `crdb_internal.execute_internally(query: string, session_bound: bool, overrides: string) -> string`,
+	2603: `crdb_internal.execute_internally(query: string, overrides: string, use_session_txn: bool) -> string`,
+	2604: `crdb_internal.execute_internally(query: string, session_bound: bool, overrides: string, use_session_txn: bool) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/workloadindexrec"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -702,6 +703,18 @@ The last argument is a JSONB object containing the following optional fields:
 			"Scans a store's storage engine, computing statistics describing the internal keys within the span [start_key, end_key).",
 			volatility.Volatile,
 		),
+	),
+	"crdb_internal.execute_internally": makeBuiltin(
+		tree.FunctionProperties{
+			Undocumented: true,
+			Category:     builtinconstants.CategoryGenerator,
+		},
+		makeInternallyExecutedQueryGeneratorOverload(false /* withSessionBound */, false /* withOverrides */, false /* withTxn */),
+		makeInternallyExecutedQueryGeneratorOverload(true /* withSessionBound */, false /* withOverrides */, false /* withTxn */),
+		makeInternallyExecutedQueryGeneratorOverload(false /* withSessionBound */, true /* withOverrides */, false /* withTxn */),
+		makeInternallyExecutedQueryGeneratorOverload(true /* withSessionBound */, true /* withOverrides */, false /* withTxn */),
+		makeInternallyExecutedQueryGeneratorOverload(false /* withSessionBound */, true /* withOverrides */, true /* withTxn */),
+		makeInternallyExecutedQueryGeneratorOverload(true /* withSessionBound */, true /* withOverrides */, true /* withTxn */),
 	),
 }
 
@@ -3511,4 +3524,206 @@ func makeSpanStatsGenerator(
 	}
 
 	return &spanStatsValueGenerator{p: evalCtx.Planner, spans: spans}, nil
+}
+
+var internallyExecutedQueryGeneratorType = types.String
+
+func makeInternallyExecutedQueryGeneratorOverload(
+	withSessionBound, withOverrides, withTxn bool,
+) tree.Overload {
+	inputTypes := tree.ParamTypes{{Name: "query", Typ: types.String}}
+	if withSessionBound {
+		inputTypes = append(inputTypes, tree.ParamType{Name: "session_bound", Typ: types.Bool})
+	}
+	if withOverrides {
+		inputTypes = append(inputTypes, tree.ParamType{Name: "overrides", Typ: types.String})
+	}
+	if withTxn {
+		if !withOverrides {
+			// In order to not confuse two boolean arguments we require that
+			// whenever 'use_session_txn' is specified, 'overrides' must be
+			// specified too.
+			panic(errors.AssertionFailedf("'use_session_txn' requires 'overrides' to be used"))
+		}
+		inputTypes = append(inputTypes, tree.ParamType{Name: "use_session_txn", Typ: types.Bool})
+	}
+	return makeGeneratorOverload(
+		inputTypes,
+		internallyExecutedQueryGeneratorType,
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+			isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if !isAdmin {
+				return nil, errors.New("crdb_internal.execute_internally() requires admin privilege")
+			}
+			numExpectedArgs, queryIdx, sessionBoundIdx, overridesIdx, txnIdx := 1, 0, 1, 2, 3
+			if withSessionBound {
+				numExpectedArgs++
+			} else {
+				overridesIdx--
+				txnIdx--
+			}
+			if withOverrides {
+				numExpectedArgs++
+			}
+			if withTxn {
+				numExpectedArgs++
+			}
+			if len(args) != numExpectedArgs {
+				return nil, errors.Newf("expected %d argument, got %d", numExpectedArgs, len(args))
+			}
+			q, ok := args[queryIdx].(*tree.DString)
+			if !ok {
+				return nil, errors.Newf("expected string argument for 'query', got %s", args[queryIdx].ResolvedType())
+			}
+			query := string(*q)
+			// Sanity check that a single statement was provided. Note that the
+			// internal executor will parse the query too, but we'd get an
+			// assertion failure error if we gave it more than one statement -
+			// we catch those cases here.
+			stmts, err := parser.Parse(query)
+			if err != nil {
+				return nil, err
+			}
+			if len(stmts) != 1 {
+				return nil, errors.Newf("only one statement is supported, %d were given", len(stmts))
+			}
+			if stmts[0].AST.StatementReturnType() == tree.Ack {
+				// We want to disallow statements that modify txn state (like
+				// BEGIN and COMMIT). Such statements (as well as some others
+				// like changing cluster settings and dealing with prepared
+				// statements) have the Ack return type, so we'll lean on the
+				// safe side and prohibit them all.
+				return nil, errors.New("this statement is disallowed")
+			}
+			var sessionBound bool
+			if withSessionBound {
+				s, ok := args[sessionBoundIdx].(*tree.DBool)
+				if !ok {
+					return nil, errors.Newf("expected bool argument for 'session_bound', got %s", args[sessionBoundIdx].ResolvedType())
+				}
+				sessionBound = bool(*s)
+			}
+			var overrides string
+			if withOverrides {
+				o, ok := args[overridesIdx].(*tree.DString)
+				if !ok {
+					return nil, errors.Newf("expected string argument for 'overrides', got %s", args[overridesIdx].ResolvedType())
+				}
+				overrides = string(*o)
+			}
+			var useTxn bool
+			if withTxn {
+				t, ok := args[txnIdx].(*tree.DBool)
+				if !ok {
+					return nil, errors.Newf("expected string argument for 'use_session_txn', got %s", args[txnIdx].ResolvedType())
+				}
+				useTxn = bool(*t)
+				if sessionBound && useTxn {
+					return nil, errors.New("when session bound internal executor is used, it always uses the session txn - omit the last argument")
+				}
+			}
+			return newInternallyExecutedQueryIterator(evalCtx, query, sessionBound, overrides, useTxn), nil
+		},
+		"Executes the provided query via the Internal Executor and prints "+
+			"out the result, in which each row is converted to a single string. "+
+			"First argument is the single query to be executed. Optional "+
+			"'session_bound' argument specifies whether the Internal Executor "+
+			"should be bound to the current session ('false' by default). "+
+			"Optional 'overrides' argument is a comma-separated list of session "+
+			"variable overrides. Optional 'use_session_txn' argument is a boolean "+
+			"indicating whether the Internal Executor should use the session's txn "+
+			"(this is only applicable when 'session_bound' is 'false', and usage of "+
+			"this option requires specifying 'overrides' argument).",
+		volatility.Volatile,
+	)
+}
+
+type internallyExecutedQueryIterator struct {
+	evalCtx      *eval.Context
+	query        string
+	sessionBound bool
+	overrides    string
+	useTxn       bool
+	formatter    *tree.FmtCtx
+
+	rows eval.InternalRows
+	a    tree.DatumAlloc
+	buf  [1]tree.Datum
+}
+
+func newInternallyExecutedQueryIterator(
+	evalCtx *eval.Context, query string, sessionBound bool, overrides string, useTxn bool,
+) *internallyExecutedQueryIterator {
+	return &internallyExecutedQueryIterator{
+		evalCtx:      evalCtx,
+		query:        query,
+		sessionBound: sessionBound,
+		overrides:    overrides,
+		useTxn:       useTxn,
+		formatter:    tree.NewFmtCtx(tree.FmtExport),
+	}
+}
+
+// ExecuteQueryViaJobExecContext executes the provided query via the JobExecCtx
+// of the eval.Context. The method is initialized in the sql package to avoid
+// import cycles.
+var ExecuteQueryViaJobExecContext func(*eval.Context, context.Context, string, *kv.Txn, sessiondata.InternalExecutorOverride, string, ...interface{}) (eval.InternalRows, error)
+
+// Start implements the eval.ValueGenerator interface.
+func (qi *internallyExecutedQueryIterator) Start(ctx context.Context, txn *kv.Txn) error {
+	opName := "internally-executed-query-builtin"
+	var ieo sessiondata.InternalExecutorOverride
+	// Always use the session's user, even in "jobs-like" mode.
+	ieo.User = qi.evalCtx.SessionData().User()
+	ieo.MultiOverride = qi.overrides
+	var rows eval.InternalRows
+	var err error
+	if qi.sessionBound {
+		rows, err = qi.evalCtx.Planner.QueryIteratorEx(ctx, opName, ieo, qi.query)
+	} else {
+		var txnArg *kv.Txn
+		if qi.useTxn {
+			txnArg = txn
+		}
+		rows, err = ExecuteQueryViaJobExecContext(qi.evalCtx, ctx, opName, txnArg, ieo, qi.query)
+	}
+	if err != nil {
+		return err
+	}
+	qi.rows = rows
+	return nil
+}
+
+// Next implements the eval.ValueGenerator interface.
+func (qi *internallyExecutedQueryIterator) Next(ctx context.Context) (bool, error) {
+	return qi.rows.Next(ctx)
+}
+
+// Values implements the eval.ValueGenerator interface.
+func (qi *internallyExecutedQueryIterator) Values() (tree.Datums, error) {
+	datums := qi.rows.Cur()
+	qi.formatter.Reset()
+	for i, v := range datums {
+		if i > 0 {
+			qi.formatter.WriteString(", ")
+		}
+		qi.formatter.FormatNode(v)
+	}
+	qi.buf[0] = qi.a.NewDString(tree.DString(qi.formatter.String()))
+	return qi.buf[:], nil
+}
+
+// Close implements the eval.ValueGenerator interface.
+func (qi *internallyExecutedQueryIterator) Close(context.Context) {
+	if qi.rows != nil {
+		_ = qi.rows.Close()
+	}
+}
+
+// ResolvedType implements the eval.ValueGenerator interface.
+func (qi *internallyExecutedQueryIterator) ResolvedType() *types.T {
+	return internallyExecutedQueryGeneratorType
 }

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -51,6 +51,11 @@ type InternalExecutorOverride struct {
 	// cardinality estimation in the optimizer.
 	// TODO(#102954): this should be removed when #102954 is fixed.
 	OptimizerUseHistograms bool
+	// MultiOverride, if set, is a comma-separated list of variable_name=value
+	// overrides. For example, 'Database=foo,OptimizerUseHistograms=true'. These
+	// overrides are performed on the best-effort basis - see SessionData.Update
+	// for more details.
+	MultiOverride string
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sessiondata/session_data_test.go
+++ b/pkg/sql/sessiondata/session_data_test.go
@@ -11,6 +11,7 @@
 package sessiondata
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -82,4 +83,56 @@ func TestStack(t *testing.T) {
 	copiedElem.Database = "some other value"
 	require.Equal(t, s.Elems(), []*SessionData{initialElem, secondElem, copiedElem})
 	require.Equal(t, s.Base(), initialElem)
+}
+
+func TestUpdateSessionData(t *testing.T) {
+	var sd SessionData
+	unchangedLocal := sd.LocalOnlySessionData.String()
+	unchangedRemote := sd.SessionData.String()
+	for _, tc := range []struct {
+		variable  string
+		value     string
+		localOnly bool
+		// If set, then the update must have succeeded.
+		expectedSubstring string
+	}{
+		// string type.
+		{variable: "Database", value: "foo", localOnly: false, expectedSubstring: `database:"foo"`},
+		// This variable uses string type under the hood but has the custom
+		// cast type which isn't handled, so the update should be a no-op.
+		{variable: "UserProto", value: "foo", localOnly: false},
+		// This variable has a custom type that isn't handled, so the update
+		// should be a no-op.
+		{variable: "DataConversionConfig", value: "foo", localOnly: false},
+		// This variable has a custom type that is handled.
+		{variable: "VectorizeMode", value: "on", localOnly: false, expectedSubstring: `vectorize_mode:on`},
+		// duration type.
+		{variable: "LockTimeout", value: "42s", localOnly: false, expectedSubstring: `lock_timeout:<seconds:42 >`},
+		// This variable has a custom name, int64 type.
+		{variable: "OptimizerFKCascadesLimit", value: "123", localOnly: true, expectedSubstring: `optimizer_fk_cascades_limit:123`},
+		// bool type.
+		{variable: "DefaultTxnReadOnly", value: "true", localOnly: true, expectedSubstring: `default_txn_read_only:true`},
+		// float64 type.
+		{variable: "LargeFullScanRows", value: "12.34", localOnly: true, expectedSubstring: `large_full_scan_rows:12.34`},
+		// int32 type.
+		{variable: "OptSplitScanLimit", value: "123", localOnly: true, expectedSubstring: `opt_split_scan_limit:123`},
+	} {
+		sd = SessionData{}
+		ok := sd.Update(tc.variable, tc.value)
+		local, remote := sd.LocalOnlySessionData.String(), sd.SessionData.String()
+		if tc.expectedSubstring != "" {
+			require.True(t, ok)
+			if tc.localOnly {
+				require.True(t, strings.Contains(local, tc.expectedSubstring))
+				require.Equal(t, unchangedRemote, remote)
+			} else {
+				require.True(t, strings.Contains(remote, tc.expectedSubstring))
+				require.Equal(t, unchangedLocal, local)
+			}
+		} else {
+			require.False(t, ok)
+			require.Equal(t, unchangedLocal, local)
+			require.Equal(t, unchangedRemote, remote)
+		}
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #118456.

/cc @cockroachdb/release

---

This commit introduces a new undocumented generator builtin `crdb_internal.execute_internally` which executes the provided string argument (which can be almost any single query) via the internal executor and then converts each resulting row into a string that is returned. This seems like a useful thing to have in general, but in particular when trying to understand the plans used by the internal queries.

Additionally, this commit provides several overloads of this new builtin:
- an optional boolean argument 'session_bound' indicates whether the query execution should happen via the IE that is bound to the session invoking it or not (if not, then it'll be "jobs-like" execution that creates a fresh session data - the only exception is that the user of this fresh session data is overridden to the session's user)
- an optional string argument 'overrides' which specifies comma-separated list of session overrides, e.g. `'Database=foo,OptimizerUseHistograms=true'`.  These overrides apply as the very last step when initializing the session data for the internal executor and could allow us reproduce queries from different contexts. Note that these overrides are applied on a best-effort basis and mostly don't support custom types in the protobuf messages.
- an optional boolean argument 'use_session_txn' which specifies that the session's txn must be used when 'session_bound' is false. Usage of this parameter requires that 'overrides' parameter is also specified (in order to distinguish this boolean from the other one). Note that an error is returned whenever using the session-bound executor because there we always use the session's txn, so this parameter would be redundant and probably confusing (like can it be run as a nested txn?).

The builtin is undocumented, so there is no release note. I envision that only CRDB people should use this builtin. The only requirement imposed on it is that the user is the admin. The query gets executed under the session's user, so this should be ok from the security's point of view. Also some statements that modify txn state are prohibited.

Fixes: #118426.

Release note: None

Release justification: low-risk improvement to observability of internal queries.