### PR TITLE
builtins: simplify some telemetry business

### DIFF
--- a/pkg/sql/sem/builtins/builtinsregistry/builtins_registry.go
+++ b/pkg/sql/sem/builtins/builtinsregistry/builtins_registry.go
@@ -31,10 +31,6 @@ func Register(name string, props *tree.FunctionProperties, overloads []tree.Over
 	if _, exists := registry[name]; exists {
 		panic("duplicate builtin: " + name)
 	}
-	for i := range overloads {
-		var hook func()
-		overloads[i].OnTypeCheck = &hook
-	}
 	registry[name] = definition{
 		props:     props,
 		overloads: overloads,

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -210,10 +210,8 @@ type Overload struct {
 	// statement which will be executed as a common table expression in the query.
 	SQLFn SQLFnOverload
 
-	// OnTypeCheck is called every time this overload is type checked.
-	// This is a pointer so that it can be set in a builtinsregistry hook, which
-	// gets a copy of the overload struct.
-	OnTypeCheck *func()
+	// OnTypeCheck, if set, is called every time this overload is type checked.
+	OnTypeCheck func()
 
 	// SpecializedVecBuiltin is used to let the vectorized engine
 	// know when an Overload has a specialized vectorized operator.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1392,8 +1392,8 @@ func (expr *FuncExpr) TypeCheck(
 	if err := semaCtx.checkVolatility(overloadImpl.Volatility); err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s()", def.Name)
 	}
-	if overloadImpl.OnTypeCheck != nil && *overloadImpl.OnTypeCheck != nil {
-		(*overloadImpl.OnTypeCheck)()
+	if overloadImpl.OnTypeCheck != nil {
+		overloadImpl.OnTypeCheck()
 	}
 	return expr, nil
 }

--- a/pkg/sql/sqltelemetry/scalar.go
+++ b/pkg/sql/sqltelemetry/scalar.go
@@ -26,9 +26,9 @@ func BuiltinCounter(name, signature string) telemetry.Counter {
 
 func init() {
 	builtinsregistry.AddSubscription(func(name string, _ *tree.FunctionProperties, os []tree.Overload) {
-		for _, o := range os {
-			c := BuiltinCounter(name, o.Signature(false))
-			*o.OnTypeCheck = func() {
+		for i := range os {
+			c := BuiltinCounter(name, os[i].Signature(false))
+			os[i].OnTypeCheck = func() {
 				telemetry.Inc(c)
 			}
 		}


### PR DESCRIPTION
This commit removes one layer of indirection for `OnTypeCheck` callback that we set for each builtin for telemetry purposes. I believe there is no need to store the function by a pointer if we simply modify the original overload from the slice (rather than its copy). Additionally, we don't need to set this field on the main path since we already have non-nil check.

Epic: None

Release note: None