### PR TITLE
sql: grant to all tables did not skip privileges on sequences

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
@@ -32,11 +32,22 @@ SET ROLE root
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s TO testuser
 
-query TTTTTB colnames
+# This should be a no-op, since backup privellege is not
+# supported on sequences.
+query T noticetrace
+GRANT BACKUP ON ALL TABLES IN SCHEMA S TO testuser
+----
+NOTICE: some privileges have no effect on sequences: [BACKUP]
+
+statement error pgcode 0LP01 invalid privilege type BACKUP for sequence
+GRANT BACKUP ON ALL SEQUENCES IN SCHEMA S TO testuser
+
+query TTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
 test           s            q              testuser  SELECT          false
+test           s            t              testuser  BACKUP          false
 
 statement ok
 GRANT USAGE ON ALL SEQUENCES IN SCHEMA s TO testuser
@@ -47,6 +58,7 @@ SHOW GRANTS FOR testuser
 database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
 test           s            q              testuser  SELECT          false
 test           s            q              testuser  USAGE           false
+test           s            t              testuser  BACKUP          false
 
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s, s2 TO testuser, testuser2
@@ -58,6 +70,7 @@ database_name  schema_name  relation_name  grantee    privilege_type  is_grantab
 test           s            q              testuser   SELECT          false
 test           s            q              testuser   USAGE           false
 test           s            q              testuser2  SELECT          false
+test           s            t              testuser   BACKUP          false
 test           s2           q              testuser   SELECT          false
 test           s2           q              testuser2  SELECT          false
 
@@ -70,6 +83,7 @@ SHOW GRANTS FOR testuser, testuser2
 database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
 test           s            q              testuser   ALL             false
 test           s            q              testuser2  ALL             false
+test           s            t              testuser   BACKUP          false
 test           s2           q              testuser   ALL             false
 test           s2           q              testuser2  ALL             false
 
@@ -102,6 +116,7 @@ SHOW GRANTS FOR testuser, testuser2
 database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
 test           s            q              testuser   ALL             false
 test           s            q              testuser2  ALL             false
+test           s            t              testuser   BACKUP          false
 test           s2           q              testuser   ALL             false
 test           s2           q              testuser2  ALL             false
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -397,7 +397,7 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 									descs,
 									DescriptorWithObjectType{
 										descriptor: mut,
-										objectType: privilege.Table,
+										objectType: mut.GetObjectType(),
 									})
 							}
 						}


### PR DESCRIPTION
Previously, grant privilege to all tables attempted to apply privileges meant only for tables on to sequences. This could lead to validation error preventing certain combinations like "GRANT BACKUP ON ALL TABLES..." from working correctly. To address this, this patch adds support for correctly propogating the object type and skipping over unsupported privileges. When an unsupported privilege is encountered on an object other then a sequence a warning is now logged.

Fixes: #117861

Release note (bug fix): GRANT <...> ON ALL TABLES could fail if sequences existed and they did not support a privilege (for example BACKUP).