### PR TITLE
dev: if a `PKG` is supplied, only build that package with lints enabled

### DIFF
--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -110,8 +110,9 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 	if len(pkgs) > 1 {
 		return fmt.Errorf("can only lint a single package (found %s)", strings.Join(pkgs, ", "))
 	}
+	var pkg string
 	if len(pkgs) == 1 {
-		pkg := strings.TrimRight(pkgs[0], "/")
+		pkg = strings.TrimRight(pkgs[0], "/")
 		if !strings.HasPrefix(pkg, "./") {
 			pkg = "./" + pkg
 		}
@@ -121,7 +122,15 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 	if err != nil {
 		return err
 	}
-	if !short && filter == "" {
+	if pkg != "" && filter == "" {
+		toLint := strings.TrimPrefix(pkg, "./")
+		args := []string{"build", toLint, "--//build/toolchains:nogo_flag"}
+		if numCPUs != 0 {
+			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+		}
+		logCommand("bazel", args...)
+		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+	} else if !short && filter == "" {
 		args := []string{
 			"build",
 			"//pkg/cmd/cockroach-short",
@@ -136,7 +145,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 		}
 		logCommand("bazel", args...)
 		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
-	} else if !short {
+	} else if filter != "" {
 		log.Printf("Skipping running extra lint checks with `nogo` due to provided test filter")
 	} else if short {
 		log.Printf("Skipping running extra lint checks with `nogo` due to --short")


### PR DESCRIPTION
The idea here is that if you supply a package, you want to see lint results for that package, regardless of whether you've passed in `--short`.

Closes #119927.
Epic: none
Release note: None