### PR TITLE
streamingccl: hide all query params

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/streamingccl",
-        "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/ccl/streamingccl/streamclient/pgconn.go
+++ b/pkg/ccl/streamingccl/streamclient/pgconn.go
@@ -32,12 +32,6 @@ const (
 	sslRootCertURLParam = "sslrootcert"
 )
 
-var RedactableURLParameters = []string{
-	sslCertURLParam,
-	sslKeyURLParam,
-	sslRootCertURLParam,
-}
-
 func setupPGXConfig(remote *url.URL, options *options) (*pgx.ConnConfig, error) {
 	noInlineCertURI, tlsInfo, err := uriWithInlineTLSCertsRemoved(remote)
 	if err != nil {

--- a/pkg/ccl/streamingccl/streamingest/testdata/simple
+++ b/pkg/ccl/streamingccl/streamingest/testdata/simple
@@ -23,12 +23,12 @@ CREATE FUNCTION strip_host(s string) returns string language sql AS $$ select co
 query-sql as=destination-system
 SELECT strip_host(description) FROM [SHOW JOBS] WHERE job_type='REPLICATION STREAM INGESTION'
 ----
-CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF source ON ('postgres://root@?sslcert=redacted&sslkey=redacted&sslmode=verify-full&sslrootcert=redacted')
+CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF source ON ('postgres://root@?redacted')
 
 query-sql as=destination-system
 SELECT strip_host(source_cluster_uri) FROM [SHOW TENANT destination WITH REPLICATION STATUS]
 ----
-postgres://root@?sslcert=redacted&sslkey=redacted&sslmode=verify-full&sslrootcert=redacted
+postgres://root@?redacted
 
 # The session on the source should have an app name set.
 query-sql as=source-system


### PR DESCRIPTION
With the ssl param values redacted you already needed to go find the real URI elsewhere to use it, so really the only thing this was telling you was *where* it is replicating from, which the host is enough to do, and the params were just adding noise to the output.

Release note: none.
Epic: none.