### PR TITLE
roachtest: admission-control/elastic-io deflake

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -174,19 +174,3 @@ func registerIntentResolutionOverload(r registry.Registry) {
 		},
 	})
 }
-
-// Returns the mean over the last n samples. If n > len(items), returns the mean
-// over the entire items slice.
-func getMeanOverLastN(n int, items []float64) float64 {
-	count := n
-	if len(items) < n {
-		count = len(items)
-	}
-	sum := float64(0)
-	i := 0
-	for i < count {
-		sum += items[len(items)-1-i]
-		i++
-	}
-	return sum / float64(count)
-}

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -232,3 +232,19 @@ func maybeUseMemoryBudget(t test.Test, budget int) option.StartOpts {
 	}
 	return startOpts
 }
+
+// Returns the mean over the last n samples. If n > len(items), returns the mean
+// over the entire items slice.
+func getMeanOverLastN(n int, items []float64) float64 {
+	count := n
+	if len(items) < n {
+		count = len(items)
+	}
+	sum := float64(0)
+	i := 0
+	for i < count {
+		sum += items[len(items)-1-i]
+		i++
+	}
+	return sum / float64(count)
+}


### PR DESCRIPTION
Similar to https://github.com/cockroachdb/cockroach/pull/114446, we now take the mean over the last two minutes for determining high L0 sublevel count.

Fixes #119838.

Release note: None