### PR TITLE
sql/sem/tree: add FmtForFingerprint functions to collapse long lists 

### DIFF
--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "export.go",
         "expr.go",
         "format.go",
+        "format_fingerprint.go",
         "function_definition.go",
         "function_name.go",
         "grant.go",

--- a/pkg/sql/sem/tree/adjust_constants.go
+++ b/pkg/sql/sem/tree/adjust_constants.go
@@ -21,6 +21,21 @@ import (
 // FmtHideConstants or FmtShortenConstants is set in the flags and the node is
 // affected by that format.
 func (ctx *FmtCtx) formatNodeOrAdjustConstants(n NodeFormatter) {
+	if ctx.flags.HasFlags(FmtCollapseLists) {
+		// This is a more aggressive form of collapsing lists than the cases
+		// provided by FmtHideConstants and FmtShortenConstants.
+		switch v := n.(type) {
+		case *ValuesClause:
+			v.formatForFingerprint(ctx)
+			return
+		case *Tuple:
+			v.formatForFingerprint(ctx)
+			return
+		case *Array:
+			v.formatForFingerprint(ctx)
+			return
+		}
+	}
 	if ctx.flags.HasFlags(FmtHideConstants) {
 		switch v := n.(type) {
 		case *ValuesClause:
@@ -312,6 +327,14 @@ func (node *DArray) formatShortenConstants(ctx *FmtCtx) {
 
 func arityIndicator(n int) Expr {
 	return NewUnresolvedName(arityString(n))
+}
+
+// arityIndicatorNoBounds is like arityIndicator, but it does not include the
+// bounds in the name. It's used when we don't care about differentiating
+// between different bounds, such as in formatting the statement as a
+// representative query for fingerprint generation.
+func arityIndicatorNoBounds() Expr {
+	return NewUnresolvedName(genericArityIndicator)
 }
 
 func arityString(n int) string {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -172,7 +172,16 @@ const (
 	// FmtShortenConstants shortens long lists in tuples, VALUES and array
 	// expressions. FmtHideConstants takes precedence over it.
 	FmtShortenConstants
+
+	// FmtCollapseLists instructs the pretty-printer to shorten lists
+	// containing only literals, placeholders and/or similar subexpressions
+	// of literals/placeholders to their first element (scrubbed) followed
+	// by "__more__". E.g.
+	//  SELECT * FROM foo where v IN (1, 2+2, $1, $2*3) => SELECT * FROM foo where v IN (_, __more__)
+	FmtCollapseLists
 )
+
+const genericArityIndicator = "__more__"
 
 // PasswordSubstitution is the string that replaces
 // passwords unless FmtShowPasswords is specified.

--- a/pkg/sql/sem/tree/format_fingerprint.go
+++ b/pkg/sql/sem/tree/format_fingerprint.go
@@ -1,0 +1,155 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// exprContainsOnlyConstantsAndPlaceholders checks if parts of an expression contains only
+// values that would be scrubbed for statement fingerprinting such as literals, placeholders
+// or datums. This can be used to determine if an expression can be shortened since it
+// does not contain any interesting information.
+type exprContainsOnlyConstantsAndPlaceholders struct {
+	containsNonConstExpr bool
+}
+
+var _ Visitor = &exprContainsOnlyConstantsAndPlaceholders{}
+
+func (v *exprContainsOnlyConstantsAndPlaceholders) VisitPre(
+	expr Expr,
+) (recurse bool, newExpr Expr) {
+	switch expr.(type) {
+	case Datum, Constant, *Placeholder:
+		return false, expr
+	case *Tuple, *Array, *CastExpr, *BinaryExpr, *UnaryExpr, *ParenExpr:
+		return !v.containsNonConstExpr, expr
+	default:
+		v.containsNonConstExpr = true
+		return false, expr
+	}
+}
+
+// onlyLiteralsAndPlaceholders is used to determine if the expression only contains
+// literals and/or placeholders. This includes subexpressions such as tuples, arrays
+// casts, binary expressions and unary expressions only containing literals
+// and/or placeholders.
+// See exprContainsOnlyConstantsAndPlaceholders for more details.
+// Examples:
+//
+//	(1+2, 3+4, 5+6)              -> true
+//	(1+2, b, c)                  -> false
+//	ARRAY[$1, 1, 3, 'ok']        -> true
+//	ARRAY[$1, 1, 3, 'ok', b]     -> false
+//	(-$1, 2, 'hello')            -> true
+//	(-$1, (2+$2)::INT, 'hello')  -> true
+func onlyLiteralsAndPlaceholders(exprs Exprs) bool {
+	v := exprContainsOnlyConstantsAndPlaceholders{}
+	for i := 0; i < len(exprs); i++ {
+		WalkExprConst(&v, exprs[i])
+		if v.containsNonConstExpr {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (v *exprContainsOnlyConstantsAndPlaceholders) VisitPost(expr Expr) Expr { return expr }
+
+// Formatting VALUES for a fingerprint shortens multi-value VALUES clauses to a VALUES
+// clause with a single value.
+// Subexpressions containing only literals and/or placeholders in the first element
+// will also be collapsed.
+// Examples:
+// VALUES (a,b,c), (d,e,f) -> VALUES (a, b, c), (__more__)
+// VALUES ((a, b), (c, d)), ((e, f), (g, h)) -> VALUES ((a, b), (__more__)), (__more__)
+func (node *ValuesClause) formatForFingerprint(ctx *FmtCtx) {
+	ctx.WriteString("VALUES (")
+	ok := canCollapseExprs(node.Rows[0])
+	if ok {
+		exprs := Exprs{node.Rows[0][0], arityIndicatorNoBounds()}
+		exprs.Format(ctx)
+	} else {
+		node.Rows[0].Format(ctx)
+	}
+
+	ctx.WriteByte(')')
+	if len(node.Rows) > 1 {
+		ctx.Printf(", (%s)", genericArityIndicator)
+	}
+}
+
+// canCollapseExprs returns true if the list of expressions has more than 1 element and
+// each expression contains only literals, placeholders and/or simple subexpressions
+// containing only literals/placeholders. This is used to determine if the list can
+// be collapsed into a special shortened representation when generating a representative
+// query for statement fingerprints.
+func canCollapseExprs(exprs Exprs) bool {
+	if len(exprs) < 2 {
+		return false
+	}
+
+	return onlyLiteralsAndPlaceholders(exprs)
+}
+
+// formatForFingerprint shortens tuples containing only literals, placeholders
+// and/or simple expressions containing only literals and/or placeholders as a
+// tuple of its first element, and `__more__` indicating the rest of
+// the elements.
+// Examples:
+//
+//	  ()                -> ()
+//	  (1)               -> (1)
+//		(1, 2)            -> (1, __more__)
+//		(1, 2, 3)         -> (1, __more__)
+//		ROW()             -> ROW()
+//		ROW($1, $2, $3)   -> ROW($1, __more__)
+//		(1+2, 2+3, 3+4)   -> (1 + 2, __more__)
+//		(1+2, b, c)       -> (1 + 2, b, c)
+//		($1, 1, 3, 'ok')  -> ($1, __more__)
+func (node *Tuple) formatForFingerprint(ctx *FmtCtx) {
+	ok := canCollapseExprs(node.Exprs)
+	if !ok {
+		node.Format(ctx)
+		return
+	}
+
+	v2 := *node
+	exprs := Exprs{node.Exprs[0], arityIndicatorNoBounds()}
+	v2.Exprs = exprs
+	if len(node.Labels) > 1 {
+		if len(v2.Exprs) >= 2 {
+			v2.Labels = node.Labels
+		} else if len(node.Labels) > 0 {
+			v2.Labels = node.Labels[:1]
+		}
+	}
+	v2.Format(ctx)
+}
+
+// formatForFingerprint formats array expressions containing only
+// literals or placeholders that are longer than 1 element as an array
+// expression of its first element.
+// e.g.
+//
+//	  array[]              -> array[]
+//	  array[1]             -> array[1]
+//		array[1, 2]          -> array[1, __more__]
+//		array[1, 2, 3]       -> array[1, __more__]
+//		array[1+2, 2+3, 3+4] -> array[1 + 2, __more__]
+func (node *Array) formatForFingerprint(ctx *FmtCtx) {
+	ok := canCollapseExprs(node.Exprs)
+	if !ok {
+		node.Format(ctx)
+		return
+	}
+
+	v2 := *node
+	v2.Exprs = Exprs{node.Exprs[0], arityIndicatorNoBounds()}
+	v2.Format(ctx)
+}

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessionphase",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
@@ -1122,6 +1123,107 @@ func TestFingerprintCreation(t *testing.T) {
 			require.Equal(t, tc.count, count)
 		}
 	})
+}
+
+type testQuery struct {
+	stmt string
+	args []interface{}
+}
+
+func TestEnhancedFingerprintCreation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	testServer, sqlConn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer testServer.Stopper().Stop(ctx)
+
+	testConn := sqlutils.MakeSQLRunner(sqlConn)
+	testConn.Exec(t, "CREATE TABLE t ( a INT, b INT, c INT, d INT, e INT, f INT)")
+	testConn.Exec(t, `SET CLUSTER SETTING sql.stats.statement_fingerprint.format_mask = $1`, tree.FmtCollapseLists)
+
+	testCases := []struct {
+		stmts       []testQuery // Queries that should have the same fingerprint.
+		fingerprint string      // Expected fingerprint.
+	}{
+		{
+			stmts:       []testQuery{{stmt: "SELECT * FROM t WHERE a IN (1)"}},
+			fingerprint: "SELECT * FROM t WHERE a IN (_,)",
+		},
+		{
+			stmts:       []testQuery{{stmt: "SELECT * FROM t WHERE a IN ()"}},
+			fingerprint: "SELECT * FROM t WHERE a IN ()",
+		},
+		{
+			stmts:       []testQuery{{stmt: "SELECT * FROM t WHERE (0,0) IN ((1,2), (3,4), (5,6))"}},
+			fingerprint: "SELECT * FROM t WHERE (_, __more__) IN ((_, __more__), __more__)",
+		},
+		{
+			stmts: []testQuery{
+				// Test more clauses are collapsed into the same special representation.
+				{stmt: "SELECT * FROM t WHERE a IN (1,2)"},
+				{stmt: "SELECT * FROM t WHERE a IN (1,2,3)"},
+				{stmt: "SELECT * FROM t WHERE a IN (1,2,3,4,5,6,7,8,9,10,11,12)"},
+				{stmt: "SELECT * FROM t WHERE a IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14)"},
+				{stmt: "SELECT * FROM t WHERE a IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23)"},
+				{stmt: `SELECT * FROM t WHERE a IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,
+						26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,
+						59,60,61,62,63,64)`},
+				{stmt: `SELECT * FROM t WHERE a IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,
+						26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,
+						59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,
+						92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110)`},
+				{stmt: `SELECT * FROM t WHERE a IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,
+						26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,
+						59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,
+						92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,
+						119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,
+						144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,
+						169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,
+						194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,
+						219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,
+						244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,
+						269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,
+						294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,
+						319,320,321,322,323,324,325,326,327,328,329,330,331,332,333,334,335,336,337,338,339,340,341,342,343,
+						344,345,346,347,348,349,350,351,352,353,354,355,356,357,358,359,360,361,362,363,364,365,366,367,368,
+						369,370,371,372,373,374,375,376,377,378,379,380,381,382,383,384,385,386,387,388,389,390,391,392,393,
+						394,395,396,397,398,399,400,401,402,403,404,405,406,407,408,409,410,411,412,413,414,415,416,417,418,
+						419,420,421,422,423,424,425,426,427,428,429,430,431,432,433,434,435,436,437,438,439,440,441,442,443,
+						444,445,446,447,448,449,450,451,452,453,454,455,456,457,458,459,460,461,462,463,464,465,466,467,468,
+						469,470,471,472,473,474,475,476,477,478,479,480,481,482,483,484,485,486,487,488,489,490,491,492,493,
+						494,495,496,497,498,499,500,501,502,503,504,505,506,507,508,509,510,511,512,513,514,515,516,517,518,
+						519,520,521,522,523,524,525,526,527,528,529,530,531,532,533,534,535,536,537,538,539,540,541,542,$1)`,
+					args: []interface{}{543},
+				},
+				// Test mix of placeholders, constants, casts, unary expressions and binary expressions. Since it only
+				// contains literals and placeholders it should be collapsed into the same special representation.
+				{stmt: `SELECT * FROM t WHERE a in (1,2,3,4,5,$1,7,8,-$2,$3,11,12*3,13,'14'::INT,15,16+16,17,18,19,20,21,22,23,24,25)`,
+					args: []interface{}{6, 9, 10}},
+			},
+			fingerprint: "SELECT * FROM t WHERE a IN (_, __more__)",
+		},
+	}
+
+	testConn.Exec(t, "SET application_name = 'app1'")
+	for _, tc := range testCases {
+		for _, s := range tc.stmts {
+			testConn.Exec(t, s.stmt, s.args...)
+		}
+
+		row := testConn.QueryRow(t, `
+SELECT sum((statistics -> 'statistics' ->> 'cnt')::INT)
+FROM CRDB_INTERNAL.STATEMENT_STATISTICS WHERE app_name = 'app1'
+AND metadata ->> 'query'=$1 GROUP BY metadata ->> 'query'`, tc.fingerprint)
+		var count int
+		row.Scan(&count)
+
+		if count != len(tc.stmts) {
+			fingerprints := testConn.QueryStr(t,
+				`SELECT DISTINCT metadata ->> 'query'  FROM crdb_internal.statement_statistics WHERE app_name = 'app1'`)
+			t.Fatalf("expected count: %d for fingerprint: %s, got: %d\nrow:%v", len(tc.stmts), tc.fingerprint, count, fingerprints)
+		}
+	}
 }
 
 func TestSQLStatsIdleLatencies(t *testing.T) {


### PR DESCRIPTION
Please note only the latest commit should be reviewed here.

---------------
Add functions for the `FmtForFingerprint` flag to shorten long lists
to a representative two element list where the second element is simply
`__more__` to represent the rest of the list.

Specifically, where `FmtHideConstants` would shorten tuples, arrays and
VALUES clauses to its first two elements if it coontains only literals
and placeholders, `FmtCollapseLists` shortens these lists to its first
element if all items in the list are any combination of placeholders,
literals, or a simple subexpressions containing only literals and/or
placeholders.

Enabling this behaviour for statement fingerprint generation can be done
via setting the cluster setting `sql.stats.statement_fingerprint.format_mask`
to include `FmtCollapseLists`.

```
FmtHideConstants (previous behaviour):
VALUES ((1, 2), (3, 4)), ((5, 6), (7, 8)), ((9, 10), (11, 12)) ->
VALUES ((_, _), (_, _)), ((_, _), (_, _)), ((_, _), (_, _))

ARRAY[1, 2, 3+4] ->
ARRAY[_, _, _+4]

SELECT * FROM foo WHERE a IN (1, 2, 3, 4, 5) ->
SELECT * FROM foo WHERE a IN (1, 2, __more1_10__)

---

FmtHideConstants | FmtCollapseLists:
VALUES ((1, 2), (3, 4)), ((5, 6), (7, 8)), ((9, 10), (11, 12)) ->
VALUES ((_, __more__), __more__), (__more__)

ARRAY[1, 2, 3+4] ->
ARRAY[_, __more__]

SELECT * FROM foo WHERE a IN (1, 2, 3, 4, 5) ->
SELECT * FROM foo WHERE a IN (1, __more__)
```


Epic: none
Part of: #120409
Release note: none