### PR TITLE
c2c: prevent NPE in SHOW TENANT WITH REPLICATION STATUS

### DIFF
--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -168,8 +168,9 @@ func (n *showTenantNode) getTenantValues(
 						// Protected timestamp might not be set yet, no need to fail.
 						log.Warningf(params.ctx, "protected timestamp unavailable for tenant %q and job %d: %v",
 							tenantInfo.Name, jobId, err)
+					} else {
+						values.protectedTimestamp = record.Timestamp
 					}
-					values.protectedTimestamp = record.Timestamp
 				}
 			}
 		case mtinfopb.DataStateReady, mtinfopb.DataStateDrop:


### PR DESCRIPTION
If the user ran SHOW TENANT ... WITH REPLICATION STATUS before the stream ingestion job pts was set, a null pointer exception would occur and crash the node. This patch fixes this bug.

Epic: None

Release note: none