### PR TITLE
roachtest: enable schema change testing during version upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -153,12 +153,6 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"test schema change step",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			// TODO: re-enable once #116586 is addressed.
-			if h.Context.Finalizing {
-				l.Printf("schemachange workload has been flaking when run during upgrades; skipping")
-				return nil
-			}
-
 			randomNode := h.RandomNode(rng, c.All())
 			// The schemachange workload is designed to work up to one
 			// version back. Therefore, we upload a compatible `workload`


### PR DESCRIPTION
This was previously disabled in 06eaaa0.

Now that the bug in #116649 has been resolved, we can enable it again.

fixes https://github.com/cockroachdb/cockroach/issues/116586
Release note: None