### PR TITLE
kv: bound minimum raft scheduler workers per store

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -467,26 +467,31 @@ func TestStoreConfigSetDefaultsNumStores(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testcases := map[string]struct {
-		conc        int
-		defaultConc int
-		numStores   int
-		expectConc  int
+		conc                   int
+		defaultConc            int
+		defaultMinConcPerStore int
+		numStores              int
+		expectConc             int
 	}{
-		"zero default is retained":         {defaultConc: 0, numStores: 4, expectConc: 0},
-		"negative default is retained":     {defaultConc: -1, numStores: 4, expectConc: -1},
-		"zero stores retains default":      {defaultConc: 4, expectConc: 4},
-		"explicit value not distributed":   {conc: 4, numStores: 2, expectConc: 4},
-		"explicit value overrides default": {conc: 4, defaultConc: 16, numStores: 2, expectConc: 4},
-		"default value is distributed":     {defaultConc: 16, numStores: 4, expectConc: 4},
-		"default value uses ceil division": {defaultConc: 16, numStores: 5, expectConc: 4},
-		"all stores have at least 1":       {defaultConc: 4, numStores: 10, expectConc: 1},
+		"zero default is retained":                            {defaultConc: 0, numStores: 4, expectConc: 0},
+		"negative default is retained":                        {defaultConc: -1, numStores: 4, expectConc: -1},
+		"zero stores retains default":                         {defaultConc: 4, expectConc: 4},
+		"explicit value not distributed":                      {conc: 4, numStores: 2, expectConc: 4},
+		"explicit value overrides default":                    {conc: 4, defaultConc: 16, numStores: 2, expectConc: 4},
+		"default value is distributed":                        {defaultConc: 16, numStores: 4, expectConc: 4},
+		"default value is distributed with per-store min":     {defaultConc: 16, defaultMinConcPerStore: 8, numStores: 4, expectConc: 8},
+		"default value uses ceil division":                    {defaultConc: 16, numStores: 5, expectConc: 4},
+		"default value uses ceil division with per-store min": {defaultConc: 16, defaultMinConcPerStore: 8, numStores: 5, expectConc: 8},
+		"all stores have at least 1":                          {defaultConc: 4, numStores: 10, expectConc: 1},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			defer func(original int) {
-				defaultRaftSchedulerConcurrency = original // restore global default
-			}(defaultRaftSchedulerConcurrency)
+			defer func(originalConc, originalMinConcPerStore int) {
+				defaultRaftSchedulerConcurrency = originalConc // restore global default
+				defaultRaftSchedulerMinConcurrencyPerStore = originalMinConcPerStore
+			}(defaultRaftSchedulerConcurrency, defaultRaftSchedulerMinConcurrencyPerStore)
 			defaultRaftSchedulerConcurrency = tc.defaultConc
+			defaultRaftSchedulerMinConcurrencyPerStore = tc.defaultMinConcPerStore
 			cfg := StoreConfig{RaftSchedulerConcurrency: tc.conc}
 			cfg.SetDefaults(tc.numStores)
 			require.Equal(t, tc.expectConc, cfg.RaftSchedulerConcurrency)


### PR DESCRIPTION
In a448edc2, we switched from replicating COCKROACH_SCHEDULER_CONCURRENCY on each store to evenly distributing the workers across each store. For example, in an 8-store, 32-vCPU node, the number of raft scheduler workers per store went from 96 to 12.

This was done to avoid scheduler thrashing and excessive memory usage in many-store nodes. Unfortunately, we have seen that this change could also lead to situations where workers were spread so thin across stores in a many-store system that any single store's worker pool could not keep up with temporary imbalanced load. In extreme cases where the `PreIngestDelay` mechanism is kicking in, this could lead to high scheduler latency across replica on the store.

This commit establishes an intermediate solution. We will continue to distribute workers across stores, but we will also ensure that each store has at least `COCKROACH_SCHEDULER_MIN_CONCURRENCY_PER_STORE` workers. This will prevents any single store from being able to absorb imbalanced load. The value defaults to `GOMAXPROCS`, so that in the previous example, each store would have at least 32 workers.

Epic: None

Release note (ops change): a minimum Raft scheduler concurrency is now enforced per store so that nodes with many stores do not spread workers too thin. This avoids high scheduler latency across replicas on a store when load is imbalanced.