### PR TITLE
plpgsql: add support for SET TRANSACTION statements

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_txn
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_txn
@@ -3,6 +3,9 @@
 statement ok
 CREATE TABLE t (x INT);
 
+statement ok
+CREATE TABLE xy (x INT, y INT);
+
 # Variables are preserved across both COMMIT and ROLLBACK.
 statement ok
 CREATE PROCEDURE p(a INT, b INT) LANGUAGE PLpgSQL AS $$
@@ -603,6 +606,382 @@ statement error pgcode 0A000 pq: unimplemented: COMMIT or ROLLBACK with AND CHAI
 CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
   BEGIN
     ROLLBACK AND CHAIN;
+  END
+$$;
+
+subtest set_priority
+
+statement ok
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', current_setting('transaction_priority');
+    NULL;
+    COMMIT;
+    SET TRANSACTION PRIORITY HIGH;
+    RAISE NOTICE 'COMMIT; SET PRIORITY HIGH';
+    RAISE NOTICE '%', current_setting('transaction_priority');
+    COMMIT;
+    SET TRANSACTION PRIORITY LOW;
+    RAISE NOTICE 'COMMIT; SET PRIORITY LOW';
+    RAISE NOTICE '%', current_setting('transaction_priority');
+    COMMIT;
+    RAISE NOTICE 'COMMIT;';
+    RAISE NOTICE '%', current_setting('transaction_priority');
+    ROLLBACK;
+    SET TRANSACTION PRIORITY HIGH;
+    RAISE NOTICE 'ROLLBACK; SET PRIORITY HIGH';
+    RAISE NOTICE '%', current_setting('transaction_priority');
+    NULL;
+    ROLLBACK;
+    SET TRANSACTION PRIORITY LOW;
+    RAISE NOTICE 'ROLLBACK; SET PRIORITY LOW';
+    RAISE NOTICE '%', current_setting('transaction_priority');
+    ROLLBACK;
+    RAISE NOTICE 'ROLLBACK;';
+    RAISE NOTICE '%', current_setting('transaction_priority');
+  END
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: normal
+NOTICE: COMMIT; SET PRIORITY HIGH
+NOTICE: high
+NOTICE: COMMIT; SET PRIORITY LOW
+NOTICE: low
+NOTICE: COMMIT;
+NOTICE: normal
+NOTICE: ROLLBACK; SET PRIORITY HIGH
+NOTICE: high
+NOTICE: ROLLBACK; SET PRIORITY LOW
+NOTICE: low
+NOTICE: ROLLBACK;
+NOTICE: normal
+
+query T
+SHOW TRANSACTION PRIORITY;
+----
+normal
+
+subtest set_read
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    COMMIT;
+    SET TRANSACTION READ ONLY;
+    RAISE NOTICE 'COMMIT; SET READ ONLY';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    NULL;
+    COMMIT;
+    SET TRANSACTION READ WRITE;
+    RAISE NOTICE 'COMMIT; SET READ WRITE';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    COMMIT;
+    SET TRANSACTION READ ONLY;
+    RAISE NOTICE 'COMMIT; SET READ ONLY';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    COMMIT;
+    RAISE NOTICE 'COMMIT;';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    ROLLBACK;
+    SET TRANSACTION READ ONLY;
+    RAISE NOTICE 'ROLLBACK; SET READ ONLY';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    NULL;
+    ROLLBACK;
+    SET TRANSACTION READ WRITE;
+    RAISE NOTICE 'ROLLBACK; SET READ WRITE';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    ROLLBACK;
+    SET TRANSACTION READ ONLY;
+    RAISE NOTICE 'ROLLBACK; SET READ ONLY';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+    ROLLBACK;
+    RAISE NOTICE 'ROLLBACK;';
+    RAISE NOTICE '%', current_setting('transaction_read_only');
+  END
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: off
+NOTICE: COMMIT; SET READ ONLY
+NOTICE: on
+NOTICE: COMMIT; SET READ WRITE
+NOTICE: off
+NOTICE: COMMIT; SET READ ONLY
+NOTICE: on
+NOTICE: COMMIT;
+NOTICE: off
+NOTICE: ROLLBACK; SET READ ONLY
+NOTICE: on
+NOTICE: ROLLBACK; SET READ WRITE
+NOTICE: off
+NOTICE: ROLLBACK; SET READ ONLY
+NOTICE: on
+NOTICE: ROLLBACK;
+NOTICE: off
+
+query T
+SHOW transaction_read_only;
+----
+off
+
+subtest set_timestamp
+
+let $start_ts
+SELECT now()::TIMESTAMP;
+
+let $ts_1
+SELECT ('$start_ts'::TIMESTAMP - '1s'::INTERVAL)::TIMESTAMP;
+
+let $ts_2
+SELECT ('$start_ts'::TIMESTAMP - '2s'::INTERVAL)::TIMESTAMP;
+
+let $ts_3
+SELECT ('$start_ts'::TIMESTAMP - '3s'::INTERVAL)::TIMESTAMP;
+
+let $ts_4
+SELECT ('$start_ts'::TIMESTAMP - '4s'::INTERVAL)::TIMESTAMP;
+
+# We can't directly check the txn timestamps, since they would change on each
+# test iteration. So instead, we check how they compare to one another, e.g.
+# $ts_1 > $ts_2.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  DECLARE
+    ts TIMESTAMP := now();
+  BEGIN
+    IF now() <> ts THEN RAISE EXCEPTION '1'; END IF;
+    COMMIT;
+    IF now() < ts THEN RAISE EXCEPTION '2 %s, %s', now(), ts; END IF;
+    COMMIT;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_1';
+    IF now() <> '$ts_1' THEN RAISE EXCEPTION '3'; END IF;
+    COMMIT;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_2';
+    IF now() <> '$ts_2' THEN RAISE EXCEPTION '4'; END IF;
+    ROLLBACK;
+    -- The behavior should revert to the default, and the timestamp should
+    -- once again be larger than that of the original transaction.
+    IF now() <= ts THEN RAISE EXCEPTION '5'; END IF;
+    ROLLBACK;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_3';
+    IF now() <> '$ts_3' THEN RAISE EXCEPTION '6'; END IF;
+    NULL;
+    ROLLBACK;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_4';
+    IF now() <> '$ts_4' THEN RAISE EXCEPTION '7'; END IF;
+  END
+$$;
+
+statement ok
+CALL p();
+
+let $ts_1
+SELECT now();
+
+statement ok
+INSERT INTO xy VALUES (1, 1);
+
+let $ts_2
+SELECT now();
+
+statement ok
+INSERT INTO xy VALUES (2, 2);
+
+let $ts_3
+SELECT now();
+
+statement ok
+INSERT INTO xy VALUES (3, 3);
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', (SELECT count(*) FROM xy);
+    NULL;
+    COMMIT;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_1';
+    RAISE NOTICE '%', (SELECT count(*) FROM xy);
+    NULL;
+    ROLLBACK;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_2';
+    RAISE NOTICE '%', (SELECT count(*) FROM xy);
+    COMMIT;
+    SET TRANSACTION AS OF SYSTEM TIME '$ts_3';
+    RAISE NOTICE '%', (SELECT count(*) FROM xy);
+    ROLLBACK;
+    RAISE NOTICE '%', (SELECT count(*) FROM xy);
+  END
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: 3
+NOTICE: 0
+NOTICE: 1
+NOTICE: 2
+NOTICE: 3
+
+subtest set_isolation
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    COMMIT;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    RAISE NOTICE 'COMMIT; SET ISOLATION LEVEL READ COMMITTED';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    COMMIT;
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+    RAISE NOTICE 'COMMIT; SET ISOLATION LEVEL SERIALIZABLE';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    NULL;
+    COMMIT;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    RAISE NOTICE 'COMMIT; SET ISOLATION LEVEL READ COMMITTED';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    COMMIT;
+    RAISE NOTICE 'COMMIT;';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    NULL;
+    ROLLBACK;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    RAISE NOTICE 'ROLLBACK; SET ISOLATION LEVEL READ COMMITTED';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    ROLLBACK;
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+    RAISE NOTICE 'ROLLBACK; SET ISOLATION LEVEL SERIALIZABLE';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    NULL;
+    ROLLBACK;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    RAISE NOTICE 'ROLLBACK; SET ISOLATION LEVEL READ COMMITTED';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    ROLLBACK;
+    RAISE NOTICE 'ROLLBACK;';
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+  END
+$$;
+
+skipif config local-read-committed
+query T noticetrace
+CALL p();
+----
+NOTICE: serializable
+NOTICE: COMMIT; SET ISOLATION LEVEL READ COMMITTED
+NOTICE: read committed
+NOTICE: COMMIT; SET ISOLATION LEVEL SERIALIZABLE
+NOTICE: serializable
+NOTICE: COMMIT; SET ISOLATION LEVEL READ COMMITTED
+NOTICE: read committed
+NOTICE: COMMIT;
+NOTICE: serializable
+NOTICE: ROLLBACK; SET ISOLATION LEVEL READ COMMITTED
+NOTICE: read committed
+NOTICE: ROLLBACK; SET ISOLATION LEVEL SERIALIZABLE
+NOTICE: serializable
+NOTICE: ROLLBACK; SET ISOLATION LEVEL READ COMMITTED
+NOTICE: read committed
+NOTICE: ROLLBACK;
+NOTICE: serializable
+
+skipif config local-read-committed
+query T
+SHOW TRANSACTION ISOLATION LEVEL;
+----
+serializable
+
+# It is possible to execute multiple SET TRANSACTION statements.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    COMMIT;
+    SET TRANSACTION PRIORITY HIGH;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    RAISE NOTICE '%', current_setting('transaction_isolation');
+    RAISE NOTICE '%', current_setting('transaction_priority');
+  END
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: read committed
+NOTICE: high
+
+statement ok
+DROP PROCEDURE p;
+
+# SET TRANSACTION cannot be run after any statement other than COMMIT, ROLLBACK,
+# or another SET TRANSACTION statement.
+statement error pgcode 25001 pq: SET TRANSACTION must be called before any query
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    COMMIT;
+    RAISE NOTICE 'setting isolation level';
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+  END
+$$;
+
+statement error pgcode 25001 pq: SET TRANSACTION must be called before any query
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    COMMIT;
+    x := x + 1;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+  END
+$$;
+
+# The same SET TRANSACTION statement cannot be run twice in the same
+# transaction.
+statement error pgcode 42601 pq: isolation level specified multiple times
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    COMMIT;
+    SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+  END
+$$;
+
+statement error pgcode 42601 pq: user priority specified multiple times
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    ROLLBACK;
+    SET TRANSACTION PRIORITY HIGH;
+    SET TRANSACTION PRIORITY LOW;
+  END
+$$;
+
+statement error pgcode 42601 pq: read mode specified multiple times
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    COMMIT;
+    SET TRANSACTION READ ONLY;
+    SET TRANSACTION READ ONLY;
+  END
+$$;
+
+statement error pgcode 42601 pq: AS OF SYSTEM TIME specified multiple times
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  BEGIN
+    ROLLBACK;
+    SET TRANSACTION AS OF SYSTEM TIME '-1s';
+    SET TRANSACTION AS OF SYSTEM TIME '-1s';
   END
 $$;
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1535,6 +1535,10 @@ type connExecutor struct {
 			// transaction.
 			txnOp tree.StoredProcTxnOp
 
+			// txnModes allows for SET TRANSACTION statements to apply to the new txn
+			// that starts after the COMMIT/ROLLBACK.
+			txnModes *tree.TransactionModes
+
 			// resumeProc, if non-nil, contains the plan for a CALL statement that
 			// will continue execution of a stored procedure that previously suspended
 			// execution in order to commit or abort its transaction. The planner
@@ -2642,10 +2646,11 @@ func (ex *connExecutor) execCmd() (retErr error) {
 		// NOTE: we will eventually reach the default case below when the retries
 		// terminate.
 	default:
-		// Finish cleaning up the stored proc state by resetting the "resume" plan.
-		// The stored procedure has finished execution, either successfully or with
-		// an error.
+		// Finish cleaning up the stored proc state by resetting the "resume" plan
+		// and transaction modes. The stored procedure has finished execution,
+		// either successfully or with an error.
 		ex.extraTxnState.storedProcTxnState.resumeProc = nil
+		ex.extraTxnState.storedProcTxnState.txnModes = nil
 	}
 
 	if err := ex.updateTxnRewindPosMaybe(ctx, cmd, pos, advInfo); err != nil {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -536,6 +536,16 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 	}(ctx, res)
 
+	// Special handling for SET TRANSACTION statements within a stored procedure
+	// that uses COMMIT or ROLLBACK. This has to happen before the call to
+	// resetPlanner to ensure that the settings are propagated correctly.
+	if txnModes := ex.planner.storedProcTxnState.getTxnModes(); txnModes != nil {
+		_, err = ex.planner.SetTransaction(ctx, &tree.SetTransaction{Modes: *txnModes})
+		if err != nil {
+			return makeErrEvent(err)
+		}
+	}
+
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.
 	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1262,5 +1262,7 @@ func (b *Builder) buildTxnControl(
 		f.Memo().SetRoot(f.ConstructCall(continuationProc), f.Memo().RootProps())
 		return f.DetachMemo(), nil
 	}
-	return tree.NewTxnControlExpr(txnExpr.TxnOp, args, gen, txnExpr.Def.Name, txnExpr.Def.Typ), nil
+	return tree.NewTxnControlExpr(
+		txnExpr.TxnOp, txnExpr.TxnModes, args, gen, txnExpr.Def.Name, txnExpr.Def.Typ,
+	), nil
 }

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -427,6 +427,10 @@ func (h *hasher) HashType(val *types.T) {
 	}
 }
 
+func (h *hasher) HashExpr(val tree.Expr) {
+	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
+}
+
 func (h *hasher) HashTypedExpr(val tree.TypedExpr) {
 	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
 }
@@ -791,6 +795,16 @@ func (h *hasher) HashStoredProcTxnOp(val tree.StoredProcTxnOp) {
 	h.HashUint64(uint64(val))
 }
 
+func (h *hasher) HashTransactionModes(val tree.TransactionModes) {
+	h.HashUint64(uint64(val.Isolation))
+	h.HashUint64(uint64(val.UserPriority))
+	h.HashUint64(uint64(val.ReadWriteMode))
+	if val.AsOf.Expr != nil {
+		h.HashExpr(val.AsOf.Expr)
+	}
+	h.HashUint64(uint64(val.Deferrable))
+}
+
 // ----------------------------------------------------------------------
 //
 // Equality functions
@@ -925,6 +939,10 @@ func (h *hasher) areDatumsWithTypeEqual(ldatums, rdatums tree.Datums, ltyp, rtyp
 		return h.IsTypeEqual(ltyp, rtyp)
 	}
 	return true
+}
+
+func (h *hasher) IsExprEqual(l, r tree.Expr) bool {
+	return l == r
 }
 
 func (h *hasher) IsTypedExprEqual(l, r tree.TypedExpr) bool {
@@ -1331,6 +1349,12 @@ func (h *hasher) IsUDFDefinitionEqual(l, r *UDFDefinition) bool {
 
 func (h *hasher) IsStoredProcTxnOpEqual(l, r tree.StoredProcTxnOp) bool {
 	return l == r
+}
+
+func (h *hasher) IsTransactionModesEqual(l, r tree.TransactionModes) bool {
+	return l.Isolation == r.Isolation && l.UserPriority == r.UserPriority &&
+		l.ReadWriteMode == r.ReadWriteMode && l.AsOf.Expr == r.AsOf.Expr &&
+		l.Deferrable == r.Deferrable
 }
 
 // encodeDatum turns the given datum into an encoded string of bytes. If two

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -329,6 +329,12 @@ func TestInterner(t *testing.T) {
 			{val1: tupTyp3, val2: tupTyp4, equal: false},
 		}},
 
+		{hashFn: in.hasher.HashExpr, eqFn: in.hasher.IsExprEqual, variations: []testVariation{
+			{val1: tup1, val2: tup1, equal: true},
+			{val1: tup1, val2: tup2, equal: false},
+			{val1: tup2, val2: tup3, equal: false},
+		}},
+
 		{hashFn: in.hasher.HashTypedExpr, eqFn: in.hasher.IsTypedExprEqual, variations: []testVariation{
 			{val1: tup1, val2: tup1, equal: true},
 			{val1: tup1, val2: tup2, equal: false},
@@ -437,6 +443,54 @@ func TestInterner(t *testing.T) {
 				val1:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
 				val2:  ScanFlags{NoIndexJoin: true, ForceIndex: true, Direction: tree.Ascending, Index: 1},
 				equal: true,
+			},
+		}},
+
+		{hashFn: in.hasher.HashTransactionModes, eqFn: in.hasher.IsTransactionModesEqual, variations: []testVariation{
+			{
+				val1:  tree.TransactionModes{},
+				val2:  tree.TransactionModes{},
+				equal: true,
+			},
+			{
+				val1:  tree.TransactionModes{Isolation: tree.ReadCommittedIsolation},
+				val2:  tree.TransactionModes{Isolation: tree.ReadCommittedIsolation},
+				equal: true,
+			},
+			{
+				val1:  tree.TransactionModes{Isolation: tree.ReadCommittedIsolation},
+				val2:  tree.TransactionModes{Isolation: tree.SerializableIsolation},
+				equal: false,
+			},
+			{
+				val1:  tree.TransactionModes{UserPriority: tree.Low},
+				val2:  tree.TransactionModes{UserPriority: tree.Low},
+				equal: true,
+			},
+			{
+				val1:  tree.TransactionModes{UserPriority: tree.Low},
+				val2:  tree.TransactionModes{UserPriority: tree.High},
+				equal: false,
+			},
+			{
+				val1:  tree.TransactionModes{ReadWriteMode: tree.ReadOnly},
+				val2:  tree.TransactionModes{ReadWriteMode: tree.ReadOnly},
+				equal: true,
+			},
+			{
+				val1:  tree.TransactionModes{ReadWriteMode: tree.ReadOnly},
+				val2:  tree.TransactionModes{ReadWriteMode: tree.ReadWrite},
+				equal: false,
+			},
+			{
+				val1:  tree.TransactionModes{AsOf: tree.AsOfClause{Expr: tz1}},
+				val2:  tree.TransactionModes{AsOf: tree.AsOfClause{Expr: tz1}},
+				equal: true,
+			},
+			{
+				val1:  tree.TransactionModes{AsOf: tree.AsOfClause{Expr: tz1}},
+				val2:  tree.TransactionModes{AsOf: tree.AsOfClause{Expr: tz2}},
+				equal: false,
 			},
 		}},
 

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1291,6 +1291,10 @@ define TxnControlPrivate {
     # aborted.
     TxnOp StoredProcTxnOp
 
+    # TxnModes allows SET TRANSACTION statements to apply to the new transaction
+    # that follows the COMMIT/ROLLBACK.
+    TxnModes TransactionModes
+
     # Props is used when building the plan for the continuation SP.
     Props PhysProps
 

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -623,6 +623,13 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			return b.callContinuation(&con, s)
 
 		case *ast.Execute:
+			if _, ok := t.SqlStmt.(*tree.SetTransaction); ok {
+				// SET TRANSACTION must happen immediately after a COMMIT or ROLLBACK
+				// statement. When we handle COMMIT/ROLLBACK, we check for following
+				// SET TRANSACTION statements, so encountering one here means it's in an
+				// incorrect location.
+				panic(setTxnNotAfterControlStmtErr)
+			}
 			if len(t.Target) > 1 {
 				seenTargets := make(map[ast.Variable]struct{})
 				for _, name := range t.Target {
@@ -865,10 +872,29 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 				name = "_stmt_rollback"
 				txnOpType = tree.StoredProcTxnRollback
 			}
+			// Check the following statements for SET TRANSACTION statements, which
+			// apply to the new transaction that begins after the COMMIT/ROLLBACK.
+			//
+			// Note: SET TRANSACTION statements are only allowed immediately following
+			// COMMIT or ROLLBACK (or another SET TRANSACTION), in the same block.
+			var txnModes tree.TransactionModes
+			for stmts = stmts[i+1:]; len(stmts) > 0; stmts = stmts[1:] {
+				execStmt, ok := stmts[0].(*ast.Execute)
+				if !ok {
+					break
+				}
+				setTxnStmt, ok := execStmt.SqlStmt.(*tree.SetTransaction)
+				if !ok {
+					break
+				}
+				if err := txnModes.Merge(setTxnStmt.Modes); err != nil {
+					panic(err)
+				}
+			}
 			con := b.makeContinuation(name)
 			con.def.Volatility = volatility.Volatile
-			b.appendPlpgSQLStmts(&con, stmts[i+1:])
-			return b.callContinuationWithTxnOp(&con, s, txnOpType)
+			b.appendPlpgSQLStmts(&con, stmts)
+			return b.callContinuationWithTxnOp(&con, s, txnOpType, txnModes)
 
 		default:
 			panic(unsupportedPLStmtErr)
@@ -1621,7 +1647,7 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 // continuation in a TxnControlExpr that will commit or abort the current
 // transaction before resuming execution with the continuation.
 func (b *plpgsqlBuilder) callContinuationWithTxnOp(
-	con *continuation, s *scope, txnOp tree.StoredProcTxnOp,
+	con *continuation, s *scope, txnOp tree.StoredProcTxnOp, txnModes tree.TransactionModes,
 ) *scope {
 	if con == nil {
 		panic(errors.AssertionFailedf("nil continuation with transaction control"))
@@ -1633,9 +1659,10 @@ func (b *plpgsqlBuilder) callContinuationWithTxnOp(
 	returnScope := s.push()
 	args := b.makeContinuationArgs(con, s)
 	txnControlExpr := b.ob.factory.ConstructTxnControl(args, &memo.TxnControlPrivate{
-		TxnOp: txnOp,
-		Props: returnScope.makePhysicalProps(),
-		Def:   con.def,
+		TxnOp:    txnOp,
+		TxnModes: txnModes,
+		Props:    returnScope.makePhysicalProps(),
+		Def:      con.def,
 	})
 	returnColName := scopeColName("").WithMetadataName(con.def.Name)
 	b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, txnControlExpr)
@@ -2074,5 +2101,9 @@ var (
 		"PL/pgSQL COMMIT/ROLLBACK is not allowed inside a user-defined function")
 	txnControlWithChainErr = unimplemented.NewWithIssue(119646,
 		"COMMIT or ROLLBACK with AND CHAIN syntax is not yet implemented",
+	)
+	setTxnNotAfterControlStmtErr = errors.WithHint(
+		pgerror.New(pgcode.ActiveSQLTransaction, "SET TRANSACTION must be called before any query"),
+		"PL/pgSQL SET TRANSACTION statements must immediately follow COMMIT or ROLLBACK",
 	)
 )

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -197,6 +197,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"WithID":               {fullName: "opt.WithID", passByVal: true},
 		"UDFDefinition":        {fullName: "memo.UDFDefinition", isPointer: true},
 		"StoredProcTxnOp":      {fullName: "tree.StoredProcTxnOp", passByVal: true},
+		"TransactionModes":     {fullName: "tree.TransactionModes", passByVal: true},
 		"Ordering":             {fullName: "opt.Ordering", passByVal: true},
 		"OrderingChoice":       {fullName: "props.OrderingChoice", passByVal: true},
 		"GroupingOrder":        {fullName: "memo.GroupingOrder", passByVal: true},

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -309,9 +309,10 @@ type TxnControlPlanGenerator func(
 // the session to end the current transaction, and provides a plan to resume
 // execution in a new transaction in the form of StoredProcContinuation.
 type TxnControlExpr struct {
-	Op   StoredProcTxnOp
-	Args TypedExprs
-	Gen  TxnControlPlanGenerator
+	Op    StoredProcTxnOp
+	Modes TransactionModes
+	Args  TypedExprs
+	Gen   TxnControlPlanGenerator
 
 	Name string
 	Typ  *types.T
@@ -321,14 +322,20 @@ var _ Expr = &TxnControlExpr{}
 
 // NewTxnControlExpr returns a new TxnControlExpr that is well-typed.
 func NewTxnControlExpr(
-	opType StoredProcTxnOp, args TypedExprs, gen TxnControlPlanGenerator, name string, typ *types.T,
+	opType StoredProcTxnOp,
+	txnModes TransactionModes,
+	args TypedExprs,
+	gen TxnControlPlanGenerator,
+	name string,
+	typ *types.T,
 ) *TxnControlExpr {
 	return &TxnControlExpr{
-		Op:   opType,
-		Args: args,
-		Gen:  gen,
-		Name: name,
-		Typ:  typ,
+		Op:    opType,
+		Modes: txnModes,
+		Args:  args,
+		Gen:   gen,
+		Name:  name,
+		Typ:   typ,
 	}
 }
 


### PR DESCRIPTION
#### plpgsql: add support for SET TRANSACTION statements

This commit adds support for `SET TRANSACTION` in PL/pgSQL stored
procedures. `SET TRANSACTION` can only follow `COMMIT` or `ROLLBACK`;
any other usage will result in an error. This can be used to set the
transaction timestamp, isolation level, priority, or set the transaction
to read-only.

Fixes #120455

Release note (sql change): PL/pgSQL stored procedures now allow usage
of the `SET TRANSACTION` statement immediately after `COMMIT` or `ROLLBACK`.
This allows setting the transaction isolation level, timestamp, or priority,
as well as setting the transaction to read-only.