### PR TITLE
sql,storage: disable writing ImportEpochs

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/import-epoch
+++ b/pkg/ccl/backupccl/testdata/backup-restore/import-epoch
@@ -6,6 +6,11 @@ new-cluster name=s1
 ----
 
 exec-sql
+SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=true;
+----
+
+
+exec-sql
 CREATE DATABASE d;
 USE d;
 CREATE TABLE foo (i INT PRIMARY KEY, s STRING);

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -410,6 +410,7 @@ func (r *importResumer) prepareTablesForIngestion(
 	var desc *descpb.TableDescriptor
 
 	useImportEpochs := p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V24_1)
+	useImportEpochs = useImportEpochs && importEpochs.Get(&p.ExecCfg().Settings.SV)
 	for i, table := range details.Tables {
 		if !table.IsNew {
 			desc, err = prepareExistingTablesForIngestion(ctx, txn, descsCol, table.Desc, useImportEpochs)
@@ -1254,6 +1255,13 @@ var retryDuration = settings.RegisterDurationSetting(
 	"duration during which the IMPORT can be retried in face of non-permanent errors",
 	time.Minute*2,
 	settings.PositiveDuration,
+)
+
+var importEpochs = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"bulkio.import.write_import_epoch.enabled",
+	"controls whether IMPORT will write ImportEpoch's to descriptors",
+	false,
 )
 
 func getFractionCompleted(job *jobs.Job) float64 {

--- a/pkg/sql/importer/import_mvcc_test.go
+++ b/pkg/sql/importer/import_mvcc_test.go
@@ -53,6 +53,7 @@ func TestMVCCValueHeaderImportEpoch(t *testing.T) {
 
 	// Create a table where the first row ( in sort order) comes from an IMPORT
 	// while the second comes from an INSERT.
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=true`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (a INT8)`)
 	sqlDB.Exec(t, `INSERT INTO d.t VALUES ('2')`)
 	sqlDB.Exec(t, `IMPORT INTO d.t CSV DATA ($1)`, srv.URL)


### PR DESCRIPTION
Stress tests of the tenant-backup nemesis have shown that there is a problem when writing ImportEpochs.

While we debug this problem, disabling the writing of ImportEpochs should stop the test from failing.

Epic: none
Release note: none