### PR TITLE
backupccl: clean up memory accounting a bit

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -806,13 +806,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 
 	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
-
 	var memSize int64
-	defer func() {
-		if memSize != 0 {
-			mem.Shrink(ctx, memSize)
-		}
-	}()
 
 	if backupManifest == nil || forceReadBackupManifest {
 		backupManifest, memSize, err = b.readManifestOnResume(ctx, &mem, p.ExecCfg(), defaultStore,


### PR DESCRIPTION
This commit removes some redundant `Shrink` calls (because the memory account is closed right after) as well as the memory account argument to `readBackupPartitionDescriptor` function (because it has only one caller that passes `nil`) to simplify the accounting a bit.

Epic: None

Release note: None