### PR TITLE
WIP sql: support OUT parameters for overload resolution in procedures

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
@@ -3,9 +3,124 @@
 subtest types
 
 statement ok
+CREATE PROCEDURE p(IN param1 INT, OUT param2 INT) AS $$ BEGIN SELECT param1 INTO param2; END; $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42883 procedure p\(\) does not exist
+CALL p();
+
+statement error pgcode 42883 procedure p\(int\) does not exist
+CALL p(1);
+
+statement error pgcode 42883 procedure p\(int, int, int\) does not exist
+CALL p(1, 2, 3);
+
+statement ok
+CREATE PROCEDURE p(IN param1 FLOAT, OUT param2 FLOAT) AS $$ BEGIN SELECT param1 INTO param2; END; $$ LANGUAGE PLpgSQL;
+
+query I colnames
+CALL p(1, 2);
+----
+param2
+1
+
+query R colnames
+CALL p(1.1, 2.2);
+----
+param2
+1.1
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT) AS $$ BEGIN SELECT param2 INTO param1; END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p(OUT param2 INT, IN param1 INT) AS $$ BEGIN SELECT param1 INTO param2; END; $$ LANGUAGE PLpgSQL;
+
+query I colnames
+CALL p(1, 2);
+----
+param2
+2
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, OUT param3 INT) AS $$
+BEGIN
+  SELECT 1 INTO param1;
+  SELECT param2 INTO param3;
+END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, IN param3 INT) AS $$ BEGIN SELECT param2 + param3 INTO param1; END; $$ LANGUAGE PLpgSQL;
+
+query I colnames
+CALL p(1, 2, 3);
+----
+param1
+5
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(INOUT param1 INT, IN param2 INT) AS $$ BEGIN SELECT param1 + param2 INTO param1; END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT, OUT param3 INT) AS $$
+BEGIN
+  SELECT 1 INTO param1;
+  SELECT 2 INTO param2;
+  SELECT 3 INTO param3;
+END; $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42725 procedure p\(int, int, int\) is not unique
+CALL p(1, 2, 3);
+
+statement error pgcode 42725 procedure name "p" is not unique
+DROP PROCEDURE p;
+
+# Postgres seems to special-case the DROP behavior when none of the parameter
+# classes are specified for the argument types - it permissively treats them as
+# IN or OUT in order to match the maximum number overloads. As a result, PG
+# often returns 'procedure name "p" is not unique' error. Replicating that
+# behavior is tricky and seems not worth it, so we, instead, treat all argument
+# types with unspecified parameter class as having the IN class.
+
+# Postgres returns 'procedure name "p" is not unique' error here.
+statement error pgcode 42883 procedure p\(int,int,int\) does not exist
+DROP PROCEDURE p(INT, INT, INT);
+
+# Postgres returns 'procedure name "p" is not unique' error here.
+statement ok
+DROP PROCEDURE p(INT, INT);
+
+query III colnames
+CALL p(-1, -2, -3);
+----
+param1  param2  param3
+1       2       3
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, IN param3 INT) AS $$ BEGIN SELECT param2 + param3 INTO param1; END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT, INT, INT);
+
+statement error pgcode 42725 procedure name "p" is not unique
+DROP PROCEDURE p;
+
+# Postgres here drops the overload with 3 OUT parameters.
+statement error pgcode 42883 procedure p\(int,int,int\) does not exist
+DROP PROCEDURE p(INT, INT, INT);
+
+statement ok
+DROP PROCEDURE p(OUT INT, OUT INT, OUT INT);
+
+statement ok
+DROP PROCEDURE p(OUT INT, IN INT);
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
 CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
 
-statement error procedure public.p does not exist
+statement error pgcode 42883 procedure p\(\) does not exist
 CALL p();
 
 query I colnames
@@ -28,10 +143,10 @@ statement ok
 CREATE PROCEDURE p(IN INT, INOUT INT) AS $$ BEGIN END $$ LANGUAGE PLpgSQL;
 
 # Argument expressions for IN and INOUT parameters are evaluated.
-statement error division by zero
+statement error pgcode 22012 division by zero
 CALL p(1 // 0, 1)
 
-statement error division by zero
+statement error pgcode 22012 division by zero
 CALL p(1, 1 // 0)
 
 statement ok
@@ -75,7 +190,7 @@ DROP PROCEDURE p(OUT INT);
 statement ok
 CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO param2; END $$ LANGUAGE PLpgSQL;
 
-statement error pq: procedure p\(int\) does not exist
+statement error pgcode 42883 pq: procedure p\(int\) does not exist
 DROP PROCEDURE p(INT);
 
 statement ok
@@ -199,7 +314,7 @@ DROP PROCEDURE p(OUT INT);
 statement ok
 CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO param2; END $$ LANGUAGE PLpgSQL;
 
-statement error pq: procedure p\(int\) does not exist
+statement error pgcode 42883 pq: procedure p\(int\) does not exist
 DROP PROCEDURE p(INT);
 
 statement ok
@@ -419,7 +534,7 @@ column1  param2  column3
 NULL     3       NULL
 
 # But then the IN parameter name cannot be changed anymore.
-statement error cannot change name of input parameter "in_param"
+statement error pgcode 42P13 cannot change name of input parameter "in_param"
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param_new INT, OUT INT) AS $$ BEGIN SELECT in_param_new INTO param2; END; $$ LANGUAGE PLpgSQL;
 
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
@@ -5,6 +5,35 @@ subtest types
 statement ok
 CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
 
+statement error procedure public.p does not exist
+CALL p();
+
+query I colnames
+CALL p(NULL);
+----
+param
+1
+
+# Argument expressions for OUT parameters shouldn't be evaluated.
+query I colnames
+CALL p(1 // 0);
+----
+param
+1
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(IN INT, INOUT INT) AS $$ BEGIN END $$ LANGUAGE PLpgSQL;
+
+# Argument expressions for IN and INOUT parameters are evaluated.
+statement error division by zero
+CALL p(1 // 0, 1)
+
+statement error division by zero
+CALL p(1, 1 // 0)
+
 statement ok
 DROP PROCEDURE p;
 
@@ -15,6 +44,12 @@ BEGIN
   SELECT 2 INTO param2;
   SELECT 3 INTO param3;
 END $$ LANGUAGE PLpgSQL;
+
+query II colnames
+CALL p(-1, -2, NULL);
+----
+param2  param3
+2       3
 
 statement ok
 DROP PROCEDURE p;
@@ -69,11 +104,28 @@ BEGIN
 END
 $$ LANGUAGE PLpgSQL;
 
+query II colnames
+CALL p(3, NULL);
+----
+param1  param2
+3       2
+
+query II noticetrace
+CALL p(3, NULL);
+----
+NOTICE: 2
+
 statement ok
 DROP PROCEDURE p;
 
 statement ok
 CREATE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 3 INTO param1; END $$ LANGUAGE PLpgSQL;
+
+query II colnames
+CALL p(1, NULL);
+----
+param1  param2
+3       NULL
 
 statement ok
 CREATE OR REPLACE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$
@@ -86,6 +138,19 @@ BEGIN
 END
 $$ LANGUAGE PLpgSQL;
 
+query II colnames
+CALL p(1, NULL);
+----
+param1  param2
+3       4
+
+query II noticetrace
+CALL p(1, NULL);
+----
+NOTICE: 1 <NULL>
+NOTICE: 3 <NULL>
+NOTICE: 3 4
+
 statement ok
 DROP PROCEDURE p;
 
@@ -96,6 +161,12 @@ BEGIN
   SELECT 2 INTO param2;
 END
 $$ LANGUAGE PLpgSQL;
+
+query II colnames
+CALL p(3, NULL);
+----
+param1  param2
+1       2
 
 statement ok
 DROP PROCEDURE p;
@@ -208,6 +279,12 @@ CREATE PROCEDURE p_same_name(IN a INT, OUT a INT) AS $$ BEGIN RETURN a; END $$ L
 statement ok
 CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) AS $$ BEGIN SELECT param_in INTO param_out; END $$ LANGUAGE PLpgSQL;
 
+query I colnames
+CALL p_names(1, NULL);
+----
+param_out
+1
+
 statement error pgcode 42601 RETURN cannot have a parameter in a procedure
 CREATE PROCEDURE p_in_int(IN param INT) AS $$ BEGIN RETURN param; END; $$ LANGUAGE PLpgSQL;
 
@@ -259,6 +336,12 @@ subtest default_parameter_names
 statement ok
 CREATE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ BEGIN param2 = 2; END; $$ LANGUAGE PLpgSQL;
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+NULL     2       NULL
+
 # However, attempting to access the parameter by the default names is invalid.
 statement error pgcode 42601 pq: \"column1\" is not a known variable
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ BEGIN SELECT 1 INTO column1; END; $$ LANGUAGE PLpgSQL;
@@ -283,6 +366,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT 
   END;
 $$
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+NULL     NULL    3
+
 # Then we can omit the default OUT parameter name again (but still cannot use it
 # in the body).
 statement error pgcode 42601 pq: \"column3\" is not a known variable
@@ -302,6 +391,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT 
   END;
 $$
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+NULL     2       NULL
+
 # Introducing the IN parameter name is ok.
 statement ok
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param INT, OUT INT) AS $$ BEGIN SELECT in_param INTO param2; END; $$ LANGUAGE PLpgSQL;
@@ -317,6 +412,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN in_param I
   END;
 $$
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+NULL     3       NULL
+
 # But then the IN parameter name cannot be changed anymore.
 statement error cannot change name of input parameter "in_param"
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param_new INT, OUT INT) AS $$ BEGIN SELECT in_param_new INTO param2; END; $$ LANGUAGE PLpgSQL;
@@ -328,3 +429,9 @@ CREATE TYPE typ AS (a INT, b INT);
 
 statement ok
 CREATE PROCEDURE p_udt(OUT param typ) AS $$ BEGIN param := (1, 2); END $$ LANGUAGE PLpgSQL;
+
+query T colnames
+CALL p_udt(NULL);
+----
+param
+(1,2)

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
@@ -1,13 +1,20 @@
 # LogicTest: !local-mixed-23.1
 
+subtest types
+
 statement ok
-CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1; END $$ LANGUAGE PLpgSQL;
+CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
 
 statement ok
 DROP PROCEDURE p;
 
 statement ok
-CREATE PROCEDURE p(IN param1 INT, INOUT param2 INT, OUT param3 INT) AS $$ BEGIN SELECT 1, 2; END $$ LANGUAGE PLpgSQL;
+CREATE PROCEDURE p(IN param1 INT, INOUT param2 INT, OUT param3 INT) AS $$
+BEGIN
+  SELECT 1 INTO param1;
+  SELECT 2 INTO param2;
+  SELECT 3 INTO param3;
+END $$ LANGUAGE PLpgSQL;
 
 statement ok
 DROP PROCEDURE p;
@@ -23,3 +30,301 @@ CREATE PROCEDURE p(INOUT param INT) AS $$ BEGIN SELECT 'hello'; END $$ LANGUAGE 
 
 statement ok
 DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO param1; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT);
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO param2; END $$ LANGUAGE PLpgSQL;
+
+statement error pq: procedure p\(int\) does not exist
+DROP PROCEDURE p(INT);
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT, OUT text, OUT INT);
+
+statement error pgcode 42804 RETURN cannot have a parameter in function with OUT parameters
+CREATE PROCEDURE p(OUT INT) AS $$ BEGIN RETURN NULL; END $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42804 RETURN cannot have a parameter in function with OUT parameters
+CREATE PROCEDURE p(OUT INT, OUT INT) AS $$ BEGIN RETURN NULL; END $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42804 RETURN cannot have a parameter in function with OUT parameters
+CREATE PROCEDURE p(INOUT INT) AS $$ BEGIN RETURN NULL; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$
+BEGIN
+  param2 := 2;
+  RAISE NOTICE '%', param2;
+END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 3 INTO param1; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$
+BEGIN
+  RAISE NOTICE '% %', param1, param2;
+  param1 = 3;
+  RAISE NOTICE '% %', param1, param2;
+  SELECT 4 INTO param2;
+  RAISE NOTICE '% %', param1, param2;
+END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$
+BEGIN
+  param1 := 1;
+  SELECT 2 INTO param2;
+END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p;
+
+# Verify that overload resolution works correctly when dropping procedures (OUT
+# arguments are ignored).
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT);
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO param1; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT);
+
+# TODO(119502): uncomment this and call the procedure when $i notation is
+# supported.
+# statement ok
+# CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO $2; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ BEGIN SELECT 1 INTO param2; END $$ LANGUAGE PLpgSQL;
+
+statement error pq: procedure p\(int\) does not exist
+DROP PROCEDURE p(INT);
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$ BEGIN SELECT 1 INTO param; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT, OUT text, OUT INT);
+
+subtest end
+
+subtest show_create
+
+statement ok
+CREATE PROCEDURE p_param_types(IN p1 INT, INOUT p2 INT, IN OUT p3 INT, OUT p4 INT) AS $$
+BEGIN
+  SELECT p2, p3, p1;
+END
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_param_types];
+----
+CREATE PROCEDURE public.p_param_types(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, OUT p4 INT8)
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+  SELECT p2, p3, p1;
+  END;
+$$
+
+statement ok
+DROP PROCEDURE p_param_types;
+
+statement ok
+CREATE PROCEDURE p_param_types(OUT param INT) AS $$
+BEGIN
+  SELECT 1;
+END
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_param_types];
+----
+CREATE PROCEDURE public.p_param_types(OUT param INT8)
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+  SELECT 1;
+  END;
+$$
+
+statement ok
+DROP PROCEDURE p_param_types;
+
+subtest end
+
+subtest parameter_names
+
+# Unlike for SQL procedures, sharing of parameter names is not allowed across
+# different "parameter namespaces" (IN vs OUT).
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(IN a INT, IN a INT) AS $$ BEGIN RETURN a + a; END $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(IN a INT, INOUT a INT) AS $$ BEGIN RETURN a + a; END $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(OUT a INT, INOUT a INT) AS $$ BEGIN RETURN a + a; END $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(IN a INT, OUT a INT) AS $$ BEGIN RETURN a; END $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) AS $$ BEGIN SELECT param_in INTO param_out; END $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42601 RETURN cannot have a parameter in a procedure
+CREATE PROCEDURE p_in_int(IN param INT) AS $$ BEGIN RETURN param; END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p_in_int(IN param INT) AS $$ BEGIN END; $$ LANGUAGE PLpgSQL;
+
+# Unlike for functions, changing OUT parameter name is not ok.
+statement ok
+CREATE PROCEDURE p_out_int(OUT param INT) AS $$ BEGIN param = 2; END; $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_out_int(OUT param_new INT) AS $$ BEGIN param_new = 2; END; $$ LANGUAGE PLpgSQL;
+
+# Changing IN or INOUT parameter name is not allowed.
+statement error pgcode 42P13 pq: cannot change name of input parameter "param"
+CREATE OR REPLACE PROCEDURE p_in_int(IN param_new INT) AS $$ BEGIN END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE PROCEDURE p_inout_int(INOUT param INT) AS $$ BEGIN param = 2; END; $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 pq: cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_inout_int(INOUT param_new INT) AS $$ BEGIN param_new = 2; END; $$ LANGUAGE PLpgSQL;
+
+subtest end
+
+subtest changing_parameters
+
+statement ok
+CREATE PROCEDURE p_int(IN param INT) AS $$ BEGIN END; $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 pq: cannot change whether a procedure has output parameters
+CREATE OR REPLACE PROCEDURE p_int(INOUT param INT) AS $$ BEGIN param = 2; END; $$ LANGUAGE PLpgSQL;
+
+# Note that in postgres this returns an error with the same code but with
+# "cannot change whether a procedure has output parameters" as the message.
+statement error pgcode 42P13 pq: parameter name "param" used more than once
+CREATE OR REPLACE PROCEDURE p_int(IN param INT, OUT param INT) AS $$ BEGIN param = 2; END; $$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42P13 pq: cannot change whether a procedure has output parameters
+CREATE OR REPLACE PROCEDURE p_int(IN param INT, OUT param_out INT) AS $$ BEGIN param = 2; END; $$ LANGUAGE PLpgSQL;
+
+subtest end
+
+subtest default_parameter_names
+
+# Parameter names are optional. Each unnamed OUT parameter with ordinal 'i'
+# (among all OUT parameters) gets the default name that is "column" || i.
+
+statement ok
+CREATE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ BEGIN param2 = 2; END; $$ LANGUAGE PLpgSQL;
+
+# However, attempting to access the parameter by the default names is invalid.
+statement error pgcode 42601 pq: \"column1\" is not a known variable
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ BEGIN SELECT 1 INTO column1; END; $$ LANGUAGE PLpgSQL;
+
+# Introducing the OUT parameter name is disallowed because it'd change the
+# return type.
+statement error pgcode 42P13 cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT param3 INT) AS $$ BEGIN param2 = 2; END; $$ LANGUAGE PLpgSQL;
+
+# Introducing the name that matches the default OUT parameter name is allowed.
+statement ok
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT column3 INT) AS $$ BEGIN SELECT 3 INTO column3; END; $$ LANGUAGE PLpgSQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT column3 INT8)
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+  SELECT 3 INTO column3;
+  END;
+$$
+
+# Then we can omit the default OUT parameter name again (but still cannot use it
+# in the body).
+statement error pgcode 42601 pq: \"column3\" is not a known variable
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ BEGIN SELECT 3 INTO column3; END; $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ BEGIN param2 = 2; END; $$ LANGUAGE PLpgSQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+  param2 := 2;
+  END;
+$$
+
+# Introducing the IN parameter name is ok.
+statement ok
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param INT, OUT INT) AS $$ BEGIN SELECT in_param INTO param2; END; $$ LANGUAGE PLpgSQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN in_param INT8, OUT INT8)
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+  SELECT in_param INTO param2;
+  END;
+$$
+
+# But then the IN parameter name cannot be changed anymore.
+statement error cannot change name of input parameter "in_param"
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param_new INT, OUT INT) AS $$ BEGIN SELECT in_param_new INTO param2; END; $$ LANGUAGE PLpgSQL;
+
+subtest end
+
+statement ok
+CREATE TYPE typ AS (a INT, b INT);
+
+statement ok
+CREATE PROCEDURE p_udt(OUT param typ) AS $$ BEGIN param := (1, 2); END $$ LANGUAGE PLpgSQL;

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -488,4 +488,66 @@ SELECT get_body_str('p_rewrite');
 ----
 "BEGIN\nUPDATE test.public.t_rewrite SET w = b'\\xa0':::@100107 WHERE w = b'\\x80':::@100107 RETURNING w;\nEND;\n"
 
+statement ok
+DROP PROCEDURE p_rewrite();
+
+statement ok
+CREATE PROCEDURE p_rewrite(INOUT param1 weekday, OUT param2 weekday) AS
+$$
+  BEGIN
+    param2 = param1;
+    param1 = 'friday'::weekday;
+  END
+$$ LANGUAGE PLPGSQL;
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"BEGIN\nparam2 := param1;\nparam1 := b'\\xc0':::@100107;\nEND;\n"
+
+query TT
+SHOW CREATE PROCEDURE p_rewrite;
+----
+p_rewrite  CREATE PROCEDURE public.p_rewrite(INOUT param1 test.public.weekday, OUT param2 test.public.weekday)
+             LANGUAGE plpgsql
+             AS $$
+             BEGIN
+             param2 := param1;
+             param1 := 'friday':::test.public.weekday;
+             END;
+           $$
+
+statement ok
+ALTER TYPE weekday RENAME VALUE 'friday' TO 'humpday';
+
+statement ok
+ALTER TYPE weekday RENAME TO workday;
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"BEGIN\nparam2 := param1;\nparam1 := b'\\xc0':::@100107;\nEND;\n"
+
+query TT
+SHOW CREATE PROCEDURE p_rewrite;
+----
+p_rewrite  CREATE PROCEDURE public.p_rewrite(INOUT param1 test.public.workday, OUT param2 test.public.workday)
+             LANGUAGE plpgsql
+             AS $$
+             BEGIN
+             param2 := param1;
+             param1 := 'humpday':::test.public.workday;
+             END;
+           $$
+
+# Reset types for subtest.
+statement ok
+ALTER TYPE workday RENAME TO weekday;
+
+statement ok
+ALTER TYPE weekday RENAME VALUE 'humpday' TO 'friday';
+
+statement ok
+DROP PROCEDURE p_rewrite;
+
 subtest end

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -185,6 +185,7 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	existing, err := params.p.matchRoutine(
 		params.ctx, maybeExistingFuncObj, false, /* required */
 		tree.UDFRoutine|tree.ProcedureRoutine,
+		false,
 	)
 	if err != nil {
 		return err
@@ -382,6 +383,7 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 	existing, err := params.p.matchRoutine(
 		params.ctx, maybeExistingFuncObj, false, /* required */
 		tree.UDFRoutine|tree.ProcedureRoutine,
+		false,
 	)
 	if err != nil {
 		return err
@@ -448,6 +450,7 @@ func (p *planner) mustGetMutableFunctionForAlter(
 	ol, err := p.matchRoutine(
 		ctx, routineObj, true, /* required */
 		tree.UDFRoutine|tree.ProcedureRoutine,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -472,6 +475,9 @@ func toSchemaOverloadSignature(fnDesc *funcdesc.Mutable) descpb.SchemaDescriptor
 		class := funcdesc.ToTreeRoutineParamClass(param.Class)
 		if tree.IsParamIncludedIntoSignature(class, ret.IsProcedure) {
 			ret.ArgTypes = append(ret.ArgTypes, param.Type)
+		}
+		if tree.IsInParamClass(class) {
+			ret.InputTypes = append(ret.InputTypes, param.Type)
 		}
 	}
 	return ret

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -184,7 +184,7 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	maybeExistingFuncObj.FuncName.ObjectName = n.n.NewName
 	existing, err := params.p.matchRoutine(
 		params.ctx, maybeExistingFuncObj, false, /* required */
-		tree.UDFRoutine|tree.ProcedureRoutine, false, /* inDropOrReplaceContext */
+		tree.UDFRoutine|tree.ProcedureRoutine,
 	)
 	if err != nil {
 		return err
@@ -381,7 +381,7 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 	maybeExistingFuncObj.FuncName.ExplicitSchema = true
 	existing, err := params.p.matchRoutine(
 		params.ctx, maybeExistingFuncObj, false, /* required */
-		tree.UDFRoutine|tree.ProcedureRoutine, false, /* inDropOrReplaceContext */
+		tree.UDFRoutine|tree.ProcedureRoutine,
 	)
 	if err != nil {
 		return err
@@ -447,7 +447,7 @@ func (p *planner) mustGetMutableFunctionForAlter(
 ) (*funcdesc.Mutable, error) {
 	ol, err := p.matchRoutine(
 		ctx, routineObj, true, /* required */
-		tree.UDFRoutine|tree.ProcedureRoutine, false, /* inDropOrReplaceContext */
+		tree.UDFRoutine|tree.ProcedureRoutine,
 	)
 	if err != nil {
 		return nil, err
@@ -472,9 +472,6 @@ func toSchemaOverloadSignature(fnDesc *funcdesc.Mutable) descpb.SchemaDescriptor
 		class := funcdesc.ToTreeRoutineParamClass(param.Class)
 		if tree.IsParamIncludedIntoSignature(class, ret.IsProcedure) {
 			ret.ArgTypes = append(ret.ArgTypes, param.Type)
-		}
-		if ret.IsProcedure && tree.IsInParamClass(class) {
-			ret.InputTypes = append(ret.InputTypes, param.Type)
 		}
 	}
 	return ret

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1567,6 +1567,9 @@ message SchemaDescriptor {
     optional bool return_set = 4 [(gogoproto.nullable) = false];
 
     optional bool is_procedure = 5 [(gogoproto.nullable) = false];
+
+    // InputTypes contains only IN / INOUT parameters when IsProcedure is true.
+    repeated sql.sem.types.T input_types = 6;
   }
 
   // Function contains a group of UDFs with the same name.

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -783,10 +783,14 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	}
 
 	signatureTypes := make(tree.ParamTypes, 0, len(desc.Params))
+	var procedureInputTypes tree.ParamTypes
 	for _, param := range desc.Params {
 		class := ToTreeRoutineParamClass(param.Class)
 		if tree.IsParamIncludedIntoSignature(class, desc.IsProcedure()) {
 			signatureTypes = append(signatureTypes, tree.ParamType{Name: param.Name, Typ: param.Type})
+		}
+		if desc.IsProcedure() && tree.IsInParamClass(class) {
+			procedureInputTypes = append(procedureInputTypes, tree.ParamType{Name: param.Name, Typ: param.Type})
 		}
 		ret.RoutineParams = append(ret.RoutineParams, tree.RoutineParam{
 			Name:  tree.Name(param.Name),
@@ -800,6 +804,7 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	// when the return type is based on output parameters.
 	ret.ReturnsRecordType = types.IsRecordType(desc.ReturnType.Type)
 	ret.Types = signatureTypes
+	ret.ProcedureInputTypes = procedureInputTypes
 	ret.Volatility, err = desc.getOverloadVolatility()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -783,14 +783,10 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	}
 
 	signatureTypes := make(tree.ParamTypes, 0, len(desc.Params))
-	var procedureInputTypes tree.ParamTypes
 	for _, param := range desc.Params {
 		class := ToTreeRoutineParamClass(param.Class)
 		if tree.IsParamIncludedIntoSignature(class, desc.IsProcedure()) {
 			signatureTypes = append(signatureTypes, tree.ParamType{Name: param.Name, Typ: param.Type})
-		}
-		if desc.IsProcedure() && tree.IsInParamClass(class) {
-			procedureInputTypes = append(procedureInputTypes, tree.ParamType{Name: param.Name, Typ: param.Type})
 		}
 		ret.RoutineParams = append(ret.RoutineParams, tree.RoutineParam{
 			Name:  tree.Name(param.Name),
@@ -804,7 +800,6 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	// when the return type is based on output parameters.
 	ret.ReturnsRecordType = types.IsRecordType(desc.ReturnType.Type)
 	ret.Types = signatureTypes
-	ret.ProcedureInputTypes = procedureInputTypes
 	ret.Volatility, err = desc.getOverloadVolatility()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -676,6 +676,7 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
+				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -703,6 +704,7 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
+				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -731,6 +733,7 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
+				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -760,6 +763,7 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
+				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -787,6 +791,7 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
+				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 			err: "function 1 is leakproof but not immutable",
 		},

--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -676,7 +676,6 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
-				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -704,7 +703,6 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
-				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -733,7 +731,6 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
-				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -763,7 +760,6 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
-				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 		},
 		{
@@ -791,7 +787,6 @@ func TestToOverload(t *testing.T) {
 				RoutineParams: tree.RoutineParams{
 					{Name: "arg1", Type: types.Int},
 				},
-				ProcedureInputTypes: tree.ParamTypes(nil),
 			},
 			err: "function 1 is leakproof but not immutable",
 		},

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -710,6 +710,11 @@ func SchemaDescs(schemas []*schemadesc.Mutable, descriptorRewrites jobspb.DescRe
 				if err := rewriteIDsInTypesT(sig.ReturnType, descriptorRewrites); err != nil {
 					return err
 				}
+				for _, typ := range sig.InputTypes {
+					if err := rewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
+						return err
+					}
+				}
 				newSigs = append(newSigs, *sig)
 			}
 			if len(newSigs) > 0 {

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -561,16 +561,6 @@ func (desc *immutable) GetResolvedFuncDefinition(
 			)
 		}
 		overload.Types = paramTypes
-		if sig.IsProcedure {
-			// TODO(100405): if a procedure is created on 23.2 version, then it
-			// won't have InputTypes set, so we won't populate
-			// ProcedureInputTypes correctly. Is this ok?
-			procedureInputTypes := make(tree.ParamTypes, 0, len(sig.InputTypes))
-			for _, inputType := range sig.InputTypes {
-				procedureInputTypes = append(procedureInputTypes, tree.ParamType{Typ: inputType})
-			}
-			overload.ProcedureInputTypes = procedureInputTypes
-		}
 		prefixedOverload := tree.MakeQualifiedOverload(desc.GetName(), overload)
 		funcDef.Overloads = append(funcDef.Overloads, prefixedOverload)
 	}

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -89,6 +89,14 @@ func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error
 					return iterutil.Map(err)
 				}
 			}
+			for _, typ := range sig.InputTypes {
+				if !catid.IsOIDUserDefined(typ.Oid()) {
+					continue
+				}
+				if err := fn(typ); err != nil {
+					return iterutil.Map(err)
+				}
+			}
 			if !catid.IsOIDUserDefined(sig.ReturnType.Oid()) {
 				continue
 			}
@@ -494,6 +502,7 @@ func (desc *Mutable) ReplaceOverload(
 	if !ok {
 		return errors.AssertionFailedf("unexpectedly didn't find a function %s", name)
 	}
+	// TODO
 	for i := range fn.Signatures {
 		sig := fn.Signatures[i]
 		match := len(oldArgTypes) == len(sig.ArgTypes)
@@ -561,6 +570,7 @@ func (desc *immutable) GetResolvedFuncDefinition(
 			)
 		}
 		overload.Types = paramTypes
+		overload.ProcedureInputTypes = sig.InputTypes
 		prefixedOverload := tree.MakeQualifiedOverload(desc.GetName(), overload)
 		funcDef.Overloads = append(funcDef.Overloads, prefixedOverload)
 	}

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -111,7 +111,7 @@ func (n *createFunctionNode) startExec(params runParams) error {
 			if isNew {
 				err = n.createNewFunction(udfMutableDesc, mutScDesc, params)
 			} else {
-				err = n.replaceFunction(udfMutableDesc, params)
+				err = n.replaceFunction(udfMutableDesc, mutScDesc, params)
 			}
 			if err != nil {
 				return err
@@ -156,9 +156,14 @@ func (n *createFunctionNode) createNewFunction(
 		return err
 	}
 	signatureTypes := make([]*types.T, 0, len(udfDesc.Params))
+	var inputTypes []*types.T
 	for _, param := range udfDesc.Params {
-		if tree.IsParamIncludedIntoSignature(funcdesc.ToTreeRoutineParamClass(param.Class), udfDesc.IsProcedure()) {
+		class := funcdesc.ToTreeRoutineParamClass(param.Class)
+		if tree.IsParamIncludedIntoSignature(class, udfDesc.IsProcedure()) {
 			signatureTypes = append(signatureTypes, param.Type)
+		}
+		if udfDesc.IsProcedure() && tree.IsInParamClass(class) {
+			inputTypes = append(inputTypes, param.Type)
 		}
 	}
 	scDesc.AddFunction(
@@ -169,6 +174,7 @@ func (n *createFunctionNode) createNewFunction(
 			ReturnType:  returnType,
 			ReturnSet:   udfDesc.ReturnType.ReturnSet,
 			IsProcedure: udfDesc.IsProcedure(),
+			InputTypes:  inputTypes,
 		},
 	)
 	if err := params.p.writeSchemaDescChange(params.ctx, scDesc, "Create Function"); err != nil {
@@ -178,19 +184,18 @@ func (n *createFunctionNode) createNewFunction(
 	return nil
 }
 
-func (n *createFunctionNode) replaceFunction(udfDesc *funcdesc.Mutable, params runParams) error {
-	if n.cf.IsProcedure && !udfDesc.IsProcedure() {
-		return errors.WithDetailf(
-			pgerror.Newf(pgcode.WrongObjectType, "cannot change routine kind"),
-			"%q is a function",
-			udfDesc.Name,
-		)
-	}
+func (n *createFunctionNode) replaceFunction(
+	udfDesc *funcdesc.Mutable, scDesc *schemadesc.Mutable, params runParams,
+) error {
 
-	if !n.cf.IsProcedure && udfDesc.IsProcedure() {
+	if n.cf.IsProcedure != udfDesc.IsProcedure() {
+		formatStr := "%q is a function"
+		if udfDesc.IsProcedure() {
+			formatStr = "%q is a procedure"
+		}
 		return errors.WithDetailf(
 			pgerror.Newf(pgcode.WrongObjectType, "cannot change routine kind"),
-			"%q is a procedure",
+			formatStr,
 			udfDesc.Name,
 		)
 	}
@@ -205,6 +210,9 @@ func (n *createFunctionNode) replaceFunction(udfDesc *funcdesc.Mutable, params r
 	isSameUDT := types.IsOIDUserDefinedType(retType.Oid()) && retType.Oid() ==
 		udfDesc.ReturnType.Type.Oid()
 	if n.cf.ReturnType.SetOf != udfDesc.ReturnType.ReturnSet || (!retType.Equal(udfDesc.ReturnType.Type) && !isSameUDT) {
+		if udfDesc.IsProcedure() && (retType.Family() == types.VoidFamily || udfDesc.ReturnType.Type.Family() == types.VoidFamily) {
+			return pgerror.Newf(pgcode.InvalidFunctionDefinition, "cannot change whether a procedure has output parameters")
+		}
 		return pgerror.Newf(pgcode.InvalidFunctionDefinition, "cannot change return type of existing function")
 	}
 	if isSameUDT {
@@ -216,6 +224,18 @@ func (n *createFunctionNode) replaceFunction(udfDesc *funcdesc.Mutable, params r
 	// checked.
 	if err = n.validateParameters(udfDesc); err != nil {
 		return err
+	}
+	// origSignatureTypes stores the original signature types of this overload
+	// if we're dealing with a procedure.
+	var origSignatureTypes []*types.T
+	if udfDesc.IsProcedure() {
+		origSignatureTypes = make([]*types.T, 0, len(udfDesc.Params))
+		for _, param := range udfDesc.Params {
+			class := funcdesc.ToTreeRoutineParamClass(param.Class)
+			if tree.IsParamIncludedIntoSignature(class, true /* isProcedure */) {
+				origSignatureTypes = append(origSignatureTypes, param.Type)
+			}
+		}
 	}
 	// All parameter changes, if any, are allowed, so update the descriptor
 	// accordingly.
@@ -275,6 +295,47 @@ func (n *createFunctionNode) replaceFunction(udfDesc *funcdesc.Mutable, params r
 		return err
 	}
 
+	if udfDesc.IsProcedure() {
+		// For procedures, it is possible to change the signature of the
+		// overload (by merging some parameters into INOUT parameter or doing
+		// the opposite), and in this case we need to update the schema
+		// descriptor.
+		signatureTypes := make([]*types.T, 0, len(udfDesc.Params))
+		var inputTypes []*types.T
+		for _, param := range udfDesc.Params {
+			class := funcdesc.ToTreeRoutineParamClass(param.Class)
+			if tree.IsParamIncludedIntoSignature(class, udfDesc.IsProcedure()) {
+				signatureTypes = append(signatureTypes, param.Type)
+			}
+			if udfDesc.IsProcedure() && tree.IsInParamClass(class) {
+				inputTypes = append(inputTypes, param.Type)
+			}
+		}
+		signatureChanged := len(origSignatureTypes) != len(signatureTypes)
+		for i := 0; !signatureChanged && i < len(origSignatureTypes); i++ {
+			signatureChanged = !origSignatureTypes[i].Equivalent(signatureTypes[i])
+		}
+		if signatureChanged {
+			if err = scDesc.ReplaceOverload(
+				udfDesc.GetName(),
+				origSignatureTypes,
+				descpb.SchemaDescriptor_FunctionSignature{
+					ID:          udfDesc.GetID(),
+					ArgTypes:    signatureTypes,
+					ReturnType:  retType,
+					ReturnSet:   udfDesc.ReturnType.ReturnSet,
+					IsProcedure: true,
+					InputTypes:  inputTypes,
+				},
+			); err != nil {
+				return err
+			}
+			if err = params.p.writeSchemaDescChange(params.ctx, scDesc, "Replace Function"); err != nil {
+				return err
+			}
+		}
+	}
+
 	return params.p.writeFuncSchemaChange(params.ctx, udfDesc)
 }
 
@@ -295,8 +356,10 @@ func (n *createFunctionNode) getMutableFuncDesc(
 		FuncName: n.cf.Name,
 		Params:   n.cf.Params,
 	}
-	existing, err := params.p.matchRoutine(params.ctx, &routineObj,
-		false /* required */, tree.UDFRoutine|tree.ProcedureRoutine)
+	existing, err := params.p.matchRoutine(
+		params.ctx, &routineObj, false, /* required */
+		tree.UDFRoutine|tree.ProcedureRoutine, true, /* inDropOrReplaceContext */
+	)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -270,7 +270,8 @@ SELECT database_name,
 				return nil, err
 			}
 			ol, err := fd.MatchOverload(
-				signatureTypes, fn.FuncName.Schema(), &d.evalCtx.SessionData().SearchPath, routineType,
+				signatureTypes, fn.FuncName.Schema(),
+				&d.evalCtx.SessionData().SearchPath, routineType,
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -265,7 +265,7 @@ SELECT database_name,
 			if err != nil {
 				return nil, err
 			}
-			signatureTypes, err := fn.SignatureTypes(d.ctx, d.catalog)
+			signatureTypes, err := fn.SignatureTypes(d.ctx, d.catalog, routineType, false /* inDropOrReplaceContext */)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -265,7 +265,7 @@ SELECT database_name,
 			if err != nil {
 				return nil, err
 			}
-			signatureTypes, err := fn.SignatureTypes(d.ctx, d.catalog, routineType, false /* inDropOrReplaceContext */)
+			signatureTypes, err := fn.SignatureTypes(d.ctx, d.catalog, routineType)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -271,7 +271,7 @@ SELECT database_name,
 			}
 			ol, err := fd.MatchOverload(
 				signatureTypes, fn.FuncName.Schema(),
-				&d.evalCtx.SessionData().SearchPath, routineType,
+				&d.evalCtx.SessionData().SearchPath, routineType, false,
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/drop_function.go
+++ b/pkg/sql/drop_function.go
@@ -61,7 +61,7 @@ func (p *planner) DropFunction(ctx context.Context, n *tree.DropRoutine) (ret pl
 	}
 	fnResolved := intsets.MakeFast()
 	for _, fn := range n.Routines {
-		ol, err := p.matchRoutine(ctx, &fn, !n.IfExists, routineType)
+		ol, err := p.matchRoutine(ctx, &fn, !n.IfExists, routineType, false)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +123,11 @@ func (n *dropFunctionNode) Close(ctx context.Context)           {}
 // returned if the function is not found. An error is also returning if a
 // builtin function is matched.
 func (p *planner) matchRoutine(
-	ctx context.Context, routineObj *tree.RoutineObj, required bool, routineType tree.RoutineType,
+	ctx context.Context,
+	routineObj *tree.RoutineObj,
+	required bool,
+	routineType tree.RoutineType,
+	isCreate bool,
 ) (*tree.QualifiedOverload, error) {
 	path := p.CurrentSearchPath()
 	unresolvedName := routineObj.FuncName.ToUnresolvedObjectName().ToUnresolvedName()
@@ -145,7 +149,7 @@ func (p *planner) matchRoutine(
 	if err != nil {
 		return nil, err
 	}
-	ol, err := fnDef.MatchOverload(signatureTypes, routineObj.FuncName.Schema(), &path, routineType)
+	ol, err := fnDef.MatchOverload(signatureTypes, routineObj.FuncName.Schema(), &path, routineType, isCreate)
 	if err != nil {
 		if !required && errors.Is(err, tree.ErrRoutineUndefined) {
 			return nil, nil

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -1,5 +1,7 @@
 # LogicTest: !local-mixed-23.1
 
+subtest types
+
 statement error pgcode 42601 pq: at or near "float": syntax error
 CREATE PROCEDURE p(OUT param INT) RETURNS FLOAT AS $$ SELECT 1; $$ LANGUAGE SQL;
 
@@ -21,8 +23,41 @@ DROP PROCEDURE p;
 statement error pgcode 42P13 pq: return type mismatch in function declared to return record
 CREATE PROCEDURE p(INOUT param1 INT, OUT param2 INT) AS $$ SELECT 1, 2, 3; $$ LANGUAGE SQL;
 
-statement error pgcode 42P13 pq: return type mismatch in function declared to return int
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
 CREATE PROCEDURE p(INOUT param INT) AS $$ SELECT 'hello'; $$ LANGUAGE SQL;
+
+# Verify that function resolution works correctly when dropping procedures (OUT
+# arguments are ignored).
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT);
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ SELECT 1, 2; $$ LANGUAGE SQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT);
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ SELECT 1, 2; $$ LANGUAGE SQL;
+
+statement error pq: procedure p\(int\) does not exist
+DROP PROCEDURE p(INT);
+
+statement ok
+DROP PROCEDURE p;
+
+subtest end
+
+subtest show_create
 
 statement ok
 CREATE PROCEDURE p(IN p1 INT, INOUT p2 INT, IN OUT p3 INT, OUT p4 INT) AS $$
@@ -37,3 +72,198 @@ CREATE PROCEDURE public.p(IN p1 INT8, INOUT p2 INT8, INOUT p3 INT8, OUT p4 INT8)
   AS $$
   SELECT p2, p3, p1;
 $$
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(OUT param INT) AS $$
+SELECT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p];
+----
+CREATE PROCEDURE public.p(OUT param INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT 1;
+$$
+
+statement ok
+DROP PROCEDURE p;
+
+subtest end
+
+subtest parameter_names
+
+# Sharing of parameter names is only allowed across two different "parameter
+# namespaces" (IN vs OUT).
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(IN a INT, IN a INT) LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(IN a INT, INOUT a INT) LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement error pgcode 42P13 pq: parameter name "a" used more than once
+CREATE PROCEDURE p_same_name(OUT a INT, INOUT a INT) LANGUAGE SQL AS $$ SELECT 1, 1 $$;
+
+statement ok
+CREATE PROCEDURE p_same_name(IN a INT, OUT a INT) LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_same_name(IN a INT, OUT a INT) LANGUAGE SQL AS $$ SELECT a $$;
+
+statement error pgcode 42703 pq: column "param_out" does not exist
+CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) LANGUAGE SQL AS $$ SELECT param_out $$;
+
+statement ok
+CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) LANGUAGE SQL AS $$ SELECT param_in $$;
+
+statement ok
+CREATE PROCEDURE p_out_int(OUT param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+statement ok
+CREATE PROCEDURE p_in_int(IN param INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+statement ok
+CREATE PROCEDURE p_inout_int(INOUT param INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+# Unlike for functions, changing single OUT parameter name is not ok.
+statement error pgcode 42P13 pq: cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_out_int(OUT param_new INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+# Changing IN or INOUT parameter name is not allowed.
+statement error pgcode 42P13 pq: cannot change name of input parameter "param"
+CREATE OR REPLACE PROCEDURE p_in_int(IN param_new INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+statement error pgcode 42P13 pq: cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_inout_int(INOUT param_new INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+subtest end
+
+subtest changing_parameters
+
+statement ok
+CREATE PROCEDURE p_int(IN param INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+statement error pgcode 42P13 pq: cannot change whether a procedure has output parameters
+CREATE OR REPLACE PROCEDURE p_int(IN param INT, OUT INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+statement ok
+DROP PROCEDURE p_int;
+
+statement ok
+CREATE PROCEDURE p_int(IN param INT, OUT INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+statement error pgcode 42P13 pq: cannot change whether a procedure has output parameters
+CREATE OR REPLACE PROCEDURE p_int(IN param INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+# We can change the order of parameters across IN and OUT "namespaces" as long
+# as we preserve the right ordering within each "namespace".
+statement ok
+CREATE PROCEDURE p_3_in_2_out(IN param1 INT, IN param2 INT, IN param3 INT, OUT param1 INT, OUT param2 INT) AS $$ SELECT (param1, param2 + param3); $$ LANGUAGE SQL;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_3_in_2_out(IN param1 INT, OUT param1 INT, IN param2 INT, IN param3 INT, OUT param2 INT) AS $$ SELECT (param1, param2 + param3); $$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_3_in_2_out];
+----
+CREATE PROCEDURE public.p_3_in_2_out(IN param1 INT8, OUT param1 INT8, IN param2 INT8, IN param3 INT8, OUT param2 INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT (param1, param2 + param3);
+$$
+
+# We can also merge some parameters as long as they have the same names.
+statement error pgcode 42P13 pq: cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_3_in_2_out(INOUT param1 INT, IN param2 INT, INOUT param3 INT) AS $$ SELECT (1, 1); $$ LANGUAGE SQL;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_3_in_2_out(INOUT param1 INT, INOUT param2 INT, IN param3 INT) AS $$ SELECT (param1, param2 + param3); $$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_3_in_2_out];
+----
+CREATE PROCEDURE public.p_3_in_2_out(INOUT param1 INT8, INOUT param2 INT8, IN param3 INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT (param1, param2 + param3);
+$$
+
+subtest end
+
+subtest default_parameter_names
+
+# Parameter names are optional. Each unnamed output parameter with ordinal 'i'
+# (among all output parameters) gets the default name that is "column" || i.
+
+statement ok
+CREATE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+$$
+
+# Introducing the OUT parameter name is disallowed because it'd change the
+# return type.
+statement error cannot change return type of existing function
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT param3 INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
+
+# Introducing the name that matches the default OUT parameter name is allowed.
+statement ok
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT column3 INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT column3 INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+$$
+
+# Then we can omit the default OUT parameter name again.
+statement ok
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT (1:::INT8, 2:::INT8, 3:::INT8);
+$$
+
+# Introducing the IN parameter name is ok.
+statement ok
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param INT, OUT INT) AS $$ SELECT (in_param, 2, 3); $$ LANGUAGE SQL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE PROCEDURE p_default_names];
+----
+CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN in_param INT8, OUT INT8)
+  LANGUAGE SQL
+  AS $$
+  SELECT (in_param, 2, 3);
+$$
+
+# But then the IN parameter name cannot be changed anymore.
+statement error cannot change name of input parameter "in_param"
+CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param_new INT, OUT INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
+
+subtest end
+
+statement ok
+CREATE TYPE typ AS (a INT, b INT);
+
+statement ok
+CREATE PROCEDURE p_udt(OUT typ) AS $$ SELECT (1, 2); $$ LANGUAGE SQL;

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -6,7 +6,119 @@ statement error pgcode 42601 pq: at or near "float": syntax error
 CREATE PROCEDURE p(OUT param INT) RETURNS FLOAT AS $$ SELECT 1; $$ LANGUAGE SQL;
 
 statement ok
+CREATE PROCEDURE p(IN param1 INT, OUT param2 INT) AS $$ SELECT param1; $$ LANGUAGE SQL;
+
+statement error pgcode 42883 procedure p\(\) does not exist
+CALL p();
+
+statement error pgcode 42883 procedure p\(int\) does not exist
+CALL p(1);
+
+statement error pgcode 42883 procedure p\(int, int, int\) does not exist
+CALL p(1, 2, 3);
+
+statement ok
+CREATE PROCEDURE p(IN param1 FLOAT, OUT param2 FLOAT) AS $$ SELECT param1; $$ LANGUAGE SQL;
+
+query I colnames
+CALL p(1, 2);
+----
+param2
+1
+
+query R colnames
+CALL p(1.1, 2.2);
+----
+param2
+1.1
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT) AS $$ SELECT param2; $$ LANGUAGE SQL;
+
+statement ok
+CREATE OR REPLACE PROCEDURE p(OUT param2 INT, IN param1 INT) AS $$ SELECT param1; $$ LANGUAGE SQL;
+
+query I colnames
+CALL p(1, 2);
+----
+param2
+2
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, OUT param3 INT) AS $$ SELECT (1, param2); $$ LANGUAGE SQL;
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, IN param3 INT) AS $$ SELECT param2 + param3; $$ LANGUAGE SQL;
+
+query I colnames
+CALL p(1, 2, 3);
+----
+param1
+5
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(INOUT param1 INT, IN param2 INT) AS $$ SELECT param1 + param2; $$ LANGUAGE SQL;
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT, OUT param3 INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
+
+statement error pgcode 42725 procedure p\(int, int, int\) is not unique
+CALL p(1, 2, 3);
+
+statement error pgcode 42725 procedure name "p" is not unique
+DROP PROCEDURE p;
+
+# Postgres seems to special-case the DROP behavior when none of the parameter
+# classes are specified for the argument types - it permissively treats them as
+# IN or OUT in order to match the maximum number overloads. As a result, PG
+# often returns 'procedure name "p" is not unique' error. Replicating that
+# behavior is tricky and seems not worth it, so we, instead, treat all argument
+# types with unspecified parameter class as having the IN class.
+
+# Postgres returns 'procedure name "p" is not unique' error here.
+statement error pgcode 42883 procedure p\(int,int,int\) does not exist
+DROP PROCEDURE p(INT, INT, INT);
+
+# Postgres returns 'procedure name "p" is not unique' error here.
+statement ok
+DROP PROCEDURE p(INT, INT);
+
+statement ok
+CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, IN param3 INT) AS $$ SELECT param2 + param3; $$ LANGUAGE SQL;
+
+statement ok
+DROP PROCEDURE p(OUT INT, INT, INT);
+
+query III colnames
+CALL p(-1, -2, -3);
+----
+param1  param2  param3
+1       2       3
+
+statement error pgcode 42725 procedure name "p" is not unique
+DROP PROCEDURE p;
+
+# Postgres here drops the overload with 3 OUT parameters.
+statement error pgcode 42883 procedure p\(int,int,int\) does not exist
+DROP PROCEDURE p(INT, INT, INT);
+
+statement ok
+DROP PROCEDURE p(OUT INT, OUT INT, OUT INT);
+
+statement ok
+DROP PROCEDURE p(OUT INT, INT);
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
 CREATE PROCEDURE p(OUT param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+statement error pgcode 42883 procedure p\(\) does not exist
+CALL p();
+
+statement error pgcode 42723 function "p" already exists with same argument types
+CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ SELECT (1, 2); $$ LANGUAGE SQL;
 
 # Argument expressions for OUT parameters shouldn't be evaluated.
 query I colnames
@@ -22,11 +134,11 @@ statement ok
 CREATE PROCEDURE p(IN INT, INOUT INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
 
 # Argument expressions for IN and INOUT parameters are evaluated.
-statement error division by zero
-CALL p(1 // 0, 1)
+statement error pgcode 22012 division by zero
+CALL p(1 // 0, 1);
 
-statement error division by zero
-CALL p(1, 1 // 0)
+statement error pgcode 22012 division by zero
+CALL p(1, 1 // 0);
 
 statement ok
 DROP PROCEDURE p;
@@ -86,7 +198,7 @@ DROP PROCEDURE p(OUT INT);
 statement ok
 CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT) AS $$ SELECT 1, 2; $$ LANGUAGE SQL;
 
-statement error pq: procedure p\(int\) does not exist
+statement error pgcode 42883 pq: procedure p\(int\) does not exist
 DROP PROCEDURE p(INT);
 
 statement ok
@@ -310,7 +422,7 @@ column1  param2  column3
 
 # Introducing the OUT parameter name is disallowed because it'd change the
 # return type.
-statement error cannot change return type of existing function
+statement error pgcode 42P13 cannot change return type of existing function
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT param3 INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
 
 # Introducing the name that matches the default OUT parameter name is allowed.
@@ -371,7 +483,7 @@ column1  param2  column3
 3        2       3
 
 # But then the IN parameter name cannot be changed anymore.
-statement error cannot change name of input parameter "in_param"
+statement error pgcode 42P13 cannot change name of input parameter "in_param"
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param_new INT, OUT INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -8,6 +8,26 @@ CREATE PROCEDURE p(OUT param INT) RETURNS FLOAT AS $$ SELECT 1; $$ LANGUAGE SQL;
 statement ok
 CREATE PROCEDURE p(OUT param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
 
+# Argument expressions for OUT parameters shouldn't be evaluated.
+query I colnames
+CALL p(1 // 0);
+----
+param
+1
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(IN INT, INOUT INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+# Argument expressions for IN and INOUT parameters are evaluated.
+statement error division by zero
+CALL p(1 // 0, 1)
+
+statement error division by zero
+CALL p(1, 1 // 0)
+
 statement ok
 DROP PROCEDURE p;
 
@@ -16,6 +36,23 @@ CREATE PROCEDURE p(IN param1 INT, INOUT param2 INT, OUT param3 INT) AS $$ SELECT
 
 statement error pgcode 42883 procedure p\(int, int\) does not exist
 CALL p(1, 2)
+
+query II colnames
+CALL p(3, 4, NULL);
+----
+param2  param3
+1       2
+
+statement ok
+DROP PROCEDURE p;
+
+statement ok
+CREATE PROCEDURE p(IN param1 INT, IN param2 INT) AS $$ SELECT 1, 2; $$ LANGUAGE SQL;
+
+# This procedure returns VOID type, so this result should be empty.
+query empty
+CALL p(3, 4);
+----
 
 statement ok
 DROP PROCEDURE p;
@@ -112,8 +149,20 @@ CREATE PROCEDURE p_same_name(OUT a INT, INOUT a INT) LANGUAGE SQL AS $$ SELECT 1
 statement ok
 CREATE PROCEDURE p_same_name(IN a INT, OUT a INT) LANGUAGE SQL AS $$ SELECT 1 $$;
 
+query I colnames
+CALL p_same_name(2, NULL);
+----
+a
+1
+
 statement ok
 CREATE OR REPLACE PROCEDURE p_same_name(IN a INT, OUT a INT) LANGUAGE SQL AS $$ SELECT a $$;
+
+query I colnames
+CALL p_same_name(2, NULL);
+----
+a
+2
 
 statement error pgcode 42703 pq: column "param_out" does not exist
 CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) LANGUAGE SQL AS $$ SELECT param_out $$;
@@ -121,14 +170,37 @@ CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) LANGUAGE SQL AS $$ 
 statement ok
 CREATE PROCEDURE p_names(IN param_in INT, OUT param_out INT) LANGUAGE SQL AS $$ SELECT param_in $$;
 
+query I colnames
+CALL p_names(2, NULL);
+----
+param_out
+2
+
 statement ok
 CREATE PROCEDURE p_out_int(OUT param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+query I colnames
+CALL p_out_int(NULL);
+----
+param
+1
 
 statement ok
 CREATE PROCEDURE p_in_int(IN param INT) AS $$ SELECT param; $$ LANGUAGE SQL;
 
+# This procedure returns VOID type, so this result should be empty.
+query empty
+CALL p_in_int(2);
+----
+
 statement ok
 CREATE PROCEDURE p_inout_int(INOUT param INT) AS $$ SELECT param; $$ LANGUAGE SQL;
+
+query I colnames
+CALL p_inout_int(2);
+----
+param
+2
 
 # Unlike for functions, changing single OUT parameter name is not ok.
 statement error pgcode 42P13 pq: cannot change return type of existing function
@@ -165,6 +237,12 @@ CREATE OR REPLACE PROCEDURE p_int(IN param INT) AS $$ SELECT param; $$ LANGUAGE 
 statement ok
 CREATE PROCEDURE p_3_in_2_out(IN param1 INT, IN param2 INT, IN param3 INT, OUT param1 INT, OUT param2 INT) AS $$ SELECT (param1, param2 + param3); $$ LANGUAGE SQL;
 
+query II colnames
+CALL p_3_in_2_out(2, 2, 2, NULL, NULL);
+----
+param1  param2
+2       4
+
 statement ok
 CREATE OR REPLACE PROCEDURE p_3_in_2_out(IN param1 INT, OUT param1 INT, IN param2 INT, IN param3 INT, OUT param2 INT) AS $$ SELECT (param1, param2 + param3); $$ LANGUAGE SQL;
 
@@ -176,6 +254,12 @@ CREATE PROCEDURE public.p_3_in_2_out(IN param1 INT8, OUT param1 INT8, IN param2 
   AS $$
   SELECT (param1, param2 + param3);
 $$
+
+query II colnames
+CALL p_3_in_2_out(2, NULL, 2, 2, NULL);
+----
+param1  param2
+2       4
 
 # We can also merge some parameters as long as they have the same names.
 statement error pgcode 42P13 pq: cannot change return type of existing function
@@ -192,6 +276,12 @@ CREATE PROCEDURE public.p_3_in_2_out(INOUT param1 INT8, INOUT param2 INT8, IN pa
   AS $$
   SELECT (param1, param2 + param3);
 $$
+
+query II colnames
+CALL p_3_in_2_out(2, 2, 2);
+----
+param1  param2
+2       4
 
 subtest end
 
@@ -212,6 +302,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT 
   SELECT (1:::INT8, 2:::INT8, 3:::INT8);
 $$
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+1        2       3
+
 # Introducing the OUT parameter name is disallowed because it'd change the
 # return type.
 statement error cannot change return type of existing function
@@ -230,6 +326,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT 
   SELECT (1:::INT8, 2:::INT8, 3:::INT8);
 $$
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+1        2       3
+
 # Then we can omit the default OUT parameter name again.
 statement ok
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN INT, OUT INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
@@ -242,6 +344,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN INT8, OUT 
   AS $$
   SELECT (1:::INT8, 2:::INT8, 3:::INT8);
 $$
+
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+1        2       3
 
 # Introducing the IN parameter name is ok.
 statement ok
@@ -256,6 +364,12 @@ CREATE PROCEDURE public.p_default_names(OUT INT8, OUT param2 INT8, IN in_param I
   SELECT (in_param, 2, 3);
 $$
 
+query III colnames
+CALL p_default_names(NULL, NULL, 3, NULL);
+----
+column1  param2  column3
+3        2       3
+
 # But then the IN parameter name cannot be changed anymore.
 statement error cannot change name of input parameter "in_param"
 CREATE OR REPLACE PROCEDURE p_default_names(OUT INT, OUT param2 INT, IN in_param_new INT, OUT INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
@@ -267,3 +381,10 @@ CREATE TYPE typ AS (a INT, b INT);
 
 statement ok
 CREATE PROCEDURE p_udt(OUT typ) AS $$ SELECT (1, 2); $$ LANGUAGE SQL;
+
+# TODO(100405): this currently results in an internal error.
+# query T colnames
+# CALL p_udt(NULL);
+# ----
+# column1
+# (1,2)

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -59,11 +59,15 @@ param1
 statement error pgcode 42723 function "p" already exists with same argument types
 CREATE PROCEDURE p(INOUT param1 INT, IN param2 INT) AS $$ SELECT param1 + param2; $$ LANGUAGE SQL;
 
+# TODO
+statement ok
+DROP PROCEDURE p(INT, INT, INT)
+
 statement ok
 CREATE PROCEDURE p(OUT param1 INT, OUT param2 INT, OUT param3 INT) AS $$ SELECT (1, 2, 3); $$ LANGUAGE SQL;
 
-statement error pgcode 42725 procedure p\(int, int, int\) is not unique
-CALL p(1, 2, 3);
+# statement error pgcode 42725 procedure p\(int, int, int\) is not unique
+# CALL p(1, 2, 3);
 
 statement error pgcode 42725 procedure name "p" is not unique
 DROP PROCEDURE p;
@@ -75,13 +79,17 @@ DROP PROCEDURE p;
 # behavior is tricky and seems not worth it, so we, instead, treat all argument
 # types with unspecified parameter class as having the IN class.
 
-# Postgres returns 'procedure name "p" is not unique' error here.
-statement error pgcode 42883 procedure p\(int,int,int\) does not exist
-DROP PROCEDURE p(INT, INT, INT);
+# statement error pgcode 42725 procedure name "p" is not unique
+# DROP PROCEDURE p(INT, INT, INT);
 
-# Postgres returns 'procedure name "p" is not unique' error here.
+# Postgres returns 'procedure name "p" is not unique' error here whereas we
+# drop (OUT INT, IN INT) overload.
 statement ok
 DROP PROCEDURE p(INT, INT);
+
+# TODO
+statement ok
+DROP PROCEDURE p(OUT INT, OUT INT, OUT INT);
 
 statement ok
 CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, IN param3 INT) AS $$ SELECT param2 + param3; $$ LANGUAGE SQL;
@@ -89,24 +97,24 @@ CREATE PROCEDURE p(OUT param1 INT, IN param2 INT, IN param3 INT) AS $$ SELECT pa
 statement ok
 DROP PROCEDURE p(OUT INT, INT, INT);
 
-query III colnames
-CALL p(-1, -2, -3);
-----
-param1  param2  param3
-1       2       3
+# query III colnames
+# CALL p(-1, -2, -3);
+# ----
+# param1  param2  param3
+# 1       2       3
 
-statement error pgcode 42725 procedure name "p" is not unique
-DROP PROCEDURE p;
+# statement error pgcode 42725 procedure name "p" is not unique
+# DROP PROCEDURE p;
 
 # Postgres here drops the overload with 3 OUT parameters.
-statement error pgcode 42883 procedure p\(int,int,int\) does not exist
-DROP PROCEDURE p(INT, INT, INT);
+# statement error pgcode 42883 procedure p\(int,int,int\) does not exist
+# DROP PROCEDURE p(INT, INT, INT);
 
-statement ok
-DROP PROCEDURE p(OUT INT, OUT INT, OUT INT);
+# statement ok
+# DROP PROCEDURE p(OUT INT, OUT INT, OUT INT);
 
-statement ok
-DROP PROCEDURE p(OUT INT, INT);
+# statement ok
+# DROP PROCEDURE p(OUT INT, INT);
 
 statement ok
 DROP PROCEDURE p;

--- a/pkg/sql/logictest/testdata/logic_test/udf_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_rewrite
@@ -153,6 +153,34 @@ SELECT get_body_str('p_rewrite');
 statement ok
 DROP PROCEDURE p_rewrite();
 
+statement ok
+CREATE PROCEDURE p_rewrite(OUT weekday) AS
+$$
+  SELECT 'thursday'::weekday;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"SELECT b'\\xa0':::@100107;"
+
+statement ok
+DROP PROCEDURE p_rewrite();
+
+statement ok
+CREATE PROCEDURE p_rewrite(INOUT weekday) AS
+$$
+  SELECT 'thursday'::weekday;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"SELECT b'\\xa0':::@100107;"
+
+statement ok
+DROP PROCEDURE p_rewrite;
+
 subtest end
 
 subtest rewrite_udf_calling_duf

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -440,7 +440,7 @@ func (md *Metadata) CheckDependencies(
 				// "<func> is not a function" error here. Instead, we'll return
 				// false and attempt to rebuild the statement.
 				toCheck, err := definition.MatchOverload(
-					overload.Types.Types(),
+					[][]*types.T{overload.Types.Types()},
 					name.Schema(),
 					&evalCtx.SessionData().SearchPath,
 					tree.UDFRoutine|tree.BuiltinRoutine|tree.ProcedureRoutine,

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -444,6 +444,7 @@ func (md *Metadata) CheckDependencies(
 					name.Schema(),
 					&evalCtx.SessionData().SearchPath,
 					tree.UDFRoutine|tree.BuiltinRoutine|tree.ProcedureRoutine,
+					false,
 				)
 				if err != nil || toCheck.Oid != overload.Oid || toCheck.Version != overload.Version {
 					return false, err

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -248,14 +248,16 @@ func (b *Builder) buildRoutine(
 			panic(unimplemented.NewWithIssue(88947,
 				"variadiac user-defined functions are not yet supported"))
 		}
-		params = make(opt.ColList, len(paramTypes))
+		params = make(opt.ColList, 0, len(paramTypes))
 		for i := range paramTypes {
-
+			if isProcedure && o.RoutineParams[i].Class == tree.RoutineParamOut {
+				continue
+			}
 			paramType := &paramTypes[i]
 			argColName := funcParamColName(tree.Name(paramType.Name), i)
 			col := b.synthesizeColumn(bodyScope, argColName, paramType.Typ, nil /* expr */, nil /* scalar */)
-			col.setParamOrd(i)
-			params[i] = col.id
+			col.setParamOrd(len(params))
+			params = append(params, col.id)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -213,15 +213,23 @@ func (b *Builder) buildRoutine(
 	// Build the argument expressions.
 	var args memo.ScalarListExpr
 	if len(f.Exprs) > 0 {
-		args = make(memo.ScalarListExpr, len(f.Exprs))
+		args = make(memo.ScalarListExpr, 0, len(f.Exprs))
 		for i, pexpr := range f.Exprs {
-			args[i] = b.buildScalar(
+			if isProcedure && o.RoutineParams[i].Class == tree.RoutineParamOut {
+				// For procedures, OUT parameters need to be specified in the
+				// CALL statement, but they are not evaluated and shouldn't be
+				// passed down to the UDF Call (since the body can only
+				// reference the input parameters which we refer to by their
+				// ordinals).
+				continue
+			}
+			args = append(args, b.buildScalar(
 				pexpr.(tree.TypedExpr),
 				inScope,
 				nil, /* outScope */
 				nil, /* outCol */
 				colRefs,
-			)
+			))
 		}
 	}
 	// Create a new scope for building the statements in the function body. We

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -165,6 +165,7 @@ func (b *Builder) buildRoutine(
 	f *tree.FuncExpr, def *tree.ResolvedFunctionDefinition, inScope *scope, colRefs *opt.ColSet,
 ) (out opt.ScalarExpr, isMultiColDataSource bool) {
 	o := f.ResolvedOverload()
+	isProcedure := o.Type == tree.ProcedureRoutine
 	b.factory.Metadata().AddUserDefinedFunction(o, f.Func.ReferenceByName)
 
 	// Validate that the return types match the original return types defined in
@@ -234,7 +235,12 @@ func (b *Builder) buildRoutine(
 	bodyScope := b.allocScope()
 	var params opt.ColList
 	if o.Types.Length() > 0 {
-		paramTypes, ok := o.Types.(tree.ParamTypes)
+		// Add all input parameters to the scope.
+		inputTypes := o.Types
+		if isProcedure {
+			inputTypes = o.ProcedureInputTypes
+		}
+		paramTypes, ok := inputTypes.(tree.ParamTypes)
 		if !ok {
 			panic(unimplemented.NewWithIssue(88947,
 				"variadiac user-defined functions are not yet supported"))
@@ -337,8 +343,7 @@ func (b *Builder) buildRoutine(
 		}
 		var expr memo.RelExpr
 		var physProps *physical.Required
-		isProc := o.Type == tree.ProcedureRoutine
-		plBuilder := newPLpgSQLBuilder(b, def.Name, colRefs, routineParams, rtyp, isProc)
+		plBuilder := newPLpgSQLBuilder(b, def.Name, colRefs, routineParams, rtyp, isProcedure)
 		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		finishResolveType(stmtScope)
 		expr, physProps, isMultiColDataSource =

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -243,18 +243,14 @@ func (b *Builder) buildRoutine(
 	bodyScope := b.allocScope()
 	var params opt.ColList
 	if o.Types.Length() > 0 {
-		// Add all input parameters to the scope.
-		inputTypes := o.Types
-		if isProcedure {
-			inputTypes = o.ProcedureInputTypes
-		}
-		paramTypes, ok := inputTypes.(tree.ParamTypes)
+		paramTypes, ok := o.Types.(tree.ParamTypes)
 		if !ok {
 			panic(unimplemented.NewWithIssue(88947,
 				"variadiac user-defined functions are not yet supported"))
 		}
 		params = make(opt.ColList, len(paramTypes))
 		for i := range paramTypes {
+
 			paramType := &paramTypes[i]
 			argColName := funcParamColName(tree.Name(paramType.Name), i)
 			col := b.synthesizeColumn(bodyScope, argColName, paramType.Typ, nil /* expr */, nil /* scalar */)

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -638,82 +638,78 @@ CALL p_out(NULL, NULL);
 ----
 call
  └── procedure: p_out
-      ├── args
-      │    ├── null
-      │    └── null
-      ├── params: x:1 y:2
       └── body
            └── limit
-                ├── columns: stmt_if_2:12
+                ├── columns: stmt_if_2:10
                 ├── project
-                │    ├── columns: stmt_if_2:12
+                │    ├── columns: stmt_if_2:10
                 │    ├── project
-                │    │    ├── columns: x:5!null y:4
+                │    │    ├── columns: x:3!null y:2
                 │    │    ├── project
-                │    │    │    ├── columns: y:4 x:3
+                │    │    │    ├── columns: y:2 x:1
                 │    │    │    ├── project
-                │    │    │    │    ├── columns: x:3
+                │    │    │    │    ├── columns: x:1
                 │    │    │    │    ├── values
                 │    │    │    │    │    └── tuple
                 │    │    │    │    └── projections
-                │    │    │    │         └── cast: INT8 [as=x:3]
+                │    │    │    │         └── cast: INT8 [as=x:1]
                 │    │    │    │              └── null
                 │    │    │    └── projections
-                │    │    │         └── cast: INT8 [as=y:4]
+                │    │    │         └── cast: INT8 [as=y:2]
                 │    │    │              └── null
                 │    │    └── projections
-                │    │         └── const: 1 [as=x:5]
+                │    │         └── const: 1 [as=x:3]
                 │    └── projections
-                │         └── case [as=stmt_if_2:12]
+                │         └── case [as=stmt_if_2:10]
                 │              ├── true
                 │              ├── when
                 │              │    ├── gt
-                │              │    │    ├── variable: x:5
+                │              │    │    ├── variable: x:3
                 │              │    │    └── const: 0
                 │              │    └── subquery
                 │              │         └── project
-                │              │              ├── columns: stmt_if_1:10
+                │              │              ├── columns: stmt_if_1:8
                 │              │              ├── project
-                │              │              │    ├── columns: y:9!null
+                │              │              │    ├── columns: y:7!null
                 │              │              │    ├── values
                 │              │              │    │    └── tuple
                 │              │              │    └── projections
-                │              │              │         └── const: 2 [as=y:9]
+                │              │              │         └── const: 2 [as=y:7]
                 │              │              └── projections
-                │              │                   └── udf: stmt_if_1 [as=stmt_if_1:10]
+                │              │                   └── udf: stmt_if_1 [as=stmt_if_1:8]
                 │              │                        ├── args
-                │              │                        │    ├── variable: x:5
-                │              │                        │    └── variable: y:9
-                │              │                        ├── params: x:6 y:7
+                │              │                        │    ├── variable: x:3
+                │              │                        │    └── variable: y:7
+                │              │                        ├── params: x:4 y:5
                 │              │                        └── body
                 │              │                             └── project
-                │              │                                  ├── columns: "_implicit_return":8
+                │              │                                  ├── columns: "_implicit_return":6
                 │              │                                  ├── values
                 │              │                                  │    └── tuple
                 │              │                                  └── projections
-                │              │                                       └── cast: RECORD [as="_implicit_return":8]
+                │              │                                       └── cast: RECORD [as="_implicit_return":6]
                 │              │                                            └── tuple
-                │              │                                                 ├── variable: x:6
-                │              │                                                 └── variable: y:7
+                │              │                                                 ├── variable: x:4
+                │              │                                                 └── variable: y:5
                 │              └── subquery
                 │                   └── project
-                │                        ├── columns: stmt_if_1:11
+                │                        ├── columns: stmt_if_1:9
                 │                        ├── values
                 │                        │    └── tuple
                 │                        └── projections
-                │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
+                │                             └── udf: stmt_if_1 [as=stmt_if_1:9]
                 │                                  ├── args
-                │                                  │    ├── variable: x:5
-                │                                  │    └── variable: y:4
-                │                                  ├── params: x:6 y:7
+                │                                  │    ├── variable: x:3
+                │                                  │    └── variable: y:2
+                │                                  ├── params: x:4 y:5
                 │                                  └── body
                 │                                       └── project
-                │                                            ├── columns: "_implicit_return":8
+                │                                            ├── columns: "_implicit_return":6
                 │                                            ├── values
                 │                                            │    └── tuple
                 │                                            └── projections
-                │                                                 └── cast: RECORD [as="_implicit_return":8]
+                │                                                 └── cast: RECORD [as="_implicit_return":6]
                 │                                                      └── tuple
-                │                                                           ├── variable: x:6
-                │                                                           └── variable: y:7
+                │                                                           ├── variable: x:4
+                │                                                           └── variable: y:5
                 └── const: 1

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -83,7 +83,6 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 
 	// Resolve the parameter names and types.
 	signatureTypes := make(tree.ParamTypes, 0, len(c.Params))
-	var procedureInputTypes tree.ParamTypes
 	var outParamTypes []*types.T
 	var outParamNames []string
 	for i := range c.Params {
@@ -94,12 +93,6 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 		}
 		if tree.IsParamIncludedIntoSignature(param.Class, c.IsProcedure) {
 			signatureTypes = append(signatureTypes, tree.ParamType{
-				Name: string(param.Name),
-				Typ:  typ,
-			})
-		}
-		if c.IsProcedure && tree.IsInParamClass(param.Class) {
-			procedureInputTypes = append(procedureInputTypes, tree.ParamType{
 				Name: string(param.Name),
 				Typ:  typ,
 			})
@@ -169,16 +162,15 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 	}
 	tc.currUDFOid++
 	overload := &tree.Overload{
-		Oid:                 tc.currUDFOid,
-		Types:               signatureTypes,
-		ReturnType:          tree.FixedReturnType(retType),
-		Body:                body,
-		Volatility:          v,
-		CalledOnNullInput:   calledOnNullInput,
-		Language:            language,
-		Type:                routineType,
-		RoutineParams:       c.Params,
-		ProcedureInputTypes: procedureInputTypes,
+		Oid:               tc.currUDFOid,
+		Types:             signatureTypes,
+		ReturnType:        tree.FixedReturnType(retType),
+		Body:              body,
+		Volatility:        v,
+		CalledOnNullInput: calledOnNullInput,
+		Language:          language,
+		Type:              routineType,
+		RoutineParams:     c.Params,
 	}
 	overload.ReturnsRecordType = types.IsRecordType(retType)
 	if c.ReturnType != nil && c.ReturnType.SetOf {

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -100,6 +100,8 @@ func getPlanColumns(plan planNode, mut bool) colinfo.ResultColumns {
 		return n.columns
 	case *showFingerprintsNode:
 		return n.columns
+	case *callNode:
+		return n.getResultColumns()
 
 	// Nodes with a fixed schema.
 	case *scrubNode:

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -332,7 +332,7 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 		descs := make([]DescriptorWithObjectType, 0, len(targetRoutines))
 		fnResolved := catalog.DescriptorIDSet{}
 		for _, f := range targetRoutines {
-			overload, err := p.matchRoutine(ctx, &f, true /* required */, routineType)
+			overload, err := p.matchRoutine(ctx, &f, true /* required */, routineType, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -332,7 +332,7 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 		descs := make([]DescriptorWithObjectType, 0, len(targetRoutines))
 		fnResolved := catalog.DescriptorIDSet{}
 		for _, f := range targetRoutines {
-			overload, err := p.matchRoutine(ctx, &f, true /* required */, routineType, false /* inDropOrReplaceContext */)
+			overload, err := p.matchRoutine(ctx, &f, true /* required */, routineType)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -332,7 +332,7 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 		descs := make([]DescriptorWithObjectType, 0, len(targetRoutines))
 		fnResolved := catalog.DescriptorIDSet{}
 		for _, f := range targetRoutines {
-			overload, err := p.matchRoutine(ctx, &f, true /* required */, routineType)
+			overload, err := p.matchRoutine(ctx, &f, true /* required */, routineType, false /* inDropOrReplaceContext */)
 			if err != nil {
 				return nil, err
 			}
@@ -345,13 +345,13 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 			if err != nil {
 				return nil, err
 			}
-			if isFuncs && fnDesc.IsProcedure() {
+			if isFuncs == fnDesc.IsProcedure() {
+				arg := "function"
+				if fnDesc.IsProcedure() {
+					arg = "procedure"
+				}
 				return nil, pgerror.Newf(pgcode.WrongObjectType, "%q is not a %s",
-					fnDesc.Name, "function")
-			}
-			if !isFuncs && !fnDesc.IsProcedure() {
-				return nil, pgerror.Newf(pgcode.WrongObjectType, "%q is not a %s",
-					fnDesc.Name, "procedure")
+					fnDesc.Name, arg)
 			}
 			descs = append(descs, DescriptorWithObjectType{
 				descriptor: fnDesc,

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -32,26 +32,65 @@ import (
 // A callNode executes a procedure.
 type callNode struct {
 	proc *tree.RoutineExpr
+	r    tree.Datums
 }
 
 var _ planNode = &callNode{}
 
 // startExec implements the planNode interface.
 func (d *callNode) startExec(params runParams) error {
-	// Until OUT and INOUT parameters are supported, all procedures return no
-	// results, so we can ignore the results of the routine.
-	_, err := eval.Expr(params.ctx, params.EvalContext(), d.proc)
-	return err
+	res, err := eval.Expr(params.ctx, params.EvalContext(), d.proc)
+	if err != nil {
+		return err
+	}
+	if d.proc.Typ.Family() == types.VoidFamily {
+		// With VOID return type we expect no rows to be produced, so we should
+		// get NULL value from the expression evaluation.
+		if res != tree.DNull {
+			return errors.AssertionFailedf("expected NULL, got %T", res)
+		}
+		return nil
+	}
+	tuple, ok := tree.AsDTuple(res)
+	if !ok {
+		return errors.AssertionFailedf("expected a tuple, got %T", res)
+	}
+	d.r = tuple.D
+	return nil
 }
 
 // Next implements the planNode interface.
-func (d *callNode) Next(params runParams) (bool, error) { return false, nil }
+func (d *callNode) Next(params runParams) (bool, error) {
+	return d.r != nil, nil
+}
 
 // Values implements the planNode interface.
-func (d *callNode) Values() tree.Datums { return nil }
+func (d *callNode) Values() tree.Datums {
+	r := d.r
+	d.r = nil
+	return r
+}
 
 // Close implements the planNode interface.
 func (d *callNode) Close(ctx context.Context) {}
+
+func (d *callNode) getResultColumns() colinfo.ResultColumns {
+	// The schema of the result row is specified in the tuple contents except
+	// when the return type is VOID (in which case the callNode returns
+	// nothing).
+	if d.proc.Typ.Family() == types.VoidFamily {
+		return colinfo.ResultColumns{}
+	}
+	names, typs := d.proc.Typ.TupleLabels(), d.proc.Typ.TupleContents()
+	cols := make(colinfo.ResultColumns, len(names))
+	for i := range cols {
+		cols[i] = colinfo.ResultColumn{
+			Name: names[i],
+			Typ:  typs[i],
+		}
+	}
+	return cols
+}
 
 // EvalRoutineExpr returns the result of evaluating the routine. It calls the
 // routine's ForEachPlan closure to generate a plan for each statement in the
@@ -245,10 +284,8 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 
 		var w rowResultWriter
 		openCursor := stmtIdx == 1 && g.expr.CursorDeclaration != nil
-		if isFinalPlan && !g.expr.Procedure {
-			// The result of this statement is the routine's output. This is never the
-			// case for a procedure, which does not output any rows (since we do not
-			// yet support OUT or INOUT parameters).
+		if isFinalPlan {
+			// The result of this statement is the routine's output.
 			w = rrw
 		} else if openCursor {
 			// The result of the first statement will be used to open a SQL cursor.

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1293,12 +1293,12 @@ func (b *builderState) ResolveRoutine(
 		panic(err)
 	}
 
-	signatureTypes, err := routineObj.SignatureTypes(b.ctx, b.cr)
+	signatureTypes, err := routineObj.SignatureTypes(b.ctx, b.cr, routineType, p.IsDropRoutine)
 	if err != nil {
 		return nil
 	}
-	ol, err := fd.MatchOverload(
-		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType,
+	ol, err := fd.MatchOverloadEx(
+		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType, p.IsDropRoutine,
 	)
 	if err != nil {
 		if p.IsExistenceOptional && errors.Is(err, tree.ErrRoutineUndefined) {

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1295,7 +1295,7 @@ func (b *builderState) ResolveRoutine(
 
 	signatureTypes, err := routineObj.SignatureTypes(b.ctx, b.cr, routineType)
 	if err != nil {
-		return nil
+		panic(err)
 	}
 	ol, err := fd.MatchOverload(
 		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType,

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1293,12 +1293,12 @@ func (b *builderState) ResolveRoutine(
 		panic(err)
 	}
 
-	signatureTypes, err := routineObj.SignatureTypes(b.ctx, b.cr, routineType, p.IsDropRoutine)
+	signatureTypes, err := routineObj.SignatureTypes(b.ctx, b.cr, routineType)
 	if err != nil {
 		return nil
 	}
-	ol, err := fd.MatchOverloadEx(
-		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType, p.IsDropRoutine,
+	ol, err := fd.MatchOverload(
+		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType,
 	)
 	if err != nil {
 		if p.IsExistenceOptional && errors.Is(err, tree.ErrRoutineUndefined) {

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1298,7 +1298,7 @@ func (b *builderState) ResolveRoutine(
 		panic(err)
 	}
 	ol, err := fd.MatchOverload(
-		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType,
+		signatureTypes, routineObj.FuncName.Schema(), b.semaCtx.SearchPath, routineType, p.IsCreate,
 	)
 	if err != nil {
 		if p.IsExistenceOptional && errors.Is(err, tree.ErrRoutineUndefined) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -51,6 +51,7 @@ func CreateFunction(b BuildCtx, n *tree.CreateRoutine) {
 		ResolveParams{
 			IsExistenceOptional: true,
 			RequireOwnership:    true,
+			IsCreate:            true,
 		},
 		tree.UDFRoutine|tree.ProcedureRoutine,
 	)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -352,10 +352,6 @@ type ResolveParams struct {
 	// ResolveTypes if set, instructs the catalog reader to resolve types
 	// and not just tables, sequences, and views.
 	ResolveTypes bool
-
-	// IsDropRoutine, if set, indicates that the resolution is being performed
-	// for a DROP FUNCTION or DROP PROCEDURE statement.
-	IsDropRoutine bool
 }
 
 // NameResolver looks up elements in the catalog by name, and vice-versa.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -352,6 +352,8 @@ type ResolveParams struct {
 	// ResolveTypes if set, instructs the catalog reader to resolve types
 	// and not just tables, sequences, and views.
 	ResolveTypes bool
+
+	IsCreate bool
 }
 
 // NameResolver looks up elements in the catalog by name, and vice-versa.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -352,6 +352,10 @@ type ResolveParams struct {
 	// ResolveTypes if set, instructs the catalog reader to resolve types
 	// and not just tables, sequences, and views.
 	ResolveTypes bool
+
+	// IsDropRoutine, if set, indicates that the resolution is being performed
+	// for a DROP FUNCTION or DROP PROCEDURE statement.
+	IsDropRoutine bool
 }
 
 // NameResolver looks up elements in the catalog by name, and vice-versa.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
@@ -37,6 +37,7 @@ func DropFunction(b BuildCtx, n *tree.DropRoutine) {
 	for _, f := range n.Routines {
 		elts := b.ResolveRoutine(&f, ResolveParams{
 			IsExistenceOptional: n.IfExists,
+			IsDropRoutine:       true,
 		}, routineType)
 		_, _, fn := scpb.FindFunction(elts)
 		if fn == nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
@@ -37,7 +37,6 @@ func DropFunction(b BuildCtx, n *tree.DropRoutine) {
 	for _, f := range n.Routines {
 		elts := b.ResolveRoutine(&f, ResolveParams{
 			IsExistenceOptional: n.IfExists,
-			IsDropRoutine:       true,
 		}, routineType)
 		_, _, fn := scpb.FindFunction(elts)
 		if fn == nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
@@ -37,6 +37,7 @@ func DropFunction(b BuildCtx, n *tree.DropRoutine) {
 	for _, f := range n.Routines {
 		elts := b.ResolveRoutine(&f, ResolveParams{
 			IsExistenceOptional: n.IfExists,
+			IsCreate:            false,
 		}, routineType)
 		_, _, fn := scpb.FindFunction(elts)
 		if fn == nil {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -634,8 +634,12 @@ func (i *immediateVisitor) SetObjectParentID(ctx context.Context, op scop.SetObj
 			IsProcedure: t.IsProcedure(),
 		}
 		for _, p := range t.Params {
-			if tree.IsParamIncludedIntoSignature(funcdesc.ToTreeRoutineParamClass(p.Class), ol.IsProcedure) {
+			class := funcdesc.ToTreeRoutineParamClass(p.Class)
+			if tree.IsParamIncludedIntoSignature(class, ol.IsProcedure) {
 				ol.ArgTypes = append(ol.ArgTypes, p.Type)
+			}
+			if ol.IsProcedure && tree.IsInParamClass(class) {
+				ol.InputTypes = append(ol.InputTypes, p.Type)
 			}
 		}
 		sc.AddFunction(obj.GetName(), ol)

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -638,6 +638,9 @@ func (i *immediateVisitor) SetObjectParentID(ctx context.Context, op scop.SetObj
 			if tree.IsParamIncludedIntoSignature(class, ol.IsProcedure) {
 				ol.ArgTypes = append(ol.ArgTypes, p.Type)
 			}
+			if tree.IsInParamClass(class) {
+				ol.InputTypes = append(ol.InputTypes, p.Type)
+			}
 		}
 		sc.AddFunction(obj.GetName(), ol)
 	}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -638,9 +638,6 @@ func (i *immediateVisitor) SetObjectParentID(ctx context.Context, op scop.SetObj
 			if tree.IsParamIncludedIntoSignature(class, ol.IsProcedure) {
 				ol.ArgTypes = append(ol.ArgTypes, p.Type)
 			}
-			if ol.IsProcedure && tree.IsInParamClass(class) {
-				ol.InputTypes = append(ol.InputTypes, p.Type)
-			}
 		}
 		sc.AddFunction(obj.GetName(), ol)
 	}

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -128,7 +128,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 		// Signature types depend on the routine type, but we don't know whether
 		// we have a function or a procedure, so we'll try the function first
 		// and then the procedure if necessary.
-		funcSignatureTypes, err := fn.SignatureTypes(ctx, evalCtx.Planner, tree.UDFRoutine, false /* inDropOrReplaceContext */)
+		funcSignatureTypes, err := fn.SignatureTypes(ctx, evalCtx.Planner, tree.UDFRoutine)
 		if err != nil {
 			return nil, err
 		}
@@ -139,7 +139,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 			tree.BuiltinRoutine|tree.UDFRoutine,
 		)
 		if err1 != nil {
-			procSignatureTypes, err := fn.SignatureTypes(ctx, evalCtx.Planner, tree.ProcedureRoutine, false /* inDropOrReplaceContext */)
+			procSignatureTypes, err := fn.SignatureTypes(ctx, evalCtx.Planner, tree.ProcedureRoutine)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -135,6 +135,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 			fn.FuncName.Schema(),
 			&evalCtx.SessionData().SearchPath,
 			routineType,
+			false,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -503,25 +503,15 @@ func (node *RoutineObj) Format(ctx *FmtCtx) {
 // SignatureTypes returns a slice of types that define a "signature" of the
 // function overload:
 //   - for functions only input parameters are included;
-//   - for procedures, all parameters are included, unless
-//     inDropOrReplaceContext is true, in which case only input parameters are
-//     included.
+//   - for procedures, all parameters are included.
 func (node RoutineObj) SignatureTypes(
-	ctx context.Context,
-	res TypeReferenceResolver,
-	routineType RoutineType,
-	inDropOrReplaceContext bool,
+	ctx context.Context, res TypeReferenceResolver, routineType RoutineType,
 ) ([]*types.T, error) {
 	var typs []*types.T
 	if node.Params != nil {
 		typs = make([]*types.T, 0, len(node.Params))
-		// Generally, for procedures all parameters are included into the
-		// signature; however, when we're in a DROP or a REPLACE context, then
-		// only input parameters should be included, so we pass
-		// isProcedure=false to get that behavior.
-		isProcedure := routineType == ProcedureRoutine && !inDropOrReplaceContext
 		for _, arg := range node.Params {
-			if IsParamIncludedIntoSignature(arg.Class, isProcedure) {
+			if IsParamIncludedIntoSignature(arg.Class, routineType == ProcedureRoutine /* isProcedure */) {
 				typ, err := ResolveType(ctx, arg.Type, res)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -500,19 +500,28 @@ func (node *RoutineObj) Format(ctx *FmtCtx) {
 	}
 }
 
-// SignatureTypes returns a slice of IN parameter types of the routine. These
-// types should be used for function resolution (i.e. they define the
-// "signature" of the function overload).
+// SignatureTypes returns a slice of types that define a "signature" of the
+// function overload:
+//   - for functions only input parameters are included;
+//   - for procedures, all parameters are included, unless
+//     inDropOrReplaceContext is true, in which case only input parameters are
+//     included.
 func (node RoutineObj) SignatureTypes(
-	ctx context.Context, res TypeReferenceResolver,
+	ctx context.Context,
+	res TypeReferenceResolver,
+	routineType RoutineType,
+	inDropOrReplaceContext bool,
 ) ([]*types.T, error) {
 	var typs []*types.T
 	if node.Params != nil {
 		typs = make([]*types.T, 0, len(node.Params))
+		// Generally, for procedures all parameters are included into the
+		// signature; however, when we're in a DROP or a REPLACE context, then
+		// only input parameters should be included, so we pass
+		// isProcedure=false to get that behavior.
+		isProcedure := routineType == ProcedureRoutine && !inDropOrReplaceContext
 		for _, arg := range node.Params {
-			if arg.IsInParam() {
-				// TODO(100405): we might need to include all parameters for
-				// procedures here.
+			if IsParamIncludedIntoSignature(arg.Class, isProcedure) {
 				typ, err := ResolveType(ctx, arg.Type, res)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -261,29 +261,7 @@ func (fd *ResolvedFunctionDefinition) MergeWith(
 func (fd *ResolvedFunctionDefinition) MatchOverload(
 	paramTypes []*types.T, explicitSchema string, searchPath SearchPath, routineType RoutineType,
 ) (QualifiedOverload, error) {
-	return fd.MatchOverloadEx(paramTypes, explicitSchema, searchPath, routineType, false /* inDropOrReplaceContext */)
-}
-
-// MatchOverloadEx is the same as MatchOverload but allows the caller to specify
-// whether the matching is performing for a routine that is being dropped or
-// replaced.
-func (fd *ResolvedFunctionDefinition) MatchOverloadEx(
-	paramTypes []*types.T,
-	explicitSchema string,
-	searchPath SearchPath,
-	routineType RoutineType,
-	inDropOrReplaceContext bool,
-) (QualifiedOverload, error) {
 	matched := func(ol QualifiedOverload, schema string) bool {
-		if inDropOrReplaceContext && ol.Type == ProcedureRoutine {
-			// When dropping or replacing a procedure, all OUT parameters can be
-			// ignored. We achieve this by not including them into paramTypes
-			// which are produced by SignatureTypes call and verifying
-			// paramTypes against the input types.
-			if schema == ol.Schema && ol.ProcedureInputTypes.MatchIdentical(paramTypes) {
-				return true
-			}
-		}
 		if ol.Type == UDFRoutine || ol.Type == ProcedureRoutine {
 			return schema == ol.Schema && (paramTypes == nil || ol.params().MatchIdentical(paramTypes))
 		}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -256,12 +256,34 @@ func (fd *ResolvedFunctionDefinition) MergeWith(
 // types. The overload from the most significant schema is returned. If
 // paramTypes==nil, an error is returned if the function name is not unique in
 // the most significant schema. If paramTypes is not nil, an error with
-// ErrRoutineUndefined cause is returned if not matched found. Overloads that
+// ErrRoutineUndefined cause is returned if not matches found. Overloads that
 // don't match the types in routineType are ignored.
 func (fd *ResolvedFunctionDefinition) MatchOverload(
 	paramTypes []*types.T, explicitSchema string, searchPath SearchPath, routineType RoutineType,
 ) (QualifiedOverload, error) {
+	return fd.MatchOverloadEx(paramTypes, explicitSchema, searchPath, routineType, false /* inDropOrReplaceContext */)
+}
+
+// MatchOverloadEx is the same as MatchOverload but allows the caller to specify
+// whether the matching is performing for a routine that is being dropped or
+// replaced.
+func (fd *ResolvedFunctionDefinition) MatchOverloadEx(
+	paramTypes []*types.T,
+	explicitSchema string,
+	searchPath SearchPath,
+	routineType RoutineType,
+	inDropOrReplaceContext bool,
+) (QualifiedOverload, error) {
 	matched := func(ol QualifiedOverload, schema string) bool {
+		if inDropOrReplaceContext && ol.Type == ProcedureRoutine {
+			// When dropping or replacing a procedure, all OUT parameters can be
+			// ignored. We achieve this by not including them into paramTypes
+			// which are produced by SignatureTypes call and verifying
+			// paramTypes against the input types.
+			if schema == ol.Schema && ol.ProcedureInputTypes.MatchIdentical(paramTypes) {
+				return true
+			}
+		}
 		if ol.Type == UDFRoutine || ol.Type == ProcedureRoutine {
 			return schema == ol.Schema && (paramTypes == nil || ol.params().MatchIdentical(paramTypes))
 		}

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -245,7 +245,7 @@ func TestMatchOverload(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			path := sessiondata.MakeSearchPath(tc.path)
 			ol, err := fd.MatchOverload(
-				tc.argTypes,
+				[][]*types.T{tc.argTypes},
 				tc.explicitSchema,
 				&path,
 				tc.routineType,

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -249,6 +249,7 @@ func TestMatchOverload(t *testing.T) {
 				tc.explicitSchema,
 				&path,
 				tc.routineType,
+				false,
 			)
 			if tc.expectedErr != "" {
 				require.Regexp(t, tc.expectedErr, err.Error())

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -272,10 +272,6 @@ type Overload struct {
 	// the signature of the function), RoutineParams contains all parameters as
 	// well as their class.
 	RoutineParams RoutineParams
-	// ProcedureInputTypes are all IN / INOUT parameters of a procedure. It
-	// remains unset if Type is not ProcedureRoutine and is only populated when
-	// UDFContainsOnlySignature is true.
-	ProcedureInputTypes TypeList
 }
 
 // params implements the overloadImpl interface.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -272,6 +272,10 @@ type Overload struct {
 	// the signature of the function), RoutineParams contains all parameters as
 	// well as their class.
 	RoutineParams RoutineParams
+	// ProcedureInputTypes are all IN / INOUT parameters of a procedure. It
+	// remains unset if Type is not ProcedureRoutine and is only populated when
+	// UDFContainsOnlySignature is true.
+	ProcedureInputTypes TypeList
 }
 
 // params implements the overloadImpl interface.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -274,7 +274,8 @@ type Overload struct {
 	// Note that unlike Types (which only contains input parameters and defines
 	// the signature of the function), RoutineParams contains all parameters as
 	// well as their class.
-	RoutineParams RoutineParams
+	RoutineParams       RoutineParams
+	ProcedureInputTypes []*types.T
 }
 
 // params implements the overloadImpl interface.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -131,6 +131,9 @@ func (c FunctionClass) String() string {
 }
 
 // RoutineType specifies the type of routine represented by an overload.
+//
+// WARNING: in some places we use bitwise-OR to represent multiple routine
+// types, so exact comparison might be incorrect.
 type RoutineType uint8
 
 const (

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -487,7 +487,7 @@ func TestGetMostSignificantOverload(t *testing.T) {
 			}
 			overload, err := getMostSignificantOverload(
 				tc.overloads, impls, filters, tc.searchPath, &expr, nil, /* typedInputExprs */
-				func() string { return "some signature" },
+				func() string { return "some signature" }, nil,
 			)
 			if tc.expectedErr != "" {
 				require.Error(t, err)

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -664,7 +664,7 @@ func (*BeginTransaction) StatementType() StatementType { return TypeTCL }
 func (*BeginTransaction) StatementTag() string { return "BEGIN" }
 
 // StatementReturnType implements the Statement interface.
-func (*Call) StatementReturnType() StatementReturnType { return Ack }
+func (*Call) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.
 func (*Call) StatementType() StatementType { return TypeTCL }


### PR DESCRIPTION
This commit finalizes the overload resolution for procedures. In
particular, unlike for UDFs (which only include input parameters into
the signature as well as the invocation), for procedures the "signature"
depends on the context:
- on the main path, when calling the procedure, all parameters need to
be specified, including OUT parameters (customarilly, NULL values are
passed for them)
- but in DROP or REPLACE context, OUT parameters are ignored.

This commit audits all callers to use the first behavior by default, and
then customizes the resolution logic for the second case where
applicable.

This two-way behavior required plumbing the input types into the
overload struct for procedures (including into the proto).

An additional quirk of procedures when comparing to UDFs is that if any
output parameters are specified, they define a RECORD return type (even
with a single column). This required some adjustments to the existing
logic.

Note that this commit doesn't have any tests that actually call the
procedures, because that logic is implemented in the following commit
(previously, since we didn't support output parameters, procedures
always returned VOID / NULL).

Release note: None