### PR TITLE
release-23.2: server: fix TestStructuredEventLogging test

### DIFF
--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -54,11 +54,16 @@ func startSampleEnvironment(
 	runtimeSampler *status.RuntimeStatSampler,
 	sessionRegistry *sql.SessionRegistry,
 	rootMemMonitor *mon.BytesMonitor,
+	testingKnobs base.TestingKnobs,
 ) error {
+	metricsSampleInterval := base.DefaultMetricsSampleInterval
+	if p, ok := testingKnobs.Server.(*TestingKnobs); ok && p.EnvironmentSampleInterval != time.Duration(0) {
+		metricsSampleInterval = p.EnvironmentSampleInterval
+	}
 	cfg := sampleEnvironmentCfg{
 		st:                   settings,
 		stopper:              stopper,
-		minSampleInterval:    base.DefaultMetricsSampleInterval,
+		minSampleInterval:    metricsSampleInterval,
 		goroutineDumpDirName: goroutineDumpDirName,
 		heapProfileDirName:   heapProfileDirName,
 		cpuProfileDirName:    cpuProfileDirName,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1894,6 +1894,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.runtime,
 		s.status.sessionRegistry,
 		s.sqlServer.execCfg.RootMemoryMonitor,
+		s.cfg.TestingKnobs,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/status/runtime_stats_test.go
+++ b/pkg/server/status/runtime_stats_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -35,16 +36,22 @@ func TestStructuredEventLogging(t *testing.T) {
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	ctx := context.Background()
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				EnvironmentSampleInterval: 500 * time.Millisecond,
+			},
+		},
+	})
 	defer s.Stopper().Stop(ctx)
 
 	testStartTs := timeutil.Now()
 
-	// Wait 10 seconds for the first runtime stats entry to log
-	time.Sleep(10 * time.Second)
+	// Wait longer than EnvironmentSampleInterval duration.
+	time.Sleep(time.Second)
 
 	// Ensure that the entry hits the OS so it can be read back below.
-	log.FlushFiles()
+	log.FlushAllSync()
 
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -756,6 +756,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			s.runtime,
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
+			s.cfg.TestingKnobs,
 		); err != nil {
 			return err
 		}

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -186,6 +186,9 @@ type TestingKnobs struct {
 	// waiting for any active configuration environments to
 	// complete their tasks.
 	AutoConfigProfileStartupWaitTime *time.Duration
+
+	// EnvironmentSampleInterval overrides base.DefaultMetricsSampleInterval when used to construct sampleEnvironmentCfg.
+	EnvironmentSampleInterval time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from #119728.

/cc @cockroachdb/release

---

Before, `TestStructuredEventLogging` test could fail because of following potential problems:
- it used `FlushFiles()` async function to ensure that logs are persisted, and it wasn't guaranteed that validation of results is done after flushing completed.
- it used 10 seconds interval to wait for logs to persist, and `DefaultMetricsSampleInterval` is also equals to 10 seconds so there's a chance that logs won't be persisted before validation.

Current change introduces:
- new testing knob to override default metrics sample interval and use it in test. It doesn't fix an issue directly, but allows to reduce time for test execution and also increase time to wait until logs persisted.
- `log.FlushAllSync` used instead of `log.FlushFiles` to persist logs synchronously.

Related issue: https://github.com/cockroachdb/cockroach/issues/119363
Related issue: https://github.com/cockroachdb/cockroach/issues/117735

Release note: None

Epic: None

Release justification: non-production code changes
