### PR TITLE
changefeedccl: remove collated string collation key from output

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -54,7 +54,14 @@ func (e *csvEncoder) EncodeValue(
 	e.buf.Reset()
 	if err := updatedRow.ForEachColumn().Datum(func(d tree.Datum, col cdcevent.ResultColumn) error {
 		e.formatter.Reset()
-		e.formatter.FormatNode(d)
+
+		switch di := d.(type) {
+		case *tree.DCollatedString:
+			e.formatter.WriteString(di.Contents)
+		default:
+			e.formatter.FormatNode(d)
+		}
+
 		return e.writer.WriteField(&e.formatter.Buffer)
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, collated strings would output their collation key in changefeeds. This change makes it so that the collated string contents are output only. See https://github.com/cockroachdb/cockroach/issues/120696 for more info:

Closes: https://github.com/cockroachdb/cockroach/issues/120696
Release note: None