### PR TITLE
tests: run more tests on `heavy` pool, skip some under `race`/`deadlock`

### DIFF
--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -185,7 +185,8 @@ func (t *testdir) dump() error {
 		}
 		if strings.Contains(cfg.Name, "5node") ||
 			strings.Contains(cfg.Name, "fakedist") ||
-			(strings.HasPrefix(cfg.Name, "local-") && !tplCfg.Ccl) {
+			(strings.HasPrefix(cfg.Name, "local-") && !tplCfg.Ccl) ||
+			(cfg.Name == "local" && !tplCfg.Ccl) {
 			tplCfg.UseHeavyPool = true
 		}
 		subdir := filepath.Join(t.dir, cfg.Name)

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/mvcc_statistics_update_job_test.go
+++ b/pkg/sql/mvcc_statistics_update_job_test.go
@@ -49,7 +49,7 @@ func TestTenantGlobalAggregatedLivebytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "test is too slow to run under stressrace")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
 	jobID := jobs.MVCCStatisticsJobID

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -561,6 +561,9 @@ INSERT INTO t.test VALUES (1,1), (2,2), (3,3)
 func TestRaceWithBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t, "very long-running test under deadlock")
+
 	// protects backfillNotification
 	var mu syncutil.Mutex
 	var backfillNotification chan struct{}

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -8,7 +8,10 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 48,
     tags = [
         "cpu:1",


### PR DESCRIPTION
These tests are having issues on the nightlies.

Epic: CRDB-8308
Release note: None