### PR TITLE
release-23.1: roachtest: fix logic for exact replication

### DIFF
--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -105,7 +105,7 @@ func WaitForReplication(
 	var compStr string
 	switch waitForReplicationType {
 	case exactlyReplicationFactor:
-		compStr = "="
+		compStr = "!="
 	case atLeastReplicationFactor:
 		compStr = "<"
 	default:


### PR DESCRIPTION
Backport 1/1 commits from #110376.

Fixes #119518.

/cc @cockroachdb/release

---

Previously the check for exact replication was incorrectly counting the number of replicas that were NOT at the desired replication count. This fortunately worked becase it was a no-op in the only place that used it since it was run immediately when all replicas had only a single replica.

This correctly fixes the check.

Epic: none
Fixes: #109905
Fixes: #109906

Release note: None

Release justification: testing only