### PR TITLE
rttanalysis: remove extra shards from test

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -55,7 +55,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":rttanalysis"],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 16,
     deps = [
         "//pkg/base",
         "//pkg/jobs/jobspb",


### PR DESCRIPTION
There is 1 test in this package, so having 16 shards makes no sense.

Epic: CRDB-8308
Release note: None