### PR TITLE
schemachanger: prep work ALTER DATABASE .. CONFIGURE ZONE in DSC

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -725,14 +725,23 @@ func addSecondaryIndexTargetsForAddColumn(
 	}
 }
 
-func mustRetrieveTemporaryIndexElem(
+func retrieveTemporaryIndexElem(
 	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
 ) (temporaryIndexElem *scpb.TemporaryIndex) {
-	scpb.ForEachTemporaryIndex(b.QueryByID(tableID), func(current scpb.Status, target scpb.TargetStatus, e *scpb.TemporaryIndex) {
+	b.QueryByID(tableID).FilterTemporaryIndex().ForEach(func(
+		_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex,
+	) {
 		if e.IndexID == indexID {
 			temporaryIndexElem = e
 		}
 	})
+	return temporaryIndexElem
+}
+
+func mustRetrieveTemporaryIndexElem(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (temporaryIndexElem *scpb.TemporaryIndex) {
+	temporaryIndexElem = retrieveTemporaryIndexElem(b, tableID, indexID)
 	if temporaryIndexElem == nil {
 		panic(errors.AssertionFailedf("programming error: cannot find a TemporaryIndex element"+
 			" of ID %v", indexID))

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -833,8 +833,16 @@ func ensureColCanBeUsedInInboundFK(b BuildCtx, tableID catid.DescID, columnID ca
 	}
 }
 
+func retrieveTableElem(b BuildCtx, tableID catid.DescID) *scpb.Table {
+	return b.QueryByID(tableID).FilterTable().Filter(func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.Table,
+	) bool {
+		return e.TableID == tableID
+	}).MustGetZeroOrOneElement()
+}
+
 func mustRetrieveTableElem(b BuildCtx, tableID catid.DescID) *scpb.Table {
-	_, _, tblElem := scpb.FindTable(b.QueryByID(tableID))
+	tblElem := retrieveTableElem(b, tableID)
 	if tblElem == nil {
 		panic(errors.AssertionFailedf("programming error: cannot find a Table element for table %v", tableID))
 	}

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -467,16 +467,16 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		// default (whichever applies -- a database if targetID is a table,
 		// default if targetID is a database, etc.). For this, we use the last
 		// parameter getInheritedDefault to GetZoneConfigInTxn().
-		// These zones are only used for validations. The merged zone is will
+		// These zones are only used for validations. The merged zone will
 		// not be written.
 		_, completeZone, completeSubzone, err := GetZoneConfigInTxn(
 			params.ctx, params.p.txn, params.p.Descriptors(), targetID, index, partition, n.setDefault,
 		)
 
-		if errors.Is(err, errNoZoneConfigApplies) {
+		if errors.Is(err, sqlerrors.ErrNoZoneConfigApplies) {
 			// No zone config yet.
 			//
-			// GetZoneConfigInTxn will fail with errNoZoneConfigApplies when
+			// GetZoneConfigInTxn will fail with ErrNoZoneConfigApplies when
 			// the target ID is not a database object, i.e. one of the system
 			// ranges (liveness, meta, etc.), and did not have a zone config
 			// already.

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -126,7 +127,7 @@ func getShowZoneConfigRow(
 	zoneID, zone, subzone, err := GetZoneConfigInTxn(
 		ctx, p.txn, p.Descriptors(), targetID, index, partition, false, /* getInheritedDefault */
 	)
-	if errors.Is(err, errNoZoneConfigApplies) {
+	if errors.Is(err, sqlerrors.ErrNoZoneConfigApplies) {
 		// TODO(benesch): This shouldn't be the caller's responsibility;
 		// GetZoneConfigInTxn should just return the default zone config if no zone
 		// config applies.

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -479,3 +479,5 @@ var (
 	ErrNoFunction        = pgerror.New(pgcode.InvalidName, "no function specified")
 	ErrNoMatch           = pgerror.New(pgcode.UndefinedObject, "no object matched")
 )
+
+var ErrNoZoneConfigApplies = errors.New("no zone config applies")

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -38,8 +38,6 @@ func init() {
 	config.ZoneConfigHook = zoneConfigHook
 }
 
-var errNoZoneConfigApplies = errors.New("no zone config applies")
-
 // getZoneConfig recursively looks up entries in system.zones until an
 // entry that applies to the object with the specified id is
 // found. Returns the ID of the matching zone, its zone config, and an
@@ -119,7 +117,7 @@ func getZoneConfig(
 	}
 
 	// No descriptor or not a table.
-	return 0, nil, 0, nil, errNoZoneConfigApplies
+	return 0, nil, 0, nil, sqlerrors.ErrNoZoneConfigApplies
 }
 
 // completeZoneConfig takes a zone config pointer and fills in the
@@ -184,7 +182,7 @@ func zoneConfigHook(
 		false, /* getInheritedDefault */
 		mayBeTable,
 	)
-	if errors.Is(err, errNoZoneConfigApplies) {
+	if errors.Is(err, sqlerrors.ErrNoZoneConfigApplies) {
 		return nil, nil, true, nil
 	} else if err != nil {
 		return nil, nil, false, err


### PR DESCRIPTION
### sqlerrors: move gloval var errNoZoneConfigApplies into sqlerrors package

This commit is a mechnical change that moves the gloval variable
`errNoZoneConfigApplies` from package `sql` to package `sqlerrors`, as
it will be used by the DSC when we support zone config in it.

Informs: #117574
Release note: None

---

### scbuildstmt: Rerewrite a few function with better APIs

This commit cleaned up a few functions using the preferred .FilterXxx()
API to retrieve element from an element set. No functional change is
introduced.

Informs: #117574
Release note: None