### PR TITLE
kvserver: add option to skip merge queue if external files are present

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -370,6 +370,8 @@ go_test(
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/cli/exit",
+        "//pkg/cloud",
+        "//pkg/cloud/nodelocal",
         "//pkg/clusterversion",
         "//pkg/config",
         "//pkg/config/zonepb",

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -348,6 +348,14 @@ type queueConfig struct {
 	// disabledConfig is a reference to the cluster setting that controls enabling
 	// and disabling queues.
 	disabledConfig *settings.BoolSetting
+	// skipIfReplicaHasExternalFilesConfig is a reference to the
+	// clsuter setting that controls whether replicas should be
+	// processed in this queue if they have external files. May
+	// be nil.
+	//
+	// skipIfReplicaHasExternalFilesConfig is only consulted after
+	// shouldQueue returns true for the given replica.
+	skipIfReplicaHasExternalFilesConfig *settings.BoolSetting
 }
 
 // baseQueue is the base implementation of the replicaQueue interface. Queue
@@ -678,6 +686,19 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	should, priority := bq.impl.shouldQueue(ctx, now, realRepl, confReader)
 	if !should {
 		return
+	}
+
+	extConf := bq.skipIfReplicaHasExternalFilesConfig
+	if extConf != nil && extConf.Get(&bq.store.cfg.Settings.SV) {
+		hasExternal, err := realRepl.HasExternalBytes()
+		if err != nil {
+			log.Warningf(ctx, "could not determine if %s has external bytes: %s", realRepl, err)
+			return
+		}
+		if hasExternal {
+			log.Infof(ctx, "skipping %s for %s because it has external bytes", bq.name, realRepl)
+			return
+		}
 	}
 	_, err = bq.addInternal(ctx, repl.Desc(), repl.ReplicaID(), priority)
 	if !isExpectedQueueError(err) {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1041,6 +1041,19 @@ func (r *Replica) MaybeQueue(ctx context.Context, now hlc.ClockTimestamp) {
 	}
 }
 
+// HasExternalBytes returns true if the replica has a non-zero number
+// of external bytes in its underlying store. External bytes are bytes
+// in a pebble.ExternalFile. Such files can be added by AddSSTable.
+func (r *Replica) HasExternalBytes() (bool, error) {
+	desc := r.Desc()
+	sp := desc.KeySpan().AsRawSpanWithNoLocals()
+	_, _, externalBytes, err := r.store.StateEngine().ApproximateDiskBytes(sp.Key, sp.EndKey)
+	if err != nil {
+		return false, err
+	}
+	return externalBytes > 0, nil
+}
+
 // IsScratchRange returns true if this is range is a scratch range (i.e.
 // overlaps with the scratch span and has a start key <= keys.ScratchRangeMin).
 func (r *Replica) IsScratchRange() bool {


### PR DESCRIPTION
Replicas with external files are expensive to iterate. Further, they have very in-accurate stats. Here we add an option to skip the merge queue if a replica happens to have external files.

Fixes #120256

Release note: None