### PR TITLE
build: generate ssh key for roachprod-microbench

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -27,6 +27,7 @@ exit_status=0
 # Set up credentials
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
+generate_ssh_key
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity
 export ROACHPROD_CLUSTER=teamcity-microbench-${TC_BUILD_ID}


### PR DESCRIPTION
Previously, `roachprod` cluster ssh keys were managed via the cloud provider. This was recently updated, and now it is required to have an ssh key available that will be placed on the cluster via its start-up script.

See: #119106

Epic: None
Release Note: None