### PR TITLE
kvserver: move some tests to heavier pools under `race`, `deadlock`

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -131,6 +131,10 @@ go_test(
         "transaction_test.go",
     ],
     embed = [":batcheval"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",

--- a/pkg/kv/kvserver/rangelog/BUILD.bazel
+++ b/pkg/kv/kvserver/rangelog/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     embed = [":rangelog"],
     embedsrcs = ["testdata/rangelog.bin"],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "default"},
     }),
     deps = [


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None