### PR TITLE
roachtest: refactor virtual cluster API

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -80,9 +80,6 @@ var (
 
 	// storageCluster is used for cluster virtualization and multi-tenant functionality.
 	storageCluster string
-	// externalProcessNodes indicates the cluster/nodes where external
-	// process SQL instances should be deployed.
-	externalProcessNodes string
 
 	revertUpdate bool
 
@@ -211,7 +208,7 @@ func initFlags() {
 	_ = startInstanceCmd.MarkFlagRequired("storage-cluster")
 	startInstanceCmd.Flags().IntVar(&startOpts.SQLInstance,
 		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction for separate-process deployments distinct from the internal instance ID)")
-	startInstanceCmd.Flags().StringVar(&externalProcessNodes, "external-cluster", externalProcessNodes, "start service in external mode, as a separate process in the given nodes")
+	startInstanceCmd.Flags().StringVar(&startOpts.VirtualClusterLocation, "external-nodes", startOpts.VirtualClusterLocation, "if set, starts service in external mode, as a separate process in the given nodes")
 
 	// Flags for processes that stop (kill) processes.
 	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd} {

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -598,13 +598,16 @@ environment variables to the cockroach process.
 		startOpts.AdminUIPort = 0
 
 		startOpts.Target = install.StartSharedProcessForVirtualCluster
-		if externalProcessNodes != "" {
+		// If the user passed an `--external-nodes` option, we are
+		// starting a separate process virtual cluster.
+		if startOpts.VirtualClusterLocation != "" {
 			startOpts.Target = install.StartServiceForVirtualCluster
 		}
 
 		startOpts.VirtualClusterName = args[0]
-		return roachprod.StartServiceForVirtualCluster(context.Background(),
-			config.Logger, externalProcessNodes, storageCluster, startOpts, clusterSettingsOpts...)
+		return roachprod.StartServiceForVirtualCluster(
+			context.Background(), config.Logger, storageCluster, startOpts, clusterSettingsOpts...,
+		)
 	}),
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2739,7 +2739,7 @@ func (c *clusterImpl) ConnE(
 		opt(connOptions)
 	}
 	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), roachprod.PGURLOptions{
-		VirtualClusterName: connOptions.TenantName,
+		VirtualClusterName: connOptions.VirtualClusterName,
 		SQLInstance:        connOptions.SQLInstance,
 		Auth:               connOptions.AuthMode,
 	})

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2079,32 +2079,35 @@ func (c *clusterImpl) StartE(
 	return nil
 }
 
-// StartServiceForVirtualClusterE can start either external or shared process
-// virtual clusters. This can be specified in startOpts.RoachprodOpts. Set the
-// `Target` to the required virtual cluster type. Refer to the virtual cluster
-// section in the struct for more information on what fields are available for
-// virtual clusters.
-//
-// With external process virtual clusters an external process will be started on
-// each node specified in the externalNodes parameter.
-//
-// With shared process virtual clusters the required queries will be run on a
-// storage node of the cluster specified in the opts parameter.
+// StartServiceForVirtualClusterE can start either external or shared
+// process virtual clusters. This can be specified by the `startOpts`
+// passed. See the `option.Start*VirtualClusterOpts` functions.
 func (c *clusterImpl) StartServiceForVirtualClusterE(
 	ctx context.Context,
 	l *logger.Logger,
-	externalNodes option.NodeListOption,
 	startOpts option.StartOpts,
 	settings install.ClusterSettings,
-	opts ...option.Option,
 ) error {
-
-	c.setStatusForClusterOpt("starting virtual cluster", startOpts.RoachtestOpts.Worker, opts...)
-	defer c.clearStatusForClusterOpt(startOpts.RoachtestOpts.Worker)
-
+	l.Printf("starting virtual cluster")
 	clusterSettingsOpts := c.configureClusterSettingOptions(c.virtualClusterSettings, settings)
 
-	if err := roachprod.StartServiceForVirtualCluster(ctx, l, c.MakeNodes(externalNodes), c.MakeNodes(opts...), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {
+	// By default, we assume every node in the cluster is part of the
+	// storage cluster the virtual cluster needs to connect to. If the
+	// user customized the storage cluster in the `StartOpts`, we use
+	// that.
+	storageCluster := c.All()
+	if len(startOpts.SeparateProcessStorageNodes) > 0 {
+		storageCluster = startOpts.SeparateProcessStorageNodes
+	}
+
+	// If the user indicated nodes where the virtual cluster should be
+	// started, we indicate that in the roachprod opts.
+	if len(startOpts.SeparateProcessNodes) > 0 {
+		startOpts.RoachprodOpts.VirtualClusterLocation = c.MakeNodes(startOpts.SeparateProcessNodes)
+	}
+	if err := roachprod.StartServiceForVirtualCluster(
+		ctx, l, c.MakeNodes(storageCluster), startOpts.RoachprodOpts, clusterSettingsOpts...,
+	); err != nil {
 		return err
 	}
 
@@ -2119,12 +2122,10 @@ func (c *clusterImpl) StartServiceForVirtualClusterE(
 func (c *clusterImpl) StartServiceForVirtualCluster(
 	ctx context.Context,
 	l *logger.Logger,
-	externalNodes option.NodeListOption,
 	startOpts option.StartOpts,
 	settings install.ClusterSettings,
-	opts ...option.Option,
 ) {
-	if err := c.StartServiceForVirtualClusterE(ctx, l, externalNodes, startOpts, settings, opts...); err != nil {
+	if err := c.StartServiceForVirtualClusterE(ctx, l, startOpts, settings); err != nil {
 		c.t.Fatal(err)
 	}
 }
@@ -2134,18 +2135,22 @@ func (c *clusterImpl) StartServiceForVirtualCluster(
 // process virtual clusters, the corresponding service is stopped. For
 // separate process, the OS process is killed.
 func (c *clusterImpl) StopServiceForVirtualClusterE(
-	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
+	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts,
 ) error {
-	c.setStatusForClusterOpt("stopping virtual cluster", stopOpts.RoachtestOpts.Worker, opts...)
-	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
+	l.Printf("stoping virtual cluster")
+
+	nodes := c.All()
+	if len(stopOpts.SeparateProcessNodes) > 0 {
+		nodes = stopOpts.SeparateProcessNodes
+	}
 
 	return roachprod.StopServiceForVirtualCluster(
-		ctx, l, c.Name(), c.IsSecure(), stopOpts.RoachprodOpts,
+		ctx, l, c.MakeNodes(nodes), c.IsSecure(), stopOpts.RoachprodOpts,
 	)
 }
 
 func (c *clusterImpl) StopServiceForVirtualCluster(
-	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
+	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts,
 ) {
 	if err := c.StopServiceForVirtualClusterE(ctx, l, stopOpts); err != nil {
 		c.t.Fatal(err)

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -68,13 +68,13 @@ type Cluster interface {
 
 	// Starting virtual clusters.
 
-	StartServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option) error
-	StartServiceForVirtualCluster(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
+	StartServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, startOpts option.StartOpts, settings install.ClusterSettings) error
+	StartServiceForVirtualCluster(ctx context.Context, l *logger.Logger, startOpts option.StartOpts, settings install.ClusterSettings)
 
 	// Stopping virtual clusters.
 
-	StopServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option) error
-	StopServiceForVirtualCluster(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
+	StopServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts) error
+	StopServiceForVirtualCluster(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts)
 
 	// Hostnames and IP addresses of the nodes.
 

--- a/pkg/cmd/roachtest/option/connection_options.go
+++ b/pkg/cmd/roachtest/option/connection_options.go
@@ -18,12 +18,12 @@ import (
 )
 
 type ConnOption struct {
-	User        string
-	DBName      string
-	TenantName  string
-	SQLInstance int
-	AuthMode    install.PGAuthMode
-	Options     map[string]string
+	User               string
+	DBName             string
+	VirtualClusterName string
+	SQLInstance        int
+	AuthMode           install.PGAuthMode
+	Options            map[string]string
 }
 
 func User(user string) func(*ConnOption) {
@@ -32,9 +32,9 @@ func User(user string) func(*ConnOption) {
 	}
 }
 
-func TenantName(tenantName string) func(*ConnOption) {
+func VirtualClusterName(name string) func(*ConnOption) {
 	return func(option *ConnOption) {
-		option.TenantName = tenantName
+		option.VirtualClusterName = name
 	}
 }
 

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -57,11 +57,11 @@ func DefaultStartSingleNodeOpts() StartOpts {
 }
 
 // DefaultStartVirtualClusterOpts returns StartOpts for starting an external
-// process virtual cluster with the given tenant name and SQL instance.
-func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpts {
+// process virtual cluster with the given name and SQL instance.
+func DefaultStartVirtualClusterOpts(name string, sqlInstance int) StartOpts {
 	startOpts := DefaultStartOpts()
 	startOpts.RoachprodOpts.Target = install.StartServiceForVirtualCluster
-	startOpts.RoachprodOpts.VirtualClusterName = tenantName
+	startOpts.RoachprodOpts.VirtualClusterName = name
 	startOpts.RoachprodOpts.SQLInstance = sqlInstance
 	// TODO(DarrylWong): remove once #117125 is addressed.
 	startOpts.RoachprodOpts.AdminUIPort = 0
@@ -69,11 +69,11 @@ func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpt
 }
 
 // DefaultStartSharedVirtualClusterOpts returns StartOpts for starting a shared
-// process virtual cluster with the given tenant name.
-func DefaultStartSharedVirtualClusterOpts(tenantName string) StartOpts {
+// process virtual cluster with the given name.
+func DefaultStartSharedVirtualClusterOpts(name string) StartOpts {
 	startOpts := DefaultStartOpts()
 	startOpts.RoachprodOpts.Target = install.StartSharedProcessForVirtualCluster
-	startOpts.RoachprodOpts.VirtualClusterName = tenantName
+	startOpts.RoachprodOpts.VirtualClusterName = name
 	return startOpts
 }
 

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -19,6 +19,16 @@ import (
 
 // StartOpts is a type that combines the start options needed by roachprod and roachtest.
 type StartOpts struct {
+	// SeparateProcessStorageNodes is used when starting a virtual
+	// cluster, indicating the nodes that should be used as storage
+	// nodes. When not set, all nodes should be considered part of the
+	// storage cluster.
+	SeparateProcessStorageNodes NodeListOption
+	// SeparateProcessNode is used when starting a virtual cluster,
+	// indicating the nodes in which the virtual cluster should be
+	// started.
+	SeparateProcessNodes NodeListOption
+
 	RoachprodOpts install.StartOpts
 	RoachtestOpts struct {
 		Worker bool
@@ -48,21 +58,30 @@ func NewStartOpts(opts ...StartStopOption) StartOpts {
 	return startOpts
 }
 
-// DefaultStartVirtualClusterOpts returns StartOpts for starting an external
-// process virtual cluster with the given name and SQL instance.
-func DefaultStartVirtualClusterOpts(name string, sqlInstance int) StartOpts {
+// StartVirtualClusterOpts returns StartOpts for starting an external
+// process virtual cluster with the given name and on the given
+// nodes. By default, this assigns a fixed SQL instance to the new
+// processes. To change this (and allow multiple instances of the same
+// virtual cluster to coexist in the same node), use the
+// `VirtualClusterInstance` option.
+func StartVirtualClusterOpts(name string, nodes NodeListOption, opts ...StartStopOption) StartOpts {
 	startOpts := DefaultStartOpts()
 	startOpts.RoachprodOpts.Target = install.StartServiceForVirtualCluster
 	startOpts.RoachprodOpts.VirtualClusterName = name
-	startOpts.RoachprodOpts.SQLInstance = sqlInstance
+	startOpts.SeparateProcessNodes = nodes
 	// TODO(DarrylWong): remove once #117125 is addressed.
 	startOpts.RoachprodOpts.AdminUIPort = 0
+
+	for _, opt := range opts {
+		opt(&startOpts)
+	}
+
 	return startOpts
 }
 
 // DefaultStartSharedVirtualClusterOpts returns StartOpts for starting a shared
 // process virtual cluster with the given name.
-func DefaultStartSharedVirtualClusterOpts(name string) StartOpts {
+func StartSharedVirtualClusterOpts(name string) StartOpts {
 	startOpts := DefaultStartOpts()
 	startOpts.RoachprodOpts.Target = install.StartSharedProcessForVirtualCluster
 	startOpts.RoachprodOpts.VirtualClusterName = name
@@ -71,6 +90,10 @@ func DefaultStartSharedVirtualClusterOpts(name string) StartOpts {
 
 // StopOpts is a type that combines the stop options needed by roachprod and roachtest.
 type StopOpts struct {
+	// SeparateProcessNodes is used when stopping virtual clusters. It
+	// indicates the nodes in which we should stop the virtual cluster.
+	SeparateProcessNodes NodeListOption
+
 	// TODO(radu): we should use a higher-level abstraction instead of
 	// roachprod.StopOpts so we don't have to pass around signal values etc.
 	RoachprodOpts roachprod.StopOpts
@@ -84,14 +107,32 @@ func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
 
-// DefaultStopVirtualClusterOpts creates StopOpts that can be used to
-// stop the given virtual cluster and sql instance.
-func DefaultStopVirtualClusterOpts(virtualClusterName string, sqlInstance int) StopOpts {
-	opts := DefaultStopOpts()
-	opts.RoachprodOpts.VirtualClusterName = virtualClusterName
-	opts.RoachprodOpts.SQLInstance = sqlInstance
+// StopSharedVirtualClusterOpts creates StopOpts that can be used to
+// stop the shared process virtual cluster with the given name.
+func StopSharedVirtualClusterOpts(virtualClusterName string) StopOpts {
+	stopOpts := DefaultStopOpts()
+	stopOpts.RoachprodOpts.VirtualClusterName = virtualClusterName
 
-	return opts
+	return stopOpts
+}
+
+// StopVirtualClusterOpts returns stop options that can be used to
+// stop the SQL instance process serving the virtual cluster with the
+// given name. If more than one instance of the same virtual cluster
+// is running on the same node, a specific instance can be passed with
+// the `VirtualClusterInstance` option.
+func StopVirtualClusterOpts(
+	virtualClusterName string, nodes NodeListOption, opts ...StartStopOption,
+) StopOpts {
+	stopOpts := DefaultStopOpts()
+	stopOpts.RoachprodOpts.VirtualClusterName = virtualClusterName
+	stopOpts.SeparateProcessNodes = nodes
+
+	for _, opt := range opts {
+		opt(&stopOpts)
+	}
+
+	return stopOpts
 }
 
 // InMemoryDB can be used to configure StartOpts that start in-memory
@@ -126,6 +167,19 @@ func VirtualClusterInstance(instance int) StartStopOption {
 			opts.RoachprodOpts.SQLInstance = instance
 		case *StopOpts:
 			opts.RoachprodOpts.SQLInstance = instance
+		}
+	}
+}
+
+// StorageCluster indicates the set of nodes in the cluster that
+// should be used as storage cluster when starting a separate process
+// virtual cluster. By default, all nodes are considered part of the
+// storage cluster.
+func StorageCluster(nodes NodeListOption) StartStopOption {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StartOpts:
+			opts.SeparateProcessStorageNodes = nodes
 		}
 	}
 }

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -11,6 +11,8 @@
 package option
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
@@ -23,36 +25,26 @@ type StartOpts struct {
 	}
 }
 
+// StartStopOption allows us to apply optional customizations to
+// start or stop options.
+type StartStopOption func(interface{})
+
 // DefaultStartOpts returns a StartOpts populated with default values.
 func DefaultStartOpts() StartOpts {
+	return NewStartOpts()
+}
+
+// NewStartOpts returns a StartOpts populated with default values when
+// called with no options. Pass customization functions to change the
+// start options.
+func NewStartOpts(opts ...StartStopOption) StartOpts {
 	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
 	startOpts.RoachprodOpts.ScheduleBackups = true
-	return startOpts
-}
 
-// DefaultStartOptsInMemory returns a StartOpts populated with default values,
-// and with in-memory storage
-func DefaultStartOptsInMemory() StartOpts {
-	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
-	startOpts.RoachprodOpts.ScheduleBackups = true
-	// size=0.3 means 30% of available RAM.
-	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--store=type=mem,size=0.3")
-	return startOpts
-}
+	for _, opt := range opts {
+		opt(&startOpts)
+	}
 
-// DefaultStartOptsNoBackups returns a StartOpts with default values,
-// but a scheduled backup will not begin at the start of the roachtest.
-func DefaultStartOptsNoBackups() StartOpts {
-	return StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
-}
-
-// DefaultStartSingleNodeOpts returns StartOpts with default values,
-// but no init. This is helpful if node is not going to start gracefully or
-// will be terminated as init could fail even if it is a noop for a running
-// cluster.
-func DefaultStartSingleNodeOpts() StartOpts {
-	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
-	startOpts.RoachprodOpts.SkipInit = true
 	return startOpts
 }
 
@@ -100,6 +92,51 @@ func DefaultStopVirtualClusterOpts(virtualClusterName string, sqlInstance int) S
 	opts.RoachprodOpts.SQLInstance = sqlInstance
 
 	return opts
+}
+
+// InMemoryDB can be used to configure StartOpts that start in-memory
+// cockroach processes. The `size` argument must be in [0,1) and
+// indicates the percentage of RAM to be used by the process.
+func InMemoryDB(size float64) StartStopOption {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StartOpts:
+			opts.RoachprodOpts.ExtraArgs = append(
+				opts.RoachprodOpts.ExtraArgs,
+				fmt.Sprintf("--store=type=mem,size=%.1f", size),
+			)
+		}
+	}
+}
+
+func SkipInit(opts interface{}) {
+	switch opts := opts.(type) {
+	case *StartOpts:
+		opts.RoachprodOpts.SkipInit = true
+	}
+}
+
+// VirtualClusterInstance can be used to indicate the SQL instance to
+// start or stop. Only used when starting multiple instances (SQL
+// processes) of the same virtual cluster on the same node.
+func VirtualClusterInstance(instance int) StartStopOption {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StartOpts:
+			opts.RoachprodOpts.SQLInstance = instance
+		case *StopOpts:
+			opts.RoachprodOpts.SQLInstance = instance
+		}
+	}
+}
+
+// NoBackupSchedule can be used to generate StartOpts that skip the
+// creation of the default backup schedule.
+func NoBackupSchedule(opts interface{}) {
+	switch opts := opts.(type) {
+	case *StartOpts:
+		opts.RoachprodOpts.ScheduleBackups = false
+	}
 }
 
 // WithNodes returns a RunOptions that will run on the given nodes.

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -49,7 +49,7 @@ func registerActiveRecord(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		startOpts := option.DefaultStartOptsInMemory()
+		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// Activerecord uses root user with ssl disabled.
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -94,7 +94,7 @@ func registerDatabaseDrop(r registry.Registry) {
 				runTPCE(ctx, t, c, tpceOptions{
 					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
-						startOpts := option.DefaultStartOptsNoBackups()
+						startOpts := option.NewStartOpts(option.NoBackupSchedule)
 						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 							t.Fatal(err)
@@ -197,7 +197,7 @@ func registerDatabaseDrop(r registry.Registry) {
 			// test and use disk snapshots?
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					startOpts := option.DefaultStartOptsNoBackups()
+					startOpts := option.NewStartOpts(option.NoBackupSchedule)
 					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -66,7 +66,7 @@ func registerElasticIO(r registry.Registry) {
 			err := c.StartGrafana(ctx, t.L(), promCfg)
 			require.NoError(t, err)
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workAndPromNode))
-			startOpts := option.DefaultStartOptsNoBackups()
+			startOpts := option.NewStartOpts(option.NoBackupSchedule)
 			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -93,7 +93,7 @@ func registerIndexBackfill(r registry.Registry) {
 						// is not running.
 						c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
-						startOpts := option.DefaultStartOptsNoBackups()
+						startOpts := option.NewStartOpts(option.NoBackupSchedule)
 						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 							t.Fatal(err)
@@ -151,7 +151,7 @@ func registerIndexBackfill(r registry.Registry) {
 			// large index backfills while it's running.
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					startOpts := option.DefaultStartOptsNoBackups()
+					startOpts := option.NewStartOpts(option.NoBackupSchedule)
 					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload.go
@@ -47,7 +47,10 @@ func registerIndexOverload(r registry.Registry) {
 			crdbNodes := c.Spec().NodeCount - 1
 			workloadNode := c.Spec().NodeCount
 
-			c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.Range(1, crdbNodes))
+			c.Start(
+				ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule),
+				install.MakeClusterSettings(), c.Range(1, crdbNodes),
+			)
 
 			{
 				promCfg := &prometheus.Config{}

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -65,7 +65,7 @@ func registerIntentResolutionOverload(r registry.Registry) {
 			err := c.StartGrafana(ctx, t.L(), promCfg)
 			require.NoError(t, err)
 
-			startOpts := option.DefaultStartOptsNoBackups()
+			startOpts := option.NewStartOpts(option.NoBackupSchedule)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")
 			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -27,7 +27,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 	runKV := func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		nodes := c.Spec().NodeCount - 1
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
-		startOpts := option.DefaultStartOptsNoBackups()
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		startOpts.RoachprodOpts.StoreCount = 2
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
 

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -165,7 +165,6 @@ func runMultiTenantFairness(
 	_, err := systemConn.ExecContext(ctx, `SET CLUSTER SETTING server.child_metrics.enabled = true`)
 	require.NoError(t, err)
 
-	const sqlInstance = 0
 	virtualClusters := map[string]option.NodeListOption{
 		"app-fairness-n2": c.Node(2),
 		"app-fairness-n3": c.Node(3),
@@ -180,8 +179,8 @@ func runMultiTenantFairness(
 	for j, name := range virtualClusterNames {
 		node := virtualClusters[name]
 		c.StartServiceForVirtualCluster(
-			ctx, t.L(), node,
-			option.DefaultStartVirtualClusterOpts(name, sqlInstance),
+			ctx, t.L(),
+			option.StartVirtualClusterOpts(name, node),
 			install.MakeClusterSettings(),
 		)
 
@@ -205,8 +204,8 @@ func runMultiTenantFairness(
 		)
 
 		initKV := fmt.Sprintf(
-			"%s workload init kv {pgurl:%d:%s:%d}",
-			test.DefaultCockroachPath, node[0], name, sqlInstance,
+			"%s workload init kv {pgurl:%d:%s}",
+			test.DefaultCockroachPath, node[0], name,
 		)
 
 		c.Run(ctx, option.WithNodes(node), initKV)
@@ -219,7 +218,7 @@ func runMultiTenantFairness(
 	t.L().Printf("loading per-tenant data (<%s)", 10*time.Minute)
 	m1 := c.NewMonitor(ctx, c.All())
 	for name, node := range virtualClusters {
-		pgurl := fmt.Sprintf("{pgurl:%d:%s:%d}", node[0], name, sqlInstance)
+		pgurl := fmt.Sprintf("{pgurl:%d:%s}", node[0], name)
 		name := name
 		node := node
 		m1.Go(func(ctx context.Context) error {
@@ -262,7 +261,7 @@ func runMultiTenantFairness(
 	m2 := c.NewMonitor(ctx, crdbNode)
 	var n int
 	for name, node := range virtualClusters {
-		pgurl := fmt.Sprintf("{pgurl:%d:%s:%d}", node[0], name, sqlInstance)
+		pgurl := fmt.Sprintf("{pgurl:%d:%s}", node[0], name)
 		n++
 
 		name := name
@@ -304,7 +303,7 @@ func runMultiTenantFairness(
 	for j, name := range virtualClusterNames {
 		node := virtualClusters[name]
 
-		vcdb := c.Conn(ctx, t.L(), node[0], option.VirtualClusterName(name), option.SQLInstance(sqlInstance))
+		vcdb := c.Conn(ctx, t.L(), node[0], option.VirtualClusterName(name))
 		defer vcdb.Close()
 
 		_, err := vcdb.ExecContext(ctx, "USE kv")

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -304,7 +304,7 @@ func runMultiTenantFairness(
 	for j, name := range virtualClusterNames {
 		node := virtualClusters[name]
 
-		vcdb := c.Conn(ctx, t.L(), node[0], option.TenantName(name), option.SQLInstance(sqlInstance))
+		vcdb := c.Conn(ctx, t.L(), node[0], option.VirtualClusterName(name), option.SQLInstance(sqlInstance))
 		defer vcdb.Close()
 
 		_, err := vcdb.ExecContext(ctx, "USE kv")

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -138,7 +138,7 @@ func runMultiTenantFairness(
 
 	t.L().Printf("starting cockroach (<%s)", time.Minute)
 	c.Start(ctx, t.L(),
-		option.DefaultStartOptsNoBackups(),
+		option.NewStartOpts(option.NoBackupSchedule),
 		install.MakeClusterSettings(),
 		crdbNode,
 	)

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -54,7 +54,7 @@ func registerSnapshotOverload(r registry.Registry) {
 			crdbNodes := c.Spec().NodeCount - 1
 			workloadNode := crdbNodes + 1
 			for i := 1; i <= crdbNodes; i++ {
-				startOpts := option.DefaultStartOptsNoBackups()
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
 				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--attrs=n%d", i))
 				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(i))
 			}

--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -197,7 +197,10 @@ func registerTPCCSevereOverload(r registry.Registry) {
 			roachNodes := c.Range(1, c.Spec().NodeCount-1)
 			workloadNode := c.Spec().NodeCount
 
-			c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
+			c.Start(
+				ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule),
+				install.MakeClusterSettings(), roachNodes,
+			)
 
 			t.Status("initializing (~1h)")
 			c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload fixtures import tpcc --checks=false --warehouses=10000 {pgurl:1}")

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -278,7 +278,7 @@ func setupAllocationBench(
 	t.Status("starting cluster")
 	for i := 1; i <= spec.nodes; i++ {
 		// Don't start a backup schedule as this test reports to roachperf.
-		startOpts := option.DefaultStartOptsNoBackups()
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 			"--vmodule=store_rebalancer=2,allocator=2,replicate_queue=2")
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(i))

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -41,7 +41,7 @@ func registerAllocator(r registry.Registry) {
 		nodes := c.Spec().NodeCount - 1
 
 		// Don't start scheduled backups in this perf sensitive test that reports to roachperf
-		startOpts := option.DefaultStartOptsNoBackups()
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		startOpts.RoachprodOpts.ExtraArgs = []string{"--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5"}
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, start))
 		db := c.Conn(ctx, t.L(), 1)

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -25,7 +25,7 @@ import (
 
 var asyncpgRunTestCmd = fmt.Sprintf(`
 source venv/bin/activate &&
-cd /mnt/data1/asyncpg && 
+cd /mnt/data1/asyncpg &&
 PGPORT={pgport:1} PGHOST=localhost PGUSER=%s PGPASSWORD=%s PGSSLROOTCERT=$HOME/%s/ca.crt PGSSLMODE=require PGDATABASE=defaultdb python3 setup.py test > asyncpg.stdout
 `, install.DefaultUser, install.DefaultPassword, install.CockroachNodeCertsDir)
 
@@ -47,7 +47,7 @@ func registerAsyncpg(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -641,7 +641,7 @@ func runBackupMVCCRangeTombstones(
 	c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 	// c2c tests still use the old multitenant API, which does not support non root authentication
-	conn := c.Conn(ctx, t.L(), 1, option.TenantName(config.tenantName), option.AuthMode(install.AuthRootCert))
+	conn := c.Conn(ctx, t.L(), 1, option.VirtualClusterName(config.tenantName), option.AuthMode(install.AuthRootCert))
 
 	// Configure cluster.
 	t.Status("configuring cluster")

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -100,7 +100,7 @@ func importBankDataSplit(
 
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings())
 	runImportBankDataSplit(ctx, rows, ranges, t, c)
 	return dest
 }
@@ -635,7 +635,7 @@ func runBackupMVCCRangeTombstones(
 ) {
 	if !config.skipClusterSetup {
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload") // required for tpch
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings())
 	}
 	t.Status("starting csv servers")
 	c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -154,7 +154,7 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 
 	require.NoError(bd.t, clusterupgrade.StartWithSettings(ctx, bd.t.L(), bd.c,
 		bd.sp.hardware.getCRDBNodes(),
-		option.DefaultStartOptsNoBackups(),
+		option.NewStartOpts(option.NoBackupSchedule),
 		install.BinaryOption(binaryPath)))
 
 	bd.assertCorrectCockroachBinary(ctx)

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -498,7 +498,7 @@ func (rd *replicationDriver) setupC2C(
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 
 	// TODO(msbutler): allow for backups once this test stabilizes a bit more.
-	srcStartOps := option.DefaultStartOptsNoBackups()
+	srcStartOps := option.NewStartOpts(option.NoBackupSchedule)
 	srcStartOps.RoachprodOpts.InitTarget = 1
 
 	roachtestutil.SetDefaultAdminUIPort(c, &srcStartOps.RoachprodOpts)
@@ -506,7 +506,7 @@ func (rd *replicationDriver) setupC2C(
 	c.Start(ctx, t.L(), srcStartOps, srcClusterSetting, srcCluster)
 
 	// TODO(msbutler): allow for backups once this test stabilizes a bit more.
-	dstStartOps := option.DefaultStartOptsNoBackups()
+	dstStartOps := option.NewStartOpts(option.NoBackupSchedule)
 	dstStartOps.RoachprodOpts.InitTarget = rd.rs.srcNodes + 1
 	roachtestutil.SetDefaultAdminUIPort(c, &dstStartOps.RoachprodOpts)
 	dstClusterSetting := install.MakeClusterSettings()

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -309,7 +309,7 @@ func (kv replicateKV) runDriver(
 		require.NotEqual(t, "", kv.antiRegion, "if partitionKVDatabaseInRegion is set, then antiRegion must be set")
 		t.L().Printf("constrain the kv database to region %s", kv.partitionKVDatabaseInRegion)
 		alterStmt := fmt.Sprintf("ALTER DATABASE kv CONFIGURE ZONE USING constraints = '[+region=%s]'", kv.partitionKVDatabaseInRegion)
-		srcTenantConn := c.Conn(workloadCtx, t.L(), setup.src.nodes.RandNode()[0], option.TenantName(setup.src.name))
+		srcTenantConn := c.Conn(workloadCtx, t.L(), setup.src.nodes.RandNode()[0], option.VirtualClusterName(setup.src.name))
 		srcTenantSQL := sqlutils.MakeSQLRunner(srcTenantConn)
 		srcTenantSQL.Exec(t, alterStmt)
 		defer kv.checkRegionalConstraints(t, setup, srcTenantSQL)
@@ -792,9 +792,9 @@ func (rd *replicationDriver) onFingerprintMismatch(
 	ctx context.Context, startTime, endTime hlc.Timestamp,
 ) {
 	rd.t.L().Printf("conducting table level fingerprints")
-	srcTenantConn := rd.c.Conn(ctx, rd.t.L(), 1, option.TenantName(rd.setup.src.name))
+	srcTenantConn := rd.c.Conn(ctx, rd.t.L(), 1, option.VirtualClusterName(rd.setup.src.name))
 	defer srcTenantConn.Close()
-	dstTenantConn := rd.c.Conn(ctx, rd.t.L(), rd.rs.srcNodes+1, option.TenantName(rd.setup.dst.name))
+	dstTenantConn := rd.c.Conn(ctx, rd.t.L(), rd.rs.srcNodes+1, option.VirtualClusterName(rd.setup.dst.name))
 	defer dstTenantConn.Close()
 	fingerprintBisectErr := replicationutils.InvestigateFingerprints(ctx, srcTenantConn, dstTenantConn,
 		startTime,

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -39,7 +39,7 @@ func runConnectionLatencyTest(
 
 	settings := install.MakeClusterSettings()
 	// Don't start a backup schedule as this roachtest reports roachperf results.
-	err = c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings)
+	err = c.StartE(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings)
 	require.NoError(t, err)
 
 	urlTemplate := func(host string) string {

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -360,7 +360,7 @@ func runDecommission(
 			db := c.Conn(ctx, t.L(), pinnedNode)
 			defer db.Close()
 
-			startOpts := option.DefaultStartSingleNodeOpts()
+			startOpts := option.NewStartOpts(option.SkipInit)
 			startOpts.RoachprodOpts.JoinTargets = []int{pinnedNode}
 			extraArgs := []string{
 				fmt.Sprintf("--attrs=node%d", node),
@@ -744,7 +744,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 				targetNodeA, targetNodeB, runNode)
 			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Nodes(targetNodeA, targetNodeB))
 			// The node is in a decomissioned state, so don't attempt to run scheduled backups.
-			c.Start(ctx, t.L(), withDecommissionVMod(option.DefaultStartSingleNodeOpts()),
+			c.Start(ctx, t.L(), withDecommissionVMod(option.NewStartOpts(option.SkipInit)),
 				settings, c.Nodes(targetNodeA, targetNodeB))
 
 			if _, err := h.recommission(ctx, c.Nodes(targetNodeA, targetNodeB), runNode); err == nil {
@@ -807,7 +807,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 			// Bring targetNode it back up to verify that its replicas still get
 			// removed.
-			c.Start(ctx, t.L(), option.DefaultStartSingleNodeOpts(), settings, c.Node(targetNode))
+			c.Start(ctx, t.L(), option.NewStartOpts(option.SkipInit), settings, c.Node(targetNode))
 		}
 
 		// Run decommission a second time to wait until the replicas have
@@ -885,7 +885,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 				t.Fatal(err)
 			}
 			joinAddr := internalAddrs[0]
-			startOpts := option.DefaultStartSingleNodeOpts()
+			startOpts := option.NewStartOpts(option.SkipInit)
 			startOpts.RoachprodOpts.ExtraArgs = append(
 				startOpts.RoachprodOpts.ExtraArgs,
 				"--join",

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -376,7 +376,7 @@ func setupDecommissionBench(
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workloadNode))
 	for i := 1; i <= benchSpec.nodes; i++ {
 		// Don't start a scheduled backup as this roachtest reports to roachperf.
-		startOpts := option.DefaultStartOptsNoBackups()
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 			fmt.Sprintf("--attrs=node%d", i),
 			"--vmodule=store_rebalancer=5,allocator=5,allocator_scorer=5,replicate_queue=5")

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -38,7 +38,7 @@ func registerDisaggRebalance(r registry.Registry) {
 		Timeout:           1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			s3dir := fmt.Sprintf("s3://%s/disagg-rebalance/%s?AUTH=implicit", testutils.BackupTestingBucketLongTTL(), c.Name())
-			startOpts := option.DefaultStartOptsNoBackups()
+			startOpts := option.NewStartOpts(option.NoBackupSchedule)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--experimental-shared-storage=%s", s3dir))
 			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, 3))
 

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -44,7 +44,7 @@ func registerDjango(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -58,7 +58,10 @@ func registerGopg(r registry.Registry) {
 		// See: https://github.com/go-pg/pg/pull/1996
 		// TODO(darrylwong): once the above change is part of a release,
 		// upgrade support to that version and enable secure mode.
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(
+			ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB),
+			install.MakeClusterSettings(install.SecureOption(false)),
+		)
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -36,7 +36,7 @@ func registerGORM(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -94,7 +94,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		startOpts := option.DefaultStartOptsInMemory()
+		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// Hibernate uses a hardcoded connection string with ssl disabled.
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -33,7 +33,10 @@ func registerJasyncSQL(r registry.Registry) {
 		// jasync does not support changing the default sslmode for postgresql, defaulting
 		// sslmode=disable. See: https://github.com/jasync-sql/jasync-sql/issues/422
 		// TODO(darrylwong): If the above issue is addressed we can enable secure mode
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(
+			ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB),
+			install.MakeClusterSettings(install.SecureOption(false)),
+		)
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -165,7 +165,7 @@ func executeNodeShutdown(
 	t.Status(fmt.Sprintf("restarting %s (node restart test is done)\n", target))
 	// Don't begin another backup schedule, as the parent test driver has already
 	// set or disallowed the automatic backup schedule.
-	if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(),
+	if err := c.StartE(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule),
 		install.MakeClusterSettings(cfg.restartSettings...), target); err != nil {
 		return errors.Wrapf(err, "could not restart node %s", target)
 	}

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -49,7 +49,7 @@ func registerKnex(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -89,7 +89,7 @@ func registerKV(r registry.Registry) {
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 		// Don't start a scheduled backup on this perf sensitive roachtest that reports to roachperf.
-		startOpts := option.DefaultStartOptsNoBackups()
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		if opts.ssds > 1 && !opts.raid0 {
 			startOpts.RoachprodOpts.StoreCount = opts.ssds
 		}
@@ -438,7 +438,7 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			settings := install.MakeClusterSettings(install.ClusterSettingsOption{
 				"sql.stats.automatic_collection.enabled": "false",
 			})
-			c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, nodes))
+			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.Range(1, nodes))
 			m := c.NewMonitor(ctx, c.Range(1, nodes))
 
 			db := c.Conn(ctx, t.L(), 1)
@@ -681,7 +681,7 @@ func registerKVSplits(r registry.Registry) {
 
 				settings := install.MakeClusterSettings()
 				settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=1m", "COCKROACH_DISABLE_QUIESCENCE="+strconv.FormatBool(!item.quiesce))
-				startOpts := option.DefaultStartOptsNoBackups()
+				startOpts := option.NewStartOpts(option.NoBackupSchedule)
 				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--cache=256MiB")
 				c.Start(ctx, t.L(), startOpts, settings, c.Range(1, nodes))
 

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -118,8 +118,10 @@ func registerKV(r registry.Registry) {
 			}
 		}
 		if opts.sharedProcessMT {
-			startOpts = option.DefaultStartSharedVirtualClusterOpts(appTenantName)
-			c.StartServiceForVirtualCluster(ctx, t.L(), c.Range(1, nodes), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
+			startOpts = option.StartSharedVirtualClusterOpts(appTenantName)
+			c.StartServiceForVirtualCluster(
+				ctx, t.L(), startOpts, install.MakeClusterSettings(),
+			)
 		}
 
 		t.Status("running workload")

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -229,7 +229,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 		// splitting can significantly change the underlying layout of the table and
 		// affect benchmark results.
 		c.Wipe(ctx, roachNodes)
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), roachNodes)
 		time.Sleep(restartWait)
 
 		// We currently only support one loadGroup.

--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -42,7 +42,7 @@ func registerLedger(r registry.Registry) {
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 
 			// Don't start a scheduled backup on this perf sensitive roachtest that reports to roachperf.
-			c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
+			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), roachNodes)
 
 			t.Status("running workload")
 			m := c.NewMonitor(ctx, roachNodes)

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -37,7 +37,7 @@ func registerLibPQ(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -265,7 +265,7 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 		// rely on query and workload failures to expose that.
 		m.ExpectDeaths(int32(len(remaining)))
 		settings.Env = append(settings.Env, "COCKROACH_SCAN_INTERVAL=10s")
-		c.Start(ctx, t.L(), option.DefaultStartSingleNodeOpts(), settings, c.Nodes(remaining...))
+		c.Start(ctx, t.L(), option.NewStartOpts(option.SkipInit), settings, c.Nodes(remaining...))
 
 		t.L().Printf("waiting for nodes to restart")
 		if err = timeutil.RunWithTimeout(ctx, "wait-for-restart", time.Minute,
@@ -473,7 +473,7 @@ func runHalfOnlineRecoverLossOfQuorum(
 		t.L().Printf("performing rolling restart of surviving nodes")
 		for _, id := range remaining {
 			c.Stop(ctx, t.L(), stopOpts, c.Node(id))
-			c.Start(ctx, t.L(), option.DefaultStartSingleNodeOpts(), settings, c.Node(id))
+			c.Start(ctx, t.L(), option.NewStartOpts(option.SkipInit), settings, c.Node(id))
 		}
 
 		t.L().Printf("waiting for nodes to process recovery")

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2301,7 +2301,7 @@ func (u *CommonTestUtils) resetCluster(
 
 	cockroachPath := clusterupgrade.CockroachPathForVersion(u.t, version)
 	return clusterupgrade.StartWithSettings(
-		ctx, l, u.cluster, u.roachNodes, option.DefaultStartOptsNoBackups(),
+		ctx, l, u.cluster, u.roachNodes, option.NewStartOpts(option.NoBackupSchedule),
 		install.BinaryOption(cockroachPath), install.SecureOption(true),
 	)
 }

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -34,19 +34,16 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 
 	// Start a virtual cluster.
 	const virtualClusterName = "acceptance-tenant"
-	const sqlInstance = 0 // only one instance of this virtual cluster
 	virtualClusterNode := c.Node(1)
 	c.StartServiceForVirtualCluster(
-		ctx, t.L(), virtualClusterNode,
-		option.DefaultStartVirtualClusterOpts(virtualClusterName, sqlInstance),
+		ctx, t.L(),
+		option.StartVirtualClusterOpts(virtualClusterName, virtualClusterNode),
 		install.MakeClusterSettings(),
-		storageNodes,
 	)
 
 	virtualClusterURL := func() string {
 		urls, err := c.ExternalPGUrl(ctx, t.L(), virtualClusterNode, roachprod.PGURLOptions{
 			VirtualClusterName: virtualClusterName,
-			SQLInstance:        sqlInstance,
 		})
 		require.NoError(t, err)
 
@@ -64,12 +61,11 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 	t.L().Printf("stopping the virtual cluster instance")
 	c.StopServiceForVirtualCluster(
 		ctx, t.L(),
-		option.DefaultStopVirtualClusterOpts(virtualClusterName, sqlInstance),
-		virtualClusterNode,
+		option.StopVirtualClusterOpts(virtualClusterName, virtualClusterNode),
 	)
 
 	db := c.Conn(
-		ctx, t.L(), virtualClusterNode[0], option.VirtualClusterName(virtualClusterName), option.SQLInstance(sqlInstance),
+		ctx, t.L(), virtualClusterNode[0], option.VirtualClusterName(virtualClusterName),
 	)
 	defer db.Close()
 

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -69,7 +69,7 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 	)
 
 	db := c.Conn(
-		ctx, t.L(), virtualClusterNode[0], option.TenantName(virtualClusterName), option.SQLInstance(sqlInstance),
+		ctx, t.L(), virtualClusterNode[0], option.VirtualClusterName(virtualClusterName), option.SQLInstance(sqlInstance),
 	)
 	defer db.Close()
 

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -74,9 +74,13 @@ func runMultiTenantDistSQL(
 	for i := 0; i < numInstances; i++ {
 		node := (i % c.Spec().NodeCount) + 1
 		sqlInstance := i / c.Spec().NodeCount
-		instStartOps := option.DefaultStartVirtualClusterOpts(tenantName, sqlInstance)
+		instStartOps := option.StartVirtualClusterOpts(
+			tenantName, c.Node(node),
+			option.StorageCluster(storageNodes),
+			option.VirtualClusterInstance(sqlInstance),
+		)
 		t.L().Printf("Starting instance %d on node %d", i, node)
-		c.StartServiceForVirtualCluster(ctx, t.L(), c.Node(node), instStartOps, settings, storageNodes)
+		c.StartServiceForVirtualCluster(ctx, t.L(), instStartOps, settings)
 		nodes.Add(i + 1)
 	}
 

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -87,7 +87,7 @@ func runMultiTenantDistSQL(
 
 	m := c.NewMonitor(ctx, c.Nodes(1, 2, 3))
 
-	inst1Conn, err := c.ConnE(ctx, t.L(), 1, option.TenantName(tenantName))
+	inst1Conn, err := c.ConnE(ctx, t.L(), 1, option.VirtualClusterName(tenantName))
 	require.NoError(t, err)
 	_, err = inst1Conn.Exec("CREATE TABLE t(n INT, i INT,s STRING, PRIMARY KEY(n,i))")
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func runMultiTenantDistSQL(
 		m.Go(func(ctx context.Context) error {
 			node := (li % c.Spec().NodeCount) + 1
 			sqlInstance := li / c.Spec().NodeCount
-			dbi, err := c.ConnE(ctx, t.L(), node, option.TenantName(tenantName), option.SQLInstance(sqlInstance))
+			dbi, err := c.ConnE(ctx, t.L(), node, option.VirtualClusterName(tenantName), option.SQLInstance(sqlInstance))
 			require.NoError(t, err)
 			iter := 0
 			for {

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -47,8 +47,8 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 			clusterSettings := install.MakeClusterSettings()
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), clusterSettings, crdbNodes)
 
-			startOpts := option.DefaultStartSharedVirtualClusterOpts(appTenantName)
-			c.StartServiceForVirtualCluster(ctx, t.L(), crdbNodes, startOpts, clusterSettings, crdbNodes)
+			startOpts := option.StartSharedVirtualClusterOpts(appTenantName)
+			c.StartServiceForVirtualCluster(ctx, t.L(), startOpts, clusterSettings)
 
 			t.Status(`initialize tpcc workload`)
 			initCmd := fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d {pgurl%s:%s}`,

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -44,7 +44,7 @@ func runMultiTenantTPCH(
 	// one at a time (using the given url as a parameter to the 'workload run'
 	// command). The runtimes are accumulated in the perf helper.
 	runTPCH := func(node int, virtualClusterName string, sqlInstance int, setupIdx int) {
-		conn := c.Conn(ctx, t.L(), node, option.TenantName(virtualClusterName), option.SQLInstance(sqlInstance))
+		conn := c.Conn(ctx, t.L(), node, option.VirtualClusterName(virtualClusterName), option.SQLInstance(sqlInstance))
 		setting := fmt.Sprintf("SET CLUSTER SETTING sql.distsql.direct_columnar_scans.enabled = %t", enableDirectScans)
 		t.Status(setting)
 		if _, err := conn.Exec(setting); err != nil {
@@ -120,7 +120,7 @@ func runMultiTenantTPCH(
 		t.Fatal(err)
 	}
 
-	virtualClusterConn := c.Conn(ctx, t.L(), gatewayNode, option.TenantName(appTenantName), option.SQLInstance(sqlInstance))
+	virtualClusterConn := c.Conn(ctx, t.L(), gatewayNode, option.VirtualClusterName(appTenantName), option.SQLInstance(sqlInstance))
 	defer virtualClusterConn.Close()
 
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -31,7 +31,7 @@ func runMultiTenantTPCH(
 	ctx context.Context, t test.Test, c cluster.Cluster, enableDirectScans bool, sharedProcess bool,
 ) {
 	start := func() {
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.All())
 	}
 	start()
 

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -164,7 +164,7 @@ func runMultiTenantUpgrade(
 	settings.Binary = currentBinary
 	// TODO (msbutler): investigate why the scheduled backup command fails due to a `Is the Server
 	// running?` error.
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, kvNodes)
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, kvNodes)
 	time.Sleep(time.Second)
 
 	t.Status("checking the pre-upgrade sql server still works after the system tenant binary upgrade")

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -372,7 +372,7 @@ func startInMemoryTenant(
 		var err error
 		// The old multitenant API does not create a default admin user for virtual clusters, so root
 		// authentication is used instead.
-		tenantConn, err = c.ConnE(ctx, t.L(), nodes.RandNode()[0], option.TenantName(tenantName), option.AuthMode(install.AuthRootCert))
+		tenantConn, err = c.ConnE(ctx, t.L(), nodes.RandNode()[0], option.VirtualClusterName(tenantName), option.AuthMode(install.AuthRootCert))
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -91,7 +91,7 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 	s := install.MakeClusterSettings()
 	s.Env = append(s.Env, "COCKROACH_SCAN_INTERVAL=30s")
 	// Disable an automatic scheduled backup as it would mess with the gc ttl this test relies on.
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), s)
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), s)
 
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -56,7 +56,7 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 	settings := install.MakeClusterSettings()
 
 	// Don't create a backup schedule as this test shuts the cluster down immediately.
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, serverNodes)
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, serverNodes)
 	require.NoError(t, c.StopE(ctx, t.L(), option.DefaultStopOpts(), serverNodes))
 
 	t.L().Printf("restarting nodes...")
@@ -71,14 +71,14 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 	// Currently, creating a scheduled backup at start fails, potentially due to
 	// the induced network partition. Further investigation required to allow scheduled backups
 	// to run on this test.
-	startOpts := option.DefaultStartOptsNoBackups()
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--locality=node=1", "--accept-sql-without-tls")
 	c.Start(ctx, t.L(), startOpts, settings, c.Node(1))
 
 	// See comment above about env vars.
 	// "--env=COCKROACH_SCAN_INTERVAL=200ms",
 	// "--env=COCKROACH_SCAN_MAX_IDLE_TIME=20ms",
-	startOpts = option.DefaultStartOptsNoBackups()
+	startOpts = option.NewStartOpts(option.NoBackupSchedule)
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--locality=node=other", "--accept-sql-without-tls")
 	c.Start(ctx, t.L(), startOpts, settings, c.Range(2, n-1))
 

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -43,7 +43,7 @@ func registerNodeJSPostgres(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		settings := install.MakeClusterSettings()
-		err := c.StartE(ctx, t.L(), option.DefaultStartOptsInMemory(), settings)
+		err := c.StartE(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), settings)
 		require.NoError(t, err)
 
 		err = repeatRunE(ctx, t, c, node, "create test database",

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -42,7 +42,7 @@ func registerNpgsql(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 )
 
@@ -30,6 +31,11 @@ const (
 	statusFail
 	statusSkip
 )
+
+// This `startOpts` option configures in-memory databases to use a
+// fixed (30%) amount of memory and is used in a variety of client
+// library tests.
+var sqlClientsInMemoryDB = option.InMemoryDB(0.3)
 
 // alterZoneConfigAndClusterSettings changes the zone configurations so that GC
 // occurs more quickly and jobs are retained for less time. This is useful for

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -41,7 +41,7 @@ func registerPgjdbc(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -43,7 +43,7 @@ func registerPgx(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -33,7 +33,7 @@ func registerPop(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		startOpts := option.DefaultStartOptsInMemory()
+		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		// pop expects secure clusters, indicated by cockroach_ssl, to have SQL Port 26259.
 		// See: https://github.com/gobuffalo/pop/blob/main/database.yml#L26-L28
 		startOpts.RoachprodOpts.SQLPort = 26259

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -39,7 +39,7 @@ func registerPsycopg(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -77,7 +77,7 @@ func registerRebalanceLoad(r registry.Registry) {
 		// This test asserts on the distribution of CPU utilization between nodes
 		// in the cluster, having backups also running could lead to unrelated
 		// flakes - disable backup schedule.
-		startOpts := option.DefaultStartOptsNoBackups()
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		roachNodes := c.Range(1, c.Spec().NodeCount-1)
 		appNode := c.Node(c.Spec().NodeCount)
 		numNodes := len(roachNodes)

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -879,7 +879,7 @@ func (rd *restoreDriver) defaultClusterSettings() []install.ClusterSettingOption
 }
 
 func (rd *restoreDriver) roachprodOpts() option.StartOpts {
-	opts := option.DefaultStartOptsNoBackups()
+	opts := option.NewStartOpts(option.NoBackupSchedule)
 	opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs, rd.sp.extraArgs...)
 	return opts
 }

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -58,7 +58,7 @@ func registerRubyPG(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		startOpts := option.DefaultStartOptsInMemory()
+		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// TODO(darrylwong): ruby-pg is currently being updated to run on Ubuntu 22.04.
 		// Once complete, fix up ruby_pg_helpers to accept a tls connection.

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -33,7 +33,7 @@ func registerRustPostgres(r registry.Registry) {
 		t.Status("setting up cockroach")
 
 		// We hardcode port 5433 since that's the port rust-postgres expects.
-		startOpts := option.DefaultStartOptsInMemory()
+		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		startOpts.RoachprodOpts.SQLPort = 5433
 		// rust-postgres currently doesn't support changing the config through
 		// the environment, which means we can't pass it ssl connection details

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -41,7 +41,7 @@ func registerSequelize(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -436,7 +436,7 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 	// TODO(DarrylWong): enable metamorphic contants once issue is resolved
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true")
-	startOpts := option.DefaultStartOptsNoBackups()
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 		"--vmodule=split_queue=2,store_rebalancer=2,allocator=2,replicate_queue=2,"+
 			"decider=3,replica_split_load=1",

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -123,7 +123,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Phew, after having setup all that, let's actually run the test.
 
 	t.Status("setting up cockroach")
-	c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+	c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 	version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 	if err != nil {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1455,8 +1455,8 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 
 	var db *gosql.DB
 	if b.SharedProcessMT {
-		startOpts = option.DefaultStartSharedVirtualClusterOpts(appTenantName)
-		c.StartServiceForVirtualCluster(ctx, t.L(), roachNodes, startOpts, settings, roachNodes)
+		startOpts = option.StartSharedVirtualClusterOpts(appTenantName)
+		c.StartServiceForVirtualCluster(ctx, t.L(), startOpts, settings)
 		db = c.Conn(ctx, t.L(), 1, option.VirtualClusterName(appTenantName))
 	} else {
 		db = c.Conn(ctx, t.L(), 1)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1457,7 +1457,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 	if b.SharedProcessMT {
 		startOpts = option.DefaultStartSharedVirtualClusterOpts(appTenantName)
 		c.StartServiceForVirtualCluster(ctx, t.L(), roachNodes, startOpts, settings, roachNodes)
-		db = c.Conn(ctx, t.L(), 1, option.TenantName(appTenantName))
+		db = c.Conn(ctx, t.L(), 1, option.VirtualClusterName(appTenantName))
 	} else {
 		db = c.Conn(ctx, t.L(), 1)
 	}

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -34,7 +34,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		disableStreamer bool,
 	) {
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(numNodes))
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.Range(1, numNodes-1))
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.Range(1, numNodes-1))
 
 		conn := c.Conn(ctx, t.L(), 1)
 		if disableStreamer {
@@ -53,7 +53,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 	restartCluster := func(ctx context.Context, c cluster.Cluster, t test.Test) {
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, numNodes-1))
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.Range(1, numNodes-1))
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.Range(1, numNodes-1))
 	}
 
 	// checkConcurrency returns an error if at least one node of the cluster

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -63,7 +63,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 	}
 
 	t.Status("starting nodes")
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), roachNodes)
 
 	m := c.NewMonitor(ctx, roachNodes)
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -520,7 +520,7 @@ func getTPCHVecWorkloadCmd(numRunsPerQuery, queryNum int, sharedProcessMT bool) 
 func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tpchVecTestCase) {
 	firstNode := c.Node(1)
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", firstNode)
-	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings())
 
 	var conn *gosql.DB
 	var disableMergeQueue bool

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -530,8 +530,8 @@ func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tp
 		if _, err := singleTenantConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
 			t.Fatal(err)
 		}
-		startOpts := option.DefaultStartSharedVirtualClusterOpts(appTenantName)
-		c.StartServiceForVirtualCluster(ctx, t.L(), c.All(), startOpts, install.MakeClusterSettings(), c.All())
+		startOpts := option.StartSharedVirtualClusterOpts(appTenantName)
+		c.StartServiceForVirtualCluster(ctx, t.L(), startOpts, install.MakeClusterSettings())
 		conn = c.Conn(ctx, t.L(), c.All().RandNode()[0], option.VirtualClusterName(appTenantName))
 	} else {
 		conn = c.Conn(ctx, t.L(), 1)

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -312,7 +312,7 @@ func (p *tpchVecPerfTest) postTestRunHook(
 				if p.sharedProcessMT() {
 					tenantName = appTenantName
 				}
-				tempConn, err := c.ConnE(ctx, t.L(), 1, option.TenantName(tenantName))
+				tempConn, err := c.ConnE(ctx, t.L(), 1, option.VirtualClusterName(tenantName))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -532,7 +532,7 @@ func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tp
 		}
 		startOpts := option.DefaultStartSharedVirtualClusterOpts(appTenantName)
 		c.StartServiceForVirtualCluster(ctx, t.L(), c.All(), startOpts, install.MakeClusterSettings(), c.All())
-		conn = c.Conn(ctx, t.L(), c.All().RandNode()[0], option.TenantName(appTenantName))
+		conn = c.Conn(ctx, t.L(), c.All().RandNode()[0], option.VirtualClusterName(appTenantName))
 	} else {
 		conn = c.Conn(ctx, t.L(), 1)
 		disableMergeQueue = true

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -44,7 +44,7 @@ func registerTypeORM(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		c.Start(ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB), install.MakeClusterSettings(), c.All())
 
 		cockroachVersion, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -221,7 +221,7 @@ func UsingRuntimeAssertions(t test.Test) bool {
 // if runtime assertions are enabled, and the default values otherwise.
 // A scheduled backup will not begin at the start of the roachtest.
 func maybeUseMemoryBudget(t test.Test, budget int) option.StartOpts {
-	startOpts := option.DefaultStartOptsNoBackups()
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
 	if UsingRuntimeAssertions(t) {
 		// When running tests with runtime assertions enabled, increase
 		// SQL's memory budget to avoid 'budget exceeded' failures.

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -292,7 +292,7 @@ func binaryUpgradeStep(
 ) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		if err := clusterupgrade.RestartNodesWithNewBinary(
-			ctx, t, t.L(), u.c, nodes, option.DefaultStartOptsNoBackups(), newVersion,
+			ctx, t, t.L(), u.c, nodes, option.NewStartOpts(option.NoBackupSchedule), newVersion,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -68,7 +68,7 @@ func registerYCSB(r registry.Registry) {
 		}
 
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, nodes))
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.Range(1, nodes))
 
 		db := c.Conn(ctx, t.L(), 1)
 		err := enableIsolationLevels(ctx, t, db)

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2940,6 +2940,21 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 	return nil
 }
 
+// allPublicAddrs returns a string that can be used when starting cockroach to
+// indicate the location of all nodes in the cluster.
+func (c *SyncedCluster) allPublicAddrs(ctx context.Context) (string, error) {
+	var addrs []string
+	for _, node := range c.Nodes {
+		port, err := c.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
+		if err != nil {
+			return "", err
+		}
+		addrs = append(addrs, fmt.Sprintf("%s:%d", c.Host(node), port))
+	}
+
+	return strings.Join(addrs, ","), nil
+}
+
 // GenFilenameFromArgs given a list of cmd args, returns an alphahumeric string up to
 // `maxLen` in length with hyphen delimiters, suitable for use in a filename.
 // e.g. ["/bin/bash", "-c", "'sudo dmesg > dmesg.txt'"] -> binbash-c-sudo-dmesg

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -562,7 +562,7 @@ const (
 	DefaultPassword = "cockroachdb"
 )
 
-// NodeURL constructs a postgres URL. If sharedTenantName is not empty, it will
+// NodeURL constructs a postgres URL. If virtualClusterName is not empty, it will
 // be used as the virtual cluster name in the URL. This is used to connect to a
 // shared process running services for multiple virtual clusters.
 func (c *SyncedCluster) NodeURL(

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -136,10 +136,11 @@ type StartOpts struct {
 	EncryptedStores bool
 
 	// -- Options that apply only to the StartServiceForVirtualCluster target --
-	VirtualClusterName string
-	VirtualClusterID   int
-	SQLInstance        int
-	StorageCluster     *SyncedCluster
+	VirtualClusterName     string
+	VirtualClusterID       int
+	VirtualClusterLocation string // where separate process virtual clusters will be started
+	SQLInstance            int
+	StorageCluster         *SyncedCluster
 }
 
 func (s *StartOpts) IsVirtualCluster() bool {

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -12,8 +12,6 @@ package roachprod
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -38,16 +36,7 @@ func StartServiceForVirtualCluster(
 		return err
 	}
 
-	var kvAddrs []string
-	for _, node := range sc.Nodes {
-		port, err := sc.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
-		if err != nil {
-			return err
-		}
-		kvAddrs = append(kvAddrs, fmt.Sprintf("%s:%d", sc.Host(node), port))
-	}
-	startOpts.KVAddrs = strings.Join(kvAddrs, ",")
-	startOpts.KVCluster = sc
+	startOpts.StorageCluster = sc
 
 	var startCluster *install.SyncedCluster
 	if externalCluster == "" {

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -25,7 +25,6 @@ import (
 func StartServiceForVirtualCluster(
 	ctx context.Context,
 	l *logger.Logger,
-	externalCluster string,
 	storageCluster string,
 	startOpts install.StartOpts,
 	clusterSettingsOpts ...install.ClusterSettingOption,
@@ -38,25 +37,21 @@ func StartServiceForVirtualCluster(
 
 	startOpts.StorageCluster = sc
 
-	var startCluster *install.SyncedCluster
-	if externalCluster == "" {
-		// If we are starting a service in shared process mode, `Start` is
-		// called on the storage cluster itself.
-		startCluster = sc
-	} else {
+	// If we are starting a service in shared process mode, `Start` is
+	// called on the storage cluster itself.
+	startCluster := sc
+
+	if startOpts.Target == install.StartServiceForVirtualCluster {
+		l.Printf("Starting SQL/HTTP instances for the virtual cluster")
 		// If we are starting a service in external process mode, `Start`
 		// is called on the nodes where the SQL server processed should be
 		// created.
-		ec, err := newCluster(l, externalCluster, clusterSettingsOpts...)
+		ec, err := newCluster(l, startOpts.VirtualClusterLocation, clusterSettingsOpts...)
 		if err != nil {
 			return err
 		}
 
 		startCluster = ec
-	}
-
-	if startOpts.Target == install.StartServiceForVirtualCluster {
-		l.Printf("Starting SQL/HTTP instances for the virtual cluster")
 	}
 	return startCluster.Start(ctx, l, startOpts)
 }


### PR DESCRIPTION
**roachtest: rename `TenantName` to `VirtualClusterName`**
This is a roachtest API; the renaming makes it more consistent with
the naming used by the roachprod API.

**roachprod: remove `KV*` fields from `StartOpts`**
Instead, use `StorageCluster` instead of `KVCluster` (for consistency
across the codebase). `KVAddrs` is also deprecated as a field, as it
can be generated on demand.

**roachtest: make startOpts customizations composable**
Previously, the `option` package would define a number of "default"
start options that could be used when starting cockroach: `NoBackups`,
to disable the roachprod backup schedule; `InMemory`, to start an
in-memory database; `SingleNode`, to skip initialization, etc. This
created a pattern where every different use would lead to the creation
of another method that used the default options except for _some_
setting.

This is less than ideal since it doesn't compose: if we wanted to
create start options to skip init *and* the backup schedule, one would
either need to create a new, bespoke function, or reach directly to
roachprod-level options in the test.

In this commit, we use the well established functional options
pattern, allowing the start options to easily compose. Instead of
writing:

```go
startOpts := option.DefaultStartOptsNoBackups()
```

we now write:

```go
startOpts := option.NewStartOpts(option.NoBackupSchedule)
```

The `NewStartOpts` function takes a list of options that customize the
start options generated.

**roachtest: simplify `StartServiceForVirtualCluster`**
This commit refactors the API exposed to tests when they want to
create virtual clusters. Specifically, we no longer require a "storage
cluster" when creating a shared process virtual cluster, and we also
make use of the functional options pattern introduced earlier in order
to allow the caller to customize where and how the virtual cluster is
to be deployed.

Callers can now create a new shared-process virtual cluster by using
`option.StartSharedVirtualClusterOpts`, which just takes a virtual
cluster name. For separate process tenants, there is
`option.StartVirtualClusterOpts` which takes the virtual cluster name
and the nodes where the SQL server should be deployed.

We also change the API so that callers are only required to pass a
"SQL instance" if the test is deploying more than one instance of the
same virtual cluster on the same node. The concept of "SQL instance"
is confusing and foreign to most engineers, and it only really matters
in the case of several instances of the same VC in the same node.