### PR TITLE
storage/fs: implement vfs.FS within fs.Env

### DIFF
--- a/pkg/ccl/cliccl/ear.go
+++ b/pkg/ccl/cliccl/ear.go
@@ -38,7 +38,7 @@ func runDecrypt(cmd *cobra.Command, args []string) (returnErr error) {
 	defer env.Close()
 
 	// Open the specified file through the FS, decrypting it.
-	f, err := env.DefaultFS.Open(inPath)
+	f, err := env.Open(inPath)
 	if err != nil {
 		return errors.Wrapf(err, "could not open input file %s", inPath)
 	}

--- a/pkg/ccl/cliccl/ear_test.go
+++ b/pkg/ccl/cliccl/ear_test.go
@@ -62,7 +62,7 @@ func TestDecrypt(t *testing.T) {
 	require.NoError(t, err)
 
 	// Find a manifest file to check.
-	files, err := p.List(dir)
+	files, err := p.Env().List(dir)
 	require.NoError(t, err)
 	sort.Strings(files)
 	var manifestPath string

--- a/pkg/cli/auto_decrypt_fs.go
+++ b/pkg/cli/auto_decrypt_fs.go
@@ -267,7 +267,7 @@ func (afs *autoDecryptFS) maybeSwitchFS(path string) (vfs.FS, error) {
 	if e, err := afs.getEnv(path); err != nil {
 		return nil, err
 	} else if e != nil {
-		return e.DefaultFS, nil
+		return e, nil
 	}
 	return vfs.Default, nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1251,7 +1251,7 @@ func TestEvalAddSSTable(t *testing.T) {
 							require.Nil(t, result.Replicated.AddSSTable)
 						} else {
 							require.NotNil(t, result.Replicated.AddSSTable)
-							require.NoError(t, fs.WriteFile(engine, "sst", result.Replicated.AddSSTable.Data))
+							require.NoError(t, fs.WriteFile(engine.Env(), "sst", result.Replicated.AddSSTable.Data))
 							require.NoError(t, engine.IngestLocalFiles(ctx, []string{"sst"}))
 						}
 
@@ -1669,7 +1669,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	_, err := batcheval.EvalAddSSTable(ctx, engine, cArgs, &resp)
 	require.NoError(t, err)
 
-	require.NoError(t, fs.WriteFile(engine, "sst", sst))
+	require.NoError(t, fs.WriteFile(engine.Env(), "sst", sst))
 	require.NoError(t, engine.IngestLocalFiles(ctx, []string{"sst"}))
 
 	statsEvaled := statsBefore

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3920,7 +3920,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// Iterate over all the tested SSTs and check that they're byte-by-byte equal.
 		var dumpDir string
 		for i := range sstNamesSubset {
-			actualSST, err := fs.ReadFile(receivingEng, sstNamesSubset[i])
+			actualSST, err := fs.ReadFile(receivingEng.Env(), sstNamesSubset[i])
 			if err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/client_replica_gc_test.go
+++ b/pkg/kv/kvserver/client_replica_gc_test.go
@@ -113,10 +113,10 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 		if dir == "" {
 			t.Fatal("no sideloaded directory")
 		}
-		if err := eng.MkdirAll(dir, os.ModePerm); err != nil {
+		if err := eng.Env().MkdirAll(dir, os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
-		if err := fs.WriteFile(eng, filepath.Join(dir, "i1000000.t100000"), []byte("foo")); err != nil {
+		if err := fs.WriteFile(eng.Env(), filepath.Join(dir, "i1000000.t100000"), []byte("foo")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -127,7 +127,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 					repl1.RaftLock()
 					dir := repl1.SideloadedRaftMuLocked().Dir()
 					repl1.RaftUnlock()
-					_, err := eng.Stat(dir)
+					_, err := eng.Env().Stat(dir)
 					if oserror.IsNotExist(err) {
 						return nil
 					}

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -102,7 +102,7 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 
 	assertExists := func(exists bool) {
 		t.Helper()
-		_, err := ss.eng.Stat(ss.dir)
+		_, err := ss.eng.Env().Stat(ss.dir)
 		if !exists {
 			require.True(t, oserror.IsNotExist(err), err)
 		} else {
@@ -260,7 +260,7 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 		// First add a file that shouldn't be in the sideloaded storage to ensure
 		// sane behavior when directory can't be removed after full truncate.
 		nonRemovableFile := filepath.Join(ss.Dir(), "cantremove.xx")
-		f, err := eng.Create(nonRemovableFile)
+		f, err := eng.Env().Create(nonRemovableFile)
 		if err != nil {
 			t.Fatalf("could not create non i*.t* file in sideloaded storage: %+v", err)
 		}
@@ -273,18 +273,18 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 		// is optional. But the file should still be there!
 		require.NoError(t, err)
 		{
-			_, err := eng.Stat(nonRemovableFile)
+			_, err := eng.Env().Stat(nonRemovableFile)
 			require.NoError(t, err)
 		}
 
 		// Now remove extra file and let truncation proceed to remove directory.
-		require.NoError(t, eng.Remove(nonRemovableFile))
+		require.NoError(t, eng.Env().Remove(nonRemovableFile))
 
 		// Test that directory is removed when filepath.Glob returns 0 matches.
 		_, _, err = ss.TruncateTo(ctx, math.MaxUint64)
 		require.NoError(t, err)
 		// Ensure directory is removed, now that all files should be gone.
-		_, err = eng.Stat(ss.Dir())
+		_, err = eng.Env().Stat(ss.Dir())
 		require.True(t, oserror.IsNotExist(err), "%v", err)
 		// Ensure HasAnyEntry doesn't find anything.
 		found, err := ss.HasAnyEntry(ctx, 0, 10000)
@@ -323,7 +323,7 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 		require.Zero(t, retainedByTruncateTo)
 		require.Equal(t, freedByTruncateTo, freed)
 		// Ensure directory is removed when all records are removed.
-		_, err = eng.Stat(ss.Dir())
+		_, err = eng.Env().Stat(ss.Dir())
 		require.True(t, oserror.IsNotExist(err), "%v", err)
 	}()
 
@@ -570,7 +570,7 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 			if test.size != size {
 				t.Fatalf("expected %d sideloadedSize, but found %d", test.size, size)
 			}
-			actKeys, err := sideloaded.eng.List(sideloaded.Dir())
+			actKeys, err := sideloaded.eng.Env().List(sideloaded.Dir())
 			if oserror.IsNotExist(err) {
 				t.Log("swallowing IsNotExist")
 				err = nil
@@ -638,7 +638,7 @@ func TestSideloadStorageSync(t *testing.T) {
 		ss = newTestingSideloadStorage(eng)
 
 		// The sideloaded directory must exist because all its parents are synced.
-		_, err = eng.Stat(ss.Dir())
+		_, err = eng.Env().Stat(ss.Dir())
 		require.NoError(t, err)
 
 		// The stored entry is still durable if we synced the sideloaded storage

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -783,7 +783,7 @@ func (r *Replica) computeChecksumPostApply(
 		// certain of completing the check. Since we're already in a goroutine
 		// that's about to end, just sleep for a few seconds and then terminate.
 		auxDir := r.store.TODOEngine().GetAuxiliaryDir()
-		_ = r.store.TODOEngine().MkdirAll(auxDir, os.ModePerm)
+		_ = r.store.TODOEngine().Env().MkdirAll(auxDir, os.ModePerm)
 		path := base.PreventedStartupFile(auxDir)
 
 		const attentionFmt = `ATTENTION:
@@ -826,7 +826,7 @@ creation. These directories should be deleted, or inspected with caution.
 `
 		attentionArgs := []any{r, desc.Replicas(), redact.Safe(auxDir), redact.Safe(path)}
 		preventStartupMsg := fmt.Sprintf(attentionFmt, attentionArgs...)
-		if err := fs.WriteFile(r.store.TODOEngine(), path, []byte(preventStartupMsg)); err != nil {
+		if err := fs.WriteFile(r.store.TODOEngine().Env(), path, []byte(preventStartupMsg)); err != nil {
 			log.Warningf(ctx, "%v", err)
 		}
 

--- a/pkg/kv/kvserver/replica_corruption.go
+++ b/pkg/kv/kvserver/replica_corruption.go
@@ -51,7 +51,7 @@ func (r *Replica) setCorruptRaftMuLocked(
 	r.mu.destroyStatus.Set(cErr, destroyReasonRemoved)
 
 	auxDir := r.store.TODOEngine().GetAuxiliaryDir()
-	_ = r.store.TODOEngine().MkdirAll(auxDir, os.ModePerm)
+	_ = r.store.TODOEngine().Env().MkdirAll(auxDir, os.ModePerm)
 	path := base.PreventedStartupFile(auxDir)
 
 	preventStartupMsg := fmt.Sprintf(`ATTENTION:
@@ -64,7 +64,7 @@ A file preventing this node from restarting was placed at:
 %s
 `, r, path)
 
-	if err := fs.WriteFile(r.store.TODOEngine(), path, []byte(preventStartupMsg)); err != nil {
+	if err := fs.WriteFile(r.store.TODOEngine().Env(), path, []byte(preventStartupMsg)); err != nil {
 		log.Warningf(ctx, "%v", err)
 	}
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -744,7 +744,7 @@ func addSSTablePreApply(
 	// filesystem supports it, rather than writing a new copy of it. We cannot
 	// pass it the path in the sideload store as the engine deletes the passed
 	// path on success.
-	if linkErr := env.eng.Link(path, ingestPath); linkErr != nil {
+	if linkErr := env.eng.Env().Link(path, ingestPath); linkErr != nil {
 		// We're on a weird file system that doesn't support Link. This is unlikely
 		// to happen in any "normal" deployment but we have a fallback path anyway.
 		log.Eventf(ctx, "copying SSTable for ingestion at index %d, term %d: %s", index, term, ingestPath)
@@ -781,19 +781,19 @@ func ingestViaCopy(
 ) error {
 	// TODO(tschottdorf): remove this once sideloaded storage guarantees its
 	// existence.
-	if err := eng.MkdirAll(filepath.Dir(ingestPath), os.ModePerm); err != nil {
+	if err := eng.Env().MkdirAll(filepath.Dir(ingestPath), os.ModePerm); err != nil {
 		panic(err)
 	}
-	if _, err := eng.Stat(ingestPath); err == nil {
+	if _, err := eng.Env().Stat(ingestPath); err == nil {
 		// The file we want to ingest exists. This can happen since the
 		// ingestion may apply twice (we ingest before we mark the Raft
 		// command as committed). Just unlink the file (the storage engine
 		// created a hard link); after that we're free to write it again.
-		if err := eng.Remove(ingestPath); err != nil {
+		if err := eng.Env().Remove(ingestPath); err != nil {
 			return errors.Wrapf(err, "while removing existing file during ingestion of %s", ingestPath)
 		}
 	}
-	if err := kvserverbase.WriteFileSyncing(ctx, ingestPath, sst.Data, eng, 0600, st, limiter); err != nil {
+	if err := kvserverbase.WriteFileSyncing(ctx, ingestPath, sst.Data, eng.Env(), 0600, st, limiter); err != nil {
 		return errors.Wrapf(err, "while ingesting %s", ingestPath)
 	}
 	if err := eng.IngestLocalFiles(ctx, []string{ingestPath}); err != nil {

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -251,7 +251,7 @@ func TestRaftSSTableSideloadingTruncation(t *testing.T) {
 		fmtSideloaded := func() []string {
 			tc.repl.raftMu.Lock()
 			defer tc.repl.raftMu.Unlock()
-			fs, _ := tc.repl.store.TODOEngine().List(tc.repl.raftMu.sideloaded.Dir())
+			fs, _ := tc.repl.store.TODOEngine().Env().List(tc.repl.raftMu.sideloaded.Dir())
 			sort.Strings(fs)
 			return fs
 		}

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage.go
@@ -73,7 +73,7 @@ func (s *SSTSnapshotStorage) NewScratchSpace(
 
 // Clear removes all created directories and SSTs.
 func (s *SSTSnapshotStorage) Clear() error {
-	return s.engine.RemoveAll(s.dir)
+	return s.engine.Env().RemoveAll(s.dir)
 }
 
 // scratchClosed is called when an SSTSnapshotStorageScratch created by this
@@ -94,7 +94,7 @@ func (s *SSTSnapshotStorage) scratchClosed(rangeID roachpb.RangeID) {
 		// Suppressing an error here is okay, as orphaned directories are at worst
 		// a performance issue when we later walk directories in pebble.Capacity()
 		// but not a correctness issue.
-		_ = s.engine.RemoveAll(filepath.Join(s.dir, strconv.Itoa(int(rangeID))))
+		_ = s.engine.Env().RemoveAll(filepath.Join(s.dir, strconv.Itoa(int(rangeID))))
 	}
 }
 
@@ -115,7 +115,7 @@ func (s *SSTSnapshotStorageScratch) filename(id int) string {
 }
 
 func (s *SSTSnapshotStorageScratch) createDir() error {
-	err := s.storage.engine.MkdirAll(s.snapDir, os.ModePerm)
+	err := s.storage.engine.Env().MkdirAll(s.snapDir, os.ModePerm)
 	s.dirCreated = s.dirCreated || err == nil
 	return err
 }
@@ -176,7 +176,7 @@ func (s *SSTSnapshotStorageScratch) Close() error {
 	}
 	s.closed = true
 	defer s.storage.scratchClosed(s.rangeID)
-	return s.storage.engine.RemoveAll(s.snapDir)
+	return s.storage.engine.Env().RemoveAll(s.snapDir)
 }
 
 // SSTSnapshotStorageFile is an SST file managed by a
@@ -209,9 +209,9 @@ func (f *SSTSnapshotStorageFile) ensureFile() error {
 	}
 	var err error
 	if f.bytesPerSync > 0 {
-		f.file, err = fs.CreateWithSync(f.scratch.storage.engine, f.filename, int(f.bytesPerSync))
+		f.file, err = fs.CreateWithSync(f.scratch.storage.engine.Env(), f.filename, int(f.bytesPerSync))
 	} else {
-		f.file, err = f.scratch.storage.engine.Create(f.filename)
+		f.file, err = f.scratch.storage.engine.Env().Create(f.filename)
 	}
 	if err != nil {
 		return err

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -52,7 +52,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
 
 	// Check that the storage lazily creates the directories on first write.
-	_, err := eng.Stat(scratch.snapDir)
+	_, err := eng.Env().Stat(scratch.snapDir)
 	if !oserror.IsNotExist(err) {
 		t.Fatalf("expected %s to not exist", scratch.snapDir)
 	}
@@ -65,7 +65,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 
 	// Check that the storage lazily creates the files on write.
 	for _, fileName := range scratch.SSTs() {
-		_, err := eng.Stat(fileName)
+		_, err := eng.Env().Stat(fileName)
 		if !oserror.IsNotExist(err) {
 			t.Fatalf("expected %s to not exist", fileName)
 		}
@@ -75,7 +75,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 
 	// After writing to files, check that they have been flushed to disk.
 	for _, fileName := range scratch.SSTs() {
-		f, err := eng.Open(fileName)
+		f, err := eng.Env().Open(fileName)
 		require.NoError(t, err)
 		data, err := io.ReadAll(f)
 		require.NoError(t, err)
@@ -98,17 +98,17 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	// Check that Close removes the snapshot directory as well as the range
 	// directory.
 	require.NoError(t, scratch.Close())
-	_, err = eng.Stat(scratch.snapDir)
+	_, err = eng.Env().Stat(scratch.snapDir)
 	if !oserror.IsNotExist(err) {
 		t.Fatalf("expected %s to not exist", scratch.snapDir)
 	}
 	rangeDir := filepath.Join(sstSnapshotStorage.dir, strconv.Itoa(int(scratch.rangeID)))
-	_, err = eng.Stat(rangeDir)
+	_, err = eng.Env().Stat(rangeDir)
 	if !oserror.IsNotExist(err) {
 		t.Fatalf("expected %s to not exist", rangeDir)
 	}
 	require.NoError(t, sstSnapshotStorage.Clear())
-	_, err = eng.Stat(sstSnapshotStorage.dir)
+	_, err = eng.Env().Stat(sstSnapshotStorage.dir)
 	if !oserror.IsNotExist(err) {
 		t.Fatalf("expected %s to not exist", sstSnapshotStorage.dir)
 	}
@@ -134,7 +134,7 @@ func TestSSTSnapshotStorageConcurrentRange(t *testing.T) {
 		scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, snapUUID)
 
 		// Check that the storage lazily creates the directories on first write.
-		_, err := eng.Stat(scratch.snapDir)
+		_, err := eng.Env().Stat(scratch.snapDir)
 		if !oserror.IsNotExist(err) {
 			return errors.Errorf("expected %s to not exist", scratch.snapDir)
 		}
@@ -147,7 +147,7 @@ func TestSSTSnapshotStorageConcurrentRange(t *testing.T) {
 
 		// Check that the storage lazily creates the files on write.
 		for _, fileName := range scratch.SSTs() {
-			_, err := eng.Stat(fileName)
+			_, err := eng.Env().Stat(fileName)
 			if !oserror.IsNotExist(err) {
 				return errors.Errorf("expected %s to not exist", fileName)
 			}
@@ -157,7 +157,7 @@ func TestSSTSnapshotStorageConcurrentRange(t *testing.T) {
 
 		// After writing to files, check that they have been flushed to disk.
 		for _, fileName := range scratch.SSTs() {
-			f, err := eng.Open(fileName)
+			f, err := eng.Env().Open(fileName)
 			require.NoError(t, err)
 			data, err := io.ReadAll(f)
 			require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestSSTSnapshotStorageConcurrentRange(t *testing.T) {
 
 		// Check that Close removes the snapshot directory.
 		require.NoError(t, scratch.Close())
-		_, err = eng.Stat(scratch.snapDir)
+		_, err = eng.Env().Stat(scratch.snapDir)
 		if !oserror.IsNotExist(err) {
 			return errors.Errorf("expected %s to not exist", scratch.snapDir)
 		}
@@ -207,12 +207,12 @@ func TestSSTSnapshotStorageConcurrentRange(t *testing.T) {
 	// Ensure that the range directory was deleted after the scratches were
 	// closed.
 	rangeDir := filepath.Join(sstSnapshotStorage.dir, strconv.Itoa(int(testRangeID)))
-	_, err := eng.Stat(rangeDir)
+	_, err := eng.Env().Stat(rangeDir)
 	if !oserror.IsNotExist(err) {
 		t.Fatalf("expected %s to not exist", rangeDir)
 	}
 	require.NoError(t, sstSnapshotStorage.Clear())
-	_, err = eng.Stat(sstSnapshotStorage.dir)
+	_, err = eng.Env().Stat(sstSnapshotStorage.dir)
 	if !oserror.IsNotExist(err) {
 		t.Fatalf("expected %s to not exist", sstSnapshotStorage.dir)
 	}
@@ -288,7 +288,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	var actualSSTs [][]byte
 	fileNames := msstw.scratch.SSTs()
 	for _, file := range fileNames {
-		sst, err := fs.ReadFile(eng, file)
+		sst, err := fs.ReadFile(eng.Env(), file)
 		require.NoError(t, err)
 		actualSSTs = append(actualSSTs, sst)
 	}
@@ -360,7 +360,7 @@ func TestMultiSSTWriterAddLastSpan(t *testing.T) {
 			var actualSSTs [][]byte
 			fileNames := msstw.scratch.SSTs()
 			for _, file := range fileNames {
-				sst, err := fs.ReadFile(eng, file)
+				sst, err := fs.ReadFile(eng.Env(), file)
 				require.NoError(t, err)
 				actualSSTs = append(actualSSTs, sst)
 			}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6727,7 +6727,7 @@ func TestReplicaCorruption(t *testing.T) {
 	}
 
 	// Should have laid down marker file to prevent startup.
-	_, err := tc.engine.Stat(base.PreventedStartupFile(tc.engine.GetAuxiliaryDir()))
+	_, err := tc.engine.Env().Stat(base.PreventedStartupFile(tc.engine.GetAuxiliaryDir()))
 	require.NoError(t, err)
 
 	// Should have triggered fatal error.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3321,7 +3321,7 @@ func (s *Store) checkpointSpans(desc *roachpb.RangeDescriptor) []roachpb.Span {
 // the provided key spans. If spans is empty, it includes the entire store.
 func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
 	checkpointBase := s.checkpointsDir()
-	_ = s.TODOEngine().MkdirAll(checkpointBase, os.ModePerm)
+	_ = s.TODOEngine().Env().MkdirAll(checkpointBase, os.ModePerm)
 	// Create the checkpoint in a "pending" directory first. If we fail midway, it
 	// should be clear that the directory contains an incomplete checkpoint.
 	pendingDir := filepath.Join(checkpointBase, tag+"_pending")
@@ -3330,7 +3330,7 @@ func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
 	}
 	// Atomically rename the directory when it represents a complete checkpoint.
 	checkpointDir := filepath.Join(checkpointBase, tag)
-	if err := s.TODOEngine().Rename(pendingDir, checkpointDir); err != nil {
+	if err := s.TODOEngine().Env().Rename(pendingDir, checkpointDir); err != nil {
 		return "", err
 	}
 	return checkpointDir, nil
@@ -3360,7 +3360,7 @@ func (s *Store) computeMetrics(ctx context.Context) (m storage.Metrics, err erro
 	s.metrics.updateEnvStats(*envStats)
 
 	{
-		dirs, err := s.TODOEngine().List(s.checkpointsDir())
+		dirs, err := s.TODOEngine().Env().List(s.checkpointsDir())
 		if err != nil { // skip NotFound or any other error
 			dirs = nil
 		}

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -115,7 +115,6 @@ go_test(
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/eval",
         "//pkg/sql/types",
-        "//pkg/storage",
         "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/colcontainerutils",

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -278,9 +277,8 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 	// We use an on-disk engine for this test since we're testing FS interactions
 	// and want to get the same behavior as a non-testing environment.
 	tempPath, dirCleanup := testutils.TempDir(t)
-	ngn, err := storage.Open(ctx, fs.MustInitPhysicalTestingEnv(tempPath), cluster.MakeClusterSettings(), storage.CacheSize(0))
-	require.NoError(t, err)
-	defer ngn.Close()
+	env := fs.MustInitPhysicalTestingEnv(tempPath)
+	defer env.Close()
 	defer dirCleanup()
 
 	newVectorizedFlow := func(queriesSpilled *metric.Counter) *vectorizedFlow {
@@ -288,7 +286,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 			&flowinfra.FlowBase{
 				FlowCtx: execinfra.FlowCtx{
 					Cfg: &execinfra.ServerConfig{
-						TempFS:          ngn,
+						TempFS:          env,
 						TempStoragePath: tempPath,
 						VecFDSemaphore:  &colexecop.TestingSemaphore{},
 						Metrics: &execinfra.DistSQLMetrics{
@@ -304,12 +302,12 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 		).(*vectorizedFlow)
 	}
 
-	dirs, err := ngn.List(tempPath)
+	dirs, err := env.List(tempPath)
 	require.NoError(t, err)
 	numDirsTheTestStartedWith := len(dirs)
 	checkDirs := func(t *testing.T, numExtraDirs int) {
 		t.Helper()
-		dirs, err := ngn.List(tempPath)
+		dirs, err := env.List(tempPath)
 		require.NoError(t, err)
 		expectedNumDirs := numDirsTheTestStartedWith + numExtraDirs
 		require.Equal(t, expectedNumDirs, len(dirs), "expected %d directories but found %d: %s", expectedNumDirs, len(dirs), dirs)
@@ -373,12 +371,12 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 		errCh := make(chan error)
 		go func() {
 			createTempDir(ctx)
-			errCh <- ngn.MkdirAll(filepath.Join(vf.GetPath(ctx), "async"), os.ModePerm)
+			errCh <- env.MkdirAll(filepath.Join(vf.GetPath(ctx), "async"), os.ModePerm)
 		}()
 		createTempDir(ctx)
 		// Both goroutines should be able to create their subdirectories within the
 		// flow's temporary directory.
-		require.NoError(t, ngn.MkdirAll(filepath.Join(vf.GetPath(ctx), "main_goroutine"), os.ModePerm))
+		require.NoError(t, env.MkdirAll(filepath.Join(vf.GetPath(ctx), "main_goroutine"), os.ModePerm))
 		require.NoError(t, <-errCh)
 		vf.Cleanup(ctx)
 		checkDirs(t, 0)

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -93,7 +93,7 @@ func getInitialStateEngine(
 	}
 
 	// We now copy the initial state to the desired FS.
-	ok, err := vfs.Clone(vfs.Default, env.DefaultFS, dataDir, env.Dir, vfs.CloneSync)
+	ok, err := vfs.Clone(vfs.Default, env, dataDir, env.Dir, vfs.CloneSync)
 	require.NoError(b, err)
 	require.True(b, ok)
 

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -2116,7 +2116,7 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 			return cmp < 0
 		})
 		sstFileName := fmt.Sprintf("tmp-ingest-%d", i)
-		sstFile, err := eng.Create(sstFileName)
+		sstFile, err := eng.Env().Create(sstFileName)
 		require.NoError(b, err)
 		// No improvement with v3 since the multiple versions are in different
 		// files.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/rangekey"
 	"github.com/cockroachdb/pebble/sstable"
-	"github.com/cockroachdb/pebble/vfs"
 	"github.com/cockroachdb/redact"
 	prometheusgo "github.com/prometheus/client_model/go"
 )
@@ -1080,8 +1079,6 @@ type Engine interface {
 	// of the callback since it could cause a deadlock (since the callback may
 	// be invoked while holding mutexes).
 	RegisterFlushCompletedCallback(cb func())
-	// Filesystem functionality.
-	vfs.FS
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used. If spans is not empty, the checkpoint excludes

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1407,7 +1407,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 		if err := sst.Finish(); err != nil {
 			t.Fatal(err)
 		}
-		if err := fs.WriteFile(db2, `ingest`, memFile.Data()); err != nil {
+		if err := fs.WriteFile(db2.Env(), `ingest`, memFile.Data()); err != nil {
 			t.Fatal(err)
 		}
 		if err := db2.IngestLocalFiles(ctx, []string{`ingest`}); err != nil {

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -269,11 +269,10 @@ func WALFailover(mode base.WALFailoverMode, storeEnvs fs.Envs) ConfigOption {
 			secondaryEnv.Close()
 		})
 
-		secondaryFS := secondaryEnv.DefaultFS
 		secondary := wal.Dir{
-			FS: secondaryFS,
+			FS: secondaryEnv,
 			// Use auxiliary/wals-among-stores within the other stores directory.
-			Dirname: secondaryFS.PathJoin(secondaryEnv.Dir, base.AuxiliaryDir, "wals-among-stores"),
+			Dirname: secondaryEnv.PathJoin(secondaryEnv.Dir, base.AuxiliaryDir, "wals-among-stores"),
 		}
 
 		if mode == base.WALFailoverAmongStores {
@@ -352,7 +351,7 @@ func Open(
 	cfg.Env = env
 	cfg.Settings = settings
 	cfg.Opts = DefaultPebbleOptions()
-	cfg.Opts.FS = env.DefaultFS
+	cfg.Opts.FS = env
 	cfg.Opts.ReadOnly = env.IsReadOnly()
 	for _, opt := range opts {
 		if err := opt(&cfg); err != nil {

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -91,7 +91,7 @@ func TestPebbleIterator_Corruption(t *testing.T) {
 	require.Panics(t, func() { iter.Close() })
 
 	// Should have laid down marker file to prevent startup.
-	_, err = p.Stat(base.PreventedStartupFile(p.GetAuxiliaryDir()))
+	_, err = p.Env().Stat(base.PreventedStartupFile(p.GetAuxiliaryDir()))
 	require.NoError(t, err)
 }
 

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -108,5 +108,5 @@ func newPebbleTempEngine(
 	return &pebbleTempEngine{
 		db:        p.db,
 		closeFunc: env.Close,
-	}, p, nil
+	}, env, nil
 }

--- a/pkg/storage/temp_engine_test.go
+++ b/pkg/storage/temp_engine_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,7 +30,7 @@ func TestNewPebbleTempEngine(t *testing.T) {
 	tempDir, tempDirCleanup := testutils.TempDir(t)
 	defer tempDirCleanup()
 
-	db, fs, err := NewPebbleTempEngine(context.Background(), base.TempStorageConfig{
+	db, filesystem, err := NewPebbleTempEngine(context.Background(), base.TempStorageConfig{
 		Path:     tempDir,
 		Settings: cluster.MakeTestingClusterSettings(),
 	}, base.StoreSpec{Path: tempDir})
@@ -39,7 +40,7 @@ func TestNewPebbleTempEngine(t *testing.T) {
 	defer db.Close()
 
 	// Temp engine initialized with the temporary directory.
-	if dir := fs.(*Pebble).path; tempDir != dir {
+	if dir := filesystem.(*fs.Env).Dir; tempDir != dir {
 		t.Fatalf("temp engine initialized with unexpected parent directory.\nexpected %s\nactual %s",
 			tempDir, dir)
 	}

--- a/pkg/testutils/colcontainerutils/BUILD.bazel
+++ b/pkg/testutils/colcontainerutils/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/settings/cluster",
         "//pkg/sql/colcontainer",
         "//pkg/storage",
         "//pkg/storage/fs",

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -45,24 +44,14 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 		cleanup = append(cleanup, cleanupFunc)
 	}
 
-	ngn, err := storage.Open(
-		context.Background(),
-		fsEnv,
-		cluster.MakeClusterSettings(),
-		storage.ForTesting,
-		storage.CacheSize(0))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	if inMem {
-		if err := ngn.MkdirAll(inMemDirName, os.ModePerm); err != nil {
+		if err := fsEnv.MkdirAll(inMemDirName, os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	cleanup = append(cleanup, ngn.Close)
-	cfg.FS = ngn
+	cleanup = append(cleanup, fsEnv.Close)
+	cfg.FS = fsEnv
 	cfg.GetPather = colcontainer.GetPatherFunc(func(context.Context) string { return path })
 	if err := cfg.EnsureDefaults(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Adapt fs.Env to implement vfs.FS and ensure all uses respect read-only mode when configured. This commit also removes use of the storage.Engine as a vfs.FS in favor of accessing its Env().

Epic: none
Release note: none