### PR TITLE
streamingccl: elide MVCCValueHeaders from SSTs

### DIFF
--- a/pkg/ccl/streamingccl/replicationutils/utils_test.go
+++ b/pkg/ccl/streamingccl/replicationutils/utils_test.go
@@ -69,6 +69,7 @@ func TestScanSST(t *testing.T) {
 		storageutils.RangeKV("ca", "da", 20, ""),
 		// Delete range for t3s - t3e, emitting nothing.
 		storageutils.RangeKV("e", "f", 25, ""),
+		storageutils.PointKVWithImportEpoch("g", 25, 1, "val"),
 	})
 
 	checkScan := func(scanWithin roachpb.Span,
@@ -99,6 +100,11 @@ func TestScanSST(t *testing.T) {
 		[]storage.MVCCRangeKey{
 			storageutils.RangeKey("a", "b", 10),
 		})
+	checkScan(roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")},
+		[]storage.MVCCKeyValue{
+			storageutils.PointKVWithImportEpoch("g", 25, 1, "val"),
+		},
+		[]storage.MVCCRangeKey{})
 
 	checkScan(roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
 		[]storage.MVCCKeyValue{

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -767,10 +767,19 @@ func (sip *streamIngestionProcessor) bufferSST(sst *kvpb.RangeFeedSSTable) error
 	defer sp.Finish()
 	return replicationutils.ScanSST(sst, sst.Span,
 		func(keyVal storage.MVCCKeyValue) error {
+			// TODO(ssd): We technically get MVCCValueHeaders in our
+			// SSTs. But currently there are so many ways _not_ to
+			// get them that writing them here would just be
+			// confusing until we fix them all.
+			mvccValue, err := storage.DecodeValueFromMVCCValue(keyVal.Value)
+			if err != nil {
+				return err
+			}
+
 			return sip.bufferKV(&roachpb.KeyValue{
 				Key: keyVal.Key.Key,
 				Value: roachpb.Value{
-					RawBytes:  keyVal.Value,
+					RawBytes:  mvccValue.RawBytes,
 					Timestamp: keyVal.Key.Timestamp,
 				},
 			})

--- a/pkg/testutils/storageutils/kv.go
+++ b/pkg/testutils/storageutils/kv.go
@@ -59,6 +59,26 @@ func PointKVWithLocalTS(key string, ts int, localTS int, value string) storage.M
 	}
 }
 
+// PointKVWithImportEpoch creates an MVCCKeyValue for the given string key/value,
+// timestamp, and ImportEpoch.
+func PointKVWithImportEpoch(
+	key string, ts int, importEpoch uint32, value string,
+) storage.MVCCKeyValue {
+	var mvccValue storage.MVCCValue
+	if value != "" {
+		mvccValue = StringValue(value)
+	}
+	mvccValue.ImportEpoch = importEpoch
+	v, err := storage.EncodeMVCCValue(mvccValue)
+	if err != nil {
+		panic(err)
+	}
+	return storage.MVCCKeyValue{
+		Key:   PointKey(key, ts),
+		Value: v,
+	}
+}
+
 // RangeKey creates an MVCCRangeKey for the given string key and timestamp
 // (in walltime seconds).
 func RangeKey(start, end string, ts int) storage.MVCCRangeKey {


### PR DESCRIPTION
We don't get MVCCValueHeaders during backfills or via the rangefeed. We need to support this eventually, but for now it is better to consistently _not_ have thm.

Epic: none
Release note: None