### PR TITLE
logictest: skip distsql_stats under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1,5 +1,7 @@
 # LogicTest: 5node
 
+skip under race
+
 # Disable histogram collection.
 statement ok
 SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false


### PR DESCRIPTION
Fixes #120484

Release note: None