### PR TITLE
scbuild: skip TestBuildIsMemoryMonitored under duress

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -292,7 +292,7 @@ func TestBuildIsMemoryMonitored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderDeadlock(t, "takes too long")
+	skip.UnderDuress(t, "takes too long; creates thousands of tables")
 
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{


### PR DESCRIPTION
This test creates thousands of tables, so running it under race or stress takes too long.

fixes https://github.com/cockroachdb/cockroach/issues/120538
Release note: None