### PR TITLE
test: Change owner of multitenant-multiregion

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -60,16 +60,6 @@ func registerAcceptance(r registry.Registry) {
 				name: "multitenant",
 				fn:   runAcceptanceMultitenant,
 			},
-			{
-				name:     "multitenant-multiregion",
-				fn:       runAcceptanceMultitenantMultiRegion,
-				numNodes: 9,
-				nodeRegions: []string{"us-west1-b", "us-west1-b", "us-west1-b",
-					"us-west1-b", "us-west1-b", "us-west1-b",
-					"us-east1-b", "us-east1-b", "us-east1-b"},
-				requiresLicense: true,
-				disallowLocal:   true,
-			},
 		},
 		registry.OwnerObsInf: {
 			{name: "status-server", fn: runStatusServer},
@@ -106,6 +96,16 @@ func registerAcceptance(r registry.Registry) {
 				name:     "mismatched-locality",
 				fn:       runMismatchedLocalityTest,
 				numNodes: 3,
+			},
+			{
+				name:     "multitenant-multiregion",
+				fn:       runAcceptanceMultitenantMultiRegion,
+				numNodes: 9,
+				nodeRegions: []string{"us-west1-b", "us-west1-b", "us-west1-b",
+					"us-west1-b", "us-west1-b", "us-west1-b",
+					"us-east1-b", "us-east1-b", "us-east1-b"},
+				requiresLicense: true,
+				disallowLocal:   true,
 			},
 		},
 	}


### PR DESCRIPTION
Changing the ownership of the multitenant-multiregion test to SQL Foundations, due to the fact that there is no longer a multi-tenant virtual team, and this test was created recently by the Foundations team.

Epic: None
Release note: None