### PR TITLE
cli: add support for remote files in debug range-data

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -905,6 +905,7 @@ func init() {
 		f := debugRangeDataCmd.Flags()
 		cliflagcfg.BoolFlag(f, &debugCtx.replicated, cliflags.Replicated)
 		cliflagcfg.IntFlag(f, &debugCtx.maxResults, cliflags.Limit)
+		cliflagcfg.StringFlag(f, &serverCfg.SharedStorage, cliflags.SharedStorage)
 	}
 	{
 		f := debugGossipValuesCmd.Flags()


### PR DESCRIPTION
Previously, if a Checkpoint was created due to a storage-level replica corruption, we wouldn't be able to read the checkpoint if it contained any remote (shared or external) files as the pebble instance opened with `debug range-data` would not be started with the relevant RemoteStorageFactory.

This change adds the same SharedStorage/RemoteStorageFactory params as the usual Pebble start in pkg/server/config.go, so that these checkpoints can be opened.

Fixes #119960.

Epic: None.
Release note: None