### PR TITLE
bazci: only set extra params if provided on command-line

### DIFF
--- a/pkg/cmd/bazci/process-bep-file/main.go
+++ b/pkg/cmd/bazci/process-bep-file/main.go
@@ -131,13 +131,17 @@ func process() error {
 				}
 			}
 			if seenNew {
+				var extraParamsSlice []string
+				if *extraParams != "" {
+					extraParamsSlice = strings.Split(*extraParams, ",")
+				}
 				if err := githubpost.PostFromTestXMLWithFailurePoster(
 					ctx, engflow.FailurePoster(res, engflow.FailurePosterOptions{
 						Sha:            sha,
 						InvocationId:   invocation.InvocationId,
 						ServerName:     *serverName,
 						GithubApiToken: githubApiToken,
-						ExtraParams:    strings.Split(*extraParams, ","),
+						ExtraParams:    extraParamsSlice,
 					}), testXml); err != nil {
 					fmt.Printf("could not post to GitHub: got error %+v", err)
 				}


### PR DESCRIPTION
This was accidentally regressed in #120352.

Epic: CRDB-8308
Release note: None