### PR TITLE
server: include WAL failover path within the stores status

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4090,11 +4090,14 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | store_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.StoresResponse-int32) |  |  | [reserved](#support-status) |
 | encryption_status | [bytes](#cockroach.server.serverpb.StoresResponse-bytes) |  | encryption_status is a serialized ccl/storageccl/engineccl/enginepbccl/stats.go::EncryptionStatus protobuf. | [reserved](#support-status) |
 | total_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Basic file stats when encryption is enabled. Total files/bytes. | [reserved](#support-status) |
 | total_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  | [reserved](#support-status) |
 | active_key_files | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  | Files/bytes using the active data key. | [reserved](#support-status) |
 | active_key_bytes | [uint64](#cockroach.server.serverpb.StoresResponse-uint64) |  |  | [reserved](#support-status) |
+| dir | [string](#cockroach.server.serverpb.StoresResponse-string) |  | dir is the path to the store's data directory on the node. | [reserved](#support-status) |
+| wal_failover_path | [string](#cockroach.server.serverpb.StoresResponse-string) |  | wal_failover_path encodes the path to the secondary WAL directory used for failover in the event of high write latency to the primary WAL. | [reserved](#support-status) |
 
 
 

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -341,6 +341,11 @@ message StoreProperties {
   optional bool encrypted = 1 [(gogoproto.nullable) = false];
   // read_only indicates whether the store is attached read_only.
   optional bool read_only = 2 [(gogoproto.nullable) = false];
+  // dir is the path to the store's data directory on the node.
+  optional string dir = 4 [(gogoproto.nullable) = false];
+  // wal_failover_path encodes the path to the secondary WAL directory used for
+  // failover in the event of high write latency to the primary WAL.
+  optional string wal_failover_path = 5;
 
   // disk_properties reports details about the underlying filesystem,
   // when the store is supported by a file store. Unset otherwise.

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1598,6 +1598,11 @@ message StoreDetails {
     (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"
   ];
+  int32 node_id = 7 [
+    (gogoproto.customname) = "NodeID",
+    (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+  ];
 
   // TODO(mberhault): add a lot more information about stores. eg:
   // - path
@@ -1615,6 +1620,11 @@ message StoreDetails {
   // Files/bytes using the active data key.
   uint64 active_key_files = 5;
   uint64 active_key_bytes = 6;
+  // dir is the path to the store's data directory on the node.
+  string dir = 8;
+  // wal_failover_path encodes the path to the secondary WAL directory used for
+  // failover in the event of high write latency to the primary WAL.
+  string wal_failover_path = 9 [(gogoproto.nullable) = true];
 }
 
 message StoresResponse {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1101,8 +1101,6 @@ func newPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		}
 	}
 
-	storeProps := computeStoreProperties(ctx, cfg.Dir, opts.ReadOnly, cfg.Env.Encryption != nil /* encryptionEnabled */)
-
 	p = &Pebble{
 		FS:                opts.FS,
 		readOnly:          opts.ReadOnly,
@@ -1112,7 +1110,7 @@ func newPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		ballastSize:       cfg.BallastSize,
 		maxSize:           cfg.MaxSize,
 		attrs:             cfg.Attrs,
-		properties:        storeProps,
+		properties:        computeStoreProperties(ctx, cfg),
 		settings:          cfg.Settings,
 		env:               cfg.Env,
 		logger:            opts.LoggerAndTracer,


### PR DESCRIPTION
Expand the response from the /_status/stores endpoint to include the store's data directory and the path to the configured WAL failover secondary if configured.

Close #119795.

Epic: CRDB-35401
Release note: Adds a new field to the stores