### PR TITLE
bulk: add exponential backoff to addSSTable

### DIFF
--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/mon",
+        "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",


### PR DESCRIPTION
Previously on retryable errors in addSSTable we'd retry immediately.  In cases where we're failing because a remote node is down, we're more likely to be successful if we retry only after some backoff. This commit adds an exponential backoff which retries 10 times, with max duration ~30 seconds. This should at least allow for the toleration of lease transfers with downed nodes.

Release note: None

Fixes: #120050