### PR TITLE
release-22.2: roachprod: avoid adding new keys to project metadata when creating clusters

### DIFF
--- a/pkg/roachprod/config/BUILD.bazel
+++ b/pkg/roachprod/config/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     deps = [
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//oserror",
     ],
 )
 

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -12,12 +12,10 @@ package config
 
 import (
 	"context"
-	"io/fs"
 	"os"
 	"os/user"
 	"path"
 	"regexp"
-	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -126,9 +124,15 @@ func SSHPublicKeyPath() (string, error) {
 	}
 
 	for _, name := range defaultPubKeyNames {
-		idx := slices.IndexFunc(dirEnts, func(entry fs.DirEntry) bool {
-			return name == entry.Name()
-		})
+		idx := func() int {
+			for j, entry := range dirEnts {
+				if name == entry.Name() {
+					return j
+				}
+			}
+
+			return -1
+		}()
 		if idx == -1 {
 			continue
 		}

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -12,11 +12,14 @@ package config
 
 import (
 	"context"
+	"os"
 	"os/user"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 )
 
 var (
@@ -33,6 +36,10 @@ var (
 	MaxConcurrency = 32
 	// CockroachDevLicense is used by both roachprod and tools that import it.
 	CockroachDevLicense = envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")
+
+	// SSHPublicKeyPath is the path to the public key that is expected
+	// to exist in order to set up new roachprod clusters.
+	SSHPublicKeyPath = os.ExpandEnv("${HOME}/.ssh/id_rsa.pub")
 )
 
 func init() {
@@ -96,3 +103,17 @@ func IsLocalClusterName(clusterName string) bool {
 }
 
 var localClusterRegex = regexp.MustCompile(`^local(|-[a-zA-Z0-9\-]+)$`)
+
+// SSHPublicKey returns the contents of the default public key
+// expected by roachprod.
+func SSHPublicKey() (string, error) {
+	sshKey, err := os.ReadFile(SSHPublicKeyPath)
+	if err != nil {
+		if oserror.IsNotExist(err) {
+			return "", errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", SSHPublicKeyPath)
+		}
+		return "", errors.Wrap(err, "failed to read public SSH key")
+	}
+
+	return string(sshKey), nil
+}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1118,11 +1118,10 @@ fi
 	}
 
 	if len(c.AuthorizedKeys) > 0 {
-		// When clusters are created using cloud APIs they only have a subset of
-		// desired keys installed on a subset of users. This code distributes
-		// additional authorized_keys to both the current user (your username on
-		// gce and the shared user on aws) as well as to the shared user on both
-		// platforms.
+		// When clusters are created using cloud APIs they only have a
+		// subset of desired keys installed on a subset of users. This
+		// code distributes additional authorized_keys the current user
+		// (i.e., the shared user).
 		if err := c.Parallel(l, "adding additional authorized keys", len(c.Nodes), 0, func(i int) (*RunResultDetails, error) {
 			node := c.Nodes[i]
 			const cmd = `
@@ -1134,20 +1133,11 @@ on_exit() {
     rm -f "${tmp1}" "${tmp2}"
 }
 trap on_exit EXIT
-if [[ -f ~/.ssh/authorized_keys ]]; then
-    cat ~/.ssh/authorized_keys > "${tmp1}"
-fi
+cat ~/.ssh/authorized_keys > "${tmp1}"
 echo "${keys_data}" >> "${tmp1}"
 sort -u < "${tmp1}" > "${tmp2}"
 install --mode 0600 "${tmp2}" ~/.ssh/authorized_keys
-if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
-    sudo install --mode 0600 \
-        --owner ` + config.SharedUser + `\
-        --group ` + config.SharedUser + `\
-        "${tmp2}" ~` + config.SharedUser + `/.ssh/authorized_keys
-fi
 `
-
 			sess := c.newSession(l, node, cmd, withDebugName("ssh-add-extra-keys"))
 			defer sess.Close()
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -600,13 +600,6 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
 	if err != nil {
 		return err
 	}
-	// For GCP clusters we need to use the config.OSUser even if the client
-	// requested the shared user.
-	for i := range installCluster.VMs {
-		if cloudCluster.VMs[i].Provider == gce.ProviderName {
-			installCluster.VMs[i].RemoteUser = config.OSUser.Username
-		}
-	}
 	if err := installCluster.Wait(ctx, l); err != nil {
 		return err
 	}

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_time//rate",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -389,8 +389,11 @@ func (p *Provider) ConfigSSH(zones []string) error {
 				if err != nil {
 					return err
 				}
-				log.Infof(context.Background(), "imported %s as %s in region %s",
-					config.SSHPublicKeyPath, keyName, region)
+				sshPublicKeyPath, err := config.SSHPublicKeyPath()
+				if err != nil {
+					return err
+				}
+				log.Infof(context.Background(), "imported %s as %s in region %s", sshPublicKeyPath, keyName, region)
 			}
 			return nil
 		})

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -390,7 +390,7 @@ func (p *Provider) ConfigSSH(zones []string) error {
 					return err
 				}
 				log.Infof(context.Background(), "imported %s as %s in region %s",
-					sshPublicKeyFile, keyName, region)
+					config.SSHPublicKeyPath, keyName, region)
 			}
 			return nil
 		})

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -14,16 +14,12 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/oserror"
 )
-
-const sshPublicKeyFile = "${HOME}/.ssh/id_rsa.pub"
 
 // sshKeyExists checks to see if there is a an SSH key with the given name in the given region.
 func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
@@ -51,11 +47,7 @@ func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
 func (p *Provider) sshKeyImport(keyName, region string) error {
-	_, err := os.Stat(os.ExpandEnv(sshPublicKeyFile))
-	if err != nil {
-		if oserror.IsNotExist(err) {
-			return errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", sshPublicKeyFile)
-		}
+	if _, err := config.SSHPublicKey(); err != nil {
 		return err
 	}
 
@@ -80,7 +72,7 @@ func (p *Provider) sshKeyImport(keyName, region string) error {
 		"ec2", "import-key-pair",
 		"--region", region,
 		"--key-name", keyName,
-		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyFile),
+		"--public-key-material", fmt.Sprintf("fileb://%s", config.SSHPublicKeyPath),
 		"--tag-specifications", tagSpecs,
 	}
 	err = p.runJSONCommand(args, &data)
@@ -99,16 +91,13 @@ func (p *Provider) sshKeyName() (string, error) {
 		return "", err
 	}
 
-	keyBytes, err := os.ReadFile(os.ExpandEnv(sshPublicKeyFile))
+	sshKey, err := config.SSHPublicKey()
 	if err != nil {
-		if oserror.IsNotExist(err) {
-			return "", errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", sshPublicKeyFile)
-		}
 		return "", err
 	}
 
 	hash := sha1.New()
-	if _, err := hash.Write(keyBytes); err != nil {
+	if _, err := hash.Write([]byte(sshKey)); err != nil {
 		return "", err
 	}
 	hashBytes := hash.Sum(nil)

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -47,7 +47,8 @@ func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
 func (p *Provider) sshKeyImport(keyName, region string) error {
-	if _, err := config.SSHPublicKey(); err != nil {
+	sshPublicKeyPath, err := config.SSHPublicKeyPath()
+	if err != nil {
 		return err
 	}
 
@@ -72,7 +73,7 @@ func (p *Provider) sshKeyImport(keyName, region string) error {
 		"ec2", "import-key-pair",
 		"--region", region,
 		"--key-name", keyName,
-		"--public-key-material", fmt.Sprintf("fileb://%s", config.SSHPublicKeyPath),
+		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyPath),
 		"--tag-specifications", tagSpecs,
 	}
 	err = p.runJSONCommand(args, &data)

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -15,7 +15,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -144,16 +143,9 @@ func (p *Provider) Create(
 ) error {
 	providerOpts := vmProviderOpts.(*ProviderOpts)
 	// Load the user's SSH public key to configure the resulting VMs.
-	var sshKey string
-	sshFile := os.ExpandEnv("${HOME}/.ssh/id_rsa.pub")
-	if _, err := os.Stat(sshFile); err == nil {
-		if bytes, err := os.ReadFile(sshFile); err == nil {
-			sshKey = string(bytes)
-		} else {
-			return errors.Wrapf(err, "could not read SSH public key file")
-		}
-	} else {
-		return errors.Wrapf(err, "could not find SSH public key file")
+	sshKey, err := config.SSHPublicKey()
+	if err != nil {
+		return err
 	}
 
 	m := getAzureDefaultLabelMap(opts)

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -393,19 +393,12 @@ func (p *Provider) CleanSSH() error {
 	return nil
 }
 
-// ConfigSSH is part of the vm.Provider interface
+// ConfigSSH is part of the vm.Provider interface. For this provider,
+// it verifies that the test runner has a public SSH key, as that is
+// required when setting up new clusters.
 func (p *Provider) ConfigSSH(zones []string) error {
-	// Populate SSH config files with Host entries from each instance in active projects.
-	for _, prj := range p.GetProjects() {
-		args := []string{"compute", "config-ssh", "--project", prj, "--quiet"}
-		cmd := exec.Command("gcloud", args...)
-
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
-		}
-	}
-	return nil
+	_, err := config.SSHPublicKey()
+	return err
 }
 
 func (p *Provider) editLabels(vms vm.List, labels map[string]string, remove bool) error {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachprod: avoid adding new keys to project metadata when creating clusters" (#119106)
  * 1/1 commits from "roachprod: search ssh directory for keys" (#120251)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test only changes.