### PR TITLE
opt/memo: extend OutputCols with VirtualCols in statistics builder

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3744,6 +3744,10 @@ func (m *sessionDataMutator) SetPLpgSQLUseStrictInto(val bool) {
 	m.data.PLpgSQLUseStrictInto = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseVirtualComputedColumnStats(val bool) {
+	m.data.OptimizerUseVirtualComputedColumnStats = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6115,6 +6115,7 @@ optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 optimizer_use_provided_ordering_fix                        on
+optimizer_use_virtual_computed_column_stats                on
 override_multi_region_zone_config                          off
 parallelize_multi_key_lookup_joins_enabled                 off
 password_encryption                                        scram-sha-256

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2897,6 +2897,7 @@ optimizer_use_lock_op_for_serializable                     off                 N
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                          off                 NULL      NULL        NULL        string
 optimizer_use_provided_ordering_fix                        on                  NULL      NULL        NULL        string
+optimizer_use_virtual_computed_column_stats                on                  NULL      NULL        NULL        string
 override_multi_region_zone_config                          off                 NULL      NULL        NULL        string
 parallelize_multi_key_lookup_joins_enabled                 off                 NULL      NULL        NULL        string
 password_encryption                                        scram-sha-256       NULL      NULL        NULL        string
@@ -3074,6 +3075,7 @@ optimizer_use_lock_op_for_serializable                     off                 N
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                          off                 NULL  user     NULL      off                 off
 optimizer_use_provided_ordering_fix                        on                  NULL  user     NULL      on                  on
+optimizer_use_virtual_computed_column_stats                on                  NULL  user     NULL      on                  on
 override_multi_region_zone_config                          off                 NULL  user     NULL      off                 off
 parallelize_multi_key_lookup_joins_enabled                 off                 NULL  user     NULL      false               false
 password_encryption                                        scram-sha-256       NULL  user     NULL      scram-sha-256       scram-sha-256
@@ -3250,6 +3252,7 @@ optimizer_use_lock_op_for_serializable                     NULL    NULL     NULL
 optimizer_use_multicol_stats                               NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_provided_ordering_fix                        NULL    NULL     NULL     NULL        NULL
+optimizer_use_virtual_computed_column_stats                NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                          NULL    NULL     NULL     NULL        NULL
 parallelize_multi_key_lookup_joins_enabled                 NULL    NULL     NULL     NULL        NULL
 password_encryption                                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -136,6 +136,7 @@ optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 optimizer_use_provided_ordering_fix                        on
+optimizer_use_virtual_computed_column_stats                on
 override_multi_region_zone_config                          off
 parallelize_multi_key_lookup_joins_enabled                 off
 password_encryption                                        scram-sha-256

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -730,6 +730,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 	h.evalCtx.SessionData().InsertFastPath = true
 	h.evalCtx.SessionData().OptSplitScanLimit = tabledesc.MaxBucketAllowed
 	h.evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
+	h.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
 
 	// Set up the test catalog.
 	h.testCat = testcat.New()

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2238,7 +2238,7 @@ quality of service: regular
 query T
 EXPLAIN (OPT, MEMO) SELECT * FROM tc JOIN t ON k=a
 ----
-memo (optimized, ~17KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~18KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7] [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7] [distribution: test]" [presentation: a:1,b:2,k:6,v:7] [distribution: test])
@@ -2315,7 +2315,7 @@ TABLE t
  ├── tableoid oid [hidden] [system]
  └── PRIMARY INDEX t_pkey
       └── k int not null
-memo (optimized, ~17KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~18KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1,b:2,k:6,v:7] [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1,b:2,k:6,v:7] [distribution: test]" [presentation: a:1,b:2,k:6,v:7] [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -700,7 +700,7 @@ upsert bc
 query T
 EXPLAIN (OPT, MEMO, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
 ----
-memo (optimized, ~33KB, required=[presentation: info:19] [distribution: test])
+memo (optimized, ~34KB, required=[presentation: info:19] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:19] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1544,7 +1544,7 @@ delete f
 query T
 EXPLAIN (OPT, MEMO, REDACT) DELETE FROM f WHERE f = 8.5
 ----
-memo (optimized, ~15KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~16KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1690,7 +1690,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM bc WHERE b >= 1.0 AND b < 2.0
 ----
-memo (optimized, ~11KB, required=[presentation: info:5] [distribution: test])
+memo (optimized, ~12KB, required=[presentation: info:5] [distribution: test])
  ├── G1: (explain G2 [presentation: b:1,c:2] [distribution: test])
  │    └── [presentation: info:5] [distribution: test]
  │         ├── best: (explain G2="[presentation: b:1,c:2] [distribution: test]" [presentation: b:1,c:2] [distribution: test])
@@ -1841,7 +1841,7 @@ select
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM g WHERE (g || 'abc') LIKE '%ggg%'
 ----
-memo (optimized, ~12KB, required=[presentation: info:7] [distribution: test])
+memo (optimized, ~13KB, required=[presentation: info:7] [distribution: test])
  ├── G1: (explain G2 [presentation: g:1] [distribution: test])
  │    └── [presentation: info:7] [distribution: test]
  │         ├── best: (explain G2="[presentation: g:1] [distribution: test]" [presentation: g:1] [distribution: test])
@@ -1972,7 +1972,7 @@ select
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT a FROM a WHERE a % 8 > 2
 ----
-memo (optimized, ~6KB, required=[presentation: info:5] [distribution: test])
+memo (optimized, ~7KB, required=[presentation: info:5] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1] [distribution: test])
  │    └── [presentation: info:5] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1] [distribution: test]" [presentation: a:1] [distribution: test])
@@ -2439,7 +2439,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM bc JOIN f ON b = f + 1
 ----
-memo (optimized, ~26KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~27KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [presentation: b:1,c:2,f:5] [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[presentation: b:1,c:2,f:5] [distribution: test]" [presentation: b:1,c:2,f:5] [distribution: test])
@@ -2824,7 +2824,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT f, g FROM f, LATERAL (SELECT count(DISTINCT c + f + 1) * 2 AS g FROM bc WHERE b * f < 10)
 ----
-memo (optimized, ~32KB, required=[presentation: info:12] [distribution: test])
+memo (optimized, ~33KB, required=[presentation: info:12] [distribution: test])
  ├── G1: (explain G2 [presentation: f:1,g:11] [distribution: test])
  │    └── [presentation: info:12] [distribution: test]
  │         ├── best: (explain G2="[presentation: f:1,g:11] [distribution: test]" [presentation: f:1,g:11] [distribution: test])
@@ -3103,7 +3103,7 @@ anti-join-apply
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM a WHERE a > ALL (SELECT c::int + 2 FROM bc WHERE b > a::float * 3)
 ----
-memo (optimized, ~21KB, required=[presentation: info:11] [distribution: test])
+memo (optimized, ~22KB, required=[presentation: info:11] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1] [distribution: test])
  │    └── [presentation: info:11] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1] [distribution: test]" [presentation: a:1] [distribution: test])

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -176,6 +176,7 @@ type Memo struct {
 	useProvidedOrderingFix                     bool
 	mergeJoinsEnabled                          bool
 	plpgsqlUseStrictInto                       bool
+	useVirtualComputedColumnStats              bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -250,6 +251,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useProvidedOrderingFix:                     evalCtx.SessionData().OptimizerUseProvidedOrderingFix,
 		mergeJoinsEnabled:                          evalCtx.SessionData().OptimizerMergeJoinsEnabled,
 		plpgsqlUseStrictInto:                       evalCtx.SessionData().PLpgSQLUseStrictInto,
+		useVirtualComputedColumnStats:              evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -398,6 +400,7 @@ func (m *Memo) IsStale(
 		m.useProvidedOrderingFix != evalCtx.SessionData().OptimizerUseProvidedOrderingFix ||
 		m.mergeJoinsEnabled != evalCtx.SessionData().OptimizerMergeJoinsEnabled ||
 		m.plpgsqlUseStrictInto != evalCtx.SessionData().PLpgSQLUseStrictInto ||
+		m.useVirtualComputedColumnStats != evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -436,6 +436,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerMergeJoinsEnabled = false
 	notStale()
 
+	// Stale optimizer_use_virtual_computed_column_stats.
+	evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
+	stale()
+	evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -662,7 +662,15 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 			var colOrd int
 			for i := 0; i < stat.ColumnCount(); i++ {
 				colOrd = stat.ColumnOrdinal(i)
-				cols.Add(tabID.ColumnID(colOrd))
+				col := tabID.ColumnID(colOrd)
+				cols.Add(col)
+				if tab.Column(colOrd).IsVirtualComputed() {
+					// We only add virtual columns if we have statistics on them, so that
+					// in higher groups we can decide whether to look up statistics on
+					// virtual columns or on the columns used in their defining
+					// expressions.
+					stats.VirtualCols.Add(col)
+				}
 			}
 
 			// We currently only use average column sizes of single column
@@ -803,6 +811,7 @@ func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relationa
 
 	inputStats := sb.makeTableStatistics(scan.Table)
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	pred := scan.PartialIndexPredicate(sb.md)
 
 	// If the constraints and pred are nil, then this scan is an unconstrained
@@ -1030,6 +1039,7 @@ func (sb *statisticsBuilder) buildSelect(sel *SelectExpr, relProps *props.Relati
 	s.Available = sb.availabilityFromInput(sel)
 	inputStats := sel.Input.Relational().Statistics()
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 
 	sb.filterRelExpr(sel.Filters, sel, relProps.NotNullCols, relProps, s, &sel.Input.Relational().FuncDeps)
 
@@ -1072,6 +1082,7 @@ func (sb *statisticsBuilder) buildProject(prj *ProjectExpr, relProps *props.Rela
 	inputStats := prj.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -1171,6 +1182,7 @@ func (sb *statisticsBuilder) buildInvertedFilter(
 	// -----------------------------------
 	inputStats := invFilter.Input.Relational().Statistics()
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	corr := sb.correlationFromMultiColDistinctCounts(constrainedCols, invFilter, s)
 	s.ApplySelectivity(sb.selectivityFromConstrainedCols(constrainedCols, histCols, invFilter, s, corr))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(invFilter, relProps.NotNullCols, constrainedCols))
@@ -1222,6 +1234,16 @@ func (sb *statisticsBuilder) buildJoin(
 	leftCols := h.leftProps.OutputCols.Copy()
 	rightCols := h.rightProps.OutputCols.Copy()
 	equivReps := h.filtersFD.EquivReps()
+
+	switch h.joinType {
+	case opt.SemiJoinOp, opt.SemiJoinApplyOp, opt.AntiJoinOp, opt.AntiJoinApplyOp:
+		// For semi- and anti-joins, colStatJoin will only be called with columns
+		// from the left side.
+		s.VirtualCols.UnionWith(leftStats.VirtualCols)
+	default:
+		s.VirtualCols.UnionWith(leftStats.VirtualCols)
+		s.VirtualCols.UnionWith(rightStats.VirtualCols)
+	}
 
 	// Shortcut if there are no ON conditions. Note that for lookup join, there
 	// are implicit equality conditions on KeyCols.
@@ -1741,6 +1763,8 @@ func (sb *statisticsBuilder) buildIndexJoin(indexJoin *IndexJoinExpr, relProps *
 	inputStats := indexJoin.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
+	s.VirtualCols.UnionWith(sb.makeTableStatistics(indexJoin.Table).VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -1818,6 +1842,7 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 	s.Available = sb.availabilityFromInput(zigzag)
 
 	leftStats := zigzag.leftProps.Statistics()
+	rightStats := zigzag.rightProps.Statistics()
 	equivReps := h.filtersFD.EquivReps()
 
 	// We assume that we only plan zigzag joins in cases where the result set
@@ -1825,6 +1850,9 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 	// row counts, and where the left and right sides are indexes on the same
 	// table. Their row count should be the same, so use either row count.
 	s.RowCount = leftStats.RowCount
+
+	s.VirtualCols.UnionWith(leftStats.VirtualCols)
+	s.VirtualCols.UnionWith(rightStats.VirtualCols)
 
 	// Calculate distinct counts for constrained columns
 	// -------------------------------------------------
@@ -1916,6 +1944,9 @@ func (sb *statisticsBuilder) buildGroupBy(groupNode RelExpr, relProps *props.Rel
 	groupingPrivate := groupNode.Private().(*GroupingPrivate)
 	groupingColSet := groupingPrivate.GroupingCols
 
+	inputStats := sb.statsFromChild(groupNode, 0 /* childIdx */)
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
+
 	if groupingColSet.Empty() {
 		if groupNode.Op() == opt.ScalarGroupByOp {
 			// ScalarGroupBy always returns exactly one row.
@@ -1924,12 +1955,9 @@ func (sb *statisticsBuilder) buildGroupBy(groupNode RelExpr, relProps *props.Rel
 			// GroupBy with empty grouping columns returns 0 or 1 rows, depending
 			// on whether input has rows. If input has < 1 row, use that, as that
 			// represents the probability of having 0 vs. 1 rows.
-			inputStats := sb.statsFromChild(groupNode, 0 /* childIdx */)
 			s.RowCount = min(1, inputStats.RowCount)
 		}
 	} else {
-		inputStats := sb.statsFromChild(groupNode, 0 /* childIdx */)
-
 		if groupingPrivate.ErrorOnDup != "" {
 			// If any input group has more than one row, then the distinct operator
 			// will raise an error, so in non-error cases it has the same number of
@@ -2027,6 +2055,12 @@ func (sb *statisticsBuilder) buildSetNode(setNode RelExpr, relProps *props.Relat
 
 	leftStats := sb.statsFromChild(setNode, 0 /* childIdx */)
 	rightStats := sb.statsFromChild(setNode, 1 /* childIdx */)
+
+	// TODO(michae2): Set operations and with-scans currently act as barriers for
+	// VirtualCols, due to the column ID translation. To fix this we would need to
+	// rewrite virtual computed column expressions in terms of the translated
+	// column IDs, and would need to store the rewritten expressions somewhere
+	// other than TableMeta.
 
 	// These calculations are an upper bound on the row count. It's likely that
 	// there is some overlap between the two sets, but not full overlap.
@@ -2233,6 +2267,7 @@ func (sb *statisticsBuilder) buildLimit(limit *LimitExpr, relProps *props.Relati
 
 	// Copy row count from input.
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 
 	// Update row count if limit is a constant and row count is non-zero.
 	if cnst, ok := limit.Limit.(*ConstExpr); ok && inputStats.RowCount > 0 {
@@ -2275,6 +2310,7 @@ func (sb *statisticsBuilder) buildTopK(topK *TopKExpr, relProps *props.Relationa
 
 	// Copy row count from input.
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 
 	// Update row count if row count and k are non-zero.
 	if inputStats.RowCount > 0 && topK.K > 0 {
@@ -2316,6 +2352,7 @@ func (sb *statisticsBuilder) buildOffset(offset *OffsetExpr, relProps *props.Rel
 
 	// Copy row count from input.
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 
 	// Update row count if offset is a constant and row count is non-zero.
 	if cnst, ok := offset.Offset.(*ConstExpr); ok && inputStats.RowCount > 0 {
@@ -2397,6 +2434,7 @@ func (sb *statisticsBuilder) buildOrdinality(ord *OrdinalityExpr, relProps *prop
 	inputStats := ord.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -2442,7 +2480,7 @@ func (sb *statisticsBuilder) buildWindow(window *WindowExpr, relProps *props.Rel
 
 	// The row count of a window is equal to the row count of its input.
 	s.RowCount = inputStats.RowCount
-
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -2526,7 +2564,7 @@ func (sb *statisticsBuilder) buildProjectSet(
 	// Multiply by the input row count to get the total.
 	inputStats := projectSet.Input.Relational().Statistics()
 	s.RowCount = zipRowCount * inputStats.RowCount
-
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -2640,6 +2678,13 @@ func (sb *statisticsBuilder) buildWithScan(
 
 	s.Available = bindingProps.Statistics().Available
 	s.RowCount = bindingProps.Statistics().RowCount
+
+	// TODO(michae2): Set operations and with-scans currently act as barriers for
+	// VirtualCols, due to the column ID translation. To fix this we would need to
+	// rewrite virtual computed column expressions in terms of the translated
+	// column IDs, and would need to store the rewritten expressions somewhere
+	// other than TableMeta.
+
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -2677,6 +2722,7 @@ func (sb *statisticsBuilder) buildMutation(mutation RelExpr, relProps *props.Rel
 	inputStats := sb.statsFromChild(mutation, 0 /* childIdx */)
 
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -2714,6 +2760,7 @@ func (sb *statisticsBuilder) buildLock(lock *LockExpr, relProps *props.Relationa
 	inputStats := lock.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
@@ -2745,6 +2792,7 @@ func (sb *statisticsBuilder) buildBarrier(barrier *BarrierExpr, relProps *props.
 	inputStats := barrier.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
+	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -249,6 +249,17 @@ func (sb *statisticsBuilder) clear() {
 	sb.md = nil
 }
 
+// colStatCols returns the set of columns which may be looked up in
+// props.Statistics().ColStats, which includes props.OutputCols and any virtual
+// computed columns we have statistics on that are in scope.
+func (sb *statisticsBuilder) colStatCols(props *props.Relational) opt.ColSet {
+	if sb.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats &&
+		!props.Statistics().VirtualCols.Empty() {
+		return props.OutputCols.Union(props.Statistics().VirtualCols)
+	}
+	return props.OutputCols
+}
+
 // colStatFromChild retrieves a column statistic from a specific child of the
 // given expression.
 func (sb *statisticsBuilder) colStatFromChild(
@@ -259,7 +270,7 @@ func (sb *statisticsBuilder) colStatFromChild(
 	child := e.Child(childIdx).(RelExpr)
 	childProps := child.Relational()
 	if !colSet.SubsetOf(childProps.OutputCols) {
-		colSet = colSet.Intersection(childProps.OutputCols)
+		colSet = colSet.Intersection(sb.colStatCols(childProps))
 		if colSet.Empty() {
 			// All the columns in colSet are outer columns; therefore, we can treat
 			// them as a constant.
@@ -338,24 +349,26 @@ func (sb *statisticsBuilder) colStatFromInput(
 
 	if lookupJoin != nil || invertedJoin != nil || zigzagJoin != nil ||
 		opt.IsJoinOp(e) || e.Op() == opt.MergeJoinOp {
+
 		var leftProps *props.Relational
 		if zigzagJoin != nil {
 			leftProps = &zigzagJoin.leftProps
 		} else {
 			leftProps = e.Child(0).(RelExpr).Relational()
 		}
+		intersectsLeft := sb.colStatCols(leftProps).Intersects(colSet)
 
-		intersectsLeft := leftProps.OutputCols.Intersects(colSet)
-		var intersectsRight bool
+		var rightProps *props.Relational
 		if lookupJoin != nil {
-			intersectsRight = lookupJoin.lookupProps.OutputCols.Intersects(colSet)
+			rightProps = &lookupJoin.lookupProps
 		} else if invertedJoin != nil {
-			intersectsRight = invertedJoin.lookupProps.OutputCols.Intersects(colSet)
+			rightProps = &invertedJoin.lookupProps
 		} else if zigzagJoin != nil {
-			intersectsRight = zigzagJoin.rightProps.OutputCols.Intersects(colSet)
+			rightProps = &zigzagJoin.rightProps
 		} else {
-			intersectsRight = e.Child(1).(RelExpr).Relational().OutputCols.Intersects(colSet)
+			rightProps = e.Child(1).(RelExpr).Relational()
 		}
+		intersectsRight := sb.colStatCols(rightProps).Intersects(colSet)
 
 		// It's possible that colSet intersects both left and right if we have a
 		// lookup join that was converted from an index join, so check the left
@@ -1095,7 +1108,7 @@ func (sb *statisticsBuilder) colStatProject(
 	// Columns may be passed through from the input, or they may reference a
 	// higher scope (in the case of a correlated subquery), or they
 	// may be synthesized by the projection operation.
-	inputCols := prj.Input.Relational().OutputCols
+	inputCols := sb.colStatCols(prj.Input.Relational())
 	reqInputCols := colSet.Intersection(inputCols)
 	nonNullFound := false
 	reqSynthCols := colSet.Difference(inputCols)
@@ -1110,6 +1123,7 @@ func (sb *statisticsBuilder) colStatProject(
 		for i := range prj.Projections {
 			item := &prj.Projections[i]
 			if reqSynthCols.Contains(item.Col) {
+				// TODO(michae2): Check for matching virtual column expressions here.
 				reqInputCols.UnionWith(item.scalar.OuterCols)
 
 				// If the element is not a null constant, account for that
@@ -1231,8 +1245,8 @@ func (sb *statisticsBuilder) buildJoin(
 
 	leftStats := h.leftProps.Statistics()
 	rightStats := h.rightProps.Statistics()
-	leftCols := h.leftProps.OutputCols.Copy()
-	rightCols := h.rightProps.OutputCols.Copy()
+	leftCols := sb.colStatCols(h.leftProps)
+	rightCols := sb.colStatCols(h.rightProps)
 	equivReps := h.filtersFD.EquivReps()
 
 	switch h.joinType {
@@ -1316,8 +1330,8 @@ func (sb *statisticsBuilder) buildJoin(
 	constrainedCols = sb.tryReduceJoinCols(
 		constrainedCols,
 		s,
-		h.leftProps.OutputCols,
-		h.rightProps.OutputCols,
+		leftCols,
+		rightCols,
 		&h.leftProps.FuncDeps,
 		&h.rightProps.FuncDeps,
 	)
@@ -1334,7 +1348,7 @@ func (sb *statisticsBuilder) buildJoin(
 		// calculations. It will be fixed below.
 		s.RowCount = leftStats.RowCount
 		s.ApplySelectivity(sb.selectivityFromEquivalenciesSemiJoin(
-			equivReps, h.leftProps.OutputCols, h.rightProps.OutputCols, &h.filtersFD, join, s,
+			equivReps, leftCols, rightCols, &h.filtersFD, join, s,
 		))
 		var oredTermSelectivity props.Selectivity
 		oredTermSelectivity, numUnappliedConjuncts =
@@ -1394,7 +1408,7 @@ func (sb *statisticsBuilder) buildJoin(
 	switch h.joinType {
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp, opt.AntiJoinOp, opt.AntiJoinApplyOp:
 		// Keep only column stats from the left side.
-		s.ColStats.RemoveIntersecting(h.rightProps.OutputCols)
+		s.ColStats.RemoveIntersecting(rightCols)
 	}
 
 	// The above calculation is for inner joins. Other joins need to remove stats
@@ -1403,12 +1417,12 @@ func (sb *statisticsBuilder) buildJoin(
 	case opt.LeftJoinOp, opt.LeftJoinApplyOp:
 		// Keep only column stats from the right side. The stats from the left side
 		// are not valid.
-		s.ColStats.RemoveIntersecting(h.leftProps.OutputCols)
+		s.ColStats.RemoveIntersecting(leftCols)
 
 	case opt.RightJoinOp:
 		// Keep only column stats from the left side. The stats from the right side
 		// are not valid.
-		s.ColStats.RemoveIntersecting(h.rightProps.OutputCols)
+		s.ColStats.RemoveIntersecting(rightCols)
 
 	case opt.FullJoinOp:
 		// Do not keep any column stats.
@@ -1534,6 +1548,9 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 		rightProps = join.Child(1).(RelExpr).Relational()
 	}
 
+	leftCols := sb.colStatCols(leftProps)
+	rightCols := sb.colStatCols(rightProps)
+
 	switch joinType {
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp, opt.AntiJoinOp, opt.AntiJoinApplyOp:
 		// Column stats come from left side of join.
@@ -1560,8 +1577,8 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 		inputRowCount := leftProps.Statistics().RowCount * rightProps.Statistics().RowCount
 		leftNullCount := leftProps.Statistics().RowCount
 		rightNullCount := rightProps.Statistics().RowCount
-		leftColsAreEmpty := !leftProps.OutputCols.Intersects(colSet)
-		rightColsAreEmpty := !rightProps.OutputCols.Intersects(colSet)
+		leftColsAreEmpty := !leftCols.Intersects(colSet)
+		rightColsAreEmpty := !rightCols.Intersects(colSet)
 		if rightColsAreEmpty {
 			colStat = sb.copyColStat(colSet, s, sb.colStatFromJoinLeft(colSet, join))
 			leftNullCount = colStat.NullCount
@@ -1577,12 +1594,9 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 				colStat.ApplySelectivity(s.Selectivity, inputRowCount)
 			}
 		} else {
-			// Column stats come from both sides of join.
-			leftCols := leftProps.OutputCols.Intersection(colSet)
-			rightCols := rightProps.OutputCols.Intersection(colSet)
 			// Make a copy of the input column stats so we don't modify the originals.
-			leftColStat := *sb.colStatFromJoinLeft(leftCols, join)
-			rightColStat := *sb.colStatFromJoinRight(rightCols, join)
+			leftColStat := *sb.colStatFromJoinLeft(leftCols.Intersection(colSet), join)
+			rightColStat := *sb.colStatFromJoinRight(rightCols.Intersection(colSet), join)
 
 			leftNullCount = leftColStat.NullCount
 			rightNullCount = rightColStat.NullCount
@@ -1775,7 +1789,7 @@ func (sb *statisticsBuilder) colStatIndexJoin(
 	s := relProps.Statistics()
 
 	inputProps := join.Input.Relational()
-	inputCols := inputProps.OutputCols
+	inputCols := sb.colStatCols(inputProps)
 
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = 1
@@ -2580,7 +2594,7 @@ func (sb *statisticsBuilder) colStatProjectSet(
 
 	inputProps := projectSet.Input.Relational()
 	inputStats := inputProps.Statistics()
-	inputCols := inputProps.OutputCols
+	inputCols := sb.colStatCols(inputProps)
 
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = 1
@@ -2635,7 +2649,7 @@ func (sb *statisticsBuilder) colStatProjectSet(
 					zipColsNullCount *= (s.RowCount - inputStats.RowCount) / s.RowCount
 				}
 
-				if item.ScalarProps().OuterCols.Intersects(inputProps.OutputCols) {
+				if item.ScalarProps().OuterCols.Intersects(inputCols) {
 					// The column(s) are correlated with the input, so they may have a
 					// distinct value for each distinct row of the input.
 					zipColsDistinctCount *= inputStats.RowCount * UnknownDistinctCountRatio
@@ -3082,8 +3096,8 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 			panic(errors.AssertionFailedf("rowsProcessed not supported for operator type %v", redact.Safe(e.Op())))
 		}
 
-		leftCols := e.Child(0).(RelExpr).Relational().OutputCols
-		rightCols := e.Child(1).(RelExpr).Relational().OutputCols
+		leftCols := sb.colStatCols(e.Child(0).(RelExpr).Relational())
+		rightCols := sb.colStatCols(e.Child(1).(RelExpr).Relational())
 		filters := e.Child(2).(*FiltersExpr)
 
 		// Remove ON conditions that are not equality conditions,
@@ -3282,6 +3296,7 @@ func (sb *statisticsBuilder) applyFilters(
 func (sb *statisticsBuilder) applyFiltersItem(
 	filter *FiltersItem, e RelExpr, relProps *props.Relational,
 ) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
+	// TODO(michae2): Check for matching virtual column expressions here.
 	if isEqualityWithTwoVars(filter.Condition) {
 		// Equalities are handled by applyEquivalencies.
 		return 0, opt.ColSet{}, opt.ColSet{}
@@ -4398,6 +4413,7 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 			// is able to build column equivalencies.
 			switch disjuncts[i].(type) {
 			case *EqExpr, *AndExpr:
+				// TODO(michae2): Check for matching virtual column expressions here.
 				if andFilters, ok = addEqExprConjuncts(disjuncts[i], andFilters, e.Memo()); !ok {
 					numUnappliedConjuncts++
 					continue
@@ -4428,7 +4444,8 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 			equivReps := FD.EquivReps()
 			if semiJoin {
 				singleSelectivity = sb.selectivityFromEquivalenciesSemiJoin(
-					equivReps, h.leftProps.OutputCols, h.rightProps.OutputCols, FD, e, s,
+					equivReps, sb.colStatCols(h.leftProps), sb.colStatCols(h.rightProps),
+					FD, e, s,
 				)
 			} else {
 				singleSelectivity = sb.selectivityFromEquivalencies(equivReps, FD, e, s)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -203,7 +203,7 @@ SELECT 1 AS a, 1+z AS b, left(x, 10)::TIMESTAMP AS c, left(x, 10)::TIMESTAMPTZ A
 FROM b
 WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
-memo (optimized, ~7KB, required=[presentation: a:5,b:6,c:7,d:8])
+memo (optimized, ~8KB, required=[presentation: a:5,b:6,c:7,d:8])
  ├── G1: (project G2 G3)
  │    └── [presentation: a:5,b:6,c:7,d:8]
  │         ├── best: (project G2 G3)
@@ -301,7 +301,7 @@ memo (optimized, ~9KB, required=[presentation: x:13,y:14])
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a)
 ----
-memo (optimized, ~5KB, required=[presentation: array_agg:6])
+memo (optimized, ~6KB, required=[presentation: array_agg:6])
  ├── G1: (scalar-group-by G2 G3 cols=())
  │    └── [presentation: array_agg:6]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -338,7 +338,7 @@ memo (optimized, ~7KB, required=[presentation: array_agg:6])
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a ORDER BY y)
 ----
-memo (optimized, ~5KB, required=[presentation: array_agg:6])
+memo (optimized, ~6KB, required=[presentation: array_agg:6])
  ├── G1: (scalar-group-by G2 G3 cols=(),ordering=+2)
  │    └── [presentation: array_agg:6]
  │         ├── best: (scalar-group-by G2="[ordering: +2]" G3 cols=(),ordering=+2)
@@ -357,7 +357,7 @@ memo (optimized, ~5KB, required=[presentation: array_agg:6])
 memo
 SELECT array_cat_agg(arr) FROM (SELECT * FROM a)
 ----
-memo (optimized, ~5KB, required=[presentation: array_cat_agg:6])
+memo (optimized, ~6KB, required=[presentation: array_cat_agg:6])
  ├── G1: (scalar-group-by G2 G3 cols=())
  │    └── [presentation: array_cat_agg:6]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -394,7 +394,7 @@ memo (optimized, ~7KB, required=[presentation: array_cat_agg:6])
 memo
 SELECT array_cat_agg(arr) FROM (SELECT * FROM a ORDER BY y)
 ----
-memo (optimized, ~5KB, required=[presentation: array_cat_agg:6])
+memo (optimized, ~6KB, required=[presentation: array_cat_agg:6])
  ├── G1: (scalar-group-by G2 G3 cols=(),ordering=+2)
  │    └── [presentation: array_cat_agg:6]
  │         ├── best: (scalar-group-by G2="[ordering: +2]" G3 cols=(),ordering=+2)

--- a/pkg/sql/opt/memo/testdata/stats/virtual
+++ b/pkg/sql/opt/memo/testdata/stats/virtual
@@ -1,0 +1,518 @@
+# Test that we propagate statistics for virtual computed columns correctly.
+
+exec-ddl
+CREATE TABLE abc (a INT PRIMARY KEY, b INT AS (a % 10) VIRTUAL, c INT, INDEX (b))
+----
+
+# Use statistics from:
+#   INSERT INTO abc (a) SELECT generate_series(0, 19)
+# Assume we have collected statistics on b, including histograms.
+exec-ddl
+ALTER TABLE abc INJECT STATISTICS '[
+    {
+        "avg_size": 8,
+        "columns": [
+            "a"
+        ],
+        "created_at": "2024-03-06 19:42:11.250622",
+        "distinct_count": 20,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "0"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "2"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "3"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "4"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "5"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "6"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "7"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "8"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "9"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "10"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "11"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "12"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "13"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "14"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "15"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "16"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "17"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "18"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "19"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "null_count": 0,
+        "row_count": 20
+    },
+    {
+        "avg_size": 8,
+        "columns": [
+            "b"
+        ],
+        "created_at": "2024-03-06 19:42:11.250622",
+        "distinct_count": 10,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "0"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "2"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "3"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "4"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "5"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "6"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "7"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "8"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2,
+                "num_range": 0,
+                "upper_bound": "9"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "null_count": 0,
+        "row_count": 20
+    },
+    {
+        "avg_size": 0,
+        "columns": [
+            "c"
+        ],
+        "created_at": "2024-03-06 19:42:11.250622",
+        "distinct_count": 1,
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "null_count": 20,
+        "row_count": 20
+    }
+]'
+----
+
+# Check that we can call colStatScan with a virtual column, even without the
+# usual project in place.
+norm colstat=2
+SELECT a FROM abc
+----
+scan abc
+ ├── columns: a:1(int!null)
+ ├── computed column expressions
+ │    └── b:2
+ │         └── a:1 % 10 [type=int]
+ ├── stats: [rows=20, distinct(2)=10, null(2)=0]
+ │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │   virtcolstats: (2)
+ └── key: (1)
+
+# It should also work with the usual project on top.
+norm colstat=2
+SELECT b FROM abc
+----
+project
+ ├── columns: b:2(int!null)
+ ├── immutable
+ ├── stats: [rows=20, distinct(2)=10, null(2)=0]
+ │   virtcolstats: (2)
+ ├── scan abc
+ │    ├── columns: a:1(int!null)
+ │    ├── computed column expressions
+ │    │    └── b:2
+ │    │         └── a:1 % 10 [type=int]
+ │    ├── stats: [rows=20, distinct(2)=10, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    └── key: (1)
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Push a select below the project.
+norm colstat=1 colstat=2 expect=PushSelectIntoProject
+SELECT b FROM abc WHERE a % 2 = 0
+----
+project
+ ├── columns: b:2(int!null)
+ ├── immutable
+ ├── stats: [rows=6.666667, distinct(1)=6.66667, null(1)=0, distinct(2)=5.55556, null(2)=0]
+ │   virtcolstats: (2)
+ ├── select
+ │    ├── columns: a:1(int!null)
+ │    ├── immutable
+ │    ├── stats: [rows=6.666667, distinct(1)=6.66667, null(1)=0, distinct(2)=5.55556, null(2)=0]
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── (a:1 % 2) = 0 [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# TODO(michae2): We need special handling for InlineSelectVirtualColumns, so
+# skip filtering on b until we have that.
+
+# Distinct on top of the project.
+norm
+SELECT DISTINCT b FROM abc
+----
+distinct-on
+ ├── columns: b:2(int!null)
+ ├── grouping columns: b:2(int!null)
+ ├── immutable
+ ├── stats: [rows=10, distinct(2)=10, null(2)=0]
+ │   virtcolstats: (2)
+ ├── key: (2)
+ └── project
+      ├── columns: b:2(int!null)
+      ├── immutable
+      ├── stats: [rows=20, distinct(2)=10, null(2)=0]
+      │   virtcolstats: (2)
+      ├── scan abc
+      │    ├── columns: a:1(int!null)
+      │    ├── computed column expressions
+      │    │    └── b:2
+      │    │         └── a:1 % 10 [type=int]
+      │    ├── stats: [rows=20, distinct(2)=10, null(2)=0]
+      │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+      │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+      │    │   virtcolstats: (2)
+      │    └── key: (1)
+      └── projections
+           └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Push a join below the project.
+opt colstat=1 colstat=2 colstat=6 colstat=7
+SELECT x.b FROM abc x JOIN abc y ON x.a = y.a + 1 WHERE y.a < 5
+----
+project
+ ├── columns: b:2(int!null)
+ ├── immutable
+ ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=4.01263, null(2)=0, distinct(6)=1, null(6)=5, distinct(7)=3.02042, null(7)=0]
+ │   virtcolstats: (2,7)
+ └── project
+      ├── columns: b:2(int!null) a:1(int!null) column11:11(int!null)
+      ├── immutable
+      ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=4.01263, null(2)=0, distinct(7)=3.02042, null(7)=0, distinct(11)=5, null(11)=0]
+      │   virtcolstats: (2,7)
+      ├── fd: (1)-->(2), (1)==(11), (11)==(1)
+      ├── inner-join (lookup abc)
+      │    ├── columns: a:1(int!null) column11:11(int!null)
+      │    ├── key columns: [11] = [1]
+      │    ├── lookup columns are key
+      │    ├── immutable
+      │    ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(11)=5, null(11)=0]
+      │    │   virtcolstats: (2,7)
+      │    ├── fd: (1)==(11), (11)==(1)
+      │    ├── project
+      │    │    ├── columns: column11:11(int!null)
+      │    │    ├── immutable
+      │    │    ├── stats: [rows=5, distinct(7)=4.375, null(7)=0, distinct(11)=5, null(11)=0]
+      │    │    │   virtcolstats: (7)
+      │    │    ├── scan abc
+      │    │    │    ├── columns: a:6(int!null)
+      │    │    │    ├── constraint: /6: [ - /4]
+      │    │    │    ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(7)=4.375, null(7)=0]
+      │    │    │    │   histogram(6)=  0  1  0  1  0  1  0  1  0  1
+      │    │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4
+      │    │    │    │   virtcolstats: (7)
+      │    │    │    └── key: (6)
+      │    │    └── projections
+      │    │         └── a:6 + 1 [as=column11:11, type=int, outer=(6), immutable]
+      │    └── filters (true)
+      └── projections
+           └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Push an index join below the project.
+opt colstat=1 colstat=2 colstat=3
+SELECT * FROM abc@abc_b_idx
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=1, null(3)=20]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── index-join abc
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=1, null(3)=20]
+ │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    └── scan abc@abc_b_idx
+ │         ├── columns: a:1(int!null)
+ │         ├── flags: force-index=abc_b_idx
+ │         ├── stats: [rows=20]
+ │         │   virtcolstats: (2)
+ │         └── key: (1)
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Push a limit below the project.
+norm colstat=1 colstat=2
+SELECT a, b FROM abc ORDER BY a LIMIT 5
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=4.375, null(2)=0]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── ordering: +1
+ ├── limit
+ │    ├── columns: a:1(int!null)
+ │    ├── internal-ordering: +1
+ │    ├── cardinality: [0 - 5]
+ │    ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=4.375, null(2)=0]
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── ordering: +1
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    ├── ordering: +1
+ │    │    └── limit hint: 5.00
+ │    └── 5 [type=int]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Set operations currently act as barriers for virtual column stats. Make sure
+# we don't panic, though stats will be less accurate. (Only columns 11 and 12
+# matter for these stats, the others are to check that we don't panic.)
+norm colstat=1 colstat=2 colstat=6 colstat=7 colstat=11 colstat=12
+SELECT a % 10 FROM (SELECT a FROM abc UNION ALL SELECT a FROM abc)
+----
+project
+ ├── columns: "?column?":12(int!null)
+ ├── immutable
+ ├── stats: [rows=40, distinct(1)=1, null(1)=40, distinct(2)=1, null(2)=40, distinct(6)=1, null(6)=40, distinct(7)=1, null(7)=40, distinct(11)=40, null(11)=0, distinct(12)=40, null(12)=0]
+ ├── union-all
+ │    ├── columns: a:11(int!null)
+ │    ├── left columns: abc.a:1(int)
+ │    ├── right columns: abc.a:6(int)
+ │    ├── stats: [rows=40, distinct(11)=40, null(11)=0]
+ │    ├── scan abc
+ │    │    ├── columns: abc.a:1(int!null)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── abc.a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   virtcolstats: (2)
+ │    │    └── key: (1)
+ │    └── scan abc
+ │         ├── columns: abc.a:6(int!null)
+ │         ├── computed column expressions
+ │         │    └── b:7
+ │         │         └── abc.a:6 % 10 [type=int]
+ │         ├── stats: [rows=20, distinct(6)=20, null(6)=0]
+ │         │   histogram(6)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │         │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │         │   virtcolstats: (7)
+ │         └── key: (6)
+ └── projections
+      └── a:11 % 10 [as="?column?":12, type=int, outer=(11), immutable]
+
+# With-scans currently act as barriers for virtual column stats. Make sure we
+# don't panic, though stats will be less accurate. (Only columns 6 and 7 matter
+# for these stats, the others are to check that we don't panic.)
+norm colstat=1 colstat=2 colstat=6 colstat=7
+WITH w AS MATERIALIZED (SELECT a FROM abc) SELECT a % 10 FROM w
+----
+with &1 (w)
+ ├── columns: "?column?":7(int!null)
+ ├── materialized
+ ├── immutable
+ ├── stats: [rows=20]
+ ├── scan abc
+ │    ├── columns: abc.a:1(int!null)
+ │    ├── computed column expressions
+ │    │    └── b:2
+ │    │         └── abc.a:1 % 10 [type=int]
+ │    ├── stats: [rows=20, distinct(1)=20, null(1)=0]
+ │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │   virtcolstats: (2)
+ │    └── key: (1)
+ └── project
+      ├── columns: "?column?":7(int!null)
+      ├── immutable
+      ├── stats: [rows=20, distinct(1)=1, null(1)=20, distinct(2)=1, null(2)=20, distinct(6)=20, null(6)=0, distinct(7)=20, null(7)=0]
+      ├── with-scan &1 (w)
+      │    ├── columns: a:6(int!null)
+      │    ├── mapping:
+      │    │    └──  abc.a:1(int) => a:6(int)
+      │    ├── stats: [rows=20, distinct(6)=20, null(6)=0]
+      │    └── key: (6)
+      └── projections
+           └── a:6 % 10 [as="?column?":7, type=int, outer=(6), immutable]

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -82,6 +82,7 @@ func TestBuilder(t *testing.T) {
 				evalCtx.SessionData().OptimizerUseHistograms = true
 				evalCtx.SessionData().OptimizerUseMultiColStats = true
 				evalCtx.SessionData().LocalityOptimizedSearch = true
+				evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
 
 				var o xform.Optimizer
 				o.Init(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -313,6 +313,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().OptimizerUseImprovedJoinElimination = true
 	ot.evalCtx.SessionData().OptimizerUseProvidedOrderingFix = true
 	ot.evalCtx.SessionData().OptimizerMergeJoinsEnabled = true
+	ot.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
 
 	return ot
 }

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -355,7 +355,7 @@ sort
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
 ----
-memo (optimized, ~6KB, required=[presentation: y:2,z:3] [ordering: +2])
+memo (optimized, ~7KB, required=[presentation: y:2,z:3] [ordering: +2])
  ├── G1: (project G2 G3 y z)
  │    ├── [presentation: y:2,z:3] [ordering: +2]
  │    │    ├── best: (sort G1)
@@ -741,7 +741,7 @@ memo (optimized, ~8KB, required=[presentation: y:2] [ordering: +7])
 memo
 SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY y, ordinality
 ----
-memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +2,+7])
+memo (optimized, ~7KB, required=[presentation: y:2] [ordering: +2,+7])
  ├── G1: (ordinality G2 ordering=+2)
  │    ├── [presentation: y:2] [ordering: +2,+7]
  │    │    ├── best: (ordinality G2="[ordering: +2]" ordering=+2)
@@ -760,7 +760,7 @@ memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +2,+7])
 memo
 SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY ordinality, y
 ----
-memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +7])
+memo (optimized, ~7KB, required=[presentation: y:2] [ordering: +7])
  ├── G1: (ordinality G2 ordering=+2)
  │    ├── [presentation: y:2] [ordering: +7]
  │    │    ├── best: (ordinality G2="[ordering: +2]" ordering=+2)

--- a/pkg/sql/opt/xform/testdata/rules/cycle
+++ b/pkg/sql/opt/xform/testdata/rules/cycle
@@ -62,7 +62,7 @@ expropt disable=MemoCycleTestRelRuleFilter skip-race
 ----
 error: memo group optimization passes surpassed limit of 100000; there may be a cycle in the memo
 details:
-memo (not optimized, ~15KB, required=[], cycle=[G1->G3->G5->G5])
+memo (not optimized, ~16KB, required=[], cycle=[G1->G3->G5->G5])
  ├── G1: (left-join G2 G3 G4)
  ├── G2: (scan ab,cols=()) (scan ab@ab_b_idx,cols=())
  │    └── []

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -449,7 +449,7 @@ project
 memo
 SELECT min(a) FROM abc
 ----
-memo (optimized, ~6KB, required=[presentation: min:7])
+memo (optimized, ~7KB, required=[presentation: min:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: min:7]
  │         ├── best: (scalar-group-by G4 G5 cols=())
@@ -475,7 +475,7 @@ memo (optimized, ~6KB, required=[presentation: min:7])
 memo
 SELECT min(b) FROM abc
 ----
-memo (optimized, ~7KB, required=[presentation: min:7])
+memo (optimized, ~8KB, required=[presentation: min:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: min:7]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -511,7 +511,7 @@ memo (optimized, ~7KB, required=[presentation: min:7])
 memo
 SELECT max(a) FROM abc
 ----
-memo (optimized, ~6KB, required=[presentation: max:7])
+memo (optimized, ~7KB, required=[presentation: max:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:7]
  │         ├── best: (scalar-group-by G4 G5 cols=())
@@ -537,7 +537,7 @@ memo (optimized, ~6KB, required=[presentation: max:7])
 memo
 SELECT max(b) FROM abc
 ----
-memo (optimized, ~7KB, required=[presentation: max:7])
+memo (optimized, ~8KB, required=[presentation: max:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:7]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -650,7 +650,7 @@ scalar-group-by
 memo
 SELECT max(b) FROM abc
 ----
-memo (optimized, ~7KB, required=[presentation: max:7])
+memo (optimized, ~8KB, required=[presentation: max:7])
  ├── G1: (scalar-group-by G2 G3 cols=()) (scalar-group-by G4 G5 cols=())
  │    └── [presentation: max:7]
  │         ├── best: (scalar-group-by G2 G3 cols=())
@@ -1701,7 +1701,7 @@ scalar-group-by
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY w) GROUP BY u,v
 ----
-memo (optimized, ~9KB, required=[presentation: array_agg:7])
+memo (optimized, ~10KB, required=[presentation: array_agg:7])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:7]
  │         ├── best: (project G2 G3 array_agg)
@@ -1966,7 +1966,7 @@ memo (optimized, ~15KB, required=[presentation: sum:7])
 memo
 SELECT array_agg(w) FROM (SELECT * FROM kuvw ORDER BY w DESC) GROUP BY u,v
 ----
-memo (optimized, ~8KB, required=[presentation: array_agg:7])
+memo (optimized, ~9KB, required=[presentation: array_agg:7])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:7]
  │         ├── best: (project G2 G3 array_agg)
@@ -2173,7 +2173,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
 memo
 SELECT DISTINCT ON (w, u) u, v, w FROM kuvw ORDER BY w, u, v DESC
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4,+2])
  ├── G1: (distinct-on G2 G3 cols=(2,4),ordering=-3 opt(2,4))
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +4,+2]
  │    │    ├── best: (distinct-on G2="[ordering: +4,+2,-3]" G3 cols=(2,4),ordering=-3 opt(2,4))
@@ -2298,7 +2298,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~25KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~26KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2365,7 +2365,7 @@ memo (optimized, ~25KB, required=[presentation: w:12] [ordering: +13,+1])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
 ----
-memo (optimized, ~26KB, required=[])
+memo (optimized, ~27KB, required=[])
  ├── G1: (insert G2 G3 G4 G5 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 G4 G5 xyz)
@@ -2422,7 +2422,7 @@ memo (optimized, ~26KB, required=[])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
-memo (optimized, ~27KB, required=[])
+memo (optimized, ~28KB, required=[])
  ├── G1: (upsert G2 G3 G4 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 G4 xyz)
@@ -3432,7 +3432,7 @@ INDEX gg (g)
 memo
 SELECT d, e, count(*) FROM defg GROUP BY d, e LIMIT 10
 ----
-memo (optimized, ~19KB, required=[presentation: d:1,e:2,count:8])
+memo (optimized, ~20KB, required=[presentation: d:1,e:2,count:8])
  ├── G1: (limit G2 G3) (limit G4 G3) (limit G5 G3) (limit G6 G3)
  │    └── [presentation: d:1,e:2,count:8]
  │         ├── best: (limit G4="[limit hint: 10.00]" G3)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -227,7 +227,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~44KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~46KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -289,7 +289,7 @@ memo (optimized, ~44KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:1
 memo
 SELECT * FROM abc, stu, xyz, pqr WHERE a = 1
 ----
-memo (optimized, ~29KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~30KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (inner-join G3 G2 G4)
@@ -335,7 +335,7 @@ SELECT *
 FROM stu, abc, xyz, pqr
 WHERE u = a AND a = x AND x = p
 ----
-memo (optimized, ~38KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~40KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+6) (merge-join G3 G2 G5 inner-join,+6,+3) (lookup-join G3 G5 stu@uts,keyCols=[6],outCols=(1-3,6-8,12-14,18-22))
  │    └── [presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (merge-join G2="[ordering: +3]" G3="[ordering: +(6|12|18)]" G5 inner-join,+3,+6)
@@ -1269,7 +1269,7 @@ memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
 memo expect=ReorderJoins
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (full-join G2 G3 G4)
@@ -1355,7 +1355,7 @@ full-join (hash)
 memo expect-not=ReorderJoins
 SELECT * FROM abc INNER LOOKUP JOIN xyz ON a=x
 ----
-memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9))
@@ -1438,7 +1438,7 @@ New expression 1 of 1:
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (left-join G2 G3 G4)
@@ -1937,7 +1937,7 @@ inner-join (lookup xyz@xy)
 memo disable=(EliminateJoinUnderProjectLeft,EliminateJoinUnderProjectRight)
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~19KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
+memo (optimized, ~20KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+6,+7,+8) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+8,+7,+6) (lookup-join G2 G5 stu [as=r],keyCols=[1 2 3],outCols=(1-3,6-8)) (lookup-join G2 G5 stu@uts [as=r],keyCols=[3 2 1],outCols=(1-3,6-8)) (merge-join G3 G2 G5 inner-join,+6,+7,+8,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+8,+7,+6,+3,+2,+1) (lookup-join G3 G5 stu [as=l],keyCols=[6 7 8],outCols=(1-3,6-8)) (lookup-join G3 G5 stu@uts [as=l],keyCols=[8 7 6],outCols=(1-3,6-8))
  │    └── [presentation: s:1,t:2,u:3,s:6,t:7,u:8]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +6,+7,+8]" G5 inner-join,+1,+2,+3,+6,+7,+8)
@@ -7204,7 +7204,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~35KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~36KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)
@@ -10157,7 +10157,7 @@ SELECT 1 FROM (VALUES (1), (1)) JOIN (VALUES (1), (1), (1)) ON true
 UNION ALL
 SELECT 1 FROM (VALUES (1), (1), (1)) JOIN (VALUES (1), (1)) ON true
 ----
-memo (optimized, ~22KB, required=[presentation: ?column?:7])
+memo (optimized, ~23KB, required=[presentation: ?column?:7])
  ├── G1: (union-all G2 G3)
  │    └── [presentation: ?column?:7]
  │         ├── best: (union-all G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -312,7 +312,7 @@ New expression 3 of 3:
 memo set=reorder_joins_limit=0 expect-not=ReorderJoins
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~23KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+1,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (merge-join G2="[ordering: +1]" G3 G5 inner-join,+1,+10)
@@ -360,7 +360,7 @@ memo (optimized, ~23KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
 memo set=reorder_joins_limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~34KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+10) (merge-join G3 G2 G8 inner-join,+10,+1) (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12)) (merge-join G5 G6 G8 inner-join,+5,+11) (merge-join G6 G5 G8 inner-join,+11,+5) (lookup-join G6 G8 cy,keyCols=[11],outCols=(1,2,5,6,9-12))
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12))
@@ -521,7 +521,7 @@ inner-join (cross)
 memo set=reorder_joins_limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~30KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~31KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)
@@ -587,7 +587,7 @@ memo (optimized, ~30KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:
 memo set=reorder_joins_limit=3
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~65KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~66KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (inner-join G13 G14 G12) (inner-join G14 G13 G12) (inner-join G15 G16 G12) (inner-join G16 G15 G12) (inner-join G17 G18 G12) (inner-join G18 G17 G12) (merge-join G3 G2 G19 inner-join,+6,+2) (merge-join G6 G5 G19 inner-join,+10,+6) (merge-join G9 G8 G19 inner-join,+10,+6) (merge-join G11 G10 G19 inner-join,+13,+10) (merge-join G14 G13 G19 inner-join,+13,+10) (merge-join G16 G15 G19 inner-join,+13,+10) (lookup-join G17 G19 abc,keyCols=[10],outCols=(1,2,5,6,9,10,13-16)) (merge-join G18 G17 G19 inner-join,+13,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2774,7 +2774,7 @@ SELECT (
 )
   FROM table80901_1 AS tab_42921;
 ----
-memo (optimized, ~68KB, required=[presentation: ?column?:50])
+memo (optimized, ~70KB, required=[presentation: ?column?:50])
  ├── G1: (project G2 G3)
  │    └── [presentation: ?column?:50]
  │         ├── best: (project G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -1690,7 +1690,7 @@ top-k
 memo expect=GenerateTopK
 SELECT * FROM a ORDER BY k LIMIT 1
 ----
-memo (optimized, ~4KB, required=[presentation: k:1,i:2,f:3,s:4,j:5])
+memo (optimized, ~5KB, required=[presentation: k:1,i:2,f:3,s:4,j:5])
  ├── G1: (limit G2 G3 ordering=+1) (scan a,cols=(1-5),lim=1) (top-k G2 &{1 +1 })
  │    └── [presentation: k:1,i:2,f:3,s:4,j:5]
  │         ├── best: (scan a,cols=(1-5),lim=1)
@@ -1840,7 +1840,7 @@ INDEX df (d, f)
 memo expect=GenerateLimitedTopKScans
 SELECT d, e FROM defg ORDER BY d, e LIMIT 10
 ----
-memo (optimized, ~14KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
+memo (optimized, ~15KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
  ├── G1: (limit G2 G3 ordering=+1,+2) (top-k G2 &{10 +1,+2 }) (top-k G4 &{10 +1,+2 }) (top-k G5 &{10 +1,+2 }) (top-k G6 &{10 +1,+2 }) (top-k G2 &{10 +1,+2 +1}) (top-k G4 &{10 +1,+2 +1}) (top-k G5 &{10 +1,+2 +1}) (top-k G6 &{10 +1,+2 +1})
  │    ├── [presentation: d:1,e:2] [ordering: +1,+2]
  │    │    ├── best: (top-k G2 &{10 +1,+2 })
@@ -1971,7 +1971,7 @@ top-k
 memo expect-not=GenerateLimitedTopKScans
 SELECT d, f, e FROM defg@{NO_INDEX_JOIN} ORDER BY d, f, e LIMIT 10
 ----
-memo (optimized, ~4KB, required=[presentation: d:1,f:3,e:2] [ordering: +1,+3,+2])
+memo (optimized, ~5KB, required=[presentation: d:1,f:3,e:2] [ordering: +1,+3,+2])
  ├── G1: (limit G2 G3 ordering=+1,+3,+2) (top-k G2 &{10 +1,+3,+2 }) (top-k G2 &{10 +1,+3,+2 +1,+3})
  │    ├── [presentation: d:1,f:3,e:2] [ordering: +1,+3,+2]
  │    │    ├── best: (top-k G2 &{10 +1,+3,+2 })

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -343,7 +343,7 @@ memo (optimized, ~9KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
 memo expect-not=GeneratePartialIndexScans
 SELECT i FROM p WHERE s = 'bar'
 ----
-memo (optimized, ~10KB, required=[presentation: i:2])
+memo (optimized, ~11KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
@@ -629,7 +629,7 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-memo (optimized, ~9KB, required=[presentation: k:1])
+memo (optimized, ~10KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -979,7 +979,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1
 ----
-memo (optimized, ~8KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G4 G5)
@@ -1274,7 +1274,7 @@ New expression 2 of 2:
 memo
 SELECT s, i, f FROM kifs WHERE s='foo' ORDER BY s DESC, i
 ----
-memo (optimized, ~7KB, required=[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)])
+memo (optimized, ~8KB, required=[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)])
  ├── G1: (select G2 G3) (scan kifs@s_idx,cols=(2-4),constrained) (index-join G4 kifs,cols=(2-4))
  │    ├── [presentation: s:4,i:2,f:3] [ordering: +2 opt(4)]
  │    │    ├── best: (sort G1)
@@ -1742,7 +1742,7 @@ CREATE INDEX idx2 ON p (i) WHERE s = 'foo'
 memo
 SELECT i FROM p WHERE i = 3 AND s = 'foo'
 ----
-memo (optimized, ~22KB, required=[presentation: i:2])
+memo (optimized, ~23KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
@@ -1816,7 +1816,7 @@ CREATE INDEX idx ON p (i) WHERE s = 'foo'
 memo expect-not=GenerateConstrainedScans
 SELECT i FROM p WHERE s = 'bar' AND i = 5
 ----
-memo (optimized, ~9KB, required=[presentation: i:2])
+memo (optimized, ~10KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
@@ -2696,7 +2696,7 @@ project
 memo expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j @> '{"a": "b"}'
 ----
-memo (optimized, ~8KB, required=[presentation: k:1])
+memo (optimized, ~9KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k) (project G4 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G4 G3 k)
@@ -2724,7 +2724,7 @@ memo (optimized, ~8KB, required=[presentation: k:1])
 memo expect-not=GenerateInvertedIndexScans
 SELECT k FROM b@{NO_INDEX_JOIN} WHERE j @> '{"a": "b"}'
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
+memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (project G2 G3 k)
  │    └── [presentation: k:1]
  │         ├── best: (project G2 G3 k)
@@ -8443,7 +8443,7 @@ inner-join (zigzag pqr@q pqr@r)
 memo expect=GenerateZigzagJoins
 SELECT q,r FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~16KB, required=[presentation: q:2,r:3])
+memo (optimized, ~17KB, required=[presentation: q:2,r:3])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (zigzag-join G3 pqr@q pqr@r)
  │    └── [presentation: q:2,r:3]
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
@@ -8524,7 +8524,7 @@ inner-join (lookup pqr)
 memo expect=GenerateZigzagJoins
 SELECT q,r,s FROM pqr WHERE q = 1 AND r = 2
 ----
-memo (optimized, ~19KB, required=[presentation: q:2,r:3,s:4])
+memo (optimized, ~20KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
@@ -9121,7 +9121,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~39KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~40KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -11198,7 +11198,7 @@ CREATE TABLE t58390 (
 memo
 SELECT * FROM t58390 WHERE a > 1 OR b > 1
 ----
-memo (optimized, ~23KB, required=[presentation: k:1,a:2,b:3,c:4])
+memo (optimized, ~24KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G1: (select G2 G3) (index-join G4 t58390,cols=(1-4)) (distinct-on G5 G6 cols=(1)) (distinct-on G5 G6 cols=(1),ordering=+1)
  │    └── [presentation: k:1,a:2,b:3,c:4]
  │         ├── best: (select G2 G3)
@@ -11313,7 +11313,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~35KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~36KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -490,6 +490,10 @@ message LocalOnlySessionData {
   // which throws a runtime error when the SQL statement doesn't return exactly
   // one row. This is useful for oracle compatibility.
   bool plpgsql_use_strict_into = 123 [(gogoproto.customname) = "PLpgSQLUseStrictInto"];
+  // OptimizerUseVirtualComputedColumnStats indicates whether we should use
+  // statistics on virtual computed columns for cardinality estimation in the
+  // optimizer.
+  bool optimizer_use_virtual_computed_column_stats = 124;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -144,7 +144,7 @@ DEALLOCATE ALL
 ----
 
 exec
-SET prepared_statements_cache_size = '10 KiB'
+SET prepared_statements_cache_size = '12 KiB'
 ----
 
 wire_prepare pscs1

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3242,6 +3242,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_virtual_computed_column_stats`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_virtual_computed_column_stats`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_virtual_computed_column_stats", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseVirtualComputedColumnStats(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
**opt: add props.Statistics.VirtualCols**

As of #118241 we now collect table statistics on virtual computed
columns, but do not yet use them in statistics builder. The difficulty
with using these stats in statistics builder is that virtual computed
columns are synthesized by various non-Scan expressions (Project,
Select, etc). When calculating stats for these non-Scan expressions, we
need to find the virtual column stats even though the virtual columns
are not produced by the input to these expressions.

To solve this, we add a VirtualCols set to props.Statistics which holds
all of the virtual columns that could be produced by the input to a
group. Expressions that could synthesize virtual columns will look in
this set to discover whether there are statistics for any of the scalar
expressions they render. If there are, they will call colStatXXX using
the virtual column ID as if the virtual column had originated from
their input.

This commit adds VirtualCols but does not yet use it.

Note that we cannot currently pass VirtualCols up through set operations
or with-scans, due to the column ID translation they use.

Informs: #68254

Epic: CRDB-8949

Release note: None

---

**sql: add optimizer_use_virtual_computed_column_stats session variable**

Informs: #68254

Epic: CRDB-8949

Release note (sql): Add new session variable
`optimizer_use_virtual_computed_column_stats`. When this variable is
enabled, the optimizer will make use of table statistics on virtual
computed columns.

---

**opt/memo: extend OutputCols with VirtualCols in statistics builder**

Throughout statistics builder we use OutputCols to determine which
columns come from the input to an expression. We then typically call
colStatXXX with those columns as part of statistics calculation.

In order to use statistics on virtual computed columns, we need to call
colStatXXX on any virtual columns that could come from our input, even
if they are not passed upward through OutputCols. To do this we extend
OutputCols with the VirtualCols set we built in a previous commit. This
commit replaces almost all usages of OutputCols in statistics builder
with a call to helper function colStatCols, which returns a union of
OutputCols and VirtualCols.

This is enough to get the optimizer to use statistics on virtual
computed columns in some simple plans. More complex plans will require
matching the virtual column scalar expressions, which will be in the
next PR. I've left some TODOs marking spots where this next PR will
touch.

Informs: #68254

Epic: CRDB-8949

Release note: None