### PR TITLE
tests: move some tests to `heavy` pools in `race`, `deadlock`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -109,7 +109,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":streamingest"],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 16,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/server/storage_api/BUILD.bazel
+++ b/pkg/server/storage_api/BUILD.bazel
@@ -25,6 +25,10 @@ go_test(
         "rangelog_test.go",
         "ranges_test.go",
     ],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/build",

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -71,7 +71,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "default"},
     }),
     shard_count = 16,


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None