### PR TITLE
dev: more informative message on `dev lint --short`

### DIFF
--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -137,7 +137,9 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 		logCommand("bazel", args...)
 		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	} else if !short {
-		log.Printf("Skipping building cockroach-short with nogo due to provided test filter")
+		log.Printf("Skipping running extra lint checks with `nogo` due to provided test filter")
+	} else if short {
+		log.Printf("Skipping running extra lint checks with `nogo` due to --short")
 	}
 	return nil
 }


### PR DESCRIPTION
Here we weren't being clear about what work was being skipped when you pass `--short`. This should hopefully be clearer.

Also tweak the message if you pass a test filter.

See #119927

Epic: none
Release note: None