### PR TITLE
backupccl: clear InProgressImportStartTime in RESTORE

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2284,6 +2284,11 @@ func (r *restoreResumer) publishDescriptors(
 			}
 			mutTable.RowLevelTTL.ScheduleID = j.ScheduleID()
 		}
+
+		// If this was an importing table, it is now effectively _not_
+		// importing.
+		mutTable.FinalizeImport()
+
 		newTables = append(newTables, mutTable.TableDesc())
 
 		// Convert any mutations that were in progress on the table descriptor

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -391,3 +391,59 @@ select DISTINCT index_name FROM [SHOW INDEXES FROM d2.foo2];
 foo2_pkey
 foo2_idx
 foo2_new_idx
+
+
+exec-sql
+CREATE DATABASE re_restore_test;
+USE re_restore_test;
+CREATE TABLE tab1 (i INT PRIMARY KEY, s STRING);
+INSERT INTO tab1 VALUES (42, 'pre-import');
+----
+
+query-sql
+SELECT * FROM re_restore_test.tab1;
+----
+42 pre-import
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint
+IMPORT INTO re_restore_test.tab1 (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+exec-sql
+BACKUP DATABASE re_restore_test INTO 'nodelocal://1/with-paused-import';
+----
+
+exec-sql
+RESTORE DATABASE re_restore_test FROM LATEST IN 'nodelocal://1//with-paused-import' WITH new_db_name=re_restore_test2;
+----
+
+# Should have the pre-import state
+query-sql
+SELECT * FROM re_restore_test2.tab1;
+----
+42 pre-import
+
+# Add another row
+exec-sql
+INSERT INTO re_restore_test2.tab1 VALUES (43, 'post-import-post-restore');
+----
+
+exec-sql
+BACKUP DATABASE re_restore_test2 INTO 'nodelocal://1/after-restore';
+----
+
+exec-sql
+RESTORE DATABASE re_restore_test2 FROM LATEST IN 'nodelocal://1//after-restore' WITH new_db_name=re_restore_test3;
+----
+
+query-sql
+SELECT * FROM re_restore_test3.tab1;
+----
+42 pre-import
+43 post-import-post-restore


### PR DESCRIPTION
Currently, RESTORE elides data from the in-progress import using MVCC timestamps and the stored InProgressImportStartTime, effectively restoring the table to the pre-import state.

However, we were failing to clear the descriptor field when bringing the tables back online. As a result, a subsequent backup and restore of that table would end up eliding data from the online table.

Epic: none

Release note (bug fix): Fixes an issue in which a RESTORE of a backup that itself contained a table created by the RESTORE of a table with an in-progress IMPORT would fail to restore all rows.