### PR TITLE
sql: improve INSERT dependency tracking for UDFs and SPs

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2216,6 +2216,13 @@ func TestTenantLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestTenantLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestTenantLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1446,6 +1446,13 @@ func TestTenantLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestTenantLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestTenantLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/procedure_deps
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_deps
@@ -1,0 +1,302 @@
+# LogicTest: !local-mixed-23.1
+
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  def INT DEFAULT 10,
+  c INT,
+  drop_sel INT,
+  drop_ins INT,
+  drop_ins2 INT,
+  drop_ups INT,
+  drop_ups2 INT,
+  drop_up INT,
+  drop_del INT
+)
+
+# --------------------------------------------------
+# SELECT
+# --------------------------------------------------
+
+statement ok
+CREATE PROCEDURE sel() LANGUAGE SQL AS $$
+  SELECT a, b FROM t;
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"sel\" depends on it
+DROP TABLE t
+
+statement ok
+ALTER TABLE t RENAME COLUMN c TO c2
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_sel
+
+statement ok
+DROP PROCEDURE sel
+
+# --------------------------------------------------
+# INSERT
+# --------------------------------------------------
+
+statement ok
+CREATE PROCEDURE ins() LANGUAGE SQL AS $$
+  INSERT INTO t VALUES (1, 10, DEFAULT);
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ins\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the INSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c2 TO c3
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ins
+
+statement ok
+CALL ins()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+
+statement ok
+DROP PROCEDURE ins
+
+statement ok
+CREATE PROCEDURE ins2() LANGUAGE SQL AS $$
+  INSERT INTO t (a, b, def) VALUES (2, 20, DEFAULT);
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ins2\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the INSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins2\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins2\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins2\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c3 TO c4
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ins2
+
+statement ok
+CALL ins2()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+2  20  10
+
+statement ok
+DROP PROCEDURE ins2
+
+# --------------------------------------------------
+# UPSERT
+# --------------------------------------------------
+
+statement ok
+CREATE PROCEDURE ups() LANGUAGE SQL AS $$
+  UPSERT INTO t VALUES (3, 30, DEFAULT);
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ups\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the UPSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c4 TO c5
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ups
+
+statement ok
+CALL ups()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+2  20  10
+3  30  10
+
+statement ok
+DROP PROCEDURE ups
+
+statement ok
+CREATE PROCEDURE ups2() LANGUAGE SQL AS $$
+  UPSERT INTO t (a, b, def) VALUES (4, 40, DEFAULT);
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ups2\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the UPSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups2\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups2\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups2\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c5 TO c6
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ups2
+
+statement ok
+CALL ups2()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+2  20  10
+3  30  10
+4  40  10
+
+statement ok
+DROP PROCEDURE ups2
+
+# --------------------------------------------------
+# UPDATE
+# --------------------------------------------------
+
+statement ok
+CREATE PROCEDURE up() LANGUAGE SQL AS $$
+  UPDATE t SET b = 11 WHERE a = 1;
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"up\" depends on it
+DROP TABLE t
+
+statement error pgcode 2BP01 cannot rename column \"a\" because function \"up\" depends on it
+ALTER TABLE t RENAME COLUMN a TO a2
+
+statement ok
+ALTER TABLE t RENAME COLUMN c6 TO c7
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_up
+
+statement ok
+CALL up()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  11  10
+2  20  10
+3  30  10
+4  40  10
+
+statement ok
+DROP PROCEDURE up
+
+# --------------------------------------------------
+# DELETE
+# --------------------------------------------------
+
+statement ok
+CREATE PROCEDURE del() LANGUAGE SQL AS $$
+  DELETE FROM t WHERE a = 1;
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"del\" depends on it
+DROP TABLE t
+
+statement error pgcode 2BP01 cannot rename column \"a\" because function \"del\" depends on it
+ALTER TABLE t RENAME COLUMN a TO a2
+
+statement ok
+ALTER TABLE t RENAME COLUMN c7 TO c8
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_del
+
+statement ok
+CALL del()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+2  20  10
+3  30  10
+4  40  10
+
+statement ok
+DROP PROCEDURE del
+
+statement ok
+DROP TABLE t

--- a/pkg/sql/logictest/testdata/logic_test/procedure_deps
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_deps
@@ -6,13 +6,13 @@ CREATE TABLE t (
   b INT,
   def INT DEFAULT 10,
   c INT,
-  drop_sel INT,
+  drop_sel INT,  cascade_sel INT,
   drop_ins INT,
-  drop_ins2 INT,
+  drop_ins2 INT, cascade_ins2 INT,
   drop_ups INT,
-  drop_ups2 INT,
-  drop_up INT,
-  drop_del INT
+  drop_ups2 INT, cascade_ups2 INT,
+  drop_up INT,   cascade_up INT,
+  drop_del INT,  cascade_del INT
 )
 
 # --------------------------------------------------
@@ -21,7 +21,7 @@ CREATE TABLE t (
 
 statement ok
 CREATE PROCEDURE sel() LANGUAGE SQL AS $$
-  SELECT a, b FROM t;
+  SELECT a, b, cascade_sel FROM t;
 $$
 
 skipif config local-legacy-schema-changer
@@ -39,7 +39,13 @@ statement ok
 ALTER TABLE t DROP COLUMN drop_sel
 
 statement ok
-DROP PROCEDURE sel
+CALL sel()
+
+statement ok
+ALTER TABLE t DROP COLUMN cascade_sel CASCADE
+
+statement error pgcode 42883 procedure sel does not exist
+CALL sel()
 
 # --------------------------------------------------
 # INSERT
@@ -88,7 +94,7 @@ DROP PROCEDURE ins
 
 statement ok
 CREATE PROCEDURE ins2() LANGUAGE SQL AS $$
-  INSERT INTO t (a, b, def) VALUES (2, 20, DEFAULT);
+  INSERT INTO t (a, b, cascade_ins2, def) VALUES (2, 20, 200, DEFAULT);
 $$
 
 skipif config local-legacy-schema-changer
@@ -126,7 +132,10 @@ SELECT a, b, def FROM t
 2  20  10
 
 statement ok
-DROP PROCEDURE ins2
+ALTER TABLE t DROP COLUMN cascade_ins2 CASCADE
+
+statement error pgcode 42883 procedure ins2 does not exist
+CALL ins2()
 
 # --------------------------------------------------
 # UPSERT
@@ -177,7 +186,7 @@ DROP PROCEDURE ups
 
 statement ok
 CREATE PROCEDURE ups2() LANGUAGE SQL AS $$
-  UPSERT INTO t (a, b, def) VALUES (4, 40, DEFAULT);
+  UPSERT INTO t (a, b, cascade_ups2, def) VALUES (4, 40, 400, DEFAULT);
 $$
 
 skipif config local-legacy-schema-changer
@@ -217,7 +226,10 @@ SELECT a, b, def FROM t
 4  40  10
 
 statement ok
-DROP PROCEDURE ups2
+ALTER TABLE t DROP COLUMN cascade_ups2 CASCADE
+
+statement error pgcode 42883 procedure ups2 does not exist
+CALL ups2()
 
 # --------------------------------------------------
 # UPDATE
@@ -225,7 +237,7 @@ DROP PROCEDURE ups2
 
 statement ok
 CREATE PROCEDURE up() LANGUAGE SQL AS $$
-  UPDATE t SET b = 11 WHERE a = 1;
+  UPDATE t SET b = 11 WHERE a = 1 AND cascade_up IS NULL
 $$
 
 skipif config local-legacy-schema-changer
@@ -238,6 +250,10 @@ DROP TABLE t
 
 statement error pgcode 2BP01 cannot rename column \"a\" because function \"up\" depends on it
 ALTER TABLE t RENAME COLUMN a TO a2
+
+# TODO(#120836): Track dependencies of SET columns.
+# statement error pgcode 2BP01 cannot rename column \"b\" because function \"up\" depends on it
+# ALTER TABLE t RENAME COLUMN b TO b2
 
 statement ok
 ALTER TABLE t RENAME COLUMN c6 TO c7
@@ -257,7 +273,10 @@ SELECT a, b, def FROM t
 4  40  10
 
 statement ok
-DROP PROCEDURE up
+ALTER TABLE t DROP COLUMN cascade_up CASCADE
+
+statement error pgcode 42883 procedure up does not exist
+CALL up()
 
 # --------------------------------------------------
 # DELETE
@@ -265,7 +284,7 @@ DROP PROCEDURE up
 
 statement ok
 CREATE PROCEDURE del() LANGUAGE SQL AS $$
-  DELETE FROM t WHERE a = 1;
+  DELETE FROM t WHERE a = 1 AND cascade_del = 1
 $$
 
 skipif config local-legacy-schema-changer
@@ -291,12 +310,16 @@ CALL del()
 query III rowsort
 SELECT a, b, def FROM t
 ----
+1  11  10
 2  20  10
 3  30  10
 4  40  10
 
 statement ok
-DROP PROCEDURE del
+ALTER TABLE t DROP COLUMN cascade_del CASCADE
+
+statement error pgcode 42883 procedure del does not exist
+CALL del()
 
 statement ok
 DROP TABLE t

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -104,7 +104,7 @@ statement error pgcode 2BP01 cannot drop table ab because other objects depend o
 DROP TABLE ab
 
 onlyif config local-legacy-schema-changer
-statement error pgcode 2BP01 pq: cannot drop relation \"ab\" because function \"ins\" depends on it\nHINT: consider dropping \"ins\" first.
+statement error pgcode 2BP01 pq: cannot drop relation \"ab\" because function \"ins_ab\" depends on it\nHINT: consider dropping \"ins_ab\" first.
 DROP TABLE ab
 
 statement error pgcode 2BP01 cannot drop function \"ins_ab\" because other objects \(\[test.public.ins\]\) still depend on it

--- a/pkg/sql/logictest/testdata/logic_test/udf_deps
+++ b/pkg/sql/logictest/testdata/logic_test/udf_deps
@@ -6,13 +6,13 @@ CREATE TABLE t (
   b INT,
   def INT DEFAULT 10,
   c INT,
-  drop_sel INT,
+  drop_sel INT,  cascade_sel INT,
   drop_ins INT,
-  drop_ins2 INT,
+  drop_ins2 INT, cascade_ins2 INT,
   drop_ups INT,
-  drop_ups2 INT,
-  drop_up INT,
-  drop_del INT
+  drop_ups2 INT, cascade_ups2 INT,
+  drop_up INT,   cascade_up INT,
+  drop_del INT,  cascade_del INT
 )
 
 # --------------------------------------------------
@@ -21,7 +21,7 @@ CREATE TABLE t (
 
 statement ok
 CREATE FUNCTION sel() RETURNS VOID LANGUAGE SQL AS $$
-  SELECT a, b FROM t;
+  SELECT a, b, cascade_sel FROM t;
 $$
 
 skipif config local-legacy-schema-changer
@@ -39,7 +39,13 @@ statement ok
 ALTER TABLE t DROP COLUMN drop_sel
 
 statement ok
-DROP FUNCTION sel
+SELECT sel()
+
+statement ok
+ALTER TABLE t DROP COLUMN cascade_sel CASCADE
+
+statement error pgcode 42883 unknown function: sel\(\)
+SELECT sel()
 
 # --------------------------------------------------
 # INSERT
@@ -88,7 +94,7 @@ DROP FUNCTION ins
 
 statement ok
 CREATE FUNCTION ins2() RETURNS VOID LANGUAGE SQL AS $$
-  INSERT INTO t (a, b, def) VALUES (2, 20, DEFAULT);
+  INSERT INTO t (a, b, cascade_ins2, def) VALUES (2, 20, 200, DEFAULT);
 $$
 
 skipif config local-legacy-schema-changer
@@ -126,7 +132,10 @@ SELECT a, b, def FROM t
 2  20  10
 
 statement ok
-DROP FUNCTION ins2
+ALTER TABLE t DROP COLUMN cascade_ins2 CASCADE
+
+statement error pgcode 42883 unknown function: ins2\(\)
+SELECT ins2()
 
 # --------------------------------------------------
 # UPSERT
@@ -177,7 +186,7 @@ DROP FUNCTION ups
 
 statement ok
 CREATE FUNCTION ups2() RETURNS VOID LANGUAGE SQL AS $$
-  UPSERT INTO t (a, b, def) VALUES (4, 40, DEFAULT);
+  UPSERT INTO t (a, b, cascade_ups2, def) VALUES (4, 40, 400, DEFAULT);
 $$
 
 skipif config local-legacy-schema-changer
@@ -217,7 +226,10 @@ SELECT a, b, def FROM t
 4  40  10
 
 statement ok
-DROP FUNCTION ups2
+ALTER TABLE t DROP COLUMN cascade_ups2 CASCADE
+
+statement error pgcode 42883 unknown function: ups2\(\)
+SELECT ups2()
 
 # --------------------------------------------------
 # UPDATE
@@ -225,7 +237,7 @@ DROP FUNCTION ups2
 
 statement ok
 CREATE FUNCTION up() RETURNS VOID LANGUAGE SQL AS $$
-  UPDATE t SET b = 11 WHERE a = 1;
+  UPDATE t SET b = 11 WHERE a = 1 AND cascade_up IS NULL
 $$
 
 skipif config local-legacy-schema-changer
@@ -238,6 +250,10 @@ DROP TABLE t
 
 statement error pgcode 2BP01 cannot rename column \"a\" because function \"up\" depends on it
 ALTER TABLE t RENAME COLUMN a TO a2
+
+# TODO(#120836): Track dependencies of SET columns.
+# statement error pgcode 2BP01 cannot rename column \"b\" because function \"up\" depends on it
+# ALTER TABLE t RENAME COLUMN b TO b2
 
 statement ok
 ALTER TABLE t RENAME COLUMN c6 TO c7
@@ -257,7 +273,10 @@ SELECT a, b, def FROM t
 4  40  10
 
 statement ok
-DROP FUNCTION up
+ALTER TABLE t DROP COLUMN cascade_up CASCADE
+
+statement error pgcode 42883 unknown function: up\(\)
+SELECT up()
 
 # --------------------------------------------------
 # DELETE
@@ -265,7 +284,7 @@ DROP FUNCTION up
 
 statement ok
 CREATE FUNCTION del() RETURNS VOID LANGUAGE SQL AS $$
-  DELETE FROM t WHERE a = 1;
+  DELETE FROM t WHERE a = 1 AND cascade_del = 1
 $$
 
 skipif config local-legacy-schema-changer
@@ -291,12 +310,16 @@ SELECT del()
 query III rowsort
 SELECT a, b, def FROM t
 ----
+1  11  10
 2  20  10
 3  30  10
 4  40  10
 
 statement ok
-DROP FUNCTION del
+ALTER TABLE t DROP COLUMN cascade_del CASCADE
+
+statement error pgcode 42883 unknown function: del\(\)
+SELECT del()
 
 statement ok
 DROP TABLE t

--- a/pkg/sql/logictest/testdata/logic_test/udf_deps
+++ b/pkg/sql/logictest/testdata/logic_test/udf_deps
@@ -1,0 +1,296 @@
+# LogicTest: !local-mixed-23.1
+
+statement ok
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  def INT DEFAULT 10,
+  c INT,
+  d INT,
+  e INT,
+  f INT,
+  g INT,
+  h INT
+)
+
+# --------------------------------------------------
+# SELECT
+# --------------------------------------------------
+
+statement ok
+CREATE FUNCTION sel() RETURNS VOID LANGUAGE SQL AS $$
+  SELECT a, b FROM t;
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"sel\" depends on it
+DROP TABLE t
+
+statement ok
+ALTER TABLE t RENAME COLUMN c TO c2
+
+statement ok
+ALTER TABLE t DROP COLUMN d
+
+statement ok
+DROP FUNCTION sel
+
+# --------------------------------------------------
+# INSERT
+# --------------------------------------------------
+
+statement ok
+CREATE FUNCTION ins() RETURNS VOID LANGUAGE SQL AS $$
+  INSERT INTO t VALUES (1, 10, DEFAULT);
+$$
+
+# statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+# DROP TABLE t
+#
+# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# # the INSERT statement, or use column IDs instead.
+# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins\" depends on it
+# ALTER TABLE t RENAME COLUMN b TO b2
+#
+# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins\" depends on it
+# ALTER TABLE t DROP COLUMN b
+#
+# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins\" depends on it
+# ALTER TABLE t DROP COLUMN def
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ins\" depends on it
+# ALTER TABLE t RENAME COLUMN c2 TO c3
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ins\" depends on it
+# ALTER TABLE t DROP COLUMN e
+
+statement ok
+SELECT ins()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+
+statement ok
+DROP FUNCTION ins
+
+statement ok
+CREATE FUNCTION ins2() RETURNS VOID LANGUAGE SQL AS $$
+  INSERT INTO t (a, b, def) VALUES (2, 20, DEFAULT);
+$$
+
+# statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+# DROP TABLE t
+#
+# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# # the INSERT statement, or use column IDs instead.
+# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins\" depends on it
+# ALTER TABLE t RENAME COLUMN b TO b2
+#
+# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins\" depends on it
+# ALTER TABLE t DROP COLUMN b
+#
+# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins\" depends on it
+# ALTER TABLE t DROP COLUMN def
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ins\" depends on it
+# ALTER TABLE t RENAME COLUMN c2 TO c3
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ins\" depends on it
+# ALTER TABLE t DROP COLUMN e
+
+statement ok
+SELECT ins2()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+2  20  10
+
+statement ok
+DROP FUNCTION ins2
+
+# --------------------------------------------------
+# UPSERT
+# --------------------------------------------------
+
+statement ok
+CREATE FUNCTION ups() RETURNS VOID LANGUAGE SQL AS $$
+  UPSERT INTO t VALUES (3, 30, DEFAULT);
+$$
+
+# statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+# DROP TABLE t
+#
+# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# # the INSERT statement, or use column IDs instead.
+# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups\" depends on it
+# ALTER TABLE t RENAME COLUMN b TO b2
+#
+# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups\" depends on it
+# ALTER TABLE t DROP COLUMN b
+#
+# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups\" depends on it
+# ALTER TABLE t DROP COLUMN def
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ups\" depends on it
+# ALTER TABLE t RENAME COLUMN c2 TO c3
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ups\" depends on it
+# ALTER TABLE t DROP COLUMN f
+
+statement ok
+SELECT ups()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+2  20  10
+3  30  10
+
+statement ok
+DROP FUNCTION ups
+
+statement ok
+CREATE FUNCTION ups2() RETURNS VOID LANGUAGE SQL AS $$
+  UPSERT INTO t (a, b, def) VALUES (4, 40, DEFAULT);
+$$
+
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# # the INSERT statement, or use column IDs instead.
+# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups2\" depends on it
+# ALTER TABLE t RENAME COLUMN b TO b2
+#
+# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups2\" depends on it
+# ALTER TABLE t DROP COLUMN b
+#
+# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups2\" depends on it
+# ALTER TABLE t DROP COLUMN def
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ups2\" depends on it
+# ALTER TABLE t RENAME COLUMN c2 TO c3
+#
+# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
+# # dependency tracking) so we should probably allow it too.
+# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ups2\" depends on it
+# ALTER TABLE t DROP COLUMN f
+
+statement ok
+SELECT ups2()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  10  10
+2  20  10
+3  30  10
+4  40  10
+
+statement ok
+DROP FUNCTION ups2
+
+# --------------------------------------------------
+# UPDATE
+# --------------------------------------------------
+
+statement ok
+CREATE FUNCTION up() RETURNS VOID LANGUAGE SQL AS $$
+  UPDATE t SET b = 11 WHERE a = 1;
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"up\" depends on it
+DROP TABLE t
+
+statement error pgcode 2BP01 cannot rename column \"a\" because function \"up\" depends on it
+ALTER TABLE t RENAME COLUMN a TO a2
+
+statement ok
+ALTER TABLE t RENAME COLUMN c2 TO c3
+
+statement ok
+ALTER TABLE t DROP COLUMN g
+
+statement ok
+SELECT up()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+1  11  10
+2  20  10
+3  30  10
+4  40  10
+
+statement ok
+DROP FUNCTION up
+
+# --------------------------------------------------
+# DELETE
+# --------------------------------------------------
+
+statement ok
+CREATE FUNCTION del() RETURNS VOID LANGUAGE SQL AS $$
+  DELETE FROM t WHERE a = 1;
+$$
+
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"del\" depends on it
+DROP TABLE t
+
+statement error pgcode 2BP01 cannot rename column \"a\" because function \"del\" depends on it
+ALTER TABLE t RENAME COLUMN a TO a2
+
+statement ok
+ALTER TABLE t RENAME COLUMN c3 TO c4
+
+statement ok
+ALTER TABLE t DROP COLUMN h
+
+statement ok
+SELECT del()
+
+query III rowsort
+SELECT a, b, def FROM t
+----
+2  20  10
+3  30  10
+4  40  10
+
+statement ok
+DROP FUNCTION del
+
+statement ok
+DROP TABLE t

--- a/pkg/sql/logictest/testdata/logic_test/udf_deps
+++ b/pkg/sql/logictest/testdata/logic_test/udf_deps
@@ -6,11 +6,13 @@ CREATE TABLE t (
   b INT,
   def INT DEFAULT 10,
   c INT,
-  d INT,
-  e INT,
-  f INT,
-  g INT,
-  h INT
+  drop_sel INT,
+  drop_ins INT,
+  drop_ins2 INT,
+  drop_ups INT,
+  drop_ups2 INT,
+  drop_up INT,
+  drop_del INT
 )
 
 # --------------------------------------------------
@@ -34,7 +36,7 @@ statement ok
 ALTER TABLE t RENAME COLUMN c TO c2
 
 statement ok
-ALTER TABLE t DROP COLUMN d
+ALTER TABLE t DROP COLUMN drop_sel
 
 statement ok
 DROP FUNCTION sel
@@ -48,29 +50,30 @@ CREATE FUNCTION ins() RETURNS VOID LANGUAGE SQL AS $$
   INSERT INTO t VALUES (1, 10, DEFAULT);
 $$
 
-# statement error pgcode 2BP01 cannot drop table t because other objects depend on it
-# DROP TABLE t
-#
-# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
-# # the INSERT statement, or use column IDs instead.
-# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins\" depends on it
-# ALTER TABLE t RENAME COLUMN b TO b2
-#
-# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins\" depends on it
-# ALTER TABLE t DROP COLUMN b
-#
-# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins\" depends on it
-# ALTER TABLE t DROP COLUMN def
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ins\" depends on it
-# ALTER TABLE t RENAME COLUMN c2 TO c3
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ins\" depends on it
-# ALTER TABLE t DROP COLUMN e
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ins\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the INSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c2 TO c3
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ins
 
 statement ok
 SELECT ins()
@@ -88,29 +91,30 @@ CREATE FUNCTION ins2() RETURNS VOID LANGUAGE SQL AS $$
   INSERT INTO t (a, b, def) VALUES (2, 20, DEFAULT);
 $$
 
-# statement error pgcode 2BP01 cannot drop table t because other objects depend on it
-# DROP TABLE t
-#
-# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
-# # the INSERT statement, or use column IDs instead.
-# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins\" depends on it
-# ALTER TABLE t RENAME COLUMN b TO b2
-#
-# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins\" depends on it
-# ALTER TABLE t DROP COLUMN b
-#
-# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins\" depends on it
-# ALTER TABLE t DROP COLUMN def
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ins\" depends on it
-# ALTER TABLE t RENAME COLUMN c2 TO c3
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ins\" depends on it
-# ALTER TABLE t DROP COLUMN e
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ins2\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the INSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ins2\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ins2\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ins2\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c3 TO c4
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ins2
 
 statement ok
 SELECT ins2()
@@ -133,29 +137,30 @@ CREATE FUNCTION ups() RETURNS VOID LANGUAGE SQL AS $$
   UPSERT INTO t VALUES (3, 30, DEFAULT);
 $$
 
-# statement error pgcode 2BP01 cannot drop table t because other objects depend on it
-# DROP TABLE t
-#
-# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
-# # the INSERT statement, or use column IDs instead.
-# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups\" depends on it
-# ALTER TABLE t RENAME COLUMN b TO b2
-#
-# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups\" depends on it
-# ALTER TABLE t DROP COLUMN b
-#
-# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups\" depends on it
-# ALTER TABLE t DROP COLUMN def
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ups\" depends on it
-# ALTER TABLE t RENAME COLUMN c2 TO c3
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ups\" depends on it
-# ALTER TABLE t DROP COLUMN f
+skipif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop table t because other objects depend on it
+DROP TABLE t
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ups\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the UPSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c4 TO c5
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ups
 
 statement ok
 SELECT ups()
@@ -175,29 +180,30 @@ CREATE FUNCTION ups2() RETURNS VOID LANGUAGE SQL AS $$
   UPSERT INTO t (a, b, def) VALUES (4, 40, DEFAULT);
 $$
 
+skipif config local-legacy-schema-changer
 statement error pgcode 2BP01 cannot drop table t because other objects depend on it
 DROP TABLE t
 
-# # NOTE: Postgres allows this. We cannot until we can rewrite the column names in
-# # the INSERT statement, or use column IDs instead.
-# statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups2\" depends on it
-# ALTER TABLE t RENAME COLUMN b TO b2
-#
-# statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups2\" depends on it
-# ALTER TABLE t DROP COLUMN b
-#
-# statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups2\" depends on it
-# ALTER TABLE t DROP COLUMN def
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot rename column \"c2\" because function \"ups2\" depends on it
-# ALTER TABLE t RENAME COLUMN c2 TO c3
-#
-# # TODO(mgartner): This is allowed in Postgres (when using sql_body for
-# # dependency tracking) so we should probably allow it too.
-# statement error pgcode 2BP01 cannot drop column \"e\" because function \"ups2\" depends on it
-# ALTER TABLE t DROP COLUMN f
+onlyif config local-legacy-schema-changer
+statement error pgcode 2BP01 cannot drop relation \"t\" because function \"ups2\" depends on it
+DROP TABLE t
+
+# NOTE: Postgres allows this. We cannot until we can rewrite the column names in
+# the UPSERT statement, or use column IDs instead.
+statement error pgcode 2BP01 cannot rename column \"b\" because function \"ups2\" depends on it
+ALTER TABLE t RENAME COLUMN b TO b2
+
+statement error pgcode 2BP01 cannot drop column \"b\" because function \"ups2\" depends on it
+ALTER TABLE t DROP COLUMN b
+
+statement error pgcode 2BP01 cannot drop column \"def\" because function \"ups2\" depends on it
+ALTER TABLE t DROP COLUMN def
+
+statement ok
+ALTER TABLE t RENAME COLUMN c5 TO c6
+
+statement ok
+ALTER TABLE t DROP COLUMN drop_ups2
 
 statement ok
 SELECT ups2()
@@ -234,10 +240,10 @@ statement error pgcode 2BP01 cannot rename column \"a\" because function \"up\" 
 ALTER TABLE t RENAME COLUMN a TO a2
 
 statement ok
-ALTER TABLE t RENAME COLUMN c2 TO c3
+ALTER TABLE t RENAME COLUMN c6 TO c7
 
 statement ok
-ALTER TABLE t DROP COLUMN g
+ALTER TABLE t DROP COLUMN drop_up
 
 statement ok
 SELECT up()
@@ -274,10 +280,10 @@ statement error pgcode 2BP01 cannot rename column \"a\" because function \"del\"
 ALTER TABLE t RENAME COLUMN a TO a2
 
 statement ok
-ALTER TABLE t RENAME COLUMN c3 TO c4
+ALTER TABLE t RENAME COLUMN c7 TO c8
 
 statement ok
-ALTER TABLE t DROP COLUMN h
+ALTER TABLE t DROP COLUMN drop_del
 
 statement ok
 SELECT del()

--- a/pkg/sql/logictest/testdata/logic_test/udf_fk
+++ b/pkg/sql/logictest/testdata/logic_test/udf_fk
@@ -436,7 +436,7 @@ statement ok
 DROP TABLE grandchild_cascade;
 
 statement ok
-DROP TABLE child_cascade;
+DROP TABLE child_cascade CASCADE;
 
 statement ok
 CREATE TABLE child_cascade (

--- a/pkg/sql/logictest/testdata/logic_test/udf_insert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_insert
@@ -237,8 +237,7 @@ SELECT f_drop(5,100,101);
 ----
 (5,100,101)
 
-# TODO(#102771): Expected error due to f_drop's dependency on c.
-statement ok
+statement error pgcode 2BP01 cannot drop column \"c\" because function \"f_drop\" depends on it
 ALTER TABLE t_alter DROP COLUMN c;
 
 query T

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2171,6 +2171,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1422,6 +1422,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1422,6 +1422,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2178,6 +2178,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1436,6 +1436,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2192,6 +2192,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1408,6 +1408,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2178,6 +2178,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -1415,6 +1415,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -2192,6 +2192,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2206,6 +2206,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1436,6 +1436,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1576,6 +1576,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_deps")
+}
+
 func TestLogic_procedure_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2409,6 +2409,13 @@ func TestLogic_udf_delete(
 	runLogicTest(t, "udf_delete")
 }
 
+func TestLogic_udf_deps(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_deps")
+}
+
 func TestLogic_udf_fk(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -350,6 +350,17 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		mb.buildUpsert(returning)
 	}
 
+	if b.trackSchemaDeps {
+		dep := opt.SchemaDep{DataSource: tab}
+		// Track dependencies on insert columns.
+		for i := range mb.insertColIDs {
+			if mb.insertColIDs[i] != 0 && !mb.implicitInsertCols.Contains(mb.insertColIDs[i]) {
+				dep.ColumnOrdinals.Add(i)
+			}
+		}
+		b.schemaDeps = append(b.schemaDeps, dep)
+	}
+
 	return mb.outScope
 }
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -83,6 +83,12 @@ type mutationBuilder struct {
 	// is empty if this is not an Insert/Upsert operator.
 	insertColIDs opt.OptionalColList
 
+	// implicitInsertCols contains columns in insertColIDs which were not given
+	// explicit values in the insert statement, if b.trackSchemaDeps is true.
+	// It does not include columns that were explicitly given the value of
+	// DEFAULT, e.g., INSERT INTO t VALUES (1, DEFAULT).
+	implicitInsertCols opt.ColSet
+
 	// fetchColIDs lists the input column IDs storing values which are fetched
 	// from the target table in order to provide existing values that will form
 	// lookup and update values. Its length is always equal to the number of
@@ -693,6 +699,11 @@ func (mb *mutationBuilder) addSynthesizedDefaultCols(
 
 		// Remember id of newly synthesized column.
 		colIDs[i] = newCol
+
+		// Track columns that were not explicitly set in the insert statement.
+		if mb.b.trackSchemaDeps {
+			mb.implicitInsertCols.Add(newCol)
+		}
 
 		// Add corresponding target column.
 		mb.targetColList = append(mb.targetColList, tabColID)

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1278,6 +1278,11 @@ func TestSchemaChangeComparator_procedure(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_procedure_deps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure_deps"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_procedure_params(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/procedure_params"

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1898,6 +1898,11 @@ func TestSchemaChangeComparator_udf_delete(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_delete"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_udf_deps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_deps"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_udf_fk(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_fk"


### PR DESCRIPTION
#### sql/logictest: add tests for UDF dependency tracking with mutations

Release note: None

#### sql: track INSERT dependencies for UDFs and SPs

UDF and SP dependencies on tables and their columns through `INSERT`
statements are now tracked. Dropping or renaming these tables or
columns is prohibited while the UDF or SP exists.

Fixes #102771

Release note: None

#### sql/logictest: add tests for SP dependency tracking with mutations

These tests are identical to the tests in `udf_dep`, except the
functions have been replaced with procedures.

Release note: None

#### sql/logictest: add tests for UDF/SP with mutations and CASCADING drops

Release note: None
