### PR TITLE
logictest: for sqlite logic tests, run only on `default` pool

### DIFF
--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
@@ -8,7 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "ccl_test",

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -272,7 +272,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
-    exec_properties = {{ if .UseHeavyPool }}select({
+    exec_properties = {{ if .SqliteLogicTest }}{"test.Pool": "default"},{{ else if .UseHeavyPool }}select({
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),{{ else }}{"test.Pool": "large"},{{ end }}

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:2",

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-mixed-23.1/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-mixed-23.1/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-mixed-23.2/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-read-committed/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-read-committed/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:1",

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -8,10 +8,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "default"},
     shard_count = 48,
     tags = [
         "cpu:1",


### PR DESCRIPTION
These tests don't actually run on remote execution so they never need
more resources than by default. If that changes, we can undo this
change.

Epic: [CRDB-8308](https://cockroachlabs.atlassian.net/browse/CRDB-8308)
Release note: None