### PR TITLE
roachtest: limit payload sizes in backup-restore/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2563,8 +2563,14 @@ func tpccWorkloadCmd(
 func bankWorkloadCmd(
 	l *logger.Logger, testRNG *rand.Rand, roachNodes option.NodeListOption, mock bool,
 ) (init *roachtestutil.Command, run *roachtestutil.Command) {
-	bankPayload := bankPossiblePayloadBytes[testRNG.Intn(len(bankPossiblePayloadBytes))]
 	bankRows := bankPossibleRows[testRNG.Intn(len(bankPossibleRows))]
+	possiblePayloads := bankPossiblePayloadBytes
+	// force smaller row counts to use smaller payloads too to avoid making lots
+	// of large revisions of a handful of keys.
+	if bankRows < 1000 {
+		possiblePayloads = []int{16, 64}
+	}
+	bankPayload := possiblePayloads[testRNG.Intn(len(possiblePayloads))]
 
 	if mock {
 		bankPayload = 9


### PR DESCRIPTION
Previously it could randomly choose to revise only 100 rows with 16kb payloads in every revision. While this usually works when run on 512mb ranges, it can flake when run on 64mb ranges as that many large revisions exceeds the range's capacity.

Release note: none.
Epic: none.