### PR TITLE
syncutil/intmap: pick up recent upstream changes

### DIFF
--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -329,8 +329,9 @@ func (e *entry) delete() (value unsafe.Pointer, hadValue bool) {
 //
 // Range does not necessarily correspond to any consistent snapshot of the Map's
 // contents: no key will be visited more than once, but if the value for any key
-// is stored or deleted concurrently, Range may reflect any mapping for that key
-// from any point during the Range call.
+// is stored or deleted concurrently (including by f), Range may reflect any
+// mapping for that key from any point during the Range call. Range does not
+// block other methods on the receiver; even f itself may call any method on m.
 //
 // Range may be O(N) with the number of elements in the map even if f returns
 // false after a constant number of calls.

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -42,6 +42,13 @@ import (
 // The zero IntMap is valid and empty.
 //
 // An IntMap must not be copied after first use.
+//
+// In the terminology of the Go memory model, IntMap arranges that a write
+// operation “synchronizes before” any read operation that observes the effect
+// of the write, where read and write operations are defined as follows.
+// Load, LoadAndDelete, LoadOrStore are read operations;
+// Delete, LoadAndDelete, and Store are write operations;
+// and LoadOrStore is a write operation when it returns loaded set to false.
 type IntMap struct {
 	mu Mutex
 

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -91,7 +91,8 @@ var expunged = unsafe.Pointer(new(int))
 type entry struct {
 	// p points to the value stored for the entry.
 	//
-	// If p == nil, the entry has been deleted and m.dirty == nil.
+	// If p == nil, the entry has been deleted, and either m.dirty == nil or
+	// m.dirty[key] is e.
 	//
 	// If p == expunged, the entry has been deleted, m.dirty != nil, and the entry
 	// is missing from m.dirty.

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -21,24 +21,27 @@ import (
 	"unsafe"
 )
 
-// IntMap is a concurrent map with amortized-constant-time loads, stores, and
-// deletes.  It is safe for multiple goroutines to call a Map's methods
-// concurrently.
+// IntMap is like a Go map[int64]interface{} but is safe for concurrent use by
+// multiple goroutines without additional locking or coordination.
+// Loads, stores, and deletes run in amortized constant time.
 //
-// It is optimized for use in concurrent loops with keys that are
-// stable over time, and either few steady-state stores, or stores
-// localized to one goroutine per key.
+// The IntMap type is specialized. Most code should use a plain Go map instead,
+// with separate locking or coordination, for better type safety and to make it
+// easier to maintain other invariants along with the map content.
 //
-// For use cases that do not share these attributes, it will likely have
-// comparable or worse performance and worse type safety than an ordinary
-// map paired with a read-write mutex.
+// The IntMap type is optimized for two common use cases: (1) when the entry for
+// a given key is only ever written once but read many times, as in caches that
+// only grow, or (2) when multiple goroutines read, write, and overwrite entries
+// for disjoint sets of keys. In these two cases, use of an IntMap may
+// significantly reduce lock contention compared to a Go map paired with a
+// separate Mutex or RWMutex.
 //
-// Nil values are not supported; to use an IntMap as a set store a
-// dummy non-nil pointer instead of nil.
+// Nil values are not supported; to use an IntMap as a set store a dummy non-nil
+// pointer instead of nil.
 //
-// The zero Map is valid and empty.
+// The zero IntMap is valid and empty.
 //
-// A Map must not be copied after first use.
+// An IntMap must not be copied after first use.
 type IntMap struct {
 	mu Mutex
 

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -292,6 +292,7 @@ func (m *IntMap) LoadAndDelete(key int64) (value unsafe.Pointer, loaded bool) {
 			e, ok = read.m[key]
 			if !ok && read.amended {
 				e, ok = m.dirty[key]
+				delete(m.dirty, key)
 				// Regardless of whether the entry was present, record a miss: this key
 				// will take the slow path until the dirty map is promoted to the read
 				// map.

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -187,17 +187,13 @@ func (m *IntMap) Store(key int64, value unsafe.Pointer) {
 // If the entry is expunged, tryStore returns false and leaves the entry
 // unchanged.
 func (e *entry) tryStore(r unsafe.Pointer) bool {
-	p := atomic.LoadPointer(&e.p)
-	if p == expunged {
-		return false
-	}
 	for {
-		if atomic.CompareAndSwapPointer(&e.p, p, r) {
-			return true
-		}
-		p = atomic.LoadPointer(&e.p)
+		p := atomic.LoadPointer(&e.p)
 		if p == expunged {
 			return false
+		}
+		if atomic.CompareAndSwapPointer(&e.p, p, r) {
+			return true
 		}
 	}
 }

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -21,8 +21,8 @@ import (
 	"unsafe"
 )
 
-// IntMap is like a Go map[int64]interface{} but is safe for concurrent use by
-// multiple goroutines without additional locking or coordination.
+// IntMap is like a Go map[int64]any but is safe for concurrent use by multiple
+// goroutines without additional locking or coordination.
 // Loads, stores, and deletes run in amortized constant time.
 //
 // The IntMap type is specialized. Most code should use a plain Go map instead,

--- a/pkg/util/syncutil/int_map_test.go
+++ b/pkg/util/syncutil/int_map_test.go
@@ -66,7 +66,7 @@ func (c mapCall) apply(m mapInterface) (unsafe.Pointer, bool) {
 }
 
 type mapResult struct {
-	value interface{}
+	value any
 	ok    bool
 }
 
@@ -85,15 +85,13 @@ func (mapCall) Generate(r *rand.Rand, size int) reflect.Value {
 	return reflect.ValueOf(c)
 }
 
-func applyCalls(
-	m mapInterface, calls []mapCall,
-) (results []mapResult, final map[interface{}]interface{}) {
+func applyCalls(m mapInterface, calls []mapCall) (results []mapResult, final map[any]any) {
 	for _, c := range calls {
 		v, ok := c.apply(m)
 		results = append(results, mapResult{v, ok})
 	}
 
-	final = make(map[interface{}]interface{})
+	final = make(map[any]any)
 	m.Range(func(k int64, v unsafe.Pointer) bool {
 		final[k] = v
 		return true
@@ -102,15 +100,15 @@ func applyCalls(
 	return results, final
 }
 
-func applyMap(calls []mapCall) ([]mapResult, map[interface{}]interface{}) {
+func applyMap(calls []mapCall) ([]mapResult, map[any]any) {
 	return applyCalls(new(IntMap), calls)
 }
 
-func applyRWMutexMap(calls []mapCall) ([]mapResult, map[interface{}]interface{}) {
+func applyRWMutexMap(calls []mapCall) ([]mapResult, map[any]any) {
 	return applyCalls(new(RWMutexMap), calls)
 }
 
-func applyDeepCopyMap(calls []mapCall) ([]mapResult, map[interface{}]interface{}) {
+func applyDeepCopyMap(calls []mapCall) ([]mapResult, map[any]any) {
 	return applyCalls(new(DeepCopyMap), calls)
 }
 

--- a/pkg/util/syncutil/int_map_test.go
+++ b/pkg/util/syncutil/int_map_test.go
@@ -216,3 +216,53 @@ func TestIssue40999(t *testing.T) {
 		runtime.GC()
 	}
 }
+
+func TestMapRangeNestedCall(t *testing.T) { // Issue 46399
+	var m IntMap
+	for i := 0; i < 3; i++ {
+		m.Store(int64(i), unsafe.Pointer(new(int)))
+	}
+	m.Range(func(key int64, value unsafe.Pointer) bool {
+		m.Range(func(key int64, value unsafe.Pointer) bool {
+			// We should be able to load the key offered in the Range callback,
+			// because there are no concurrent Delete involved in this tested map.
+			if v, ok := m.Load(key); !ok || !reflect.DeepEqual(v, value) {
+				t.Fatalf("Nested Range loads unexpected value, got %+v want %+v", v, value)
+			}
+
+			// We didn't keep 42 and a value into the map before, if somehow we loaded
+			// a value from such a key, meaning there must be an internal bug regarding
+			// nested range in the Map.
+			if _, loaded := m.LoadOrStore(42, unsafe.Pointer(new(int))); loaded {
+				t.Fatalf("Nested Range loads unexpected value, want store a new value")
+			}
+
+			// Try to Store then LoadAndDelete the corresponding value with the key
+			// 42 to the Map. In this case, the key 42 and associated value should be
+			// removed from the Map. Therefore any future range won't observe key 42
+			// as we checked in above.
+			val := unsafe.Pointer(new(int))
+			m.Store(42, val)
+			if v, loaded := m.LoadAndDelete(42); !loaded || !reflect.DeepEqual(v, val) {
+				t.Fatalf("Nested Range loads unexpected value, got %v, want %v", v, val)
+			}
+			return true
+		})
+
+		// Remove key from Map on-the-fly.
+		m.Delete(key)
+		return true
+	})
+
+	// After a Range of Delete, all keys should be removed and any
+	// further Range won't invoke the callback. Hence length remains 0.
+	length := 0
+	m.Range(func(key int64, value unsafe.Pointer) bool {
+		length++
+		return true
+	})
+
+	if length != 0 {
+		t.Fatalf("Unexpected sync.Map size, got %v want %v", length, 0)
+	}
+}

--- a/pkg/util/syncutil/int_map_test.go
+++ b/pkg/util/syncutil/int_map_test.go
@@ -29,13 +29,14 @@ import (
 type mapOp string
 
 const (
-	opLoad        = mapOp("Load")
-	opStore       = mapOp("Store")
-	opLoadOrStore = mapOp("LoadOrStore")
-	opDelete      = mapOp("Delete")
+	opLoad          = mapOp("Load")
+	opStore         = mapOp("Store")
+	opLoadOrStore   = mapOp("LoadOrStore")
+	opLoadAndDelete = mapOp("LoadAndDelete")
+	opDelete        = mapOp("Delete")
 )
 
-var mapOps = [...]mapOp{opLoad, opStore, opLoadOrStore, opDelete}
+var mapOps = [...]mapOp{opLoad, opStore, opLoadOrStore, opLoadAndDelete, opDelete}
 
 // mapCall is a quick.Generator for calls on mapInterface.
 type mapCall struct {
@@ -53,6 +54,8 @@ func (c mapCall) apply(m mapInterface) (unsafe.Pointer, bool) {
 		return nil, false
 	case opLoadOrStore:
 		return m.LoadOrStore(c.k, c.v)
+	case opLoadAndDelete:
+		return m.LoadAndDelete(c.k)
 	case opDelete:
 		m.Delete(c.k)
 		return nil, false


### PR DESCRIPTION
This PR picks up the following [recent changes](https://github.com/golang/go/commits/master/src/sync/map.go) from the upstream stdlib `sync.Map` code:

- golang/go@b0144b3
- golang/go@a71ca3d
- golang/go@2580d0e
- golang/go@d5a5a13
- golang/go@1749f39
- golang/go@94953d3
- golang/go@2e8dbae
- golang/go@756c352
- golang/go@3f15093

It stops before golang/go@395323c, because that major addition to the interface will be easier to merge into this fork after the fork switches over to using generics in a separate PR.

Epic: None
Release note: None