### PR TITLE
plpgsql: allow nested blocks in a block with an exception handler

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
@@ -405,6 +405,37 @@ NOTICE: outer handler
 NOTICE: inner block
 NOTICE: inner handler 100
 
+# A block can be nested inside another block that has an exception handler.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    RAISE NOTICE 'outer block: %', x;
+    BEGIN
+      x := x + 1;
+      RAISE NOTICE 'inner block: %', x;
+      SELECT 1 // 0;
+    EXCEPTION WHEN division_by_zero THEN
+      x := x + 1;
+      RAISE NOTICE 'inner handler: %', x;
+      SELECT 1 // 0;
+    END;
+  EXCEPTION WHEN division_by_zero THEN
+    x := x + 1;
+    RAISE NOTICE 'outer handler: %', x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: outer block: 0
+NOTICE: inner block: 1
+NOTICE: inner handler: 2
+NOTICE: outer handler: 3
+
 subtest error
 
 statement ok
@@ -454,25 +485,6 @@ CREATE PROCEDURE p() AS $$
     BEGIN
       RAISE NOTICE '%', x;
     END;
-  END
-$$ LANGUAGE PLpgSQL;
-
-# A block cannot currently be nested in a block with an exception handler
-# (tracked in #118551).
-statement error pgcode 0A000 pq: unimplemented: PL/pgSQL blocks cannot yet be nested within a block that has an exception handler
-CREATE PROCEDURE p() AS $$
-  DECLARE
-    x INT := 0;
-  BEGIN
-    RAISE NOTICE '%', x;
-    DECLARE
-      y INT := 1 // x;
-    BEGIN
-      RAISE NOTICE '% %', x, y;
-    END;
-  EXCEPTION
-    WHEN division_by_zero THEN
-      RAISE NOTICE 'oops!';
   END
 $$ LANGUAGE PLpgSQL;
 

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -222,6 +222,9 @@ type plBlock struct {
 	label string
 
 	// vars is an ordered list of variables declared in a PL/pgSQL block.
+	//
+	// INVARIANT: the variables of a parent (ancestor) block *always* form a
+	// prefix of the variables of a child (descendant) block.
 	vars []ast.Variable
 
 	// varTypes maps from the name of each variable in the scope to its type.
@@ -280,11 +283,6 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 	if astBlock.Label != "" {
 		panic(blockLabelErr)
 	}
-	if b.block().hasExceptionHandler {
-		// The parent block has an exception handler. Exception handlers and nested
-		// blocks are not yet compatible.
-		panic(nestedBlockExceptionErr)
-	}
 	b.ensureScopeHasExpr(s)
 	block := b.pushBlock(plBlock{
 		label:     astBlock.Label,
@@ -294,6 +292,15 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 		cursors:   make(map[ast.Variable]ast.CursorDeclaration),
 	})
 	defer b.popBlock()
+	if len(astBlock.Exceptions) > 0 || b.hasExceptionHandler() {
+		// If the current block or some ancestor block has an exception handler, it
+		// is necessary to maintain the BlockState with a reference to the parent
+		// BlockState (if any).
+		block.state = &tree.BlockState{}
+		if parent := b.parentBlock(); parent != nil {
+			block.state.Parent = parent.state
+		}
+	}
 	// First, handle the variable declarations.
 	for i := range astBlock.Decls {
 		switch dec := astBlock.Decls[i].(type) {
@@ -351,7 +358,6 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 		// The routine is volatile to prevent inlining. Only the block and
 		// variable-assignment routines need to be volatile; see the buildExceptions
 		// comment for details.
-		block.state = &tree.BlockState{}
 		block.hasExceptionHandler = true
 		blockCon := b.makeContinuation("exception_block")
 		blockCon.def.ExceptionBlock = exceptions
@@ -1681,6 +1687,15 @@ func (b *plpgsqlBuilder) block() *plBlock {
 	return &b.blocks[len(b.blocks)-1]
 }
 
+// parentBlock returns the parent block for the current PL/pgSQL block. It
+// returns nil if the current block does not have a parent.
+func (b *plpgsqlBuilder) parentBlock() *plBlock {
+	if len(b.blocks) <= 1 {
+		return nil
+	}
+	return &b.blocks[len(b.blocks)-2]
+}
+
 // pushBlock puts the given block on the stack. It is used when entering the
 // scope of a PL/pgSQL block.
 func (b *plpgsqlBuilder) pushBlock(bs plBlock) *plBlock {
@@ -1840,9 +1855,6 @@ var (
 	)
 	nonCompositeErr = pgerror.New(pgcode.DatatypeMismatch,
 		"cannot return non-composite value from function returning composite type",
-	)
-	nestedBlockExceptionErr = unimplemented.New("exception handler for nested blocks",
-		"PL/pgSQL blocks cannot yet be nested within a block that has an exception handler",
 	)
 	returnWithOUTParameterErr = pgerror.New(pgcode.DatatypeMismatch,
 		"RETURN cannot have a parameter in function with OUT parameters",


### PR DESCRIPTION
#### execbuilder,plpgsql: don't build redundant exception handler

There was some leftover logic for building the branches of a routine's
exception handler after some refactoring in #110998. This didn't affect
correctness, but added unnecessary overhead. This commit removes the
extra work.

#### plpgsql: allow nested blocks in a block with an exception handler

This commit removes the restriction on nesting PL/pgSQL blocks within
a block that has an exception handler. This is accomplished by tracking
the number of variables that are in scope for each block, and using that
information to determine which arguments to supply to the exception
handler for a block. This relies on the invariant that the variables of
a parent block always form a prefix of the variables of a child block.

Fixes #118551

Release note (sql change): PL/pgSQL blocks can now be nested in a block
that has an exception handler.