### PR TITLE
sql: default sql.stats.statement_fingerprint.format_mask to use special flags

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -1,4 +1,4 @@
-# LogicTest: 3node-tenant
+ # LogicTest: 3node-tenant
 
 query II
 SELECT count(distinct(node_id)), count(*)  FROM crdb_internal.node_runtime_info
@@ -543,11 +543,11 @@ SELECT key, max_retries, failure_count
  WHERE application_name = 'test_max_retry'
 ORDER BY key
 ----
-CREATE SEQUENCE s                                                         0  0
-DROP SEQUENCE s                                                           0  0
-RESET application_name                                                    0  0
-SELECT IF(nextval('_') < _, crdb_internal.force_retry('_'::INTERVAL), _)  0  1
-SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)                2  1
+CREATE SEQUENCE s                                                     0  0
+DROP SEQUENCE s                                                       0  0
+RESET application_name                                                0  0
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  1
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  1
 
 query T
 SELECT crdb_internal.cluster_name()

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -427,7 +427,7 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 		{stmt: `CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)`},
 		{
 			stmt:        `INSERT INTO posts_t VALUES (1, 'foo')`,
-			fingerprint: `INSERT INTO posts_t VALUES (_, '_')`,
+			fingerprint: `INSERT INTO posts_t VALUES (_, __more__)`,
 		},
 		{stmt: `SELECT * FROM posts_t`},
 	}
@@ -446,7 +446,7 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 		{stmt: `CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)`},
 		{
 			stmt:        `INSERT INTO posts_nt VALUES (1, 'foo')`,
-			fingerprint: `INSERT INTO posts_nt VALUES (_, '_')`,
+			fingerprint: `INSERT INTO posts_nt VALUES (_, __more__)`,
 		},
 		{stmt: `SELECT * FROM posts_nt`},
 	}

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -18,7 +18,7 @@ for {set i 0} {$i < 10} {incr i} {
   set timeout 1
   send "select key from crdb_internal.node_statement_statistics order by count desc limit 1;\r"
   expect {
-    "SELECT city, id FROM vehicles WHERE city = \$1" {
+    "SELECT city, id FROM vehicles WHERE city = _" {
       set workloadRunning 1
       break
     }

--- a/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
@@ -95,7 +95,7 @@ eexpect root@
 send "PREPARE p AS SELECT * FROM t WHERE k = \$1;\r"
 eexpect root@
 
-send "SELECT crdb_internal.request_statement_bundle('SELECT * FROM t WHERE k = \$1', 0::FLOAT, 0::INTERVAL, 0::INTERVAL);\r"
+send "SELECT crdb_internal.request_statement_bundle('SELECT * FROM t WHERE k = _', 0::FLOAT, 0::INTERVAL, 0::INTERVAL);\r"
 eexpect root@
 
 send "EXECUTE p(1);\r"

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -86,7 +86,7 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 		{query: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`, count: 1, numRows: 0},
 		{
 			query:         `INSERT INTO posts VALUES (1, 'foo')`,
-			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
+			fingerprinted: `INSERT INTO posts VALUES (_, __more__)`,
 			count:         1,
 			numRows:       1,
 		},
@@ -222,7 +222,7 @@ func TestStatusAPITransactions(t *testing.T) {
 		{query: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`, count: 1, numRows: 0},
 		{
 			query:         `INSERT INTO posts VALUES (1, 'foo')`,
-			fingerprinted: `INSERT INTO posts VALUES (_, _)`,
+			fingerprinted: `INSERT INTO posts VALUES (_, __more__)`,
 			count:         1,
 			numRows:       1,
 		},
@@ -425,7 +425,7 @@ func TestStatusAPIStatements(t *testing.T) {
 		{stmt: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`},
 		{
 			stmt:          `INSERT INTO posts VALUES (1, 'foo')`,
-			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
+			fingerprinted: `INSERT INTO posts VALUES (_, __more__)`,
 		},
 		{stmt: `SELECT * FROM posts`},
 	}
@@ -730,7 +730,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 		{stmt: `CREATE DATABASE football`, respQuery: `CREATE DATABASE football`, fullScan: false, distSQL: false, failed: false, count: 1},
 		{stmt: `SET database = football`, respQuery: `SET database = football`, fullScan: false, distSQL: false, failed: false, count: 1},
 		{stmt: `CREATE TABLE players (id INT PRIMARY KEY, name TEXT, position TEXT, age INT,goals INT)`, respQuery: `CREATE TABLE players (id INT8 PRIMARY KEY, name STRING, "position" STRING, age INT8, goals INT8)`, fullScan: false, distSQL: false, failed: false, count: 1},
-		{stmt: `INSERT INTO players (id, name, position, age, goals) VALUES (1, 'Lionel Messi', 'Forward', 34, 672), (2, 'Cristiano Ronaldo', 'Forward', 36, 674)`, respQuery: `INSERT INTO players(id, name, "position", age, goals) VALUES (_, '_', __more1_10__), (__more1_10__)`, fullScan: false, distSQL: false, failed: false, count: 1},
+		{stmt: `INSERT INTO players (id, name, position, age, goals) VALUES (1, 'Lionel Messi', 'Forward', 34, 672), (2, 'Cristiano Ronaldo', 'Forward', 36, 674)`, respQuery: `INSERT INTO players(id, name, "position", age, goals) VALUES (_, __more__), (__more__)`, fullScan: false, distSQL: false, failed: false, count: 1},
 		{stmt: `SELECT avg(goals) FROM players`, respQuery: `SELECT avg(goals) FROM players`, fullScan: true, distSQL: true, failed: false, count: 1},
 		{stmt: `SELECT name FROM players WHERE age >= 32`, respQuery: `SELECT name FROM players WHERE age >= _`, fullScan: true, distSQL: true, failed: false, count: 1},
 	}
@@ -882,7 +882,7 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 		{stmt: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`},
 		{
 			stmt:          `INSERT INTO posts VALUES (1, 'foo')`,
-			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
+			fingerprinted: `INSERT INTO posts VALUES (_, __more__)`,
 		},
 		{stmt: `SELECT * FROM posts`},
 	}
@@ -1061,7 +1061,7 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 		thirdServerSQL.Exec(t, stmt)
 	}
 
-	query := `INSERT INTO posts VALUES (_, '_')`
+	query := `INSERT INTO posts VALUES (_, __more__)`
 	fingerprintID := appstatspb.ConstructStatementFingerprintID(query, true, `roachblog`)
 	path := fmt.Sprintf(`stmtdetails/%v`, fingerprintID)
 

--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -89,7 +89,7 @@ CREATE TABLE t.test (x INT PRIMARY KEY);
 
 	foundStat := false
 	for _, stat := range stats {
-		if stat.Key.Query == "INSERT INTO _ VALUES ($1)" {
+		if stat.Key.Query == "INSERT INTO _ VALUES (_)" {
 			foundStat = true
 			if stat.Stats.Count != 2 {
 				t.Fatal("expected to find 2 invocations, found", stat.Stats.Count)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3525,11 +3525,20 @@ var allowSnapshotIsolation = settings.RegisterBoolSetting(
 var logIsolationLevelLimiter = log.Every(10 * time.Second)
 
 // Bitmask for enabling various query fingerprint formatting styles.
+// We don't publish this setting because most users should not need
+// to tweak the fingerprint generation.
 var queryFormattingForFingerprintsMask = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"sql.stats.statement_fingerprint.format_mask",
-	"enables setting additional fmt flags for statement fingerprint formatting",
-	0,
+	"enables setting additional fmt flags for statement fingerprint formatting. "+
+		"Flags set here will be applied in addition to FmtHideConstants",
+	int64(tree.FmtCollapseLists|tree.FmtConstantsAsUnderscores),
+	settings.WithValidateInt(func(i int64) error {
+		if i == 0 || int64(tree.FmtCollapseLists|tree.FmtConstantsAsUnderscores)&i == i {
+			return nil
+		}
+		return errors.Newf("invalid value %d", i)
+	}),
 )
 
 func (ex *connExecutor) txnIsolationLevelToKV(

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -546,7 +546,7 @@ func TestPrepareStatisticsMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that query and querySummary are equal in crdb_internal.statement_statistics.metadata.
-	rows, err := sqlDB.Query(`SELECT metadata->>'query', metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE 'SELECT $1::INT8'`)
+	rows, err := sqlDB.Query(`SELECT metadata->>'query', metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE 'SELECT _::INT8'`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/idxrecommendations/idx_recommendations_test.go
+++ b/pkg/sql/idxrecommendations/idx_recommendations_test.go
@@ -85,7 +85,7 @@ func TestIndexRecommendationsStats(t *testing.T) {
 		for i := 0; i < (minExecutions + 2); i++ {
 			testConn.Exec(t, `INSERT INTO t3 VALUES($1)`, i)
 			rows := testConn.QueryRow(t, "SELECT index_recommendations FROM CRDB_INTERNAL.STATEMENT_STATISTICS "+
-				" WHERE metadata ->> 'db' = 'idxrectest' AND metadata ->> 'query' = 'INSERT INTO t3 VALUES ($1)'")
+				" WHERE metadata ->> 'db' = 'idxrectest' AND metadata ->> 'query' = 'INSERT INTO t3 VALUES (_)'")
 			rows.Scan(&recommendations)
 
 			require.Equal(t, "{}", recommendations)

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -860,11 +860,11 @@ SELECT key, max_retries, failure_count
  WHERE application_name = 'test_max_retry'
 ORDER BY key
 ----
-CREATE SEQUENCE s                                                         0  0
-DROP SEQUENCE s                                                           0  0
-RESET application_name                                                    0  0
-SELECT IF(nextval('_') < _, crdb_internal.force_retry('_'::INTERVAL), _)  0  1
-SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)                2  1
+CREATE SEQUENCE s                                                     0  0
+DROP SEQUENCE s                                                       0  0
+RESET application_name                                                0  0
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_), _)            2  1
+SELECT IF(nextval(_) < _, crdb_internal.force_retry(_::INTERVAL), _)  0  1
 
 query T
 SELECT database_name FROM crdb_internal.node_statement_statistics limit 1

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -64,10 +64,10 @@ SET application_name = ''
 query TTB
 SELECT txn_fingerprint_id, key, implicit_txn FROM crdb_internal.node_statement_statistics WHERE application_name = 'multi_stmts_test' ORDER BY txn_fingerprint_id
 ----
-3783666325893023269  SET application_name = '_'  true
-6795574265959791651  SELECT '_'                  true
-6795574265959791651  SELECT _, _                 true
-6795574265959791651  SELECT _, _, _              true
+11423158778792053189  SELECT _                  true
+11423158778792053189  SELECT _, _               true
+11423158778792053189  SELECT _, _, _            true
+6692757627851618087   SET application_name = _  true
 
 statement ok
 CREATE TABLE test(x INT, y INT, z INT); INSERT INTO test(x, y, z) VALUES (0,0,0);
@@ -156,20 +156,20 @@ SELECT key,flags
 FROM test.crdb_internal.node_statement_statistics
 WHERE application_name = 'valuetest' ORDER BY key, flags
 ----
-key                                                               flags
-INSERT INTO test VALUES (_, _, __more1_10__), (__more1_10__)              ·
-SELECT (_, _, __more1_10__) FROM test WHERE _                             ·
+key                                                                       flags
+INSERT INTO test VALUES (_, __more__), (__more__)                         ·
+SELECT (_, __more__) FROM test WHERE _                                    ·
 SELECT key FROM test.crdb_internal.node_statement_statistics              ·
 SELECT sin(_)                                                             ·
 SELECT sqrt(_)                                                            ·
-SELECT x FROM (VALUES (_, _, __more1_10__), (__more1_10__)) AS t (x)      ·
+SELECT x FROM (VALUES (_, __more__), (__more__)) AS t (x)                 ·
 SELECT x FROM test WHERE y = (_ / z)                                      +
 SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)                         ·
-SELECT x FROM test WHERE y IN (_, _, __more1_10__)                        +
-SELECT x FROM test WHERE y NOT IN (_, _, __more1_10__)                    ·
+SELECT x FROM test WHERE y IN (_, __more__)                               +
+SELECT x FROM test WHERE y NOT IN (_, __more__)                           ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions.enabled" = DEFAULT  ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions.enabled" = _        ·
-SET application_name = '_'                                                ·
+SET application_name = _                                                  ·
 SET distsql = "on"                                                        ·
 SHOW CLUSTER SETTING "debug.panic_on_failed_assertions.enabled"           ·
 SHOW application_name                                                     ·
@@ -194,6 +194,7 @@ SELECT key,
  WHERE key = 'SELECT _'
 ----
 key       svc_ok  parse_ok  plan_ok  run_ok  ovh_ok
+SELECT _  true    true      true     true    true
 SELECT _  true    true      true     true    true
 SELECT _  true    true      true     true    true
 

--- a/pkg/sql/pgwire/testdata/pgtest/tuple
+++ b/pkg/sql/pgwire/testdata/pgtest/tuple
@@ -89,7 +89,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"error in argument for $1: could not parse \"(1,cat)\" as type tuple: cannot parse anonymous record type","Detail":"statement name \"s4\"\n--\nportal name \"p4\"\n--\nstatement summary \"SELECT $1 AS a\""}
+{"Type":"ErrorResponse","Code":"0A000","Message":"error in argument for $1: could not parse \"(1,cat)\" as type tuple: cannot parse anonymous record type","Detail":"statement name \"s4\"\n--\nportal name \"p4\"\n--\nstatement summary \"SELECT _ AS a\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
@@ -164,7 +164,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: tuple requires a 4 byte header for binary format","Detail":"bufferLength=0\n--\nstatement name \"s_empty_param\"\n--\nportal name \"p_empty_param\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: tuple requires a 4 byte header for binary format","Detail":"bufferLength=0\n--\nstatement name \"s_empty_param\"\n--\nportal name \"p_empty_param\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # negative length tuple
@@ -189,7 +189,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: tuple must have non-negative number of elements","Detail":"numberOfElements=-1\n--\nstatement name \"s_negative_tuple\"\n--\nportal name \"p_negative_tuple\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: tuple must have non-negative number of elements","Detail":"numberOfElements=-1\n--\nstatement name \"s_negative_tuple\"\n--\nportal name \"p_negative_tuple\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # not enough bytes for element OID
@@ -214,7 +214,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element OID for binary format","Detail":"elementIdx=0 bufferLength=4 bufferStartIdx=4 bufferEndIdx=8\n--\nstatement name \"s_element_oid_no_bytes\"\n--\nportal name \"p_element_oid_no_bytes\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element OID for binary format","Detail":"elementIdx=0 bufferLength=4 bufferStartIdx=4 bufferEndIdx=8\n--\nstatement name \"s_element_oid_no_bytes\"\n--\nportal name \"p_element_oid_no_bytes\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # element OID not found
@@ -240,7 +240,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: element type not found for OID 0","Detail":"elementIdx=0 bufferLength=8 bufferStartIdx=4 bufferEndIdx=8\n--\nstatement name \"s_element_oid_not_found\"\n--\nportal name \"p_element_oid_not_found\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: element type not found for OID 0","Detail":"elementIdx=0 bufferLength=8 bufferStartIdx=4 bufferEndIdx=8\n--\nstatement name \"s_element_oid_not_found\"\n--\nportal name \"p_element_oid_not_found\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # not enough bytes for element size
@@ -266,7 +266,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element size for binary format","Detail":"elementIdx=0 bufferLength=8 bufferStartIdx=8 bufferEndIdx=12\n--\nstatement name \"s_element_size_no_bytes\"\n--\nportal name \"p_element_size_no_bytes\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element size for binary format","Detail":"elementIdx=0 bufferLength=8 bufferStartIdx=8 bufferEndIdx=12\n--\nstatement name \"s_element_size_no_bytes\"\n--\nportal name \"p_element_size_no_bytes\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # null element
@@ -313,7 +313,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: unsupported binary bool: ","Detail":"statement name \"s_element_needs_bytes\"\n--\nportal name \"p_element_needs_bytes\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: unsupported binary bool: ","Detail":"statement name \"s_element_needs_bytes\"\n--\nportal name \"p_element_needs_bytes\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # not enough bytes for element
@@ -340,7 +340,7 @@ ErrorResponse
 ReadyForQuery
 ----
 {"Type":"ParseComplete"}
-{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element for binary format","Detail":"elementIdx=0 bufferLength=12 bufferStartIdx=12 bufferEndIdx=13\n--\nstatement name \"s_element_no_bytes\"\n--\nportal name \"p_element_no_bytes\"\n--\nstatement summary \"SELECT $1::r\""}
+{"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element for binary format","Detail":"elementIdx=0 bufferLength=12 bufferStartIdx=12 bufferEndIdx=13\n--\nstatement name \"s_element_no_bytes\"\n--\nportal name \"p_element_no_bytes\"\n--\nstatement summary \"SELECT _::r\""}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 # Test binary encoding of a generic tuple result.

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -117,7 +117,7 @@ func TestInsightsIntegration(t *testing.T) {
 			"cpu_sql_nanos, "+
 			"COALESCE(error_code, '') error_code "+
 			"FROM crdb_internal.node_execution_insights where "+
-			"query = $1 and app_name = $2 ", "SELECT pg_sleep($1)", appName)
+			"query = $1 and app_name = $2 ", "SELECT pg_sleep(_)", appName)
 
 		var query, status string
 		var startInsights, endInsights time.Time
@@ -165,7 +165,7 @@ func TestInsightsIntegration(t *testing.T) {
 			"cpu_sql_nanos, "+
 			"COALESCE(last_error_code, '') last_error_code "+
 			"FROM crdb_internal.cluster_txn_execution_insights WHERE "+
-			"query = $1 and app_name = $2 ", "SELECT pg_sleep($1)", appName)
+			"query = $1 and app_name = $2 ", "SELECT pg_sleep(_)", appName)
 
 		var query string
 		var startInsights, endInsights time.Time
@@ -495,7 +495,7 @@ WHERE app_name = $1`, appName)
 					return row.Scan(&query, &problems, &status, &errorCode, &errorMsg)
 				})
 
-				require.Equal(t, "SELECT * FROM myusers WHERE city = '_' ; UPDATE myusers SET name = '_' WHERE city = '_'", query)
+				require.Equal(t, "SELECT * FROM myusers WHERE city = _ ; UPDATE myusers SET name = _ WHERE city = _", query)
 				expectedProblem := "{FailedExecution}"
 				replacedSlowProblems := problems
 				if problems != expectedProblem {
@@ -614,25 +614,25 @@ func TestInsightsPriorityIntegration(t *testing.T) {
 		{
 			setPriorityQuery:      "SET TRANSACTION PRIORITY LOW",
 			query:                 "INSERT INTO t(id, s) VALUES ('test', 'originalValue')",
-			queryNoValues:         "INSERT INTO t(id, s) VALUES ('_', '_')",
+			queryNoValues:         "INSERT INTO t(id, s) VALUES (_, __more__)",
 			expectedPriorityValue: "low",
 		},
 		{
 			setPriorityQuery:      "SET TRANSACTION PRIORITY NORMAL",
 			query:                 "UPDATE t set s = 'updatedValue' where id = 'test'",
-			queryNoValues:         "UPDATE t SET s = '_' WHERE id = '_'",
+			queryNoValues:         "UPDATE t SET s = _ WHERE id = _",
 			expectedPriorityValue: "normal",
 		},
 		{
 			setPriorityQuery:      "SELECT 1", // use a dummy query to validate default scenario
 			query:                 "UPDATE t set s = 'updatedValue'",
-			queryNoValues:         "UPDATE t SET s = '_'",
+			queryNoValues:         "UPDATE t SET s = _",
 			expectedPriorityValue: "normal",
 		},
 		{
 			setPriorityQuery:      "SET TRANSACTION PRIORITY HIGH",
 			query:                 "DELETE FROM t WHERE t.s = 'originalValue'",
-			queryNoValues:         "DELETE FROM t WHERE t.s = '_'",
+			queryNoValues:         "DELETE FROM t WHERE t.s = _",
 			expectedPriorityValue: "high",
 		},
 	}

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -799,6 +799,7 @@ func TestFingerprintCreation(t *testing.T) {
 
 	testConn := sqlutils.MakeSQLRunner(sqlConn)
 	testConn.Exec(t, "CREATE TABLE t (v INT)")
+	testConn.Exec(t, `SET CLUSTER SETTING sql.stats.statement_fingerprint.format_mask = 0`)
 
 	var count int64
 
@@ -1296,7 +1297,7 @@ func TestSQLStatsIdleLatencies(t *testing.T) {
 		},
 		{
 			name:     "no latency - prepared statement (implicit txn)",
-			stmtLats: map[string]float64{"SELECT $1::INT8": 0},
+			stmtLats: map[string]float64{"SELECT _::INT8": 0},
 			txnLat:   0,
 			ops: func(t *testing.T, db *gosql.DB) {
 				stmt, err := db.Prepare("SELECT $1::INT")
@@ -1353,7 +1354,7 @@ func TestSQLStatsIdleLatencies(t *testing.T) {
 		},
 		{
 			name:     "prepared statement",
-			stmtLats: map[string]float64{"SELECT $1::INT8": 0.1},
+			stmtLats: map[string]float64{"SELECT _::INT8": 0.1},
 			txnLat:   0.2,
 			ops: func(t *testing.T, db *gosql.DB) {
 				stmt, err := db.Prepare("SELECT $1::INT")
@@ -1370,7 +1371,7 @@ func TestSQLStatsIdleLatencies(t *testing.T) {
 		},
 		{
 			name:     "prepared statement inside transaction",
-			stmtLats: map[string]float64{"SELECT $1::INT8": 0.1},
+			stmtLats: map[string]float64{"SELECT _::INT8": 0.1},
 			txnLat:   0.2,
 			ops: func(t *testing.T, db *gosql.DB) {
 				tx, err := db.Begin()

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -145,7 +145,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 	// Verify that EXECUTE triggers diagnostics collection (#66048).
 	t.Run("execute", func(t *testing.T) {
 		id, err := registry.InsertRequestInternal(
-			ctx, "SELECT x + $1 FROM test", anyPlan, noAntiMatch,
+			ctx, "SELECT x + _ FROM test", anyPlan, noAntiMatch,
 			sampleAll, noLatencyThreshold, noExpiration,
 		)
 		require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 	t.Run("conditional with concurrency", func(t *testing.T) {
 		minExecutionLatency := 100 * time.Millisecond
 		reqID, err := registry.InsertRequestInternal(
-			ctx, "SELECT pg_sleep($1)", anyPlan, noAntiMatch,
+			ctx, "SELECT pg_sleep(_)", anyPlan, noAntiMatch,
 			sampleAll, minExecutionLatency, noExpiration,
 		)
 		require.NoError(t, err)

--- a/pkg/sql/testdata/sql_activity_update_job
+++ b/pkg/sql/testdata/sql_activity_update_job
@@ -115,7 +115,7 @@ system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, metadata
 ----
 2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
 2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
-2024-01-01 01:00:00 +0000 UTC,"SET application_name = $1",1
+2024-01-01 01:00:00 +0000 UTC,"SET application_name = _",1
 2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
 2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
 
@@ -123,7 +123,7 @@ run-sql useApp=true
 SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
 system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
 ----
-2024-01-01 01:00:00 +0000 UTC,["905a8c5efc1a5827"],1
+2024-01-01 01:00:00 +0000 UTC,["e4e9b6317139aad1"],1
 2024-01-01 01:00:00 +0000 UTC,["1d2a16425a50b884"],3
 2024-01-01 01:00:00 +0000 UTC,["78da04360628cf28"],1
 2024-01-01 02:00:00 +0000 UTC,["2e9ed501bad29d2a"],1
@@ -136,7 +136,7 @@ system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, metadata -
 ----
 2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
 2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
-2024-01-01 01:00:00 +0000 UTC,"SET application_name = $1",1
+2024-01-01 01:00:00 +0000 UTC,"SET application_name = _",1
 2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
 2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
 
@@ -144,7 +144,7 @@ run-sql useApp=true
 SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
 system.transaction_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
 ----
-2024-01-01 01:00:00 +0000 UTC,["905a8c5efc1a5827"],1
+2024-01-01 01:00:00 +0000 UTC,["e4e9b6317139aad1"],1
 2024-01-01 01:00:00 +0000 UTC,["1d2a16425a50b884"],3
 2024-01-01 01:00:00 +0000 UTC,["78da04360628cf28"],1
 2024-01-01 02:00:00 +0000 UTC,["2e9ed501bad29d2a"],1

--- a/pkg/sql/testdata/telemetry/sql-stats
+++ b/pkg/sql/testdata/telemetry/sql-stats
@@ -23,7 +23,7 @@ error: pq: failed to satisfy CHECK constraint (a > 1:::INT8)
 sql-stats
  └── $ some app
       ├── [nodist] CREATE TABLE _ (_ INT8, CONSTRAINT _ CHECK (_ > _))
-      └── [nodist] INSERT INTO _ SELECT _(ARRAY[_, _, __more1_10__])
+      └── [nodist] INSERT INTO _ SELECT _(ARRAY[_, __more__])
 
 # Verify statements are correctly separated by app.
 sql-stats
@@ -43,5 +43,5 @@ sql-stats
       ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
       ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
       ├── [nodist] CREATE TABLE _ (_ INT8, _ INT8)
-      ├── [nodist] INSERT INTO _ VALUES (_, _), (__more1_10__)
-      └── [nodist] SET application_name = '_'
+      ├── [nodist] INSERT INTO _ VALUES (_, __more__), (__more__)
+      └── [nodist] SET application_name = _

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -98,7 +98,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 3806682926156079000,
+	"StatementFingerprintID": 2101516650360650000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -111,9 +111,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		3806682926156079000
+		2101516650360650000
 	],
-	"TransactionFingerprintID": 11220631332681050000,
+	"TransactionFingerprintID": 12846987492365242000,
 	"User": "root"
 }
 
@@ -152,7 +152,7 @@ SET application_name = '$ internal-console-app';
 	"EventType": "sampled_query",
 	"PlanGist": "Ais=",
 	"Statement": "SET application_name = ‹'$ internal-console-app'›",
-	"StatementFingerprintID": 12632102921712570000,
+	"StatementFingerprintID": 16494915433690409000,
 	"StmtPosInTxn": 1,
 	"Tag": "SET",
 	"User": "root"
@@ -232,7 +232,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 3806682926156079000,
+	"StatementFingerprintID": 2101516650360650000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -245,9 +245,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		3806682926156079000
+		2101516650360650000
 	],
-	"TransactionFingerprintID": 11220631332681050000,
+	"TransactionFingerprintID": 12846987492365242000,
 	"User": "root"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -363,7 +363,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 7,
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 3806682926156079000,
+	"StatementFingerprintID": 2101516650360650000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -378,7 +378,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "40001",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 17983543787721968000,
+	"StatementFingerprintID": 8086151951699049000,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -393,7 +393,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 3806682926156079000,
+	"StatementFingerprintID": 2101516650360650000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -436,10 +436,10 @@ COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		3806682926156079000,
+		2101516650360650000,
 		8086151951699049000
 	],
-	"TransactionFingerprintID": 15834298315376988000,
+	"TransactionFingerprintID": 3750030760852548600,
 	"User": "root"
 }
 


### PR DESCRIPTION
Please note only the latest commit should be reviewed.

------------------------
By default `sql.stats.statement_fingerprint.format_mask` is now
set to `FmtCollapseLists|FmtConstantsAsUnderscores` to reduce
statement fingerprint cardinality due to long constant lists and
variations in constant formatting. Note that the default fmt flag
for statement fingerprint generation is `FmtHideConstants`. Any
flags set with sql.stats.statement_fingerprint.format_mask will be
OR'd with `FmtHideConstants`.

Closes: https://github.com/cockroachdb/cockroach/issues/120409

Release note (sql change): Users will see the following changes
in their generated statement fingerprints from sql stats:
- lists with only literals/placeholders and similar subexpressions are
shortened to their first item followed by "__more__", e.g.
- constants and placeholders are all replaced with the same character,
an underscore `_`
```
SELECT * FROM foo WHERE f IN (1, $1, 1+2) ->
SELECT * FROM foo WHERE f IN (_, __more__)
```