### PR TITLE
sql: block rename on UDFs referenced by other UDFs

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2216,6 +2216,13 @@ func TestTenantLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestTenantLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestTenantLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -228,6 +228,13 @@ func TestBackupRollbacks_base_create_function(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_create_function_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -617,6 +624,13 @@ func TestBackupRollbacksMixedVersion_base_create_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1012,6 +1026,13 @@ func TestBackupSuccess_base_create_function(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_create_function_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1401,6 +1422,13 @@ func TestBackupSuccessMixedVersion_base_create_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1671,7 +1671,11 @@ message FunctionDescriptor {
   // IsProcedure is true if the descriptor represents a procedure.
   optional bool is_procedure = 21 [(gogoproto.nullable) = false];
 
-  // Next field id is 22
+  // DependsOnFunctions are the user defined functions that this function
+  // depends on.
+  repeated uint32 depends_on_functions = 22  [(gogoproto.casttype) = "ID"];
+
+  // Next field id is 23
 }
 
 // Descriptor is a union type for descriptors for tables, schemas, databases,

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -966,6 +966,10 @@ type FunctionDescriptor interface {
 	// GetDependsOnTypes returns a list of IDs of the types this function depends on.
 	GetDependsOnTypes() []descpb.ID
 
+	// GetDependsOnFunctions returns a list of IDs of functions this function depends
+	// on.
+	GetDependsOnFunctions() []descpb.ID
+
 	// GetDependedOnBy returns a list of back-references of this function.
 	GetDependedOnBy() []descpb.FunctionDescriptor_Reference
 

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -319,6 +319,7 @@ var validationMap = []struct {
 			"DependsOn":                     {status: iSolemnlySwearThisFieldIsValidated},
 			"DependsOnTypes":                {status: iSolemnlySwearThisFieldIsValidated},
 			"DependedOnBy":                  {status: iSolemnlySwearThisFieldIsValidated},
+			"DependsOnFunctions":            {status: iSolemnlySwearThisFieldIsValidated},
 			"State":                         {status: thisFieldReferencesNoObjects},
 			"OfflineReason":                 {status: thisFieldReferencesNoObjects},
 			"ModificationTime":              {status: thisFieldReferencesNoObjects},

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -121,6 +121,20 @@ type ValidationDescGetter interface {
 	GetDescriptor(id descpb.ID) (Descriptor, error)
 }
 
+// ValidateOutboundFunctionRef validates outbound reference to a function descriptor
+// depID.
+func ValidateOutboundFunctionRef(depID descpb.ID, vdg ValidationDescGetter) error {
+	referencedFunction, err := vdg.GetFunctionDescriptor(depID)
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid depends-on function reference")
+	}
+	if referencedFunction.Dropped() {
+		return errors.AssertionFailedf("depends-on function %q (%d) is dropped",
+			referencedFunction.GetName(), referencedFunction.GetID())
+	}
+	return nil
+}
+
 // ValidateOutboundTableRef validates outbound reference to relation descriptor
 // depID from descriptor selfID.
 func ValidateOutboundTableRef(depID descpb.ID, vdg ValidationDescGetter) error {

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -64,7 +64,8 @@ func (n *createFunctionNode) startExec(params runParams) error {
 
 	for _, dep := range n.planDeps {
 		if dbID := dep.desc.GetParentID(); dbID != n.dbDesc.GetID() && dbID != keys.SystemDatabaseID {
-			return pgerror.Newf(pgcode.FeatureNotSupported, "the function cannot refer to other databases")
+			return pgerror.Newf(pgcode.FeatureNotSupported, "dependent relation %s cannot be from another database",
+				dep.desc.GetName())
 		}
 	}
 
@@ -74,7 +75,8 @@ func (n *createFunctionNode) startExec(params runParams) error {
 			return err
 		}
 		if dbID := funcDesc.GetParentID(); dbID != n.dbDesc.GetID() && dbID != keys.SystemDatabaseID {
-			return pgerror.Newf(pgcode.FeatureNotSupported, "the function cannot refer to other databases")
+			return pgerror.Newf(pgcode.FeatureNotSupported, "dependent function %s cannot be from another database",
+				funcDesc.GetName())
 		}
 	}
 
@@ -177,9 +179,6 @@ func (n *createFunctionNode) createNewFunction(
 }
 
 func (n *createFunctionNode) replaceFunction(udfDesc *funcdesc.Mutable, params runParams) error {
-	// TODO(chengxiong): add validation that the function is not referenced. This
-	// is needed when we start allowing function references from other objects.
-
 	if n.cf.IsProcedure && !udfDesc.IsProcedure() {
 		return errors.WithDetailf(
 			pgerror.Newf(pgcode.WrongObjectType, "cannot change routine kind"),

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -36,13 +37,16 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+type functionDependencies map[catid.DescID]struct{}
+
 type createFunctionNode struct {
 	cf *tree.CreateRoutine
 
-	dbDesc   catalog.DatabaseDescriptor
-	scDesc   catalog.SchemaDescriptor
-	planDeps planDependencies
-	typeDeps typeDependencies
+	dbDesc       catalog.DatabaseDescriptor
+	scDesc       catalog.SchemaDescriptor
+	planDeps     planDependencies
+	typeDeps     typeDependencies
+	functionDeps functionDependencies
 }
 
 func (n *createFunctionNode) ReadingOwnWrites() {}
@@ -60,6 +64,16 @@ func (n *createFunctionNode) startExec(params runParams) error {
 
 	for _, dep := range n.planDeps {
 		if dbID := dep.desc.GetParentID(); dbID != n.dbDesc.GetID() && dbID != keys.SystemDatabaseID {
+			return pgerror.Newf(pgcode.FeatureNotSupported, "the function cannot refer to other databases")
+		}
+	}
+
+	for funcRef := range n.functionDeps {
+		funcDesc, err := params.p.Descriptors().ByIDWithLeased(params.p.Txn()).Get().Function(params.ctx, funcRef)
+		if err != nil {
+			return err
+		}
+		if dbID := funcDesc.GetParentID(); dbID != n.dbDesc.GetID() && dbID != keys.SystemDatabaseID {
 			return pgerror.Newf(pgcode.FeatureNotSupported, "the function cannot refer to other databases")
 		}
 	}
@@ -245,6 +259,18 @@ func (n *createFunctionNode) replaceFunction(udfDesc *funcdesc.Mutable, params r
 	if err := params.p.removeTypeBackReferences(params.ctx, udfDesc.DependsOnTypes, udfDesc.ID, jobDesc); err != nil {
 		return err
 	}
+	for _, id := range udfDesc.DependsOnFunctions {
+		backRefMutable, err := params.p.Descriptors().MutableByID(params.p.txn).Function(params.ctx, id)
+		if err != nil {
+			return err
+		}
+		if err := backRefMutable.RemoveFunctionReference(udfDesc.ID); err != nil {
+			return err
+		}
+		if err := params.p.writeFuncSchemaChange(params.ctx, backRefMutable); err != nil {
+			return err
+		}
+	}
 	// Add all new references.
 	if err := n.addUDFReferences(udfDesc, params); err != nil {
 		return err
@@ -405,6 +431,23 @@ func (n *createFunctionNode) addUDFReferences(udfDesc *funcdesc.Mutable, params 
 		if err := params.p.addTypeBackReference(params.ctx, id, udfDesc.ID, jobDesc); err != nil {
 			return err
 		}
+	}
+
+	udfDesc.DependsOnFunctions = make([]descpb.ID, 0, len(n.functionDeps))
+	for id := range n.functionDeps {
+		// Add a back reference.
+		backRefDesc, err := params.p.Descriptors().MutableByID(params.p.Txn()).Function(params.ctx, id)
+		if err != nil {
+			return err
+		}
+		if err := backRefDesc.AddFunctionReference(udfDesc.ID); err != nil {
+			return err
+		}
+		if err := params.p.writeFuncSchemaChange(params.ctx, backRefDesc); err != nil {
+			return err
+		}
+		// Add a reference to the dependency in here.
+		udfDesc.DependsOnFunctions = append(udfDesc.DependsOnFunctions, id)
 	}
 
 	// Add forward references to UDF descriptor.

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1064,7 +1064,11 @@ func (e *distSQLSpecExecFactory) ConstructCreateView(
 }
 
 func (e *distSQLSpecExecFactory) ConstructCreateFunction(
-	schema cat.Schema, cf *tree.CreateRoutine, deps opt.SchemaDeps, typeDeps opt.SchemaTypeDeps,
+	schema cat.Schema,
+	cf *tree.CreateRoutine,
+	deps opt.SchemaDeps,
+	typeDeps opt.SchemaTypeDeps,
+	functionDeps opt.SchemaFunctionDeps,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: create function")
 }

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -108,7 +108,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		}
 	}
 
-	if err := d.resolveCollectedObjects(ctx, p); err != nil {
+	if err := d.resolveCollectedObjects(ctx, true /*dropDatabase*/, p); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -117,7 +117,7 @@ func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode,
 
 	}
 
-	if err := d.resolveCollectedObjects(ctx, p); err != nil {
+	if err := d.resolveCollectedObjects(ctx, false /*dropDatabase*/, p); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -263,26 +263,46 @@ CREATE FUNCTION f_called_by_b2() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 + f_cal
 statement ok;
 CREATE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT (f_called_by_b2()) /f_called_by_b2() FROM f_called_by_b() $$;
 
-onlyif config local-legacy-schema-changer
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2, test.public.f_b\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
-onlyif config local-legacy-schema-changer
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b2\" because other objects \(\[test.public.f_b\]\) still depend on it
 DROP FUNCTION f_called_by_b2;
 
 statement ok
 CREATE OR REPLACE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 
-onlyif config local-legacy-schema-changer
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
 statement ok
-CREATE OR REPLACE FUNCTION f_called_by_b2()  RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+ALTER FUNCTION f_called_by_b RENAME to f_called_by_b_1;
+ALTER FUNCTION f_called_by_b2 RENAME to f_called_by_b_2;
+
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b_1\" because other objects \(\[test.public.f_called_by_b_2\]\) still depend on it
+DROP FUNCTION f_called_by_b_1;
 
 statement ok
-DROP FUNCTION f_called_by_b;
+CREATE TABLE t1_with_b_2_ref(j int default f_called_by_b_1() CHECK (f_called_by_b_1() > 0));
+CREATE SCHEMA altSchema;
 
 statement ok
-DROP FUNCTION f_called_by_b2;
+ALTER FUNCTION f_called_by_b_1 SET SCHEMA altSchema;
+
+statement ok
+DROP SCHEMA altSchema CASCADE;
+
+statement error pgcode 42883 unknown function: f_called_by_b_2()
+SELECT * FROM  f_called_by_b_2();
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t1_with_b_2_ref];
+----
+CREATE TABLE public.t1_with_b_2_ref (
+  j INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t1_with_b_2_ref_pkey PRIMARY KEY (rowid ASC)
+)
+
+statement ok
+DROP FUNCTION f_b;

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -289,12 +289,19 @@ CREATE SCHEMA altSchema;
 statement ok
 ALTER FUNCTION f_called_by_b_1 SET SCHEMA altSchema;
 
+skipif config local-legacy-schema-changer
 statement ok
 DROP SCHEMA altSchema CASCADE;
 
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b_1\" because other object \(\[test.public.f_called_by_b_2, test.public.t1_with_b_2_ref\]\) still depend on it
+DROP SCHEMA altSchema CASCADE;
+
+skipif config local-legacy-schema-changer
 statement error pgcode 42883 unknown function: f_called_by_b_2()
 SELECT * FROM  f_called_by_b_2();
 
+skipif config local-legacy-schema-changer
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t1_with_b_2_ref];
 ----
@@ -303,6 +310,11 @@ CREATE TABLE public.t1_with_b_2_ref (
   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
   CONSTRAINT t1_with_b_2_ref_pkey PRIMARY KEY (rowid ASC)
 )
+
+onlyif config local-legacy-schema-changer
+statement ok
+DROP FUNCTION f_called_by_b_2;
+DROP TABLE t1_with_b_2_ref;
 
 statement ok
 DROP FUNCTION f_b;

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -250,3 +250,39 @@ statement error pgcode 42883 unknown function: f114677\(\)
 SHOW CREATE FUNCTION f114677;
 
 subtest end
+
+
+subtest functions_calling_functions
+
+statement ok
+CREATE FUNCTION f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement ok
+CREATE FUNCTION f_called_by_b2() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 + f_called_by_b() $$;
+
+statement ok;
+CREATE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT (f_called_by_b2()) /f_called_by_b2() FROM f_called_by_b() $$;
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2, test.public.f_b\]\) still depend on it
+DROP FUNCTION f_called_by_b;
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b2\" because other objects \(\[test.public.f_b\]\) still depend on it
+DROP FUNCTION f_called_by_b2;
+
+statement ok
+CREATE OR REPLACE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
+DROP FUNCTION f_called_by_b;
+
+statement ok
+CREATE OR REPLACE FUNCTION f_called_by_b2()  RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement ok
+DROP FUNCTION f_called_by_b;
+
+statement ok
+DROP FUNCTION f_called_by_b2;

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -118,7 +118,7 @@ CREATE OR REPLACE PROCEDURE p2() LANGUAGE SQL AS $$
   CALL p();
 $$
 
-statement error pgcode 42883 unknown function: p\(\)
+statement error pgcode 42809 p\(\) is a procedure
 CREATE FUNCTION err(i INT) RETURNS VOID LANGUAGE SQL AS 'SELECT p()'
 
 statement error pgcode 0A000 unimplemented: CALL usage inside a function definition

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -412,3 +412,20 @@ statement error pgcode 42P13 null input attribute not allowed in procedure defin
 CREATE PROCEDURE pv() AS 'SELECT 1' STRICT LANGUAGE SQL;
 
 subtest end
+
+
+subtest udf_calling_udfs
+
+# Validate we can have UDF's both in the select and from clauses.
+statement ok
+CREATE FUNCTION udfCall(i int) RETURNS INT LANGUAGE SQL AS 'SELECT 100+i';
+CREATE FUNCTION udfCallNest(i int, j int) RETURNS INT LANGUAGE SQL AS 'SELECT udfCall(i) + j';
+CREATE FUNCTION udfCallNest_2(i int, j int) RETURNS INT LANGUAGE SQL AS 'SELECT udfCall(i) + udfCall(j) + udfCallNest(i, j)';
+CREATE FUNCTION udfCallNest_3(i int, j int) RETURNS INT  LANGUAGE SQL AS 'SELECT  udfCall(j) + udfCallNest(i, j) + udfCallNest_2(i, j) + 1 FROM udfCallNest_2(i, j)';
+
+query I
+SELECT * FROM udfCallNest_3(1, 2)
+----
+512
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -1,0 +1,20 @@
+statement ok
+CREATE FUNCTION lower_hello() RETURNS STRING LANGUAGE SQL AS $$ SELECT lower('hello') $$;
+
+statement ok
+CREATE FUNCTION upper_hello() RETURNS STRING LANGUAGE SQL AS $$ SELECT upper(lower_hello()) $$;
+
+statement ok
+CREATE FUNCTION nested_udf_for_from() RETURNS STRING LANGUAGE SQL AS $$ SELECT * FROM upper_hello()$$;
+
+statement ok
+CREATE FUNCTION concat_hello() RETURNS STRING LANGUAGE SQL AS $$ SELECT upper(lower_hello()) || upper_hello() || lower_hello() $$;
+
+query TTTT
+SELECT upper_hello(), nested_udf_for_from(), lower_hello(), concat_hello()
+----
+HELLO  HELLO  hello  HELLOHELLOhello
+
+# Validate recursion doesn't work today.
+statement error pgcode 42883 unknown function: recursion_check\(\)
+CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -18,3 +18,7 @@ HELLO  HELLO  hello  HELLOHELLOhello
 # Validate recursion doesn't work today.
 statement error pgcode 42883 unknown function: recursion_check\(\)
 CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;
+
+# Validate that function renaming is blocked.
+statement error pgcode 2BP01 cannot rename function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.nested_udf_for_from, test.public.concat_hello\]\) still depend on it
+ALTER FUNCTION lower_hello rename to lower_hello_new

--- a/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
+++ b/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
@@ -97,17 +97,21 @@ CREATE FUNCTION f_in_udf() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 let $fn_oid
 SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'f_in_udf'
 
-# TODO(chengxiong,mgartner): Fix this test when we enable support of calling UDFs from UDFs.
-statement error pgcode 42883 pq: function \d+ not found
+statement ok
 CREATE FUNCTION f_using_udf() RETURNS INT LANGUAGE SQL AS $$ SELECT [FUNCTION $fn_oid]() $$;
+
+query I
+SELECT f_using_udf()
+----
+1
 
 # 814 is the OID of builtin function "length" with signature, and it's ok to
 # call it from a UDF.
 statement ok
-CREATE FUNCTION f_using_udf() RETURNS INT LANGUAGE SQL AS $$ SELECT [FUNCTION 814]('abc') $$;
+CREATE FUNCTION f_using_udf_2() RETURNS INT LANGUAGE SQL AS $$ SELECT [FUNCTION 814]('abc') $$;
 
 query I
-SELECT f_using_udf();
+SELECT f_using_udf_2();
 ----
 3
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_rewrite
@@ -154,3 +154,24 @@ statement ok
 DROP PROCEDURE p_rewrite();
 
 subtest end
+
+subtest rewrite_udf_calling_duf
+
+statement ok
+CREATE FUNCTION nested_func() RETURNS INT AS $$
+  SELECT 1;
+$$ LANGUAGE SQL
+
+statement ok
+CREATE PROCEDURE p_rewrite() AS $$
+  SELECT nested_func();
+  SELECT * FROM nested_func();
+$$ LANGUAGE SQL
+
+# TODO(fqazi): Renaming function calls will break today until #120351 is completed.
+query T
+SELECT get_body_str('p_rewrite');
+----
+"SELECT public.nested_func();\nSELECT nested_func FROM ROWS FROM (public.nested_func());"
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -36,16 +36,11 @@ ALTER TABLE test_tbl_t ALTER COLUMN b SET ON UPDATE (test_tbl_f());
 subtest end
 
 
-subtest disallow_udf_in_views_and_udf
+subtest disallow_udf_in_views
 
 statement ok
 CREATE FUNCTION test_vf_f() RETURNS STRING LANGUAGE SQL AS $$ SELECT lower('hello') $$;
 
-statement error pgcode 42883 pq: unknown function: test_vf_f\(\)\nHINT:.*intention was to use a user-defined function in the function body, which is currently not supported.
-CREATE FUNCTION test_vf_g() RETURNS STRING LANGUAGE SQL AS $$ SELECT test_vf_f() $$;
-
-statement ok
-CREATE FUNCTION test_vf_g() RETURNS STRING LANGUAGE SQL AS $$ SELECT lower('hello') $$;
 
 statement error pgcode 42883 pq: unknown function: test_vf_f\(\)\nHINT:.*intention was to use a user-defined function in the view query, which is currently not supported.
 CREATE VIEW v AS SELECT test_vf_f();
@@ -84,10 +79,10 @@ CREATE FUNCTION f_cross_db(cross_db1.sc.workday) RETURNS INT LANGUAGE SQL AS $$ 
 statement error pgcode 0A000 pq: cross database type references are not supported: cross_db1.sc.workday
 CREATE FUNCTION f_cross_db() RETURNS cross_db1.sc.workday LANGUAGE SQL AS $$ SELECT 'MON'::cross_db1.sc.workday $$;
 
-statement error pgcode 0A000 pq: the function cannot refer to other databases
+statement error pgcode 0A000 pq: dependent relation tbl cannot be from another database
 CREATE FUNCTION f_cross_db() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM cross_db1.sc.tbl $$;
 
-statement error pgcode 0A000 pq: the function cannot refer to other databases
+statement error pgcode 0A000 pq: dependent relation v cannot be from another database
 CREATE FUNCTION f_cross_db() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM cross_db1.sc.v $$;
 
 subtest end
@@ -139,7 +134,7 @@ CREATE FUNCTION rec(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT CASE i WHEN 0 THE
 statement ok
 CREATE FUNCTION other_udf() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 
-statement error pgcode 42883 unknown function: other_udf()
+statement ok
 CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT other_udf()'
 
 subtest end

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2171,6 +2171,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2178,6 +2178,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2192,6 +2192,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2178,6 +2178,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.1/generated_test.go
@@ -2115,6 +2115,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_in_column_defaults(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -2199,6 +2199,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-read-committed/generated_test.go
+++ b/pkg/sql/logictest/tests/local-read-committed/generated_test.go
@@ -2171,6 +2171,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2206,6 +2206,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2416,6 +2416,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_calling_udf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_calling_udf")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -84,6 +84,7 @@ func (b *Builder) buildCreateFunction(
 		cf.Syntax,
 		cf.Deps,
 		cf.TypeDeps,
+		cf.FuncDeps,
 	)
 	return execPlan{root: root}, colOrdMap{}, err
 }

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -775,6 +775,7 @@ define CreateFunction {
     Cr *tree.CreateRoutine
     Deps opt.SchemaDeps
     TypeDeps opt.SchemaTypeDeps
+    FunctionDeps opt.SchemaFunctionDeps
 }
 
 # LiteralValues allows datums to be planned directly that are type checked

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -591,6 +591,15 @@ func (h *hasher) HashUniqueOrdinals(val cat.UniqueOrdinals) {
 	h.hash = hash
 }
 
+func (h *hasher) HashSchemaFunctionDeps(val opt.SchemaFunctionDeps) {
+	hash := h.hash
+	val.ForEach(func(i int) {
+		hash ^= internHash(i)
+		hash *= prime64
+	})
+	h.hash = hash
+}
+
 func (h *hasher) HashSchemaDeps(val opt.SchemaDeps) {
 	// Hash the length and address of the first element.
 	h.HashInt(len(val))
@@ -1040,6 +1049,10 @@ func (h *hasher) IsUniqueOrdinalsEqual(l, r cat.UniqueOrdinals) bool {
 		}
 	}
 	return true
+}
+
+func (h *hasher) IsSchemaFunctionDepsEqual(l, r opt.SchemaFunctionDeps) bool {
+	return l.Equals(r)
 }
 
 func (h *hasher) IsSchemaDepsEqual(l, r opt.SchemaDeps) bool {

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -74,11 +74,14 @@ define CreateFunctionPrivate {
     # Syntax is the CREATE FUNCTION AST node.
     Syntax CreateRoutine
 
-    # Deps contains the data source dependencies of the view.
+    # Deps contains the data source dependencies of the function.
     Deps SchemaDeps
 
-    # TypeDeps contains the type dependencies of the view.
+    # TypeDeps contains the type dependencies of the function.
     TypeDeps SchemaTypeDeps
+
+    # FuncDeps contains the function dependencies of the function.
+    FuncDeps SchemaFunctionDeps
 }
 
 # Explain returns information about the execution plan of the "input"

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -144,11 +144,7 @@ type Builder struct {
 
 	// insideUDF is true when the current expressions are being built within a
 	// UDF.
-	// TODO(mgartner): Once other UDFs can be referenced from within a UDF, a
-	// boolean will not be sufficient to track whether or not we are in a UDF.
-	// We'll need to track the depth of the UDFs we are building expressions
-	// within.
-	insideUDF bool
+	insideUDF int
 
 	// insideDataSource is true when we are processing a data source.
 	insideDataSource bool
@@ -162,8 +158,9 @@ type Builder struct {
 	// inner view/function).
 	trackSchemaDeps bool
 
-	schemaDeps     opt.SchemaDeps
-	schemaTypeDeps opt.SchemaTypeDeps
+	schemaDeps         opt.SchemaDeps
+	schemaFunctionDeps opt.SchemaFunctionDeps
+	schemaTypeDeps     opt.SchemaTypeDeps
 
 	// If set, the data source names in the AST are rewritten to the fully
 	// qualified version (after resolution). Used to construct the strings for

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -50,11 +50,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 	schID := b.factory.Metadata().AddSchema(sch)
 	cf.Name.ObjectNamePrefix = resName
 
-	// TODO(#88198): this is a hack to disallow UDF usage in UDF and we will
-	// need to lift this hack when we plan to allow it.
-	preFuncResolver := b.semaCtx.FunctionResolver
-	b.semaCtx.FunctionResolver = nil
-
 	b.insideFuncDef = true
 	b.trackSchemaDeps = true
 	// Make sure datasource names are qualified.
@@ -70,7 +65,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		b.evalCtx.Annotations = oldEvalCtxAnn
 		b.semaCtx.Annotations = oldSemaCtxAnn
 
-		b.semaCtx.FunctionResolver = preFuncResolver
 		switch recErr := recover().(type) {
 		case nil:
 			// No error.

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -132,13 +132,16 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 	// the function body.
 	var deps opt.SchemaDeps
 	var typeDeps opt.SchemaTypeDeps
+	var functionDeps opt.SchemaFunctionDeps
 
 	afterBuildStmt := func() {
+		functionDeps.UnionWith(b.schemaFunctionDeps)
 		deps = append(deps, b.schemaDeps...)
 		typeDeps.UnionWith(b.schemaTypeDeps)
 		// Reset the tracked dependencies for next statement.
 		b.schemaDeps = nil
 		b.schemaTypeDeps = intsets.Fast{}
+		b.schemaFunctionDeps = intsets.Fast{}
 
 		// Reset the annotations to the original values
 		b.evalCtx.Annotations = oldEvalCtxAnn
@@ -383,6 +386,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			Syntax:   cf,
 			Deps:     deps,
 			TypeDeps: typeDeps,
+			FuncDeps: functionDeps,
 		},
 	)
 	return outScope

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -167,7 +167,7 @@ func (b *Builder) buildScalar(
 			OriginalExpr: s.Subquery,
 			Ordering:     s.ordering,
 			RequestedCol: inCol,
-			WithinUDF:    b.insideUDF,
+			WithinUDF:    b.insideUDF > 0,
 		}
 		out = b.factory.ConstructArrayFlatten(s.node, &subqueryPrivate)
 

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -404,7 +404,7 @@ func (b *Builder) buildMultiRowSubquery(
 		))
 	}
 
-	if b.insideUDF {
+	if b.insideUDF != 0 {
 		// Any expressions cannot be built by the optimizer within a UDF, so
 		// build them as subqueries with ScalarGroupBy expressions instead.
 		sub := b.factory.CustomFuncs().ConstructGroupByAny(scalar, cmp, input)

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -242,6 +242,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"UniqueOrdinals":       {fullName: "cat.UniqueOrdinals", passByVal: true},
 		"SchemaDeps":           {fullName: "opt.SchemaDeps", passByVal: true},
 		"SchemaTypeDeps":       {fullName: "opt.SchemaTypeDeps", passByVal: true},
+		"SchemaFunctionDeps":   {fullName: "opt.SchemaFunctionDeps", passByVal: true},
 		"Locking":              {fullName: "opt.Locking", passByVal: true},
 		"CTEMaterializeClause": {fullName: "tree.CTEMaterializeClause", passByVal: true},
 		"SpanExpression":       {fullName: "inverted.SpanExpression", isPointer: true, usePointerIntern: true},

--- a/pkg/sql/opt/schema_dependencies.go
+++ b/pkg/sql/opt/schema_dependencies.go
@@ -14,8 +14,15 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 )
+
+type SchemaFunctionDeps = intsets.Fast
+
+type SchemaFunctionDep struct {
+	FunctionDefinition *tree.ResolvedFunctionDefinition
+}
 
 // SchemaDeps contains information about the dependencies of objects in a
 // schema, like a view or function.

--- a/pkg/sql/reference_provider.go
+++ b/pkg/sql/reference_provider.go
@@ -29,6 +29,7 @@ type tableDescReferences []descpb.TableDescriptor_Reference
 type referenceProvider struct {
 	tableReferences     map[descpb.ID]tableDescReferences
 	viewReferences      map[descpb.ID]tableDescReferences
+	referencedFunctions catalog.DescriptorIDSet
 	referencedSequences catalog.DescriptorIDSet
 	referencedTypes     catalog.DescriptorIDSet
 	allRelationIDs      catalog.DescriptorIDSet
@@ -59,6 +60,16 @@ func (r *referenceProvider) ForEachTableReference(
 			if err := f(id, ref.IndexID, ref.ColumnIDs); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// ForEachFunctionReference implements scbuildstmt.ReferenceProvider.
+func (r *referenceProvider) ForEachFunctionReference(f func(functionID descpb.ID) error) error {
+	for _, functionID := range r.referencedFunctions.Ordered() {
+		if err := f(functionID); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -110,7 +121,7 @@ func (f *referenceProviderFactory) NewReferenceProvider(
 	// For the time being this is only used for CREATE FUNCTION. We need to handle
 	// CREATE VIEW when it's needed.
 	createFnExpr := optFactory.Memo().RootExpr().(*memo.CreateFunctionExpr)
-	tableReferences, typeReferences, _, err := toPlanDependencies(createFnExpr.Deps, createFnExpr.TypeDeps, createFnExpr.FuncDeps)
+	tableReferences, typeReferences, functionReferences, err := toPlanDependencies(createFnExpr.Deps, createFnExpr.TypeDeps, createFnExpr.FuncDeps)
 	if err != nil {
 		return nil, err
 	}
@@ -141,6 +152,9 @@ func (f *referenceProviderFactory) NewReferenceProvider(
 		}
 	}
 
+	for functionID := range functionReferences {
+		ret.referencedFunctions.Add(functionID)
+	}
 	return ret, nil
 }
 

--- a/pkg/sql/reference_provider.go
+++ b/pkg/sql/reference_provider.go
@@ -110,7 +110,7 @@ func (f *referenceProviderFactory) NewReferenceProvider(
 	// For the time being this is only used for CREATE FUNCTION. We need to handle
 	// CREATE VIEW when it's needed.
 	createFnExpr := optFactory.Memo().RootExpr().(*memo.CreateFunctionExpr)
-	tableReferences, typeReferences, err := toPlanDependencies(createFnExpr.Deps, createFnExpr.TypeDeps)
+	tableReferences, typeReferences, _, err := toPlanDependencies(createFnExpr.Deps, createFnExpr.TypeDeps, createFnExpr.FuncDeps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1898,6 +1898,11 @@ func TestSchemaChangeComparator_udf(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_udf_calling_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_calling_udf"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_udf_delete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_delete"

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1578,6 +1578,14 @@ func (b *builderState) WrapFunctionBody(
 		panic(err)
 	}
 
+	if err := refProvider.ForEachFunctionReference(func(id descpb.ID) error {
+		fnBody.UsesFunctionIDs = append(fnBody.UsesFunctionIDs,
+			id)
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+
 	fnBody.UsesSequenceIDs = refProvider.ReferencedSequences().Ordered()
 	fnBody.UsesTypeIDs = refProvider.ReferencedTypes().Ordered()
 	return fnBody

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -184,6 +184,7 @@ func CreateFunction(b BuildCtx, n *tree.CreateRoutine) {
 	refProvider := b.BuildReferenceProvider(n)
 	validateTypeReferences(b, refProvider, db.DatabaseID)
 	validateFunctionRelationReferences(b, refProvider, db.DatabaseID)
+	validateFunctionToFunctionReferences(b, refProvider, db.DatabaseID)
 	b.Add(b.WrapFunctionBody(fnID, fnBodyStr, lang, refProvider))
 	b.LogEventForExistingTarget(&fn)
 }
@@ -205,6 +206,29 @@ func validateFunctionRelationReferences(
 				"dependent relation %s cannot be from another database",
 				namespace.Name))
 		}
+	}
+}
+
+// validateFunctionToFunctionReferences validates no function references are
+// cross database.
+func validateFunctionToFunctionReferences(
+	b BuildCtx, refProvider ReferenceProvider, parentDBID descpb.ID,
+) {
+	err := refProvider.ForEachFunctionReference(func(id descpb.ID) error {
+		funcElts := b.QueryByID(id)
+		funcName := funcElts.FilterFunctionName().MustGetOneElement()
+		schemaParent := funcElts.FilterSchemaChild().MustGetOneElement()
+		schemaNamespace := b.QueryByID(schemaParent.SchemaID).FilterNamespace().MustGetOneElement()
+		if schemaNamespace.DatabaseID != parentDBID {
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"dependent function %s cannot be from another database",
+				funcName.Name)
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
 	}
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -200,11 +200,10 @@ func validateFunctionRelationReferences(
 	for _, id := range refProvider.ReferencedRelationIDs().Ordered() {
 		_, _, namespace := scpb.FindNamespace(b.QueryByID(id))
 		if namespace.DatabaseID != parentDBID {
-			name := tree.MakeTypeNameWithPrefix(b.NamePrefix(namespace), namespace.Name)
 			panic(pgerror.Newf(
 				pgcode.FeatureNotSupported,
-				"the function cannot refer to other databases",
-				name.String()))
+				"dependent relation %s cannot be from another database",
+				namespace.Name))
 		}
 	}
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -417,6 +417,9 @@ type ReferenceProvider interface {
 	// ForEachViewReference iterate through all referenced views and the reference
 	// details with the given function.
 	ForEachViewReference(f func(viewID descpb.ID, colIDs descpb.ColumnIDs) error) error
+	// ForEachFunctionReference iterates through all referenced functions for each
+	// function.
+	ForEachFunctionReference(f func(id descpb.ID) error) error
 	// ReferencedSequences returns all referenced sequence IDs
 	ReferencedSequences() catalog.DescriptorIDSet
 	// ReferencedTypes returns all referenced type IDs (not including implicit

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -901,6 +901,7 @@ func (w *walkCtx) walkFunction(fnDesc catalog.FunctionDescriptor) {
 			}
 		}
 	}
+	fnBody.UsesFunctionIDs = append(fnBody.UsesFunctionIDs, fnDesc.GetDependsOnFunctions()...)
 	for _, backRef := range fnDesc.GetDependedOnBy() {
 		w.backRefs.Add(backRef.ID)
 	}

--- a/pkg/sql/schemachanger/scdecomp/testdata/function
+++ b/pkg/sql/schemachanger/scdecomp/testdata/function
@@ -82,6 +82,7 @@ ElementState:
     functionId: 110
     lang:
       lang: SQL
+    usesFunctionIds: []
     usesSequenceIds:
     - 105
     usesTables:

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -451,6 +451,24 @@ func (i *immediateVisitor) RemoveBackReferencesInRelations(
 	return nil
 }
 
+func (i *immediateVisitor) RemoveBackReferenceInFunctions(
+	ctx context.Context, op scop.RemoveBackReferenceInFunctions,
+) error {
+	for _, f := range op.FunctionIDs {
+		backRefFunc, err := i.checkOutFunction(ctx, f)
+		if err != nil {
+			return err
+		}
+		for i, dep := range backRefFunc.DependedOnBy {
+			if dep.ID == op.BackReferencedDescriptorID {
+				backRefFunc.DependedOnBy = append(backRefFunc.DependedOnBy[:i], backRefFunc.DependedOnBy[i+1:]...)
+				break
+			}
+		}
+	}
+	return nil
+}
+
 func removeViewBackReferencesInRelation(
 	ctx context.Context, m *immediateVisitor, relationID, backReferencedID descpb.ID,
 ) error {
@@ -515,6 +533,7 @@ func (i *immediateVisitor) UpdateFunctionRelationReferences(
 	}
 	relIDs := catalog.DescriptorIDSet{}
 	relIDToReferences := make(map[descpb.ID][]descpb.TableDescriptor_Reference)
+	functionIDs := catalog.DescriptorIDSet{}
 
 	for _, ref := range op.TableReferences {
 		relIDs.Add(ref.TableID)
@@ -543,6 +562,18 @@ func (i *immediateVisitor) UpdateFunctionRelationReferences(
 		}
 		relIDToReferences[seqID] = append(relIDToReferences[seqID], dep)
 	}
+
+	for _, functionRef := range op.FunctionReferences {
+		backRefFunc, err := i.checkOutFunction(ctx, functionRef)
+		if err != nil {
+			return err
+		}
+		if err := backRefFunc.AddFunctionReference(op.FunctionID); err != nil {
+			return err
+		}
+		functionIDs.Add(functionRef)
+	}
+	fn.DependsOnFunctions = functionIDs.Ordered()
 
 	for relID, refs := range relIDToReferences {
 		if err := updateBackReferencesInRelation(ctx, i, relID, op.FunctionID, refs); err != nil {

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -530,6 +530,13 @@ type RemoveBackReferenceInTypes struct {
 	TypeIDs                    []descpb.ID
 }
 
+type RemoveBackReferenceInFunctions struct {
+	immediateMutationOp
+
+	BackReferencedDescriptorID descpb.ID
+	FunctionIDs                []descpb.ID
+}
+
 // UpdateTableBackReferencesInSequences updates back references to a table expression
 // (in a column or a check constraint) in the specified sequences.
 type UpdateTableBackReferencesInSequences struct {
@@ -807,10 +814,11 @@ type UpdateFunctionTypeReferences struct {
 
 type UpdateFunctionRelationReferences struct {
 	immediateMutationOp
-	FunctionID      descpb.ID
-	TableReferences []scpb.FunctionBody_TableReference
-	ViewReferences  []scpb.FunctionBody_ViewReference
-	SequenceIDs     []descpb.ID
+	FunctionID         descpb.ID
+	TableReferences    []scpb.FunctionBody_TableReference
+	ViewReferences     []scpb.FunctionBody_ViewReference
+	SequenceIDs        []descpb.ID
+	FunctionReferences []descpb.ID
 }
 
 type SetObjectParentID struct {

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -85,6 +85,7 @@ type ImmediateMutationVisitor interface {
 	UpdateTableBackReferencesInTypes(context.Context, UpdateTableBackReferencesInTypes) error
 	UpdateTypeBackReferencesInTypes(context.Context, UpdateTypeBackReferencesInTypes) error
 	RemoveBackReferenceInTypes(context.Context, RemoveBackReferenceInTypes) error
+	RemoveBackReferenceInFunctions(context.Context, RemoveBackReferenceInFunctions) error
 	UpdateTableBackReferencesInSequences(context.Context, UpdateTableBackReferencesInSequences) error
 	RemoveBackReferencesInRelations(context.Context, RemoveBackReferencesInRelations) error
 	AddTableConstraintBackReferencesInFunctions(context.Context, AddTableConstraintBackReferencesInFunctions) error
@@ -445,6 +446,11 @@ func (op UpdateTypeBackReferencesInTypes) Visit(ctx context.Context, v Immediate
 // Visit is part of the ImmediateMutationOp interface.
 func (op RemoveBackReferenceInTypes) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.RemoveBackReferenceInTypes(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op RemoveBackReferenceInFunctions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.RemoveBackReferenceInFunctions(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -720,6 +720,7 @@ message FunctionBody {
   repeated ViewReference uses_views = 5 [(gogoproto.nullable) = false];
   repeated uint32 uses_sequence_ids = 6 [(gogoproto.customname) = "UsesSequenceIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   repeated uint32 uses_type_ids = 7 [(gogoproto.customname) = "UsesTypeIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  repeated uint32 uses_function_ids = 8   [(gogoproto.customname) = "UsesFunctionIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
 }
 
 message FunctionParamDefaultExpression {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -181,6 +181,7 @@ FunctionBody : []UsesTables
 FunctionBody : []UsesViews
 FunctionBody : []UsesSequenceIDs
 FunctionBody : []UsesTypeIDs
+FunctionBody : []UsesFunctionIDs
 
 object FunctionLeakProof
 

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_function_body.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_function_body.go
@@ -36,10 +36,11 @@ func init() {
 				}),
 				emit(func(this *scpb.FunctionBody) *scop.UpdateFunctionRelationReferences {
 					return &scop.UpdateFunctionRelationReferences{
-						FunctionID:      this.FunctionID,
-						TableReferences: this.UsesTables,
-						ViewReferences:  this.UsesViews,
-						SequenceIDs:     this.UsesSequenceIDs,
+						FunctionID:         this.FunctionID,
+						TableReferences:    this.UsesTables,
+						ViewReferences:     this.UsesViews,
+						SequenceIDs:        this.UsesSequenceIDs,
+						FunctionReferences: this.UsesFunctionIDs,
 					}
 				}),
 			),
@@ -72,7 +73,14 @@ func init() {
 						BackReferencedID: this.FunctionID,
 						RelationIDs:      relationIDs,
 					}
-				})),
+				}),
+				emit(func(this *scpb.FunctionBody) *scop.RemoveBackReferenceInFunctions {
+					return &scop.RemoveBackReferenceInFunctions{
+						BackReferencedDescriptorID: this.FunctionID,
+						FunctionIDs:                append([]descpb.ID(nil), this.UsesFunctionIDs...),
+					}
+				}),
+			),
 		),
 	)
 }

--- a/pkg/sql/schemachanger/scplan/testdata/drop_function
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_function
@@ -21,7 +21,7 @@ $$;
 ops
 DROP FUNCTION f;
 ----
-StatementPhase stage 1 of 1 with 12 MutationType ops
+StatementPhase stage 1 of 1 with 13 MutationType ops
   transitions:
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
@@ -65,6 +65,8 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
       - 104
       - 106
       - 105
+    *scop.RemoveBackReferenceInFunctions
+      BackReferencedDescriptorID: 109
     *scop.NotImplementedForPublicObjects
       DescID: 109
       ElementType: scpb.Owner
@@ -93,7 +95,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 19 MutationType ops
+PreCommitPhase stage 2 of 2 with 20 MutationType ops
   transitions:
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
@@ -137,6 +139,8 @@ PreCommitPhase stage 2 of 2 with 19 MutationType ops
       - 104
       - 106
       - 105
+    *scop.RemoveBackReferenceInFunctions
+      BackReferencedDescriptorID: 109
     *scop.NotImplementedForPublicObjects
       DescID: 109
       ElementType: scpb.Owner

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -230,6 +230,13 @@ func TestEndToEndSideEffects_create_function(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_create_function_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -619,6 +626,13 @@ func TestExecuteWithDMLInjection_create_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1014,6 +1028,13 @@ func TestGenerateSchemaChangeCorpus_create_function(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_create_function_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1403,6 +1424,13 @@ func TestPause_create_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1798,6 +1826,13 @@ func TestPauseMixedVersion_create_function(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_create_function_in_txn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2187,6 +2222,13 @@ func TestRollback_create_function(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_create_function_calling_function(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.definition
@@ -1,0 +1,29 @@
+setup
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT,
+  C INT,
+  INDEX t_idx_b(b),
+  INDEX t_idx_c(c)
+);
+CREATE SEQUENCE sq1;
+CREATE VIEW v AS SELECT a FROM t;
+CREATE TYPE notmyworkday AS ENUM ('Monday', 'Tuesday');
+CREATE TABLE t2(a notmyworkday);
+CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT a FROM t;
+  SELECT b FROM t@t_idx_b;
+  SELECT c FROM t@t_idx_c;
+  SELECT a FROM v;
+  SELECT nextval('sq1');
+$$;
+CREATE FUNCTION f2(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f(a) + f(a);
+$$;
+----
+
+test
+CREATE FUNCTION f3(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f2(a) + f(a);
+$$;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.explain
@@ -1,0 +1,96 @@
+/* setup */
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT,
+  C INT,
+  INDEX t_idx_b(b),
+  INDEX t_idx_c(c)
+);
+CREATE SEQUENCE sq1;
+CREATE VIEW v AS SELECT a FROM t;
+CREATE TYPE notmyworkday AS ENUM ('Monday', 'Tuesday');
+CREATE TABLE t2(a notmyworkday);
+CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT a FROM t;
+  SELECT b FROM t@t_idx_b;
+  SELECT c FROM t@t_idx_c;
+  SELECT a FROM v;
+  SELECT nextval('sq1');
+$$;
+CREATE FUNCTION f2(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f(a) + f(a);
+$$;
+
+/* test */
+EXPLAIN (DDL) CREATE FUNCTION f3(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f2(a) + f(a);
+$$;
+----
+Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹f3›(IN ‹a› ‹notmyworkday›)
+	RETURNS INT8
+	VOLATILE
+	LANGUAGE SQL
+	AS $$SELECT public.f2(‹a›) + public.f(‹a›);$$;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Function:{DescID: 112 (f3+)}
+ │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 112 (f3+), ReferencedDescID: 101 (public)}
+ │         │    ├── ABSENT → PUBLIC FunctionName:{DescID: 112 (f3+)}
+ │         │    ├── ABSENT → PUBLIC FunctionVolatility:{DescID: 112 (f3+)}
+ │         │    ├── ABSENT → PUBLIC Owner:{DescID: 112 (f3+)}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 112 (f3+), Name: "admin"}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 112 (f3+), Name: "public"}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 112 (f3+), Name: "root"}
+ │         │    └── ABSENT → PUBLIC FunctionBody:{DescID: 112 (f3+)}
+ │         └── 12 Mutation operations
+ │              ├── CreateFunctionDescriptor {"Function":{"FunctionID":112}}
+ │              ├── SetFunctionName {"FunctionID":112,"Name":"f3"}
+ │              ├── SetFunctionVolatility {"FunctionID":112,"Volatility":1}
+ │              ├── UpdateOwner {"Owner":{"DescriptorID":112,"Owner":"root"}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":112,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":112,"Privileges":1048576,"UserName":"public"}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":112,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+ │              ├── SetFunctionBody {"Body":{"Body":"SELECT f2(a) + f...","FunctionID":112}}
+ │              ├── UpdateFunctionTypeReferences {"FunctionID":112}
+ │              ├── UpdateFunctionRelationReferences {"FunctionID":112}
+ │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":112,"SchemaID":101}}
+ │              └── MarkDescriptorAsPublic {"DescriptorID":112}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 9 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Function:{DescID: 112 (f3+)}
+      │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 112 (f3+), ReferencedDescID: 101 (public)}
+      │    │    ├── PUBLIC → ABSENT FunctionName:{DescID: 112 (f3+)}
+      │    │    ├── PUBLIC → ABSENT FunctionVolatility:{DescID: 112 (f3+)}
+      │    │    ├── PUBLIC → ABSENT Owner:{DescID: 112 (f3+)}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 112 (f3+), Name: "admin"}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 112 (f3+), Name: "public"}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 112 (f3+), Name: "root"}
+      │    │    └── PUBLIC → ABSENT FunctionBody:{DescID: 112 (f3+)}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 9 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Function:{DescID: 112 (f3+)}
+           │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 112 (f3+), ReferencedDescID: 101 (public)}
+           │    ├── ABSENT → PUBLIC FunctionName:{DescID: 112 (f3+)}
+           │    ├── ABSENT → PUBLIC FunctionVolatility:{DescID: 112 (f3+)}
+           │    ├── ABSENT → PUBLIC Owner:{DescID: 112 (f3+)}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 112 (f3+), Name: "admin"}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 112 (f3+), Name: "public"}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 112 (f3+), Name: "root"}
+           │    └── ABSENT → PUBLIC FunctionBody:{DescID: 112 (f3+)}
+           └── 12 Mutation operations
+                ├── CreateFunctionDescriptor {"Function":{"FunctionID":112}}
+                ├── SetFunctionName {"FunctionID":112,"Name":"f3"}
+                ├── SetFunctionVolatility {"FunctionID":112,"Volatility":1}
+                ├── UpdateOwner {"Owner":{"DescriptorID":112,"Owner":"root"}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":112,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":112,"Privileges":1048576,"UserName":"public"}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":112,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+                ├── SetFunctionBody {"Body":{"Body":"SELECT f2(a) + f...","FunctionID":112}}
+                ├── UpdateFunctionTypeReferences {"FunctionID":112}
+                ├── UpdateFunctionRelationReferences {"FunctionID":112}
+                ├── SetObjectParentID {"ObjParent":{"ChildObjectID":112,"SchemaID":101}}
+                └── MarkDescriptorAsPublic {"DescriptorID":112}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.explain_shape
@@ -1,0 +1,34 @@
+/* setup */
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT,
+  C INT,
+  INDEX t_idx_b(b),
+  INDEX t_idx_c(c)
+);
+CREATE SEQUENCE sq1;
+CREATE VIEW v AS SELECT a FROM t;
+CREATE TYPE notmyworkday AS ENUM ('Monday', 'Tuesday');
+CREATE TABLE t2(a notmyworkday);
+CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT a FROM t;
+  SELECT b FROM t@t_idx_b;
+  SELECT c FROM t@t_idx_c;
+  SELECT a FROM v;
+  SELECT nextval('sq1');
+$$;
+CREATE FUNCTION f2(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f(a) + f(a);
+$$;
+
+/* test */
+EXPLAIN (DDL, SHAPE) CREATE FUNCTION f3(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f2(a) + f(a);
+$$;
+----
+Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹f3›(IN ‹a› ‹notmyworkday›)
+	RETURNS INT8
+	VOLATILE
+	LANGUAGE SQL
+	AS $$SELECT public.f2(‹a›) + public.f(‹a›);$$;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.side_effects
@@ -1,0 +1,433 @@
+/* setup */
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT,
+  C INT,
+  INDEX t_idx_b(b),
+  INDEX t_idx_c(c)
+);
+CREATE SEQUENCE sq1;
+CREATE VIEW v AS SELECT a FROM t;
+CREATE TYPE notmyworkday AS ENUM ('Monday', 'Tuesday');
+CREATE TABLE t2(a notmyworkday);
+CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT a FROM t;
+  SELECT b FROM t@t_idx_b;
+  SELECT c FROM t@t_idx_c;
+  SELECT a FROM v;
+  SELECT nextval('sq1');
+$$;
+CREATE FUNCTION f2(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f(a) + f(a);
+$$;
+----
+...
++object {100 101 t} -> 104
++object {100 101 sq1} -> 105
++object {100 101 v} -> 106
++object {100 101 notmyworkday} -> 107
++object {100 101 _notmyworkday} -> 108
++object {100 101 t2} -> 109
+
+/* test */
+CREATE FUNCTION f3(a notmyworkday)  RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT f2(a) + f(a);
+$$;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CREATE FUNCTION
+increment telemetry for sql.schema.create_function
+write *eventpb.CreateFunction to event log:
+  functionName: defaultdb.public.f3
+  sql:
+    descriptorId: 112
+    statement: "CREATE FUNCTION ‹defaultdb›.‹public›.‹f3›(IN ‹a› ‹notmyworkday›)\n\tRETURNS INT8\n\tVOLATILE\n\tLANGUAGE SQL\n\tAS $$SELECT public.f2(‹a›) + public.f(‹a›);$$"
+    tag: CREATE FUNCTION
+    user: root
+## StatementPhase stage 1 of 1 with 12 MutationType ops
+upsert descriptor #112
+  -
+  +function:
+  +  dependsOn:
+  +  - 104
+  +  - 105
+  +  - 106
+  +  dependsOnFunctions:
+  +  - 110
+  +  - 111
+  +  dependsOnTypes:
+  +  - 107
+  +  - 108
+  +  functionBody: SELECT f2(a) + f(a);
+  +  id: 112
+  +  lang: SQL
+  +  modificationTime: {}
+  +  name: f3
+  +  nullInputBehavior: CALLED_ON_NULL_INPUT
+  +  params:
+  +  - class: IN
+  +    name: a
+  +    type:
+  +      family: EnumFamily
+  +      oid: 100107
+  +      udtMetadata:
+  +        arrayTypeOid: 100108
+  +  parentId: 100
+  +  parentSchemaId: 101
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "1048576"
+  +      userProto: public
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  returnType:
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  version: "1"
+  +  volatility: VOLATILE
+upsert descriptor #101
+  ...
+             oid: 20
+             width: 64
+  +    f3:
+  +      signatures:
+  +      - argTypes:
+  +        - family: EnumFamily
+  +          oid: 100107
+  +          udtMetadata:
+  +            arrayTypeOid: 100108
+  +        id: 112
+  +        returnType:
+  +          family: IntFamily
+  +          oid: 20
+  +          width: 64
+     id: 101
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #104
+  ...
+       id: 111
+       indexId: 3
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 2
+  +    id: 112
+  +    indexId: 2
+  +  - columnIds:
+  +    - 3
+  +    id: 112
+  +    indexId: 3
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 2
+  +    id: 112
+  +    indexId: 2
+  +  - columnIds:
+  +    - 3
+  +    id: 112
+  +    indexId: 3
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 2
+  +    id: 112
+  +    indexId: 2
+  +  - columnIds:
+  +    - 3
+  +    id: 112
+  +    indexId: 3
+     families:
+     - columnIds:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #105
+  ...
+     - byId: true
+       id: 111
+  +  - byId: true
+  +    id: 112
+     formatVersion: 3
+     id: 105
+  ...
+       start: "1"
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #106
+  ...
+       - 1
+       id: 111
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+     dependsOn:
+     - 104
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+     viewQuery: SELECT a FROM defaultdb.public.t
+upsert descriptor #107
+  ...
+     - 110
+     - 111
+  -  version: "4"
+  +  - 112
+  +  version: "5"
+upsert descriptor #108
+  ...
+     - 110
+     - 111
+  -  version: "4"
+  +  - 112
+  +  version: "5"
+upsert descriptor #110
+  ...
+     dependedOnBy:
+     - id: 111
+  +  - id: 112
+     dependsOn:
+     - 104
+  ...
+         oid: 20
+         width: 64
+  -  version: "2"
+  +  version: "3"
+     volatility: VOLATILE
+upsert descriptor #111
+   function:
+  +  dependedOnBy:
+  +  - id: 112
+     dependsOn:
+     - 104
+  ...
+         oid: 20
+         width: 64
+  -  version: "1"
+  +  version: "2"
+     volatility: VOLATILE
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 12 MutationType ops
+upsert descriptor #112
+  -
+  +function:
+  +  dependsOn:
+  +  - 104
+  +  - 105
+  +  - 106
+  +  dependsOnFunctions:
+  +  - 110
+  +  - 111
+  +  dependsOnTypes:
+  +  - 107
+  +  - 108
+  +  functionBody: SELECT f2(a) + f(a);
+  +  id: 112
+  +  lang: SQL
+  +  modificationTime: {}
+  +  name: f3
+  +  nullInputBehavior: CALLED_ON_NULL_INPUT
+  +  params:
+  +  - class: IN
+  +    name: a
+  +    type:
+  +      family: EnumFamily
+  +      oid: 100107
+  +      udtMetadata:
+  +        arrayTypeOid: 100108
+  +  parentId: 100
+  +  parentSchemaId: 101
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "1048576"
+  +      userProto: public
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  returnType:
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  version: "1"
+  +  volatility: VOLATILE
+upsert descriptor #101
+  ...
+             oid: 20
+             width: 64
+  +    f3:
+  +      signatures:
+  +      - argTypes:
+  +        - family: EnumFamily
+  +          oid: 100107
+  +          udtMetadata:
+  +            arrayTypeOid: 100108
+  +        id: 112
+  +        returnType:
+  +          family: IntFamily
+  +          oid: 20
+  +          width: 64
+     id: 101
+     modificationTime: {}
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #104
+  ...
+       id: 111
+       indexId: 3
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 2
+  +    id: 112
+  +    indexId: 2
+  +  - columnIds:
+  +    - 3
+  +    id: 112
+  +    indexId: 3
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 2
+  +    id: 112
+  +    indexId: 2
+  +  - columnIds:
+  +    - 3
+  +    id: 112
+  +    indexId: 3
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 2
+  +    id: 112
+  +    indexId: 2
+  +  - columnIds:
+  +    - 3
+  +    id: 112
+  +    indexId: 3
+     families:
+     - columnIds:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #105
+  ...
+     - byId: true
+       id: 111
+  +  - byId: true
+  +    id: 112
+     formatVersion: 3
+     id: 105
+  ...
+       start: "1"
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #106
+  ...
+       - 1
+       id: 111
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+  +  - columnIds:
+  +    - 1
+  +    id: 112
+     dependsOn:
+     - 104
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+     viewQuery: SELECT a FROM defaultdb.public.t
+upsert descriptor #107
+  ...
+     - 110
+     - 111
+  -  version: "4"
+  +  - 112
+  +  version: "5"
+upsert descriptor #108
+  ...
+     - 110
+     - 111
+  -  version: "4"
+  +  - 112
+  +  version: "5"
+upsert descriptor #110
+  ...
+     dependedOnBy:
+     - id: 111
+  +  - id: 112
+     dependsOn:
+     - 104
+  ...
+         oid: 20
+         width: 64
+  -  version: "2"
+  +  version: "3"
+     volatility: VOLATILE
+upsert descriptor #111
+   function:
+  +  dependedOnBy:
+  +  - id: 112
+     dependsOn:
+     - 104
+  ...
+         oid: 20
+         width: 64
+  -  version: "1"
+  +  version: "2"
+     volatility: VOLATILE
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_1_of_7.explain
@@ -29,7 +29,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── DELETE_ONLY      → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 18 Mutation operations
+      │    └── 19 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
@@ -38,6 +38,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_2_of_7.explain
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 17 Mutation operations
+      │    └── 18 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
@@ -38,6 +38,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_3_of_7.explain
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 17 Mutation operations
+      │    └── 18 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
@@ -38,6 +38,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_4_of_7.explain
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 17 Mutation operations
+      │    └── 18 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
@@ -38,6 +38,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_5_of_7.explain
@@ -28,13 +28,14 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 17 Mutation operations
+      │    └── 18 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":104}
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_6_of_7.explain
@@ -28,13 +28,14 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 17 Mutation operations
+      │    └── 18 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":104}
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn/create_function_in_txn__rollback_7_of_7.explain
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
-      │    └── 17 Mutation operations
+      │    └── 18 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
@@ -38,6 +38,7 @@ Schema change plan for rolling back CREATE UNIQUE INDEX ‹idx› ON ‹defaultd
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.FunctionNam..."}
+      │         ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":105}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.explain
@@ -36,7 +36,7 @@ Schema change plan for DROP FUNCTION ‹""›.‹""›.‹f›;
  │         │    ├── PUBLIC → ABSENT  FunctionLeakProof:{DescID: 109 (f-)}
  │         │    ├── PUBLIC → ABSENT  FunctionNullInputBehavior:{DescID: 109 (f-)}
  │         │    └── PUBLIC → ABSENT  FunctionBody:{DescID: 109 (f-)}
- │         └── 12 Mutation operations
+ │         └── 13 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":109}
  │              ├── RemoveObjectParent {"ObjectID":109,"ParentSchemaID":101}
  │              ├── NotImplementedForPublicObjects {"DescID":109,"ElementType":"scpb.FunctionNam..."}
@@ -45,6 +45,7 @@ Schema change plan for DROP FUNCTION ‹""›.‹""›.‹f›;
  │              ├── NotImplementedForPublicObjects {"DescID":109,"ElementType":"scpb.FunctionNul..."}
  │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":109}
  │              ├── RemoveBackReferencesInRelations {"BackReferencedID":109}
+ │              ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":109}
  │              ├── NotImplementedForPublicObjects {"DescID":109,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":109,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":109,"User":"public"}
@@ -78,7 +79,7 @@ Schema change plan for DROP FUNCTION ‹""›.‹""›.‹f›;
  │         │    ├── PUBLIC → ABSENT  FunctionLeakProof:{DescID: 109 (f-)}
  │         │    ├── PUBLIC → ABSENT  FunctionNullInputBehavior:{DescID: 109 (f-)}
  │         │    └── PUBLIC → ABSENT  FunctionBody:{DescID: 109 (f-)}
- │         └── 19 Mutation operations
+ │         └── 20 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":109}
  │              ├── RemoveObjectParent {"ObjectID":109,"ParentSchemaID":101}
  │              ├── NotImplementedForPublicObjects {"DescID":109,"ElementType":"scpb.FunctionNam..."}
@@ -87,6 +88,7 @@ Schema change plan for DROP FUNCTION ‹""›.‹""›.‹f›;
  │              ├── NotImplementedForPublicObjects {"DescID":109,"ElementType":"scpb.FunctionNul..."}
  │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":109}
  │              ├── RemoveBackReferencesInRelations {"BackReferencedID":109}
+ │              ├── RemoveBackReferenceInFunctions {"BackReferencedDescriptorID":109}
  │              ├── NotImplementedForPublicObjects {"DescID":109,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":109,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":109,"User":"public"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.side_effects
@@ -40,7 +40,7 @@ write *eventpb.DropFunction to event log:
     statement: DROP FUNCTION ‹""›.‹""›.‹f›
     tag: DROP FUNCTION
     user: root
-## StatementPhase stage 1 of 1 with 12 MutationType ops
+## StatementPhase stage 1 of 1 with 13 MutationType ops
 upsert descriptor #101
    schema:
   -  functions:
@@ -144,7 +144,7 @@ upsert descriptor #109
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 19 MutationType ops
+## PreCommitPhase stage 2 of 2 with 20 MutationType ops
 upsert descriptor #101
    schema:
   -  functions:

--- a/pkg/upgrade/upgrades/first_upgrade_test.go
+++ b/pkg/upgrade/upgrades/first_upgrade_test.go
@@ -250,9 +250,10 @@ func TestFirstUpgradeRepair(t *testing.T) {
 	tdb.CheckQueryResults(t, "SELECT test.public.f()", [][]string{{"1"}})
 
 	// The corruption should interfere with DDL statements.
-	const errRE = "referenced table ID 123456789: referenced descriptor not found"
+	const errRE = "relation \"foo\" \\(106\\): invalid foreign key backreference: missing table=123456789: referenced table ID 123456789: referenced descriptor not found"
 	tdb.ExpectErr(t, errRE, "ALTER TABLE test.public.foo RENAME TO bar")
-	tdb.ExpectErr(t, errRE, "ALTER FUNCTION test.public.f RENAME TO g")
+	const errReForFunction = " function \"f\" \\(107\\): referenced descriptor ID 123456789: referenced descriptor not found"
+	tdb.ExpectErr(t, errReForFunction, "ALTER FUNCTION test.public.f RENAME TO g")
 
 	// Check that the corruption is detected by invalid_objects.
 	const qDetectCorruption = `SELECT count(*) FROM "".crdb_internal.invalid_objects`


### PR DESCRIPTION
Previously, we allowed renaming a UDF that was referenced by another
UDF. This could cause the referencing UDF to break, since references are
by name today. Longer term we want to referenced by IDs instead, but
this is more complex. To address this, in the short term we are going to
disallow renaming of functions referenced by other functions to prevent
this.

Fixes: #120366

Release note: None