### PR TITLE
cluster-ui: fix rows written value on insights page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -154,7 +154,7 @@ export function makeStatementInsightsColumns(): ColumnDescriptor<StmtInsightEven
       title: insightsTableTitles.rowsProcessed(execType),
       className: cx("statements-table__col-rows-read"),
       cell: (item: StmtInsightEvent) =>
-        `${Count(item.rowsRead)} Reads / ${Count(item.rowsRead)} Writes`,
+        `${Count(item.rowsRead)} Reads / ${Count(item.rowsWritten)} Writes`,
       sort: (item: StmtInsightEvent) => item.rowsRead + item.rowsWritten,
       showByDefault: true,
     },


### PR DESCRIPTION
Rows written was incorrectly showing the value for rows read.
Now it will show the correct value for rows written.

Epic: none

Release note (bug fix): Fixes rows written value on insights page.