### PR TITLE
release-23.1: ui: improve db page nodes/regions query

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
@@ -69,9 +69,10 @@ const deriveDatabaseDetails = (
   isTenant: boolean,
 ): DatabasesPageDataDatabase => {
   const dbStats = dbDetails?.data?.results.stats;
-  const nodes = dbStats?.replicaData.replicas || [];
+  // TODO #118957 (xinhaoz) Use store id to regions mapping.
+  const stores = dbStats?.replicaData.storeIDs || [];
   const nodesByRegionString = getNodesByRegionString(
-    nodes,
+    stores,
     nodeRegionsByID,
     isTenant,
   );
@@ -86,7 +87,7 @@ const deriveDatabaseDetails = (
     name: database,
     spanStats: dbStats?.spanStats,
     tables: dbDetails?.data?.results.tablesResp,
-    nodes: nodes,
+    nodes: stores,
     nodesByRegionString,
     numIndexRecommendations,
   };

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
@@ -76,8 +76,7 @@ describe("DatabaseDetails sagas", () => {
           range_count: 20,
         },
         replicaData: {
-          replicas: [1, 2, 3],
-          regions: ["this", "is", "a", "region"],
+          storeIDs: [1, 2, 3],
         },
         indexStats: { num_index_recommendations: 4 },
       },

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -156,8 +156,7 @@ describe("rest api", function () {
           {
             rows: [
               {
-                replicas: [1, 2, 3],
-                regions: ["gcp-europe-west1", "gcp-europe-west2"],
+                store_ids: [1, 2, 3],
               },
             ],
           },

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -101,25 +101,6 @@ function stubGet(path: string, writer: $protobuf.Writer, prefix: string) {
   fetchMock.get(`${prefix}${path}`, writer.finish());
 }
 
-export function createMockDatabaseRangesForTable(
-  numRangesCreate: number,
-  numNodes: number,
-): clusterUiApi.DatabaseDetailsRow[] {
-  const res = [];
-  const replicas = [];
-  for (let i = 1; i <= numNodes; i++) {
-    replicas.push(i);
-  }
-  for (let i = 0; i < numRangesCreate; i++) {
-    res.push({
-      replicas: replicas,
-      regions: ["gcp-europe-west1", "gcp-europe-west2"],
-      range_size: 10,
-    });
-  }
-  return res;
-}
-
 export function stubSqlApiCall<T>(
   req: clusterUiApi.SqlExecutionRequest,
   mockTxnResults: mockSqlTxnResult<T>[],

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -246,16 +246,13 @@ describe("Databases Page", function () {
         {
           rows: [
             {
-              replicas: [1, 2, 3],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              store_ids: [1, 2, 3],
             },
             {
-              replicas: [1, 2, 3],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              store_ids: [1, 2, 3],
             },
             {
-              replicas: [1, 2, 3],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              store_ids: [1, 2, 3],
             },
           ],
         },


### PR DESCRIPTION
Backport 1/1 commits from #118904.

Release justification: bug fix

/cc @cockroachdb/release

---

This commit rewrites the query to fetch node and region information for a db
in the databases page in db-console. The runtime of the query is improved
by removing the expressions used to extract the region information in the
`replica_locality` column of the ranges table since this field was not used
in the client.

The function `createMockDatabaseRangesForTable` in `fakeApi.ts` is also
deleted as it has no callers.

Part of: #114690

Release note: None

-----------------------------------
https://www.loom.com/share/cec82ea6c26849e28cfea31d66fdc719
