### PR TITLE
pkg/util/log: enable bufferedSink usage with fileSink as experimental

### DIFF
--- a/pkg/util/log/buffered_sink.go
+++ b/pkg/util/log/buffered_sink.go
@@ -84,17 +84,25 @@ type bufferFmtConfig struct {
 }
 
 func newBufferFmtConfig(bufferFmt *logconfig.BufferFormat) *bufferFmtConfig {
-	fmtType := logconfig.BufferFormat("newline")
-	if bufferFmt != nil {
-		fmtType = *bufferFmt
+	// Use newline by default.
+	cfg := bufferFmtConfig{delimiter: "\n", fmtType: logconfig.BufferFmtNewline}
+	if bufferFmt == nil {
+		return &cfg
 	}
 
-	cfg := bufferFmtConfig{delimiter: "\n", fmtType: fmtType}
-
-	if fmtType == logconfig.BufferFmtJsonArray {
-		cfg.suffix = "]"
-		cfg.prefix = "["
+	switch *bufferFmt {
+	case logconfig.BufferFmtNewline:
+		// Do nothing, we'll return the default cfg after.
+	case logconfig.BufferFmtJsonArray:
+		cfg.fmtType = logconfig.BufferFmtJsonArray
 		cfg.delimiter = ","
+		cfg.prefix = "["
+		cfg.suffix = "]"
+	case logconfig.BufferFmtNone:
+		cfg.fmtType = logconfig.BufferFmtNone
+		cfg.delimiter = ""
+	default:
+		panic(errors.AssertionFailedf("unknown BufferFormat: %v", *bufferFmt))
 	}
 
 	return &cfg

--- a/pkg/util/log/logconfig/BUILD.bazel
+++ b/pkg/util/log/logconfig/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/log/logconfig",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/build",
         "//pkg/util/humanizeutil",
         "//pkg/util/log/logpb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -1172,6 +1172,7 @@ type constrainedString interface {
 const (
 	BufferFmtJsonArray BufferFormat = "json-array"
 	BufferFmtNewline   BufferFormat = "newline"
+	BufferFmtNone      BufferFormat = "none"
 )
 
 // BufferFormat is a string restricted to "json-array" and "newline".

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -794,7 +794,7 @@ capture-stray-errors:
   dir: /default-dir
   max-group-size: 100MiB
 
-# Check that buffering works with file sinks when the correct env var is set.
+# Check that buffering works with file sinks.
 yaml
 file-defaults:
   buffered-writes: false
@@ -813,7 +813,7 @@ sinks:
         max-staleness: 5s
         flush-trigger-size: 1.0MiB
         max-buffer-size: 50MiB
-        format: newline
+        format: none
   stderr:
     filter: NONE
     buffering:
@@ -826,7 +826,7 @@ capture-stray-errors:
   dir: /default-dir
   max-group-size: 100MiB
 
-# Check that buffering and buffered-writes are incompatible together
+# Check that buffering and buffered-writes are incompatible together.
 yaml
 file-defaults:
   buffered-writes: true

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -793,3 +793,46 @@ capture-stray-errors:
   enable: true
   dir: /default-dir
   max-group-size: 100MiB
+
+# Check that buffering works with file sinks when the correct env var is set.
+yaml
+file-defaults:
+  buffered-writes: false
+  buffering:
+    max-staleness: 5s
+    flush-trigger-size: 1.0MiB
+    max-buffer-size: 50MiB
+----
+sinks:
+  file-groups:
+    default:
+      channels: {INFO: all}
+      buffered-writes: false
+      filter: INFO
+      buffering:
+        max-staleness: 5s
+        flush-trigger-size: 1.0MiB
+        max-buffer-size: 50MiB
+        format: newline
+  stderr:
+    filter: NONE
+    buffering:
+      max-staleness: 5s
+      flush-trigger-size: 1.0MiB
+      max-buffer-size: 50MiB
+      format: newline
+capture-stray-errors:
+  enable: true
+  dir: /default-dir
+  max-group-size: 100MiB
+
+# Check that buffering and buffered-writes are incompatible together
+yaml
+file-defaults:
+  buffered-writes: true
+  buffering:
+    max-staleness: 5s
+    flush-trigger-size: 1.0MiB
+    max-buffer-size: 50MiB
+----
+ERROR: Unable to use "buffered-writes" in conjunction with a "buffering" configuration. These configuration options are mutually exclusive.

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/errors"
@@ -379,14 +378,10 @@ func (c *Config) newFileSinkConfig(groupName string) *FileSinkConfig {
 func (c *Config) validateFileSinkConfig(fc *FileSinkConfig) error {
 	propagateFileDefaults(&fc.FileDefaults, c.FileDefaults)
 	if !fc.Buffering.IsNone() {
-		// We cannot use unimplemented.WithIssue() here because of a
-		// circular dependency.
-		err := errors.UnimplementedError(
-			errors.IssueLink{IssueURL: build.MakeIssueURL(72452)},
-			`unimplemented: "buffering" not yet supported for file-groups`)
-		err = errors.WithHint(err, `Use "buffered-writes".`)
-		err = errors.WithTelemetry(err, "#72452")
-		return err
+		if fc.BufferedWrites != nil && *fc.BufferedWrites {
+			return errors.Newf(`Unable to use "buffered-writes" in conjunction with a "buffering" configuration. ` +
+				`These configuration options are mutually exclusive.`)
+		}
 	}
 	if fc.Dir != c.FileDefaults.Dir {
 		// A directory was specified explicitly. Normalize it.

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -382,6 +382,10 @@ func (c *Config) validateFileSinkConfig(fc *FileSinkConfig) error {
 			return errors.Newf(`Unable to use "buffered-writes" in conjunction with a "buffering" configuration. ` +
 				`These configuration options are mutually exclusive.`)
 		}
+		// To preserve the format of log files, avoid additional formatting in the
+		// buffering configuration.
+		fmtNone := BufferFmtNone
+		fc.Buffering.Format = &fmtNone
 	}
 	if fc.Dir != c.FileDefaults.Dir {
 		// A directory was specified explicitly. Normalize it.


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/72452

Epic: CRDB-35401

For some time, two buffering mechanisms have existed within the log
package. One is controlled by `buffered-writes`, which is only used by
the file sink. `buffered-writes` buffers writes until a buffer is full,
after which it flushes the buffer to an underlying file. This is not an
asynchronous operation.

Separately, the `bufferedSink` was introduced to provide an async
buffering mechanism. This was originally intended for network log sinks
such as the `fluentSink` and `httpSink`. Originally, the `bufferedSink`
was not allowed for use with the `fileSink` as we already had a
buffering mechanism available.

Today, we find ourselves in a situation where we aim to make CRDB even
more resilient in the face of disk failures. However, some of these
efforts like WAL failover are unable to achieve their goals if the
logging subsystem isn't resilient to disk unavailability as well.

Today, if a file sink is configured to write to an unavailable disk, any
goroutine making a logging call to one of those sinks will hang as the
underlying i/o operations used are unable to interact with the disk.
This can have a severe negative impact on cluster performance and
throughput, even when using `buffered-writes: true`.

As a way to alleviate this pain, this patch experimentally enables the
usage of the `bufferedSink` with the `fileSink`. The `bufferedSink` is
used to "wrap" an underlying sink (such as a `fileSink`), and
asynchronously outputs buffered data to said sink. It is especially good
at shielding writers from any problems with the underlying sink, which
makes it a great candidate to help us accomplish our resiliency goals
when it comes to disk outage scenarios.

Users can leverage the `bufferedSink` by using the `buffering` config option. 
For example:

```
file-defaults:
  buffered-writes: false
  buffering:
    max-staleness: 5s
    flush-trigger-size: 1.0MiB
    max-buffer-size: 50MiB
```

Note that we don't allow both `buffered-writes` and `buffering` to be
used together. This patch adds a validation step to ensure this.

Release note (ops change): Users have the ability to update their log
configuration to enable asynchronous buffering of `file-group` log
sinks via the `buffering` [configuration
options](https://www.cockroachlabs.com/docs/stable/configure-logs#log-buffering-for-network-sinks).

The `buffering` configuration can be applied to `file-defaults` or
individual `file-groups` as needed.

Note however that `buffering` and `buffered-writes` are incompatible for
the time being. If you'd like to try the `buffering` option on a file
log sink, it's necessary to explicitly set `buffered-writes: false`. For
example:
```
file-defaults:
  buffered-writes: false
  buffering:
    max-staleness: 1s
    flush-trigger-size: 256KiB
    max-buffer-size: 50MiB
```
We recommend a `max-staleness: 1s` and `flush-trigger-size: 256KiB` when
using this feature with file log sinks.