### PR TITLE
sql: fix minor procedure bugs and add UDF/SP mixed tests

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2293,6 +2293,13 @@ func TestTenantLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestTenantLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestTenantLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/proc_invokes_proc
+++ b/pkg/sql/logictest/testdata/logic_test/proc_invokes_proc
@@ -90,3 +90,29 @@ statement ok
 DROP PROCEDURE ins3;
 DROP PROCEDURE ins_ab;
 DROP TABLE ab;
+
+statement ok
+CREATE TABLE i (i INT);
+
+statement ok
+CREATE PROCEDURE insert1(n INT) LANGUAGE SQL AS $$
+  INSERT INTO i VALUES (n);
+$$
+
+statement ok
+CREATE PROCEDURE insert2(n INT) LANGUAGE SQL AS $$
+  CALL insert1(n);
+$$
+
+statement ok
+CALL insert2(11)
+
+query I
+SELECT * FROM i
+----
+11
+
+statement ok
+DROP PROCEDURE insert2;
+DROP PROCEDURE insert1;
+DROP TABLE i;

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -94,8 +94,11 @@ SELECT p(1)
 
 # The error message for a non-existent procedure should mention "procedure" not
 # "function".
-statement error pgcode 42883 procedure no_exist does not exist\nHINT: No procedure matches the given name and argument types. You might need to add explicit type casts.
+statement error pgcode 42883 procedure no_exist does not exist\nHINT: No procedure matches the given name.
 CALL no_exist()
+
+statement error pgcode 42883 procedure p\(int, string\) does not exist\nHINT: No procedure matches the given name and argument types. You might need to add explicit type casts.
+CALL p(1, 'foo')
 
 # The error message for a non-existent function within a procedure call should
 # still mention "function".

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -114,3 +114,22 @@ statement ok
 DROP FUNCTION ins;
 DROP FUNCTION ins_ab;
 DROP TABLE ab;
+
+statement ok
+CREATE FUNCTION identity1(n INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT n;
+$$
+
+statement ok
+CREATE FUNCTION identity2(n INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT identity1(n);
+$$
+
+query I
+SELECT identity2(11)
+----
+11
+
+statement ok
+DROP FUNCTION identity2;
+DROP FUNCTION identity1;

--- a/pkg/sql/logictest/testdata/logic_test/udf_procedure_mix
+++ b/pkg/sql/logictest/testdata/logic_test/udf_procedure_mix
@@ -1,0 +1,55 @@
+# LogicTest: !local-mixed-23.1 !local-mixed-23.2
+
+statement ok
+CREATE TABLE sums (
+  i INT PRIMARY KEY,
+  sum INT
+)
+
+statement ok
+CREATE FUNCTION sum_1_to_n(n INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT sum(i) FROM generate_series(1, n) g(i);
+$$
+
+# A procedure can invoke a UDF.
+statement ok
+CREATE PROCEDURE insert_sum(n INT) LANGUAGE SQL AS $$
+  INSERT INTO sums VALUES (n, sum_1_to_n(n)) ON CONFLICT DO NOTHING;
+$$
+
+statement ok
+CALL insert_sum(1);
+CALL insert_sum(4);
+CALL insert_sum(10);
+
+query II rowsort
+SELECT * FROM sums
+----
+1   1
+4   10
+10  55
+
+# A UDF can invoke a procedure.
+statement ok
+CREATE FUNCTION fetch_sum_1_to_n(n INT) RETURNS INT LANGUAGE SQL AS $$
+  CALL insert_sum(n);
+  SELECT sum FROM sums WHERE i = n;
+$$
+
+query I
+SELECT fetch_sum_1_to_n(4)
+----
+10
+
+query I
+SELECT fetch_sum_1_to_n(9)
+----
+45
+
+query II rowsort
+SELECT * FROM sums
+----
+1   1
+4   10
+9   45
+10  55

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2248,6 +2248,13 @@ func TestLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2255,6 +2255,13 @@ func TestLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2269,6 +2269,13 @@ func TestLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2255,6 +2255,13 @@ func TestLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2283,6 +2283,13 @@ func TestLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2486,6 +2486,13 @@ func TestLogic_udf_privileges_mutations(
 	runLogicTest(t, "udf_privileges_mutations")
 }
 
+func TestLogic_udf_procedure_mix(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_procedure_mix")
+}
+
 func TestLogic_udf_record(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1063,6 +1063,12 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		// can handle overloads with the same name.
 		def, err := t.Func.Resolve(s.builder.ctx, semaCtx.SearchPath, semaCtx.FunctionResolver)
 		if err != nil {
+			if t.InCall && errors.Is(err, tree.ErrRoutineUndefined) {
+				panic(errors.WithHint(
+					pgerror.Newf(pgcode.UndefinedFunction, "procedure %s does not exist", t.Func),
+					"No procedure matches the given name.",
+				))
+			}
 			panic(err)
 		}
 

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -85,8 +85,14 @@ func (s *subquery) Walk(v tree.Visitor) tree.Expr {
 
 // TypeCheck is part of the tree.Expr interface.
 func (s *subquery) TypeCheck(
-	_ context.Context, _ *tree.SemaContext, desired *types.T,
+	_ context.Context, semaCtx *tree.SemaContext, desired *types.T,
 ) (tree.TypedExpr, error) {
+	if semaCtx != nil && semaCtx.Properties.IsSet(tree.RejectSubqueries) {
+		// This is the same error as in tree.Subquery.TypeCheck.
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+			"subqueries are not allowed in %s", semaCtx.Properties.Context())
+	}
+
 	if s.typ != nil {
 		return s, nil
 	}

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1953,6 +1953,11 @@ func TestSchemaChangeComparator_udf_privileges_mutations(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_privileges_mutations"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_udf_procedure_mix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_procedure_mix"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_udf_record(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_record"


### PR DESCRIPTION
#### sql: fix bugs with procedures passing arguments to other procedures

This commit fixes a limitation where a procedure could not pass an
argument through to another procedure, like:

    CREATE PROCEDURE p(n INT) LANGUAGE SQL AS $$
      CALL other_proc(n);
    $$

To lift this restriction, the body of a procedure must be type-checked
with respect to the current scope which contains the procedures named
parameters. This change required a few subsequent changes to prevent
regressions:

  1. Copying some logic that ensures that `CALL` arguments are not
     subqueries to `optbuilder.subquery.TypeCheck`.
  2. Using `FuncExpr.InCall` instead of `CallAncestor` to determine the
     correct verbiage for error messages of procedures. `CallAncestor`
     is no longer used and has been removed.

Epic: None

Release note: None

#### sql/logictest: add tests for UDFs and SPs calling each other

Release note: None
