### PR TITLE
plpgsql: allow RETURN with no expression

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
@@ -112,7 +112,7 @@ call
                                │              ├── const: '' [type=string]
                                │              └── const: '00000' [type=string]
                                └── values
-                                    ├── columns: stmt_return_3:4(void)
+                                    ├── columns: "_implicit_return":4(void)
                                     ├── cardinality: [1 - 1]
                                     ├── stats: [rows=1]
                                     ├── key: ()

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_params
@@ -639,6 +639,8 @@ NULL     0       NULL
 
 subtest end
 
+subtest return_col_names
+
 statement ok
 CREATE TYPE typ AS (a INT, b INT);
 CREATE FUNCTION f_udt() RETURNS typ AS $$ BEGIN RETURN (1, 2); END; $$ LANGUAGE PLpgSQL;
@@ -666,3 +668,55 @@ SELECT b FROM f_udt()
 ----
 b
 2
+
+subtest implicit_return
+
+# A routine with OUT-parameters should implicitly return the OUT-parameters when
+# control flow exits. In addition, RETURN; with no expression immediately
+# returns.
+statement ok
+CREATE FUNCTION f(OUT x INT, OUT y INT, n INT) AS $$
+  BEGIN
+    x := 1;
+    IF n = 0 THEN
+      y := 2;
+      RETURN;
+    ELSIF n = 1 THEN
+      y := 3;
+    END IF;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query TTT
+SELECT f(0), f(1), f(2);
+----
+(1,2)  (1,3)  (1,)
+
+# Implicit RETURN statements apply to exception handlers.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(OUT x INT, OUT y INT, n INT) AS $$
+  BEGIN
+    x := 1;
+    SELECT 1 // 0;
+  EXCEPTION WHEN division_by_zero THEN
+    y := 2;
+    IF n = 0 THEN
+      x := 3;
+      RETURN;
+    END IF;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query TT
+SELECT f(0), f(1);
+----
+(3,2)  (1,2)
+
+statement ok
+DROP FUNCTION f;
+
+statement error pgcode 42804 pq: RETURN cannot have a parameter in function with OUT parameters
+CREATE FUNCTION f(OUT x INT, OUT y INT, n INT) AS $$ BEGIN RETURN (5, 6); END $$ LANGUAGE PLpgSQL;
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2899,7 +2899,7 @@ CREATE OR REPLACE FUNCTION f(x INT) RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-subtest end
+subtest return_void
 
 statement ok
 CREATE FUNCTION f_empty() RETURNS VOID AS $$ BEGIN END; $$ LANGUAGE PLpgSQL;
@@ -2908,3 +2908,20 @@ query T
 SELECT f_empty()
 ----
 NULL
+
+# Regression test for #108298 - allow an empty RETURN expression for
+# void-returning routines.
+statement ok
+CREATE OR REPLACE FUNCTION f_empty() RETURNS VOID AS $$ BEGIN RETURN; END; $$ LANGUAGE PLpgSQL;
+
+query T
+SELECT f_empty()
+----
+NULL
+
+# Regression test for #114849 - return expected error when a return expression
+# is supplied for a void-returning routine.
+statement error pgcode 42804 pq: RETURN cannot have a parameter in function returning void
+CREATE FUNCTION void_return_expr() RETURNS VOID AS $$ BEGIN RETURN 5; END; $$ LANGUAGE PLpgSQL;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -93,11 +93,11 @@ call
                 │                                  ├── params: arg_k:15 new_i:16 new_s:17 c:18
                 │                                  └── body
                 │                                       └── project
-                │                                            ├── columns: stmt_if_7:56
+                │                                            ├── columns: stmt_if_6:56
                 │                                            ├── values
                 │                                            │    └── tuple
                 │                                            └── projections
-                │                                                 └── case [as=stmt_if_7:56]
+                │                                                 └── case [as=stmt_if_6:56]
                 │                                                      ├── true
                 │                                                      ├── when
                 │                                                      │    ├── gt
@@ -105,11 +105,11 @@ call
                 │                                                      │    │    └── const: 0
                 │                                                      │    └── subquery
                 │                                                      │         └── project
-                │                                                      │              ├── columns: "_stmt_exec_5":41
+                │                                                      │              ├── columns: "_stmt_exec_4":41
                 │                                                      │              ├── values
                 │                                                      │              │    └── tuple
                 │                                                      │              └── projections
-                │                                                      │                   └── udf: _stmt_exec_5 [as="_stmt_exec_5":41]
+                │                                                      │                   └── udf: _stmt_exec_4 [as="_stmt_exec_4":41]
                 │                                                      │                        ├── args
                 │                                                      │                        │    ├── variable: arg_k:15
                 │                                                      │                        │    ├── variable: new_i:16
@@ -150,19 +150,19 @@ call
                 │                                                      │                                            ├── params: arg_k:19 new_i:20 new_s:21 c:22
                 │                                                      │                                            └── body
                 │                                                      │                                                 └── project
-                │                                                      │                                                      ├── columns: stmt_return_4:23
+                │                                                      │                                                      ├── columns: "_implicit_return":23
                 │                                                      │                                                      ├── values
                 │                                                      │                                                      │    └── tuple
                 │                                                      │                                                      └── projections
-                │                                                      │                                                           └── cast: VOID [as=stmt_return_4:23]
+                │                                                      │                                                           └── cast: VOID [as="_implicit_return":23]
                 │                                                      │                                                                └── null
                 │                                                      └── subquery
                 │                                                           └── project
-                │                                                                ├── columns: "_stmt_exec_6":55
+                │                                                                ├── columns: "_stmt_exec_5":55
                 │                                                                ├── values
                 │                                                                │    └── tuple
                 │                                                                └── projections
-                │                                                                     └── udf: _stmt_exec_6 [as="_stmt_exec_6":55]
+                │                                                                     └── udf: _stmt_exec_5 [as="_stmt_exec_5":55]
                 │                                                                          ├── args
                 │                                                                          │    ├── variable: arg_k:15
                 │                                                                          │    ├── variable: new_i:16
@@ -196,11 +196,11 @@ call
                 │                                                                                              ├── params: arg_k:19 new_i:20 new_s:21 c:22
                 │                                                                                              └── body
                 │                                                                                                   └── project
-                │                                                                                                        ├── columns: stmt_return_4:23
+                │                                                                                                        ├── columns: "_implicit_return":23
                 │                                                                                                        ├── values
                 │                                                                                                        │    └── tuple
                 │                                                                                                        └── projections
-                │                                                                                                             └── cast: VOID [as=stmt_return_4:23]
+                │                                                                                                             └── cast: VOID [as="_implicit_return":23]
                 │                                                                                                                  └── null
                 └── const: 1
 
@@ -294,7 +294,7 @@ call
                 │                   │              ├── const: ''
                 │                   │              └── const: '00000'
                 │                   └── project
-                │                        ├── columns: "_stmt_raise_7":26
+                │                        ├── columns: "_stmt_raise_6":26
                 │                        ├── barrier
                 │                        │    ├── columns: x:18 y:19 z:20!null
                 │                        │    └── project
@@ -322,7 +322,7 @@ call
                 │                        │                   ├── variable: z:17
                 │                        │                   └── const: 1
                 │                        └── projections
-                │                             └── udf: _stmt_raise_7 [as="_stmt_raise_7":26]
+                │                             └── udf: _stmt_raise_6 [as="_stmt_raise_6":26]
                 │                                  ├── args
                 │                                  │    ├── variable: x:18
                 │                                  │    ├── variable: y:19
@@ -330,11 +330,11 @@ call
                 │                                  ├── params: x:21 y:22 z:23
                 │                                  └── body
                 │                                       ├── project
-                │                                       │    ├── columns: stmt_raise_8:24
+                │                                       │    ├── columns: stmt_raise_7:24
                 │                                       │    ├── values
                 │                                       │    │    └── tuple
                 │                                       │    └── projections
-                │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:24]
+                │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_7:24]
                 │                                       │              ├── const: 'NOTICE'
                 │                                       │              ├── concat
                 │                                       │              │    ├── concat
@@ -423,11 +423,11 @@ call
                 │                                                                               │              ├── const: ''
                 │                                                                               │              └── const: '00000'
                 │                                                                               └── project
-                │                                                                                    ├── columns: stmt_return_6:15
+                │                                                                                    ├── columns: "_implicit_return":15
                 │                                                                                    ├── values
                 │                                                                                    │    └── tuple
                 │                                                                                    └── projections
-                │                                                                                         └── cast: VOID [as=stmt_return_6:15]
+                │                                                                                         └── cast: VOID [as="_implicit_return":15]
                 │                                                                                              └── null
                 └── const: 1
 
@@ -494,21 +494,21 @@ call
                 │                   │              ├── const: ''
                 │                   │              └── const: '00000'
                 │                   └── project
-                │                        ├── columns: exception_block_8:17
+                │                        ├── columns: exception_block_7:17
                 │                        ├── values
                 │                        │    └── tuple
                 │                        └── projections
-                │                             └── udf: exception_block_8 [as=exception_block_8:17]
+                │                             └── udf: exception_block_7 [as=exception_block_7:17]
                 │                                  ├── args
                 │                                  │    └── variable: x:2
                 │                                  ├── params: x:12
                 │                                  ├── body
                 │                                  │    └── project
-                │                                  │         ├── columns: "_stmt_exec_9":16
+                │                                  │         ├── columns: "_stmt_exec_8":16
                 │                                  │         ├── values
                 │                                  │         │    └── tuple
                 │                                  │         └── projections
-                │                                  │              └── udf: _stmt_exec_9 [as="_stmt_exec_9":16]
+                │                                  │              └── udf: _stmt_exec_8 [as="_stmt_exec_8":16]
                 │                                  │                   ├── args
                 │                                  │                   │    └── variable: x:12
                 │                                  │                   ├── params: x:13
@@ -560,11 +560,11 @@ call
                 │                                  │                                                                │              ├── const: ''
                 │                                  │                                                                │              └── const: '00000'
                 │                                  │                                                                └── project
-                │                                  │                                                                     ├── columns: stmt_return_6:7
+                │                                  │                                                                     ├── columns: "_implicit_return":7
                 │                                  │                                                                     ├── values
                 │                                  │                                                                     │    └── tuple
                 │                                  │                                                                     └── projections
-                │                                  │                                                                          └── cast: VOID [as=stmt_return_6:7]
+                │                                  │                                                                          └── cast: VOID [as="_implicit_return":7]
                 │                                  │                                                                               └── null
                 │                                  └── exception-handler
                 │                                       └── SQLSTATE '22012'
@@ -613,10 +613,107 @@ call
                 │                                                                                    │              ├── const: ''
                 │                                                                                    │              └── const: '00000'
                 │                                                                                    └── project
-                │                                                                                         ├── columns: stmt_return_6:7
+                │                                                                                         ├── columns: "_implicit_return":7
                 │                                                                                         ├── values
                 │                                                                                         │    └── tuple
                 │                                                                                         └── projections
-                │                                                                                              └── cast: VOID [as=stmt_return_6:7]
+                │                                                                                              └── cast: VOID [as="_implicit_return":7]
                 │                                                                                                   └── null
+                └── const: 1
+
+# Build an implicit RETURN statement for a routine with OUT params.
+exec-ddl
+CREATE PROCEDURE p_out(OUT x INT, OUT y INT) AS $$
+  BEGIN
+    x := 1;
+    IF x > 0 THEN
+      y := 2;
+    END IF;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+CALL p_out(NULL, NULL);
+----
+call
+ └── procedure: p_out
+      ├── args
+      │    ├── null
+      │    └── null
+      ├── params: x:1 y:2
+      └── body
+           └── limit
+                ├── columns: stmt_if_2:12
+                ├── project
+                │    ├── columns: stmt_if_2:12
+                │    ├── project
+                │    │    ├── columns: x:5!null y:4
+                │    │    ├── project
+                │    │    │    ├── columns: y:4 x:3
+                │    │    │    ├── project
+                │    │    │    │    ├── columns: x:3
+                │    │    │    │    ├── values
+                │    │    │    │    │    └── tuple
+                │    │    │    │    └── projections
+                │    │    │    │         └── cast: INT8 [as=x:3]
+                │    │    │    │              └── null
+                │    │    │    └── projections
+                │    │    │         └── cast: INT8 [as=y:4]
+                │    │    │              └── null
+                │    │    └── projections
+                │    │         └── const: 1 [as=x:5]
+                │    └── projections
+                │         └── case [as=stmt_if_2:12]
+                │              ├── true
+                │              ├── when
+                │              │    ├── gt
+                │              │    │    ├── variable: x:5
+                │              │    │    └── const: 0
+                │              │    └── subquery
+                │              │         └── project
+                │              │              ├── columns: stmt_if_1:10
+                │              │              ├── project
+                │              │              │    ├── columns: y:9!null
+                │              │              │    ├── values
+                │              │              │    │    └── tuple
+                │              │              │    └── projections
+                │              │              │         └── const: 2 [as=y:9]
+                │              │              └── projections
+                │              │                   └── udf: stmt_if_1 [as=stmt_if_1:10]
+                │              │                        ├── args
+                │              │                        │    ├── variable: x:5
+                │              │                        │    └── variable: y:9
+                │              │                        ├── params: x:6 y:7
+                │              │                        └── body
+                │              │                             └── project
+                │              │                                  ├── columns: "_implicit_return":8
+                │              │                                  ├── values
+                │              │                                  │    └── tuple
+                │              │                                  └── projections
+                │              │                                       └── cast: RECORD [as="_implicit_return":8]
+                │              │                                            └── tuple
+                │              │                                                 ├── variable: x:6
+                │              │                                                 └── variable: y:7
+                │              └── subquery
+                │                   └── project
+                │                        ├── columns: stmt_if_1:11
+                │                        ├── values
+                │                        │    └── tuple
+                │                        └── projections
+                │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
+                │                                  ├── args
+                │                                  │    ├── variable: x:5
+                │                                  │    └── variable: y:4
+                │                                  ├── params: x:6 y:7
+                │                                  └── body
+                │                                       └── project
+                │                                            ├── columns: "_implicit_return":8
+                │                                            ├── values
+                │                                            │    └── tuple
+                │                                            └── projections
+                │                                                 └── cast: RECORD [as="_implicit_return":8]
+                │                                                      └── tuple
+                │                                                           ├── variable: x:6
+                │                                                           └── variable: y:7
                 └── const: 1

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -128,7 +128,7 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 	}
 	// Push back the first token so that it's included in the SQL string.
 	l.PushBack(1)
-	startPos, endPos, _, err := l.readSQLConstruct(false /* isExpr */, ';')
+	startPos, endPos, _, err := l.readSQLConstruct(false /* isExpr */, false /* allowEmpty */, ';')
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func (l *lexer) MakeDynamicExecuteStmt() (*plpgsqltree.DynamicExecute, error) {
 }
 
 func (l *lexer) readSQLConstruct(
-	isExpr bool, terminator1 int, terminators ...int,
+	isExpr, allowEmpty bool, terminator1 int, terminators ...int,
 ) (startPos, endPos, terminatorMet int, err error) {
 	if l.parser.Lookahead() != -1 {
 		// Push back the lookahead token so that it can be included.
@@ -302,7 +302,7 @@ func (l *lexer) readSQLConstruct(
 	if endPos > len(l.tokens) {
 		endPos = len(l.tokens)
 	}
-	if endPos <= startPos {
+	if endPos < startPos || (!allowEmpty && endPos == startPos) {
 		if isExpr {
 			return 0, 0, 0, errors.New("missing expression")
 		} else {
@@ -346,7 +346,7 @@ func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) 
 		}
 		// Read past the INTO.
 		l.lastPos++
-		startPos, endPos, _, err := l.readSQLConstruct(true /* isExpr */, ';')
+		startPos, endPos, _, err := l.readSQLConstruct(true /* isExpr */, false /* allowEmpty */, ';')
 		if err != nil {
 			return nil, err
 		}
@@ -379,9 +379,20 @@ func (l *lexer) ReadSqlExpr(
 ) (sqlStr string, terminatorMet int, err error) {
 	var startPos, endPos int
 	startPos, endPos, terminatorMet, err = l.readSQLConstruct(
-		true /* isExpr */, terminator1, terminators...,
+		true /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
 	)
 	return l.getStr(startPos, endPos), terminatorMet, err
+}
+
+// ReadReturnExpr handles reading the expression for a RETURN statement, which
+// can be nonexistent.
+func (l *lexer) ReadReturnExpr() (sqlStr string, err error) {
+	var startPos, endPos int
+	startPos, endPos, _, err = l.readSQLConstruct(true /* isExpr */, true /* allowEmpty */, ';')
+	if err != nil || startPos == endPos {
+		return "", err
+	}
+	return l.getStr(startPos, endPos), err
 }
 
 func (l *lexer) ReadSqlStatement(
@@ -389,7 +400,7 @@ func (l *lexer) ReadSqlStatement(
 ) (sqlStr string, terminatorMet int, err error) {
 	var startPos, endPos int
 	startPos, endPos, terminatorMet, err = l.readSQLConstruct(
-		false /* isExpr */, terminator1, terminators...,
+		false /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
 	)
 	return l.getStr(startPos, endPos), terminatorMet, err
 }

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return
@@ -84,6 +84,60 @@ RETURN (1, 'string');
 END;
  -- identifiers removed
 
+parse
+DECLARE
+BEGIN
+  RETURN;
+END
+----
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+BEGIN
+  RETURN   ;
+END
+----
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+RETURN;
+END;
+ -- identifiers removed
+
 error
 DECLARE
 BEGIN
@@ -165,19 +219,6 @@ We appreciate your feedback.
 error
 DECLARE
 BEGIN
-  RETURN;
-END
-----
-at or near "return": syntax error: missing expression
-DETAIL: source SQL:
-DECLARE
-BEGIN
-  RETURN;
-  ^
-
-error
-DECLARE
-BEGIN
   RETURN (NULL;
 END
 ----
@@ -222,12 +263,12 @@ BEGIN
   RETURN 1, 'string';
 END
 ----
-at or near "string": syntax error: query returned 2 columns
+at or near ";": syntax error: query returned 2 columns
 DETAIL: source SQL:
 DECLARE
 BEGIN
   RETURN 1, 'string';
-            ^
+                    ^
 
 error
 DECLARE
@@ -235,9 +276,9 @@ BEGIN
   RETURN 1, (2, 3, 4, 5);
 END
 ----
-at or near ")": syntax error: query returned 2 columns
+at or near ";": syntax error: query returned 2 columns
 DETAIL: source SQL:
 DECLARE
 BEGIN
   RETURN 1, (2, 3, 4, 5);
-                       ^
+                        ^

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -790,9 +790,6 @@ func (s *Continue) WalkStmt(visitor StatementVisitor) Statement {
 type Return struct {
 	StatementImpl
 	Expr Expr
-	// Implicit is set if this Return statement was not originally in the body
-	// and was added by us.
-	Implicit bool
 }
 
 func (s *Return) CopyNode() *Return {

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -789,8 +789,7 @@ func (s *Continue) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_return
 type Return struct {
 	StatementImpl
-	Expr   Expr
-	RetVar Variable
+	Expr Expr
 	// Implicit is set if this Return statement was not originally in the body
 	// and was added by us.
 	Implicit bool
@@ -802,10 +801,9 @@ func (s *Return) CopyNode() *Return {
 }
 
 func (s *Return) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString("RETURN ")
-	if s.Expr == nil {
-		ctx.FormatNode(&s.RetVar)
-	} else {
+	ctx.WriteString("RETURN")
+	if s.Expr != nil {
+		ctx.WriteByte(' ')
 		ctx.FormatNode(s.Expr)
 	}
 	ctx.WriteString(";\n")


### PR DESCRIPTION
#### plpgsql: add parser support for RETURN with no expression

This commit adds support in the PL/pgSQL parser for RETURN statements
with no expression, like `RETURN;`.

#### plpgsql: allow RETURN with no expression

This commit adds support for `RETURN` statements with no expression.
This applies to routines with OUT-parameters, and those with a VOID
return type. This commit also refactors handling of implicit RETURN
statements for the previously mentioned cases. This ensures that implicit
returns are added in all possible control flow paths, including
exception handlers.

Informs #100405
Fixes #114849
Fixes #108298

Release note (sql change): Added support for `RETURN` statements with
no expression for routines with OUT-parameters and routines with a `VOID`
return type.