### PR TITLE
sql: fix data race in hyrdration for table implicit record types

### DIFF
--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -204,7 +204,7 @@ func (v *tableImplicitRecordType) AsTypesT() *types.T {
 	typs := make([]*types.T, len(cols))
 	names := make([]string, len(cols))
 	for i, col := range cols {
-		typs[i] = col.GetType()
+		typs[i] = col.GetType().CopyForHydrate()
 		names[i] = col.GetName()
 	}
 	// the catalog.TypeDescriptor will be an alias to this Tuple type, which contains


### PR DESCRIPTION
This commit fixes a data race due to hydration for the implicit record type created for a table. The race was possible because while the record type was newly created in the `AsTypesT` method, its elements were not copied.

Fixes #120054

Release note: None