### PR TITLE
security,jobs: some improvements for `deadlock`, `race`

### DIFF
--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -558,6 +558,7 @@ func TestBatchJobsCreation(t *testing.T) {
 				if test.batchSize > 10 {
 					skip.UnderStress(t, "skipping stress test for batch size ", test.batchSize)
 					skip.UnderRace(t, "skipping test for batch size ", test.batchSize)
+					skip.UnderDeadlock(t, "skipping test for batch size ", test.batchSize)
 				}
 
 				args := base.TestServerArgs{

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -72,6 +72,10 @@ go_test(
         "x509_test.go",
     ],
     embed = [":security"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer",


### PR DESCRIPTION
* Skip heavy `TestBatchJobsCreation` tests under `deadlock` as well
* Run `security` tests under `large` for `deadlock`/`race`

Epic: CRDB-8308
Release note: None