### PR TITLE
kvserver: enqueue replicas into lease queue on config update

### DIFF
--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -114,7 +114,8 @@ func TestStoreRaftReplicaID(t *testing.T) {
 
 // TestStoreLoadReplicaQuiescent tests whether replicas are initially quiescent
 // when loaded during store start, with eager Raft group initialization. Epoch
-// lease ranges should be quiesced, but expiration leases shouldn't.
+// lease ranges will initially be quiesced (unless acquired by a store replica
+// queue), but expiration leases shouldn't.
 func TestStoreLoadReplicaQuiescent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -142,6 +143,10 @@ func TestStoreLoadReplicaQuiescent(t *testing.T) {
 					},
 					Store: &kvserver.StoreTestingKnobs{
 						DisableScanner: true,
+						// The lease queue will unquiesce the range and acquire the
+						// proscribed leases upon restart. The range should quiesce again
+						// in the regular duration.
+						DisableLeaseQueue: true,
 					},
 				},
 				StoreSpecs: []base.StoreSpec{

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1028,6 +1028,9 @@ func (r *Replica) MaybeQueue(ctx context.Context, now hlc.ClockTimestamp) {
 			h.MaybeAdd(ctx, r, now)
 		})
 	}
+	r.store.leaseQueue.Async(ctx, "span config update", true /* wait */, func(ctx context.Context, h queueHelper) {
+		h.MaybeAdd(ctx, r, now)
+	})
 	// The replicate queue has a relatively more expensive queue check
 	// (shouldQueue), because it scales with the number of stores, and
 	// performs more checks.


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/119155, we introduced a new lease queue which took over the lease
related responsibilities from the replicate queue. The lease queue did
not get proactively enqueued into on span config updates, like the
previous logic in the replicate queue. This led a series of tests which
rely on this behavior to fail, as lease preferences weren't quickly
being adhered to after zone config changes which included lease
preferences.

Fixes: https://github.com/cockroachdb/cockroach/issues/120332
Fixes: https://github.com/cockroachdb/cockroach/issues/120334
Release note: None