### PR TITLE
roachtest: bump max ranges threshold in splits/load/ycsb/e/nodes=3/obj=cpu

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -409,7 +409,7 @@ func registerLoadSplits(r registry.Registry) {
 				// YCSB/E has a zipfian distribution with 95% scans (limit 1k) and 5%
 				// inserts.
 				minimumRanges:     5,
-				maximumRanges:     15,
+				maximumRanges:     18,
 				initialRangeCount: 2,
 				load: ycsbSplitLoad{
 					workload:     "e",


### PR DESCRIPTION
Fixes #120163.

Avoids rare test flakes.

Release note: None