### PR TITLE
sql/catalog: address session based leasing bugs

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -132,10 +132,6 @@ func (m *Manager) sessionBasedLeasingModeAtLeast(
 	return m.getSessionBasedLeasingMode(ctx) >= minimumMode
 }
 
-func hasSessionBasedLeasingDesc(ctx context.Context, settings *cluster.Settings) bool {
-	return !settings.Version.IsActive(ctx, clusterversion.V24_1_SessionBasedLeasingUpgradeDescriptor)
-}
-
 func readSessionBasedLeasingMode(
 	ctx context.Context, settings *cluster.Settings,
 ) SessionBasedLeasingMode {

--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -114,6 +114,7 @@ type RegionProvider interface {
 type CachedDatabaseRegions interface {
 	IsMultiRegion() bool
 	GetRegionEnumTypeDesc() catalog.RegionEnumTypeDescriptor
+	GetSystemDatabaseVersion() *roachpb.Version
 }
 
 type livenessProber struct {

--- a/pkg/sql/regions/BUILD.bazel
+++ b/pkg/sql/regions/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/roachpb",
         "//pkg/server/serverpb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descs",

--- a/pkg/sql/regions/cached_db_regions.go
+++ b/pkg/sql/regions/cached_db_regions.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 )
@@ -65,6 +66,11 @@ func (c *CachedDatabaseRegions) IsMultiRegion() bool {
 // database.
 func (c *CachedDatabaseRegions) GetRegionEnumTypeDesc() catalog.RegionEnumTypeDescriptor {
 	return c.dbRegionEnumDesc.AsRegionEnumTypeDescriptor()
+}
+
+// GetSystemDatabaseVersion helper to get the system database version.
+func (c *CachedDatabaseRegions) GetSystemDatabaseVersion() *roachpb.Version {
+	return c.dbDesc.DatabaseDesc().GetSystemDatabaseSchemaVersion()
 }
 
 func TestingModifyRegionEnum(


### PR DESCRIPTION
This patch addresses the following issues:
1. Previously the session based leasing upgrade had a race condition against the leasing count queries, which could cause them to incorrect expect the wrong version of the descriptor. To address this, we are going to start using the system database descriptor version to determine if synthetic descriptors should be used (instead of cluster settings).
2. The repair_schema logictest had an intermittent failure because it was force deleting and injecting descriptors instantly. This runs into an existing design limitation of the lease manager where deleted descriptors are instantly cleaned up from memory, but asynchronously removed from storage. When we inject the descriptor with the exact same versions, the lease manager would detect a duplicate row and fails renewing (in the session based model). This condition can only be hit by repair queries and in the expiry based model would lead to duplicate rows. For the purpose of testing we are going to intentionally give a new version when adding the descriptor back, since the sequence in general dangerous with repair queries (i.e. e need to confirm that the lease is no longer in use before injecting the descriptor again or set a new version).


Fixes: #120445 
Fixes #120735 
Fixes #120675
