### PR TITLE
retry: always pass context in Start

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -687,7 +687,7 @@ func (n *Node) waitUntilLive(dur time.Duration) error {
 		MaxBackoff:     500 * time.Millisecond,
 		Multiplier:     2,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		var pid int
 		n.Lock()
 		if n.cmd != nil {

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -66,7 +66,7 @@ func BenchmarkPgbenchQueryParallel(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			src := rand.New(rand.NewSource(5432))
-			r := retry.Start(retryOpts)
+			r := retry.StartWithCtx(context.Background(), retryOpts)
 			var err error
 			for pb.Next() {
 				r.Reset()

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -66,7 +66,7 @@ func BenchmarkPgbenchQueryParallel(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			src := rand.New(rand.NewSource(5432))
-			r := retry.StartWithCtx(context.Background(), retryOpts)
+			r := retry.Start(context.Background(), retryOpts)
 			var err error
 			for pb.Next() {
 				r.Reset()

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -847,7 +847,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	var res roachpb.RowCount
 	var lastProgress float32
 	var numBackupInstances int
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		res, numBackupInstances, err = backup(
 			ctx,
 			p,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -176,7 +176,7 @@ func restoreWithRetry(
 		currentPersistedSpans  jobspb.RestoreFrontierEntries
 	)
 
-	for r := retry.StartWithCtx(restoreCtx, retryOpts); r.Next(); {
+	for r := retry.Start(restoreCtx, retryOpts); r.Next(); {
 		res, err = restore(
 			restoreCtx,
 			execCtx,

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -460,7 +460,7 @@ func (r *restoreResumer) sendDownloadWorker(
 		ctx, tsp := tracing.ChildSpan(ctx, "backupccl.sendDownloadWorker")
 		defer tsp.Finish()
 
-		for rt := retry.StartWithCtx(
+		for rt := retry.Start(
 			ctx, retry.Options{InitialBackoff: time.Millisecond * 100, MaxBackoff: time.Second * 10},
 		); ; rt.Next() {
 			if err := ctx.Err(); err != nil {
@@ -567,7 +567,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	}
 
 	var lastProgressUpdate time.Time
-	for rt := retry.StartWithCtx(
+	for rt := retry.Start(
 		ctx, retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second * 10},
 	); ; rt.Next() {
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -678,7 +678,7 @@ var jobRecordRetryOpts = retry.Options{
 
 // waitForCheckpoint waits for the specified job to have a non-empty checkpoint
 func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
-	for r := retry.Start(jobRecordRetryOpts); ; {
+	for r := retry.StartWithCtx(context.Background(), jobRecordRetryOpts); ; {
 		t.Log("waiting for checkpoint")
 		progress := loadProgress(t, jf, jr)
 		if p := progress.GetChangefeed(); p != nil && p.Checkpoint != nil && len(p.Checkpoint.Spans) > 0 {
@@ -693,7 +693,7 @@ func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Reg
 
 // waitForHighwater waits for the specified job to have a non-nil highwater.
 func waitForHighwater(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
-	for r := retry.Start(jobRecordRetryOpts); ; {
+	for r := retry.StartWithCtx(context.Background(), jobRecordRetryOpts); ; {
 		t.Log("waiting for highwater")
 		progress := loadProgress(t, jf, jr)
 		if hw := progress.GetHighWater(); hw != nil && !hw.IsEmpty() {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -678,7 +678,7 @@ var jobRecordRetryOpts = retry.Options{
 
 // waitForCheckpoint waits for the specified job to have a non-empty checkpoint
 func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
-	for r := retry.StartWithCtx(context.Background(), jobRecordRetryOpts); ; {
+	for r := retry.Start(context.Background(), jobRecordRetryOpts); ; {
 		t.Log("waiting for checkpoint")
 		progress := loadProgress(t, jf, jr)
 		if p := progress.GetChangefeed(); p != nil && p.Checkpoint != nil && len(p.Checkpoint.Spans) > 0 {
@@ -693,7 +693,7 @@ func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Reg
 
 // waitForHighwater waits for the specified job to have a non-nil highwater.
 func waitForHighwater(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
-	for r := retry.StartWithCtx(context.Background(), jobRecordRetryOpts); ; {
+	for r := retry.Start(context.Background(), jobRecordRetryOpts); ; {
 		t.Log("waiting for highwater")
 		progress := loadProgress(t, jf, jr)
 		if hw := progress.GetHighWater(); hw != nil && !hw.IsEmpty() {

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -151,7 +151,7 @@ func (p *scanRequestScanner) tryAcquireMemory(
 
 	// We failed to acquire memory for this export.  Begin retry loop -- we may succeed
 	// in the future, once somebody releases memory.
-	for attempt := retry.StartWithCtx(ctx, retryOpts); attempt.Next(); {
+	for attempt := retry.Start(ctx, retryOpts); attempt.Next(); {
 		// Sink implements memory allocator interface, so acquire
 		// memory needed to hold scan reply.
 		if logMemAcquireEvery.ShouldLog() {

--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -36,7 +36,7 @@ func getRetry(ctx context.Context) Retry {
 		}
 	}
 
-	return Retry{Retry: retry.StartWithCtx(ctx, opts)}
+	return Retry{Retry: retry.Start(ctx, opts)}
 }
 
 func testingUseFastRetry() func() {

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -280,7 +280,7 @@ func (r *confluentSchemaRegistry) doWithRetry(ctx context.Context, fn func() err
 	// actionable issues in the operator's environment that which they might be
 	// able to resolve if we made them visible in a failure instead.
 	var err error
-	for retrier := retry.StartWithCtx(ctx, r.retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, r.retryOpts); retrier.Next(); {
 		err = fn()
 		if err == nil {
 			return nil

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -205,7 +205,7 @@ func (c *connector) dialTenantCluster(
 	var err error
 
 	isRetry := false
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		// Track the number of dial retries.
 		if isRetry && c.DialTenantRetries != nil {
 			c.DialTenantRetries.Inc(1)

--- a/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
+++ b/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
@@ -259,7 +259,7 @@ func (sc *spanConfigIngestor) flushEvents(ctx context.Context) error {
 		MaxRetries:     5,
 	}
 
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		sessionStart, sessionExpiration := sc.session.Start(), sc.session.Expiration()
 		if sessionExpiration.IsEmpty() {
 			return errors.Errorf("sqlliveness session has expired")

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -842,7 +842,7 @@ func waitUntilProducerActive(
 	// Make sure the producer job is active before start the stream replication.
 	var status streampb.StreamReplicationStatus
 	var err error
-	for r := retry.StartWithCtx(ctx, ro); r.Next(); {
+	for r := retry.Start(ctx, ro); r.Next(); {
 		status, err = client.Heartbeat(ctx, streamID, heartbeatTimestamp)
 		if err != nil {
 			return errors.Wrapf(err, "failed to resume ingestion job %d due to producer job %d error",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -842,7 +842,7 @@ func waitUntilProducerActive(
 	// Make sure the producer job is active before start the stream replication.
 	var status streampb.StreamReplicationStatus
 	var err error
-	for r := retry.Start(ro); r.Next(); {
+	for r := retry.StartWithCtx(ctx, ro); r.Next(); {
 		status, err = client.Heartbeat(ctx, streamID, heartbeatTimestamp)
 		if err != nil {
 			return errors.Wrapf(err, "failed to resume ingestion job %d due to producer job %d error",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -242,7 +242,7 @@ func ingestWithRetries(
 	ro := getRetryPolicy(execCtx.ExecCfg().StreamingTestingKnobs)
 	var err error
 	var lastReplicatedTime hlc.Timestamp
-	for r := retry.Start(ro); r.Next(); {
+	for r := retry.StartWithCtx(ctx, ro); r.Next(); {
 		err = ingest(ctx, execCtx, resumer)
 		if err == nil {
 			break

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -242,7 +242,7 @@ func ingestWithRetries(
 	ro := getRetryPolicy(execCtx.ExecCfg().StreamingTestingKnobs)
 	var err error
 	var lastReplicatedTime hlc.Timestamp
-	for r := retry.StartWithCtx(ctx, ro); r.Next(); {
+	for r := retry.Start(ctx, ro); r.Next(); {
 		err = ingest(ctx, execCtx, resumer)
 		if err == nil {
 			break

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -771,7 +771,7 @@ func (c *transientCluster) waitForNodeIDReadiness(
 	ctx context.Context, idx int, errCh chan error, timeoutCh <-chan time.Time,
 ) error {
 	retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond, MaxBackoff: time.Second}
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		c.infoLog(ctx, "waiting for server %d to know its node ID", idx)
 		select {
 		// Errors or premature shutdown.
@@ -814,7 +814,7 @@ func (c *transientCluster) waitForSQLReadiness(
 	baseCtx context.Context, idx int, errCh chan error, timeoutCh <-chan time.Time,
 ) error {
 	retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond, MaxBackoff: time.Second}
-	for r := retry.StartWithCtx(baseCtx, retryOpts); r.Next(); {
+	for r := retry.Start(baseCtx, retryOpts); r.Next(); {
 		ctx := logtags.AddTag(baseCtx, "n", c.servers[idx].NodeID())
 		c.infoLog(ctx, "waiting for server %d to become ready", idx)
 		select {
@@ -2161,7 +2161,7 @@ func (c *transientCluster) lockDir(
 	}
 
 	every := log.Every(1 * time.Second)
-	for retry := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 20}); retry.Next(); {
+	for retry := retry.Start(ctx, retry.Options{MaxRetries: 20}); retry.Next(); {
 		if err := tlsLock.TryLock(); err != nil {
 			if errors.Is(err, lockfile.ErrBusy) {
 				if every.ShouldLog() {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -108,7 +108,7 @@ func dialAndCheckHealth(ctx context.Context) error {
 		return err
 	}
 
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		if err := timeutil.RunWithTimeout(
 			ctx, "init-open-conn", 5*time.Second, tryConnect,
 		); err != nil {

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -535,7 +535,7 @@ func runDecommissionNodeImpl(
 	}
 
 	prevResponse := serverpb.DecommissionStatusResponse{}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		req := &serverpb.DecommissionRequest{
 			NodeIDs:          nodeIDs,
 			TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONING,

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -114,7 +114,7 @@ func (h *httpStorage) openStreamAt(
 		headers = map[string]string{"Range": fmt.Sprintf("bytes=%d-", pos)}
 	}
 
-	for attempt, retries := 0, retry.StartWithCtx(ctx, cloud.HTTPRetryOptions); retries.Next(); attempt++ {
+	for attempt, retries := 0, retry.Start(ctx, cloud.HTTPRetryOptions); retries.Next(); attempt++ {
 		resp, err := h.req(ctx, "GET", url, nil, headers)
 		if err == nil {
 			return resp, err

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -234,7 +234,7 @@ func TestHttpGet(t *testing.T) {
 					InitialBackoff: 500 * time.Microsecond,
 					MaxBackoff:     5 * time.Millisecond,
 				}
-				for attempt := retry.StartWithCtx(ctx, opts); attempt.Next(); {
+				for attempt := retry.Start(ctx, opts); attempt.Next(); {
 					s.CloseClientConnections()
 				}
 				return nil

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -305,7 +305,7 @@ func checkDMSReplicated(
 	// both tables have the same number of rows.
 	t.L().Printf("testing all data gets replicated")
 	if err := func() error {
-		for r := retry.StartWithCtx(ctx, waitForReplicationRetryOpts); r.Next(); {
+		for r := retry.Start(ctx, waitForReplicationRetryOpts); r.Next(); {
 			err := func() error {
 				var numRows int
 				if err := targetPGConn.QueryRow("SELECT count(1) FROM test_table").Scan(&numRows); err != nil {
@@ -351,7 +351,7 @@ func checkDMSReplicated(
 
 	t.L().Printf("testing all subsequent updates get replicated")
 	if err := func() error {
-		for r := retry.StartWithCtx(ctx, waitForReplicationRetryOpts); r.Next(); {
+		for r := retry.Start(ctx, waitForReplicationRetryOpts); r.Next(); {
 			err := func() error {
 				var countOfDeletedRow int
 				if err := targetPGConn.QueryRow("SELECT count(1) FROM test_table WHERE id = $1", deleteRowID).Scan(&countOfDeletedRow); err != nil {
@@ -397,7 +397,7 @@ func checkDMSNoPKTableError(ctx context.Context, t test.Test, dmsCli *dms.Client
 	}
 	t.L().Printf("testing no pk table has a table error")
 	if err := func() error {
-		for r := retry.StartWithCtx(ctx, waitForTableError); r.Next(); {
+		for r := retry.Start(ctx, waitForTableError); r.Next(); {
 			err := func() error {
 				dmsTasks, err := dmsCli.DescribeReplicationTasks(ctx, dmsDescribeTasksInput(t.BuildVersion(), "test_table_no_pk"))
 				if err != nil {
@@ -435,7 +435,7 @@ func checkFullLargeDataLoad(ctx context.Context, t test.Test, dmsCli *dms.Client
 	}
 	t.L().Printf("testing all rows from test_table_large replicate")
 	var numRows, nonUpdate = 0, 0
-	for r := retry.StartWithCtx(ctx, waitForFullLoad); r.Next(); {
+	for r := retry.Start(ctx, waitForFullLoad); r.Next(); {
 		err := func() error {
 			dmsTasks, err := dmsCli.DescribeReplicationTasks(ctx, dmsDescribeTasksInput(t.BuildVersion(), "test_table_large"))
 			if err != nil {
@@ -804,7 +804,7 @@ func setupDMSEndpointsAndTask(
 		}); err != nil {
 			return errors.Wrapf(err, "error initiating a test connection")
 		}
-		r := retry.StartWithCtx(ctx, retry.Options{
+		r := retry.Start(ctx, retry.Options{
 			InitialBackoff: 30 * time.Second,
 			MaxBackoff:     time.Minute,
 			MaxRetries:     10,
@@ -876,7 +876,7 @@ func setupDMSEndpointsAndTask(
 		}
 
 		t.L().Printf("starting replication task")
-		r := retry.StartWithCtx(ctx, retry.Options{
+		r := retry.Start(ctx, retry.Options{
 			InitialBackoff: 10 * time.Second,
 			MaxBackoff:     20 * time.Second,
 			MaxRetries:     10,
@@ -910,7 +910,7 @@ func dmsTaskStatusChecker(
 	ctx context.Context, dmsCli *dms.Client, input *dms.DescribeReplicationTasksInput, status string,
 ) error {
 	closer := make(chan struct{})
-	r := retry.StartWithCtx(ctx, retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     30 * time.Second,
 		Closer:         closer,
@@ -1141,7 +1141,7 @@ func tearDownRDSInstances(ctx context.Context, t test.Test, rdsCli *rds.Client) 
 				// group but the cluster takes a while to wind down. Ideally, we wait
 				// for the cluster to get deleted. However, there is no provided
 				// NewDBClusterDeletedWaiter, so we just have to retry it by hand.
-				r := retry.StartWithCtx(ctx, retry.Options{
+				r := retry.Start(ctx, retry.Options{
 					InitialBackoff: 30 * time.Second,
 					MaxBackoff:     time.Minute,
 					MaxRetries:     60,

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -103,7 +103,7 @@ func repeatRunE(
 	args ...string,
 ) error {
 	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -136,7 +136,7 @@ func repeatRunWithDetailsSingleNode(
 		lastResult install.RunResultDetails
 		lastError  error
 	)
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return lastResult, ctx.Err()
 		}
@@ -165,7 +165,7 @@ func repeatGitCloneE(
 	node option.NodeListOption,
 ) error {
 	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -218,7 +218,7 @@ func repeatGetLatestTag(
 		return i
 	}
 	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -86,7 +86,7 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 	rOpts := base.DefaultRetryOptions()
 	rOpts.MaxRetries = 5
 	rOpts.MaxBackoff = 10 * time.Second
-	r := retry.StartWithCtx(ctx, rOpts)
+	r := retry.Start(ctx, rOpts)
 	succeeded := false
 	for r.Next() {
 		start = timeutil.Now()

--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -206,7 +206,7 @@ func (ep *tpccChaosEventProcessor) queryPrometheus(
 	rOpts := base.DefaultRetryOptions()
 	rOpts.MaxRetries = 5
 	var warnings promv1.Warnings
-	for r := retry.Start(rOpts); r.Next(); {
+	for r := retry.StartWithCtx(ctx, rOpts); r.Next(); {
 		val, warnings, err = ep.promClient.Query(
 			ctx,
 			q,

--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -206,7 +206,7 @@ func (ep *tpccChaosEventProcessor) queryPrometheus(
 	rOpts := base.DefaultRetryOptions()
 	rOpts.MaxRetries = 5
 	var warnings promv1.Warnings
-	for r := retry.StartWithCtx(ctx, rOpts); r.Next(); {
+	for r := retry.Start(ctx, rOpts); r.Next(); {
 		val, warnings, err = ep.promClient.Query(
 			ctx,
 			q,

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -502,7 +502,7 @@ func initFollowerReadsDB(
 	// Wait until the table has completed up-replication.
 	t.L().Printf("waiting for up-replication...")
 	retryOpts := retry.Options{MaxBackoff: 15 * time.Second}
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		// Check that the table has the expected number and location of voting and
 		// non-voting replicas. The valid location sets can be larger than the
 		// expected number of replicas, in which case, multiple valid combinations
@@ -563,7 +563,7 @@ func initFollowerReadsDB(
 	}
 
 	if topology.multiRegion {
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Check that one of these replicas exists in each region. Do so by
 			// parsing the replica_localities array using the same pattern as the
 			// one used by SHOW REGIONS.
@@ -584,7 +584,7 @@ func initFollowerReadsDB(
 		}
 
 		if topology.deadPrimaryRegion {
-			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+			for r := retry.Start(ctx, retryOpts); r.Next(); {
 				// If we're going to be killing nodes in a multi-region cluster, make
 				// sure system ranges have all upreplicated as expected as well. Do so
 				// using replication reports.

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -82,7 +82,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 					// Wait for ranges to rebalance across all three regions.
 					t.L().Printf("checking replica balance")
 					retryOpts := retry.Options{MaxBackoff: 15 * time.Second}
-					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+					for r := retry.Start(ctx, retryOpts); r.Next(); {
 						WaitForUpdatedReplicationReport(ctx, t, conn)
 
 						var ok bool
@@ -103,7 +103,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 					// Wait for leases to adhere to preferences, if they aren't
 					// already.
 					t.L().Printf("checking lease preferences")
-					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+					for r := retry.Start(ctx, retryOpts); r.Next(); {
 						var ok bool
 						if err := conn.QueryRowContext(ctx, `
 							SELECT lease_holder <= $1

--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -239,7 +239,7 @@ func (j jepsenConfig) prepareBinary(
 			"test -x lein || (curl -o lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && chmod +x lein)")
 	} else {
 		var err error
-		for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 3, InitialBackoff: 5 * time.Second}); r.Next(); {
+		for r := retry.Start(ctx, retry.Options{MaxRetries: 3, InitialBackoff: 5 * time.Second}); r.Next(); {
 			if ctx.Err() != nil {
 				t.Fatal()
 			}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1510,7 +1510,7 @@ func (mvb *mixedVersionBackup) waitForDBs(
 	}
 
 	for _, dbName := range mvb.dbs {
-		r := retry.StartWithCtx(ctx, retryOptions)
+		r := retry.Start(ctx, retryOptions)
 		var err error
 		for r.Next() {
 			q := "SELECT 1 FROM [SHOW DATABASES] WHERE database_name = $1"
@@ -1631,7 +1631,7 @@ func (u *CommonTestUtils) waitForJobSuccess(
 	if internalSystemJobs {
 		jobsQuery = fmt.Sprintf("(%s)", jobutils.InternalSystemJobsBaseQuery)
 	}
-	r := retry.StartWithCtx(ctx, backupCompletionRetryOptions)
+	r := retry.Start(ctx, backupCompletionRetryOptions)
 	for r.Next() {
 		var status string
 		var payloadBytes []byte

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -291,7 +291,7 @@ func waitForZeroReplicasOnN3(ctx context.Context, t test.Test, db *gosql.DB) {
 	deadline := timeutil.Now().Add(storeDeadTimeout + time.Minute)
 	// We don't use exponential backoff here because we don't expect it to succeed
 	// immediately.
-	for r := retry.StartWithCtx(ctx, retry.Options{
+	for r := retry.Start(ctx, retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     10 * time.Second,
 	}); r.Next() && timeutil.Now().Before(deadline); {

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -159,7 +159,7 @@ func WaitForUpdatedReplicationReport(ctx context.Context, t test.Test, db *gosql
 	// Wait for a new report with a timestamp after tStart to ensure
 	// that the report picks up any new tables or zones.
 	tStart := timeutil.Now()
-	for r := retry.StartWithCtx(ctx, retry.Options{}); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		var count int
 		var gen gosql.NullTime
 		if err := db.QueryRowContext(

--- a/pkg/jobs/ingeststopped/ingesting_checker.go
+++ b/pkg/jobs/ingeststopped/ingesting_checker.go
@@ -37,7 +37,7 @@ func WaitForNoIngestingNodes(
 	ctx, sp := tracing.ChildSpan(ctx, "WaitForNoIngestingNodes")
 	defer sp.Finish()
 
-	retries := retry.StartWithCtx(ctx, retry.Options{
+	retries := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Second,
 		MaxBackoff:     time.Second * 10,
 	})

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -94,7 +94,7 @@ func (r *Registry) waitForJobsToBeTerminalOrPaused(
 		maxBackoff = *r.knobs.IntervalOverrides.WaitForJobsMaxDelay
 	}
 
-	ret := retry.StartWithCtx(ctx, retry.Options{
+	ret := retry.Start(ctx, retry.Options{
 		InitialBackoff: initialBackoff,
 		MaxBackoff:     maxBackoff,
 		Multiplier:     1.5,

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -832,7 +832,7 @@ func (b *SSTBatcher) addSSTable(
 				Multiplier:     2,
 				MaxRetries:     10,
 			}
-			for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+			for r := retry.Start(ctx, opts); r.Next(); {
 				log.VEventf(ctx, 4, "sending %s AddSSTable [%s,%s)", sz(len(item.sstBytes)), item.start, item.end)
 				// If this SST is "too small", the fixed costs associated with adding an
 				// SST – in terms of triggering flushes, extra compactions, etc – would

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -1176,7 +1176,7 @@ func IncrementValRetryable(ctx context.Context, db *DB, key roachpb.Key, inc int
 	var res KeyValue
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = db.Context().Stopper.ShouldQuiesce()
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		res, err = db.Inc(ctx, key, inc)
 		if errors.HasType(err, (*kvpb.UnhandledRetryableError)(nil)) ||
 			errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2009,7 +2009,7 @@ func (ds *DistSender) sendPartialBatch(
 	tBegin, attempts := timeutil.Now(), int64(0) // for slow log message
 	// prevTok maintains the EvictionToken used on the previous iteration.
 	var prevTok rangecache.EvictionToken
-	for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, ds.rpcRetryOptions); r.Next(); {
 		attempts++
 		pErr = nil
 		// If we've invalidated the descriptor on a send failure, re-lookup.
@@ -2549,7 +2549,7 @@ func (ds *DistSender) sendToReplicas(
 	// TODO(andrei): now that requests wait on lease transfers to complete on
 	// outgoing leaseholders instead of immediately redirecting, we should
 	// rethink this backoff policy.
-	inTransferRetry := retry.StartWithCtx(ctx, ds.rpcRetryOptions)
+	inTransferRetry := retry.Start(ctx, ds.rpcRetryOptions)
 	inTransferRetry.Next() // The first call to Next does not block.
 	var sameReplicaRetries int
 	var prevReplica roachpb.ReplicaDescriptor

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -249,7 +249,7 @@ func (s *activeMuxRangeFeed) start(ctx context.Context, m *rangefeedMuxer) error
 	}
 
 	// Start a retry loop for sending the batch to the range.
-	for r := retry.StartWithCtx(ctx, m.ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, m.ds.rpcRetryOptions); r.Next(); {
 		// If we've cleared the descriptor on failure, re-lookup.
 		if !s.token.Valid() {
 			ri, err := m.ds.getRoutingInfo(ctx, s.rSpan.Key, rangecache.EvictionToken{}, false)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -588,7 +588,7 @@ func (ds *DistSender) partialRangeFeed(
 	span := rs.AsRawSpanWithNoLocals()
 
 	// Start a retry loop for sending the batch to the range.
-	for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, ds.rpcRetryOptions); r.Next(); {
 		// If we've cleared the descriptor on a send failure, re-lookup.
 		if !token.Valid() {
 			var err error

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -201,7 +201,7 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 	// Retry loop for looking up next range in the span. The retry loop
 	// deals with retryable range descriptor lookups.
 	var err error
-	for r := retry.StartWithCtx(ctx, ri.ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, ri.ds.rpcRetryOptions); r.Next(); {
 		// Note that we pass an empty eviction token here because ri.token
 		// corresponds to the previous range.
 		var rngInfo rangecache.EvictionToken

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -986,7 +986,7 @@ func (c *connector) getClient(ctx context.Context) (*client, error) {
 // dialAddrs attempts to dial each of the configured addresses in a retry loop.
 // The method will only return a non-nil error on context cancellation.
 func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
-	for r := retry.StartWithCtx(ctx, c.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, c.rpcRetryOptions); r.Next(); {
 		// Try each address on each retry iteration (in random order).
 		for _, i := range rand.Perm(len(c.addrs)) {
 			addr := c.addrs[i]

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -272,7 +272,7 @@ var useMuxRangeFeed = util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", 
 // indicates that an initial scan error is non-recoverable.
 func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier) {
 	defer f.running.Done()
-	r := retry.StartWithCtx(ctx, f.retryOptions)
+	r := retry.Start(ctx, f.retryOptions)
 	restartLogEvery := log.Every(10 * time.Second)
 
 	if f.withInitialScan {

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -202,7 +202,7 @@ func Start[E rangefeedbuffer.Event](
 		defer cancel()
 
 		const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
-		for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+		for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 			started := timeutil.Now()
 			if err := c.Run(ctx); err != nil {
 				if errors.Is(err, context.Canceled) {

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -157,7 +157,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 	case *ClosureTxnOperation:
 		// Use a backoff loop to avoid thrashing on txn aborts. Don't wait between
 		// epochs of the same transaction to avoid waiting while holding locks.
-		retryOnAbort := retry.StartWithCtx(ctx, retry.Options{
+		retryOnAbort := retry.Start(ctx, retry.Options{
 			InitialBackoff: 1 * time.Millisecond,
 			MaxBackoff:     250 * time.Millisecond,
 		})
@@ -659,7 +659,7 @@ func resultInit(ctx context.Context, err error) Result {
 func getRangeDesc(ctx context.Context, key roachpb.Key, dbs ...*kv.DB) roachpb.RangeDescriptor {
 	var dbIdx int
 	var opts = retry.Options{}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); dbIdx = (dbIdx + 1) % len(dbs) {
+	for r := retry.Start(ctx, opts); r.Next(); dbIdx = (dbIdx + 1) % len(dbs) {
 		sender := dbs[dbIdx].NonTransactionalSender()
 		descs, _, err := kv.RangeLookup(ctx, sender, key, kvpb.CONSISTENT, 0, false)
 		if err != nil {

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -531,7 +531,7 @@ func (rp ReplicaPlanner) findRemoveVoter(
 
 	var candidates []roachpb.ReplicaDescriptor
 	deadline := timeutil.Now().Add(timeout)
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next() && timeutil.Now().Before(deadline); {
+	for r := retry.Start(ctx, retryOpts); r.Next() && timeutil.Now().Before(deadline); {
 		lastReplAdded, lastAddedTime := repl.LastReplicaAdded()
 		if timeutil.Since(lastAddedTime) > newReplicaGracePeriod {
 			lastReplAdded = 0

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1357,7 +1357,7 @@ func verifyCanReadFromAllRepls(
 		repl := repls[i]
 		g.Go(func() (err error) {
 			var shouldRetry bool
-			for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); <-r.NextCh() {
+			for r := retry.Start(ctx, retryOptions); r.Next(); <-r.NextCh() {
 				if shouldRetry, err = f(repl.Send(ctx, baRead)); !shouldRetry {
 					return err
 				}

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -106,7 +106,7 @@ func (ia *Allocator) start() {
 		for {
 			var newValue int64
 			var err error
-			for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
 					func(ctx context.Context) {
 						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, ia.opts.BlockSize)

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -106,7 +106,7 @@ func (ia *Allocator) start() {
 		for {
 			var newValue int64
 			var err error
-			for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
 					func(ctx context.Context) {
 						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, ia.opts.BlockSize)

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -379,7 +379,7 @@ func (nl *NodeLiveness) SetDraining(
 	ctx = nl.ambientCtx.AnnotateCtx(ctx)
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = nl.stopper.ShouldQuiesce()
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		oldLivenessRec, ok := nl.cache.self()
 		if !ok {
 			// There was a cache miss, let's now fetch the record from KV
@@ -639,7 +639,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 				func(ctx context.Context) error {
 					nl.cache.checkForStaleEntries(gossip.StoreTTL)
 					// Retry heartbeat in the event the conditional put fails.
-					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+					for r := retry.Start(ctx, retryOpts); r.Next(); {
 						oldLiveness, ok := nl.Self()
 						if !ok {
 							nodeID := nl.cache.selfID()
@@ -1070,7 +1070,7 @@ func (nl *NodeLiveness) updateLiveness(
 	}
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = nl.stopper.ShouldQuiesce()
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		written, err := nl.updateLivenessAttempt(ctx, update, handleCondFailed)
 		if err != nil {
 			if errors.HasType(err, (*errRetryLiveness)(nil)) {

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -150,7 +150,7 @@ func (ls *storageImpl) Update(
 // NB: An existing liveness record is not overwritten by this method, we return
 // an error instead.
 func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error {
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// We start off at epoch=0, entrusting the initial heartbeat to increment it
 		// to epoch=1 to signal the very first time the node is up and running.
 		liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0}

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -659,7 +659,7 @@ func makeVisitAvailableNodes(
 	) error {
 		visitWithRetry := func(node roachpb.NodeDescriptor) error {
 			var err error
-			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+			for r := retry.Start(ctx, retryOpts); r.Next(); {
 				log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
 				addr := node.AddressForLocality(loc)
 				var conn *grpc.ClientConn
@@ -744,7 +744,7 @@ func makeVisitNode(g *gossip.Gossip, loc roachpb.Locality, rpcCtx *rpc.Context) 
 		if err != nil {
 			return err
 		}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
 			addr := node.AddressForLocality(loc)
 			var conn *grpc.ClientConn

--- a/pkg/kv/kvserver/range_log.go
+++ b/pkg/kv/kvserver/range_log.go
@@ -246,7 +246,7 @@ func writeToRangeLogTable(
 		if err := stopper.RunAsyncTask(
 			asyncCtx, "rangelog-async", func(ctx context.Context) {
 				defer stopCancel()
-				for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+				for r := retry.Start(ctx, retryOpts); r.Next(); {
 					if err := timeutil.RunWithTimeout(ctx, "rangelog-timeout", perAttemptTimeout, func(ctx context.Context) error {
 						return s.cfg.RangeLogWriter.WriteRangeLogEvent(ctx, txn.DB(), logEvent)
 					}); err != nil {

--- a/pkg/kv/kvserver/range_log.go
+++ b/pkg/kv/kvserver/range_log.go
@@ -241,13 +241,12 @@ func writeToRangeLogTable(
 		const perAttemptTimeout = 20 * time.Second
 		const maxAttempts = 3
 		retryOpts := base.DefaultRetryOptions()
-		retryOpts.Closer = asyncCtx.Done()
 		retryOpts.MaxRetries = maxAttempts
 
 		if err := stopper.RunAsyncTask(
 			asyncCtx, "rangelog-async", func(ctx context.Context) {
 				defer stopCancel()
-				for r := retry.Start(retryOpts); r.Next(); {
+				for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 					if err := timeutil.RunWithTimeout(ctx, "rangelog-timeout", perAttemptTimeout, func(ctx context.Context) error {
 						return s.cfg.RangeLogWriter.WriteRangeLogEvent(ctx, txn.DB(), logEvent)
 					}); err != nil {

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -592,7 +592,7 @@ func (r *registration) waitForCaughtUp(ctx context.Context) error {
 		MaxBackoff:     10 * time.Second,
 		MaxRetries:     50,
 	}
-	for re := retry.StartWithCtx(ctx, opts); re.Next(); {
+	for re := retry.Start(ctx, opts); re.Next(); {
 		r.mu.Lock()
 		caughtUp := len(r.buf) == 0 && r.mu.caughtUp
 		r.mu.Unlock()

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2220,7 +2220,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 	taskCtx := r.AnnotateCtx(context.Background())
 	err = r.store.stopper.RunAsyncTask(taskCtx, "wait-for-merge", func(ctx context.Context) {
 		var pushTxnRes *kvpb.PushTxnResponse
-		for retry := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); retry.Next(); {
+		for retry := retry.Start(ctx, base.DefaultRetryOptions()); retry.Next(); {
 			// Wait for the merge transaction to complete by attempting to push it. We
 			// don't want to accidentally abort the merge transaction, so we use the
 			// minimum transaction priority. Note that a push type of
@@ -2270,7 +2270,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 			// record before our PushTxn arrived. To figure out what happened, we
 			// need to look in meta2.
 			var getRes *kvpb.GetResponse
-			for retry := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); retry.Next(); {
+			for retry := retry.Start(ctx, base.DefaultRetryOptions()); retry.Next(); {
 				metaKey := keys.RangeMetaKey(desc.EndKey)
 				res, pErr := kv.SendWrappedWith(ctx, r.store.DB().NonTransactionalSender(), kvpb.Header{
 					// Use READ_UNCOMMITTED to avoid trying to resolve intents, since

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2220,7 +2220,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 	taskCtx := r.AnnotateCtx(context.Background())
 	err = r.store.stopper.RunAsyncTask(taskCtx, "wait-for-merge", func(ctx context.Context) {
 		var pushTxnRes *kvpb.PushTxnResponse
-		for retry := retry.Start(base.DefaultRetryOptions()); retry.Next(); {
+		for retry := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); retry.Next(); {
 			// Wait for the merge transaction to complete by attempting to push it. We
 			// don't want to accidentally abort the merge transaction, so we use the
 			// minimum transaction priority. Note that a push type of
@@ -2270,7 +2270,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 			// record before our PushTxn arrived. To figure out what happened, we
 			// need to look in meta2.
 			var getRes *kvpb.GetResponse
-			for retry := retry.Start(base.DefaultRetryOptions()); retry.Next(); {
+			for retry := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); retry.Next(); {
 				metaKey := keys.RangeMetaKey(desc.EndKey)
 				res, pErr := kv.SendWrappedWith(ctx, r.store.DB().NonTransactionalSender(), kvpb.Header{
 					// Use READ_UNCOMMITTED to avoid trying to resolve intents, since

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -642,7 +642,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 	retryOpts.RandomizationFactor = 0.5
 	var lastErr error
 	splitRetryLogLimiter := log.Every(10 * time.Second)
-	for retryable := retry.StartWithCtx(ctx, retryOpts); retryable.Next(); {
+	for retryable := retry.Start(ctx, retryOpts); retryable.Next(); {
 		// The replica may have been destroyed since the start of the retry loop.
 		// We need to explicitly check this condition. Having a valid lease, as we
 		// verify below, does not imply that the range still exists: even after a
@@ -1004,7 +1004,7 @@ func (r *Replica) WaitForLeaseAppliedIndex(
 		Multiplier:     2,
 		MaxBackoff:     time.Second,
 	}
-	for retry := retry.StartWithCtx(ctx, retryOpts); retry.Next(); {
+	for retry := retry.Start(ctx, retryOpts); retry.Next(); {
 		if currentLAI := r.GetLeaseAppliedIndex(); currentLAI >= lai {
 			return currentLAI, nil
 		}
@@ -1910,7 +1910,7 @@ func (r *Replica) initializeRaftLearners(
 	descriptorOK := false
 	start := timeutil.Now()
 	retOpts := retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetries: 10}
-	for re := retry.StartWithCtx(ctx, retOpts); re.Next(); {
+	for re := retry.Start(ctx, retOpts); re.Next(); {
 		rDesc := r.Desc()
 		if rDesc.Generation >= desc.Generation {
 			descriptorOK = true
@@ -2330,7 +2330,7 @@ func prepareChangeReplicasTrigger(
 func within10s(ctx context.Context, fn func() error) error {
 	retOpts := retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetries: 10}
 	var err error
-	for re := retry.StartWithCtx(ctx, retOpts); re.Next(); {
+	for re := retry.Start(ctx, retOpts); re.Next(); {
 		err = fn()
 		if err == nil {
 			return nil
@@ -3597,7 +3597,7 @@ func (r *Replica) relocateReplicas(
 
 	every := log.Every(time.Minute)
 	for {
-		for re := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: 5 * time.Second}); re.Next(); {
+		for re := retry.Start(ctx, retry.Options{MaxBackoff: 5 * time.Second}); re.Next(); {
 			if err := ctx.Err(); err != nil {
 				return rangeDesc, err
 			}
@@ -4129,7 +4129,7 @@ func (r *Replica) adminScatter(
 	}
 
 	// Loop until we hit an error or until we hit `maxAttempts` for the range.
-	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+	for re := retry.Start(ctx, retryOpts); re.Next(); {
 		if currentAttempt == maxAttempts {
 			break
 		}

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1035,7 +1035,7 @@ func (r *Replica) AdminTransferLease(
 	if count := r.store.TestingKnobs().LeaseTransferRejectedRetryLoopCount; count != 0 {
 		retryOpts.MaxRetries = count
 	}
-	transferRejectedRetry := retry.StartWithCtx(ctx, retryOpts)
+	transferRejectedRetry := retry.Start(ctx, retryOpts)
 	transferRejectedRetry.Next() // The first call to Next does not block.
 
 	// Loop while there's an extension in progress.

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -646,7 +646,7 @@ func (rq *replicateQueue) process(
 	// Use a retry loop in order to backoff in the case of snapshot errors,
 	// usually signaling that a rebalancing reservation could not be made with the
 	// selected target.
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		requeue, err := rq.processOneChangeWithTracing(ctx, repl, desc, &conf)
 		if isSnapshotError(err) {
 			// If ChangeReplicas failed because the snapshot failed, we attempt to

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1988,7 +1988,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 			everySecond := log.Every(time.Second)
 			var err error
 			// Avoid retry.ForDuration because of https://github.com/cockroachdb/cockroach/issues/25091.
-			for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+			for r := retry.Start(ctx, opts); r.Next(); {
 				err = nil
 				if numRemaining := transferAllAway(ctx); numRemaining > 0 {
 					// Report progress to the Drain RPC.
@@ -3889,7 +3889,7 @@ func (s *Store) WaitForSpanConfigSubscription(ctx context.Context) error {
 		return nil // nothing to do here
 	}
 
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		if !s.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty() {
 			return nil
 		}

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -68,7 +68,7 @@ func (s *Store) getOrCreateReplica(
 	// process of being removed or may need to be removed. Retries in the loop
 	// imply that a removal is actually being carried out, not that we're waiting
 	// on a queue.
-	r := retry.StartWithCtx(ctx, retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Microsecond,
 		// Set the backoff up to only a small amount to wait for data that
 		// might need to be cleared.

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -68,7 +68,7 @@ func (s *Store) getOrCreateReplica(
 	// process of being removed or may need to be removed. Retries in the loop
 	// imply that a removal is actually being carried out, not that we're waiting
 	// on a queue.
-	r := retry.Start(retry.Options{
+	r := retry.StartWithCtx(ctx, retry.Options{
 		InitialBackoff: time.Microsecond,
 		// Set the backoff up to only a small amount to wait for data that
 		// might need to be cleared.

--- a/pkg/kv/kvserver/store_gossip.go
+++ b/pkg/kv/kvserver/store_gossip.go
@@ -128,7 +128,7 @@ func (s *Store) startGossip() {
 				// case we want to retry quickly.
 				retryOptions := base.DefaultRetryOptions()
 				retryOptions.Closer = s.stopper.ShouldQuiesce()
-				for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+				for r := retry.Start(ctx, retryOptions); r.Next(); {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key)); repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
 						if err := gossipFn.fn(annotatedCtx, repl); err != nil {

--- a/pkg/kv/kvserver/store_gossip.go
+++ b/pkg/kv/kvserver/store_gossip.go
@@ -128,7 +128,7 @@ func (s *Store) startGossip() {
 				// case we want to retry quickly.
 				retryOptions := base.DefaultRetryOptions()
 				retryOptions.Closer = s.stopper.ShouldQuiesce()
-				for r := retry.Start(retryOptions); r.Next(); {
+				for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key)); repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
 						if err := gossipFn.fn(annotatedCtx, repl); err != nil {

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -84,7 +84,7 @@ func (is Server) WaitForApplication(
 		// TODO(benesch): Once Replica changefeeds land, see if we can implement
 		// this request handler without polling.
 		retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Long-lived references to replicas are frowned upon, so re-fetch the
 			// replica on every turn of the loop.
 			repl, err := s.GetReplica(req.RangeID)
@@ -127,7 +127,7 @@ func (is Server) WaitForReplicaInit(
 	resp := &WaitForReplicaInitResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader, func(ctx context.Context, s *Store) error {
 		retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Long-lived references to replicas are frowned upon, so re-fetch the
 			// replica on every turn of the loop.
 			if repl, err := s.GetReplica(req.RangeID); err == nil && repl.IsInitialized() {

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -892,7 +892,7 @@ func (q *Queue) startQueryPusherTxn(
 		func(ctx context.Context) {
 			// We use a backoff/retry here in case the pusher transaction
 			// doesn't yet exist.
-			for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 				var pErr *kvpb.Error
 				var updatedPusher *roachpb.Transaction
 				updatedPusher, waitingTxns, pErr = q.queryTxnStatus(

--- a/pkg/kv/range_lookup.go
+++ b/pkg/kv/range_lookup.go
@@ -196,7 +196,7 @@ func RangeLookup(
 		Multiplier:     2,
 	}
 
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		// Determine the "Range Metadata Key" for the provided key.
 		rkey, err := addrForDir(prefetchReverse)(key)
 		if err != nil {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -161,7 +161,7 @@ func runWithMaybeRetry(
 	var res = &RunResultDetails{}
 	var cmdErr, err error
 
-	for r := retry.StartWithCtx(ctx, *retryOpts); r.Next(); {
+	for r := retry.Start(ctx, *retryOpts); r.Next(); {
 		res, err = f(ctx)
 		if err != nil {
 			// non retryable roachprod error

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -602,7 +602,7 @@ func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
 func (p *Provider) waitForIPs(
 	l *logger.Logger, names []string, regions []string, opts *ProviderOpts,
 ) error {
-	waitForIPRetry := retry.StartWithCtx(context.Background(), retry.Options{
+	waitForIPRetry := retry.Start(context.Background(), retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
 		MaxRetries:     120, // wait a bit less than 90s for IPs
@@ -1512,7 +1512,7 @@ func (p *Provider) CreateVolume(
 
 	waitForVolumeCloser := make(chan struct{})
 
-	waitForVolume := retry.StartWithCtx(context.Background(), retry.Options{
+	waitForVolume := retry.Start(context.Background(), retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
 		MaxRetries:     10,

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -12,6 +12,7 @@
 package aws
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -601,7 +602,7 @@ func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
 func (p *Provider) waitForIPs(
 	l *logger.Logger, names []string, regions []string, opts *ProviderOpts,
 ) error {
-	waitForIPRetry := retry.Start(retry.Options{
+	waitForIPRetry := retry.StartWithCtx(context.Background(), retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
 		MaxRetries:     120, // wait a bit less than 90s for IPs
@@ -1511,7 +1512,7 @@ func (p *Provider) CreateVolume(
 
 	waitForVolumeCloser := make(chan struct{})
 
-	waitForVolume := retry.Start(retry.Options{
+	waitForVolume := retry.StartWithCtx(context.Background(), retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
 		MaxRetries:     10,

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -51,7 +51,7 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 			}
 		}
 
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			clusterVersion, err := s.clusterVersion(ctx)
 			if err != nil {
 				log.Errorf(ctx, "unable to retrieve cluster version: %v", err)
@@ -100,7 +100,7 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 
 			// Run the set cluster setting version statement in a transaction
 			// until success.
-			for ur := retry.StartWithCtx(ctx, upgradeRetryOpts); ur.Next(); {
+			for ur := retry.Start(ctx, upgradeRetryOpts); ur.Next(); {
 				if _, err := s.sqlServer.internalExecutor.ExecEx(
 					ctx, "set-version", nil, /* txn */
 					sessiondata.NodeUserSessionDataOverride,

--- a/pkg/server/loss_of_quorum.go
+++ b/pkg/server/loss_of_quorum.go
@@ -157,7 +157,7 @@ func maybeRunLossOfQuorumRecoveryCleanup(
 			MaxBackoff:     time.Hour,
 			Multiplier:     2,
 		}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Nodes are already dead, but are in active state. Internal checks doesn't
 			// allow us throwing nodes away, and they need to go through legal state
 			// transitions within liveness to succeed. To achieve that we mark nodes as

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2277,7 +2277,7 @@ func (s *topLevelServer) runIdempontentSQLForInitType(
 		MaxBackoff:     10 * time.Second,
 		InitialBackoff: time.Second,
 	}
-	for r := retry.StartWithCtx(ctx, rOpts); r.Next(); {
+	for r := retry.Start(ctx, rOpts); r.Next(); {
 		if err := initAttempt(); err != nil {
 			log.Errorf(ctx, "cluster initialization attempt failed: %s", err.Error())
 			continue

--- a/pkg/server/server_controller_channel_orchestrator.go
+++ b/pkg/server/server_controller_channel_orchestrator.go
@@ -360,7 +360,7 @@ func (o *channelOrchestrator) startControlledServer(
 		var tenantStopper *stop.Stopper
 
 		var tenantServer orchestratedServer
-		for retry := retry.StartWithCtx(ctx, retryOpts); retry.Next(); {
+		for retry := retry.Start(ctx, retryOpts); retry.Next(); {
 			tenantStopper = stop.NewStopper()
 
 			// Task that is solely responsible for propagating ungraceful exits.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -491,7 +491,7 @@ func (r *refreshInstanceSessionListener) OnSessionDeleted(
 	ctx context.Context,
 ) (createAnotherSession bool) {
 	if err := r.cfg.stopper.RunAsyncTask(ctx, "refresh-instance-session", func(ctx context.Context) {
-		for i := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: time.Second * 5}); i.Next(); {
+		for i := retry.Start(ctx, retry.Options{MaxBackoff: time.Second * 5}); i.Next(); {
 			select {
 			case <-r.cfg.stopper.ShouldQuiesce():
 				return

--- a/pkg/server/tenant_auto_upgrade.go
+++ b/pkg/server/tenant_auto_upgrade.go
@@ -146,7 +146,7 @@ func (s *SQLServer) startAttemptTenantUpgrade(
 
 	// Run the set cluster setting version statement in a transaction
 	// until success.
-	for ur := retry.StartWithCtx(ctx, upgradeRetryOpts); ur.Next(); {
+	for ur := retry.Start(ctx, upgradeRetryOpts); ur.Next(); {
 		if _, err := s.internalExecutor.ExecEx(
 			ctx, "set-version", nil, /* txn */
 			sessiondata.NodeUserSessionDataOverride,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -432,7 +432,7 @@ func (ts *testServer) HeartbeatNodeLiveness() error {
 
 	var err error
 	ctx := context.Background()
-	for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 5}); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{MaxRetries: 5}); r.Next(); {
 		if err = nl.Heartbeat(ctx, l); !errors.Is(err, liveness.ErrEpochIncremented) {
 			break
 		}

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -157,7 +157,7 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 
 	var lastCheckpoint = hlc.Timestamp{}
 	const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		started := timeutil.Now()
 		if err := rc.Reconcile(ctx, lastCheckpoint, r.job.Session(), func() error {
 			if onCheckpointInterceptor != nil {

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -447,7 +447,7 @@ func updateSpanConfigRecords(
 		MaxRetries:     5,
 	}
 
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		sessionStart, sessionExpiration := session.Start(), session.Expiration()
 		if sessionExpiration.IsEmpty() {
 			return errors.Errorf("sqlliveness session has expired")

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -122,7 +122,7 @@ func CheckTwoVersionInvariant(
 	decAfterWait := descsCol.leased.lm.IncGaugeAfterLeaseDuration(lease.GaugeWaitForTwoVersionViolation)
 	defer decAfterWait()
 	// Wait until all older version leases have been released or expired.
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// Use the current clock time.
 		now := clock.Now()
 		count, err := lease.CountLeases(ctx, db, codec, regions, settings, withNewVersion, now, false /*forAnyVersion*/)

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -155,7 +155,7 @@ func (m *Manager) PublishMultiple(
 ) (map[descpb.ID]catalog.Descriptor, error) {
 	errLeaseVersionChanged := errors.New("lease version changed")
 	// Retry while getting errLeaseVersionChanged.
-	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// Wait until there are no unexpired leases on the previous versions
 		// of the descriptors.
 		expectedVersions := make(map[descpb.ID]descpb.DescriptorVersion)

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -155,7 +155,7 @@ func (m *Manager) PublishMultiple(
 ) (map[descpb.ID]catalog.Descriptor, error) {
 	errLeaseVersionChanged := errors.New("lease version changed")
 	// Retry while getting errLeaseVersionChanged.
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// Wait until there are no unexpired leases on the previous versions
 		// of the descriptors.
 		expectedVersions := make(map[descpb.ID]descpb.DescriptorVersion)

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -179,7 +179,7 @@ func (m *Manager) WaitForNoVersion(
 	// takes longer than the lease duration.
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForNoVersion)
 	defer decAfterWait()
-	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
+	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		now := m.storage.clock.Now()
 		count, err := CountLeases(ctx, m.storage.db, m.Codec(), cachedDatabaseRegions, m.settings, versions, now, true /*forAnyVersion*/)
 		if err != nil {
@@ -224,7 +224,7 @@ func (m *Manager) WaitForOneVersion(
 	// takes longer than the lease duration.
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForOneVersion)
 	defer decAfterWait()
-	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
+	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		if err := m.storage.db.KV().Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 			// Use the lower-level MaybeGetDescriptorByIDUnvalidated to avoid
 			// performing validation while waiting for leases to drain.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -179,7 +179,7 @@ func (m *Manager) WaitForNoVersion(
 	// takes longer than the lease duration.
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForNoVersion)
 	defer decAfterWait()
-	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for lastCount, r := 0, retry.Start(ctx, retryOpts); r.Next(); {
 		now := m.storage.clock.Now()
 		count, err := CountLeases(ctx, m.storage.db, m.Codec(), cachedDatabaseRegions, m.settings, versions, now, true /*forAnyVersion*/)
 		if err != nil {
@@ -224,7 +224,7 @@ func (m *Manager) WaitForOneVersion(
 	// takes longer than the lease duration.
 	decAfterWait := m.IncGaugeAfterLeaseDuration(GaugeWaitForOneVersion)
 	defer decAfterWait()
-	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for lastCount, r := 0, retry.Start(ctx, retryOpts); r.Next(); {
 		if err := m.storage.db.KV().Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 			// Use the lower-level MaybeGetDescriptorByIDUnvalidated to avoid
 			// performing validation while waiting for leases to drain.

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3986,7 +3986,7 @@ func TestLongLeaseWaitMetrics(t *testing.T) {
 		lease.LeaseDuration.Override(ctx, &st.SV, 0)
 		close(startWaiters)
 
-		r := retry.StartWithCtx(ctx, retry.Options{})
+		r := retry.Start(ctx, retry.Options{})
 		// Wait until long waits are detected in our metrics.
 		for r.Next() {
 			if srv.MustGetSQLCounter("sql.leases.long_wait_for_no_version") == 0 {
@@ -4020,7 +4020,7 @@ func TestLongLeaseWaitMetrics(t *testing.T) {
 	// Waits for one version of the descriptor to exist.
 	grp.GoCtx(func(ctx context.Context) error {
 		<-startWaiters
-		r := retry.StartWithCtx(ctx, retry.Options{})
+		r := retry.Start(ctx, retry.Options{})
 		for r.Next() {
 			// Wait for the two versions to exist.
 			if srv.MustGetSQLCounter("sql.leases.long_wait_for_two_version_invariant") == 0 {

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -258,7 +258,7 @@ func (s storage) acquire(
 	}()
 	// Run a retry loop to deal with AmbiguousResultErrors. All other error types
 	// are propagated up to the caller.
-	for r := retry.StartWithCtx(ctx, retry.Options{}); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		err := s.db.KV().Txn(ctx, acquireInTxn)
 		switch {
 		case startup.IsRetryableReplicaError(err):
@@ -321,7 +321,7 @@ func (s storage) release(
 	}()
 	// This transaction is idempotent; the retry was put in place because of
 	// NodeUnavailableErrors.
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		log.VEventf(ctx, 2, "storage releasing lease %+v", lease)
 		instanceID := s.nodeIDContainer.SQLInstanceID()
 		if instanceID == 0 {

--- a/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
+++ b/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
@@ -139,7 +139,7 @@ func updateSchedule(ctx context.Context, db isql.DB, st *cluster.Settings, clust
 		InitialBackoff: time.Second,
 		MaxBackoff:     10 * time.Minute,
 	}
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			// Ensure schedule exists.
 			var sj *jobs.ScheduledJob

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -660,7 +660,7 @@ func validateUniqueConstraint(
 		Multiplier:     1.5,
 		MaxRetries:     5,
 	}
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		values, err = txn.QueryRowEx(ctx, "validate unique constraint", txn.KV(), sessionDataOverride, query)
 		if err == nil {
 			break

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -131,7 +131,7 @@ func (s *fdCountingSemaphore) Acquire(ctx context.Context, n int) error {
 		RandomizationFactor: 0.25,
 		MaxRetries:          s.acquireMaxRetries,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		if s.TryAcquire(n) {
 			return nil
 		}

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1107,7 +1107,7 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 		// careful here.
 		rOpts.MaxRetries = 1
 	}
-	r := retry.StartWithCtx(ctx, rOpts)
+	r := retry.Start(ctx, rOpts)
 	for r.Next() {
 		if err = c.insertRowsInternal(ctx, finalBatch); err == nil {
 			// We're done with this batch of rows, so reset the buffered data

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -643,9 +643,8 @@ func asyncWriteToOtelAndSystemEventsTable(
 			// (retriable errors are already processed automatically
 			// by db.Txn)
 			retryOpts := base.DefaultRetryOptions()
-			retryOpts.Closer = ctx.Done()
 			retryOpts.MaxRetries = int(maxAttempts)
-			for r := retry.Start(retryOpts); r.Next(); {
+			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 				// Don't try too long to write if the system table is unavailable.
 				if err := timeutil.RunWithTimeout(ctx, "record-events", perAttemptTimeout, func(ctx context.Context) error {
 					return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -644,7 +644,7 @@ func asyncWriteToOtelAndSystemEventsTable(
 			// by db.Txn)
 			retryOpts := base.DefaultRetryOptions()
 			retryOpts.MaxRetries = int(maxAttempts)
-			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+			for r := retry.Start(ctx, retryOpts); r.Next(); {
 				// Don't try too long to write if the system table is unavailable.
 				if err := timeutil.RunWithTimeout(ctx, "record-events", perAttemptTimeout, func(ctx context.Context) error {
 					return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -43,7 +43,7 @@ func GetConnForOutbox(
 	ctx context.Context, dialer Dialer, sqlInstanceID base.SQLInstanceID, timeout time.Duration,
 ) (conn *grpc.ClientConn, err error) {
 	firstConnectionAttempt := timeutil.Now()
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		conn, err = dialer.DialNoBreaker(ctx, roachpb.NodeID(sqlInstanceID), rpc.DefaultClass)
 		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
 			break

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1298,7 +1298,7 @@ func ingestWithRetry(
 	var err error
 	// State to decide when to exit the retry loop.
 	lastProgressChange, lastProgress := timeutil.Now(), getFractionCompleted(job)
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		for {
 			res, err = distImport(
 				ctx, execCtx, job, tables, typeDescs, from, format, walltime, testingKnobs, procsPerNode,

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -676,7 +676,7 @@ func queryJobUntil(
 	t *testing.T, db sqlutils.DBHandle, jobID jobspb.JobID, isDone func(js jobState) bool,
 ) (js jobState) {
 	t.Helper()
-	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.StartWithCtx(context.Background(), base.DefaultRetryOptions()); r.Next(); {
 		js = queryJob(db, jobID)
 		if js.err != nil || isDone(js) {
 			break

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -676,7 +676,7 @@ func queryJobUntil(
 	t *testing.T, db sqlutils.DBHandle, jobID jobspb.JobID, isDone func(js jobState) bool,
 ) (js jobState) {
 	t.Helper()
-	for r := retry.StartWithCtx(context.Background(), base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(context.Background(), base.DefaultRetryOptions()); r.Next(); {
 		js = queryJob(db, jobID)
 		if js.err != nil || isDone(js) {
 			break

--- a/pkg/sql/importer/rollback_job.go
+++ b/pkg/sql/importer/rollback_job.go
@@ -52,7 +52,7 @@ func (r *importRollbackResumer) Resume(ctx context.Context, execCtx interface{})
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     10 * time.Minute,
 	}
-	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+	for re := retry.Start(ctx, retryOpts); re.Next(); {
 		err := r.rollbackTable(ctx, cfg, tableID)
 		if err != nil {
 			log.Errorf(ctx, "rollback of table %d failed: %s", tableID, err.Error())

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -141,7 +141,7 @@ func (p *planner) waitForDescriptorSchemaChanges(
 	// Wait for the descriptor to no longer be claimed by a schema change.
 	start := timeutil.Now()
 	logEvery := log.Every(10 * time.Second)
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		now := p.ExecCfg().Clock.Now()
 		var isBlocked bool
 		var blockingJobIDs []catpb.JobID

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2714,7 +2714,7 @@ func (r schemaChangeResumer) Resume(ctx context.Context, execCtx interface{}) er
 		// for other retriable reasons so we run it in an exponential backoff retry
 		// loop. The loop terminates only if the context is canceled.
 		var scErr error
-		for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+		for r := retry.Start(ctx, opts); r.Next(); {
 			// Note that r.Next always returns true on first run so exec will be
 			// called at least once before there is a chance for this loop to exit.
 			if err := p.ExecCfg().JobRegistry.CheckPausepoint("schemachanger.before.exec"); err != nil {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -255,7 +255,7 @@ CREATE INDEX foo ON t.test (v)
 	}
 
 	// Wait until index is created.
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
 		if len(tableDesc.PublicNonPrimaryIndexes()) == 1 {
@@ -281,7 +281,7 @@ CREATE INDEX foo ON t.test (v)
 
 	mTest.Exec(t, `ALTER INDEX t.test@foo RENAME TO ufo`)
 
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		// Ensure that the version gets incremented.
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
@@ -302,7 +302,7 @@ CREATE INDEX foo ON t.test (v)
 		mTest.Exec(t, fmt.Sprintf(`CREATE INDEX foo%d ON t.test (v)`, i))
 	}
 	// Wait until indexes are created.
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
 		if len(tableDesc.PublicNonPrimaryIndexes()) == count+1 {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -255,7 +255,7 @@ CREATE INDEX foo ON t.test (v)
 	}
 
 	// Wait until index is created.
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
 		if len(tableDesc.PublicNonPrimaryIndexes()) == 1 {
@@ -281,7 +281,7 @@ CREATE INDEX foo ON t.test (v)
 
 	mTest.Exec(t, `ALTER INDEX t.test@foo RENAME TO ufo`)
 
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		// Ensure that the version gets incremented.
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
@@ -302,7 +302,7 @@ CREATE INDEX foo ON t.test (v)
 		mTest.Exec(t, fmt.Sprintf(`CREATE INDEX foo%d ON t.test (v)`, i))
 	}
 	// Wait until indexes are created.
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
 		if len(tableDesc.PublicNonPrimaryIndexes()) == count+1 {

--- a/pkg/sql/schemachanger/corpus/corpus.go
+++ b/pkg/sql/schemachanger/corpus/corpus.go
@@ -11,6 +11,7 @@
 package corpus
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -210,7 +211,7 @@ func (cc *Collector) UpdateCorpus() error {
 // lockCorpus locks the corpus file on disk for reading/writing.
 func (cr *Reader) lockCorpus() (unlockFn func(), err error) {
 	var f *os.File
-	r := retry.Start(retry.Options{})
+	r := retry.StartWithCtx(context.Background(), retry.Options{})
 	// File creation/deletion is atomic so use it to lock the corpus on disk.
 	// Note: On Linux/Unix we can do better and use unix.Flock, but that won't
 	// be platform independent.

--- a/pkg/sql/schemachanger/corpus/corpus.go
+++ b/pkg/sql/schemachanger/corpus/corpus.go
@@ -211,7 +211,7 @@ func (cc *Collector) UpdateCorpus() error {
 // lockCorpus locks the corpus file on disk for reading/writing.
 func (cr *Reader) lockCorpus() (unlockFn func(), err error) {
 	var f *os.File
-	r := retry.StartWithCtx(context.Background(), retry.Options{})
+	r := retry.Start(context.Background(), retry.Options{})
 	// File creation/deletion is atomic so use it to lock the corpus on disk.
 	// Note: On Linux/Unix we can do better and use unix.Flock, but that won't
 	// be platform independent.

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -300,7 +300,7 @@ func (s *Storage) createInstanceRow(
 		MaxBackoff:     200 * time.Millisecond,
 		Multiplier:     2,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		log.Infof(ctx, "assigning instance id to rpc addr %s and sql addr %s", rpcAddr, sqlAddr)
 		instanceID, err := assignInstance()
 		// Instance was successfully assigned an ID.

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -218,7 +218,7 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 		Multiplier:     1.5,
 	}
 	everySecond := log.Every(time.Second)
-	for i, r := 0, retry.StartWithCtx(ctx, opts); r.Next(); {
+	for i, r := 0, retry.Start(ctx, opts); r.Next(); {
 		i++
 		if err = l.storage.Insert(ctx, s.id, s.Expiration()); err != nil {
 			if ctx.Err() != nil {
@@ -270,7 +270,7 @@ func (l *Instance) extendSession(ctx context.Context, s *session) (bool, error) 
 	var err error
 	var found bool
 	// Retry until success or until the context is canceled.
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		if found, exp, err = l.storage.Update(ctx, s.ID(), exp); err != nil {
 			if ctx.Err() != nil {
 				break

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -164,7 +164,7 @@ func (j *jobMonitor) updateSchedule(ctx context.Context, cronExpr string) {
 		InitialBackoff: time.Second,
 		MaxBackoff:     10 * time.Minute,
 	}
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		if err = j.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			// We check if we can get load the schedule, if the schedule cannot be
 			// loaded because it's not found, we recreate the schedule.

--- a/pkg/sql/tenant_update.go
+++ b/pkg/sql/tenant_update.go
@@ -333,7 +333,7 @@ func stepTenantServiceState(
 		log.Infof(ctx, "waiting for all nodes to stop service for tenant %d", inInfo.ID)
 		if err := timeutil.RunWithTimeout(ctx, "wait-for-tenant-stop", 10*time.Minute, func(ctx context.Context) error {
 			retryOpts := retry.Options{MaxBackoff: 10 * time.Second}
-			for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+			for re := retry.Start(ctx, retryOpts); re.Next(); {
 				resp, err := statusSrv.TenantServiceStatus(ctx, &serverpb.TenantServiceStatusRequest{TenantID: inInfo.ID})
 				if err != nil {
 					return errors.Wrap(err, "failed waiting for tenant service status")

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1300,7 +1300,7 @@ func (t *typeSchemaChanger) execWithRetry(ctx context.Context) error {
 		MaxBackoff:     20 * time.Second,
 		Multiplier:     1.5,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		if err := t.execCfg.JobRegistry.CheckPausepoint("typeschemachanger.before.exec"); err != nil {
 			return err
 		}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1418,7 +1418,8 @@ func (tc *TestCluster) findMemberStore(storeID roachpb.StoreID) (*kvserver.Store
 // TODO(andrei): This method takes inexplicably long.
 // I think it shouldn't need any retries. See #38565.
 func (tc *TestCluster) WaitForFullReplication() error {
-	log.Infof(context.TODO(), "WaitForFullReplication")
+	ctx := context.TODO()
+	log.Infof(ctx, "WaitForFullReplication")
 	start := timeutil.Now()
 	defer func() {
 		end := timeutil.Now()
@@ -1437,7 +1438,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 	}
 
 	notReplicated := true
-	for r := retry.Start(opts); r.Next() && notReplicated; {
+	for r := retry.StartWithCtx(ctx, opts); r.Next() && notReplicated; {
 		notReplicated = false
 		for _, s := range tc.Servers {
 			err := s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1438,7 +1438,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 	}
 
 	notReplicated := true
-	for r := retry.StartWithCtx(ctx, opts); r.Next() && notReplicated; {
+	for r := retry.Start(ctx, opts); r.Next() && notReplicated; {
 		notReplicated = false
 		for _, s := range tc.Servers {
 			err := s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
@@ -1789,7 +1789,7 @@ func (tc *TestCluster) RestartServerWithInspect(
 	return timeutil.RunWithTimeout(
 		ctx, "check-conn", 15*time.Second,
 		func(ctx context.Context) error {
-			r := retry.StartWithCtx(ctx, retry.Options{
+			r := retry.Start(ctx, retry.Options{
 				InitialBackoff: 1 * time.Millisecond,
 				MaxBackoff:     100 * time.Millisecond,
 			})

--- a/pkg/upgrade/upgradecluster/tenant_cluster.go
+++ b/pkg/upgrade/upgradecluster/tenant_cluster.go
@@ -292,7 +292,7 @@ func (t *TenantCluster) UntilClusterStable(ctx context.Context, fn func() error)
 
 	// TODO(ajstorm): this could use a test to validate that the retry behavior
 	//  does what we expect. I've tested it manually in the debugger for now.
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		if err := fn(); err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/v24_1_session_based_lease.go
+++ b/pkg/upgrade/upgrades/v24_1_session_based_lease.go
@@ -86,7 +86,7 @@ SELECT
 FROM
 	expected AS e, current AS c;
 `
-	r := retry.StartWithCtx(ctx, retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Millisecond * 500,
 		Multiplier:     2,
 		MaxBackoff:     time.Second * 10,

--- a/pkg/upgrade/upgrades/version_starvation_test.go
+++ b/pkg/upgrade/upgrades/version_starvation_test.go
@@ -92,7 +92,7 @@ func TestLeasingClusterVersionStarvation(t *testing.T) {
 			return
 		}
 		resumeBump <- struct{}{}
-		for retry := retry.Start(retry.Options{}); retry.Next(); {
+		for retry := retry.StartWithCtx(ctx, retry.Options{}); retry.Next(); {
 			_, err = tx.Exec("SELECT name from system.settings where name='version' FOR UPDATE")
 			if err != nil {
 				rollbackErr := tx.Rollback()

--- a/pkg/upgrade/upgrades/version_starvation_test.go
+++ b/pkg/upgrade/upgrades/version_starvation_test.go
@@ -92,7 +92,7 @@ func TestLeasingClusterVersionStarvation(t *testing.T) {
 			return
 		}
 		resumeBump <- struct{}{}
-		for retry := retry.StartWithCtx(ctx, retry.Options{}); retry.Next(); {
+		for retry := retry.Start(ctx, retry.Options{}); retry.Next(); {
 			_, err = tx.Exec("SELECT name from system.settings where name='version' FOR UPDATE")
 			if err != nil {
 				rollbackErr := tx.Rollback()

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -40,11 +40,11 @@ type Retry struct {
 	isReset        bool
 }
 
-// StartWithCtx returns a new Retry initialized to some default values. The
-// Retry can then be used in an exponential-backoff retry loop. If the provided
-// context is canceled (see Context.Done), the retry loop ends early, but will
-// always run at least once.
-func StartWithCtx(ctx context.Context, opts Options) Retry {
+// Start returns a new Retry initialized to some default values. The Retry can
+// then be used in an exponential-backoff retry loop. If the provided context is
+// canceled (see Context.Done), the retry loop ends early, but will always run
+// at least once.
+func Start(ctx context.Context, opts Options) Retry {
 	if opts.InitialBackoff == 0 {
 		opts.InitialBackoff = 50 * time.Millisecond
 	}
@@ -162,7 +162,7 @@ func (r *Retry) CurrentAttempt() int {
 // return is prompted by a successful invocation of `fn`.
 func (opts Options) Do(ctx context.Context, fn func(ctx context.Context) error) error {
 	var err error
-	for r := StartWithCtx(ctx, opts); r.Next(); {
+	for r := Start(ctx, opts); r.Next(); {
 		err = fn(ctx)
 		if err == nil {
 			return nil

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -40,12 +40,6 @@ type Retry struct {
 	isReset        bool
 }
 
-// Start returns a new Retry initialized to some default values. The Retry can
-// then be used in an exponential-backoff retry loop.
-func Start(opts Options) Retry {
-	return StartWithCtx(context.Background(), opts)
-}
-
 // StartWithCtx returns a new Retry initialized to some default values. The
 // Retry can then be used in an exponential-backoff retry loop. If the provided
 // context is canceled (see Context.Done), the retry loop ends early, but will

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -27,7 +27,7 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 		MaxRetries:     10,
 	}
 
-	r := StartWithCtx(context.Background(), opts)
+	r := Start(context.Background(), opts)
 	r.opts.RandomizationFactor = 0
 	for i := 0; i < 10; i++ {
 		d := r.retryIn()
@@ -47,7 +47,7 @@ func TestRetryExceedsMaxAttempts(t *testing.T) {
 	}
 
 	attempts := 0
-	for r := StartWithCtx(context.Background(), opts); r.Next(); attempts++ {
+	for r := Start(context.Background(), opts); r.Next(); attempts++ {
 	}
 
 	if expAttempts := opts.MaxRetries + 1; attempts != expAttempts {
@@ -68,7 +68,7 @@ func TestRetryReset(t *testing.T) {
 	attempts := 0
 	// Backoff loop has 1 allowed retry; we always call Reset, so
 	// just make sure we get to 2 attempts and then break.
-	for r := StartWithCtx(context.Background(), opts); r.Next(); attempts++ {
+	for r := Start(context.Background(), opts); r.Next(); attempts++ {
 		if attempts == expAttempts {
 			break
 		}
@@ -92,7 +92,7 @@ func TestRetryStop(t *testing.T) {
 	var attempts int
 
 	// Create a retry loop which will never stop without stopper.
-	for r := StartWithCtx(context.Background(), opts); r.Next(); attempts++ {
+	for r := Start(context.Background(), opts); r.Next(); attempts++ {
 		go close(closer)
 		// Don't race the stopper, just wait for it to do its thing.
 		<-opts.Closer
@@ -111,7 +111,7 @@ func TestRetryNextCh(t *testing.T) {
 		Multiplier:     2,
 		MaxRetries:     1,
 	}
-	for r := StartWithCtx(context.Background(), opts); attempts < 3; attempts++ {
+	for r := Start(context.Background(), opts); attempts < 3; attempts++ {
 		c := r.NextCh()
 		if r.currentAttempt != attempts {
 			t.Errorf("expected attempt=%d; got %d", attempts, r.currentAttempt)

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -27,7 +27,7 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 		MaxRetries:     10,
 	}
 
-	r := Start(opts)
+	r := StartWithCtx(context.Background(), opts)
 	r.opts.RandomizationFactor = 0
 	for i := 0; i < 10; i++ {
 		d := r.retryIn()
@@ -47,7 +47,7 @@ func TestRetryExceedsMaxAttempts(t *testing.T) {
 	}
 
 	attempts := 0
-	for r := Start(opts); r.Next(); attempts++ {
+	for r := StartWithCtx(context.Background(), opts); r.Next(); attempts++ {
 	}
 
 	if expAttempts := opts.MaxRetries + 1; attempts != expAttempts {
@@ -68,7 +68,7 @@ func TestRetryReset(t *testing.T) {
 	attempts := 0
 	// Backoff loop has 1 allowed retry; we always call Reset, so
 	// just make sure we get to 2 attempts and then break.
-	for r := Start(opts); r.Next(); attempts++ {
+	for r := StartWithCtx(context.Background(), opts); r.Next(); attempts++ {
 		if attempts == expAttempts {
 			break
 		}
@@ -92,7 +92,7 @@ func TestRetryStop(t *testing.T) {
 	var attempts int
 
 	// Create a retry loop which will never stop without stopper.
-	for r := Start(opts); r.Next(); attempts++ {
+	for r := StartWithCtx(context.Background(), opts); r.Next(); attempts++ {
 		go close(closer)
 		// Don't race the stopper, just wait for it to do its thing.
 		<-opts.Closer
@@ -111,7 +111,7 @@ func TestRetryNextCh(t *testing.T) {
 		Multiplier:     2,
 		MaxRetries:     1,
 	}
-	for r := Start(opts); attempts < 3; attempts++ {
+	for r := StartWithCtx(context.Background(), opts); attempts < 3; attempts++ {
 		c := r.NextCh()
 		if r.currentAttempt != attempts {
 			t.Errorf("expected attempt=%d; got %d", attempts, r.currentAttempt)

--- a/pkg/util/startup/retry.go
+++ b/pkg/util/startup/retry.go
@@ -138,7 +138,7 @@ func RunIdempotentWithRetryEx[T any](
 	var err error
 	retryOpts := startupRetryOpts
 	retryOpts.Closer = quiesce
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		result, err = f(ctx)
 		if err == nil {
 			break

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -441,7 +441,7 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		cancel()
 	}).Stop()
 	if prepareErr := func(ctx context.Context) error {
-		retry := retry.StartWithCtx(ctx, retry.Options{})
+		retry := retry.Start(ctx, retry.Options{})
 		var err error
 		for retry.Next() {
 			if err != nil {


### PR DESCRIPTION
**retry: switch all callers of Start to use StartWithCtx**

It seems to me that it's a mistake in the retry package API to provide `Start` method that doesn't take in a context object, so this commit (in combination with the following one) removes all such callsites. In particular, we now always use `StartWithCtx` method with the context we have in scope. Also, if previously the `Closer` option was set to `context.Done` channel, then it is now removed as being redundant with passing the context explicitly.

`Start` method is now removed.

Release note: None

**retry: rename StartWithCtx to Start**

This commit is a purely mechanical change.

Release note: None

Epic: None