### PR TITLE
roachprod: search ssh directory for keys

### DIFF
--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -12,9 +12,12 @@ package config
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"os/user"
+	"path"
 	"regexp"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -43,9 +46,9 @@ var (
 	// CockroachDevLicense is used by both roachprod and tools that import it.
 	CockroachDevLicense = envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")
 
-	// SSHPublicKeyPath is the path to the public key that is expected
-	// to exist in order to set up new roachprod clusters.
-	SSHPublicKeyPath = os.ExpandEnv("${HOME}/.ssh/id_rsa.pub")
+	// SSHDirectory is the path to search for SSH keys needed to set up
+	// set up new roachprod clusters.
+	SSHDirectory = os.ExpandEnv("${HOME}/.ssh")
 )
 
 func init() {
@@ -131,13 +134,51 @@ func IsLocalClusterName(clusterName string) bool {
 
 var localClusterRegex = regexp.MustCompile(`^local(|-[a-zA-Z0-9\-]+)$`)
 
+// See https://github.com/openssh/openssh-portable/blob/86bdd385/ssh_config.5#L1123-L1130
+var defaultPubKeyNames = []string{
+	"id_rsa",
+	"id_ecdsa",
+	"id_ecdsa_sk",
+	"id_ed25519",
+	"id_ed25519_sk",
+	"id_dsa",
+}
+
+// SSHPublicKeyPath returns the path to the default public key expected by
+// roachprod.
+func SSHPublicKeyPath() (string, error) {
+	dirEnts, err := os.ReadDir(SSHDirectory)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read SSH directory")
+	}
+
+	for _, name := range defaultPubKeyNames {
+		idx := slices.IndexFunc(dirEnts, func(entry fs.DirEntry) bool {
+			return name == entry.Name()
+		})
+		if idx == -1 {
+			continue
+		}
+		pubKeyPath := path.Join(SSHDirectory, name+".pub")
+		if _, err := os.Stat(pubKeyPath); err == nil {
+			return pubKeyPath, nil
+		}
+	}
+
+	return "", errors.Newf("no default public key found in %s", SSHDirectory)
+}
+
 // SSHPublicKey returns the contents of the default public key
 // expected by roachprod.
 func SSHPublicKey() (string, error) {
-	sshKey, err := os.ReadFile(SSHPublicKeyPath)
+	sshPublicKeyPath, err := SSHPublicKeyPath()
+	if err != nil {
+		return "", err
+	}
+	sshKey, err := os.ReadFile(sshPublicKeyPath)
 	if err != nil {
 		if oserror.IsNotExist(err) {
-			return "", errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", SSHPublicKeyPath)
+			return "", errors.Wrapf(err, "please run ssh-keygen externally to create a public key file")
 		}
 		return "", errors.Wrap(err, "failed to read public SSH key")
 	}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -438,7 +438,11 @@ func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
 				if err != nil {
 					return err
 				}
-				l.Printf("imported %s as %s in region %s", config.SSHPublicKeyPath, keyName, region)
+				sshPublicKeyPath, err := config.SSHPublicKeyPath()
+				if err != nil {
+					return err
+				}
+				l.Printf("imported %s as %s in region %s", sshPublicKeyPath, keyName, region)
 			}
 			return nil
 		})

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -48,7 +48,8 @@ func (p *Provider) sshKeyExists(l *logger.Logger, keyName, region string) (bool,
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
 func (p *Provider) sshKeyImport(l *logger.Logger, keyName, region string) error {
-	if _, err := config.SSHPublicKey(); err != nil {
+	sshPublicKeyPath, err := config.SSHPublicKeyPath()
+	if err != nil {
 		return err
 	}
 
@@ -73,7 +74,7 @@ func (p *Provider) sshKeyImport(l *logger.Logger, keyName, region string) error 
 		"ec2", "import-key-pair",
 		"--region", region,
 		"--key-name", keyName,
-		"--public-key-material", fmt.Sprintf("fileb://%s", config.SSHPublicKeyPath),
+		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyPath),
 		"--tag-specifications", tagSpecs,
 	}
 	err = p.runJSONCommand(l, args, &data)


### PR DESCRIPTION
Before this change, roachprod required that an id_rsa.pub file exist in the user's $HOME/.ssh directory. These days folks use other types of keys like ed25519. The github docs these days in fact explicitly tell you to use ed25519 [1]. This patch now searches for keys the same way that the openssh client does. It searches based on this list:

 * id_rsa
 * id_ecdsa
 * id_ecdsa_sk
 * id_ed25519
 * id_ed25519_sk
 * id_dsa

[1]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent

Epic: None

Release note: None