### PR TITLE
sql/logictest: skip lookup_join_local under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join_local
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join_local
@@ -1,5 +1,7 @@
 # LogicTest: local !metamorphic-batch-sizes
 
+skip under race
+
 # This test verifies that the row container used by the join reader spills to
 # disk in order to make room for the non-spillable internal state of the
 # processor.


### PR DESCRIPTION
Fixes #120609

Release note: None