### PR TITLE
changefeedccl: avoid undefined behavior in distribution test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -296,7 +296,11 @@ func newRangeDistributionTester(
 
 	// Distribute the leases exponentially across the first 5 nodes.
 	for i := 0; i < 64; i += 1 {
-		nodeID := int(math.Floor(math.Log2(float64(i)))) + 1
+		nodeID := 1
+		// Avoid log(0).
+		if i != 0 {
+			nodeID = int(math.Floor(math.Log2(float64(i)))) + 1
+		}
 		cmd := fmt.Sprintf(`ALTER TABLE x EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d], %d)`,
 			nodeID, i,
 		)


### PR DESCRIPTION
The `rangeDistributionTester` would sometimes calculate log(0) when determining the node to move a range too. Most of the time, this would be some garbage value which gets ignored. Sometimes, this may return a valid node id, causing the range distribution to be wrong and failing the test failures. This change updates the tester to handle this edge case.

Closes: https://github.com/cockroachdb/cockroach/issues/120470
Release note: None