### PR TITLE
build: fix pebble nightly build script for 23.2

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
@@ -29,7 +29,9 @@ echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 # Use the Pebble SHA from the version in the modified go.mod file.
 # Note that we need to pluck the Git SHA from the go.sum-style version, i.e.
 # v0.0.0-20220214174839-6af77d5598c9SUM => 6af77d5598c9
-PEBBLE_SHA=$(grep 'github\.com/cockroachdb/pebble' go.mod | cut -d'-' -f3)
+# In some cases if there's no Git SHA because we're right at a tag (eg. v1.1.0),
+# we have the second cut to grab the entire tag name as the SHA.
+PEBBLE_SHA=$(grep 'github\.com/cockroachdb/pebble' go.mod | cut -d'-' -f3 | cut -d' ' -f2)
 
 bazel build --define gotags=bazel,invariants \
       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test


### PR DESCRIPTION
The crl-release-23.2 branch is currently right at a version tag. This trips up the pebble_nightly_build_test_binary script as it expects it to end in a SHA like v0.0.0-20220214174839-6af77d5598c9 while it is just v1.1.0. This change fixes it to also account for that case, so crossversion tests on 23.2 can be run.

Epic: none

Release note: None