### PR TITLE
workflows: use large VM's for local roachtests

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   EXPERIMENTAL_examples_orms:
-    runs-on: [self-hosted, basic_runner_group_fips]
+    runs-on: [self-hosted, basic_big_runner_group_fips]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -122,7 +122,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   EXPERIMENTAL_local_roachtest:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, basic_big_runner_group]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
These tests are still somewhat slow and flaky. See if adding additional cores helps.

Epic: CRDB-8308
Release note: None