### PR TITLE
roachtest: deprecate multitenant_utils

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -531,14 +531,14 @@ func (rd *replicationDriver) setupC2C(
 
 	overrideSrcAndDestTenantTTL(t, srcSQL, destSQL, rd.rs.overrideTenantTTL)
 
-	createTenantAdminRole(t, "src-system", srcSQL)
-	createTenantAdminRole(t, "dst-system", destSQL)
+	deprecatedCreateTenantAdminRole(t, "src-system", srcSQL)
+	deprecatedCreateTenantAdminRole(t, "dst-system", destSQL)
 
 	srcTenantID, destTenantID := 2, 2
 	srcTenantName := "src-tenant"
 	destTenantName := "destination-tenant"
 
-	createInMemoryTenant(ctx, t, c, srcTenantName, srcCluster, true)
+	deprecatedCreateInMemoryTenant(ctx, t, c, srcTenantName, srcCluster, true)
 
 	pgURL, err := copyPGCertsAndMakeURL(ctx, t, c, srcNode, srcClusterSetting.PGUrlCertsDir, addr[0])
 	require.NoError(t, err)
@@ -983,7 +983,7 @@ func (rd *replicationDriver) main(ctx context.Context) {
 	rd.metrics.cutoverEnd = newMetricSnapshot(metricSnapper, timeutil.Now())
 
 	rd.t.L().Printf("starting the destination tenant")
-	conn := startInMemoryTenant(ctx, rd.t, rd.c, rd.setup.dst.name, rd.setup.dst.gatewayNodes)
+	conn := deprecatedStartInMemoryTenant(ctx, rd.t, rd.c, rd.setup.dst.name, rd.setup.dst.gatewayNodes)
 	conn.Close()
 
 	rd.metrics.export(rd.t, len(rd.setup.src.nodes))

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -120,7 +120,7 @@ func runAcceptanceMultitenantMultiRegion(ctx context.Context, t test.Test, c clu
 	for i, node := range c.All() {
 		region := regions[i]
 		regionInfo := fmt.Sprintf("cloud=%s,region=%s,zone=%s", c.Cloud(), regionOnly(region), region)
-		tenant := createTenantNode(ctx, t, c, c.All(), tenantID, node, tenantHTTPPort, tenantSQLPort, createTenantRegion(regionInfo))
+		tenant := deprecatedCreateTenantNode(ctx, t, c, c.All(), tenantID, node, tenantHTTPPort, tenantSQLPort, createTenantRegion(regionInfo))
 		tenant.start(ctx, t, c, "./cockroach")
 		tenants = append(tenants, tenant)
 

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -113,13 +113,13 @@ func runMultiTenantUpgrade(
 	// Create two instances of tenant 11 so that we can test with two pods
 	// running during migration.
 	const tenantNode = 2
-	tenant11a := createTenantNode(ctx, t, c, kvNodes, tenant11ID, tenantNode, tenant11aHTTPPort, tenant11aSQLPort)
+	tenant11a := deprecatedCreateTenantNode(ctx, t, c, kvNodes, tenant11ID, tenantNode, tenant11aHTTPPort, tenant11aSQLPort)
 	tenant11a.start(ctx, t, c, predecessorBinary)
 	defer tenant11a.stop(ctx, t, c)
 
-	// Since the certs are created with the createTenantNode call above, we
+	// Since the certs are created with the deprecatedCreateTenantNode call above, we
 	// call the "no certs" version of create tenant here.
-	tenant11b := createTenantNodeNoCerts(ctx, t, c, kvNodes, tenant11ID, tenantNode, tenant11bHTTPPort, tenant11bSQLPort)
+	tenant11b := deprecatedCreateTenantNodeNoCerts(ctx, t, c, kvNodes, tenant11ID, tenantNode, tenant11bHTTPPort, tenant11bSQLPort)
 	tenant11b.start(ctx, t, c, predecessorBinary)
 	defer tenant11b.stop(ctx, t, c)
 
@@ -174,7 +174,7 @@ func runMultiTenantUpgrade(
 			withResults([][]string{{"1", "bar"}}))
 
 	t.Status("starting tenant 12 server with older binary")
-	tenant12 := createTenantNode(ctx, t, c, kvNodes, tenant12ID, tenantNode, tenant12HTTPPort, tenant12SQLPort)
+	tenant12 := deprecatedCreateTenantNode(ctx, t, c, kvNodes, tenant12ID, tenantNode, tenant12HTTPPort, tenant12SQLPort)
 	tenant12.start(ctx, t, c, predecessorBinary)
 	defer tenant12.stop(ctx, t, c)
 
@@ -196,7 +196,7 @@ func runMultiTenantUpgrade(
 	runner.Exec(t, `SELECT crdb_internal.create_tenant($1::INT)`, tenant13ID)
 
 	t.Status("starting tenant 13 server with new binary")
-	tenant13 := createTenantNode(ctx, t, c, kvNodes, tenant13ID, tenantNode, tenant13HTTPPort, tenant13SQLPort)
+	tenant13 := deprecatedCreateTenantNode(ctx, t, c, kvNodes, tenant13ID, tenantNode, tenant13HTTPPort, tenant13SQLPort)
 	tenant13.start(ctx, t, c, currentBinary)
 	defer tenant13.stop(ctx, t, c)
 
@@ -356,7 +356,7 @@ func runMultiTenantUpgrade(
 	runner.Exec(t, `SELECT crdb_internal.create_tenant($1::INT)`, tenant14ID)
 
 	t.Status("verifying that the tenant 14 server works and has the proper version")
-	tenant14 := createTenantNode(ctx, t, c, kvNodes, tenant14ID, tenantNode, tenant14HTTPPort, tenant14SQLPort)
+	tenant14 := deprecatedCreateTenantNode(ctx, t, c, kvNodes, tenant14ID, tenantNode, tenant14HTTPPort, tenant14SQLPort)
 	tenant14.start(ctx, t, c, currentBinary)
 	defer tenant14.stop(ctx, t, c)
 	verifySQL(t, tenant14.pgURL,

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -107,7 +107,8 @@ func createTenantNodeInternal(
 	return tn
 }
 
-func createTenantNode(
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedCreateTenantNode(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
@@ -118,7 +119,8 @@ func createTenantNode(
 	return createTenantNodeInternal(ctx, t, c, kvnodes, tenantID, node, httpPort, sqlPort, true /* certs */, opts...)
 }
 
-func createTenantNodeNoCerts(
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedCreateTenantNodeNoCerts(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
@@ -189,7 +191,7 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	randomSeed := rand.Int63()
 	c.SetRandomSeed(randomSeed)
 	require.NoError(t, err)
-	tn.errCh = startTenantServer(
+	tn.errCh = deprecatedStartTenantServer(
 		ctx, c, c.Node(tn.node), internalIPs[0], binary, tn.kvAddrs, tn.tenantID,
 		tn.httpPort, tn.sqlPort, tn.envVars, randomSeed,
 		extraArgs...,
@@ -251,7 +253,8 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	t.L().Printf("sql server for tenant %d (instance %d) now running", tn.tenantID, tn.instanceID)
 }
 
-func startTenantServer(
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedStartTenantServer(
 	tenantCtx context.Context,
 	c cluster.Cluster,
 	node option.NodeListOption,
@@ -289,8 +292,11 @@ func startTenantServer(
 	return errCh
 }
 
-// createTenantAdminRole creates a role that can be used to log into a secure cluster's db console.
-func createTenantAdminRole(t test.Test, tenantName string, tenantSQL *sqlutils.SQLRunner) {
+// deprecatedCreateTenantAdminRole creates a role that can be used to log into a secure cluster's db console.
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedCreateTenantAdminRole(
+	t test.Test, tenantName string, tenantSQL *sqlutils.SQLRunner,
+) {
 	tenantSQL.Exec(t, fmt.Sprintf(`CREATE ROLE IF NOT EXISTS %s WITH LOGIN PASSWORD '%s'`, install.DefaultUser, install.DefaultPassword))
 	tenantSQL.Exec(t, fmt.Sprintf(`GRANT ADMIN TO %s`, install.DefaultUser))
 	t.L().Printf(`Log into %s db console with username "%s" and password "%s"`,
@@ -299,9 +305,10 @@ func createTenantAdminRole(t test.Test, tenantName string, tenantSQL *sqlutils.S
 
 const appTenantName = "app"
 
-// createInMemoryTenant runs through the necessary steps to create an in-memory
+// deprecatedCreateInMemoryTenant runs through the necessary steps to create an in-memory
 // tenant without resource limits and full dbconsole viewing privileges.
-func createInMemoryTenant(
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedCreateInMemoryTenant(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
@@ -309,15 +316,16 @@ func createInMemoryTenant(
 	nodes option.NodeListOption,
 	secure bool,
 ) {
-	db := createInMemoryTenantWithConn(ctx, t, c, tenantName, nodes, secure)
+	db := deprecatedCreateInMemoryTenantWithConn(ctx, t, c, tenantName, nodes, secure)
 	db.Close()
 }
 
-// createInMemoryTenantWithConn runs through the necessary steps to create an
+// deprecatedCreateInMemoryTenantWithConn runs through the necessary steps to create an
 // in-memory tenant without resource limits and full dbconsole viewing
 // privileges. As a convenience, it also returns a connection to the tenant (on
 // a random node in the cluster).
-func createInMemoryTenantWithConn(
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedCreateInMemoryTenantWithConn(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
@@ -330,19 +338,20 @@ func createInMemoryTenantWithConn(
 	sysSQL := sqlutils.MakeSQLRunner(sysDB)
 	sysSQL.Exec(t, "CREATE TENANT $1", tenantName)
 
-	tenantConn := startInMemoryTenant(ctx, t, c, tenantName, nodes)
+	tenantConn := deprecatedStartInMemoryTenant(ctx, t, c, tenantName, nodes)
 	tenantSQL := sqlutils.MakeSQLRunner(tenantConn)
 	if secure {
-		createTenantAdminRole(t, tenantName, tenantSQL)
+		deprecatedCreateTenantAdminRole(t, tenantName, tenantSQL)
 	}
 	return tenantConn
 }
 
-// startInMemoryTenant starts an in memory tenant that has already been created.
+// deprecatedStartInMemoryTenant starts an in memory tenant that has already been created.
 // This function also removes tenant rate limiters and sets a few cluster
 // settings on the tenant.  As a convenience, it also returns a connection to
 // the tenant (on a random node in the cluster).
-func startInMemoryTenant(
+// Deprecated: use Cluster.StartServiceForVirtualCluster instead.
+func deprecatedStartInMemoryTenant(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,


### PR DESCRIPTION
Previously, `multitenant_utils.go` provided convenience functions to start virtual clusters. These utils served as a good interim, but lacked proper integration with roachprod and the cluster interfaces. After the introduction of virtual cluster APIs in roachprod and roachtest those interfaces should rather be used from now on.

The functions exposed in `multitenant_utils.go` have been prefixed with deprecated, and given added docs to discourage any further use and point future implementations to the new API.

See: #115867

Epic: None
Release Note: None