### PR TITLE
kv: listen for quiesce signal in IncrementValRetryable

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -1177,7 +1177,9 @@ func getOneRow(runErr error, b *Batch) (KeyValue, error) {
 func IncrementValRetryable(ctx context.Context, db *DB, key roachpb.Key, inc int64) (int64, error) {
 	var err error
 	var res KeyValue
-	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+	retryOpts := base.DefaultRetryOptions()
+	retryOpts.Closer = db.Context().Stopper.ShouldQuiesce()
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		res, err = db.Inc(ctx, key, inc)
 		if errors.HasType(err, (*kvpb.UnhandledRetryableError)(nil)) ||
 			errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {


### PR DESCRIPTION
This commit makes it so that we specify `Closer` retry option in `IncrementValRetryable` to listen for the quiesce signal as well as updates the retry struct to also use the provided context. We just saw a test failure that occurred due to a slow quiesce of the test server.

Fixes: #120499.

Release note: None