### PR TITLE
sql: reserve tenant 2

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/span_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/span_builtins
@@ -26,7 +26,7 @@ skipif config 3node-tenant-default-configs
 query T
 SELECT crdb_internal.tenant_span('foo-bar')
 ----
-{"\\xfe8a","\\xfe8b"}
+{"\\xfe8b","\\xfe8c"}
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -40,9 +40,9 @@ ORDER BY id
 ----
 id  active  name
 1   true    system
-2   true    tenant-one
-3   true    two
-4   true    three
+3   true    tenant-one
+4   true    two
+5   true    three
 
 query ITTT colnames
 SHOW TENANT system
@@ -54,46 +54,46 @@ query ITTT colnames
 SHOW TENANT "tenant-one"
 ----
 id  name        data_state  service_mode
-2   tenant-one  ready       none
+3   tenant-one  ready       none
 
 query ITTT colnames
 SHOW TENANT "two"
 ----
 id  name  data_state  service_mode
-3   two   ready       none
+4   two   ready       none
 
 query ITTT colnames
 SHOW TENANT two
 ----
 id  name  data_state  service_mode
-3   two   ready       none
+4   two   ready       none
 
 query ITTT colnames
 SHOW TENANT three
 ----
 id  name   data_state  service_mode
-4   three  ready       none
+5   three  ready       none
 
 query ITTT colnames,rowsort
 SHOW TENANTS
 ----
 id  name        data_state  service_mode
 1   system      ready       shared
-2   tenant-one  ready       none
-3   two         ready       none
-4   three       ready       none
+3   tenant-one  ready       none
+4   two         ready       none
+5   three       ready       none
 
 statement error tenant name cannot be empty
-ALTER TENANT [4] RENAME TO ""
+ALTER TENANT [5] RENAME TO ""
 
 statement error tenant name cannot be NULL
-ALTER TENANT [4] RENAME TO NULL
+ALTER TENANT [5] RENAME TO NULL
 
 statement error invalid tenant name
-ALTER TENANT [4] RENAME TO "a.b"
+ALTER TENANT [5] RENAME TO "a.b"
 
 statement ok
-ALTER TENANT [4] RENAME TO blux
+ALTER TENANT [5] RENAME TO blux
 
 statement ok
 ALTER TENANT blux RENAME TO 'blix'
@@ -102,7 +102,7 @@ query ITTT colnames
 SELECT * FROM [SHOW TENANTS] WHERE id = 4
 ----
 id  name  data_state  service_mode
-4   blix  ready       none
+4   two   ready       none
 
 statement ok
 ALTER TENANT blix RENAME TO three
@@ -110,14 +110,14 @@ ALTER TENANT blix RENAME TO three
 query ITTT colnames
 SELECT * FROM [SHOW TENANTS] WHERE id = 4
 ----
-id  name   data_state  service_mode
-4   three  ready       none
+id  name  data_state  service_mode
+4   two   ready       none
 
 query ITTTT colnames
 SELECT id, name, data_state, service_mode, source_tenant_name FROM [SHOW TENANTS WITH REPLICATION STATUS] WHERE id = 4
 ----
-id  name   data_state  service_mode  source_tenant_name
-4   three  ready       none          NULL
+id  name  data_state  service_mode  source_tenant_name
+4   two   ready       none          NULL
 
 statement error tenant "seven" does not exist
 SHOW TENANT seven
@@ -163,7 +163,7 @@ FROM system.tenants WHERE name = 'four'
 ORDER BY id
 ----
 id  active  name
-5   true    four
+6   true    four
 
 statement ok
 DROP TENANT four
@@ -216,15 +216,15 @@ SHOW TENANTS
 ----
 id  name        data_state  service_mode
 1   system      ready       shared
-2   tenant-one  ready       none
-3   two         ready       none
-4   three       ready       none
+3   tenant-one  ready       none
+4   two         ready       none
+5   three       ready       none
 
 query ITTT colnames
 SHOW TENANT two
 ----
-id  name        data_state  service_mode
-3   two         ready       none
+id  name  data_state  service_mode
+4   two   ready       none
 
 user root
 
@@ -286,13 +286,13 @@ ORDER BY id
 ----
 id  active  name             deprecated_data_state  dropped_name
 1   true    system           READY                  ·
-2   true    tenant-one       READY                  ·
-3   true    two              READY                  ·
-4   true    three            READY                  ·
-5   false   NULL             DROP                   four
-6   false   NULL             DROP                   five-requiring-quotes
-7   false   NULL             DROP                   to-be-reclaimed
-8   true    to-be-reclaimed  READY                  ·
+3   true    tenant-one       READY                  ·
+4   true    two              READY                  ·
+5   true    three            READY                  ·
+6   false   NULL             DROP                   four
+7   false   NULL             DROP                   five-requiring-quotes
+8   false   NULL             DROP                   to-be-reclaimed
+9   true    to-be-reclaimed  READY                  ·
 
 # More valid tenant names.
 statement ok
@@ -305,13 +305,13 @@ SHOW TENANTS
 ----
 id  name             data_state  service_mode
 1   system           ready       shared
-2   tenant-one       ready       none
-3   two              ready       none
-4   three            ready       none
-8   to-be-reclaimed  ready       none
-9   1                ready       none
-10  a-b              ready       none
-11  hello-100        ready       none
+3   tenant-one       ready       none
+4   two              ready       none
+5   three            ready       none
+9   to-be-reclaimed  ready       none
+10  1                ready       none
+11  a-b              ready       none
+12  hello-100        ready       none
 
 subtest service_mode
 
@@ -345,13 +345,13 @@ SHOW TENANTS
 ----
 id  name             data_state  service_mode
 1   system           ready       shared
-2   tenant-one       ready       external
-3   two              ready       shared
-4   three            ready       none
-8   to-be-reclaimed  ready       none
-9   1                ready       none
-10  a-b              ready       none
-11  hello-100        ready       none
+3   tenant-one       ready       external
+4   two              ready       shared
+5   three            ready       none
+9   to-be-reclaimed  ready       none
+10  1                ready       none
+11  a-b              ready       none
+12  hello-100        ready       none
 
 statement ok
 ALTER TENANT two STOP SERVICE
@@ -364,13 +364,13 @@ SHOW TENANTS
 ----
 id  name             data_state  service_mode
 1   system           ready       shared
-2   tenant-one       ready       none
-3   two              ready       none
-4   three            ready       none
-8   to-be-reclaimed  ready       none
-9   1                ready       none
-10  a-b              ready       none
-11  hello-100        ready       none
+3   tenant-one       ready       none
+4   two              ready       none
+5   three            ready       none
+9   to-be-reclaimed  ready       none
+10  1                ready       none
+11  a-b              ready       none
+12  hello-100        ready       none
 
 statement ok
 DROP TENANT two

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -601,6 +601,12 @@ HAVING ($1 = '' OR NOT EXISTS (SELECT 1 FROM system.tenants t WHERE t.name = $1)
 	if uint64(lastIDFromSequence+1) > nextIDFromTable {
 		nextID = uint64(lastIDFromSequence + 1)
 	}
+	// ID 2 is reserved for future use: it was a "template" tenant in 23.2 UA and
+	// used for an internal test in serverless, so we can reclaim it if we want it
+	// so long as we don't allow it to be used for real tenants.
+	if nextID == 2 {
+		nextID = 3
+	}
 
 	return roachpb.MakeTenantID(nextID)
 }

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -112,8 +112,8 @@ func TestGetTenantIds(t *testing.T) {
 	}))
 	expectedIds := []roachpb.TenantID{
 		roachpb.MustMakeTenantID(1),
-		roachpb.MustMakeTenantID(2),
 		roachpb.MustMakeTenantID(3),
+		roachpb.MustMakeTenantID(4),
 	}
 	require.Equal(t, expectedIds, ids)
 
@@ -126,7 +126,7 @@ func TestGetTenantIds(t *testing.T) {
 	}))
 	expectedIds = []roachpb.TenantID{
 		roachpb.MustMakeTenantID(1),
-		roachpb.MustMakeTenantID(3),
+		roachpb.MustMakeTenantID(4),
 	}
 	require.Equal(t, expectedIds, ids)
 }


### PR DESCRIPTION
We might want this later and it is easier to reserve now than it will be then if we let 24.1 UA use it.

Release note: none.
Epic: none.