### PR TITLE
sql: handle udf invoking other udfs edge cases

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
@@ -26,6 +26,7 @@ CREATE FUNCTION sc2.f2() RETURNS INT LANGUAGE PLpgSQL AS $$
     x INT;
   BEGIN
     SELECT a INTO x FROM sc2.tbl2 LIMIT 1;
+    SELECT sc1.f1('Good'::sc1.enum1);
     RETURN x;
   END
 $$;
@@ -90,7 +91,7 @@ $$
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
 ----
-2
+3
 
 exec-sql
 DROP DATABASE db1
@@ -133,7 +134,7 @@ $$
 query-sql
 SELECT sc1.f1('Good'::db1_new.sc1.enum1)
 ----
-2
+3
 
 # Make sure function still queries from correct table.
 query-sql
@@ -149,6 +150,12 @@ exec-sql
 DROP SEQUENCE sc1.sq1
 ----
 pq: cannot drop sequence sq1 because other objects depend on it
+
+# Validate function dependencies are re-written.
+exec-sql
+DROP FUNCTION sc1.f1
+----
+pq: cannot drop function "f1" because other objects ([db1_new.sc2.f2]) still depend on it
 
 exec-sql
 DROP TABLE sc1.tbl1
@@ -170,7 +177,7 @@ HINT: consider dropping "f1" first.
 exec-sql
 DROP TYPE sc1.enum1
 ----
-pq: cannot drop type "enum1" because other objects ([db1_new.sc1.f1]) still depend on it
+pq: cannot drop type "enum1" because other objects ([db1_new.sc1.f1 db1_new.sc2.f2]) still depend on it
 
 # Test backing up and restoring a full cluster with user defined function.
 new-cluster name=s1
@@ -198,6 +205,7 @@ CREATE SCHEMA sc2;
 CREATE TABLE sc2.tbl2(a INT PRIMARY KEY);
 CREATE FUNCTION sc2.f2() RETURNS INT LANGUAGE PLpgSQL AS $$
   BEGIN
+    SELECT sc1.f1('Good'::sc1.enum1);
     RETURN (SELECT a FROM sc2.tbl2 LIMIT 1);
   END
 $$;
@@ -268,7 +276,7 @@ $$
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
 ----
-2
+3
 
 # Start a new cluster with the same IO dir.
 new-cluster name=s2 share-io-dir=s1
@@ -313,7 +321,7 @@ $$
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
 ----
-2
+3
 
 # Make sure function still queries from correct table.
 query-sql
@@ -329,6 +337,12 @@ exec-sql
 DROP SEQUENCE sc1.sq1
 ----
 pq: cannot drop sequence sq1 because other objects depend on it
+
+# Validate function dependencies are re-written.
+exec-sql
+DROP FUNCTION sc1.f1
+----
+pq: cannot drop function "f1" because other objects ([db1.sc2.f2]) still depend on it
 
 exec-sql
 DROP TABLE sc1.tbl1
@@ -350,7 +364,7 @@ HINT: consider dropping "f1" first.
 exec-sql
 DROP TYPE sc1.enum1
 ----
-pq: cannot drop type "enum1" because other objects ([db1.sc1.f1]) still depend on it
+pq: cannot drop type "enum1" because other objects ([db1.sc1.f1 db1.sc2.f2]) still depend on it
 
 # Make sure that backup and restore individual tables from schema with UDF does
 # not crash.

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/errors"
 )
 
 type alterFunctionOptionsNode struct {
@@ -200,6 +202,34 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 				tree.AsString(maybeExistingFuncObj), scDesc.GetName(),
 			)
 		}
+	}
+
+	// Disallow renaming if this rename operation will break other UDF's invoking
+	// this one.
+	var dependentFuncs []string
+	for _, dep := range fnDesc.GetDependedOnBy() {
+		desc, err := params.p.Descriptors().ByID(params.p.Txn()).Get().Desc(params.ctx, dep.ID)
+		if err != nil {
+			return err
+		}
+		_, ok := desc.(catalog.FunctionDescriptor)
+		if !ok {
+			continue
+		}
+		fullyResolvedName, err := params.p.GetQualifiedFunctionNameByID(params.ctx, int64(dep.ID))
+		if err != nil {
+			return err
+		}
+		dependentFuncs = append(dependentFuncs, fullyResolvedName.FQString())
+	}
+	if len(dependentFuncs) > 0 {
+		return errors.UnimplementedErrorf(
+			errors.IssueLink{
+				IssueURL: "https://github.com/cockroachdb/cockroach/issues/83233",
+				Detail:   "renames are disallowed because references are by name",
+			},
+			"cannot rename function %q because other functions ([%v]) still depend on it",
+			fnDesc.Name, strings.Join(dependentFuncs, ", "))
 	}
 
 	scDesc.RemoveFunction(fnDesc.GetName(), fnDesc.GetID())

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -1064,6 +1064,16 @@ func FunctionDescs(
 			}
 		}
 
+		for i, funcID := range fnDesc.DependsOnFunctions {
+			if funcRewrite, ok := descriptorRewrites[funcID]; ok {
+				fnDesc.DependsOnFunctions[i] = funcRewrite.ID
+			} else {
+				return errors.AssertionFailedf(
+					"cannot restore function %q because referenced function %d was not found",
+					fnDesc.Name, funcID)
+			}
+		}
+
 		// Rewrite back reference IDs.
 		for i, dep := range fnDesc.DependedOnBy {
 			if depRewrite, ok := descriptorRewrites[dep.ID]; ok {

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -275,31 +275,27 @@ CREATE OR REPLACE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
-statement ok
-ALTER FUNCTION f_called_by_b RENAME to f_called_by_b_1;
-ALTER FUNCTION f_called_by_b2 RENAME to f_called_by_b_2;
-
-statement error pgcode 2BP01 cannot drop function \"f_called_by_b_1\" because other objects \(\[test.public.f_called_by_b_2\]\) still depend on it
-DROP FUNCTION f_called_by_b_1;
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
+DROP FUNCTION f_called_by_b;
 
 statement ok
-CREATE TABLE t1_with_b_2_ref(j int default f_called_by_b_1() CHECK (f_called_by_b_1() > 0));
+CREATE TABLE t1_with_b_2_ref(j int default f_called_by_b() CHECK (f_called_by_b() > 0));
 CREATE SCHEMA altSchema;
 
 statement ok
-ALTER FUNCTION f_called_by_b_1 SET SCHEMA altSchema;
+ALTER FUNCTION f_called_by_b SET SCHEMA altSchema;
 
 skipif config local-legacy-schema-changer
 statement ok
 DROP SCHEMA altSchema CASCADE;
 
 onlyif config local-legacy-schema-changer
-statement error pgcode 2BP01 cannot drop function \"f_called_by_b_1\" because other object \(\[test.public.f_called_by_b_2, test.public.t1_with_b_2_ref\]\) still depend on it
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other object \(\[test.public.f_called_by_b2, test.public.t1_with_b_2_ref\]\) still depend on it
 DROP SCHEMA altSchema CASCADE;
 
 skipif config local-legacy-schema-changer
-statement error pgcode 42883 unknown function: f_called_by_b_2()
-SELECT * FROM  f_called_by_b_2();
+statement error pgcode 42883 unknown function: f_called_by_b2()
+SELECT * FROM  f_called_by_b2();
 
 skipif config local-legacy-schema-changer
 query T
@@ -313,7 +309,7 @@ CREATE TABLE public.t1_with_b_2_ref (
 
 onlyif config local-legacy-schema-changer
 statement ok
-DROP FUNCTION f_called_by_b_2;
+DROP FUNCTION f_called_by_b2;
 DROP TABLE t1_with_b_2_ref;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -18,3 +18,7 @@ HELLO  HELLO  hello  HELLOHELLOhello
 # Validate recursion doesn't work today.
 statement error pgcode 42883 unknown function: recursion_check\(\)
 CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;
+
+# Validate that function renaming is blocked.
+statement error pgcode 0A000 cannot rename function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+ALTER FUNCTION lower_hello rename to lower_hello_new


### PR DESCRIPTION
This patch addresses the following issues:

1. Previously it was possible for a UDF invoking another UDF to be broken by the referenced UDF getting re-named. This patch prevents allowing renames of UDFs which are invoked by other UDFs.
2. When restoring a UDF invoking another UDF, we did not properly remap the forward references making such backups impossible to restore. To address this, we add rewrite logic for DependsOnFunctions field.

Fixes: #120366
Epic:  CRDB-19398