### PR TITLE
drt: delete paused IMPORTs before init in tpcc_drop

### DIFF
--- a/pkg/cmd/drt/scripts/cct_tpcc_drop.sh
+++ b/pkg/cmd/drt/scripts/cct_tpcc_drop.sh
@@ -17,6 +17,14 @@ while true; do
     ((j++))
     INIT_LOG=./cct_tpcc_drop_init_$j.txt
     RUN_LOG=./cct_tpcc_drop_run_$j.txt
+
+    # Temporarily, we cleanup and paused IMPORT jobs that may exist due to
+    # node failures. Long-term, we will address these failures by making
+    # IMPORT more resilient and/or creating a variant of IMPORT which cancels
+    # itself instead of pausing.
+    ./cockroach sql --url "${PG_URL_N1}" -e "CANCEL JOBS (WITH x AS (SHOW JOBS) SELECT job_id FROM x WHERE status = 'paused' AND job_type = 'IMPORT');"
+    sleep 15
+
     ./cockroach workload init tpcc \
         --warehouses=3000 \
         --secure \


### PR DESCRIPTION
In the cct_tpcc_drop workload, we want to remove any paused IMPORTs before we try and re-init the database. Paused IMPORTs leave the affected tables offline, thus preventing init from succeeding. We're left with paused IMPORTs on occasion due to the fact that when running chaos, node failures could prevent IMPORT from making sufficient progress in the necessary time to be retried.

Release note: none
Epic: none