### PR TITLE
drt: cleanup workload runner scripts

### DIFF
--- a/pkg/cmd/drt/scripts/schemachange_run.sh
+++ b/pkg/cmd/drt/scripts/schemachange_run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+PGURLS=$(./roachprod pgurl cct-232 --external --secure --cluster application | sed s/\'//g)
+read -r -a PGURLS_ARR <<< "$PGURLS"
+
+j=0
+while true; do
+    echo ">> Starting random schema change workload"
+    ((j++))
+    LOG=./schemachange_$j.txt
+    ./workload run schemachange --verbose=1 \
+         --tolerate-errors=true \
+         --histograms /mnt/data1/schemachange_perf/stats.json \
+         --concurrency 10 \
+         --txn-log /mnt/data1/schemachange_perf/txn.log \
+         --secure \
+         --user cct_schemachange_user \
+         --db schemachange \
+         --password cct_schemachange_password \
+          "${PGURLS_ARR[@]}" | tee "$LOG"
+    if [ 0 -eq 0 ]; then
+        rm "$LOG"
+    fi
+    sleep 1
+done

--- a/pkg/cmd/drt/scripts/start_all_workloads.sh
+++ b/pkg/cmd/drt/scripts/start_all_workloads.sh
@@ -1,4 +1,6 @@
-sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_kv ./kv_run.sh
-sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_tpcc ./tpcc_run.sh
-sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_tpcc_drop ./cct_tpcc_drop.sh
-sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_schemachange ./schemachange_run.sh
+sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_kv --uid 1000 --gid 1000 ./kv_run.sh
+sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_tpcc --uid 1000 --gid 1000 ./tpcc_run.sh
+sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_tpcc_drop --uid 1000 --gid 1000 ./cct_tpcc_drop.sh
+sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_schemachange --uid 1000 --gid 1000 ./schemachange_run.sh
+sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit chaos_test --uid=1000 --gid=1000 ./chaos_helper.sh
+sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit roachtest_operations --uid 1000 --gid 1000 ./roachtest_operations_run.sh

--- a/pkg/cmd/drt/scripts/stop_all_workloads.sh
+++ b/pkg/cmd/drt/scripts/stop_all_workloads.sh
@@ -2,3 +2,4 @@ sudo systemctl stop cct_schemachange
 sudo systemctl stop cct_kv
 sudo systemctl stop cct_tpcc
 sudo systemctl stop cct_tpcc_drop
+sudo systemctl stop chaos_test

--- a/pkg/cmd/drt/scripts/tpcc_run.sh
+++ b/pkg/cmd/drt/scripts/tpcc_run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+TPCC_DB=cct_tpcc
+TPCC_USER=cct_tpcc_user
+TPCC_PASSWORD=tpcc
+PGURLS=$(./roachprod pgurl cct-232 --external --secure --cluster application | sed s/\'//g)
+
+read -r -a PGURLS_ARR <<< "$PGURLS"
+
+j=0
+while true; do
+    echo ">> Starting tpcc workload"
+    ((j++))
+    LOG=./tpcc_$j.txt
+    ./cockroach workload run tpcc \
+      --warehouses 3000 \
+      --active-warehouses 1500 \
+      --concurrency 128 \
+      --max-rate 7000 \
+      --db cct_tpcc \
+      --secure \
+      --ramp 10m \
+      --display-every 5s \
+      --duration 12h \
+      --user cct_tpcc_user \
+      --tolerate-errors \
+      --password tpcc \
+      --families \
+        "${PGURLS_ARR[@]}" | tee $LOG
+    if [ $? -eq 0 ]; then
+        rm "$LOG"
+    fi
+    sleep 1
+done


### PR DESCRIPTION
Cleanup the workload runner scripts to:

- Add the chaos test to systemd-run
- Fix a few errors in cct_tpcc_drop
- Add kv and tpcc scripts

Release note: none
Epic: none