### PR TITLE
workflows: tag `cockroach` builds for integration tests

### DIFF
--- a/build/github/acceptance-test.sh
+++ b/build/github/acceptance-test.sh
@@ -3,6 +3,7 @@
 set -euxo pipefail
 
 bazel build --config crosslinux //pkg/cmd/cockroach-short \
+    --bes_keywords integration-test-artifact-build \
     --jobs 100 $(./build/github/engflow-args.sh)
 
 ARTIFACTSDIR=$PWD/artifacts

--- a/build/github/examples-orms.sh
+++ b/build/github/examples-orms.sh
@@ -3,7 +3,10 @@
 set -euxo pipefail
 
 pushd cockroach
-bazel build //pkg/cmd/cockroach-short --config crosslinux --jobs 100 $(./build/github/engflow-args.sh)
+bazel build //pkg/cmd/cockroach-short \
+      --config crosslinux --jobs 100 \
+      --bes_keywords integration-test-artifact-build \
+      $(./build/github/engflow-args.sh)
 cp _bazel/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short ../examples-orms/cockroach
 # We need Go in the `PATH`.
 export PATH=$(dirname $(bazel run @go_sdk//:bin/go --run_under=realpath)):$PATH

--- a/build/github/local-roachtest.sh
+++ b/build/github/local-roachtest.sh
@@ -22,6 +22,7 @@ export COCKROACH_DEV_LICENSE=$(gcloud secrets versions access 1 --secret=cockroa
 set -x
 
 bazel build --config=$CROSSCONFIG $(./build/github/engflow-args.sh) \
+      --bes_keywords integration-test-artifact-build \
       --jobs 100 \
       //pkg/cmd/cockroach-short \
       //pkg/cmd/roachtest \


### PR DESCRIPTION
... with the tag `integration-test-artifact-build`. We do this to track how long it takes to build these artifacts specifically.

Epic: CRDB-8308
Release note: None