### PR TITLE
sql/schemachanger: avoid generating event logs during EXPLAIN (DDL)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1138,3 +1138,22 @@ LIMIT 2
 ----
 drop_function    {"EventType": "drop_function", "FunctionName": "defaultdb.public.f", "Statement": "DROP FUNCTION \"\".\"\".f", "Tag": "DROP FUNCTION", "User": "root"}
 create_function  {"EventType": "create_function", "FunctionName": "defaultdb.public.f", "Statement": "CREATE FUNCTION defaultdb.public.f(IN input INT8)\n\tRETURNS INT8\n\tSTABLE\n\tLANGUAGE SQL\n\tAS $$SELECT 123;$$", "Tag": "CREATE FUNCTION", "User": "root"}
+
+subtest event_logs_not_on_explain
+
+statement ok
+CREATE TABLE t1(n int);
+
+statement ok
+EXPLAIN (DDL) ALTER TABLE t1 ADD COLUMN j int;
+
+query IT
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+WHERE "eventType" = 'alter_table'
+AND info::JSONB->>'Statement' LIKE 'ALTER TABLE t1%'
+ORDER BY "timestamp" DESC, info
+----
+
+
+statement ok
+DROP table t1;

--- a/pkg/sql/schemachanger/scbuild/event_log.go
+++ b/pkg/sql/schemachanger/scbuild/event_log.go
@@ -11,6 +11,8 @@
 package scbuild
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
@@ -52,9 +54,13 @@ func (e *eventLogState) EventLogStateWithNewSourceElementID() scbuildstmt.EventL
 	}
 }
 
-func logEvents(b buildCtx, ts scpb.TargetState, loggedTargets []scpb.Target) {
+// makeEventLogCallback makes a callback that will generate event log
+// entries based on the builder targets (elements and target state).
+func makeEventLogCallback(
+	b buildCtx, ts scpb.TargetState, loggedTargets []scpb.Target,
+) LogSchemaChangerEventsFn {
 	if len(loggedTargets) == 0 {
-		return
+		return stubLogSchemaChangerEventsFn
 	}
 	var swallowedError error
 	defer scerrors.StartEventf(
@@ -62,6 +68,8 @@ func logEvents(b buildCtx, ts scpb.TargetState, loggedTargets []scpb.Target) {
 		"event logging for declarative schema change targets built for %s",
 		redact.Safe(ts.Statements[loggedTargets[0].Metadata.StatementID].StatementTag),
 	).HandlePanicAndLogError(b.Context, &swallowedError)
+	detailSlice := make([]eventpb.CommonSQLEventDetails, 0, len(loggedTargets))
+	payLoadsSlice := make([]logpb.EventPayload, 0, len(loggedTargets))
 	for _, lt := range loggedTargets {
 		descID := screl.GetDescID(lt.Element())
 		stmtID := lt.Metadata.StatementID
@@ -86,9 +94,17 @@ func logEvents(b buildCtx, ts scpb.TargetState, loggedTargets []scpb.Target) {
 		if pl == nil {
 			continue
 		}
-		if err := b.EventLogger().LogEvent(b, details, pl); err != nil {
-			panic(err)
+		detailSlice = append(detailSlice, details)
+		payLoadsSlice = append(payLoadsSlice, pl)
+	}
+	// Return a function for logging schema change events.
+	return func(ctx context.Context) error {
+		for i := range detailSlice {
+			if err := b.EventLogger().LogEvent(ctx, detailSlice[i], payLoadsSlice[i]); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
 }
 

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -82,9 +82,11 @@ func TestPlanDataDriven(t *testing.T) {
 					stmts, err := parser.Parse(d.Input)
 					require.NoError(t, err)
 					var state scpb.CurrentState
+					var logSchemaChangesFn scbuild.LogSchemaChangerEventsFn
 					for i := range stmts {
-						state, err = scbuild.Build(ctx, deps, state, stmts[i].AST, nil /* memAcc */)
+						state, logSchemaChangesFn, err = scbuild.Build(ctx, deps, state, stmts[i].AST, nil /* memAcc */)
 						require.NoError(t, err)
+						require.NoError(t, logSchemaChangesFn(ctx))
 					}
 
 					plan = sctestutils.MakePlan(t, state, scop.EarliestPhase, nil /* memAcc */)
@@ -105,7 +107,7 @@ func TestPlanDataDriven(t *testing.T) {
 					stmt := stmts[0]
 					alter, ok := stmt.AST.(*tree.AlterTable)
 					require.Truef(t, ok, "not an ALTER TABLE statement: %s", stmt.SQL)
-					_, err = scbuild.Build(ctx, deps, scpb.CurrentState{}, alter, nil /* memAcc */)
+					_, _, err = scbuild.Build(ctx, deps, scpb.CurrentState{}, alter, nil /* memAcc */)
 					require.Truef(t, scerrors.HasNotImplemented(err), "expected unimplemented, got %v", err)
 				})
 				return ""
@@ -265,11 +267,13 @@ func TestExplainPlanIsMemoryMonitored(t *testing.T) {
 	tdb.Exec(t, `use system;`)
 
 	var incumbent scpb.CurrentState
+	var logSchemaChangesFn scbuild.LogSchemaChangerEventsFn
 	sctestutils.WithBuilderDependenciesFromTestServer(tt, nodeID, func(dependencies scbuild.Dependencies) {
 		stmt, err := parser.ParseOne(`DROP DATABASE defaultdb CASCADE`)
 		require.NoError(t, err)
-		incumbent, err = scbuild.Build(ctx, dependencies, scpb.CurrentState{}, stmt.AST, nil /* memAcc */)
+		incumbent, logSchemaChangesFn, err = scbuild.Build(ctx, dependencies, scpb.CurrentState{}, stmt.AST, nil /* memAcc */)
 		require.NoError(t, err)
+		require.NoError(t, logSchemaChangesFn(ctx))
 	})
 
 	monitor := mon.NewMonitor(


### PR DESCRIPTION
Previously, the declarative schema changer could generate event log entries even when DDL was only being explained. This created a misleading impression that schema changes had been executed. This patch modifies the declarative schema changer to prevent instant logging of events. Instead, it returns a callback that can be executed before the statement phase.

Fixes: #118897

Release note (bug fix): EXPLAIN (DDL) would generate event log entries for schema changes even though they weren't executed.