### PR TITLE
streamingest: skip `TestStreamingReplanOnLag`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -805,6 +805,8 @@ func TestStreamingReplanOnLag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 120688)
+
 	skip.UnderDuressWithIssue(t, 115850, "time to scatter ranges takes too long under duress")
 
 	ctx := context.Background()


### PR DESCRIPTION
This test is very flaky.

See #120688

Epic: none
Release note: None