### PR TITLE
colexecargs: deeply reset monitor registry on Reset

### DIFF
--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -246,8 +246,12 @@ func (r *MonitorRegistry) Close(ctx context.Context) {
 
 // Reset prepares the registry for reuse.
 func (r *MonitorRegistry) Reset() {
-	// There is no need to deeply reset the memory monitoring infra slices
-	// because these objects are very tiny in the grand scheme of things.
+	for i := range r.accounts {
+		r.accounts[i] = nil
+	}
+	for i := range r.monitors {
+		r.monitors[i] = nil
+	}
 	r.accounts = r.accounts[:0]
 	r.monitors = r.monitors[:0]
 }


### PR DESCRIPTION
Given some recent issues we've had with leaks around memory monitors, it seems prudent to deeply reset the slice of monitors that is stored in the monitor registry object and is reused. Note that we haven't seen any evidence of leaks related to this registry, but this change might make things easier for GC, so seems worth it.

Epic: None

Release note: None