### PR TITLE
roachtest/cdc: increase end_time for changefeed

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -290,7 +290,7 @@ func runCDCBenchScan(
 	// finish time.
 	t.L().Printf("running changefeed %s scan", scanType)
 	with := fmt.Sprintf(`format = '%s', end_time = '%s'`,
-		format, timeutil.Now().Add(5*time.Second).Format(time.RFC3339))
+		format, timeutil.Now().Add(30*time.Second).Format(time.RFC3339))
 	switch scanType {
 	case cdcBenchInitialScan:
 		with += ", initial_scan = 'yes'"


### PR DESCRIPTION
In #120130, a roachtest failed because the end time was in the past. Previously, the end_time was set 5 seconds after the time when the changefeed statement is created. However, this time ended up being before the changefeed statement was executed. This change increases the time window to 30 seconds to allow for extra time for the test to set up.

The issue below should be closed after backporting this change.

Release note: None
Epic: None
Informs: #120130