### PR TITLE
backuppcl: pass finishesSpec field to resume span

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -636,12 +636,13 @@ func runBackupProcessor(
 								resumeTS = resp.Files[fileCount-1].EndKeyTS
 							}
 							resumeSpan = spanAndTime{
-								span:       *resp.ResumeSpan,
-								firstKeyTS: resumeTS,
-								start:      span.start,
-								end:        span.end,
-								attempts:   span.attempts,
-								lastTried:  span.lastTried,
+								span:         *resp.ResumeSpan,
+								firstKeyTS:   resumeTS,
+								start:        span.start,
+								end:          span.end,
+								attempts:     span.attempts,
+								lastTried:    span.lastTried,
+								finishesSpec: span.finishesSpec,
 							}
 						}
 

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -635,15 +635,9 @@ func runBackupProcessor(
 							if fileCount := len(resp.Files); fileCount > 0 {
 								resumeTS = resp.Files[fileCount-1].EndKeyTS
 							}
-							resumeSpan = spanAndTime{
-								span:         *resp.ResumeSpan,
-								firstKeyTS:   resumeTS,
-								start:        span.start,
-								end:          span.end,
-								attempts:     span.attempts,
-								lastTried:    span.lastTried,
-								finishesSpec: span.finishesSpec,
-							}
+							resumeSpan = span
+							resumeSpan.span = *resp.ResumeSpan
+							resumeSpan.firstKeyTS = resumeTS
 						}
 
 						if backupKnobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -339,8 +339,16 @@ func registerBackup(r registry.Registry) {
 				// total elapsed time. This is used by roachperf to compute and display
 				// the average MB/sec per node.
 				tick()
-				c.Run(ctx, option.WithNodes(c.Node(1)), `./cockroach sql --url={pgurl:1} -e "
-				BACKUP bank.bank TO 'gs://`+backupTestingBucket+`/`+dest+`?AUTH=implicit'"`)
+				conn := c.Conn(ctx, t.L(), 1)
+				defer conn.Close()
+				var jobID jobspb.JobID
+				uri := `gs://` + backupTestingBucket + `/` + dest + `?AUTH=implicit`
+				if err := conn.QueryRowContext(ctx, fmt.Sprintf("BACKUP bank.bank INTO '%s' WITH detached", uri)).Scan(&jobID); err != nil {
+					return err
+				}
+				if err := AssertReasonableFractionCompleted(ctx, t.L(), c, jobID, 2); err != nil {
+					return err
+				}
 				tick()
 
 				// Upload the perf artifacts to any one of the nodes so that the test


### PR DESCRIPTION
PR #114268 broke the plumbing for the CompletedSpans metric which allows the backup coordinator to update the FractionCompleted metric. This patch fixes this bug by passing the finishesSpec field to the resume span.

Informs #120161

Release note: none