### PR TITLE
storage: EncodeMVCCValueToBuf indicates if RawBytes was returned

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -340,7 +340,10 @@ func (b *SSTBatcher) AddMVCCKeyWithImportEpoch(
 		return err
 	}
 	mvccVal.MVCCValueHeader.ImportEpoch = importEpoch
-	b.valueScratch, err = storage.EncodeMVCCValueToBuf(mvccVal, b.valueScratch[:0])
+	buf, canRetainBuffer, err := storage.EncodeMVCCValueToBuf(mvccVal, b.valueScratch[:0])
+	if canRetainBuffer {
+		b.valueScratch = buf
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -7886,11 +7886,14 @@ func mvccExportToWriter(
 			}
 
 			if !ok && opts.IncludeMVCCValueHeader {
-				valueScratch, err = EncodeMVCCValueForExport(mvccValue, valueScratch[:0])
+				buf, canRetainBuf, err := EncodeMVCCValueForExport(mvccValue, valueScratch[:0])
 				if err != nil {
 					return kvpb.BulkOpSummary{}, ExportRequestResumeInfo{}, errors.Wrapf(err, "repackaging imported mvcc value %s", unsafeKey)
 				}
-				unsafeValue = valueScratch
+				if canRetainBuf {
+					valueScratch = buf
+				}
+				unsafeValue = buf
 			} else {
 				unsafeValue = mvccValue.Value.RawBytes
 			}

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -105,7 +105,7 @@ func TestEncodeMVCCValueForExport(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			encodedVal, err := EncodeMVCCValueForExport(tc.val, nil)
+			encodedVal, _, err := EncodeMVCCValueForExport(tc.val, nil)
 			require.NoError(t, err)
 			strippedMVCCVal, err := DecodeMVCCValue(encodedVal)
 			require.NoError(t, err)
@@ -320,7 +320,7 @@ func BenchmarkEncodeMVCCValueForExport(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					var err error
-					buf, err = EncodeMVCCValueForExport(mvccValue, buf[:0])
+					buf, _, err = EncodeMVCCValueForExport(mvccValue, buf[:0])
 					if err != nil { // for performance
 						require.NoError(b, err)
 					}
@@ -342,7 +342,7 @@ func BenchmarkEncodeMVCCValueWithAllocator(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					var err error
-					buf, err = EncodeMVCCValueToBuf(mvccValue, buf[:0])
+					buf, _, err = EncodeMVCCValueToBuf(mvccValue, buf[:0])
 					if err != nil { // for performance
 						require.NoError(b, err)
 					}


### PR DESCRIPTION
EncodeMVCCValueToBuf has a fast-path that directly returns RawBytes if the MVCCValueHeader is empty. This fast path is rather important.

However, the API encouraged callers to retain the returned buffer. But in the case of returning RawBytes, that buffer may not be safe to retain.

Fixes #120442

Release note: None