### PR TITLE
release-23.1: workload/schemachange: ignore job-rows-batch-insert error

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -463,7 +463,8 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 		// It is fixed in v23.2 and later, but there are no plans to fix it in v23.1
 		// version, so we ignore the error here.
 		// See: https://github.com/cockroachdb/cockroach/issues/115747#issuecomment-1855830157
-		if strings.Contains(pgErr.Error(), "job-rows-batch-insert: null value in column") {
+		if strings.Contains(pgErr.Error(), "job-rows-batch-insert: null value in column") ||
+			strings.Contains(pgErr.Error(), "job-rows-batch-insert: failed to satisfy CHECK constraint") {
 			return nil
 		}
 


### PR DESCRIPTION
A previous commit (30f768a953c) attempted to ignore this error. It missed one other way the error could occur.

fixes https://github.com/cockroachdb/cockroach/issues/120533
Release justification: test only change
Release note: None