### PR TITLE
opttester: add disable-check-expr flag

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -242,7 +242,10 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 			requiredCols.Add(t.Table.ColumnID(idx.Column(i).Ordinal()))
 		}
 		if !t.Cols.SubsetOf(requiredCols) {
-			panic(errors.AssertionFailedf("lookup join with columns that are not required"))
+			panic(errors.AssertionFailedf(
+				"lookup join with columns %s that are not required; required: %s",
+				t.Cols, requiredCols,
+			))
 		}
 		if t.IsFirstJoinInPairedJoiner {
 			switch t.JoinType {

--- a/pkg/sql/opt/testutils/opttester/explore_trace.go
+++ b/pkg/sql/opt/testutils/opttester/explore_trace.go
@@ -64,7 +64,7 @@ func (et *exploreTracer) Next() error {
 		panic("iteration already complete")
 	}
 
-	fo, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */, false /* disableCheckExpr */)
+	fo, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (et *exploreTracer) Next() error {
 }
 
 func (et *exploreTracer) restrictToExpr(path []memoLoc) opt.Expr {
-	fo2, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */, false /* disableCheckExpr */)
+	fo2, err := newForcingOptimizer(et.tester, et.steps, true /* ignoreNormRules */)
 	if err != nil {
 		// We should have already built the query successfully once.
 		panic(err)

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -57,10 +57,9 @@ type forcingOptimizer struct {
 
 // newForcingOptimizer creates a forcing optimizer that stops applying any rules
 // after <steps> rules are matched. If ignoreNormRules is true, normalization
-// rules don't count against this limit. If disableCheckExpr is true, expression
-// validation in CheckExpr will not run.
+// rules don't count against this limit.
 func newForcingOptimizer(
-	tester *OptTester, steps int, ignoreNormRules bool, disableCheckExpr bool,
+	tester *OptTester, steps int, ignoreNormRules bool,
 ) (*forcingOptimizer, error) {
 	fo := &forcingOptimizer{
 		remaining:   steps,
@@ -104,7 +103,7 @@ func newForcingOptimizer(
 		fo.groups.AddGroup(expr)
 	})
 
-	if disableCheckExpr {
+	if tester.Flags.DisableCheckExpr {
 		fo.o.Memo().DisableCheckExpr()
 	}
 

--- a/pkg/sql/opt/testutils/opttester/opt_steps.go
+++ b/pkg/sql/opt/testutils/opttester/opt_steps.go
@@ -109,7 +109,7 @@ func (os *optSteps) Next() error {
 		panic("iteration already complete")
 	}
 
-	fo, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */, true /* disableCheckExpr */)
+	fo, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (os *optSteps) Next() error {
 	} else if !os.Done() {
 		// The expression is not better, so suppress the lowest cost expressions
 		// so that the changed portions of the tree will be part of the output.
-		fo2, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */, true /* disableCheckExpr */)
+		fo2, err := newForcingOptimizer(os.tester, os.steps, false /* ignoreNormRules */)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### opttester: add disable-check-expr flag

This commit adds a flag for optimizer tests that skips the assertions in
`Memo.CheckExpr`. This is convenient for debugging.

Release note: None

#### opt: improve Memo.CheckExpr assertion failure message

This commit adds additional details to an assertion failure message in
`Memo.CheckExpr`.

Epic: None

Release note: None
