### PR TITLE
logictest: skip some tests under `race`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1,3 +1,5 @@
+skip under race
+
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, c));
 INSERT INTO abc VALUES (1, 1, 2), (2, 1, 1), (2, NULL, 2)

--- a/pkg/sql/logictest/testdata/logic_test/stats
+++ b/pkg/sql/logictest/testdata/logic_test/stats
@@ -1,5 +1,7 @@
 # LogicTest: !fakedist-disk
 
+skip under race
+
 # Note that we disable the "forced disk spilling" config because the histograms
 # are dropped if the stats collection reaches the memory budget limit.
 

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1,3 +1,5 @@
+skip under race
+
 subtest strict
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_unsupported
@@ -1,3 +1,5 @@
+skip under race
+
 statement ok
 CREATE TABLE a (a INT, b INT, c INT4, PRIMARY KEY (a, b));
 INSERT INTO a SELECT g//2, g, g FROM generate_series(0,2000) g(g)

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1,3 +1,5 @@
+skip under race
+
 statement ok
 CREATE TABLE kv (
   -- don't add column "a"


### PR DESCRIPTION
These tests specifically are prone to failing/timing out under `race`.

Epic: CRDB-8308
Release note: None