### PR TITLE
release-23.1.17-rc: roachprod: avoid adding new keys to project metadata when creating clusters

### DIFF
--- a/pkg/roachprod/config/BUILD.bazel
+++ b/pkg/roachprod/config/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//oserror",
     ],
 )
 

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -12,9 +12,12 @@ package config
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"os/user"
+	"path"
 	"regexp"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -43,9 +46,9 @@ var (
 	// CockroachDevLicense is used by both roachprod and tools that import it.
 	CockroachDevLicense = envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")
 
-	// SSHPublicKeyPath is the path to the public key that is expected
-	// to exist in order to set up new roachprod clusters.
-	SSHPublicKeyPath = os.ExpandEnv("${HOME}/.ssh/id_rsa.pub")
+	// SSHDirectory is the path to search for SSH keys needed to set up
+	// set up new roachprod clusters.
+	SSHDirectory = os.ExpandEnv("${HOME}/.ssh")
 )
 
 func init() {
@@ -131,13 +134,51 @@ func IsLocalClusterName(clusterName string) bool {
 
 var localClusterRegex = regexp.MustCompile(`^local(|-[a-zA-Z0-9\-]+)$`)
 
+// See https://github.com/openssh/openssh-portable/blob/86bdd385/ssh_config.5#L1123-L1130
+var defaultPubKeyNames = []string{
+	"id_rsa",
+	"id_ecdsa",
+	"id_ecdsa_sk",
+	"id_ed25519",
+	"id_ed25519_sk",
+	"id_dsa",
+}
+
+// SSHPublicKeyPath returns the path to the default public key expected by
+// roachprod.
+func SSHPublicKeyPath() (string, error) {
+	dirEnts, err := os.ReadDir(SSHDirectory)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read SSH directory")
+	}
+
+	for _, name := range defaultPubKeyNames {
+		idx := slices.IndexFunc(dirEnts, func(entry fs.DirEntry) bool {
+			return name == entry.Name()
+		})
+		if idx == -1 {
+			continue
+		}
+		pubKeyPath := path.Join(SSHDirectory, name+".pub")
+		if _, err := os.Stat(pubKeyPath); err == nil {
+			return pubKeyPath, nil
+		}
+	}
+
+	return "", errors.Newf("no default public key found in %s", SSHDirectory)
+}
+
 // SSHPublicKey returns the contents of the default public key
 // expected by roachprod.
 func SSHPublicKey() (string, error) {
-	sshKey, err := os.ReadFile(SSHPublicKeyPath)
+	sshPublicKeyPath, err := SSHPublicKeyPath()
+	if err != nil {
+		return "", err
+	}
+	sshKey, err := os.ReadFile(sshPublicKeyPath)
 	if err != nil {
 		if oserror.IsNotExist(err) {
-			return "", errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", SSHPublicKeyPath)
+			return "", errors.Wrapf(err, "please run ssh-keygen externally to create a public key file")
 		}
 		return "", errors.Wrap(err, "failed to read public SSH key")
 	}

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -12,12 +12,10 @@ package config
 
 import (
 	"context"
-	"io/fs"
 	"os"
 	"os/user"
 	"path"
 	"regexp"
-	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -153,9 +151,15 @@ func SSHPublicKeyPath() (string, error) {
 	}
 
 	for _, name := range defaultPubKeyNames {
-		idx := slices.IndexFunc(dirEnts, func(entry fs.DirEntry) bool {
-			return name == entry.Name()
-		})
+		idx := func() int {
+			for j, entry := range dirEnts {
+				if name == entry.Name() {
+					return j
+				}
+			}
+
+			return -1
+		}()
 		if idx == -1 {
 			continue
 		}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1586,11 +1586,10 @@ fi
 	}
 
 	if len(c.AuthorizedKeys) > 0 {
-		// When clusters are created using cloud APIs they only have a subset of
-		// desired keys installed on a subset of users. This code distributes
-		// additional authorized_keys to both the current user (your username on
-		// gce and the shared user on aws) as well as to the shared user on both
-		// platforms.
+		// When clusters are created using cloud APIs they only have a
+		// subset of desired keys installed on a subset of users. This
+		// code distributes additional authorized_keys the current user
+		// (i.e., the shared user).
 		if err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 			const cmd = `
 keys_data="$(cat)"
@@ -1601,20 +1600,11 @@ on_exit() {
     rm -f "${tmp1}" "${tmp2}"
 }
 trap on_exit EXIT
-if [[ -f ~/.ssh/authorized_keys ]]; then
-    cat ~/.ssh/authorized_keys > "${tmp1}"
-fi
+cat ~/.ssh/authorized_keys > "${tmp1}"
 echo "${keys_data}" >> "${tmp1}"
 sort -u < "${tmp1}" > "${tmp2}"
 install --mode 0600 "${tmp2}" ~/.ssh/authorized_keys
-if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
-    sudo install --mode 0600 \
-        --owner ` + config.SharedUser + `\
-        --group ` + config.SharedUser + `\
-        "${tmp2}" ~` + config.SharedUser + `/.ssh/authorized_keys
-fi
 `
-
 			runOpts := defaultCmdOpts("ssh-add-extra-keys")
 			runOpts.stdin = bytes.NewReader(c.AuthorizedKeys)
 			return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -608,13 +608,6 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
 	if err != nil {
 		return err
 	}
-	// For GCP clusters we need to use the config.OSUser even if the client
-	// requested the shared user.
-	for i := range installCluster.VMs {
-		if cloudCluster.VMs[i].Provider == gce.ProviderName {
-			installCluster.VMs[i].RemoteUser = config.OSUser.Username
-		}
-	}
 	if err := installCluster.Wait(ctx, l); err != nil {
 		return err
 	}
@@ -1385,11 +1378,11 @@ func Create(
 			if retErr == nil {
 				return
 			}
-			l.Errorf("Cleaning up partially-created cluster (prev err: %s)\n", retErr)
+			l.Errorf("Cleaning up partially-created cluster (prev err: %s)", retErr)
 			if err := cleanupFailedCreate(l, clusterName); err != nil {
-				l.Errorf("Error while cleaning up partially-created cluster: %s\n", err)
+				l.Errorf("Error while cleaning up partially-created cluster: %s", err)
 			} else {
-				l.Errorf("Cleaning up OK\n")
+				l.Errorf("Cleaning up OK")
 			}
 		}()
 	} else {

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
@@ -22,7 +23,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_time//rate",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -418,7 +418,11 @@ func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
 				if err != nil {
 					return err
 				}
-				l.Printf("imported %s as %s in region %s", config.SSHPublicKeyPath, keyName, region)
+				sshPublicKeyPath, err := config.SSHPublicKeyPath()
+				if err != nil {
+					return err
+				}
+				l.Printf("imported %s as %s in region %s", sshPublicKeyPath, keyName, region)
 			}
 			return nil
 		})

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
@@ -417,7 +418,7 @@ func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
 				if err != nil {
 					return err
 				}
-				l.Printf("imported %s as %s in region %s", sshPublicKeyFile, keyName, region)
+				l.Printf("imported %s as %s in region %s", config.SSHPublicKeyPath, keyName, region)
 			}
 			return nil
 		})

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -48,7 +48,8 @@ func (p *Provider) sshKeyExists(l *logger.Logger, keyName, region string) (bool,
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
 func (p *Provider) sshKeyImport(l *logger.Logger, keyName, region string) error {
-	if _, err := config.SSHPublicKey(); err != nil {
+	sshPublicKeyPath, err := config.SSHPublicKeyPath()
+	if err != nil {
 		return err
 	}
 
@@ -73,7 +74,7 @@ func (p *Provider) sshKeyImport(l *logger.Logger, keyName, region string) error 
 		"ec2", "import-key-pair",
 		"--region", region,
 		"--key-name", keyName,
-		"--public-key-material", fmt.Sprintf("fileb://%s", config.SSHPublicKeyPath),
+		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyPath),
 		"--tag-specifications", tagSpecs,
 	}
 	err = p.runJSONCommand(l, args, &data)

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -15,7 +15,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/subscriptions"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
@@ -159,16 +159,9 @@ func (p *Provider) Create(
 ) error {
 	providerOpts := vmProviderOpts.(*ProviderOpts)
 	// Load the user's SSH public key to configure the resulting VMs.
-	var sshKey string
-	sshFile := os.ExpandEnv("${HOME}/.ssh/id_rsa.pub")
-	if _, err := os.Stat(sshFile); err == nil {
-		if bytes, err := os.ReadFile(sshFile); err == nil {
-			sshKey = string(bytes)
-		} else {
-			return errors.Wrapf(err, "could not read SSH public key file")
-		}
-	} else {
-		return errors.Wrapf(err, "could not find SSH public key file")
+	sshKey, err := config.SSHPublicKey()
+	if err != nil {
+		return err
 	}
 
 	m := getAzureDefaultLabelMap(opts)

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -680,19 +680,12 @@ func (p *Provider) CleanSSH(l *logger.Logger) error {
 	return nil
 }
 
-// ConfigSSH is part of the vm.Provider interface
+// ConfigSSH is part of the vm.Provider interface. For this provider,
+// it verifies that the test runner has a public SSH key, as that is
+// required when setting up new clusters.
 func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
-	// Populate SSH config files with Host entries from each instance in active projects.
-	for _, prj := range p.GetProjects() {
-		args := []string{"compute", "config-ssh", "--project", prj, "--quiet"}
-		cmd := exec.Command("gcloud", args...)
-
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
-		}
-	}
-	return nil
+	_, err := config.SSHPublicKey()
+	return err
 }
 
 func (p *Provider) editLabels(

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
@@ -238,6 +239,9 @@ sysctl --system  # reload sysctl settings
 sudo ua enable fips --assume-yes
 {{ end }}
 
+sudo -u {{ .SharedUser }} bash -c "mkdir ~/.ssh && chmod 700 ~/.ssh"
+sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 
@@ -258,6 +262,13 @@ func writeStartupScript(
 		// TODO(DarrylWong): In the future, when all tests are run on Ubuntu 22.04, we can remove this check and default true.
 		// See: https://github.com/cockroachdb/cockroach/issues/112112
 		EnableRSAForSSH bool
+		SharedUser      string
+		PublicKey       string
+	}
+
+	publicKey, err := config.SSHPublicKey()
+	if err != nil {
+		return "", err
 	}
 
 	args := tmplParams{
@@ -266,6 +277,8 @@ func writeStartupScript(
 		Zfs:              fileSystem == vm.Zfs,
 		EnableFIPS:       enableFIPS,
 		EnableRSAForSSH:  enableRSAForSSH,
+		SharedUser:       config.SharedUser,
+		PublicKey:        publicKey,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachprod: avoid adding new keys to project metadata when creating clusters" (#119106)
  * 1/1 commits from "roachprod: search ssh directory for keys" (#120251)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test only changes.