### PR TITLE
*: various storage engine open refactors

### DIFF
--- a/pkg/ccl/cliccl/debug.go
+++ b/pkg/ccl/cliccl/debug.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflagcfg"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -213,7 +214,7 @@ func runEncryptionStatus(cmd *cobra.Command, args []string) error {
 
 	dir := args[0]
 
-	db, err := cli.OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
+	db, err := cli.OpenEngine(dir, stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/cliccl/ear.go
+++ b/pkg/ccl/cliccl/ear.go
@@ -38,7 +38,7 @@ func runDecrypt(_ *cobra.Command, args []string) (returnErr error) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := cli.OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
+	db, err := cli.OpenEngine(dir, stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return errors.Wrap(err, "could not open store")
 	}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -175,11 +175,14 @@ func (f *keyFormat) Type() string {
 // OpenEngine opens the engine at 'dir'. Depending on the supplied options,
 // an empty engine might be initialized.
 func OpenEngine(
-	dir string, stopper *stop.Stopper, opts ...storage.ConfigOption,
+	dir string, stopper *stop.Stopper, rw fs.RWMode, opts ...storage.ConfigOption,
 ) (storage.Engine, error) {
 	maxOpenFiles, err := server.SetOpenFileLimitForOneStore()
 	if err != nil {
 		return nil, err
+	}
+	if rw == fs.ReadOnly {
+		opts = append(opts, storage.ReadOnly)
 	}
 	db, err := storage.Open(
 		context.Background(),
@@ -278,7 +281,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenEngine(args[0], stopper, storage.MustExist, storage.ReadOnly)
+	db, err := OpenEngine(args[0], stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}
@@ -462,7 +465,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenEngine(args[0], stopper, storage.ReadOnly, storage.MustExist)
+	db, err := OpenEngine(args[0], stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}
@@ -582,7 +585,7 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenEngine(args[0], stopper, storage.ReadOnly, storage.MustExist)
+	db, err := OpenEngine(args[0], stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}
@@ -751,7 +754,7 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenEngine(args[0], stopper, storage.ReadOnly, storage.MustExist)
+	db, err := OpenEngine(args[0], stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}
@@ -824,7 +827,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	db, err := OpenEngine(args[0], stopper, storage.ReadOnly, storage.MustExist)
+	db, err := OpenEngine(args[0], stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}
@@ -934,7 +937,7 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenEngine(args[0], stopper,
+	db, err := OpenEngine(args[0], stopper, fs.ReadWrite,
 		storage.MustExist,
 		storage.DisableAutomaticCompactions,
 		storage.MaxConcurrentCompactions(debugCompactOpts.maxConcurrency),
@@ -1255,7 +1258,7 @@ func runDebugIntentCount(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	defer stopper.Stop(ctx)
 
-	db, err := OpenEngine(args[0], stopper, storage.MustExist, storage.ReadOnly)
+	db, err := OpenEngine(args[0], stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -148,7 +149,7 @@ func checkStoreRangeStats(
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	eng, err := OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
+	eng, err := OpenEngine(dir, stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}
@@ -222,7 +223,7 @@ func checkStoreRaftState(
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	db, err := OpenEngine(dir, stopper, storage.MustExist, storage.ReadOnly)
+	db, err := OpenEngine(dir, stopper, fs.ReadOnly, storage.MustExist)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/strutil"
@@ -324,7 +325,7 @@ func runDebugDeadReplicaCollect(cmd *cobra.Command, args []string) error {
 	} else {
 		var stores []storage.Engine
 		for _, storeSpec := range debugRecoverCollectInfoOpts.Stores.Specs {
-			db, err := OpenEngine(storeSpec.Path, stopper, storage.MustExist, storage.ReadOnly)
+			db, err := OpenEngine(storeSpec.Path, stopper, fs.ReadOnly, storage.MustExist)
 			if err != nil {
 				return errors.WithHint(errors.Wrapf(err,
 					"failed to open store at path %q", storeSpec.Path),
@@ -811,7 +812,7 @@ func applyRecoveryToLocalStore(
 	batches := make(map[roachpb.StoreID]storage.Batch)
 	stores := make([]storage.Engine, len(debugRecoverExecuteOpts.Stores.Specs))
 	for i, storeSpec := range debugRecoverExecuteOpts.Stores.Specs {
-		store, err := OpenEngine(storeSpec.Path, stopper, storage.MustExist)
+		store, err := OpenEngine(storeSpec.Path, stopper, fs.ReadWrite, storage.MustExist)
 		if err != nil {
 			return errors.Wrapf(err, "failed to open store at path %q. ensure that store path is "+
 				"correct and that it is not used by another process", storeSpec.Path)

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
@@ -121,7 +122,7 @@ func runSyncer(
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	db, err := OpenEngine(dir, stopper)
+	db, err := OpenEngine(dir, stopper, fs.ReadWrite)
 	if err != nil {
 		if expSeq == 0 {
 			// Failed on first open, before we tried to corrupt anything. Hard stop.

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -72,11 +73,11 @@ func TestOpenReadOnlyStore(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("readOnly=%t", test.readOnly), func(t *testing.T) {
-			var opts []storage.ConfigOption
+			var rwMode fs.RWMode
 			if test.readOnly {
-				opts = append(opts, storage.ReadOnly)
+				rwMode = fs.ReadOnly
 			}
-			db, err := OpenEngine(storePath, stopper, opts...)
+			db, err := OpenEngine(storePath, stopper, rwMode)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -184,7 +184,6 @@ go_test(
         "//pkg/util/uint128",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -64,7 +64,6 @@ go_test(
     ],
     embed = [":rangefeed"],
     deps = [
-        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvpb",
@@ -74,6 +73,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/util",
@@ -90,7 +90,6 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
-        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -18,13 +18,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors/oserror"
-	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,6 +95,7 @@ func BenchmarkCatchUpScan(b *testing.B) {
 		"linear-keys": {
 			numKeys:    numKeys,
 			valueBytes: valueBytes,
+			rwMode:     fs.ReadWrite,
 		},
 		// random-keys is our worst case. We write keys in
 		// random order but with timestamps that keep marching
@@ -108,6 +108,7 @@ func BenchmarkCatchUpScan(b *testing.B) {
 			randomKeyOrder: true,
 			numKeys:        numKeys,
 			valueBytes:     valueBytes,
+			rwMode:         fs.ReadWrite,
 		},
 		// mixed-case is a middling case.
 		//
@@ -140,7 +141,7 @@ func BenchmarkCatchUpScan(b *testing.B) {
 			randomKeyOrder: true,
 			numKeys:        numKeys,
 			valueBytes:     valueBytes,
-			readOnlyEngine: true,
+			rwMode:         fs.ReadOnly,
 			lBaseMaxBytes:  256,
 		},
 	}
@@ -183,7 +184,7 @@ type benchDataOptions struct {
 	numKeys        int
 	valueBytes     int
 	randomKeyOrder bool
-	readOnlyEngine bool
+	rwMode         fs.RWMode
 	lBaseMaxBytes  int64
 	numRangeKeys   int
 }
@@ -199,23 +200,22 @@ type benchOptions struct {
 // code in pkg/storage.
 //
 
-type engineMaker func(testing.TB, string, int64, bool) storage.Engine
+type engineMaker func(testing.TB, string, int64, fs.RWMode) storage.Engine
 
-func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly bool) storage.Engine {
-	opts := storage.DefaultPebbleOptions()
-	opts.FS = vfs.Default
-	opts.LBaseMaxBytes = lBaseMaxBytes
-	opts.ReadOnly = readOnly
-	peb, err := storage.NewPebble(
+func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, rw fs.RWMode) storage.Engine {
+	opts := []storage.ConfigOption{storage.LBaseMaxBytes(lBaseMaxBytes)}
+	if rw == fs.ReadOnly {
+		opts = append(opts, storage.ReadOnly)
+	}
+	eng, err := storage.Open(
 		context.Background(),
-		storage.PebbleConfig{
-			StorageConfig: base.StorageConfig{Dir: dir, Settings: cluster.MakeTestingClusterSettings()},
-			Opts:          opts,
-		})
+		storage.Filesystem(dir),
+		cluster.MakeTestingClusterSettings(),
+		opts...)
 	if err != nil {
 		b.Fatalf("could not create new pebble instance at %s: %+v", dir, err)
 	}
-	return peb
+	return eng
 }
 
 // setupData data writes numKeys keys. One version of each key
@@ -224,9 +224,9 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 // and continuing to t=5ns*(numKeys+1). The goal of this is to
 // approximate an append-only type workload.
 //
-// A read-only engin can be returned if opts.readOnlyEngine is
-// set. The goal of this is to prevent read-triggered compactions that
-// might change the distribution of data across levels.
+// A read-only engine is returned if opts.rwMode is set to fs.ReadOnly. The goal
+// of this is to prevent read-triggered compactions that might change the
+// distribution of data across levels.
 //
 // The creation of the database is time consuming, especially for
 // larger numbers of versions. The database is persisted between runs
@@ -240,7 +240,7 @@ func setupData(
 		orderStr = "random"
 	}
 	readOnlyStr := ""
-	if opts.readOnlyEngine {
+	if opts.rwMode == fs.ReadOnly {
 		readOnlyStr = "_readonly"
 	}
 	loc := fmt.Sprintf("rangefeed_bench_data_%s_%s%s_%d_%d_%d_%d",
@@ -259,10 +259,10 @@ func setupData(
 	if exists {
 		log.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
 		testutils.ReadAllFiles(filepath.Join(loc, "*"))
-		return emk(b, loc, opts.lBaseMaxBytes, opts.readOnlyEngine), loc
+		return emk(b, loc, opts.lBaseMaxBytes, opts.rwMode), loc
 	}
 
-	eng := emk(b, loc, opts.lBaseMaxBytes, false)
+	eng := emk(b, loc, opts.lBaseMaxBytes, fs.ReadWrite)
 	log.Infof(ctx, "creating rangefeed benchmark data: %s", absPath)
 
 	// Generate the same data every time.
@@ -344,9 +344,9 @@ func setupData(
 		b.Fatal(err)
 	}
 
-	if opts.readOnlyEngine {
+	if opts.rwMode == fs.ReadOnly {
 		eng.Close()
-		eng = emk(b, loc, opts.lBaseMaxBytes, opts.readOnlyEngine)
+		eng = emk(b, loc, opts.lBaseMaxBytes, opts.rwMode)
 	}
 	return eng, loc
 }

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -16,6 +16,16 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
+// RWMode is an enum for whether a filesystem is read-write or read-only.
+type RWMode int8
+
+const (
+	// ReadWrite indicates a filesystem may be both read from and written to.
+	ReadWrite RWMode = iota
+	// ReadOnly indicates a filesystem is read-only.
+	ReadOnly
+)
+
 // CreateWithSync creates a file wrapped with logic to periodically sync
 // whenever more than bytesPerSync bytes accumulate. This syncing does not
 // provide any persistency guarantees, but can prevent latency spikes.

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -203,6 +203,14 @@ func MaxConcurrentCompactions(n int) ConfigOption {
 	}
 }
 
+// LBaseMaxBytes configures the maximum number of bytes for LBase.
+func LBaseMaxBytes(v int64) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.Opts.LBaseMaxBytes = v
+		return nil
+	}
+}
+
 // PebbleOptions contains Pebble-specific options in the same format as a
 // Pebble OPTIONS file. For example:
 // [Options]


### PR DESCRIPTION
These commits are in preparation for decoupling engine and filesystem initialization.

**cli: adjust OpenEngine to take a RWMode enum**

This commit adjusts OpenEngine to take a new fs.RWMode enum indicating whether
the engine should be opened in read-only mode or read-write mode. Previously,
callers could pass an optional storage.ReadOnly option to opt into read-only
mode. Future work will require the filesystem itself be opened in either
read-write or read-only mode, requiring the 'ReadOnly' flag not be a
configuration option for the Engine but for the filesystem environment.

**batcheval,rangefeed: use storage.Open**

Use storage.Open rather than NewPebble when constructing engines for
benchmarks. In future work, NewPebble will be unexported with Open remaining
the one means of opening new engines.