### PR TITLE
plpgsql: implement labels for EXIT and CONTINUE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_unsupported
@@ -8,11 +8,3 @@ CREATE OR REPLACE PROCEDURE foo() AS $$
     RAISE NOTICE 'x: %', x;
   END
 $$ LANGUAGE PLpgSQL;
-
-statement error pgcode 0A000 pq: unimplemented: block labels are not yet supported
-CREATE OR REPLACE PROCEDURE foo() AS $$
-  <<bar>>
-  BEGIN
-    RAISE NOTICE 'baz';
-  END
-$$ LANGUAGE PLpgSQL;

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
@@ -300,8 +300,8 @@ CREATE PROCEDURE p() AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-# CONTINUE cannot apply to a block, with or without a label.
-statement error pgcode 42601 pq: CONTINUE cannot be used outside a loop
+# CONTINUE cannot apply to a block.
+statement error pgcode 42601 pq: block label \"foo\" cannot be used in CONTINUE
 CREATE PROCEDURE p() AS $$
   BEGIN
     <<foo>>
@@ -313,8 +313,86 @@ CREATE PROCEDURE p() AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+# The nested block takes precedence over the loop with the same label.
+statement error pgcode 42601 pq: block label \"foo\" cannot be used in CONTINUE
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    i INT := 0;
+  BEGIN
+    <<foo>>
+    WHILE i < 5 LOOP
+      <<foo>>
+      BEGIN
+        RAISE NOTICE 'before EXIT';
+        CONTINUE foo;
+        RAISE NOTICE 'after EXIT';
+      END;
+    END LOOP;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# EXIT with a nonexistent label.
+statement error pgcode 42601 pq: there is no label \"foo\" attached to any block or loop enclosing this statement
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    <<bar>>
+    BEGIN
+      EXIT foo;
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# CONTINUE with a nonexistent label.
+statement error pgcode 42601 pq: there is no label \"foo\" attached to any block or loop enclosing this statement
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    <<bar>>
+    BEGIN
+      CONTINUE foo;
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# It is possible to EXIT the root block.
+statement ok
+CREATE PROCEDURE p() AS $$
+  <<foo>>
+  DECLARE
+    i INT := 0;
+  BEGIN
+    WHILE i < 5 LOOP
+      RAISE NOTICE 'here';
+      EXIT foo;
+      RAISE NOTICE 'still here';
+    END LOOP;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: here
+
+# It is possible to EXIT the routine, but this always results in an
+# end-of-function error, even for a void-returning proc.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    i INT := 0;
+  BEGIN
+    WHILE i < 5 LOOP
+      EXIT p;
+    END LOOP;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 2F005 control reached end of function without RETURN
+CALL p();
+
 # CONTINUE the inner loop.
 statement ok
+DROP PROCEDURE p;
 CREATE PROCEDURE p(x INT) AS $$
   <<b1>>
   DECLARE
@@ -349,12 +427,10 @@ CREATE PROCEDURE p(x INT) AS $$
           ELSIF x = 4 THEN
             IF j = 1 THEN RAISE NOTICE 'EXIT b2'; END IF;
             EXIT b2 WHEN j = 1;
-          -- TODO(drewk): uncomment these branches when it's possible to
-          -- reference the root block.
-          -- ELSIF x = 5 THEN
-          --   EXIT b1 WHEN j = 1;
-          -- ELSE
-          --   EXIT p WHEN j = 1;
+          ELSIF x = 5 THEN
+            EXIT b1 WHEN j = 1;
+          ELSE
+            EXIT p WHEN j = 1;
           END IF;
           RAISE NOTICE '<< l2 % %', i, j;
         END LOOP l2;
@@ -448,6 +524,19 @@ NOTICE: >> l2 2 1
 NOTICE: EXIT b2
 NOTICE: << l1 2
 NOTICE: << b1 2
+
+# EXIT outer block.
+query T noticetrace
+CALL p(5);
+----
+NOTICE: >> b1 0
+NOTICE: >> l1 1
+NOTICE: >> b2 1 0
+NOTICE: >> l2 1 1
+
+# EXIT the routine.
+statement error pgcode 2F005 control reached end of function without RETURN
+CALL p(6);
 
 statement ok
 DROP PROCEDURE p;

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
@@ -261,4 +261,230 @@ NOTICE: iteration 3
 NOTICE: new value of i: 4
 NOTICE: returning
 
+subtest exit_continue_label
+
+# EXIT can apply to a block with a label.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    <<foo>>
+    BEGIN
+      RAISE NOTICE 'before EXIT';
+      EXIT foo;
+      RAISE NOTICE 'after EXIT';
+    END;
+    RAISE NOTICE 'after block';
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: before EXIT
+NOTICE: after block
+
+statement ok
+DROP PROCEDURE p;
+
+# EXIT without a label cannot apply to a block.
+statement error pgcode 42601 pq: EXIT cannot be used outside a loop, unless it has a label
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    <<foo>>
+    BEGIN
+      RAISE NOTICE 'before EXIT';
+      EXIT;
+      RAISE NOTICE 'after EXIT';
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# CONTINUE cannot apply to a block, with or without a label.
+statement error pgcode 42601 pq: CONTINUE cannot be used outside a loop
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    <<foo>>
+    BEGIN
+      RAISE NOTICE 'before EXIT';
+      CONTINUE foo;
+      RAISE NOTICE 'after EXIT';
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# CONTINUE the inner loop.
+statement ok
+CREATE PROCEDURE p(x INT) AS $$
+  <<b1>>
+  DECLARE
+    i INT := 0;
+  BEGIN
+    RAISE NOTICE '>> b1 %', i;
+    <<l1>>
+    WHILE i < 2 LOOP
+      i := i + 1;
+      RAISE NOTICE '>> l1 %', i;
+      <<b2>>
+      DECLARE
+        j int := 0;
+      BEGIN
+        RAISE NOTICE '>> b2 % %', i, j;
+        <<l2>>
+        WHILE j < i LOOP
+          j := j + 1;
+          RAISE NOTICE '>> l2 % %', i, j;
+          IF x = 0 THEN
+            IF j = 1 THEN RAISE NOTICE 'CONTINUE l2'; END IF;
+            CONTINUE l2 WHEN j = 1;
+          ELSIF x = 1 THEN
+            IF j = 1 THEN RAISE NOTICE 'EXIT l2'; END IF;
+            EXIT l2 WHEN j = 1;
+          ELSIF x = 2 THEN
+            IF j = 1 THEN RAISE NOTICE 'CONTINUE l1'; END IF;
+            CONTINUE l1 WHEN j = 1;
+          ELSIF x = 3 THEN
+            IF j = 1 THEN RAISE NOTICE 'EXIT l1'; END IF;
+            EXIT l1 WHEN j = 1;
+          ELSIF x = 4 THEN
+            IF j = 1 THEN RAISE NOTICE 'EXIT b2'; END IF;
+            EXIT b2 WHEN j = 1;
+          -- TODO(drewk): uncomment these branches when it's possible to
+          -- reference the root block.
+          -- ELSIF x = 5 THEN
+          --   EXIT b1 WHEN j = 1;
+          -- ELSE
+          --   EXIT p WHEN j = 1;
+          END IF;
+          RAISE NOTICE '<< l2 % %', i, j;
+        END LOOP l2;
+        RAISE NOTICE '<< b2 % %', i, j;
+      END;
+      RAISE NOTICE '<< l1 %', i;
+    END LOOP l1;
+    RAISE NOTICE '<< b1 %', i;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+# CONTINUE inner loop.
+query T noticetrace
+CALL p(0);
+----
+NOTICE: >> b1 0
+NOTICE: >> l1 1
+NOTICE: >> b2 1 0
+NOTICE: >> l2 1 1
+NOTICE: CONTINUE l2
+NOTICE: << b2 1 1
+NOTICE: << l1 1
+NOTICE: >> l1 2
+NOTICE: >> b2 2 0
+NOTICE: >> l2 2 1
+NOTICE: CONTINUE l2
+NOTICE: >> l2 2 2
+NOTICE: << l2 2 2
+NOTICE: << b2 2 2
+NOTICE: << l1 2
+NOTICE: << b1 2
+
+# EXIT inner loop.
+query T noticetrace
+CALL p(1);
+----
+NOTICE: >> b1 0
+NOTICE: >> l1 1
+NOTICE: >> b2 1 0
+NOTICE: >> l2 1 1
+NOTICE: EXIT l2
+NOTICE: << b2 1 1
+NOTICE: << l1 1
+NOTICE: >> l1 2
+NOTICE: >> b2 2 0
+NOTICE: >> l2 2 1
+NOTICE: EXIT l2
+NOTICE: << b2 2 1
+NOTICE: << l1 2
+NOTICE: << b1 2
+
+# CONTINUE outer loop.
+query T noticetrace
+CALL p(2);
+----
+NOTICE: >> b1 0
+NOTICE: >> l1 1
+NOTICE: >> b2 1 0
+NOTICE: >> l2 1 1
+NOTICE: CONTINUE l1
+NOTICE: >> l1 2
+NOTICE: >> b2 2 0
+NOTICE: >> l2 2 1
+NOTICE: CONTINUE l1
+NOTICE: << b1 2
+
+# EXIT outer loop.
+query T noticetrace
+CALL p(3);
+----
+NOTICE: >> b1 0
+NOTICE: >> l1 1
+NOTICE: >> b2 1 0
+NOTICE: >> l2 1 1
+NOTICE: EXIT l1
+NOTICE: << b1 1
+
+# EXIT inner block.
+query T noticetrace
+CALL p(4);
+----
+NOTICE: >> b1 0
+NOTICE: >> l1 1
+NOTICE: >> b2 1 0
+NOTICE: >> l2 1 1
+NOTICE: EXIT b2
+NOTICE: << l1 1
+NOTICE: >> l1 2
+NOTICE: >> b2 2 0
+NOTICE: >> l2 2 1
+NOTICE: EXIT b2
+NOTICE: << l1 2
+NOTICE: << b1 2
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    i INT := 0;
+  BEGIN
+    <<l1>>
+    LOOP
+      i := i + 1;
+      EXIT l1 WHEN i >= 5;
+      DECLARE
+        j int := 0;
+      BEGIN
+        <<l2>>
+        LOOP
+          j := j + 1;
+          RAISE NOTICE '% %', i, j;
+          CONTINUE l1 WHEN j >= i;
+        END LOOP l2;
+      END;
+    END LOOP l1;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: 1 1
+NOTICE: 2 1
+NOTICE: 2 2
+NOTICE: 3 1
+NOTICE: 3 2
+NOTICE: 3 3
+NOTICE: 4 1
+NOTICE: 4 2
+NOTICE: 4 3
+NOTICE: 4 4
+
 subtest end

--- a/pkg/internal/sqlsmith/plpgsql.go
+++ b/pkg/internal/sqlsmith/plpgsql.go
@@ -37,7 +37,7 @@ func (s *Smither) makePLpgSQLBlock(scope plpgsqlBlockScope) *ast.Block {
 	const maxStmts = 11
 	decls, newScope := s.makePLpgSQLDeclarations(scope)
 	body := s.makePLpgSQLStatements(newScope, maxStmts)
-	// TODO(#115271): optionally add a label when block labels are supported.
+	// TODO(#106368): optionally add a label.
 	return &ast.Block{
 		Decls: decls,
 		Body:  body,

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -336,7 +336,8 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// the volatility.
 		b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 			plBuilder := newPLpgSQLBuilder(
-				b, cf.Name.Object(), nil /* colRefs */, routineParams, funcReturnType, cf.IsProcedure,
+				b, cf.Name.Object(), stmt.AST.Label, nil, /* colRefs */
+				routineParams, funcReturnType, cf.IsProcedure,
 			)
 			stmtScope = plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		})

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -146,20 +146,17 @@ type plpgsqlBuilder struct {
 	// expressions.
 	colRefs *opt.ColSet
 
-	// returnType is the return type of the PL/pgSQL function.
+	// returnType is the return type of the PL/pgSQL routine.
 	returnType *types.T
 
-	// continuations is used to model the control flow of a PL/pgSQL function.
-	// The head of the continuations stack is used upon reaching the end of a
-	// statement block to call a function that models the statements that come
-	// next after the block. In the context of a loop, this is used to recursively
-	// call back into the loop body.
+	// continuations is a stack of sub-routines that are called to resume
+	// execution from a certain point within the PL/pgSQL routine. For example,
+	// branches of an IF-statement will call a continuation to resume execution
+	// with the statements following the IF-statement.
+	//
+	// Each continuation stores its context, and callers filter depending on this
+	// context; see also continuationType.
 	continuations []continuation
-
-	// exitContinuations is similar to continuations, but is used upon reaching an
-	// EXIT statement within a loop. It is used to resume execution with the
-	// statements that follow the loop.
-	exitContinuations []continuation
 
 	// blocks is a stack containing every block in the path from the root block to
 	// the current block. It is necessary to track the entire stack because
@@ -297,9 +294,6 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 		// There should always be a root block for the routine parameters.
 		panic(errors.AssertionFailedf("expected at least one PLpgSQL block"))
 	}
-	if astBlock.Label != "" {
-		panic(blockLabelErr)
-	}
 	b.ensureScopeHasExpr(s)
 	block := b.pushBlock(plBlock{
 		label:     astBlock.Label,
@@ -402,7 +396,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// For a nested block, push a continuation with the remaining statements
 			// before calling recursively into buildBlock. The continuation will be
 			// called when the control flow within the nested block terminates.
-			blockCon := b.makeContinuation("nested_block")
+			blockCon := b.makeContinuationWithTyp("nested_block", t.Label, continuationBlockExit)
 			b.appendPlpgSQLStmts(&blockCon, stmts[i+1:])
 			b.pushContinuation(blockCon)
 			return b.buildBlock(t, s)
@@ -521,9 +515,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			return returnScope
 
 		case *ast.Loop:
-			if t.Label != "" {
-				panic(loopLabelErr)
-			}
 			// LOOP control flow is handled similarly to IF statements, but two
 			// continuation functions are used - one that executes the loop body, and
 			// one that executes the statements following the LOOP statement. These
@@ -534,14 +525,15 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// statement, the loop body function is called. Upon reaching an EXIT
 			// statement, the exit continuation is called to model returning control
 			// flow to the statements outside the loop.
-			exitCon := b.makeContinuation("loop_exit")
+			exitCon := b.makeContinuationWithTyp("loop_exit", t.Label, continuationLoopExit)
 			b.appendPlpgSQLStmts(&exitCon, stmts[i+1:])
-			b.pushExitContinuation(exitCon)
-			loopContinuation := b.makeRecursiveContinuation("stmt_loop")
+			b.pushContinuation(exitCon)
+			loopContinuation := b.makeContinuationWithTyp("stmt_loop", t.Label, continuationLoopContinue)
+			loopContinuation.def.IsRecursive = true
 			b.pushContinuation(loopContinuation)
 			b.appendPlpgSQLStmts(&loopContinuation, t.Body)
 			b.popContinuation()
-			b.popExitContinuation()
+			b.popContinuation()
 			return b.callContinuation(&loopContinuation, s)
 
 		case *ast.While:
@@ -571,9 +563,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			return b.buildPLpgSQLStatements(b.prependStmt(loop, stmts[i+1:]), s)
 
 		case *ast.Exit:
-			if t.Label != "" {
-				panic(exitLabelErr)
-			}
 			if t.Condition != nil {
 				// EXIT with a condition is syntactic sugar for EXIT inside an IF stmt.
 				ifStmt := &ast.If{
@@ -583,17 +572,18 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 				return b.buildPLpgSQLStatements(b.prependStmt(ifStmt, stmts[i+1:]), s)
 			}
 			// EXIT statements are handled by calling the function that executes the
-			// statements after a loop. Errors if used outside a loop.
-			if con := b.getExitContinuation(); con != nil {
-				return b.callContinuation(con, s)
-			} else {
-				panic(exitOutsideLoopErr)
+			// statements after a loop. Errors if used outside either a loop or a
+			// block with a label.
+			conTypes := continuationLoopExit
+			if t.Label != unspecifiedLabel {
+				conTypes |= continuationBlockExit
 			}
+			if con := b.getContinuation(conTypes, t.Label); con != nil {
+				return b.callContinuation(con, s)
+			}
+			panic(exitOutsideLoopErr)
 
 		case *ast.Continue:
-			if t.Label != "" {
-				panic(continueLabelErr)
-			}
 			if t.Condition != nil {
 				// CONTINUE with a condition is syntactic sugar for CONTINUE inside an
 				// IF stmt.
@@ -605,11 +595,10 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			}
 			// CONTINUE statements are handled by calling the function that executes
 			// the loop body. Errors if used outside a loop.
-			if con := b.getLoopContinuation(); con != nil {
+			if con := b.getContinuation(continuationLoopContinue, t.Label); con != nil {
 				return b.callContinuation(con, s)
-			} else {
-				panic(continueOutsideLoopErr)
 			}
+			panic(continueOutsideLoopErr)
 
 		case *ast.Raise:
 			// RAISE statements allow the PLpgSQL function to send an error or a
@@ -904,8 +893,10 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			panic(unsupportedPLStmtErr)
 		}
 	}
-	// Call the parent continuation to execute the rest of the function.
-	return b.callContinuation(b.getContinuation(), s)
+	// Call the parent continuation to execute the rest of the function. Ignore
+	// loop exit continuations, which are only invoked by EXIT statements.
+	conTypes := continuationDefault | continuationLoopContinue | continuationBlockExit
+	return b.callContinuation(b.getContinuation(conTypes, unspecifiedLabel), s)
 }
 
 // resolveOpenQuery finds and validates the query that is bound to cursor for
@@ -1589,15 +1580,19 @@ func (b *plpgsqlBuilder) makeContinuation(conName string) continuation {
 			BlockState:        b.block().state,
 			RoutineType:       tree.UDFRoutine,
 		},
-		s: s,
+		typ: continuationDefault,
+		s:   s,
 	}
 }
 
-// makeRecursiveContinuation allocates a new continuation routine that can
-// recursively invoke itself.
-func (b *plpgsqlBuilder) makeRecursiveContinuation(name string) continuation {
+// makeContinuationWithTyp allocates a continuation for a loop or block, with
+// the correct label and continuation type.
+func (b *plpgsqlBuilder) makeContinuationWithTyp(
+	name, label string, typ continuationType,
+) continuation {
 	con := b.makeContinuation(name)
-	con.def.IsRecursive = true
+	con.label = label
+	con.typ = typ
 	return con
 }
 
@@ -1840,7 +1835,41 @@ type continuation struct {
 	// s is a scope initialized with the parameters of the routine. It should be
 	// used to construct the routine body statement.
 	s *scope
+
+	// label is the label of the block or loop that gave rise to this
+	// continuation, if any.
+	label string
+
+	// typ defines the context of the continuation.
+	typ continuationType
 }
+
+const unspecifiedLabel = ""
+
+// continuationType defines the context of the continuation, e.g. loop exit vs
+// continue. This is used to filter continuations when determining which one
+// must be called next.
+type continuationType uint8
+
+const (
+	// continuationDefault is used for continuations that don't interact with
+	// EXIT and CONTINUE statements.
+	continuationDefault continuationType = 1 << iota
+
+	// continuationLoopContinue encapsulates the body of a loop. CONTINUE
+	// statements jump execution to this type of continuation, as can terminal
+	// statements within the loop body.
+	continuationLoopContinue
+
+	// continuationLoopExit encapsulates the statements following a loop. Only
+	// EXIT statements can jump execution to this type of continuation.
+	continuationLoopExit
+
+	// continuationBlockExit encapsulates the statements following a PL/pgSQL
+	// block. EXIT statements can jump execution to this type of continuation, as
+	// can terminal statements within the block body.
+	continuationBlockExit
+)
 
 func (b *plpgsqlBuilder) pushContinuation(con continuation) {
 	b.continuations = append(b.continuations, con)
@@ -1852,35 +1881,23 @@ func (b *plpgsqlBuilder) popContinuation() {
 	}
 }
 
-func (b *plpgsqlBuilder) getContinuation() *continuation {
-	if len(b.continuations) == 0 {
-		return nil
-	}
-	return &b.continuations[len(b.continuations)-1]
-}
-
-func (b *plpgsqlBuilder) pushExitContinuation(con continuation) {
-	b.exitContinuations = append(b.exitContinuations, con)
-}
-
-func (b *plpgsqlBuilder) popExitContinuation() {
-	if len(b.exitContinuations) > 0 {
-		b.exitContinuations = b.exitContinuations[:len(b.exitContinuations)-1]
-	}
-}
-
-func (b *plpgsqlBuilder) getExitContinuation() *continuation {
-	if len(b.exitContinuations) == 0 {
-		return nil
-	}
-	return &b.exitContinuations[len(b.exitContinuations)-1]
-}
-
-func (b *plpgsqlBuilder) getLoopContinuation() *continuation {
+// getContinuation attempts to retrieve the most recent continuation from the
+// stack with the given required type and label.
+//
+// - allowedTypes is a bitset with each of the allowed continuation types.
+func (b *plpgsqlBuilder) getContinuation(
+	allowedTypes continuationType, label string,
+) *continuation {
 	for i := len(b.continuations) - 1; i >= 0; i-- {
-		if b.continuations[i].def.IsRecursive {
-			return &b.continuations[i]
+		if allowedTypes&b.continuations[i].typ == 0 {
+			// The caller requested to skip continuations of this type.
+			continue
 		}
+		if label != unspecifiedLabel && b.continuations[i].label != label {
+			// The caller specified the label of the continuation to retrieve.
+			continue
+		}
+		return &b.continuations[i]
 	}
 	return nil
 }
@@ -2039,18 +2056,6 @@ var (
 	)
 	recordVarErr = unimplemented.NewWithIssueDetail(114874, "RECORD variable",
 		"RECORD type for PL/pgSQL variables is not yet supported",
-	)
-	blockLabelErr = unimplemented.New("block label",
-		"block labels are not yet supported",
-	)
-	loopLabelErr = unimplemented.New("LOOP label",
-		"LOOP statement labels are not yet supported",
-	)
-	exitLabelErr = unimplemented.New("EXIT label",
-		"EXIT statement labels are not yet supported",
-	)
-	continueLabelErr = unimplemented.New("CONTINUE label",
-		"CONTINUE statement labels are not yet supported",
 	)
 	dupIntoErr = unimplemented.New("duplicate INTO target",
 		"assigning to a variable more than once in the same INTO statement is not supported",

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -166,6 +166,7 @@ type plpgsqlBuilder struct {
 	// outParams is the set of OUT parameters for the routine.
 	outParams []ast.Variable
 
+	routineName  string
 	isProcedure  bool
 	identCounter int
 }
@@ -180,7 +181,7 @@ type routineParam struct {
 
 func newPLpgSQLBuilder(
 	ob *Builder,
-	routineName string,
+	routineName, rootBlockLabel string,
 	colRefs *opt.ColSet,
 	routineParams []routineParam,
 	returnType *types.T,
@@ -192,12 +193,13 @@ func newPLpgSQLBuilder(
 		colRefs:     colRefs,
 		returnType:  returnType,
 		blocks:      make([]plBlock, 0, initialBlocksCap),
+		routineName: routineName,
 		isProcedure: isProcedure,
 	}
 	// Build the initial block for the routine parameters, which are considered
 	// PL/pgSQL variables.
 	b.pushBlock(plBlock{
-		label:    routineName,
+		label:    rootBlockLabel,
 		vars:     make([]ast.Variable, 0, len(routineParams)),
 		varTypes: make(map[ast.Variable]*types.T),
 	})
@@ -581,7 +583,24 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			if con := b.getContinuation(conTypes, t.Label); con != nil {
 				return b.callContinuation(con, s)
 			}
-			panic(exitOutsideLoopErr)
+			if t.Label == unspecifiedLabel {
+				panic(exitOutsideLoopErr)
+			}
+			if t.Label == b.rootBlock().label {
+				// An EXIT from the root block has the same handling as when the routine
+				// ends with no RETURN statement.
+				return b.handleEndOfFunction(s)
+			}
+			if t.Label == b.routineName {
+				// An EXIT from the routine name itself results in an end-of-function
+				// error, even for a VOID-returning routine or one with OUT-parameters.
+				eofCon := b.makeContinuationWithTyp("root_exit", t.Label, continuationBlockExit)
+				b.buildEndOfFunctionRaise(&eofCon)
+				return b.callContinuation(&eofCon, s)
+			}
+			panic(pgerror.Newf(pgcode.Syntax,
+				"there is no label \"%s\" attached to any block or loop enclosing this statement", t.Label,
+			))
 
 		case *ast.Continue:
 			if t.Condition != nil {
@@ -595,10 +614,24 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			}
 			// CONTINUE statements are handled by calling the function that executes
 			// the loop body. Errors if used outside a loop.
-			if con := b.getContinuation(continuationLoopContinue, t.Label); con != nil {
+			conTypes := continuationLoopContinue
+			if t.Label != unspecifiedLabel {
+				conTypes |= continuationBlockExit
+			}
+			if con := b.getContinuation(conTypes, t.Label); con != nil {
+				if con.typ == continuationBlockExit {
+					panic(pgerror.Newf(pgcode.Syntax,
+						"block label \"%s\" cannot be used in CONTINUE", t.Label,
+					))
+				}
 				return b.callContinuation(con, s)
 			}
-			panic(continueOutsideLoopErr)
+			if t.Label == unspecifiedLabel {
+				panic(continueOutsideLoopErr)
+			}
+			panic(pgerror.Newf(pgcode.Syntax,
+				"there is no label \"%s\" attached to any block or loop enclosing this statement", t.Label,
+			))
 
 		case *ast.Raise:
 			// RAISE statements allow the PLpgSQL function to send an error or a
@@ -1364,6 +1397,15 @@ func (b *plpgsqlBuilder) handleEndOfFunction(inScope *scope) *scope {
 		return returnScope
 	}
 	// Build a RAISE statement which throws an end-of-function error if executed.
+	con := b.makeContinuation("_end_of_function")
+	b.buildEndOfFunctionRaise(&con)
+	return b.callContinuation(&con, inScope)
+}
+
+// buildEndOfFunctionRaise adds to the given continuation a RAISE statement that
+// throws an end-of-function error, as well as a typed RETURN NULL to ensure
+// that type-checking works out.
+func (b *plpgsqlBuilder) buildEndOfFunctionRaise(con *continuation) {
 	args := b.makeConstRaiseArgs(
 		"ERROR", /* severity */
 		"control reached end of function without RETURN", /* message */
@@ -1371,18 +1413,17 @@ func (b *plpgsqlBuilder) handleEndOfFunction(inScope *scope) *scope {
 		"", /* hint */
 		pgcode.RoutineExceptionFunctionExecutedNoReturnStatement.String(), /* code */
 	)
-	con := b.makeContinuation("_end_of_function")
 	con.def.Volatility = volatility.Volatile
-	b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, args))
+	b.appendBodyStmt(con, b.buildPLpgSQLRaise(con.s, args))
+
 	// Build a dummy statement that returns NULL. It won't be executed, but
 	// ensures that the continuation routine's return type is correct.
 	eofColName := scopeColName("").WithMetadataName(b.makeIdentifier("end_of_function"))
 	eofScope := con.s.push()
 	typedNull := b.ob.factory.ConstructNull(b.returnType)
 	b.ob.synthesizeColumn(eofScope, eofColName, b.returnType, nil /* expr */, typedNull)
-	b.ob.constructProjectForScope(inScope, eofScope)
-	b.appendBodyStmt(&con, eofScope)
-	return b.callContinuation(&con, inScope)
+	b.ob.constructProjectForScope(con.s, eofScope)
+	b.appendBodyStmt(con, eofScope)
 }
 
 // addOneRowCheck handles INTO STRICT, where a SQL statement is required to
@@ -1934,6 +1975,11 @@ func (b *plpgsqlBuilder) parentBlock() *plBlock {
 		return nil
 	}
 	return &b.blocks[len(b.blocks)-2]
+}
+
+// rootBlock returns the root block that encapsulates the entire routine.
+func (b *plpgsqlBuilder) rootBlock() *plBlock {
+	return &b.blocks[0]
 }
 
 // pushBlock puts the given block on the stack. It is used when entering the

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -353,7 +353,9 @@ func (b *Builder) buildRoutine(
 		}
 		var expr memo.RelExpr
 		var physProps *physical.Required
-		plBuilder := newPLpgSQLBuilder(b, def.Name, colRefs, routineParams, rtyp, isProc)
+		plBuilder := newPLpgSQLBuilder(
+			b, def.Name, stmt.AST.Label, colRefs, routineParams, rtyp, isProc,
+		)
 		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		finishResolveType(stmtScope)
 		expr, physProps, isMultiColDataSource =


### PR DESCRIPTION
#### plpgsql: implement labels for EXIT and CONTINUE

This commit adds support for specifying loop and block labels as the
target of `EXIT` and `CONTINUE` statements. This can allow an outer
loop to be the target of the statement instead of the innermost loop.
It also allows for control flow to jump to the end of a labeled block.
The following commit will fix handling for the root block and correct
some error messages.

Fixes #115271

Release note (sql change): The PL/pgSQL `EXIT` and `CONTINUE` statements
can now specify which loop or block is the target via labels.

#### plpgsql: handle EXIT/CONTINUE for root block and correct errors

This commit cleans up `EXIT` and `CONTINUE` with label handling. It is
now possible to `EXIT` from the root block or the routine itself, and
the various error messages that can result from incorrect usage have
been corrected.

Informs #115271

Release note: None