### PR TITLE
pcr: skip initial splits on resume

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -290,6 +290,7 @@ func createReplicationJob(
 		Username:    p.User(),
 		Progress: jobspb.StreamIngestionProgress{
 			ReplicatedTime:        resumeTimestamp,
+			InitialSplitComplete:  revertFirst,
 			InitialRevertRequired: revertFirst,
 		},
 		Details: streamIngestionDetails,


### PR DESCRIPTION
Release note: none.
Epic: none.