### PR TITLE
roachtest: deflake admission-control/database-drop

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -40,7 +40,7 @@ func registerDatabaseDrop(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/database-drop",
-		Timeout:          10 * time.Hour,
+		Timeout:          15 * time.Hour,
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		CompatibleClouds: registry.OnlyGCE,


### PR DESCRIPTION
The setup steps for this test sometimes take a while and end up hitting the timeout. This patch increases the timeout to avoid the setup slowness from causing a test failure.

Fixes #119842.

Release note: None