### PR TITLE
sql: fix TestCachedNodeSequence failure

### DIFF
--- a/pkg/sql/sessiondatapb/sequence_cache_node.go
+++ b/pkg/sql/sessiondatapb/sequence_cache_node.go
@@ -52,7 +52,7 @@ func (sc *SequenceCacheNode) NextValue(
 		sc.mu.Lock()
 		defer sc.mu.Unlock()
 		// There is a hazard that multiple threads could add the entry, so check if it exists again with the writer lock
-		_, found = sc.cache[seqID]
+		cacheEntry, found = sc.cache[seqID]
 		if !found {
 			cacheEntry = &SequenceCacheNodeEntry{}
 			sc.cache[seqID] = cacheEntry


### PR DESCRIPTION
Previously, the test was failing because when we were checking if the cache entry existed the second time, we were not assigning the potentially existing entry to cacheEntry. Thus, it was possible for cacheEntry to be nil, causing runtime error: invalid memory address or nil pointer dereference.

Epic: none
Fixes: #120173

Release note: None