### PR TITLE
pkg/sql: skip TestTenantGlobalAggregatedLivebytes/external_secondary_tenants

### DIFF
--- a/pkg/sql/mvcc_statistics_update_job_test.go
+++ b/pkg/sql/mvcc_statistics_update_job_test.go
@@ -203,6 +203,9 @@ func TestTenantGlobalAggregatedLivebytes(t *testing.T) {
 	// Metrics should be exported for out-of-process secondary tenants, and are
 	// correct, i.e. sql_aggregated_livebytes in SQL = sum(livebytes in KV).
 	t.Run("external secondary tenants", func(t *testing.T) {
+		// Flaky test.
+		skip.WithIssue(t, 120775)
+
 		// Exact match for non stress tests, and allow values to differ by up to
 		// 5% in stress situations.
 		confidenceLevel := 0.0


### PR DESCRIPTION
Related to #120087 and #120775.

This commit skips the subtest as it seems to be quite flaky. We will unskip
this once we have figured out the cause.

Epic: none

Release note: None