### PR TITLE
db-console/debug: clarify cpu profile link

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -440,7 +440,7 @@ export default function Debug() {
             params={{ node: nodeID, seconds: "5", labels: "true" }}
           />
           <DebugTableLink
-            name="Cluster-wide CPU Profile (profiles all nodes; MEMORY OVERHEAD)"
+            name="Cluster-wide Combined CPU Profile"
             url="debug/pprof/ui/cpu/"
             params={{ node: "all", seconds: "5", labels: "true" }}
           />


### PR DESCRIPTION
The all-caps MEMORY OVERHEAD in the title for this one profile looks out of place compared to the rest of the page and is somewhat confusing: is it profiling the memory overhead, as implied by inclusion of the title which for all other links says what the tool does? Or does the tool itself have overhead? While in practice it is the latter, serving any request has _some_ overhead so this hardly worth this weird treatment.

Release note: none.
Epic: none.