### PR TITLE
util/mon: require non-nil account

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -808,13 +808,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 
 	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
-
 	var memSize int64
-	defer func() {
-		if memSize != 0 {
-			mem.Shrink(ctx, memSize)
-		}
-	}()
 
 	if backupManifest == nil || forceReadBackupManifest {
 		backupManifest, memSize, err = b.readManifestOnResume(ctx, &mem, p.ExecCfg(), defaultStore,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1802,7 +1802,9 @@ func TestBackupRestoreResume(t *testing.T) {
 					t.Fatal(err)
 				}
 				if backupinfo.IsGZipped(backupManifestBytes) {
-					backupManifestBytes, err = backupinfo.DecompressData(ctx, nil, backupManifestBytes)
+					backupManifestBytes, err = backupinfo.DecompressData(
+						ctx, mon.NewStandaloneUnlimitedAccount(), backupManifestBytes,
+					)
 					require.NoError(t, err)
 				}
 				var backupManifest backuppb.BackupManifest
@@ -4082,7 +4084,9 @@ func TestBackupRestoreChecksum(t *testing.T) {
 			t.Fatalf("%+v", err)
 		}
 		if backupinfo.IsGZipped(backupManifestBytes) {
-			backupManifestBytes, err = backupinfo.DecompressData(context.Background(), nil, backupManifestBytes)
+			backupManifestBytes, err = backupinfo.DecompressData(
+				context.Background(), mon.NewStandaloneUnlimitedAccount(), backupManifestBytes,
+			)
 			require.NoError(t, err)
 		}
 		if err := protoutil.Unmarshal(backupManifestBytes, &backupManifest); err != nil {
@@ -8485,7 +8489,7 @@ func TestIncorrectAccessOfFilesInBackupMetadata(t *testing.T) {
 	manifestPath := matches[0]
 	manifestData, err := os.ReadFile(manifestPath)
 	require.NoError(t, err)
-	manifestData, err = backupinfo.DecompressData(context.Background(), nil, manifestData)
+	manifestData, err = backupinfo.DecompressData(context.Background(), mon.NewStandaloneUnlimitedAccount(), manifestData)
 	require.NoError(t, err)
 	var backupManifest backuppb.BackupManifest
 	require.NoError(t, protoutil.Unmarshal(manifestData, &backupManifest))
@@ -8531,7 +8535,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 	manifestPath := filepath.Join(rawDir, "cross_version", backupbase.BackupMetadataName)
 	manifestData, err := os.ReadFile(manifestPath)
 	require.NoError(t, err)
-	manifestData, err = backupinfo.DecompressData(context.Background(), nil, manifestData)
+	manifestData, err = backupinfo.DecompressData(context.Background(), mon.NewStandaloneUnlimitedAccount(), manifestData)
 	require.NoError(t, err)
 	var backupManifest backuppb.BackupManifest
 	require.NoError(t, protoutil.Unmarshal(manifestData, &backupManifest))
@@ -10733,7 +10737,9 @@ func TestBackupDoNotIncludeViewSpans(t *testing.T) {
 			t.Fatalf("%+v", err)
 		}
 		if backupinfo.IsGZipped(backupManifestBytes) {
-			backupManifestBytes, err = backupinfo.DecompressData(context.Background(), nil, backupManifestBytes)
+			backupManifestBytes, err = backupinfo.DecompressData(
+				context.Background(), mon.NewStandaloneUnlimitedAccount(), backupManifestBytes,
+			)
 			require.NoError(t, err)
 		}
 		if err := protoutil.Unmarshal(backupManifestBytes, &backupManifest); err != nil {

--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
 )
@@ -314,7 +315,7 @@ func testingReadBackupManifest(
 		return nil, err
 	}
 	if backupinfo.IsGZipped(bytes) {
-		descBytes, err := backupinfo.DecompressData(ctx, nil, bytes)
+		descBytes, err := backupinfo.DecompressData(ctx, mon.NewStandaloneUnlimitedAccount(), bytes)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -404,11 +404,13 @@ func makeBackupMetadata(
 ) ([]backuppb.BackupManifest, backupinfo.LayerToBackupManifestFileIterFactory, error) {
 
 	execCfg := flowCtx.Cfg.ExecutorConfig.(*sql.ExecutorConfig)
+	memAcc := flowCtx.EvalCtx.Planner.Mon().MakeBoundAccount()
+	defer memAcc.Close(ctx)
 
 	kmsEnv := backupencryption.MakeBackupKMSEnv(execCfg.Settings, &execCfg.ExternalIODirConfig,
 		execCfg.InternalDB, spec.User())
 
-	backupManifests, _, err := backupinfo.LoadBackupManifestsAtTime(ctx, nil, spec.URIs,
+	backupManifests, _, err := backupinfo.LoadBackupManifestsAtTime(ctx, &memAcc, spec.URIs,
 		spec.User(), execCfg.DistSQLSrv.ExternalStorageFromURI, spec.Encryption, &kmsEnv, spec.EndTime)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -543,6 +543,9 @@ func restore(
 // can't be restored because the necessary tables are missing are omitted; if
 // skip_missing_foreign_keys was set, we should have aborted the RESTORE and
 // returned an error prior to this.
+//
+// The caller is responsible for shrinking `mem` by the returned size once it's
+// done with the returned manifests (unless an error is returned).
 // TODO(anzoteh96): this method returns two things: backup manifests
 // and the descriptors of the relevant manifests. Ideally, this should
 // be broken down into two methods.
@@ -553,12 +556,23 @@ func loadBackupSQLDescs(
 	details jobspb.RestoreDetails,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
-) ([]backuppb.BackupManifest, backuppb.BackupManifest, []catalog.Descriptor, int64, error) {
+) (
+	_ []backuppb.BackupManifest,
+	_ backuppb.BackupManifest,
+	_ []catalog.Descriptor,
+	memSize int64,
+	retErr error,
+) {
 	backupManifests, sz, err := backupinfo.LoadBackupManifestsAtTime(ctx, mem, details.URIs,
 		p.User(), p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, encryption, kmsEnv, details.EndTime)
 	if err != nil {
 		return nil, backuppb.BackupManifest{}, nil, 0, err
 	}
+	defer func() {
+		if retErr != nil {
+			mem.Shrink(ctx, sz)
+		}
+	}()
 
 	layerToBackupManifestFileIterFactory, err := backupinfo.GetBackupManifestIterFactories(ctx, p.ExecCfg().DistSQLSrv.ExternalStorage,
 		backupManifests, encryption, kmsEnv)
@@ -592,7 +606,6 @@ func loadBackupSQLDescs(
 	}
 	activeVersion := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
 	if err := maybeUpgradeDescriptors(activeVersion, sqlDescs, true /* skipFKsWithNoMatchingTable */); err != nil {
-		mem.Shrink(ctx, sz)
 		return nil, backuppb.BackupManifest{}, nil, 0, err
 	}
 
@@ -1734,9 +1747,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		return r.doDownloadFiles(ctx, p)
 	}
 
-	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
-	defer mem.Close(ctx)
-
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_load_descriptors_from_backup"); err != nil {
 		return err
 	}
@@ -1747,7 +1757,11 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		p.ExecCfg().InternalDB,
 		p.User(),
 	)
-	backupManifests, latestBackupManifest, sqlDescs, memSize, err := loadBackupSQLDescs(
+	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
+	defer mem.Close(ctx)
+	// Note that we ignore memSize because the memory account is closed in a
+	// defer anyway.
+	backupManifests, latestBackupManifest, sqlDescs, _, err := loadBackupSQLDescs(
 		ctx, &mem, p, details, details.Encryption, &kmsEnv,
 	)
 	if err != nil {
@@ -1756,9 +1770,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err := r.validateJobIsResumable(ctx, p.ExecCfg(), backupManifests); err != nil {
 		return err
 	}
-	defer func() {
-		mem.Shrink(ctx, memSize)
-	}()
 	backupCodec, err := backupinfo.MakeBackupCodec(backupManifests)
 	if err != nil {
 		return err

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
@@ -233,7 +234,7 @@ func getSpansFromManifest(ctx context.Context, t *testing.T, backupPath string) 
 	backupManifestBytes, err := os.ReadFile(backupPath + "/" + backupbase.BackupManifestName)
 	require.NoError(t, err)
 	var backupManifest backuppb.BackupManifest
-	decompressedBytes, err := backupinfo.DecompressData(ctx, nil, backupManifestBytes)
+	decompressedBytes, err := backupinfo.DecompressData(ctx, mon.NewStandaloneUnlimitedAccount(), backupManifestBytes)
 	require.NoError(t, err)
 	require.NoError(t, protoutil.Unmarshal(decompressedBytes, &backupManifest))
 	spans := make([]roachpb.Span, 0, len(backupManifest.Files))

--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/storageccl/encryption.go
+++ b/pkg/ccl/storageccl/encryption.go
@@ -186,7 +186,7 @@ func (e *encWriter) flush() error {
 
 // DecryptFile decrypts a file encrypted by EncryptFile, using the supplied key
 // and reading the IV from a prefix of the file. See comments on EncryptFile
-// for intended usage, and see DecryptFile
+// for intended usage, and see DecryptFile.
 func DecryptFile(
 	ctx context.Context, ciphertext, key []byte, mm *mon.BoundAccount,
 ) ([]byte, error) {

--- a/pkg/ccl/storageccl/encryption_test.go
+++ b/pkg/ccl/storageccl/encryption_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestEncryptDecrypt(t *testing.T) {
 						require.NoError(t, err)
 						require.True(t, AppearsEncrypted(ciphertext), "cipher text should appear encrypted")
 
-						decrypted, err := DecryptFile(context.Background(), ciphertext, key, nil /* mm */)
+						decrypted, err := DecryptFile(context.Background(), ciphertext, key, mon.NewStandaloneUnlimitedAccount())
 						require.NoError(t, err)
 						require.Equal(t, plaintext, decrypted)
 					})
@@ -53,7 +54,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	})
 
 	t.Run("helpful error on bad input", func(t *testing.T) {
-		_, err := DecryptFile(context.Background(), []byte("a"), key, nil /* mm */)
+		_, err := DecryptFile(context.Background(), []byte("a"), key, mon.NewStandaloneUnlimitedAccount())
 		require.EqualError(t, err, "file does not appear to be encrypted")
 	})
 
@@ -162,7 +163,7 @@ func TestEncryptDecrypt(t *testing.T) {
 					plaintext := randutil.RandBytes(rng, rng.Intn(1024*32))
 					ciphertext, err := EncryptFile(plaintext, key)
 					require.NoError(t, err)
-					decrypted, err := DecryptFile(context.Background(), ciphertext, key, nil /* mm */)
+					decrypted, err := DecryptFile(context.Background(), ciphertext, key, mon.NewStandaloneUnlimitedAccount())
 					require.NoError(t, err)
 					if len(plaintext) == 0 {
 						require.Equal(t, len(plaintext), len(decrypted))

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -56,7 +56,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 	diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
-	budget := newBudget(nil /* acc */, math.MaxInt /* limitBytes */)
+	budget := newBudget(mon.NewStandaloneUnlimitedAccount(), math.MaxInt /* limitBytes */)
 	diskBuffer := TestResultDiskBufferConstructor(tempEngine, diskMonitor)
 	b := newInOrderResultsBuffer(budget, diskBuffer)
 	defer b.close(ctx)

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -115,7 +115,9 @@ func TestInOrderResultsBuffer(t *testing.T) {
 			b.Lock()
 			numToAdd := rng.Intn(len(addOrder)) + 1
 			for i := 0; i < numToAdd; i++ {
-				b.addLocked(results[addOrder[0]])
+				r := results[addOrder[0]]
+				require.NoError(t, budget.consumeLocked(ctx, r.memoryTok.toRelease, false /* allowDebt */))
+				b.addLocked(r)
 				addOrder = addOrder[1:]
 			}
 			b.doneAddingLocked(ctx)

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -83,7 +83,7 @@ func TestStreamerLimitations(t *testing.T) {
 	s := srv.ApplicationLayer()
 
 	getStreamer := func() *kvstreamer.Streamer {
-		return getStreamer(ctx, s, math.MaxInt64, nil /* acc */)
+		return getStreamer(ctx, s, math.MaxInt64, mon.NewStandaloneUnlimitedAccount())
 	}
 
 	t.Run("non-unique requests unsupported", func(t *testing.T) {
@@ -437,7 +437,7 @@ func TestStreamerEmptyScans(t *testing.T) {
 	require.NoError(t, err)
 
 	getStreamer := func() *kvstreamer.Streamer {
-		s := getStreamer(ctx, ts, math.MaxInt64, nil /* acc */)
+		s := getStreamer(ctx, ts, math.MaxInt64, mon.NewStandaloneUnlimitedAccount())
 		// There are two column families in the table.
 		s.Init(kvstreamer.OutOfOrder, kvstreamer.Hints{UniqueRequests: true}, 2 /* maxKeysPerRow */, nil /* diskBuffer */)
 		return s

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -126,8 +126,8 @@ type EvalContext interface {
 
 	// GetResponseMemoryAccount returns a memory account to be used when
 	// generating BatchResponses. Currently only used for MVCC scans, and only
-	// non-nil on those paths (a nil account is safe to use since it functions
-	// as an unlimited account).
+	// non-nil on those paths (a nil account is replaced with standalone
+	// unlimited one later).
 	GetResponseMemoryAccount() *mon.BoundAccount
 
 	GetMaxBytes(context.Context) int64

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -467,8 +467,9 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 
 	for retries := 0; ; retries++ {
 		if retries > 0 {
-			// It is safe to call Clear on an uninitialized BoundAccount.
-			boundAccount.Clear(ctx)
+			if boundAccount != nil {
+				boundAccount.Clear(ctx)
+			}
 			log.VEventf(ctx, 2, "server-side retry of batch")
 		}
 		now := timeutil.Now()

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -296,8 +296,8 @@ func deserializeColumnarBatchesFromArrow(
 		ctx,
 		// This allocator is not connected to the memory accounting system since
 		// the accounting for these batches will be done by the SQL client, so
-		// we pass nil here.
-		nil, /* unlimitedAcc */
+		// we pass a standalone unlimited account here.
+		mon.NewStandaloneUnlimitedAccount(), /* unlimitedAcc */
 		// It'll be the responsibility of the SQL client to update the
 		// datum-backed vectors with the eval context, so we use the factory
 		// with no eval context.

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/netutil",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/sql/distsql/setup_flow_after_drain_test.go
+++ b/pkg/sql/distsql/setup_flow_after_drain_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 // Test that we can send a setup flow request to the distSQLSrv after the
@@ -39,7 +40,7 @@ func TestSetupFlowAfterDrain(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	cfg := s.DistSQLServer().(*ServerImpl).ServerConfig
 
-	remoteFlowRunner := flowinfra.NewRemoteFlowRunner(cfg.AmbientContext, cfg.Stopper, nil /* acc */)
+	remoteFlowRunner := flowinfra.NewRemoteFlowRunner(cfg.AmbientContext, cfg.Stopper, mon.NewStandaloneUnlimitedAccount())
 	remoteFlowRunner.Init(cfg.Metrics)
 	distSQLSrv := NewServer(
 		ctx,

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1598,10 +1598,6 @@ func EncodeSecondaryIndexes(
 	if len(secondaryIndexEntries) > 0 {
 		panic(errors.AssertionFailedf("length of secondaryIndexEntries was non-zero"))
 	}
-
-	if indexBoundAccount == nil || indexBoundAccount.Monitor() == nil {
-		panic(errors.AssertionFailedf("memory monitor passed to EncodeSecondaryIndexes was nil"))
-	}
 	const sizeOfIndexEntry = int64(unsafe.Sizeof(IndexEntry{}))
 
 	for i := range indexes {

--- a/pkg/sql/schemachanger/corpus/BUILD.bazel
+++ b/pkg/sql/schemachanger/corpus/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/testutils/skip",
+        "//pkg/util/mon",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/schemachanger/corpus/corpus_test.go
+++ b/pkg/sql/schemachanger/corpus/corpus_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,7 +52,9 @@ func TestValidateCorpuses(t *testing.T) {
 				SchemaChangerJobIDSupplier: func() jobspb.JobID {
 					jobID++
 					return jobID
-				}})
+				},
+				MemAcc: mon.NewStandaloneUnlimitedAccount(),
+			})
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -71,13 +71,13 @@ func Build(
 
 	// localMemAcc tracks memory allocations for local objects.
 	var localMemAcc *mon.BoundAccount
-	defer func() {
-		localMemAcc.Clear(ctx)
-	}()
 	if monitor := memAcc.Monitor(); monitor != nil {
 		acc := monitor.MakeBoundAccount()
 		localMemAcc = &acc
+	} else {
+		localMemAcc = mon.NewStandaloneUnlimitedAccount()
 	}
+	defer localMemAcc.Clear(ctx)
 	bs := newBuilderState(ctx, dependencies, incumbent, localMemAcc)
 	els := newEventLogState(dependencies, incumbent, n)
 

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -171,7 +171,7 @@ func run(
 			stmts, err := parser.Parse(d.Input)
 			require.NoError(t, err)
 			for i := range stmts {
-				output, logSchemaChangesFn, err = scbuild.Build(ctx, deps, output, stmts[i].AST, nil /* memAcc */)
+				output, logSchemaChangesFn, err = scbuild.Build(ctx, deps, output, stmts[i].AST, mon.NewStandaloneUnlimitedAccount())
 				require.NoErrorf(t, err, "%s: %s", d.Pos, stmts[i].SQL)
 				require.NoError(t, logSchemaChangesFn(ctx))
 			}
@@ -185,7 +185,7 @@ func run(
 			require.NotEmpty(t, stmts)
 
 			for _, stmt := range stmts {
-				_, _, err = scbuild.Build(ctx, deps, scpb.CurrentState{}, stmt.AST, nil /* memAcc */)
+				_, _, err = scbuild.Build(ctx, deps, scpb.CurrentState{}, stmt.AST, mon.NewStandaloneUnlimitedAccount())
 				expected := scerrors.NotImplementedError(nil)
 				require.Errorf(t, err, "%s: expected %T instead of success for", stmt.SQL, expected)
 				require.Truef(t, scerrors.HasNotImplemented(err), "%s: expected %T instead of %v", stmt.SQL, expected, err)

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -186,6 +186,9 @@ func ProtoDiff(a, b protoutil.Message, args DiffArgs, rewrites ...func(interface
 func MakePlan(
 	t *testing.T, state scpb.CurrentState, phase scop.Phase, memAcc *mon.BoundAccount,
 ) scplan.Plan {
+	if memAcc == nil {
+		memAcc = mon.NewStandaloneUnlimitedAccount()
+	}
 	plan, err := scplan.MakePlan(context.Background(), state, scplan.Params{
 		Ctx:                        context.Background(),
 		ActiveVersion:              clusterversion.TestingClusterVersion,

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -100,6 +100,7 @@ go_test(
         "//pkg/util/iterutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_golang_mock//gomock",

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
@@ -368,7 +369,7 @@ func TestSchemaChanger(t *testing.T) {
 				parsed, err := parser.Parse("ALTER TABLE db.foo ADD COLUMN j INT")
 				require.NoError(t, err)
 				require.Len(t, parsed, 1)
-				cs, logSchemaChangesFn, err = scbuild.Build(ctx, buildDeps, scpb.CurrentState{}, parsed[0].AST.(*tree.AlterTable), nil /* memAcc */)
+				cs, logSchemaChangesFn, err = scbuild.Build(ctx, buildDeps, scpb.CurrentState{}, parsed[0].AST.(*tree.AlterTable), mon.NewStandaloneUnlimitedAccount())
 				require.NoError(t, err)
 				require.NoError(t, logSchemaChangesFn(ctx))
 				{

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -83,7 +83,7 @@ func TestPlanDataDriven(t *testing.T) {
 					var state scpb.CurrentState
 					var logSchemaChangesFn scbuild.LogSchemaChangerEventsFn
 					for i := range stmts {
-						state, logSchemaChangesFn, err = scbuild.Build(ctx, deps, state, stmts[i].AST, nil /* memAcc */)
+						state, logSchemaChangesFn, err = scbuild.Build(ctx, deps, state, stmts[i].AST, mon.NewStandaloneUnlimitedAccount())
 						require.NoError(t, err)
 						require.NoError(t, logSchemaChangesFn(ctx))
 					}
@@ -106,7 +106,7 @@ func TestPlanDataDriven(t *testing.T) {
 					stmt := stmts[0]
 					alter, ok := stmt.AST.(*tree.AlterTable)
 					require.Truef(t, ok, "not an ALTER TABLE statement: %s", stmt.SQL)
-					_, _, err = scbuild.Build(ctx, deps, scpb.CurrentState{}, alter, nil /* memAcc */)
+					_, _, err = scbuild.Build(ctx, deps, scpb.CurrentState{}, alter, mon.NewStandaloneUnlimitedAccount())
 					require.Truef(t, scerrors.HasNotImplemented(err), "expected unimplemented, got %v", err)
 				})
 				return ""
@@ -270,7 +270,7 @@ func TestExplainPlanIsMemoryMonitored(t *testing.T) {
 	sctestutils.WithBuilderDependenciesFromTestServer(tt, nodeID, func(dependencies scbuild.Dependencies) {
 		stmt, err := parser.ParseOne(`DROP DATABASE defaultdb CASCADE`)
 		require.NoError(t, err)
-		incumbent, logSchemaChangesFn, err = scbuild.Build(ctx, dependencies, scpb.CurrentState{}, stmt.AST, nil /* memAcc */)
+		incumbent, logSchemaChangesFn, err = scbuild.Build(ctx, dependencies, scpb.CurrentState{}, stmt.AST, mon.NewStandaloneUnlimitedAccount())
 		require.NoError(t, err)
 		require.NoError(t, logSchemaChangesFn(ctx))
 	})

--- a/pkg/sql/schemachanger/scrun/BUILD.bazel
+++ b/pkg/sql/schemachanger/scrun/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -82,6 +83,7 @@ func runTransactionPhase(
 		ExecutionPhase:             phase,
 		SchemaChangerJobIDSupplier: deps.TransactionalJobRegistry().SchemaChangerJobID,
 		SkipPlannerSanityChecks:    !enforcePlannerSanityCheck.Get(&deps.ClusterSettings().SV),
+		MemAcc:                     mon.NewStandaloneUnlimitedAccount(),
 	})
 	if err != nil {
 		return scpb.CurrentState{}, jobspb.InvalidJobID, err
@@ -269,6 +271,7 @@ func makePostCommitPlan(
 		SchemaChangerJobIDSupplier: func() jobspb.JobID { return jobID },
 		SkipPlannerSanityChecks:    true,
 		InRollback:                 state.InRollback,
+		MemAcc:                     mon.NewStandaloneUnlimitedAccount(),
 	})
 }
 

--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -277,6 +278,7 @@ func checkExplainDiagrams(
 		ActiveVersion:              clusterversion.TestingClusterVersion,
 		ExecutionPhase:             scop.StatementPhase,
 		SchemaChangerJobIDSupplier: func() jobspb.JobID { return 1 },
+		MemAcc:                     mon.NewStandaloneUnlimitedAccount(),
 	}
 	if inRollback {
 		params.InRollback = true
@@ -320,7 +322,7 @@ func execStatementWithTestDeps(
 		deps.IncrementPhase()
 		deps.LogSideEffectf("# begin %s", deps.Phase())
 		for _, stmt := range stmts {
-			state, logSchemaChangesFn, err = scbuild.Build(ctx, deps, state, stmt.AST, nil /* memAcc */)
+			state, logSchemaChangesFn, err = scbuild.Build(ctx, deps, state, stmt.AST, mon.NewStandaloneUnlimitedAccount())
 			require.NoError(t, err, "error in builder")
 			require.NoError(t, logSchemaChangesFn(ctx), "error generating event log entries")
 			stateAfterBuildingEachStatement = append(stateAfterBuildingEachStatement, state)

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -438,8 +438,10 @@ func mvccScanToCols(
 
 	// Try to use the same root monitor (from the store) if the account is
 	// provided.
-	monitor := opts.MemoryAccount.Monitor()
-	if monitor == nil {
+	var monitor *mon.BytesMonitor
+	if opts.MemoryAccount != nil {
+		monitor = opts.MemoryAccount.Monitor()
+	} else {
 		// If we don't have the monitor, then we create a "fake" one that is not
 		// connected to the memory accounting system.
 		monitor = mon.NewMonitor(mon.Options{

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1532,12 +1532,17 @@ func mvccGetWithValueHeader(
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
 	defer mvccScanner.release()
 
+	memAccount := opts.MemoryAccount
+	if memAccount == nil {
+		memAccount = mon.NewStandaloneUnlimitedAccount()
+	}
+
 	// MVCCGet is implemented as an MVCCScan where we retrieve a single key. We
 	// specify an empty key for the end key which will ensure we don't retrieve a
 	// key different than the start key. This is a bit of a hack.
 	*mvccScanner = pebbleMVCCScanner{
 		parent:           iter,
-		memAccount:       opts.MemoryAccount,
+		memAccount:       memAccount,
 		lockTable:        opts.LockTable,
 		start:            key,
 		ts:               timestamp,
@@ -4445,9 +4450,13 @@ func mvccScanInit(
 		}, nil
 	}
 
+	memAccount := opts.MemoryAccount
+	if memAccount == nil {
+		memAccount = mon.NewStandaloneUnlimitedAccount()
+	}
 	*mvccScanner = pebbleMVCCScanner{
 		parent:           iter,
-		memAccount:       opts.MemoryAccount,
+		memAccount:       memAccount,
 		lockTable:        opts.LockTable,
 		reverse:          opts.Reverse,
 		start:            key,

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -92,6 +92,7 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 	ts := hlc.Timestamp{WallTime: 2}
 	mvccScanner := pebbleMVCCScanner{
 		parent:           iter,
+		memAccount:       mon.NewStandaloneUnlimitedAccount(),
 		reverse:          false,
 		start:            keys[0],
 		end:              roachpb.Key("d"),
@@ -156,11 +157,12 @@ func TestMVCCScanWithLargeKeyValue(t *testing.T) {
 
 	ts := hlc.Timestamp{WallTime: 2}
 	mvccScanner := pebbleMVCCScanner{
-		parent:  iter,
-		reverse: false,
-		start:   keys[0],
-		end:     roachpb.Key("e"),
-		ts:      ts,
+		parent:     iter,
+		memAccount: mon.NewStandaloneUnlimitedAccount(),
+		reverse:    false,
+		start:      keys[0],
+		end:        roachpb.Key("e"),
+		ts:         ts,
 	}
 	var results pebbleResults
 	mvccScanner.init(nil /* txn */, uncertainty.Interval{}, &results)

--- a/pkg/util/mon/BUILD.bazel
+++ b/pkg/util/mon/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/ioctx",

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -285,23 +285,6 @@ func TestBoundAccount(t *testing.T) {
 	m.Stop(ctx)
 }
 
-func TestNilBoundAccount(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-	var ba *BoundAccount
-	_ = ba.Used()
-	_ = ba.Monitor()
-	_ = ba.Allocated()
-	ba.Empty(ctx)
-	ba.Clear(ctx)
-	ba.Close(ctx)
-	require.Nil(t, ba.Resize(ctx, 0, 10))
-	require.Nil(t, ba.ResizeTo(ctx, 10))
-	require.Nil(t, ba.Grow(ctx, 10))
-	ba.Shrink(ctx, 10)
-}
-
 func TestBytesMonitor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
This PR reverts the decision from 3d7b19c2172b16aff8233ed6220266878b6f9d97 to treat `nil` `BoundAccount` as unlimited. I think it was a mistake to change the API in such a way because it can allow for some bugs to go unnoticed (for example like the one fixed in 88ebd70d7ca24d8cebe1acdcb711d4f0e840c619).

See each commit for details.

Fixes: #122153.

Release note: None