### PR TITLE
kvserver: don't apply ExcludeDataFromBackup outside config bounds

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -339,9 +339,20 @@ func (s *SystemConfig) getZoneConfigForKey(
 func (s *SystemConfig) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, error) {
+	config, _, err := s.GetSpanConfigForKeyWithBounds(ctx, key)
+	return config, err
+}
+
+// GetSpanConfigForKeyWithBounds returns the span config for the given key and
+// the bounds that span the configuration applies to. It's part of
+// spanconfig.StoreReader interface. Note that it is only usable for the system
+// tenant config.
+func (s *SystemConfig) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
 	id, zone, err := s.getZoneConfigForKey(keys.SystemSQLCodec, key)
 	if err != nil {
-		return roachpb.SpanConfig{}, err
+		return roachpb.SpanConfig{}, roachpb.Span{}, err
 	}
 	spanConfig := zone.AsSpanConfig()
 	if id <= keys.MaxReservedDescID {
@@ -354,7 +365,8 @@ func (s *SystemConfig) GetSpanConfigForKey(
 		// applicable to user tables.
 		spanConfig.GCPolicy.IgnoreStrictEnforcement = true
 	}
-	return spanConfig, nil
+	prefix := keys.SystemSQLCodec.TablePrefix(uint32(id))
+	return spanConfig, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}, nil
 }
 
 // DecodeKeyIntoZoneIDAndSuffix figures out the zone that the key belongs to.

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -333,21 +333,10 @@ func (s *SystemConfig) getZoneConfigForKey(
 	return id, s.DefaultZoneConfig, nil
 }
 
-// GetSpanConfigForKey looks of the span config for the given key. It's part of
-// spanconfig.StoreReader interface. Note that it is only usable for the system
-// tenant config.
+// GetSpanConfigForKey looks of the span config for the given key and the bounds
+// that span the configuration applies to. It's part of spanconfig.StoreReader
+// interface. Note that it is only usable for the system tenant config.
 func (s *SystemConfig) GetSpanConfigForKey(
-	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	config, _, err := s.GetSpanConfigForKeyWithBounds(ctx, key)
-	return config, err
-}
-
-// GetSpanConfigForKeyWithBounds returns the span config for the given key and
-// the bounds that span the configuration applies to. It's part of
-// spanconfig.StoreReader interface. Note that it is only usable for the system
-// tenant config.
-func (s *SystemConfig) GetSpanConfigForKeyWithBounds(
 	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	id, zone, err := s.getZoneConfigForKey(keys.SystemSQLCodec, key)

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -616,7 +616,7 @@ func TestGetZoneConfigForKey(t *testing.T) {
 			objectID = id
 			return cfg.DefaultZoneConfig, nil, false, nil
 		}
-		_, err := cfg.GetSpanConfigForKey(ctx, tc.key)
+		_, _, err := cfg.GetSpanConfigForKey(ctx, tc.key)
 		if err != nil {
 			t.Errorf("#%d: GetSpanConfigForKey(%v) got error: %v", tcNum, tc.key, err)
 		}

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1245,6 +1245,20 @@ func (s *state) GetSpanConfigForKey(
 	return *rng.config, nil
 }
 
+// GetSpanConfigForKeyWithBounds is added for the spanconfig.StoreReader interface.
+func (s *state) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	rng := s.rangeFor(ToKey(key.AsRawKey()))
+	if rng == nil {
+		panic(fmt.Sprintf("programming error: range for key %s doesn't exist", key))
+	}
+	return *rng.config, roachpb.Span{
+		Key:    rng.startKey.ToRKey().AsRawKey(),
+		EndKey: rng.endKey.ToRKey().AsRawKey(),
+	}, nil
+}
+
 // Scan is added for the rangedesc.Scanner interface, required for
 // SpanConfigConformanceReport. We ignore the span passed in and return every
 // descriptor available.

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1237,17 +1237,6 @@ func (s *state) ComputeSplitKey(
 // SpanConfigConformanceReport.
 func (s *state) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	rng := s.rangeFor(ToKey(key.AsRawKey()))
-	if rng == nil {
-		panic(fmt.Sprintf("programming error: range for key %s doesn't exist", key))
-	}
-	return *rng.config, nil
-}
-
-// GetSpanConfigForKeyWithBounds is added for the spanconfig.StoreReader interface.
-func (s *state) GetSpanConfigForKeyWithBounds(
-	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	rng := s.rangeFor(ToKey(key.AsRawKey()))
 	if rng == nil {

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -108,7 +108,12 @@ func evalExport(
 	// ExportRequest is likely to find its target data has been GC'ed at this
 	// point, and so if the range being exported is part of such a table, we do
 	// not want to send back any row data to be backed up.
-	if cArgs.EvalCtx.ExcludeDataFromBackup(ctx) {
+	excludeFromBackup, err := cArgs.EvalCtx.ExcludeDataFromBackup(ctx,
+		roachpb.Span{Key: args.Key, EndKey: args.EndKey})
+	if err != nil {
+		return result.Result{}, err
+	}
+	if excludeFromBackup {
 		log.Infof(ctx, "[%s, %s) is part of a table excluded from backup, returning empty ExportResponse", args.Key, args.EndKey)
 		return result.Result{}, nil
 	}

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -103,7 +103,7 @@ type EvalContext interface {
 	GetMaxSplitCPU(context.Context) (float64, bool)
 
 	GetGCThreshold() hlc.Timestamp
-	ExcludeDataFromBackup(ctx context.Context) bool
+	ExcludeDataFromBackup(context.Context, roachpb.Span) (bool, error)
 	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
 	GetLease() (roachpb.Lease, roachpb.Lease)
 	GetRangeInfo(context.Context) roachpb.RangeInfo
@@ -276,8 +276,8 @@ func (m *mockEvalCtxImpl) MinTxnCommitTS(
 func (m *mockEvalCtxImpl) GetGCThreshold() hlc.Timestamp {
 	return m.GCThreshold
 }
-func (m *mockEvalCtxImpl) ExcludeDataFromBackup(context.Context) bool {
-	return false
+func (m *mockEvalCtxImpl) ExcludeDataFromBackup(context.Context, roachpb.Span) (bool, error) {
+	return false, nil
 }
 func (m *mockEvalCtxImpl) GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error) {
 	panic("unimplemented")

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4283,6 +4283,14 @@ func TestMergeQueue(t *testing.T) {
 	lhsStartKey := roachpb.RKey(tc.ScratchRange(t))
 	rhsStartKey := lhsStartKey.Next().Next()
 	rhsEndKey := rhsStartKey.Next().Next()
+	lhsSp := roachpb.Span{
+		Key:    lhsStartKey.AsRawKey(),
+		EndKey: rhsStartKey.AsRawKey(),
+	}
+	rhsSp := roachpb.Span{
+		Key:    rhsStartKey.AsRawKey(),
+		EndKey: rhsEndKey.AsRawKey(),
+	}
 
 	for _, k := range []roachpb.RKey{lhsStartKey, rhsStartKey, rhsEndKey} {
 		split(t, k.AsRawKey(), hlc.Timestamp{} /* expirationTime */)
@@ -4297,12 +4305,12 @@ func TestMergeQueue(t *testing.T) {
 		if l := lhs(); l == nil {
 			t.Fatal("left-hand side range not found")
 		} else {
-			l.SetSpanConfig(conf)
+			l.SetSpanConfig(conf, lhsSp)
 		}
 		if r := rhs(); r == nil {
 			t.Fatal("right-hand side range not found")
 		} else {
-			r.SetSpanConfig(conf)
+			r.SetSpanConfig(conf, rhsSp)
 		}
 	}
 
@@ -4344,7 +4352,7 @@ func TestMergeQueue(t *testing.T) {
 		reset(t)
 		conf := conf
 		conf.RangeMinBytes *= 2
-		lhs().SetSpanConfig(conf)
+		lhs().SetSpanConfig(conf, lhsSp)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -181,14 +181,8 @@ func (m *mockSpanConfigSubscriber) ComputeSplitKey(
 
 func (m *mockSpanConfigSubscriber) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	return m.Store.GetSpanConfigForKey(ctx, key)
-}
-
-func (m *mockSpanConfigSubscriber) GetSpanConfigForKeyWithBounds(
-	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
-	return m.Store.GetSpanConfigForKeyWithBounds(ctx, key)
+	return m.Store.GetSpanConfigForKey(ctx, key)
 }
 
 func (m *mockSpanConfigSubscriber) GetProtectionTimestamps(

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -185,6 +185,12 @@ func (m *mockSpanConfigSubscriber) GetSpanConfigForKey(
 	return m.Store.GetSpanConfigForKey(ctx, key)
 }
 
+func (m *mockSpanConfigSubscriber) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	return m.Store.GetSpanConfigForKeyWithBounds(ctx, key)
+}
+
 func (m *mockSpanConfigSubscriber) GetProtectionTimestamps(
 	context.Context, roachpb.Span,
 ) ([]hlc.Timestamp, hlc.Timestamp, error) {

--- a/pkg/kv/kvserver/lease_queue.go
+++ b/pkg/kv/kvserver/lease_queue.go
@@ -97,7 +97,7 @@ func newLeaseQueue(store *Store, allocator allocatorimpl.Allocator) *leaseQueue 
 func (lq *leaseQueue) shouldQueue(
 	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
 ) (shouldQueue bool, priority float64) {
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, 0
 	}
@@ -115,7 +115,7 @@ func (lq *leaseQueue) process(
 	}
 	defer repl.allocatorToken.Release(ctx)
 
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -156,7 +156,7 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetSpanConfig(zoneConfig.AsSpanConfig())
+			repl.SetSpanConfig(zoneConfig.AsSpanConfig(), roachpb.Span{Key: tc.startKey, EndKey: tc.endKey})
 			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, config.NewSystemConfig(zoneConfig))
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1522,7 +1522,11 @@ func TestMVCCGCQueueGroupsRangeDeletions(t *testing.T) {
 	require.NoError(t, store.AddReplica(r2))
 	r2.RaftStatus()
 	r2.handleGCHintResult(ctx, &roachpb.GCHint{LatestRangeDeleteTimestamp: hlc.Timestamp{WallTime: 1}})
-	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}})
+	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}},
+		roachpb.Span{
+			Key:    key("b").AsRawKey(),
+			EndKey: key("c").AsRawKey(),
+		})
 
 	gcQueue := newMVCCGCQueue(store)
 

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -872,7 +872,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 		}
 		defer snap.Close()
 
-		conf, err := cfg.GetSpanConfigForKey(ctx, desc.StartKey)
+		conf, _, err := cfg.GetSpanConfigForKey(ctx, desc.StartKey)
 		if err != nil {
 			t.Fatalf("could not find zone config for range %s: %+v", tc.repl, err)
 		}
@@ -1468,7 +1468,7 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conf, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
 	if err != nil {
 		t.Fatalf("could not find span config for range %s", err)
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -545,7 +545,19 @@ type Replica struct {
 		minValidObservedTimestamp hlc.ClockTimestamp
 
 		// The span config for this replica.
+		//
+		// NB: Span configuration is applied asyncronously. After a span
+		// configuration change but before the replica has been split
+		// based on the new span configuration, the span stored here may
+		// not represent the span configuration for the entire replica.
+		//
+		// Use of this span configuration that may affect correct
+		// responses should be guarded by a check to confSpan below.
 		conf roachpb.SpanConfig
+		// The bounds of the span configuration. This may not match the
+		// replica's bounds in the case where a span configuration was
+		// recently updated.
+		confSpan roachpb.Span
 		// spanConfigExplicitlySet tracks whether a span config was explicitly set
 		// on this replica (as opposed to it having initialized with the default
 		// span config).
@@ -981,7 +993,7 @@ func (r *Replica) GetMaxBytes(_ context.Context) int64 {
 // to the span config was "significant". For significant changes, the caller
 // should queue up the span to all the relevant queues since they may not decide
 // to process this replica.
-func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig) bool {
+func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig, sp roachpb.Span) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	oldConf := r.mu.conf
@@ -1009,7 +1021,9 @@ func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig) bool {
 	if knobs := r.store.TestingKnobs(); knobs != nil && knobs.SetSpanConfigInterceptor != nil {
 		conf = knobs.SetSpanConfigInterceptor(r.descRLocked(), conf)
 	}
-	r.mu.conf, r.mu.spanConfigExplicitlySet = conf, true
+	r.mu.conf = conf
+	r.mu.spanConfigExplicitlySet = true
+	r.mu.confSpan = sp
 	return oldConf.HasConfigurationChange(conf)
 }
 
@@ -1198,13 +1212,35 @@ func (r *Replica) GetGCHint() roachpb.GCHint {
 
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
 // backup.
-func (r *Replica) ExcludeDataFromBackup(_ context.Context) bool {
+func (r *Replica) ExcludeDataFromBackup(ctx context.Context, sp roachpb.Span) (bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.conf.ExcludeDataFromBackup
+
+	if r.mu.conf.ExcludeDataFromBackup {
+		// If ExcludeDataFromBackup is set, we also want to ensure that
+		// we only elide data if the span configuration we currently
+		// have actually contains the requested span.
+		if r.mu.confSpan.Equal(roachpb.Span{}) {
+			return false, errors.Newf("replica's span configuration bounds not set")
+		}
+		if !r.mu.confSpan.Contains(sp) {
+			log.Warningf(ctx, "ExcludeDataFromBackup requested for span %q not containd by span config bounds %q",
+				sp,
+				r.mu.confSpan)
+			return false, nil
+		}
+	}
+	return r.mu.conf.ExcludeDataFromBackup, nil
 }
 
-func (r *Replica) excludeReplicaFromBackupRLocked() bool {
+func (r *Replica) excludeReplicaFromBackupRLocked(rspan roachpb.RSpan) bool {
+	if r.mu.conf.ExcludeDataFromBackup {
+		// If ExcludeDataFromBackup is set, we also want to ensure that
+		// we only elide data if the span configuration we currently
+		// have actually contains the requested span.
+		sp := rspan.AsRawSpanWithNoLocals()
+		return r.mu.confSpan.Contains(sp)
+	}
 	return r.mu.conf.ExcludeDataFromBackup
 }
 
@@ -1820,7 +1856,7 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 	// TODO(aayush): The above description intentionally omits some details, as
 	// they are going to be changed as part of
 	// https://github.com/cockroachdb/cockroach/issues/55293.
-	return r.checkTSAboveGCThresholdRLocked(ba.EarliestActiveTimestamp(), st, ba.IsAdmin())
+	return r.checkTSAboveGCThresholdRLocked(ba.EarliestActiveTimestamp(), st, ba.IsAdmin(), rSpan)
 }
 
 // checkExecutionCanProceedRWOrAdmin returns an error if a batch request going
@@ -1902,7 +1938,7 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	} else if !r.isRangefeedEnabledRLocked() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return errors.Errorf("[r%d] rangefeeds require the kv.rangefeed.enabled setting. See %s",
 			r.RangeID, docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
-	} else if err := r.checkTSAboveGCThresholdRLocked(ts, status, false /* isAdmin */); err != nil {
+	} else if err := r.checkTSAboveGCThresholdRLocked(ts, status, false /* isAdmin */, rSpan); err != nil {
 		return err
 	}
 	return nil
@@ -1922,7 +1958,7 @@ func (r *Replica) checkSpanInRangeRLocked(ctx context.Context, rspan roachpb.RSp
 // checkTSAboveGCThresholdRLocked returns an error if a request (identified by
 // its read timestamp) wants to read below the range's GC threshold.
 func (r *Replica) checkTSAboveGCThresholdRLocked(
-	ts hlc.Timestamp, st kvserverpb.LeaseStatus, isAdmin bool,
+	ts hlc.Timestamp, st kvserverpb.LeaseStatus, isAdmin bool, rspan roachpb.RSpan,
 ) error {
 	threshold := r.getImpliedGCThresholdRLocked(st, isAdmin)
 	if threshold.Less(ts) {
@@ -1931,7 +1967,7 @@ func (r *Replica) checkTSAboveGCThresholdRLocked(
 	return &kvpb.BatchTimestampBeforeGCError{
 		Timestamp:              ts,
 		Threshold:              threshold,
-		DataExcludedFromBackup: r.excludeReplicaFromBackupRLocked(),
+		DataExcludedFromBackup: r.excludeReplicaFromBackupRLocked(rspan),
 	}
 }
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3604,7 +3604,7 @@ func (roo *replicaRelocateOneOptions) LoadSpanConfig(
 	if err != nil {
 		return nil, errors.Wrap(err, "can't relocate range")
 	}
-	conf, err := confReader.GetSpanConfigForKey(ctx, startKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, startKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -178,8 +178,10 @@ func (rec SpanSetReplicaEvalContext) GetGCThreshold() hlc.Timestamp {
 
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
 // backup.
-func (rec SpanSetReplicaEvalContext) ExcludeDataFromBackup(ctx context.Context) bool {
-	return rec.i.ExcludeDataFromBackup(ctx)
+func (rec SpanSetReplicaEvalContext) ExcludeDataFromBackup(
+	ctx context.Context, sp roachpb.Span,
+) (bool, error) {
+	return rec.i.ExcludeDataFromBackup(ctx, sp)
 }
 
 // String implements Stringer.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -470,12 +470,12 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	}
 
 	// Find span config for this range.
-	conf, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, sp, err := confReader.GetSpanConfigForKeyWithBounds(ctx, desc.StartKey)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to lookup span config", r)
 	}
 
-	changed := r.SetSpanConfig(conf)
+	changed := r.SetSpanConfig(conf, sp)
 	if changed {
 		r.MaybeQueue(ctx, r.store.cfg.Clock.NowAsClockTimestamp())
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -470,7 +470,7 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	}
 
 	// Find span config for this range.
-	conf, sp, err := confReader.GetSpanConfigForKeyWithBounds(ctx, desc.StartKey)
+	conf, sp, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		return errors.Wrapf(err, "%s: failed to lookup span config", r)
 	}

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -605,7 +605,7 @@ func (rq *replicateQueue) shouldQueue(
 ) (shouldQueue bool, priority float64) {
 	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
 	// have that use the confReader.
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, 0
 	}
@@ -638,7 +638,7 @@ func (rq *replicateQueue) process(
 	}
 	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to
 	// have that use the confReader.
-	conf, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, repl.startKey)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -110,7 +110,11 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		repl.mu.Unlock()
 		conf := roachpb.TestingDefaultSpanConfig()
 		conf.RangeMaxBytes = test.maxBytes
-		repl.SetSpanConfig(conf)
+		sp := roachpb.Span{
+			Key:    cpy.StartKey.AsRawKey().Clone(),
+			EndKey: cpy.EndKey.AsRawKey().Clone(),
+		}
+		repl.SetSpanConfig(conf, sp)
 
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2540,12 +2540,12 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 				// adjacent table. This results in a single update, corresponding to the
 				// new table's span, which forms the right-hand side post split.
 
-				conf, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
+				conf, sp, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKeyWithBounds(replCtx, startKey)
 				if err != nil {
 					log.Errorf(replCtx, "skipped applying update, unexpected error reading from subscriber: %v", err)
 					return err
 				}
-				changed = repl.SetSpanConfig(conf)
+				changed = repl.SetSpanConfig(conf, sp)
 			}
 			if changed {
 				repl.MaybeQueue(ctx, now)
@@ -2565,13 +2565,13 @@ func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		replCtx := repl.AnnotateCtx(ctx)
 		key := repl.Desc().StartKey
-		conf, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
+		conf, confSpan, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKeyWithBounds(replCtx, key)
 		if err != nil {
 			log.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
 			return true // more
 		}
 
-		changed := repl.SetSpanConfig(conf)
+		changed := repl.SetSpanConfig(conf, confSpan)
 		if changed {
 			repl.MaybeQueue(replCtx, now)
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2540,7 +2540,7 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 				// adjacent table. This results in a single update, corresponding to the
 				// new table's span, which forms the right-hand side post split.
 
-				conf, sp, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKeyWithBounds(replCtx, startKey)
+				conf, sp, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
 				if err != nil {
 					log.Errorf(replCtx, "skipped applying update, unexpected error reading from subscriber: %v", err)
 					return err
@@ -2565,7 +2565,7 @@ func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		replCtx := repl.AnnotateCtx(ctx)
 		key := repl.Desc().StartKey
-		conf, confSpan, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKeyWithBounds(replCtx, key)
+		conf, confSpan, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
 		if err != nil {
 			log.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
 			return true // more
@@ -3576,7 +3576,7 @@ func (s *Store) AllocatorCheckRange(
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
 	}
 
-	conf, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		log.Eventf(ctx, "error retrieving span config for range %s: %s", desc, err)
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3502,9 +3502,14 @@ func TestSnapshotRateLimit(t *testing.T) {
 	require.Equal(t, int64(32<<20), limit)
 }
 
+type entry struct {
+	conf   roachpb.SpanConfig
+	bounds roachpb.Span
+}
+
 type mockSpanConfigReader struct {
 	real      spanconfig.StoreReader
-	overrides map[string]roachpb.SpanConfig
+	overrides map[string]entry
 }
 
 func (m *mockSpanConfigReader) NeedsSplit(
@@ -3522,10 +3527,19 @@ func (m *mockSpanConfigReader) ComputeSplitKey(
 func (m *mockSpanConfigReader) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, error) {
-	if conf, ok := m.overrides[string(key)]; ok {
-		return conf, nil
+	if e, ok := m.overrides[string(key)]; ok {
+		return e.conf, nil
 	}
 	return m.GetSpanConfigForKey(ctx, key)
+}
+
+func (m *mockSpanConfigReader) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	if e, ok := m.overrides[string(key)]; ok {
+		return e.conf, e.bounds, nil
+	}
+	return m.GetSpanConfigForKeyWithBounds(ctx, key)
 }
 
 var _ spanconfig.StoreReader = &mockSpanConfigReader{}
@@ -3976,8 +3990,14 @@ func TestAllocatorCheckRange(t *testing.T) {
 			if tc.spanConfig != nil {
 				mockSr := &mockSpanConfigReader{
 					real: cfg.SystemConfigProvider.GetSystemConfig(),
-					overrides: map[string]roachpb.SpanConfig{
-						"a": *tc.spanConfig,
+					overrides: map[string]entry{
+						"a": {
+							conf: *tc.spanConfig,
+							bounds: roachpb.Span{
+								Key:    []byte("a"),
+								EndKey: []byte("b"),
+							},
+						},
 					},
 				}
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3526,20 +3526,11 @@ func (m *mockSpanConfigReader) ComputeSplitKey(
 
 func (m *mockSpanConfigReader) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	if e, ok := m.overrides[string(key)]; ok {
-		return e.conf, nil
-	}
-	return m.GetSpanConfigForKey(ctx, key)
-}
-
-func (m *mockSpanConfigReader) GetSpanConfigForKeyWithBounds(
-	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	if e, ok := m.overrides[string(key)]; ok {
-		return e.conf, e.bounds, nil
+		return e.conf, roachpb.Span{}, nil
 	}
-	return m.GetSpanConfigForKeyWithBounds(ctx, key)
+	return m.GetSpanConfigForKey(ctx, key)
 }
 
 var _ spanconfig.StoreReader = &mockSpanConfigReader{}

--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -324,7 +324,7 @@ func waitForSpanConfig(
 			if err != nil {
 				return errors.Wrapf(err, "missing store on server %d", i)
 			}
-			conf, err := store.GetStoreConfig().SpanConfigSubscriber.GetSpanConfigForKey(context.Background(), key)
+			conf, _, err := store.GetStoreConfig().SpanConfigSubscriber.GetSpanConfigForKey(context.Background(), key)
 			if err != nil {
 				return errors.Wrapf(err, "missing span config for %s on server %d", key, i)
 			}

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -289,6 +289,11 @@ type StoreReader interface {
 	NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error)
 	ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) (roachpb.RKey, error)
 	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, error)
+	// GetSpanConfigForKeyWithBounds is like GetSpanConfigForKey but
+	// additionally returns a the span the configuration applies to. Callers
+	// can use this to check if a request is completely contained by the
+	// returned config.
+	GetSpanConfigForKeyWithBounds(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, roachpb.Span, error)
 }
 
 // Limiter is used to limit the number of span configs installed by secondary

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -288,12 +288,11 @@ type StoreWriter interface {
 type StoreReader interface {
 	NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error)
 	ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) (roachpb.RKey, error)
-	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, error)
-	// GetSpanConfigForKeyWithBounds is like GetSpanConfigForKey but
-	// additionally returns a the span the configuration applies to. Callers
-	// can use this to check if a request is completely contained by the
-	// returned config.
-	GetSpanConfigForKeyWithBounds(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, roachpb.Span, error)
+	// GetSpanConfigForKey returns the span configuration for the
+	// given key and the span that the retruened configuration
+	// applies to. Callers can use the returned span to check if a
+	// request is completely contained by the returned config.
+	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, roachpb.Span, error)
 }
 
 // Limiter is used to limit the number of span configs installed by secondary

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -280,7 +280,7 @@ func TestDataDriven(t *testing.T) {
 				case "key":
 					var keyStr string
 					d.ScanArgs(t, cmdArg.Key, &keyStr)
-					config, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(keyStr))
+					config, _, err := kvSubscriber.GetSpanConfigForKey(ctx, roachpb.RKey(keyStr))
 					require.NoError(t, err)
 					return fmt.Sprintf("conf=%s", spanconfigtestutils.PrintSpanConfig(config))
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -61,6 +61,13 @@ func (n *noopKVSubscriber) GetSpanConfigForKey(
 	return roachpb.SpanConfig{}, nil
 }
 
+// GetSpanConfigForKeyWithBounds is part of the spanconfig.KVSubscriber interface.
+func (n *noopKVSubscriber) GetSpanConfigForKeyWithBounds(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	return roachpb.SpanConfig{}, roachpb.Span{}, nil
+}
+
 // GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.
 func (n *noopKVSubscriber) GetProtectionTimestamps(
 	context.Context, roachpb.Span,

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -57,13 +57,6 @@ func (n *noopKVSubscriber) ComputeSplitKey(
 // GetSpanConfigForKey is part of the spanconfig.KVSubscriber interface.
 func (n *noopKVSubscriber) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	return roachpb.SpanConfig{}, nil
-}
-
-// GetSpanConfigForKeyWithBounds is part of the spanconfig.KVSubscriber interface.
-func (n *noopKVSubscriber) GetSpanConfigForKeyWithBounds(
-	context.Context, roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	return roachpb.SpanConfig{}, roachpb.Span{}, nil
 }

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -364,6 +364,16 @@ func (s *KVSubscriber) GetSpanConfigForKey(
 	return s.mu.internal.GetSpanConfigForKey(ctx, key)
 }
 
+// GetSpanConfigForKeyWithBounds is part of the spanconfig.KVSubscriber interface.
+func (s *KVSubscriber) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.mu.internal.GetSpanConfigForKeyWithBounds(ctx, key)
+}
+
 // GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.
 func (s *KVSubscriber) GetProtectionTimestamps(
 	ctx context.Context, sp roachpb.Span,

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -357,21 +357,11 @@ func (s *KVSubscriber) ComputeSplitKey(
 // GetSpanConfigForKey is part of the spanconfig.KVSubscriber interface.
 func (s *KVSubscriber) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.mu.internal.GetSpanConfigForKey(ctx, key)
-}
-
-// GetSpanConfigForKeyWithBounds is part of the spanconfig.KVSubscriber interface.
-func (s *KVSubscriber) GetSpanConfigForKeyWithBounds(
-	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.mu.internal.GetSpanConfigForKeyWithBounds(ctx, key)
+	return s.mu.internal.GetSpanConfigForKey(ctx, key)
 }
 
 // GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -231,13 +231,6 @@ func (m *manualStore) ComputeSplitKey(
 // GetSpanConfigForKey implements the spanconfig.Store interface.
 func (m *manualStore) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	panic("unimplemented")
-}
-
-// GetSpanConfigForKeyWithBounds implements the spanconfig.Store interface.
-func (m *manualStore) GetSpanConfigForKeyWithBounds(
-	context.Context, roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	panic("unimplemented")
 }

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -235,6 +235,13 @@ func (m *manualStore) GetSpanConfigForKey(
 	panic("unimplemented")
 }
 
+// GetSpanConfigForKeyWithBounds implements the spanconfig.Store interface.
+func (m *manualStore) GetSpanConfigForKeyWithBounds(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	panic("unimplemented")
+}
+
 // ForEachOverlappingSpanConfig implements the spanconfig.Store interface.
 func (m *manualStore) ForEachOverlappingSpanConfig(
 	_ context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -187,12 +187,6 @@ func (m *manualSubscriber) ComputeSplitKey(
 
 func (m *manualSubscriber) GetSpanConfigForKey(
 	context.Context, roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	panic("unimplemented")
-}
-
-func (m *manualSubscriber) GetSpanConfigForKeyWithBounds(
-	context.Context, roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	panic("unimplemented")
 }

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -191,6 +191,12 @@ func (m *manualSubscriber) GetSpanConfigForKey(
 	panic("unimplemented")
 }
 
+func (m *manualSubscriber) GetSpanConfigForKeyWithBounds(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	panic("unimplemented")
+}
+
 func (m *manualSubscriber) LastUpdated() hlc.Timestamp {
 	return m.updatedTS
 }

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -285,6 +285,13 @@ func (s *mockCluster) GetSpanConfigForKey(
 	return s.store.GetSpanConfigForKey(ctx, key)
 }
 
+// GetSpanConfigForKeyWithBounds implements spanconfig.StoreReader.
+func (s *mockCluster) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	return s.store.GetSpanConfigForKeyWithBounds(ctx, key)
+}
+
 func (s *mockCluster) addNode(desc roachpb.NodeDescriptor) {
 	_, found := s.nodes[desc.NodeID]
 	require.Falsef(s.t, found, "attempting to re-add n%d", desc.NodeID)

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -281,15 +281,8 @@ func (s *mockCluster) ComputeSplitKey(
 // GetSpanConfigForKey implements spanconfig.StoreReader.
 func (s *mockCluster) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	return s.store.GetSpanConfigForKey(ctx, key)
-}
-
-// GetSpanConfigForKeyWithBounds implements spanconfig.StoreReader.
-func (s *mockCluster) GetSpanConfigForKeyWithBounds(
-	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
-	return s.store.GetSpanConfigForKeyWithBounds(ctx, key)
+	return s.store.GetSpanConfigForKey(ctx, key)
 }
 
 func (s *mockCluster) addNode(desc roachpb.NodeDescriptor) {

--- a/pkg/spanconfig/spanconfigreporter/reporter.go
+++ b/pkg/spanconfig/spanconfigreporter/reporter.go
@@ -143,7 +143,7 @@ func (r *Reporter) SpanConfigConformance(
 			span,
 			func(descriptors ...roachpb.RangeDescriptor) error {
 				for _, desc := range descriptors {
-					conf, err := r.dep.StoreReader.GetSpanConfigForKey(ctx, desc.StartKey)
+					conf, _, err := r.dep.StoreReader.GetSpanConfigForKey(ctx, desc.StartKey)
 					if err != nil {
 						return err
 					}

--- a/pkg/spanconfig/spanconfigstore/span_store_test.go
+++ b/pkg/spanconfig/spanconfigstore/span_store_test.go
@@ -175,7 +175,7 @@ func TestRandomized(t *testing.T) {
 
 			// Ensure that the config accessed through the StoreReader interface is
 			// the same as above.
-			storeReaderConfig, found := store.getSpanConfigForKey(ctx, roachpb.RKey(testSpan.Key))
+			storeReaderConfig, _, found := store.getSpanConfigForKey(ctx, roachpb.RKey(testSpan.Key))
 			require.True(t, found)
 			require.True(t, foundSpanConfigPair.config.Equal(storeReaderConfig))
 		})
@@ -265,7 +265,7 @@ func TestRandomized(t *testing.T) {
 			require.Truef(t, querySpan.ProperlyContainsKey(curSplitKey.AsRawKey()),
 				"invalid split key %s (over span %s)", curSplitKey, querySpan)
 
-			confAtCurSplitKey, found := store.getSpanConfigForKey(ctx, curSplitKey)
+			confAtCurSplitKey, _, found := store.getSpanConfigForKey(ctx, curSplitKey)
 			require.True(t, found)
 
 			if i == 0 {

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -126,7 +126,16 @@ func (s *Store) GetSpanConfigForKey(
 ) (roachpb.SpanConfig, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	conf, _, err := s.getSpanConfigForKeyRLocked(ctx, key)
+	return conf, err
+}
 
+// GetSpanConfigForKeyWithBounds is part of the spanconfig.StoreReader interface.
+func (s *Store) GetSpanConfigForKeyWithBounds(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.getSpanConfigForKeyRLocked(ctx, key)
 }
 
@@ -134,34 +143,34 @@ func (s *Store) GetSpanConfigForKey(
 // caller to hold the Store read lock.
 func (s *Store) getSpanConfigForKeyRLocked(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	conf, found := s.mu.spanConfigStore.getSpanConfigForKey(ctx, key)
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	conf, confSpan, found := s.mu.spanConfigStore.getSpanConfigForKey(ctx, key)
 	if !found {
 		conf = s.getFallbackConfig()
 	}
 	var err error
 	conf, err = s.mu.systemSpanConfigStore.combine(key, conf)
 	if err != nil {
-		return roachpb.SpanConfig{}, err
+		return roachpb.SpanConfig{}, roachpb.Span{}, err
 	}
 
 	// No need to perform clamping if SpanConfigBounds are not enabled.
 	if !boundsEnabled.Get(&s.settings.SV) {
-		return conf, nil
+		return conf, confSpan, nil
 	}
 
 	_, tenID, err := keys.DecodeTenantPrefix(roachpb.Key(key))
 	if err != nil {
-		return roachpb.SpanConfig{}, err
+		return roachpb.SpanConfig{}, roachpb.Span{}, err
 	}
 	if tenID.IsSystem() {
 		// SpanConfig bounds do not apply to the system tenant.
-		return conf, nil
+		return conf, confSpan, nil
 	}
 
 	bounds, found := s.boundsReader.Bounds(tenID)
 	if !found {
-		return conf, nil
+		return conf, confSpan, nil
 	}
 
 	clamped := bounds.Clamp(&conf)
@@ -169,7 +178,7 @@ func (s *Store) getSpanConfigForKeyRLocked(
 	if clamped {
 		log.VInfof(ctx, 3, "span config for tenant clamped to %v", conf)
 	}
-	return conf, nil
+	return conf, confSpan, nil
 }
 
 func (s *Store) getFallbackConfig() roachpb.SpanConfig {
@@ -202,7 +211,7 @@ func (s *Store) ForEachOverlappingSpanConfig(
 	var foundOverlapping bool
 	err := s.mu.spanConfigStore.forEachOverlapping(span, func(sp roachpb.Span, conf roachpb.SpanConfig) error {
 		foundOverlapping = true
-		config, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(sp.Key))
+		config, _, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(sp.Key))
 		if err != nil {
 			return err
 		}
@@ -223,7 +232,7 @@ func (s *Store) ForEachOverlappingSpanConfig(
 	// applicable to the replica with the empty table span.
 	if !foundOverlapping {
 		log.VInfof(ctx, 3, "no overlapping span config found for span %s", span)
-		config, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(span.Key))
+		config, _, err := s.getSpanConfigForKeyRLocked(ctx, roachpb.RKey(span.Key))
 		if err != nil {
 			return err
 		}

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -123,16 +123,6 @@ func (s *Store) ComputeSplitKey(
 // GetSpanConfigForKey is part of the spanconfig.StoreReader interface.
 func (s *Store) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	conf, _, err := s.getSpanConfigForKeyRLocked(ctx, key)
-	return conf, err
-}
-
-// GetSpanConfigForKeyWithBounds is part of the spanconfig.StoreReader interface.
-func (s *Store) GetSpanConfigForKeyWithBounds(
-	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, roachpb.Span, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -160,7 +160,7 @@ func TestDataDriven(t *testing.T) {
 			case "get":
 				d.ScanArgs(t, "key", &keyStr)
 				key, _ := spanconfigtestutils.ParseKey(t, keyStr)
-				config, err := store.GetSpanConfigForKey(ctx, roachpb.RKey(key))
+				config, _, err := store.GetSpanConfigForKey(ctx, roachpb.RKey(key))
 				require.NoError(t, err)
 				return fmt.Sprintf("conf=%s", spanconfigtestutils.PrintSpanConfig(config))
 


### PR DESCRIPTION
Some span configuration updates result in a replica split. However, between the new span configuration being set on the replica and the split happening, the span configuration stored on the replica may be incorrect for a portion of the replica's keyspace.

This is a general problem with asyncronous span configuration application. But, here we introduce a specific fix for the ExcludeDataFromBackup span configuration item.

When setting the span configuration, we now also store the bounds of that span configuration. ExcludeDataFromBackup only returns true if the data being considered for exclusion is contained by those bounds.

Further, we only set DataExcludedFromBackup to true in
BatchTimestampBeforeGCError if the span of the batch that generated
the error is contained by the span configuration bound. This field is
used to ignore BatchTimestampBeforeGCErrors. As a result, not setting
it to true could result in BACKUP failures until the range
splits. However, the alternative is silently ignoring a possible real
error.

Note that this doesn't solve all problems related to DataExcludedFromBackup. For instance, span configuration propagation is asyncronous and thus data for a given table may continue to be excluded from backups for some period after `ALTER TABLE <TABLE> SET (exclude_data_from_backup = false)` has been set.

Fixes #120122

Release note (bug fix): Fix a rare condition in which a BACKUP taken shortly after ALTER TABLE <TABLE> SET (exclude_data_from_backup = true) could result in data from an unrelated table being excluded from a backup.