### PR TITLE
scripts: add `drtprod` wrapper for managing drt clusters

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# drtprod is a wrapper for roachprod for use when managing the long-lived DRT
+# clusters that ensures consistent use of the correct project-assignment vars
+# and done some additional sanity check enforcement on some flags.
+
+if [[ $1 == "start" ]]; then
+  if [[ "$*" != *"--secure"* ]]; then
+    echo "--secure is required when starting DRT clusters"
+    exit 1
+  fi
+  if [[ "$*" != *"--sql-port 26257"* ]]; then
+    # we don't use service discovery in our the drt project so use default port.
+    echo "--sql-port 26257 is required when starting DRT clusters"
+    exit 1
+  fi
+fi
+
+GCE_PROJECT=cockroach-drt  ROACHPROD_DNS="drt.crdb.io" roachprod "$@"


### PR DESCRIPTION
Release note: none.
Epic: none.