### PR TITLE
release-23.2: c2c: prevent NPE in SHOW TENANT WITH REPLICATION STATUS

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -279,6 +279,10 @@ func (s *streamIngestionResumer) handleResumeError(
 func (s *streamIngestionResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	// Protect the destination tenant's keyspan from garbage collection.
 	jobExecCtx := execCtx.(sql.JobExecContext)
+
+	if err := jobExecCtx.ExecCfg().JobRegistry.CheckPausepoint("stream_ingestion.before_protection"); err != nil {
+		return err
+	}
 	err := s.protectDestinationTenant(ctx, jobExecCtx)
 	if err != nil {
 		return s.handleResumeError(ctx, jobExecCtx, err)

--- a/pkg/ccl/streamingccl/streamingest/testdata/show_without_pts
+++ b/pkg/ccl/streamingccl/streamingest/testdata/show_without_pts
@@ -1,0 +1,19 @@
+# This test verifies that SHOW TENANT works even if a dest pts hasn't been set.
+
+create-replication-clusters
+----
+
+exec-sql as=destination-system
+SET CLUSTER SETTING jobs.debug.pausepoints = 'stream_ingestion.before_protection';
+----
+
+start-replication-stream
+----
+
+job as=destination-system wait-for-state=paused
+----
+
+query-sql as=destination-system
+SELECT replicated_time FROM [SHOW VIRTUAL CLUSTER destination WITH REPLICATION STATUS];
+----
+<nil>

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -162,8 +162,9 @@ func (n *showTenantNode) getTenantValues(
 						// Protected timestamp might not be set yet, no need to fail.
 						log.Warningf(params.ctx, "protected timestamp unavailable for tenant %q and job %d: %v",
 							tenantInfo.Name, jobId, err)
+					} else {
+						values.protectedTimestamp = record.Timestamp
 					}
-					values.protectedTimestamp = record.Timestamp
 				}
 			}
 		case mtinfopb.DataStateReady, mtinfopb.DataStateDrop:


### PR DESCRIPTION
Backport:
  * 1/1 commits from "c2c: prevent NPE in SHOW TENANT WITH REPLICATION STATUS" (#120434)
  * 1/1 commits from "streamingccl: add show tenant without pts test" (#120725)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk bug fix
