### PR TITLE
kv: deflake TestWedgedReplicaDetection using manual clock

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3"
@@ -416,11 +415,11 @@ func (r *Replica) NumPendingProposals() int {
 }
 
 func (r *Replica) IsFollowerActiveSince(
-	ctx context.Context, followerID roachpb.ReplicaID, threshold time.Duration,
+	followerID roachpb.ReplicaID, now time.Time, threshold time.Duration,
 ) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.lastUpdateTimes.isFollowerActiveSince(followerID, timeutil.Now(), threshold)
+	return r.mu.lastUpdateTimes.isFollowerActiveSince(followerID, now, threshold)
 }
 
 // GetTSCacheHighWater returns the high water mark of the replica's timestamp

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/tracker"
@@ -89,6 +88,7 @@ var logSlowRaftProposalQuotaAcquisition = quotapool.OnSlowAcquisition(
 func (r *Replica) updateProposalQuotaRaftMuLocked(
 	ctx context.Context, lastLeaderID roachpb.ReplicaID,
 ) {
+	now := r.Clock().PhysicalTime()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -119,7 +119,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 				logSlowRaftProposalQuotaAcquisition,
 			)
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
-			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.state.Desc.Replicas().Descriptors(), timeutil.Now())
+			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
 		} else if r.mu.proposalQuota != nil {
@@ -143,9 +143,8 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	}
 
 	// We're still the leader.
-
 	// Find the minimum index that active followers have acknowledged.
-	now := timeutil.Now()
+
 	// commitIndex is used to determine whether a newly added replica has fully
 	// caught up.
 	commitIndex := kvpb.RaftIndex(status.Commit)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -601,7 +601,7 @@ func (r *Replica) stepRaftGroup(req *kvserverpb.RaftMessageRequest) error {
 			wakeLeader := hasLeader && !fromLeader
 			r.maybeUnquiesceLocked(wakeLeader, false /* mayCampaign */)
 		}
-		r.mu.lastUpdateTimes.update(req.FromReplica.ReplicaID, timeutil.Now())
+		r.mu.lastUpdateTimes.update(req.FromReplica.ReplicaID, r.Clock().PhysicalTime())
 		switch req.Message.Type {
 		case raftpb.MsgPreVote, raftpb.MsgVote:
 			// If we receive a (pre)vote request, and we find our leader to be dead or
@@ -1313,7 +1313,7 @@ func (r *Replica) tick(
 	// This is likely unintentional, and the leader should likely consider itself
 	// live even when quiesced.
 	if r.isRaftLeaderRLocked() {
-		r.mu.lastUpdateTimes.update(r.replicaID, timeutil.Now())
+		r.mu.lastUpdateTimes.update(r.replicaID, r.Clock().PhysicalTime())
 	}
 
 	r.mu.ticks++

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
 	"go.etcd.io/raft/v3/tracker"
@@ -94,7 +93,7 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	st := r.raftSparseStatusRLocked()
 	if st.RaftState == raft.StateLeader {
 		r.mu.lastUpdateTimes.updateOnUnquiesce(
-			r.mu.state.Desc.Replicas().Descriptors(), st.Progress, timeutil.Now())
+			r.mu.state.Desc.Replicas().Descriptors(), st.Progress, r.Clock().PhysicalTime())
 
 	} else if st.RaftState == raft.StateFollower && st.Lead != raft.None && wakeLeader {
 		// Propose an empty command which will wake the leader.

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -437,15 +437,7 @@ func (c *Clock) PhysicalNow() int64 {
 }
 
 // PhysicalTime returns a time.Time struct using the local wall time.
-func (c *Clock) PhysicalTime() time.Time {
-	// NOTE: We don't go through c.physicalNanos() if c.timeSource is set in order
-	// to preserve the monotonic clock reading that the timeSource might provide
-	// inside its instants.
-	if c.wallClock != nil {
-		return c.wallClock.Now()
-	}
-	return timeutil.Unix(0, c.wallClock.Now().UnixNano())
-}
+func (c *Clock) PhysicalTime() time.Time { return c.wallClock.Now() }
 
 // Update takes a hybrid timestamp, usually originating from an event
 // received from another member of a distributed system. The clock is


### PR DESCRIPTION
Fixes #120375.
Fixes #82059.

This commit deflakes TestWedgedReplicaDetection by using a manual clock. This prevents slowdowns in the test environment from causing the test to fail.

Epic: None
Release note: None