### PR TITLE
roachprod: enable roachprod to be configured for external use

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -164,7 +164,7 @@ func initFlags() {
 			providerOptsContainer[providerName].ConfigureCreateFlags(createCmd.Flags())
 
 			for _, cmd := range []*cobra.Command{
-				destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
+				destroyCmd, extendCmd, listCmd, syncCmd, gcCmd, setupSSHCmd, startCmd, pgurlCmd, adminurlCmd,
 			} {
 				providerOptsContainer[providerName].ConfigureClusterFlags(cmd.Flags(), vm.AcceptMultipleProjects)
 			}

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -124,6 +124,8 @@ func initFlags() {
 	rootCmd.PersistentFlags().IntVarP(&config.MaxConcurrency, "max-concurrency", "", 32,
 		"maximum number of operations to execute on nodes concurrently, set to zero for infinite",
 	)
+	rootCmd.PersistentFlags().StringVarP(&config.EmailDomain, "email-domain", "",
+		config.DefaultEmailDomain, "email domain for users")
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -450,6 +450,13 @@ func initFlags() {
 			"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction distinct from the internal instance ID)")
 	}
 
+	for _, cmd := range []*cobra.Command{startCmd, listCmd, syncCmd} {
+		cmd.Flags().StringSliceVar(&config.DNSRequiredProviders,
+			"dns-required-providers", config.DefaultDNSRequiredProviders,
+			"the cloud providers that must be active to refresh DNS entries",
+		)
+	}
+
 	grafanaAnnotationCmd.Flags().StringArrayVar(&grafanaTags,
 		"tags", []string{}, "grafana annotation tags")
 	grafanaAnnotationCmd.Flags().StringVar(&grafanaDashboardUID,

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -57,6 +58,15 @@ var (
 
 	// EmailDomain used to form fully qualified usernames for gcloud and slack.
 	EmailDomain string
+
+	// DNSRequiredProviders is the list of cloud providers that must be active for
+	// DNS records to be synced when roachprod syncs its state.
+	DefaultDNSRequiredProviders = envOrDefaultStrings(
+		"ROACHPROD_DNS_REQUIRED_PROVIDERS", []string{"gce", "aws"},
+	)
+
+	// DNSRequiredProviders is the list of cloud providers that must be active for
+	DNSRequiredProviders []string
 )
 
 // EnvOrDefaultString returns the value of the environment variable with the
@@ -66,6 +76,13 @@ var (
 func EnvOrDefaultString(key, def string) string {
 	if v, ok := os.LookupEnv(key); ok {
 		return v
+	}
+	return def
+}
+
+func envOrDefaultStrings(key string, def []string) []string {
+	if v, ok := os.LookupEnv(key); ok {
+		return strings.Split(v, ",")
 	}
 	return def
 }

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -49,7 +49,26 @@ var (
 	// SSHDirectory is the path to search for SSH keys needed to set up
 	// set up new roachprod clusters.
 	SSHDirectory = os.ExpandEnv("${HOME}/.ssh")
+
+	// DefaultEmailDomain is used to form the full account name for GCE and Slack.
+	DefaultEmailDomain = EnvOrDefaultString(
+		"ROACHPROD_EMAIL_DOMAIN", "@cockroachlabs.com",
+	)
+
+	// EmailDomain used to form fully qualified usernames for gcloud and slack.
+	EmailDomain string
 )
+
+// EnvOrDefaultString returns the value of the environment variable with the
+// given key, or the default value if the environment variable is not set.
+//
+// Unlike envutil.EnvOrDefaultString, it does not assert properties of the key.
+func EnvOrDefaultString(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return def
+}
 
 func init() {
 	var err error
@@ -69,9 +88,6 @@ func init() {
 const (
 	// DefaultDebugDir is used to stash debug information.
 	DefaultDebugDir = "${HOME}/.roachprod/debug"
-
-	// EmailDomain is used to form the full account name for GCE and Slack.
-	EmailDomain = "@cockroachlabs.com"
 
 	// Local is the prefix used to identify local clusters.
 	// It is also used as the zone for local clusters.

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -63,7 +63,6 @@ go_test(
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
-        "//pkg/roachprod/vm/gce",
         "//pkg/roachprod/vm/gce/testutils",
         "//pkg/roachprod/vm/local",
         "//pkg/testutils/datapathutils",

--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce/testutils"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -106,14 +105,14 @@ func TestServiceNameComponents(t *testing.T) {
 func TestMaybeRegisterServices(t *testing.T) {
 	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	dnsServer, _, providerName := testutils.ProviderWithTestDNSServer(rng)
+	dnsServer, dnsProvider, providerName := testutils.ProviderWithTestDNSServer(rng)
 
 	// Create a cluster with 3 nodes.
 	makeVM := func(clusterName string, i int) vm.VM {
 		return vm.VM{
 			Provider:    providerName,
 			DNSProvider: providerName,
-			PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), gce.Subdomain),
+			PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), dnsProvider.Domain()),
 		}
 	}
 	makeCluster := func() *SyncedCluster {
@@ -171,7 +170,7 @@ func TestMultipleRegistrations(t *testing.T) {
 			return vm.VM{
 				Provider:    providerName,
 				DNSProvider: providerName,
-				PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), gce.Subdomain),
+				PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), testDNS.Domain()),
 			}
 		}
 		clusterName := fmt.Sprintf("cluster-%d", rng.Uint32())

--- a/pkg/roachprod/promhelperclient/BUILD.bazel
+++ b/pkg/roachprod/promhelperclient/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/promhelperclient",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/httputil",

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -39,8 +39,8 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 	}()
 	ctx := context.Background()
 	promUrl := "http://prom_url.com"
-	_ = os.Setenv(prometheusHostUrlEnv, promUrl)
 	c := NewPromClient()
+	c.setUrl(promUrl)
 	t.Run("UpdatePrometheusTargets fails with 400", func(t *testing.T) {
 		c.httpPut = func(ctx context.Context, reqUrl string, h *http.Header, body io.Reader) (
 			resp *http.Response, err error) {
@@ -96,8 +96,8 @@ func TestDeleteClusterConfig(t *testing.T) {
 	}()
 	ctx := context.Background()
 	promUrl := "http://prom_url.com"
-	_ = os.Setenv(prometheusHostUrlEnv, promUrl)
 	c := NewPromClient()
+	c.setUrl(promUrl)
 	t.Run("DeleteClusterConfig fails with 400", func(t *testing.T) {
 		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
 			resp *http.Response, err error) {
@@ -144,7 +144,8 @@ func Test_getToken(t *testing.T) {
 	}()
 	c := NewPromClient()
 	t.Run("insecure url", func(t *testing.T) {
-		token, err := c.getToken(ctx, "http://test.com", false, l)
+		c.setUrl("http://test.com")
+		token, err := c.getToken(ctx, false, l)
 		require.Nil(t, err)
 		require.Empty(t, token)
 	})
@@ -156,7 +157,8 @@ func Test_getToken(t *testing.T) {
 		c.newTokenSource = func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
 			return nil, fmt.Errorf("invalid")
 		}
-		token, err := c.getToken(ctx, "https://test.com", false, l)
+		c.setUrl("https://test.com")
+		token, err := c.getToken(ctx, false, l)
 		require.NotNil(t, err)
 		require.Empty(t, token)
 		require.Equal(t, "error creating GCS oauth token source from specified credential: invalid", err.Error())
@@ -169,7 +171,8 @@ func Test_getToken(t *testing.T) {
 		c.newTokenSource = func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
 			return &mockToken{token: "", err: fmt.Errorf("failed")}, nil
 		}
-		token, err := c.getToken(ctx, "https://test.com", false, l)
+		c.setUrl("https://test.com")
+		token, err := c.getToken(ctx, false, l)
 		require.NotNil(t, err)
 		require.Empty(t, token)
 		require.Equal(t, "error getting identity token: failed", err.Error())
@@ -182,7 +185,8 @@ func Test_getToken(t *testing.T) {
 		c.newTokenSource = func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) {
 			return &mockToken{token: "token"}, nil
 		}
-		token, err := c.getToken(ctx, "https://test.com", false, l)
+		c.setUrl("https://test.com")
+		token, err := c.getToken(ctx, false, l)
 		require.Nil(t, err)
 		require.Equal(t, "Bearer token", token)
 	})

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -329,7 +329,7 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 			l.Printf("Refreshing DNS entries...")
 		}
 		if err := gce.SyncDNS(l, vms); err != nil {
-			l.Errorf("failed to update %s DNS: %v", gce.Subdomain, err)
+			l.Errorf("failed to update DNS: %v", err)
 		}
 	} else {
 		if !config.Quiet {
@@ -1114,7 +1114,7 @@ func urlGenerator(
 ) ([]string, error) {
 	var urls []string
 	for i, node := range nodes {
-		host := vm.Name(c.Name, int(node)) + "." + gce.Subdomain
+		host := vm.Name(c.Name, int(node)) + "." + gce.DNSDomain()
 
 		// There are no DNS entries for local clusters.
 		if c.IsLocal() {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -319,8 +319,18 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 			refreshDNS = false
 		}
 	}
-	if !vm.Providers[aws.ProviderName].Active() {
+	// If there are no DNS required providers, we shouldn't refresh DNS,
+	// it's probably a misconfiguration.
+	if len(config.DNSRequiredProviders) == 0 {
 		refreshDNS = false
+	} else {
+		// If any of the required providers is not active, we shouldn't refresh DNS.
+		for _, p := range config.DNSRequiredProviders {
+			if !vm.Providers[p].Active() {
+				refreshDNS = false
+				break
+			}
+		}
 	}
 	// DNS entries are maintained in the GCE DNS registry for all vms, from all
 	// clouds.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -821,7 +821,7 @@ func updatePrometheusTargets(ctx context.Context, l *logger.Logger, c *install.S
 	}
 	wg.Wait()
 	if len(nodeIPPorts) > 0 {
-		if err := promhelperclient.NewPromClient().UpdatePrometheusTargets(ctx,
+		if err := promhelperclient.DefaultPromClient.UpdatePrometheusTargets(ctx,
 			c.Name, false, nodeIPPorts, !c.Secure, l); err != nil {
 			l.Errorf("creating cluster config failed for the ip:ports %v: %v", nodeIPPorts, err)
 		}
@@ -1453,7 +1453,7 @@ func Destroy(
 				// and let the caller retry.
 				cld, _ = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 			}
-			return destroyCluster(cld, l, name)
+			return destroyCluster(ctx, cld, l, name)
 		}); err != nil {
 		return err
 	}
@@ -1461,7 +1461,9 @@ func Destroy(
 	return nil
 }
 
-func destroyCluster(cld *cloud.Cloud, l *logger.Logger, clusterName string) error {
+func destroyCluster(
+	ctx context.Context, cld *cloud.Cloud, l *logger.Logger, clusterName string,
+) error {
 	c, ok := cld.Clusters[clusterName]
 	if !ok {
 		return fmt.Errorf("cluster %s does not exist", clusterName)

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -28,19 +28,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-const (
-	dnsProject = "cockroach-shared"
-	dnsZone    = "roachprod"
-)
-
-// Subdomain is the DNS subdomain to in which to maintain cluster node names.
-var Subdomain = func() string {
-	if d, ok := os.LookupEnv("ROACHPROD_DNS"); ok {
-		return d
-	}
-	return "roachprod.crdb.io"
-}()
-
 const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
@@ -340,41 +327,12 @@ func writeStartupScript(
 
 // SyncDNS replaces the configured DNS zone with the supplied hosts.
 func SyncDNS(l *logger.Logger, vms vm.List) error {
-	if Subdomain == "" {
-		return nil
-	}
+	return providerInstance.dnsProvider.syncPublicDNS(l, vms)
+}
 
-	f, err := os.CreateTemp(os.ExpandEnv("$HOME/.roachprod/"), "dns.bind")
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	// Keep imported zone file in dry run mode.
-	defer func() {
-		if err := os.Remove(f.Name()); err != nil {
-			l.Errorf("removing %s failed: %v", f.Name(), err)
-		}
-	}()
-
-	var zoneBuilder strings.Builder
-	for _, vm := range vms {
-		entry, err := vm.ZoneEntry()
-		if err != nil {
-			l.Printf("WARN: skipping: %s\n", err)
-			continue
-		}
-		zoneBuilder.WriteString(entry)
-	}
-	fmt.Fprint(f, zoneBuilder.String())
-	f.Close()
-
-	args := []string{"--project", dnsProject, "dns", "record-sets", "import",
-		f.Name(), "-z", dnsZone, "--delete-all-existing", "--zone-file-format"}
-	cmd := exec.Command("gcloud", args...)
-	output, err := cmd.CombinedOutput()
-
-	return errors.Wrapf(err, "Command: %s\nOutput: %s\nZone file contents:\n%s", cmd, output, zoneBuilder.String())
+// DNSDomain returns the configured DNS domain for public DNS A records.
+func DNSDomain() string {
+	return providerInstance.dnsProvider.publicDomain
 }
 
 type AuthorizedKey struct {
@@ -443,7 +401,7 @@ func GetUserAuthorizedKeys() (AuthorizedKeys, error) {
 	var outBuf bytes.Buffer
 	// The below command will return a stream of user:pubkey as text.
 	cmd := exec.Command("gcloud", "compute", "project-info", "describe",
-		fmt.Sprintf("--project=%s", DefaultProject()),
+		"--project="+providerInstance.metadataProject,
 		"--format=value(commonInstanceMetadata.ssh-keys)")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = &outBuf


### PR DESCRIPTION
After this change, roachprod fully works on GCP at my company with the following configuration:

```
ROACHPROD_DNS_REQUIRED_PROVIDERS=gce
ROACHPROD_EMAIL_DOMAIN=@dataexmachina.dev
ROACHPROD_GCE_DEFAULT_PROJECT=dem-ephemeral
ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT=roachprod@dem-ephemeral.iam.gserviceaccount.com
ROACHPROD_GCE_DNS_DOMAIN=roachprod.exray.cloud
ROACHPROD_GCE_DNS_MANAGED_DOMAIN=roachprod-managed.dataexmachina.dev
ROACHPROD_GCE_DNS_MANAGED_ZONE=roachprod-managed
ROACHPROD_GCE_DNS_PROJECT=dem-ephemeral
ROACHPROD_GCE_DNS_ZONE=roachprod
```

All of these configuration options can also be set via flags.

See individual commits.

Epic: none
Release note: none