### PR TITLE
restore: don't pass user name and password to tpce connection

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -222,7 +222,7 @@ func registerOnlineRestore(r registry.Registry) {
 									if workloadDuration > maxWorkloadDuration {
 										workloadDuration = maxWorkloadDuration
 									}
-									fmt.Printf("let workload run for %.2f minutes", workloadDuration.Minutes())
+									t.L().Printf("let workload run for another %.2f minutes", workloadDuration.Minutes())
 									time.Sleep(workloadDuration)
 								}
 								return nil
@@ -403,7 +403,7 @@ func waitForDownloadJob(
 			}
 			if status == string(jobs.StatusSucceeded) {
 				postDownloadDelay := time.Minute
-				l.Printf("Download job completed; let workload run for %.2f minute", postDownloadDelay.Minutes())
+				l.Printf("Download job completed; let workload run for %.2f minute before proceeding", postDownloadDelay.Minutes())
 				time.Sleep(postDownloadDelay)
 				downloadJobEndTimeLowerBound = timeutil.Now().Add(-pollingInterval).Add(-postDownloadDelay)
 				return downloadJobEndTimeLowerBound, nil

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -745,7 +745,7 @@ func (tpce tpceRestore) init(
 	spec.init(ctx, t, c, tpceCmdOptions{
 		customers:      tpce.customers,
 		racks:          sp.nodes,
-		connectionOpts: defaultTPCEConnectionOpts(),
+		connectionOpts: tpceConnectionOpts{fixtureBucket: defaultFixtureBucket},
 	})
 }
 
@@ -759,7 +759,7 @@ func (tpce tpceRestore) run(
 		customers:      tpce.customers,
 		racks:          sp.nodes,
 		threads:        sp.cpus * sp.nodes,
-		connectionOpts: defaultTPCEConnectionOpts(),
+		connectionOpts: tpceConnectionOpts{fixtureBucket: defaultFixtureBucket},
 	})
 	return err
 }


### PR DESCRIPTION
After changing restore roachtests to run on insecure clusters #119774, the online restore tests began to flake because the tpce workload continued to assume that it was operating in a secure cluster. This patch fixes this bug.

Fixes #119805

Release note: none