### PR TITLE
roachprod: urlGenerator uses url config to decide scheme

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1012,7 +1012,7 @@ func urlGenerator(
 			port = desc.Port
 		}
 		scheme := "http"
-		if c.Secure {
+		if uConfig.secure {
 			scheme = "https"
 		}
 		if !strings.HasPrefix(uConfig.path, "/") {


### PR DESCRIPTION
Previously, urlGenerator ignored urlConfig.secure and instead used cluster.secure to decide the url scheme. It is not always true that a secure cluster will want to use only secure urls. i.e. the internal grafana instance is insecure regardless of the cluster itself.

Epic: none
Release note: none
Fixes: none