### PR TITLE
workload/schemachange: disable foreign keys due to flakes

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -265,7 +265,7 @@ var opWeights = []int{
 	alterFunctionRename:               1,
 	alterFunctionSetSchema:            1,
 	alterTableAddColumn:               1,
-	alterTableAddConstraintForeignKey: 1,
+	alterTableAddConstraintForeignKey: 0, // Disabled due to #119288.
 	alterTableAddConstraintUnique:     0,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
 	alterTableAlterPrimaryKey:         1,


### PR DESCRIPTION
Until #119288 is resolved, this should be disabled.

informs #119288
Release note: None