### PR TITLE
cmd: link on the `large` pool

### DIFF
--- a/pkg/cmd/cockroach-oss/BUILD.bazel
+++ b/pkg/cmd/cockroach-oss/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
 go_binary(
     name = "cockroach-oss",
     embed = [":cockroach-oss_lib"],
+    exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/cmd/cockroach-short/BUILD.bazel
+++ b/pkg/cmd/cockroach-short/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
 go_binary(
     name = "cockroach-short",
     embed = [":cockroach-short_lib"],
+    exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )

--- a/pkg/cmd/cockroach-sql/BUILD.bazel
+++ b/pkg/cmd/cockroach-sql/BUILD.bazel
@@ -26,5 +26,6 @@ go_library(
 go_binary(
     name = "cockroach-sql",
     embed = [":cockroach-sql_lib"],
+    exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )

--- a/pkg/cmd/cockroach/BUILD.bazel
+++ b/pkg/cmd/cockroach/BUILD.bazel
@@ -25,5 +25,6 @@ disallowed_imports_test(
 go_binary(
     name = "cockroach",
     embed = [":cockroach_lib"],
+    exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )

--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -35,5 +35,6 @@ go_library(
 go_binary(
     name = "roachprod",
     embed = [":roachprod_lib"],
+    exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The `default` pool seems to be too small to perform linking efficiently. This should speed things up.

Epic: CRDB-8308

Release note: None