### PR TITLE
storage: reduce allocations when encoding MVCCValue's 

### DIFF
--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -136,16 +136,14 @@ func (v MVCCValue) SafeFormat(w redact.SafePrinter, _ rune) {
 
 // EncodeMVCCValueForExport encodes fields from the MVCCValueHeader
 // that are appropriate for export out of the cluster.
-func EncodeMVCCValueForExport(mvccValue MVCCValue) ([]byte, error) {
-	if mvccValue.ImportEpoch == 0 {
+//
+// NB: Must be updated with ExtendedEncodingSizeForExport.
+func EncodeMVCCValueForExport(mvccValue MVCCValue, b []byte) ([]byte, error) {
+	mvccValue.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp{}
+	if mvccValue.MVCCValueHeader.IsEmpty() {
 		return mvccValue.Value.RawBytes, nil
 	}
-
-	// We only export ImportEpoch.
-	mvccValue.MVCCValueHeader = enginepb.MVCCValueHeader{
-		ImportEpoch: mvccValue.ImportEpoch,
-	}
-	return EncodeMVCCValue(mvccValue)
+	return EncodeMVCCValueToBuf(mvccValue, b)
 }
 
 // When running a metamorphic build, disable the simple MVCC value encoding to
@@ -185,6 +183,8 @@ func encodedMVCCValueSize(v MVCCValue) int {
 // struct comparisons have a significant performance regression in Go 1.19 which
 // negates the inlining gain. Reconsider this with Go 1.20. See:
 // https://github.com/cockroachdb/cockroach/issues/88818
+//
+// TODO(ssd): Dedup with EncodeMVCCValueWithAllocator.
 func EncodeMVCCValue(v MVCCValue) ([]byte, error) {
 	if v.MVCCValueHeader.IsEmpty() && !disableSimpleValueEncoding {
 		// Simple encoding. Use the roachpb.Value encoding directly with no
@@ -199,6 +199,52 @@ func EncodeMVCCValue(v MVCCValue) ([]byte, error) {
 	valueSize := headerSize + len(v.Value.RawBytes)
 
 	buf := make([]byte, valueSize)
+	// 4-byte-header-len
+	binary.BigEndian.PutUint32(buf, uint32(headerLen))
+	// 1-byte-sentinel
+	buf[tagPos] = extendedEncodingSentinel
+	// mvcc-header
+	//
+	// NOTE: we don't use protoutil to avoid passing v.MVCCValueHeader through
+	// an interface, which would cause a heap allocation and incur the cost of
+	// dynamic dispatch.
+	if _, err := v.MVCCValueHeader.MarshalToSizedBuffer(buf[extendedPreludeSize:headerSize]); err != nil {
+		return nil, errors.Wrap(err, "marshaling MVCCValueHeader")
+	}
+	// <4-byte-checksum><1-byte-tag><encoded-data> or empty for tombstone
+	copy(buf[headerSize:], v.Value.RawBytes)
+	return buf, nil
+}
+
+// EncodeMVCCValueToBuf encodes an MVCCValue into its Pebble
+// representation. See the comment on MVCCValue for a description of
+// the encoding scheme.
+//
+// If extended encoding is required, the given buffer will be used if
+// it is large enough. If the provided buffer is not large enough a
+// new buffer is allocated.
+//
+// TODO(ssd): Dedup with EncodeMVCCValue.
+func EncodeMVCCValueToBuf(v MVCCValue, buf []byte) ([]byte, error) {
+	if v.MVCCValueHeader.IsEmpty() && !disableSimpleValueEncoding {
+		// Simple encoding. Use the roachpb.Value encoding directly with no
+		// modification. No need to re-allocate or copy.
+		return v.Value.RawBytes, nil
+	}
+
+	// Extended encoding. Wrap the roachpb.Value encoding with a header containing
+	// MVCC-level metadata. Requires a re-allocation and copy.
+	headerLen := v.MVCCValueHeader.Size()
+	headerSize := extendedPreludeSize + headerLen
+	valueSize := headerSize + len(v.Value.RawBytes)
+
+	if valueSize > cap(buf) {
+		buf = make([]byte, valueSize)
+	} else {
+		buf = buf[:valueSize]
+	}
+	// Extended encoding. Wrap the roachpb.Value encoding with a header containing
+	// MVCC-level metadata. Requires a copy.
 	// 4-byte-header-len
 	binary.BigEndian.PutUint32(buf, uint32(headerLen))
 	// 1-byte-sentinel


### PR DESCRIPTION
This adds a new function that lets us pass a buffer to
use when encoding MVCC values. This is very useful in loops where we
might be allocating many MVCC values in a loop, such as in
ExportRequest or in SSTBatcher.

Before:

```
BenchmarkMVCCExportToSST/importEpochs=false/numKeys=65536/numRevisions=100/exportAllRevisions=true-10                  1        1464855709 ns/op         45293904 B/op      39419 allocs/op
BenchmarkMVCCExportToSST/importEpochs=true/numKeys=65536/numRevisions=100/exportAllRevisions=true-10                   1        1919207875 ns/op        207366256 B/op   6595176 allocs/op
```

After:

```
BenchmarkMVCCExportToSST/importEpochs=false/numKeys=65536/numRevisions=100/exportAllRevisions=true-10                  1        1458935583 ns/op        45327256 B/op      39337 allocs/op
BenchmarkMVCCExportToSST/importEpochs=true/numKeys=65536/numRevisions=100/exportAllRevisions=true-10                   1        1756803250 ns/op        49162648 B/op      41369 allocs/op
```

Epic: none
Release note: None