### PR TITLE
pkg/sql/sem/tree: add FmtConstantsAsUnderscores fmt flag 

### DIFF
--- a/pkg/sql/sem/tree/adjust_constants.go
+++ b/pkg/sql/sem/tree/adjust_constants.go
@@ -21,6 +21,17 @@ import (
 // FmtHideConstants or FmtShortenConstants is set in the flags and the node is
 // affected by that format.
 func (ctx *FmtCtx) formatNodeOrAdjustConstants(n NodeFormatter) {
+	if ctx.HasFlags(FmtConstantsAsUnderscores) {
+		switch n.(type) {
+		case *Placeholder, *StrVal, Datum, Constant:
+			// If we have a placeholder, a string literal, a datum or a constant,
+			// we want to print the same special character for all of them. This
+			// is to avoid creating different fingerprints for queries that are
+			// actually equivalent.
+			ctx.WriteByte(StmtFingerprintPlaceholder)
+			return
+		}
+	}
 	if ctx.flags.HasFlags(FmtCollapseLists) {
 		// This is a more aggressive form of collapsing lists than the cases
 		// provided by FmtHideConstants and FmtShortenConstants.

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -179,9 +179,19 @@ const (
 	// by "__more__". E.g.
 	//  SELECT * FROM foo where v IN (1, 2+2, $1, $2*3) => SELECT * FROM foo where v IN (_, __more__)
 	FmtCollapseLists
+
+	// FmtConstantsAsUnderscores instructs the pretty-printer to format
+	// constants (literals, placeholders) as underscores.
+	// e.g.
+	//   SELECT 1, 'a', $1 => SELECT _, _, _
+	FmtConstantsAsUnderscores
 )
 
 const genericArityIndicator = "__more__"
+
+// StmtFingerprintPlaceholder is the char that replaces all literals and
+// placeholders in a query when computing its fingerprint.
+const StmtFingerprintPlaceholder = '_'
 
 // PasswordSubstitution is the string that replaces
 // passwords unless FmtShowPasswords is specified.


### PR DESCRIPTION
Please note that only the latest commit should be reviewed here.

---------------------------
The new AST format flag  `FmtConstantsAsUnderscores` can be used
to format placeholders and literals as the same char to reduce any potential
cardinality from variances in formatting string literals, numbers, and
placeholders. FmtConstantsAsUnderscores will replace all placeholders, literals,
and string literals with `_`.

For example:
```
FmtHideConstants:
UPDATE foo SET a = 1, b = 2, c = 3 WHERE d = $1 ->
UPDATE foo SET a = _, b = _, c = _ WHERE d = $1

UPDATE foo SET a = '1', b = 2, c = 3 WHERE d = $1 ->
UPDATE foo SET a = '_', b = _, c = _ WHERE d = $1

UPDATE foo SET a = 1, b = 2, c = 3 WHERE d = 5 ->
UPDATE foo SET a = _, b = _, c = _ WHERE d = _

FmtConstantsAsUnderscores will produce the following for all 3:
UPDATE foo SET a = _, b = _, c = _ WHERE d = _
```

Epic: none
Part of: https://github.com/cockroachdb/cockroach/issues/120409