### PR TITLE
kvserver: don't propose lease change if unknown leader

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -125,17 +125,18 @@ type propBuf struct {
 }
 
 type rangeLeaderInfo struct {
+	// leader is the Raft group's leader. Equals 0 [roachpb.ReplicaID(raft.None)]
+	// if the leader is not known/set, in which case other fields are unset too.
+	leader roachpb.ReplicaID
 	// iAmTheLeader is set if the local replica is the leader.
 	iAmTheLeader bool
-	// leaderKnown is set if the local Raft machinery knows who the leader is. If
-	// not set, all other fields are empty.
-	leaderKnown bool
-	// leader represents the Raft group's leader. Not set if leaderKnown is not
-	// set.
-	leader roachpb.ReplicaID
 	// leaderEligibleForLease is set if the leader is known and its type of
 	// replica allows it to acquire a lease.
 	leaderEligibleForLease bool
+}
+
+func (r rangeLeaderInfo) leaderKnown() bool {
+	return r.leader != roachpb.ReplicaID(raft.None)
 }
 
 type admitEntHandle struct {
@@ -698,9 +699,8 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 		if li.iAmTheLeader {
 			return false
 		}
-		leaderKnownAndEligible := li.leaderKnown && li.leaderEligibleForLease
 		ownsCurrentLease := b.p.ownsValidLease(ctx, b.clock.NowAsClockTimestamp())
-		if leaderKnownAndEligible && !ownsCurrentLease && !b.testing.allowLeaseProposalWhenNotLeader {
+		if li.leaderEligibleForLease && !ownsCurrentLease && !b.testing.allowLeaseProposalWhenNotLeader {
 			log.VEventf(ctx, 2, "not proposing lease acquisition because we're not the leader; replica %d is",
 				li.leader)
 			b.p.rejectProposalWithRedirectLocked(ctx, p, li.leader)
@@ -720,7 +720,7 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 		// also send lease extensions for an existing leaseholder.
 		if ownsCurrentLease {
 			log.VEventf(ctx, 2, "proposing lease extension even though we're not the leader; we hold the current lease")
-		} else if !li.leaderKnown {
+		} else if !li.leaderKnown() {
 			log.VEventf(ctx, 2, "proposing lease acquisition even though we're not the leader; the leader is unknown")
 		} else {
 			log.VEventf(ctx, 2, "proposing lease acquisition even though we're not the leader; the leader is ineligible")
@@ -810,8 +810,7 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 func (b *propBuf) leaderStatusRLocked(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo {
 	leaderInfo := b.p.leaderStatus(ctx, raftGroup)
 	// Sanity check.
-	if leaderInfo.leaderKnown && leaderInfo.leader == b.p.getReplicaID() &&
-		!leaderInfo.iAmTheLeader {
+	if leaderInfo.leader == b.p.getReplicaID() && !leaderInfo.iAmTheLeader {
 		log.Fatalf(ctx,
 			"inconsistent Raft state: state %s while the current replica is also the lead: %d",
 			raftGroup.BasicStatus().RaftState, leaderInfo.leader)
@@ -1402,7 +1401,6 @@ func (rp *replicaProposer) leaderStatus(
 	}
 	return rangeLeaderInfo{
 		iAmTheLeader:           iAmTheLeader,
-		leaderKnown:            leaderKnown,
 		leader:                 roachpb.ReplicaID(leader),
 		leaderEligibleForLease: leaderEligibleForLease,
 	}

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -235,7 +235,6 @@ func (t *testProposer) leaderStatus(ctx context.Context, raftGroup proposerRaft)
 	}
 	return rangeLeaderInfo{
 		iAmTheLeader:           iAmTheLeader,
-		leaderKnown:            leaderKnown,
 		leader:                 leaderRep,
 		leaderEligibleForLease: leaderEligibleForLease,
 	}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -144,6 +144,18 @@ var LeaseCheckPreferencesOnAcquisitionEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
+// RejectLeaseOnLeaderUnknown controls whether a replica that does not know the
+// current raft leader rejects a lease request.
+//
+// TODO(pav-kv): flip the default to true, and remove this setting when this
+// becomes the only behaviour.
+var RejectLeaseOnLeaderUnknown = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.lease.reject_on_leader_unknown.enabled",
+	"reject lease requests on a replica that does not know the raft leader",
+	false,
+)
+
 var leaseStatusLogLimiter = func() *log.EveryN {
 	e := log.Every(15 * time.Second)
 	e.ShouldLog() // waste the first shot


### PR DESCRIPTION
Previously we could propose a lease change if the leader was unknown. This request could stall as we waited for the lease request to fail. Not knowing the leader means we can't immediately submit this lease proposal.

With this commit, lease requests are rejected immediately if the leader is not known. We rely on the client to retry requests until a new leader has been established.

This behaviour is behind the `kv.lease.reject_on_leader_unknown.enabled` cluster setting, currently off by default.

Epic: none
Touches #120073
Touches #118435