### PR TITLE
kv: add appBatchStats.numAddSST to handleRaftReadyStats.SafeFormat

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -696,6 +696,12 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 		}
 		p.SafeString(")")
 	}
+	if n := s.apply.numAddSST; n > 0 {
+		p.Printf(", apply-sst=%d", n)
+		if c := s.apply.numAddSSTCopies; c > 0 {
+			p.Printf(" (copies=%d)", c)
+		}
+	}
 	p.SafeString("]")
 
 	if n := s.apply.stateAssertions; n > 0 {

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -103,6 +103,8 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 				numEntriesProcessed:      2,
 				numEntriesProcessedBytes: 3,
 				numEmptyEntries:          5,
+				numAddSST:                3,
+				numAddSSTCopies:          1,
 			},
 			stateAssertions:      4,
 			numConfChangeEntries: 6,

--- a/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
+++ b/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
@@ -1,3 +1,3 @@
 echo
 ----
-raft ready handling: 5.00s [append=1.00s, apply=1.00s, sync=1.00s, snap=1.00s, other=1.00s], wrote [append-batch=5.0 KiB, append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied pebble stats: [commit-wait 17ms wal-q 5ms mem-stall 8ms l0-stall 11ms wal-rot 14ms sem 2ms]
+raft ready handling: 5.00s [append=1.00s, apply=1.00s, sync=1.00s, snap=1.00s, other=1.00s], wrote [append-batch=5.0 KiB, append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches), apply-sst=3 (copies=1)], state_assertions=4, snapshot applied pebble stats: [commit-wait 17ms wal-q 5ms mem-stall 8ms l0-stall 11ms wal-rot 14ms sem 2ms]


### PR DESCRIPTION
Fixes #120072.

This commit adds debug info about the number of SSTs ingested and the number of those ingestion which required file copies to `handleRaftReadyStats.SafeFormat`. This will improve debugging.

Release note: None