### PR TITLE
sql: increase raft command size limit for some tests

### DIFF
--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -592,9 +592,11 @@ func TestLargeDynamicRows(t *testing.T) {
 	err := conn.Exec(ctx, `SET COPY_FAST_PATH_ENABLED = 'true'`)
 	require.NoError(t, err)
 
-	// 4.0 MiB is minimum, copy sets max row size to this value / 3
+	// 4.0 MiB is minimum, but due to #117070 use 5MiB instead to avoid flakes.
+	// Copy sets max row size to this value / 3.
+	const memLimit = kvserverbase.MaxCommandSizeFloor + 1<<20
 	for _, l := range []serverutils.ApplicationLayerInterface{s, s.SystemLayer()} {
-		kvserverbase.MaxCommandSize.Override(ctx, &l.ClusterSettings().SV, 4<<20)
+		kvserverbase.MaxCommandSize.Override(ctx, &l.ClusterSettings().SV, memLimit)
 	}
 
 	err = conn.Exec(ctx, "CREATE TABLE t (s STRING)")

--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -9,8 +9,10 @@ INSERT INTO src SELECT repeat('a', 100000) FROM generate_series(1, 60)
 
 user host-cluster-root
 
+# Set the memory limit a little higher than the minimum because the batch sizing
+# is inexact, tracked in #117070.
 statement ok
-SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
+SET CLUSTER SETTING kv.raft.command.max_size='5MiB';
 
 user root
 


### PR DESCRIPTION
The tests `TestLargeDynamicRows` and `TestLogic_upsert_non_metamorphic` occasionally flake because they set the raft command size limit to the minimum `4MiB`, and their batch size limiting is inexact. This commit prevents the flake by increasing the limit to `5MiB`. Making the batch size limit exact will still be tracked by #117070.

Informs #117070

Release note: None