### PR TITLE
lint_urls: add test filter so we don't run all tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
@@ -16,6 +16,7 @@ bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- \
     test //pkg/testutils/lint:lint_test \
     --config=ci --define gotags=bazel,gss,nightly,lint \
+    --test_filter=TestNightlyLint \
     --test_env=CC=$(which gcc) \
     --test_env=CXX=$(which gcc) \
     --test_env=HOME \


### PR DESCRIPTION
Epic: none
Release note: None