### PR TITLE
release-23.2: util/mon: add env var to disable monitor tree tracking

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -268,6 +268,11 @@ type BytesMonitor struct {
 	settings *cluster.Settings
 }
 
+// enableMonitorTreeTracking indicates whether tracking of all children of a
+// BytesMonitor (which is what powers TraverseTree) is enabled.
+var enableMonitorTreeTracking = envutil.EnvOrDefaultBool(
+	"COCKROACH_ENABLE_MONITOR_TREE", true)
+
 // MonitorState describes the current state of a single monitor.
 type MonitorState struct {
 	// Level tracks how many "generations" away the current monitor is from the
@@ -495,18 +500,20 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 
 	var effectiveLimit int64
 	if pool != nil {
-		// If we have a "parent" monitor, then register mm as its child by
-		// making it the head of the doubly-linked list.
-		func() {
-			pool.mu.Lock()
-			defer pool.mu.Unlock()
-			if s := pool.mu.head; s != nil {
-				s.parentMu.prevSibling = mm
-				mm.parentMu.nextSibling = s
-			}
-			pool.mu.head = mm
-			pool.mu.numChildren++
-		}()
+		if enableMonitorTreeTracking {
+			// If we have a "parent" monitor, then register mm as its child by
+			// making it the head of the doubly-linked list.
+			func() {
+				pool.mu.Lock()
+				defer pool.mu.Unlock()
+				if s := pool.mu.head; s != nil {
+					s.parentMu.prevSibling = mm
+					mm.parentMu.nextSibling = s
+				}
+				pool.mu.head = mm
+				pool.mu.numChildren++
+			}()
+		}
 		effectiveLimit = pool.limit
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #120682.

/cc @cockroachdb/release

---

Recently we have seen a few issues that were caused (or at least exacerbated) by the monitor tree tracking. This commit introduces an env var `COCKROACH_ENABLE_MONITOR_TREE` which - if set to false - will disable this monitor tree tracking. This can be our escape hatch if we see more problems around it.

It is achieved by simply not adding a monitor to the list of children of its parent (we don't need to make any changes to the `Stop` logic since it can already handle cases whenever a monitor doesn't have siblings). The impact of disabling the tracking will be useless `crdb_internal.node_memory_monitors` table as well as `memmonitoring` profiles.

The env var is undocumented since enabling it should be recommended by Queries L2.

Informs: #120564.

Epic: None

Release note: None

Release justification: low-risk escape hatch.