### PR TITLE
storage: assert non-empty timestamp in MVCCPredicateDeleteRange

### DIFF
--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -560,7 +560,7 @@ data: "k4"/10.000000000,0 -> /BYTES/v4_prime
 error: (*kvpb.LockConflictError:) conflicting locks on "k3"
 
 run error
-del_range_pred k=k3 k=k4
+del_range_pred k=k3 k=k4 ts=5
 ----
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks_max_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks_max_conflicts
@@ -109,7 +109,7 @@ data: "k1"/5.000000000,0 -> /BYTES/v1
 error: (*kvpb.LockConflictError:) conflicting locks on "k1", "k1"
 
 run error
-del_range_pred k=k1 k=k2 maxLockConflicts=2
+del_range_pred k=k1 k=k2 maxLockConflicts=2 ts=1
 ----
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1


### PR DESCRIPTION
All production callers pass a non-empty timestamp.  Here we turn that into an assertion.

Epic: none
Release note: None