### PR TITLE
roachtest: reset `failuresSuppressed` in `resetFailures`

### DIFF
--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -449,6 +449,7 @@ func (t *testImpl) resetFailures() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.mu.failures = nil
+	t.mu.failuresSuppressed = false
 }
 
 // We take the "squashed" error that contains information of all the errors for each failure.


### PR DESCRIPTION
In #119535, we introduced a `resetFailures` method that is called after a test failure when the test runner identifies that a VM was preempted while the test was running. This function makes sure that the VM preemption error is the only one visible to the issue poster, ensuring that whenever a VM is preempted, the test failure is routed to Test Eng.

However, there was one situation where we still would not get the routing right: when the test times out. In this situation, we set the internal `failuresSuppressed` field to true; in other words, `resetFailures` followed by the VM preempmtion error would not have the desired effect of making the VM preemption error visible to the issue poster. While #119535 solves the most common source of test timeouts due to preemption (a bug in the monitor), tests can run arbitrary code and can timeout if a VM is preempted.

In this commit, we reset `failuresSuppressed` in `resetFailures` to make sure that the VM preemption error is taken into account when reporting failures in arbitrary test timeouts.

Fixes: #120381

Release note: None