### PR TITLE
opt: only hoist leak-proof subqueries from CASE branches

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3844,6 +3844,10 @@ func (m *sessionDataMutator) SetOptimizerUsePolymorphicParameterFix(val bool) {
 	m.data.OptimizerUsePolymorphicParameterFix = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseConditionalHoistFix(val bool) {
+	m.data.OptimizerUseConditionalHoistFix = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/case
+++ b/pkg/sql/logictest/testdata/logic_test/case
@@ -1,0 +1,50 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON);
+
+statement ok
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+
+statement ok
+INSERT INTO a VALUES (1, 1, 1, 'foo', '{"x": "one"}');
+INSERT INTO xy VALUES (1, 2);
+
+statement error pgcode 22012 pq: division by zero
+SELECT CASE WHEN f = (SELECT 1 // 0 FROM xy WHERE x = i) THEN 100 ELSE 200 END FROM a;
+
+query I
+SELECT CASE WHEN f = 0 THEN (SELECT 1 // 0 FROM xy WHERE x = i) ELSE 200 END FROM a;
+----
+200
+
+statement error pgcode 22012 pq: division by zero
+SELECT CASE WHEN f = 1 THEN (SELECT 1 // 0 FROM xy WHERE x = i) ELSE 200 END FROM a;
+
+query I
+SELECT CASE WHEN f = 1 THEN 100 ELSE (SELECT 1 // 0 FROM xy WHERE x = i) END FROM a;
+----
+100
+
+statement error pgcode 22012 pq: division by zero
+SELECT CASE WHEN f = 0 THEN 100 ELSE (SELECT 1 // 0 FROM xy WHERE x = i) END FROM a;
+
+# Regression test for #97432 - respect CASE branch evaluation order for
+# non-leakproof expressions.
+subtest volatile-subquery
+
+query I
+SELECT CASE WHEN f = 1
+  THEN (SELECT y FROM xy WHERE x = i)
+  ELSE (SELECT 1 // 0 FROM xy WHERE x = i) END
+FROM a;
+----
+2
+
+statement error pgcode 22012 pq: division by zero
+SELECT CASE WHEN f = 0
+  THEN (SELECT y FROM xy WHERE x = i)
+  ELSE (SELECT 1 // 0 FROM xy WHERE x = i) END
+FROM a;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6172,6 +6172,7 @@ optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_prove_implication_with_virtual_computed_columns  on
 optimizer_push_offset_into_index_join                      on
+optimizer_use_conditional_hoist_fix                        on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2911,6 +2911,7 @@ optimizer_hoist_uncorrelated_equality_subqueries           on                  N
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns  on                  NULL      NULL        NULL        string
 optimizer_push_offset_into_index_join                      on                  NULL      NULL        NULL        string
+optimizer_use_conditional_hoist_fix                        on                  NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL      NULL        NULL        string
@@ -3100,6 +3101,7 @@ optimizer_hoist_uncorrelated_equality_subqueries           on                  N
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
 optimizer_prove_implication_with_virtual_computed_columns  on                  NULL  user     NULL      on                  on
 optimizer_push_offset_into_index_join                      on                  NULL  user     NULL      on                  on
+optimizer_use_conditional_hoist_fix                        on                  NULL  user     NULL      on                  on
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL  user     NULL      on                  on
@@ -3288,8 +3290,8 @@ optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
 optimizer_push_offset_into_index_join                      NULL    NULL     NULL     NULL        NULL
+optimizer_use_conditional_hoist_fix                        NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
-optimizer_use_merged_partial_statistics                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_disjunction_stats                   NULL    NULL     NULL     NULL        NULL
@@ -3301,6 +3303,7 @@ optimizer_use_improved_trigram_similarity_selectivity      NULL    NULL     NULL
 optimizer_use_improved_zigzag_join_costing                 NULL    NULL     NULL     NULL        NULL
 optimizer_use_limit_ordering_for_streaming_group_by        NULL    NULL     NULL     NULL        NULL
 optimizer_use_lock_op_for_serializable                     NULL    NULL     NULL     NULL        NULL
+optimizer_use_merged_partial_statistics                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                               NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_polymorphic_parameter_fix                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -128,6 +128,7 @@ optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_prove_implication_with_virtual_computed_columns  on
 optimizer_push_offset_into_index_join                      on
+optimizer_use_conditional_hoist_fix                        on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -316,6 +316,13 @@ func TestLogic_cascade(
 	runLogicTest(t, "cascade")
 }
 
+func TestLogic_case(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "case")
+}
+
 func TestLogic_case_sensitive_names(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -200,6 +200,7 @@ type Memo struct {
 	proveImplicationWithVirtualComputedCols    bool
 	pushOffsetIntoIndexJoin                    bool
 	usePolymorphicParameterFix                 bool
+	useConditionalHoistFix                     bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -286,6 +287,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		proveImplicationWithVirtualComputedCols:    evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns,
 		pushOffsetIntoIndexJoin:                    evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin,
 		usePolymorphicParameterFix:                 evalCtx.SessionData().OptimizerUsePolymorphicParameterFix,
+		useConditionalHoistFix:                     evalCtx.SessionData().OptimizerUseConditionalHoistFix,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -450,6 +452,7 @@ func (m *Memo) IsStale(
 		m.proveImplicationWithVirtualComputedCols != evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns ||
 		m.pushOffsetIntoIndexJoin != evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin ||
 		m.usePolymorphicParameterFix != evalCtx.SessionData().OptimizerUsePolymorphicParameterFix ||
+		m.useConditionalHoistFix != evalCtx.SessionData().OptimizerUseConditionalHoistFix ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -128,6 +128,105 @@ func (c *CustomFuncs) deriveHasHoistableSubqueryImpl(scalar opt.ScalarExpr) bool
 		}
 	}
 
+	// Special handling for conditional expressions, which maintain invariants
+	// about when input expressions are evaluated.
+	switch scalar.Op() {
+	case opt.CaseOp, opt.CoalesceOp, opt.IfErrOp:
+		return c.deriveConditionalHasHoistableSubquery(scalar)
+	}
+
+	// If HasHoistableSubquery is true for any child, then it's true for this
+	// expression as well. The exception is conditional expressions, which are
+	// handled above.
+	for i, n := 0, scalar.ChildCount(); i < n; i++ {
+		child := scalar.Child(i).(opt.ScalarExpr)
+		if c.deriveHasHoistableSubquery(child) {
+			return true
+		}
+	}
+	return false
+}
+
+// deriveConditionalHasHoistableSubquery analyzes a conditional expression for
+// subqueries that can be "hoisted" into a join and replaced with a simple
+// variable reference. It returns true when there is at least one subquery that
+// can be hoisted, even if there is a subquery within the conditional expression
+// that cannot be hoisted.
+func (c *CustomFuncs) deriveConditionalHasHoistableSubquery(scalar opt.ScalarExpr) bool {
+	if !c.f.evalCtx.SessionData().OptimizerUseConditionalHoistFix {
+		return c.legacyDeriveConditionalHasHoistableSubquery(scalar)
+	}
+	// Conditional expressions maintain invariants about when input expressions
+	// are evaluated. For example, a CASE statement does not evaluate a WHEN
+	// branch until its guard condition passes. A child expression that is
+	// conditionally evaluated can only be hoisted if it is leak-proof, since
+	// hoisting can change whether / how many times an expression is evaluated.
+	var sharedProps props.Shared
+	deriveCanHoistChild := func(child opt.ScalarExpr, isConditional bool) bool {
+		if c.deriveHasHoistableSubquery(child) {
+			if isConditional {
+				memo.BuildSharedProps(child, &sharedProps, c.f.evalCtx)
+				return sharedProps.VolatilitySet.IsLeakproof()
+			}
+			return true
+		}
+		return false
+	}
+	switch t := scalar.(type) {
+	case *memo.CaseExpr:
+		// The input expression is always evaluated.
+		if c.deriveHasHoistableSubquery(t.Input) {
+			return true
+		}
+		for i := range t.Whens {
+			whenExpr := t.Whens[i].(*memo.WhenExpr)
+			if deriveCanHoistChild(whenExpr.Condition, i > 0) {
+				// The first condition is always evaluated. The remaining conditions are
+				// conditionally evaluated.
+				return true
+			}
+			// The WHEN branches are conditionally evaluated.
+			if deriveCanHoistChild(whenExpr.Value, true /* isConditional */) {
+				return true
+			}
+		}
+		// The ELSE branch is conditionally evaluated.
+		return deriveCanHoistChild(t.OrElse, true /* isConditional */)
+	case *memo.CoalesceExpr:
+		// The first argument is always evaluated. The remaining arguments are
+		// conditionally evaluated.
+		for i := range t.Args {
+			if deriveCanHoistChild(t.Args[i], i > 0) {
+				return true
+			}
+		}
+		return false
+	case *memo.IfErrExpr:
+		// The condition expression is always evaluated. The OrElse expressions are
+		// conditionally evaluated.
+		if c.deriveHasHoistableSubquery(t.Cond) {
+			return true
+		}
+		for i := range t.OrElse {
+			if deriveCanHoistChild(t.OrElse[i], true /* isConditional */) {
+				return true
+			}
+		}
+		return false
+	default:
+		panic(errors.AssertionFailedf("unhandled op: %v", scalar.Op()))
+	}
+}
+
+// legacyDeriveConditionalHasHoistableSubquery contains the logic for analyzing
+// conditional expressions from before #97432 was fixed. It differs from
+// deriveConditionalHasHoistableSubquery mostly in its layout, but also returns
+// false early for a COALESCE with a volatile branch, when later branches may
+// still be hoistable.
+//
+// TODO(drewk): consider deleting this once we have high confidence it won't
+// lead to plan regressions.
+func (c *CustomFuncs) legacyDeriveConditionalHasHoistableSubquery(scalar opt.ScalarExpr) bool {
 	// If HasHoistableSubquery is true for any child, then it's true for this
 	// expression as well. The exception is Case/If branches that have side
 	// effects. These can only be executed if the branch test evaluates to true,
@@ -809,6 +908,7 @@ type subqueryHoister struct {
 	f       *Factory
 	mem     *memo.Memo
 	hoisted memo.RelExpr
+	scratch props.Shared
 }
 
 func (r *subqueryHoister) init(c *CustomFuncs, input memo.RelExpr) {
@@ -923,6 +1023,11 @@ func (r *subqueryHoister) hoistAll(scalar opt.ScalarExpr) opt.ScalarExpr {
 			colID = subqueryProps.OutputCols.SingleColumn()
 		}
 		return r.f.ConstructVariable(colID)
+
+	case opt.CaseOp, opt.CoalesceOp, opt.IfErrOp:
+		if r.f.evalCtx.SessionData().OptimizerUseConditionalHoistFix {
+			return r.constructConditionalExpr(scalar)
+		}
 	}
 
 	return r.f.Replace(scalar, func(nd opt.Expr) opt.Expr {
@@ -941,6 +1046,61 @@ func (r *subqueryHoister) hoistAll(scalar opt.ScalarExpr) opt.ScalarExpr {
 		}
 		return nd
 	}).(opt.ScalarExpr)
+}
+
+// constructConditionalExpr handles the special case of hoisting subqueries
+// within a conditional expression, which must maintain invariants as to when
+// its children are evaluated. For example, a branch of a CASE statement can
+// only be evaluated if its guard condition passes.
+func (r *subqueryHoister) constructConditionalExpr(scalar opt.ScalarExpr) opt.ScalarExpr {
+	maybeHoistChild := func(child opt.ScalarExpr, isConditional bool) opt.ScalarExpr {
+		if isConditional {
+			// This child expression is conditionally evaluated, so it can only be
+			// hoisted if it does not have side effects.
+			r.scratch = props.Shared{}
+			memo.BuildSharedProps(child, &r.scratch, r.f.evalCtx)
+			if !r.scratch.VolatilitySet.IsLeakproof() {
+				return child
+			}
+		}
+		return r.hoistAll(child)
+	}
+
+	switch t := scalar.(type) {
+	case *memo.CaseExpr:
+		// The input expression is unconditionally evaluated.
+		newInput := r.hoistAll(t.Input)
+		newWhens := make(memo.ScalarListExpr, len(t.Whens))
+		for i := range t.Whens {
+			// WHEN conditions other than the first are conditionally evaluated. The
+			// branches are always conditionally evaluated.
+			whenExpr := t.Whens[i].(*memo.WhenExpr)
+			newCond := maybeHoistChild(whenExpr.Condition, i > 0)
+			newVal := maybeHoistChild(whenExpr.Value, true /* isConditional */)
+			newWhens[i] = r.f.ConstructWhen(newCond, newVal)
+		}
+		// The ELSE branch is conditionally evaluated.
+		newOrElse := maybeHoistChild(t.OrElse, true /* isConditional */)
+		return r.f.ConstructCase(newInput, newWhens, newOrElse)
+	case *memo.CoalesceExpr:
+		// The first argument is unconditionally evaluated; the rest are
+		// conditional.
+		newArgs := make(memo.ScalarListExpr, len(t.Args))
+		for i, arg := range t.Args {
+			newArgs[i] = maybeHoistChild(arg, i > 0)
+		}
+		return r.f.ConstructCoalesce(newArgs)
+	case *memo.IfErrExpr:
+		// The condition expression is always evaluated. The OrElse expressions are
+		// conditionally evaluated.
+		newCond := r.hoistAll(t.Cond)
+		newOrElse := make(memo.ScalarListExpr, len(t.OrElse))
+		for i := range t.OrElse {
+			newOrElse[i] = maybeHoistChild(t.OrElse[i], true /* isConditional */)
+		}
+		return r.f.ConstructIfErr(newCond, newOrElse, t.ErrCode)
+	}
+	panic(errors.AssertionFailedf("unexpected op: %s", scalar.Op()))
 }
 
 // constructGroupByExists transforms a scalar Exists expression like this:

--- a/pkg/sql/opt/norm/testdata/rules/side_effects
+++ b/pkg/sql/opt/norm/testdata/rules/side_effects
@@ -105,7 +105,64 @@ inner-join (hash)
  └── filters
       └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
-# Decorrelate CASE WHEN branch if there are no side effects.
+# Hoist the first CASE WHEN condition even if there are side effects.
+norm
+SELECT CASE WHEN i<(SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int) THEN 4 ELSE 5 END FROM a
+----
+project
+ ├── columns: case:12
+ ├── volatile
+ ├── left-join-apply
+ │    ├── columns: i:2 x:8 y:9
+ │    ├── volatile
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── limit
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── outer: (2)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── volatile
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(8,9)
+ │    │    ├── select
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── outer: (2)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(8,9)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:8!null y:9
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    └── filters
+ │    │    │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    │    └── (random() * 10.0)::INT8
+ │    └── filters (true)
+ └── projections
+      └── CASE WHEN i:2 < y:9 THEN 4 ELSE 5 END [as=case:12, outer=(2,9)]
+
+# Hoist following CASE WHEN conditions if there are no side effects.
+norm
+SELECT CASE WHEN i<0 THEN 3 WHEN i<(SELECT y FROM xy WHERE x=i LIMIT 1) THEN 4 ELSE 5 END FROM a
+----
+project
+ ├── columns: case:12
+ ├── left-join (hash)
+ │    ├── columns: i:2 x:8 y:9
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── fd: (8)-->(9)
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── projections
+      └── CASE WHEN i:2 < 0 THEN 3 WHEN i:2 < y:9 THEN 4 ELSE 5 END [as=case:12, outer=(2,9)]
+
+# Hoist CASE WHEN branch if there are no side effects.
 norm
 SELECT CASE WHEN i<0 THEN (SELECT y FROM xy WHERE x=i LIMIT 1) ELSE 5 END FROM a
 ----
@@ -126,7 +183,7 @@ project
  └── projections
       └── CASE WHEN i:2 < 0 THEN y:9 ELSE 5 END [as=case:12, outer=(2,9)]
 
-# Decorrelate CASE ELSE branch if there are no side effects.
+# Hoist CASE ELSE branch if there are no side effects.
 norm
 SELECT * FROM a WHERE (CASE WHEN i<0 THEN 5 ELSE (SELECT y FROM xy WHERE x=i LIMIT 1) END)=k
 ----
@@ -156,7 +213,57 @@ project
       └── filters
            └── k:1 = CASE WHEN i:2 < 0 THEN 5 ELSE y:9 END [outer=(1,2,9), constraints=(/1: (/NULL - ]), fd=(2,9)-->(1)]
 
-# Don't decorrelate CASE WHEN branch if there are side effects.
+# Don't hoist CASE WHEN conditions (other than the first) if there are
+# side effects.
+norm
+SELECT CASE WHEN i<0 THEN 3 WHEN i<(SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int) THEN 4 ELSE 5 END FROM a
+----
+project
+ ├── columns: case:12
+ ├── volatile
+ ├── scan a
+ │    └── columns: i:2
+ └── projections
+      └── case [as=case:12, outer=(2), volatile, correlated-subquery]
+           ├── true
+           ├── when
+           │    ├── i:2 < 0
+           │    └── 3
+           ├── when
+           │    ├── lt
+           │    │    ├── i:2
+           │    │    └── subquery
+           │    │         └── project
+           │    │              ├── columns: y:9
+           │    │              ├── outer: (2)
+           │    │              ├── cardinality: [0 - 1]
+           │    │              ├── volatile
+           │    │              ├── key: ()
+           │    │              ├── fd: ()-->(9)
+           │    │              └── limit
+           │    │                   ├── columns: x:8!null y:9
+           │    │                   ├── outer: (2)
+           │    │                   ├── cardinality: [0 - 1]
+           │    │                   ├── volatile
+           │    │                   ├── key: ()
+           │    │                   ├── fd: ()-->(8,9)
+           │    │                   ├── select
+           │    │                   │    ├── columns: x:8!null y:9
+           │    │                   │    ├── outer: (2)
+           │    │                   │    ├── cardinality: [0 - 1]
+           │    │                   │    ├── key: ()
+           │    │                   │    ├── fd: ()-->(8,9)
+           │    │                   │    ├── scan xy
+           │    │                   │    │    ├── columns: x:8!null y:9
+           │    │                   │    │    ├── key: (8)
+           │    │                   │    │    └── fd: (8)-->(9)
+           │    │                   │    └── filters
+           │    │                   │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+           │    │                   └── (random() * 10.0)::INT8
+           │    └── 4
+           └── 5
+
+# Don't hoist CASE WHEN branch if there are side effects.
 norm
 SELECT CASE WHEN i<0 THEN (SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int) ELSE 5 END FROM a
 ----
@@ -200,7 +307,7 @@ project
            │                   └── (random() * 10.0)::INT8
            └── 5
 
-# Don't decorrelate CASE ELSE branch if there are side effects.
+# Don't hoist CASE ELSE branch if there are side effects.
 norm
 SELECT * FROM a WHERE (CASE WHEN i<0 THEN 5 ELSE (SELECT y FROM xy WHERE x=i AND 5/y>1) END)=k
 ----
@@ -244,8 +351,277 @@ select
                                     ├── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
                                     └── (5 / y:9) > 1 [outer=(9), immutable]
 
+# Case with some expressions that can be hoisted, and some which cannot.
+norm
+SELECT CASE
+  WHEN i<(SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int)
+  THEN (SELECT y FROM xy WHERE x=i LIMIT 1)
+  WHEN i<(SELECT y FROM xy WHERE x=i LIMIT 1)
+  THEN (SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int)
+  WHEN i<(SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int)
+  THEN (SELECT y FROM xy WHERE x=i LIMIT 1)
+  ELSE (SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int) END
+FROM a
+----
+project
+ ├── columns: y:36
+ ├── volatile
+ ├── left-join (hash)
+ │    ├── columns: i:2 x:8 xy.y:9 x:12 xy.y:13 x:24 xy.y:25 x:32 xy.y:33
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── volatile
+ │    ├── fd: (24)-->(25), (12)-->(13), (32)-->(33)
+ │    ├── left-join (hash)
+ │    │    ├── columns: i:2 x:8 xy.y:9 x:12 xy.y:13 x:24 xy.y:25
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── volatile
+ │    │    ├── fd: (24)-->(25), (12)-->(13)
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: i:2 x:8 xy.y:9 x:24 xy.y:25
+ │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    │    ├── volatile
+ │    │    │    ├── fd: (24)-->(25)
+ │    │    │    ├── left-join-apply
+ │    │    │    │    ├── columns: i:2 x:8 xy.y:9
+ │    │    │    │    ├── volatile
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    └── columns: i:2
+ │    │    │    │    ├── limit
+ │    │    │    │    │    ├── columns: x:8!null xy.y:9
+ │    │    │    │    │    ├── outer: (2)
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── volatile
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    ├── fd: ()-->(8,9)
+ │    │    │    │    │    ├── select
+ │    │    │    │    │    │    ├── columns: x:8!null xy.y:9
+ │    │    │    │    │    │    ├── outer: (2)
+ │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    ├── fd: ()-->(8,9)
+ │    │    │    │    │    │    ├── scan xy
+ │    │    │    │    │    │    │    ├── columns: x:8!null xy.y:9
+ │    │    │    │    │    │    │    ├── key: (8)
+ │    │    │    │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    │    │    │    │    └── (random() * 10.0)::INT8
+ │    │    │    │    └── filters (true)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:24!null xy.y:25
+ │    │    │    │    ├── key: (24)
+ │    │    │    │    └── fd: (24)-->(25)
+ │    │    │    └── filters
+ │    │    │         └── x:24 = i:2 [outer=(2,24), constraints=(/2: (/NULL - ]; /24: (/NULL - ]), fd=(2)==(24), (24)==(2)]
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:12!null xy.y:13
+ │    │    │    ├── key: (12)
+ │    │    │    └── fd: (12)-->(13)
+ │    │    └── filters
+ │    │         └── x:12 = i:2 [outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
+ │    ├── scan xy
+ │    │    ├── columns: x:32!null xy.y:33
+ │    │    ├── key: (32)
+ │    │    └── fd: (32)-->(33)
+ │    └── filters
+ │         └── x:32 = i:2 [outer=(2,32), constraints=(/2: (/NULL - ]; /32: (/NULL - ]), fd=(2)==(32), (32)==(2)]
+ └── projections
+      └── case [as=y:36, outer=(2,9,13,25,33), volatile, correlated-subquery]
+           ├── true
+           ├── when
+           │    ├── i:2 < xy.y:9
+           │    └── xy.y:25
+           ├── when
+           │    ├── i:2 < xy.y:13
+           │    └── subquery
+           │         └── project
+           │              ├── columns: xy.y:29
+           │              ├── outer: (2)
+           │              ├── cardinality: [0 - 1]
+           │              ├── volatile
+           │              ├── key: ()
+           │              ├── fd: ()-->(29)
+           │              └── limit
+           │                   ├── columns: x:28!null xy.y:29
+           │                   ├── outer: (2)
+           │                   ├── cardinality: [0 - 1]
+           │                   ├── volatile
+           │                   ├── key: ()
+           │                   ├── fd: ()-->(28,29)
+           │                   ├── select
+           │                   │    ├── columns: x:28!null xy.y:29
+           │                   │    ├── outer: (2)
+           │                   │    ├── cardinality: [0 - 1]
+           │                   │    ├── key: ()
+           │                   │    ├── fd: ()-->(28,29)
+           │                   │    ├── scan xy
+           │                   │    │    ├── columns: x:28!null xy.y:29
+           │                   │    │    ├── key: (28)
+           │                   │    │    └── fd: (28)-->(29)
+           │                   │    └── filters
+           │                   │         └── x:28 = i:2 [outer=(2,28), constraints=(/2: (/NULL - ]; /28: (/NULL - ]), fd=(2)==(28), (28)==(2)]
+           │                   └── (random() * 10.0)::INT8
+           ├── when
+           │    ├── lt
+           │    │    ├── i:2
+           │    │    └── subquery
+           │    │         └── project
+           │    │              ├── columns: xy.y:17
+           │    │              ├── outer: (2)
+           │    │              ├── cardinality: [0 - 1]
+           │    │              ├── volatile
+           │    │              ├── key: ()
+           │    │              ├── fd: ()-->(17)
+           │    │              └── limit
+           │    │                   ├── columns: x:16!null xy.y:17
+           │    │                   ├── outer: (2)
+           │    │                   ├── cardinality: [0 - 1]
+           │    │                   ├── volatile
+           │    │                   ├── key: ()
+           │    │                   ├── fd: ()-->(16,17)
+           │    │                   ├── select
+           │    │                   │    ├── columns: x:16!null xy.y:17
+           │    │                   │    ├── outer: (2)
+           │    │                   │    ├── cardinality: [0 - 1]
+           │    │                   │    ├── key: ()
+           │    │                   │    ├── fd: ()-->(16,17)
+           │    │                   │    ├── scan xy
+           │    │                   │    │    ├── columns: x:16!null xy.y:17
+           │    │                   │    │    ├── key: (16)
+           │    │                   │    │    └── fd: (16)-->(17)
+           │    │                   │    └── filters
+           │    │                   │         └── x:16 = i:2 [outer=(2,16), constraints=(/2: (/NULL - ]; /16: (/NULL - ]), fd=(2)==(16), (16)==(2)]
+           │    │                   └── (random() * 10.0)::INT8
+           │    └── xy.y:33
+           └── subquery
+                └── project
+                     ├── columns: xy.y:21
+                     ├── outer: (2)
+                     ├── cardinality: [0 - 1]
+                     ├── volatile
+                     ├── key: ()
+                     ├── fd: ()-->(21)
+                     └── limit
+                          ├── columns: x:20!null xy.y:21
+                          ├── outer: (2)
+                          ├── cardinality: [0 - 1]
+                          ├── volatile
+                          ├── key: ()
+                          ├── fd: ()-->(20,21)
+                          ├── select
+                          │    ├── columns: x:20!null xy.y:21
+                          │    ├── outer: (2)
+                          │    ├── cardinality: [0 - 1]
+                          │    ├── key: ()
+                          │    ├── fd: ()-->(20,21)
+                          │    ├── scan xy
+                          │    │    ├── columns: x:20!null xy.y:21
+                          │    │    ├── key: (20)
+                          │    │    └── fd: (20)-->(21)
+                          │    └── filters
+                          │         └── x:20 = i:2 [outer=(2,20), constraints=(/2: (/NULL - ]; /20: (/NULL - ]), fd=(2)==(20), (20)==(2)]
+                          └── (random() * 10.0)::INT8
 
-# Don't decorrelate IFERROR branch if there are side effects
+# The first argument of a COALESCE can always be hoisted.
+norm
+SELECT COALESCE((SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int), 10) FROM a;
+----
+project
+ ├── columns: coalesce:12
+ ├── volatile
+ ├── left-join-apply
+ │    ├── columns: i:2 x:8 y:9
+ │    ├── volatile
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── limit
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── outer: (2)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── volatile
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(8,9)
+ │    │    ├── select
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── outer: (2)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(8,9)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:8!null y:9
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    └── filters
+ │    │    │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    │    └── (random() * 10.0)::INT8
+ │    └── filters (true)
+ └── projections
+      └── COALESCE(y:9, 10) [as=coalesce:12, outer=(9)]
+
+# Following COALESCE arguments can be hoisted if leakproof.
+norm
+SELECT COALESCE(i, (SELECT y FROM xy WHERE x=i LIMIT 1), 10) FROM a;
+----
+project
+ ├── columns: coalesce:12
+ ├── left-join (hash)
+ │    ├── columns: i:2 x:8 y:9
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── fd: (8)-->(9)
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── projections
+      └── COALESCE(i:2, y:9, 10) [as=coalesce:12, outer=(2,9)]
+
+# A volatile COALESCE argument (other than the first) cannot be hoisted.
+norm
+SELECT COALESCE(i, (SELECT y FROM xy WHERE x=i LIMIT (random()*10)::int), 10) FROM a;
+----
+project
+ ├── columns: coalesce:12
+ ├── volatile
+ ├── scan a
+ │    └── columns: i:2
+ └── projections
+      └── coalesce [as=coalesce:12, outer=(2), volatile, correlated-subquery]
+           ├── i:2
+           ├── subquery
+           │    └── project
+           │         ├── columns: y:9
+           │         ├── outer: (2)
+           │         ├── cardinality: [0 - 1]
+           │         ├── volatile
+           │         ├── key: ()
+           │         ├── fd: ()-->(9)
+           │         └── limit
+           │              ├── columns: x:8!null y:9
+           │              ├── outer: (2)
+           │              ├── cardinality: [0 - 1]
+           │              ├── volatile
+           │              ├── key: ()
+           │              ├── fd: ()-->(8,9)
+           │              ├── select
+           │              │    ├── columns: x:8!null y:9
+           │              │    ├── outer: (2)
+           │              │    ├── cardinality: [0 - 1]
+           │              │    ├── key: ()
+           │              │    ├── fd: ()-->(8,9)
+           │              │    ├── scan xy
+           │              │    │    ├── columns: x:8!null y:9
+           │              │    │    ├── key: (8)
+           │              │    │    └── fd: (8)-->(9)
+           │              │    └── filters
+           │              │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+           │              └── (random() * 10.0)::INT8
+           └── 10
+
+# Don't hoist IFERROR branch if there are side effects
 norm
 SELECT * FROM a WHERE IFERROR(1/0, (SELECT y::DECIMAL FROM xy WHERE x = i AND 5/y>1))=k
 ----
@@ -289,7 +665,7 @@ select
                                └── projections
                                     └── xy.y:9::DECIMAL [as=y:12, outer=(9), immutable]
 
-# Decorrelate IFERROR branch if there are no side effects
+# Hoist IFERROR branch if there are no side effects
 norm
 SELECT * FROM a WHERE IFERROR((1/0)::int, (SELECT y FROM xy WHERE x = i))=k
 ----
@@ -320,3 +696,54 @@ project
       │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
       └── filters
            └── k:1 = IFERROR((1 / 0)::INT8, y:9) [outer=(1,9), immutable, constraints=(/1: (/NULL - ]), fd=(9)-->(1)]
+
+# Regression test for #97432 - only hoist leakproof subqueries from
+# conditionally-evaluated CASE branches.
+norm
+SELECT CASE WHEN f = 1
+  THEN (SELECT y FROM xy WHERE x = i) --Hoistable
+  ELSE (SELECT 1 // 0 FROM xy WHERE x = i) END --Not Hoistable
+FROM a;
+----
+project
+ ├── columns: case:17
+ ├── immutable
+ ├── left-join (hash)
+ │    ├── columns: i:2 f:3 x:13 y:14
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── fd: (13)-->(14)
+ │    ├── scan a
+ │    │    └── columns: i:2 f:3
+ │    ├── scan xy
+ │    │    ├── columns: x:13!null y:14
+ │    │    ├── key: (13)
+ │    │    └── fd: (13)-->(14)
+ │    └── filters
+ │         └── x:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
+ └── projections
+      └── case [as=case:17, outer=(2,3,14), immutable, correlated-subquery]
+           ├── true
+           ├── when
+           │    ├── f:3 = 1.0
+           │    └── y:14
+           └── subquery
+                └── project
+                     ├── columns: "?column?":12!null
+                     ├── outer: (2)
+                     ├── cardinality: [0 - 1]
+                     ├── immutable
+                     ├── key: ()
+                     ├── fd: ()-->(12)
+                     ├── select
+                     │    ├── columns: x:8!null
+                     │    ├── outer: (2)
+                     │    ├── cardinality: [0 - 1]
+                     │    ├── key: ()
+                     │    ├── fd: ()-->(8)
+                     │    ├── scan xy
+                     │    │    ├── columns: x:8!null
+                     │    │    └── key: (8)
+                     │    └── filters
+                     │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+                     └── projections
+                          └── 1 // 0 [as="?column?":12, immutable]

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -165,27 +165,27 @@ project
  ├── immutable
  ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
  ├── group-by (hash)
- │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:192!null
- │    ├── grouping columns: rownum:192!null
+ │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:193!null
+ │    ├── grouping columns: rownum:193!null
  │    ├── immutable
- │    ├── key: (192)
- │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
+ │    ├── key: (193)
+ │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
  │    ├── right-join (hash)
- │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:192!null
+ │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:193!null
  │    │    ├── immutable
- │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
+ │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
  │    │    ├── scan pg_inherits
  │    │    │    └── columns: pg_inherits.inhparent:150!null
  │    │    ├── distinct-on
- │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:192!null
- │    │    │    ├── grouping columns: rownum:192!null
+ │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:193!null
+ │    │    │    ├── grouping columns: rownum:193!null
  │    │    │    ├── immutable
- │    │    │    ├── key: (192)
- │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
+ │    │    │    ├── key: (193)
+ │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
  │    │    │    ├── right-join (hash)
- │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:192!null
+ │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:193!null
  │    │    │    │    ├── immutable
- │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
+ │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
  │    │    │    │    ├── union-all
  │    │    │    │    │    ├── columns: objoid:186!null description:189!null
  │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:177 crdb_internal.kv_catalog_comments.description:179
@@ -214,132 +214,164 @@ project
  │    │    │    │    │    └── scan kv_builtin_function_comments
  │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
  │    │    │    │    ├── ordinality
- │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:192!null
+ │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:193!null
  │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── key: (192)
- │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
+ │    │    │    │    │    ├── key: (193)
+ │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
  │    │    │    │    │    └── project
  │    │    │    │    │         ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
  │    │    │    │    │         ├── immutable
  │    │    │    │    │         ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
- │    │    │    │    │         ├── left-join (lookup pg_namespace [as=n2])
- │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    ├── key columns: [51] = [78]
- │    │    │    │    │         │    ├── lookup columns are key
- │    │    │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+ │    │    │    │    │         ├── distinct-on
+ │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:192!null
+ │    │    │    │    │         │    ├── grouping columns: rownum:192!null
+ │    │    │    │    │         │    ├── key: (192)
+ │    │    │    │    │         │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
  │    │    │    │    │         │    ├── right-join (hash)
- │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    ├── inner-join (hash)
- │    │    │    │    │         │    │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
- │    │    │    │    │         │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    │    │         │    │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
- │    │    │    │    │         │    │    │    ├── scan pg_inherits [as=i]
- │    │    │    │    │         │    │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
- │    │    │    │    │         │    │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
- │    │    │    │    │         │    │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
- │    │    │    │    │         │    │    │    │    ├── key: (49)
- │    │    │    │    │         │    │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
- │    │    │    │    │         │    │    │    └── filters
- │    │    │    │    │         │    │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
- │    │    │    │    │         │    │    ├── left-join (lookup pg_class [as=ci])
- │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    ├── key columns: [84] = [105]
- │    │    │    │    │         │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    ├── key: (1,84)
- │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    ├── left-join (lookup pg_index [as=ind])
- │    │    │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    │    ├── key columns: [966] = [84]
- │    │    │    │    │         │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    ├── second join in paired joiner
- │    │    │    │    │         │    │    │    │    ├── key: (1,84)
- │    │    │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
- │    │    │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:966 indrelid:967 continuation:987
- │    │    │    │    │         │    │    │    │    │    ├── key columns: [1] = [967]
- │    │    │    │    │         │    │    │    │    │    ├── first join in paired joiner; continuation column: continuation:987
- │    │    │    │    │         │    │    │    │    │    ├── key: (1,966)
- │    │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (966)-->(967,987)
- │    │    │    │    │         │    │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
- │    │    │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    │    │    │    ├── key columns: [8] = [36]
- │    │    │    │    │         │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
- │    │    │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    │    │    │    │    ├── key columns: [135] = [139]
- │    │    │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key columns: [1] = [134]
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── inner-join (hash)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── select
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │         │    │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
- │    │    │    │    │         │    │    │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    └── filters
- │    │    │    │    │         │    │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
- │    │    │    │    │         │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:192!null
+ │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    │         │    │    ├── scan pg_roles
+ │    │    │    │    │         │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
+ │    │    │    │    │         │    │    ├── ordinality
+ │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:192!null
+ │    │    │    │    │         │    │    │    ├── key: (192)
+ │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    │         │    │    │    └── left-join (lookup pg_namespace [as=n2])
+ │    │    │    │    │         │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         ├── key columns: [51] = [78]
+ │    │    │    │    │         │    │    │         ├── lookup columns are key
+ │    │    │    │    │         │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+ │    │    │    │    │         │    │    │         ├── right-join (hash)
+ │    │    │    │    │         │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    ├── inner-join (hash)
+ │    │    │    │    │         │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+ │    │    │    │    │         │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    │    │         │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
+ │    │    │    │    │         │    │    │         │    │    ├── scan pg_inherits [as=i]
+ │    │    │    │    │         │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
+ │    │    │    │    │         │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
+ │    │    │    │    │         │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+ │    │    │    │    │         │    │    │         │    │    │    ├── key: (49)
+ │    │    │    │    │         │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+ │    │    │    │    │         │    │    │         │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
+ │    │    │    │    │         │    │    │         │    ├── left-join (lookup pg_class [as=ci])
+ │    │    │    │    │         │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    ├── key columns: [84] = [105]
+ │    │    │    │    │         │    │    │         │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    ├── key: (1,84)
+ │    │    │    │    │         │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
+ │    │    │    │    │         │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    │    ├── key columns: [967] = [84]
+ │    │    │    │    │         │    │    │         │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    ├── second join in paired joiner
+ │    │    │    │    │         │    │    │         │    │    │    ├── key: (1,84)
+ │    │    │    │    │         │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:967 indrelid:968 continuation:988
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── key columns: [1] = [968]
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:988
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── key: (1,967)
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (967)-->(968,988)
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── select
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
+ │    │    │    │    │         │    │    │         │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    └── filters
+ │    │    │    │    │         │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
+ │    │    │    │    │         │    │    │         └── filters (true)
  │    │    │    │    │         │    │    └── filters
- │    │    │    │    │         │    │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
- │    │    │    │    │         │    └── filters (true)
+ │    │    │    │    │         │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+ │    │    │    │    │         │    └── aggregations
+ │    │    │    │    │         │         ├── const-agg [as=c.oid:1, outer=(1)]
+ │    │    │    │    │         │         │    └── c.oid:1
+ │    │    │    │    │         │         ├── const-agg [as=c.relname:2, outer=(2)]
+ │    │    │    │    │         │         │    └── c.relname:2
+ │    │    │    │    │         │         ├── const-agg [as=c.relowner:5, outer=(5)]
+ │    │    │    │    │         │         │    └── c.relowner:5
+ │    │    │    │    │         │         ├── const-agg [as=c.reltuples:10, outer=(10)]
+ │    │    │    │    │         │         │    └── c.reltuples:10
+ │    │    │    │    │         │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
+ │    │    │    │    │         │         │    └── c.relhasindex:13
+ │    │    │    │    │         │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
+ │    │    │    │    │         │         │    └── c.relpersistence:15
+ │    │    │    │    │         │         ├── const-agg [as=c.relkind:17, outer=(17)]
+ │    │    │    │    │         │         │    └── c.relkind:17
+ │    │    │    │    │         │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
+ │    │    │    │    │         │         │    └── c.relhasoids:20
+ │    │    │    │    │         │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
+ │    │    │    │    │         │         │    └── c.relhasrules:22
+ │    │    │    │    │         │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
+ │    │    │    │    │         │         │    └── c.relhastriggers:23
+ │    │    │    │    │         │         ├── const-agg [as=c.relacl:26, outer=(26)]
+ │    │    │    │    │         │         │    └── c.relacl:26
+ │    │    │    │    │         │         ├── const-agg [as=c.reloptions:27, outer=(27)]
+ │    │    │    │    │         │         │    └── c.reloptions:27
+ │    │    │    │    │         │         ├── const-agg [as=n.nspname:31, outer=(31)]
+ │    │    │    │    │         │         │    └── n.nspname:31
+ │    │    │    │    │         │         ├── const-agg [as=spcname:37, outer=(37)]
+ │    │    │    │    │         │         │    └── spcname:37
+ │    │    │    │    │         │         ├── const-agg [as=c2.relname:50, outer=(50)]
+ │    │    │    │    │         │         │    └── c2.relname:50
+ │    │    │    │    │         │         ├── const-agg [as=n2.nspname:79, outer=(79)]
+ │    │    │    │    │         │         │    └── n2.nspname:79
+ │    │    │    │    │         │         ├── const-agg [as=ci.relname:106, outer=(106)]
+ │    │    │    │    │         │         │    └── ci.relname:106
+ │    │    │    │    │         │         ├── const-agg [as=ftoptions:136, outer=(136)]
+ │    │    │    │    │         │         │    └── ftoptions:136
+ │    │    │    │    │         │         ├── const-agg [as=srvname:140, outer=(140)]
+ │    │    │    │    │         │         │    └── srvname:140
+ │    │    │    │    │         │         └── first-agg [as=rolname:158, outer=(158)]
+ │    │    │    │    │         │              └── rolname:158
  │    │    │    │    │         └── projections
- │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5), immutable, correlated-subquery]
- │    │    │    │    │                   └── coalesce
- │    │    │    │    │                        ├── subquery
- │    │    │    │    │                        │    └── project
- │    │    │    │    │                        │         ├── columns: rolname:158
- │    │    │    │    │                        │         ├── outer: (5)
- │    │    │    │    │                        │         ├── cardinality: [0 - 1]
- │    │    │    │    │                        │         ├── key: ()
- │    │    │    │    │                        │         ├── fd: ()-->(158)
- │    │    │    │    │                        │         └── limit
- │    │    │    │    │                        │              ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
- │    │    │    │    │                        │              ├── outer: (5)
- │    │    │    │    │                        │              ├── cardinality: [0 - 1]
- │    │    │    │    │                        │              ├── key: ()
- │    │    │    │    │                        │              ├── fd: ()-->(157,158)
- │    │    │    │    │                        │              ├── select
- │    │    │    │    │                        │              │    ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
- │    │    │    │    │                        │              │    ├── outer: (5)
- │    │    │    │    │                        │              │    ├── fd: ()-->(157)
- │    │    │    │    │                        │              │    ├── limit hint: 1.00
- │    │    │    │    │                        │              │    ├── scan pg_roles
- │    │    │    │    │                        │              │    │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
- │    │    │    │    │                        │              │    │    └── limit hint: 1.01
- │    │    │    │    │                        │              │    └── filters
- │    │    │    │    │                        │              │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
- │    │    │    │    │                        │              └── 1
- │    │    │    │    │                        └── (('unknown (OID=' || c.relowner:5) || ')')::NAME
+ │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
+ │    │    │    │    │                   └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
  │    │    │    │    └── filters
  │    │    │    │         └── objoid:186 = c.oid:1 [outer=(1,186), constraints=(/1: (/NULL - ]; /186: (/NULL - ]), fd=(1)==(186), (186)==(1)]
  │    │    │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -169,27 +169,27 @@ sort
       ├── immutable
       ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
       ├── group-by (hash)
-      │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:192!null
-      │    ├── grouping columns: rownum:192!null
+      │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:193!null
+      │    ├── grouping columns: rownum:193!null
       │    ├── immutable
-      │    ├── key: (192)
-      │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
+      │    ├── key: (193)
+      │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
       │    ├── right-join (hash)
-      │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:192!null
+      │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:193!null
       │    │    ├── immutable
-      │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
+      │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
       │    │    ├── scan pg_inherits
       │    │    │    └── columns: pg_inherits.inhparent:150!null
       │    │    ├── distinct-on
-      │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:192!null
-      │    │    │    ├── grouping columns: rownum:192!null
+      │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:193!null
+      │    │    │    ├── grouping columns: rownum:193!null
       │    │    │    ├── immutable
-      │    │    │    ├── key: (192)
-      │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
+      │    │    │    ├── key: (193)
+      │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
       │    │    │    ├── right-join (hash)
-      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:192!null
+      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:193!null
       │    │    │    │    ├── immutable
-      │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
+      │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
       │    │    │    │    ├── union-all
       │    │    │    │    │    ├── columns: objoid:186!null description:189!null
       │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:177 crdb_internal.kv_catalog_comments.description:179
@@ -218,132 +218,164 @@ sort
       │    │    │    │    │    └── scan kv_builtin_function_comments
       │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
       │    │    │    │    ├── ordinality
-      │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:192!null
+      │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:193!null
       │    │    │    │    │    ├── immutable
-      │    │    │    │    │    ├── key: (192)
-      │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
+      │    │    │    │    │    ├── key: (193)
+      │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
       │    │    │    │    │    └── project
       │    │    │    │    │         ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
       │    │    │    │    │         ├── immutable
       │    │    │    │    │         ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
-      │    │    │    │    │         ├── left-join (lookup pg_namespace [as=n2])
-      │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    ├── key columns: [51] = [78]
-      │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+      │    │    │    │    │         ├── distinct-on
+      │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:192!null
+      │    │    │    │    │         │    ├── grouping columns: rownum:192!null
+      │    │    │    │    │         │    ├── key: (192)
+      │    │    │    │    │         │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
       │    │    │    │    │         │    ├── right-join (hash)
-      │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    ├── inner-join (hash)
-      │    │    │    │    │         │    │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
-      │    │    │    │    │         │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    │         │    │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
-      │    │    │    │    │         │    │    │    ├── scan pg_inherits [as=i]
-      │    │    │    │    │         │    │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
-      │    │    │    │    │         │    │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
-      │    │    │    │    │         │    │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
-      │    │    │    │    │         │    │    │    │    ├── key: (49)
-      │    │    │    │    │         │    │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
-      │    │    │    │    │         │    │    │    └── filters
-      │    │    │    │    │         │    │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
-      │    │    │    │    │         │    │    ├── left-join (lookup pg_class [as=ci])
-      │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    ├── key columns: [84] = [105]
-      │    │    │    │    │         │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    ├── key: (1,84)
-      │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    ├── left-join (lookup pg_index [as=ind])
-      │    │    │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    │    ├── key columns: [966] = [84]
-      │    │    │    │    │         │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    ├── second join in paired joiner
-      │    │    │    │    │         │    │    │    │    ├── key: (1,84)
-      │    │    │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
-      │    │    │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:966 indrelid:967 continuation:987
-      │    │    │    │    │         │    │    │    │    │    ├── key columns: [1] = [967]
-      │    │    │    │    │         │    │    │    │    │    ├── first join in paired joiner; continuation column: continuation:987
-      │    │    │    │    │         │    │    │    │    │    ├── key: (1,966)
-      │    │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (966)-->(967,987)
-      │    │    │    │    │         │    │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
-      │    │    │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    │    │    │    ├── key columns: [8] = [36]
-      │    │    │    │    │         │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── key columns: [135] = [139]
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key columns: [1] = [134]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── inner-join (hash)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
-      │    │    │    │    │         │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:192!null
+      │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    │         │    │    ├── scan pg_roles
+      │    │    │    │    │         │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
+      │    │    │    │    │         │    │    ├── ordinality
+      │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:192!null
+      │    │    │    │    │         │    │    │    ├── key: (192)
+      │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    │         │    │    │    └── left-join (lookup pg_namespace [as=n2])
+      │    │    │    │    │         │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         ├── key columns: [51] = [78]
+      │    │    │    │    │         │    │    │         ├── lookup columns are key
+      │    │    │    │    │         │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+      │    │    │    │    │         │    │    │         ├── right-join (hash)
+      │    │    │    │    │         │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    ├── inner-join (hash)
+      │    │    │    │    │         │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+      │    │    │    │    │         │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │         │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
+      │    │    │    │    │         │    │    │         │    │    ├── scan pg_inherits [as=i]
+      │    │    │    │    │         │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
+      │    │    │    │    │         │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
+      │    │    │    │    │         │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+      │    │    │    │    │         │    │    │         │    │    │    ├── key: (49)
+      │    │    │    │    │         │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+      │    │    │    │    │         │    │    │         │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
+      │    │    │    │    │         │    │    │         │    ├── left-join (lookup pg_class [as=ci])
+      │    │    │    │    │         │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    ├── key columns: [84] = [105]
+      │    │    │    │    │         │    │    │         │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    ├── key: (1,84)
+      │    │    │    │    │         │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
+      │    │    │    │    │         │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    │    ├── key columns: [967] = [84]
+      │    │    │    │    │         │    │    │         │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    ├── second join in paired joiner
+      │    │    │    │    │         │    │    │         │    │    │    ├── key: (1,84)
+      │    │    │    │    │         │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:967 indrelid:968 continuation:988
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── key columns: [1] = [968]
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:988
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── key: (1,967)
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (967)-->(968,988)
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
+      │    │    │    │    │         │    │    │         │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    └── filters
+      │    │    │    │    │         │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
+      │    │    │    │    │         │    │    │         └── filters (true)
       │    │    │    │    │         │    │    └── filters
-      │    │    │    │    │         │    │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
-      │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │         │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+      │    │    │    │    │         │    └── aggregations
+      │    │    │    │    │         │         ├── const-agg [as=c.oid:1, outer=(1)]
+      │    │    │    │    │         │         │    └── c.oid:1
+      │    │    │    │    │         │         ├── const-agg [as=c.relname:2, outer=(2)]
+      │    │    │    │    │         │         │    └── c.relname:2
+      │    │    │    │    │         │         ├── const-agg [as=c.relowner:5, outer=(5)]
+      │    │    │    │    │         │         │    └── c.relowner:5
+      │    │    │    │    │         │         ├── const-agg [as=c.reltuples:10, outer=(10)]
+      │    │    │    │    │         │         │    └── c.reltuples:10
+      │    │    │    │    │         │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
+      │    │    │    │    │         │         │    └── c.relhasindex:13
+      │    │    │    │    │         │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
+      │    │    │    │    │         │         │    └── c.relpersistence:15
+      │    │    │    │    │         │         ├── const-agg [as=c.relkind:17, outer=(17)]
+      │    │    │    │    │         │         │    └── c.relkind:17
+      │    │    │    │    │         │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
+      │    │    │    │    │         │         │    └── c.relhasoids:20
+      │    │    │    │    │         │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
+      │    │    │    │    │         │         │    └── c.relhasrules:22
+      │    │    │    │    │         │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
+      │    │    │    │    │         │         │    └── c.relhastriggers:23
+      │    │    │    │    │         │         ├── const-agg [as=c.relacl:26, outer=(26)]
+      │    │    │    │    │         │         │    └── c.relacl:26
+      │    │    │    │    │         │         ├── const-agg [as=c.reloptions:27, outer=(27)]
+      │    │    │    │    │         │         │    └── c.reloptions:27
+      │    │    │    │    │         │         ├── const-agg [as=n.nspname:31, outer=(31)]
+      │    │    │    │    │         │         │    └── n.nspname:31
+      │    │    │    │    │         │         ├── const-agg [as=spcname:37, outer=(37)]
+      │    │    │    │    │         │         │    └── spcname:37
+      │    │    │    │    │         │         ├── const-agg [as=c2.relname:50, outer=(50)]
+      │    │    │    │    │         │         │    └── c2.relname:50
+      │    │    │    │    │         │         ├── const-agg [as=n2.nspname:79, outer=(79)]
+      │    │    │    │    │         │         │    └── n2.nspname:79
+      │    │    │    │    │         │         ├── const-agg [as=ci.relname:106, outer=(106)]
+      │    │    │    │    │         │         │    └── ci.relname:106
+      │    │    │    │    │         │         ├── const-agg [as=ftoptions:136, outer=(136)]
+      │    │    │    │    │         │         │    └── ftoptions:136
+      │    │    │    │    │         │         ├── const-agg [as=srvname:140, outer=(140)]
+      │    │    │    │    │         │         │    └── srvname:140
+      │    │    │    │    │         │         └── first-agg [as=rolname:158, outer=(158)]
+      │    │    │    │    │         │              └── rolname:158
       │    │    │    │    │         └── projections
-      │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5), immutable, correlated-subquery]
-      │    │    │    │    │                   └── coalesce
-      │    │    │    │    │                        ├── subquery
-      │    │    │    │    │                        │    └── project
-      │    │    │    │    │                        │         ├── columns: rolname:158
-      │    │    │    │    │                        │         ├── outer: (5)
-      │    │    │    │    │                        │         ├── cardinality: [0 - 1]
-      │    │    │    │    │                        │         ├── key: ()
-      │    │    │    │    │                        │         ├── fd: ()-->(158)
-      │    │    │    │    │                        │         └── limit
-      │    │    │    │    │                        │              ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
-      │    │    │    │    │                        │              ├── outer: (5)
-      │    │    │    │    │                        │              ├── cardinality: [0 - 1]
-      │    │    │    │    │                        │              ├── key: ()
-      │    │    │    │    │                        │              ├── fd: ()-->(157,158)
-      │    │    │    │    │                        │              ├── select
-      │    │    │    │    │                        │              │    ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
-      │    │    │    │    │                        │              │    ├── outer: (5)
-      │    │    │    │    │                        │              │    ├── fd: ()-->(157)
-      │    │    │    │    │                        │              │    ├── limit hint: 1.00
-      │    │    │    │    │                        │              │    ├── scan pg_roles
-      │    │    │    │    │                        │              │    │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
-      │    │    │    │    │                        │              │    │    └── limit hint: 1.01
-      │    │    │    │    │                        │              │    └── filters
-      │    │    │    │    │                        │              │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
-      │    │    │    │    │                        │              └── 1
-      │    │    │    │    │                        └── (('unknown (OID=' || c.relowner:5) || ')')::NAME
+      │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
+      │    │    │    │    │                   └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
       │    │    │    │    └── filters
       │    │    │    │         └── objoid:186 = c.oid:1 [outer=(1,186), constraints=(/1: (/NULL - ]; /186: (/NULL - ]), fd=(1)==(186), (186)==(1)]
       │    │    │    └── aggregations

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -188,6 +188,11 @@ func TestSchemaChangeComparator_cascade(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cascade"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_case(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/case"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_case_sensitive_names(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/case_sensitive_names"

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -541,6 +541,10 @@ message LocalOnlySessionData {
   // statistics merged from partial and full statistics for cardinality
   // estimation in the optimizer.
   bool optimizer_use_merged_partial_statistics = 137;
+  // OptimizerUseConditionalHoistFix, when true, prevents the optimizer from
+  // hoisting a volatile expression that is conditionally executed by a CASE,
+  // COALESCE, or IFERR expression.
+  bool optimizer_use_conditional_hoist_fix = 138;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3295,6 +3295,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_use_conditional_hoist_fix`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_conditional_hoist_fix`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_conditional_hoist_fix", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseConditionalHoistFix(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseConditionalHoistFix), nil
+		},
+		GlobalDefault: globalTrue,
+	},
+
+	// CockroachDB extension.
 	`optimizer_use_trigram_similarity_optimization`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_trigram_similarity_optimization`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Previously, decorrelation rules could hoist a correlated subquery from a conditional branch of a `CASE`, `COALESCE`, or `IFERR` expression even if it wasn't leakproof. This could cause side effects to occur out of order, and violated CRDB's volatility guarantees. This bug occurred when one branch had a subquery that _could_ be hoisted, which would trigger logic that hoisted _all_ correlated subqueries.

This commit fixes the above problem, so that only leakproof subqueries are hoisted. It also adds a session setting,
`optimizer_use_conditional_hoist_fix`, which can toggle the fix.

Fixes #97432

Release note (bug fix): Fixed a bug that could cause a CASE statement with multiple subqueries to produces the side effects of one of the subqueries even if it shouldn't have been evaluated.