### PR TITLE
roachtest: increase kv.transaction.internal.max_auto_retries for alterpk-bank

### DIFF
--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -40,7 +40,7 @@ func registerAlterPK(r registry.Registry) {
 	// runAlterPKBank runs a primary key change while the bank workload runs.
 	runAlterPKBank := func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		const numRows = 1000000
-		const duration = 1 * time.Minute
+		const duration = 3 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)
 
@@ -72,12 +72,14 @@ func registerAlterPK(r registry.Registry) {
 			// Wait for the initialization to finish. Once it's done,
 			// sleep for some time, then alter the primary key.
 			<-initDone
-			time.Sleep(duration / 10)
+			time.Sleep(duration / 30)
 
 			t.Status("beginning primary key change")
+			defer func() { pkChangeDone <- struct{}{} }()
 			db := c.Conn(ctx, t.L(), roachNodes[0])
 			defer db.Close()
 			cmds := []string{
+				`SET CLUSTER SETTING kv.transaction.internal.max_auto_retries = 10000`,
 				`USE bank;`,
 				`ALTER TABLE bank ALTER COLUMN balance SET NOT NULL;`,
 				`ALTER TABLE bank ALTER PRIMARY KEY USING COLUMNS (id, balance)`,
@@ -93,7 +95,6 @@ func registerAlterPK(r registry.Registry) {
 				}
 			}
 			t.Status("primary key change finished")
-			pkChangeDone <- struct{}{}
 			return nil
 		})
 		m.Wait()


### PR DESCRIPTION
The change in 79219f705fc76eae5753ea5e28b7077dfacfd213 added an upper bound to automatic retries performed in the db.Txn runner.

This test was affected. It runs an ALTER PRIMARY KEY while DML is happenning on the table concurrently. Increasing the retry count makes it pass again.

Another approach may have been to treat the "Terminating retry loop due to too many retries" error as itself retryable at the job runner level. But that seems a bit harder to reason about, and it would be a larger behavior change that affects all schema change jobs.

This patch also fixes the test so it doesn't deadlock if the ALTER PRIMARY KEY fails.

fixes https://github.com/cockroachdb/cockroach/issues/119622
Release note: None