### PR TITLE
rpc,security, cli: Add cert-distinguished-name root/node cli flag

### DIFF
--- a/build/github/acceptance-test.sh
+++ b/build/github/acceptance-test.sh
@@ -2,6 +2,10 @@
 
 set -euxo pipefail
 
+set +x
+export COCKROACH_DEV_LICENSE=$(gcloud secrets versions access 1 --secret=cockroach-dev-license)
+set -x
+
 bazel build --config crosslinux //pkg/cmd/cockroach-short \
     --bes_keywords integration-test-artifact-build \
     --jobs 100 $(./build/github/engflow-args.sh)
@@ -18,6 +22,7 @@ bazel test //pkg/acceptance:acceptance_test \
   "--test_tmpdir=$ARTIFACTSDIR" \
   --test_arg=-l="$ARTIFACTSDIR" \
   --test_arg=-b=$COCKROACH \
+  --test_env=COCKROACH_DEV_LICENSE \
   --test_env=TZ=America/New_York \
   --test_timeout=1800 \
   --build_event_binary_file=bes.bin

--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/testutils/serverutils",  # keep
         "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",  # keep
+        "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/randutil",  # keep
         "//pkg/util/stop",

--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -172,6 +172,13 @@ func TestDockerCLI_test_disable_replication(t *testing.T) {
 	runTestDockerCLI(t, "test_disable_replication", "../cli/interactive_tests/test_disable_replication.tcl")
 }
 
+func TestDockerCLI_test_distinguished_name_validation(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_distinguished_name_validation", "../cli/interactive_tests/test_distinguished_name_validation.tcl")
+}
+
 func TestDockerCLI_test_dump_sig(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
@@ -221,6 +222,7 @@ func runTestDockerCLI(t *testing.T, testNameSuffix, testFilePath string) {
 	containerConfig.Env = []string{
 		"CI=1", // Disables the initial color query by the termenv library.
 		fmt.Sprintf("PGUSER=%s", username.RootUser),
+		fmt.Sprintf("COCKROACH_DEV_LICENSE=%s", envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")),
 	}
 	ctx := context.Background()
 	if err := testDockerOneShot(ctx, t, "cli_test_"+testNameSuffix, containerConfig); err != nil {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -873,6 +873,26 @@ fields. It is permissible for the <cert-principal> string to contain colons.
 `,
 	}
 
+	RootCertDistinguishedName = FlagInfo{
+		Name: "root-cert-distinguished-name",
+		Description: `
+A string of comma separated list of distinguished-name
+<attribute-type>=<attribute-value> mappings in accordance with RFC4514 for the root
+user. This strictly needs to match the DN subject in the client certificate
+provided for root user if this flag is set.
+`,
+	}
+
+	NodeCertDistinguishedName = FlagInfo{
+		Name: "node-cert-distinguished-name",
+		Description: `
+A string of comma separated list of distinguished-name
+<attribute-type>=<attribute-value> mappings in accordance with RFC4514 for the node
+user. This strictly needs to match the DN subject in the client certificate
+provided for node user if this flag is set.
+`,
+	}
+
 	CAKey = FlagInfo{
 		Name:        "ca-key",
 		EnvVar:      "COCKROACH_CA_KEY",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -480,6 +480,8 @@ var startCtx struct {
 	serverSSLCertsDir      string
 	serverCertPrincipalMap []string
 	serverListenAddr       string
+	serverRootCertDN       string
+	serverNodeCertDN       string
 
 	// The TLS auto-handshake parameters.
 	initToken             string
@@ -533,6 +535,8 @@ func setStartContextDefaults() {
 	startCtx.serverInsecure = baseCfg.Insecure
 	startCtx.serverSSLCertsDir = base.DefaultCertsDirectory
 	startCtx.serverCertPrincipalMap = nil
+	startCtx.serverRootCertDN = ""
+	startCtx.serverNodeCertDN = ""
 	startCtx.serverListenAddr = ""
 	startCtx.unencryptedLocalhostHTTP = false
 	startCtx.tempDir = ""

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -493,6 +493,12 @@ func init() {
 		// Certificate principal map.
 		cliflagcfg.StringSliceFlag(f, &startCtx.serverCertPrincipalMap, cliflags.CertPrincipalMap)
 
+		// Root cert distinguished name
+		cliflagcfg.StringFlag(f, &startCtx.serverRootCertDN, cliflags.RootCertDistinguishedName)
+
+		// Node cert distinguished name
+		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertDN, cliflags.NodeCertDistinguishedName)
+
 		// Cluster name verification.
 		cliflagcfg.VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		cliflagcfg.BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification)
@@ -576,6 +582,12 @@ func init() {
 
 		// All certs command want to map CNs to SQL principals.
 		cliflagcfg.StringSliceFlag(f, &certCtx.certPrincipalMap, cliflags.CertPrincipalMap)
+
+		// Root cert distinguished name
+		cliflagcfg.StringFlag(f, &startCtx.serverRootCertDN, cliflags.RootCertDistinguishedName)
+
+		// Node cert distinguished name
+		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertDN, cliflags.NodeCertDistinguishedName)
 
 		if cmd == listCertsCmd {
 			// The 'list' subcommand does not write to files and thus does
@@ -1081,6 +1093,12 @@ func tenantIDFromFile(
 // It is only called when the command being ran is one of the start commands.
 func extraServerFlagInit(cmd *cobra.Command) error {
 	if err := security.SetCertPrincipalMap(startCtx.serverCertPrincipalMap); err != nil {
+		return err
+	}
+	if err := security.SetRootSubject(startCtx.serverRootCertDN); err != nil {
+		return err
+	}
+	if err := security.SetNodeSubject(startCtx.serverNodeCertDN); err != nil {
 		return err
 	}
 	serverCfg.User = username.NodeUserName()

--- a/pkg/cli/interactive_tests/test_distinguished_name_validation.tcl
+++ b/pkg/cli/interactive_tests/test_distinguished_name_validation.tcl
@@ -1,0 +1,161 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+variable certs_dir "my-safe-directory"
+variable custom_ca_dir "custom-ca-directory"
+variable db_dir "logs/db"
+
+set ::env(COCKROACH_INSECURE) "false"
+set ::env(COCKROACH_HOST) "localhost"
+spawn /bin/bash
+send "PS1=':''/# '\r"
+
+variable prompt ":/# "
+eexpect $prompt
+
+
+send "mkdir -p $certs_dir\r"
+eexpect $prompt
+send "mkdir -p $custom_ca_dir\r"
+eexpect $prompt
+
+send "$argv cert create-ca --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+
+# Copy openssl CA cnf for generating custom client certs.
+set ca_cnf_file [file join [file dirname $argv0] "ocsp_ca.cnf"]
+send "cp $ca_cnf_file $custom_ca_dir/ca.cnf\r"
+eexpect $prompt
+
+report "GENERATING serial.txt index.txt files"
+send "touch index.txt; echo '01' > serial.txt\r"
+eexpect $prompt
+
+send "$argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+send "$argv cert create-client root --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+
+proc start_secure_server {argv certs_dir extra} {
+    report "BEGIN START SECURE SERVER"
+    send "$argv start-single-node --host=localhost --socket-dir=. --certs-dir=$certs_dir --store=$::db_dir --pid-file=server_pid --background $extra >>expect-cmd.log 2>&1\r";
+    eexpect $::prompt
+    send "$argv sql --certs-dir=$certs_dir -e 'select 1'\r";
+    eexpect $::prompt
+    report "SETTING COCKROACH DEV LICENSE KEY"
+    set stmt1 "SET CLUSTER SETTING enterprise.license = \"$::env(COCKROACH_DEV_LICENSE)\";"
+    set stmt2 "SET CLUSTER SETTING cluster.organization = \"Cockroach Labs - Production Testing\";"
+    set license_sql_file "license_settings.sql"
+    set fo [open $license_sql_file w]
+    foreach sql_stmts {stmt1 stmt2} {
+        puts $fo [set $sql_stmts]
+    }
+    close $fo
+    system "$argv sql --certs-dir=$certs_dir --file $license_sql_file"
+    report "END START SECURE SERVER"
+}
+
+proc restart_secure_server_distinguished_name_flags {argv certs_dir root_dn node_dn extra} {
+    stop_server $argv
+    report "BEGIN START SECURE SERVER WITH DN FLAGS"
+    send "rm -f server_pid;
+            $argv start-single-node --host=localhost --root-cert-distinguished-name='$root_dn' --node-cert-distinguished-name='$node_dn' --socket-dir=. --certs-dir=$certs_dir --store=$::db_dir --pid-file=server_pid --background $extra >>expect-cmd.log 2>&1;\r"
+    eexpect $::prompt
+    report "END START SECURE SERVER WITH DN FLAGS"
+}
+
+proc expect_exit_status {expected} {
+    set status [lindex [wait] 3]
+    if {$status != $expected} {
+        report "unexpected exit status $status"
+        exit 1
+    }
+}
+
+proc create_user_cert {argv certs_dir name} {
+    report "GENERATING CERT FOR USER $name"
+    send "openssl genrsa -out $::certs_dir/client.$name.key\r"
+    eexpect $::prompt
+    send "openssl req -new -key $::certs_dir/client.$name.key -out client.$name.csr -batch -subj /O=Cockroach/CN=$name\r"
+    eexpect $::prompt
+    send "openssl ca -config $::custom_ca_dir/ca.cnf -keyfile $::certs_dir/ca.key -cert $::certs_dir/ca.crt -policy signing_policy -extensions signing_client_req -out $certs_dir/client.$name.crt -outdir . -in client.$name.csr -batch\r"
+    eexpect $::prompt
+    # Uncomment the next line to see more details about the generated cert
+    #system "openssl x509 -in $::certs_dir/client.$name.crt -text"
+    send "$argv sql --certs-dir=$::certs_dir -e 'create user $name'\r"
+    eexpect $::prompt
+    send "$argv sql --certs-dir=$::certs_dir --user=$name -e 'select 1'\r"
+    eexpect $::prompt
+}
+
+proc generate_root_or_node_cert {argv certs_dir name} {
+    report "GENERATING CERT FOR USER $name"
+    send "openssl genrsa -out $::certs_dir/client.$name.key \r"
+    eexpect $::prompt
+    send "openssl req -new -key $::certs_dir/client.$name.key -out client.$name.csr -batch -subj /O=Cockroach/CN=$name \r"
+    eexpect $::prompt
+    send "openssl ca -config $::custom_ca_dir/ca.cnf -keyfile $::certs_dir/ca.key -cert $::certs_dir/ca.crt -policy signing_policy -extensions signing_client_req -out $certs_dir/client.$name.crt -outdir . -in client.$name.csr -batch \r"
+    eexpect $::prompt
+    # Uncomment the next line to see more details about the generated cert
+    #system "openssl x509 -in $::certs_dir/client.$name.crt -text"
+    send "$argv sql --certs-dir=$::certs_dir --user=$name -e 'select 1' \r"
+    eexpect $::prompt
+}
+
+proc set_role_subject_for_user {argv name role_subject} {
+    report "SETTING SUBJECT ROLE OPTION for USER $name with SUBJECT $role_subject"
+    send "$argv sql --certs-dir=$::certs_dir -e 'alter role $name with subject \"$role_subject\" login';\r"
+    eexpect $::prompt
+}
+
+start_secure_server $argv $certs_dir ""
+
+# Create users and make sure they can each log in.
+create_user_cert $argv $certs_dir goofus
+create_user_cert $argv $certs_dir gallant
+
+# Check cert still works without setting role subject option
+send "$argv sql --certs-dir=$certs_dir --user=goofus -e 'select 1'\r"
+eexpect $::prompt
+
+report "Validating subject role option can be set and enforced"
+
+# Set invalid role subject option for user and check login fails
+set_role_subject_for_user $argv goofus "O=NotCockroach,CN=invalid"
+start_test "invalid role option for cert user goofus"
+send "$argv sql --certs-dir=$certs_dir --user=goofus -e 'select 1'\r"
+eexpect "certificate authentication failed for user \"goofus\""
+end_test
+
+# Set valid role subject option for user and check login passes
+set_role_subject_for_user $argv goofus "O=Cockroach,CN=goofus"
+start_test "valid role option for cert user goofus"
+send "$argv sql --certs-dir=$certs_dir --user=goofus -e 'select 1'\r"
+eexpect $::prompt
+end_test
+
+report "Validating node-cert-distinguished-nane and root-cert-distinguished-name can be set and enforced"
+# create a new root certificate using custom ca
+send "rm -f $certs_dir/client.root.*\r"
+eexpect $::prompt
+generate_root_or_node_cert $argv $certs_dir root
+
+# Set invalid root-cert-distinguished-nane for cockroach server and check root login fails
+set root_dn "O=foo,CN=invalid"
+# need to provide correct node dn to start cockroach server as it depends on this to be equal to node.crt dn subject
+set node_dn "O=Cockroach,CN=node"
+restart_secure_server_distinguished_name_flags $argv $certs_dir "O=foo,CN=invalid" "O=bar,CN=invalid" ""
+start_test "invalid root-cert-distinguished-name"
+send "$argv sql --certs-dir=$certs_dir --user=root -e 'select 1'\r"
+eexpect "certificate authentication failed for user \"root\""
+end_test
+
+# Set valid root-cert-distinguished-nane for cockroach server and check login passes
+stop_server $argv
+restart_secure_server_distinguished_name_flags $argv $certs_dir "O=Cockroach,CN=root" "O=Cockroach,CN=node" ""
+start_test "valid node-cert-distinguished-nane and root-cert-distinguished-name"
+send "$argv sql --certs-dir=$certs_dir --user=root -e 'select 1'\r"
+eexpect $::prompt
+end_test
+
+stop_server $argv

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -32,6 +32,62 @@ var certPrincipalMap struct {
 	m map[string]string
 }
 
+type userCertDistinguishedNameMu struct {
+	syncutil.RWMutex
+	dn *ldap.DN
+}
+
+func (c *userCertDistinguishedNameMu) setDN(dn *ldap.DN) {
+	c.Lock()
+	defer c.Unlock()
+	c.dn = dn
+}
+
+func (c *userCertDistinguishedNameMu) unsetDN() {
+	c.Lock()
+	defer c.Unlock()
+	c.dn = nil
+}
+
+func (c *userCertDistinguishedNameMu) getDN() (dn *ldap.DN) {
+	c.Lock()
+	defer c.Unlock()
+	dn = c.dn
+	return dn
+}
+
+func (c *userCertDistinguishedNameMu) setDNWithString(dnString string) error {
+	if len(dnString) == 0 {
+		c.unsetDN()
+		return nil
+	}
+
+	dn, err := distinguishedname.ParseDN(dnString)
+	if err != nil {
+		return errors.Errorf("invalid distinguished name string: %q", dnString)
+	}
+	c.setDN(dn)
+	return nil
+}
+
+var rootSubjectMu, nodeSubjectMu userCertDistinguishedNameMu
+
+func SetRootSubject(rootDNString string) error {
+	return rootSubjectMu.setDNWithString(rootDNString)
+}
+
+func UnsetRootSubject() {
+	rootSubjectMu.unsetDN()
+}
+
+func SetNodeSubject(nodeDNString string) error {
+	return nodeSubjectMu.setDNWithString(nodeDNString)
+}
+
+func UnsetNodeSubject() {
+	nodeSubjectMu.unsetDN()
+}
+
 // CertificateUserScope indicates the scope of a user certificate i.e. which
 // tenant the user is allowed to authenticate on. Older client certificates
 // without a tenant scope are treated as global certificates which can
@@ -62,6 +118,49 @@ type UserAuthHook func(
 	systemIdentity username.SQLUsername,
 	clientConnection bool,
 ) error
+
+// applyRootOrNodeDNFlag returns distinguished name set for root or node user
+// via root-cert-distinguished-name and node-cert-distinguished flags
+// respectively if systemIdentity conforms to one of these 2 users. It may also
+// return previously set subject option and systemIdentity is not root or node.
+// Root and Node roles cannot have subject role option set for them.
+func applyRootOrNodeDNFlag(
+	previouslySetRoleSubject *ldap.DN, systemIdentity username.SQLUsername,
+) (dn *ldap.DN) {
+	dn = previouslySetRoleSubject
+	switch {
+	case systemIdentity.IsRootUser():
+		dn = rootSubjectMu.getDN()
+	case systemIdentity.IsNodeUser():
+		dn = nodeSubjectMu.getDN()
+	}
+	return dn
+}
+
+// CheckCertDNMatchesRootDNorNodeDN returns `rootOrNodeDNSet` which validates
+// whether rootDN or nodeDN is currently set using their respective CLI flags
+// *-cert-distinguished-name. It also returns `certDNMatchesRootOrNodeDN` which
+// validates whether DN contained in cert being presented exactly matches rootDN
+// or nodeDN (provided they are set).
+func CheckCertDNMatchesRootDNorNodeDN(
+	cert *x509.Certificate,
+) (rootOrNodeDNSet bool, certDNMatchesRootOrNodeDN bool) {
+	rootDN := rootSubjectMu.getDN()
+	nodeDN := nodeSubjectMu.getDN()
+
+	if rootDN != nil || nodeDN != nil {
+		rootOrNodeDNSet = true
+		certDN, err := distinguishedname.ParseDNFromCertificate(cert)
+		if err != nil {
+			return rootOrNodeDNSet, certDNMatchesRootOrNodeDN
+		}
+		// certDNMatchesRootOrNodeDN is true if certDN exactly matches set rootDN or set nodeDN
+		if (rootDN != nil && certDN.Equal(rootDN)) || (nodeDN != nil && certDN.Equal(nodeDN)) {
+			certDNMatchesRootOrNodeDN = true
+		}
+	}
+	return rootOrNodeDNSet, certDNMatchesRootOrNodeDN
+}
 
 // SetCertPrincipalMap sets the global principal map. Each entry in the mapping
 // list must either be empty or have the format <source>:<dest>. The principal
@@ -199,6 +298,8 @@ func UserAuthCertHook(
 			return errors.Errorf("using tenant client certificate as user certificate is not allowed")
 		}
 
+		roleSubject = applyRootOrNodeDNFlag(roleSubject, systemIdentity)
+
 		var certSubject *ldap.DN
 		if roleSubject != nil {
 			var err error
@@ -331,8 +432,8 @@ func ValidateUserScope(
 	certSubject *ldap.DN,
 ) bool {
 	// if subject role option is set, it must match the certificate subject
-	if roleSubject != nil && !roleSubject.Equal(certSubject) {
-		return false
+	if roleSubject != nil {
+		return roleSubject.Equal(certSubject)
 	}
 	for _, scope := range certUserScope {
 		if scope.Username == user {

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -338,94 +338,124 @@ func TestAuthenticationHook(t *testing.T) {
 	fieldMismatchSubjectDNString := "O=Cockroach,OU=Marketing Team,UID=b8b40653-7f74-4f14-8a61-59f7f3b18184,CN=foo"
 	subsetSubjectDNString := "O=Cockroach,OU=Order Processing Team,CN=foo"
 	fieldMismatchOnlyOnCommonNameString := "O=Cockroach,OU=Order Processing Team,UID=b8b40653-7f74-4f14-8a61-59f7f3b18184,CN=bar"
+	rootDNString := "O=Cockroach,OU=Order Processing Team,UID=b8b40653-7f74-4f14-8a61-59f7f3b18184,CN=root"
+	nodeDNString := "O=Cockroach,OU=Order Processing Team,UID=b8b40653-7f74-4f14-8a61-59f7f3b18184,CN=node"
 
 	testCases := []struct {
-		insecure               bool
-		tlsSpec                string
-		username               username.SQLUsername
-		principalMap           string
-		buildHookSuccess       bool
-		publicHookSuccess      bool
-		privateHookSuccess     bool
-		tenantID               roachpb.TenantID
-		isSubjectRoleOptionSet bool
-		expectedErr            string
+		insecure                   bool
+		tlsSpec                    string
+		username                   username.SQLUsername
+		distinguishedNameString    string
+		principalMap               string
+		buildHookSuccess           bool
+		publicHookSuccess          bool
+		privateHookSuccess         bool
+		tenantID                   roachpb.TenantID
+		isSubjectRoleOptionOrDNSet bool
+		expectedErr                string
 	}{
 		// Insecure mode, empty username.
-		{true, "", username.SQLUsername{}, "", true, false, false, roachpb.SystemTenantID, false, `user is missing`},
+		{true, "", username.SQLUsername{}, subjectDNString, "", true, false, false, roachpb.SystemTenantID, false, `user is missing`},
 		// Insecure mode, non-empty username.
-		{true, "", fooUser, "", true, true, false, roachpb.SystemTenantID, false, `user "foo" is not allowed`},
+		{true, "", fooUser, subjectDNString, "", true, true, false, roachpb.SystemTenantID, false, `user "foo" is not allowed`},
 		// Secure mode, no TLS state.
-		{false, "", username.SQLUsername{}, "", false, false, false, roachpb.SystemTenantID, false, `no client certificates in request`},
+		{false, "", username.SQLUsername{}, subjectDNString, "", false, false, false, roachpb.SystemTenantID, false, `no client certificates in request`},
 		// Secure mode, bad user.
-		{false, "(CN=foo)", username.NodeUserName(), "", true, false, false, roachpb.SystemTenantID,
+		{false, "(CN=foo)", username.NodeUserName(), nodeDNString, "", true, false, false, roachpb.SystemTenantID,
 			false, `certificate authentication failed for user "node"`},
 		// Secure mode, node user.
-		{false, "(CN=node)", username.NodeUserName(), "", true, true, true, roachpb.SystemTenantID, false, ``},
+		{false, "(CN=node)", username.NodeUserName(), nodeDNString, "", true, true, true, roachpb.SystemTenantID, false, ``},
 		// Secure mode, node cert and unrelated user.
-		{false, "(CN=node)", fooUser, "", true, false, false, roachpb.SystemTenantID,
+		{false, "(CN=node)", fooUser, subjectDNString, "", true, false, false, roachpb.SystemTenantID,
 			false, `certificate authentication failed for user "foo"`},
 		// Secure mode, root user.
-		{false, "(CN=root)", username.NodeUserName(), "", true, false, false, roachpb.SystemTenantID,
+		{false, "(CN=root)", username.NodeUserName(), nodeDNString, "", true, false, false, roachpb.SystemTenantID,
 			false, `certificate authentication failed for user "node"`},
 		// Secure mode, tenant cert, foo user.
-		{false, "(OU=Tenants,CN=foo)", fooUser, "", true, false, false, roachpb.SystemTenantID,
+		{false, "(OU=Tenants,CN=foo)", fooUser, subjectDNString, "", true, false, false, roachpb.SystemTenantID,
 			false, `using tenant client certificate as user certificate is not allowed`},
 		// Secure mode, multiple cert principals.
-		{false, "(CN=foo)dns:bar", fooUser, "", true, true, false, roachpb.SystemTenantID, false, `user "foo" is not allowed`},
-		{false, "(CN=foo)dns:bar", barUser, "", true, true, false, roachpb.SystemTenantID, false, `user "bar" is not allowed`},
+		{false, "(CN=foo)dns:bar", fooUser, subjectDNString, "", true, true, false, roachpb.SystemTenantID, false, `user "foo" is not allowed`},
+		{false, "(CN=foo)dns:bar", barUser, subjectDNString, "", true, true, false, roachpb.SystemTenantID, false, `user "bar" is not allowed`},
 		// Secure mode, principal map.
-		{false, "(CN=foo)dns:bar", blahUser, "foo:blah", true, true, false, roachpb.SystemTenantID, false, `user "blah" is not allowed`},
-		{false, "(CN=foo)dns:bar", blahUser, "bar:blah", true, true, false, roachpb.SystemTenantID, false, `user "blah" is not allowed`},
-		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, "", true, true, false, roachpb.MustMakeTenantID(123),
+		{false, "(CN=foo)dns:bar", blahUser, subjectDNString, "foo:blah", true, true, false, roachpb.SystemTenantID, false, `user "blah" is not allowed`},
+		{false, "(CN=foo)dns:bar", blahUser, subjectDNString, "bar:blah", true, true, false, roachpb.SystemTenantID, false, `user "blah" is not allowed`},
+		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
 			false, `user "foo" is not allowed`},
-		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, "", true, false, false, roachpb.SystemTenantID,
+		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", fooUser, subjectDNString, "", true, false, false, roachpb.SystemTenantID,
 			false, `certificate authentication failed for user "foo"`},
-		{false, "(CN=foo)", fooUser, "", true, true, false, roachpb.MustMakeTenantID(123),
+		{false, "(CN=foo)", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
 			false, `user "foo" is not allowed`},
-		{false, "(CN=foo)uri:crdb://tenant/1/user/foo", fooUser, "", true, false, false, roachpb.MustMakeTenantID(123),
+		{false, "(CN=foo)uri:crdb://tenant/1/user/foo", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
 			false, `certificate authentication failed for user "foo"`},
-		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", blahUser, "", true, false, false, roachpb.MustMakeTenantID(123),
+		{false, "(CN=foo)uri:crdb://tenant/123/user/foo", blahUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
 			false, `certificate authentication failed for user "blah"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option not set.
-		{false, "(" + subjectDNString + ")", fooUser, "", true, true, false, roachpb.MustMakeTenantID(123),
+		{false, "(" + subjectDNString + ")", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
 			false, `user "foo" is not allowed`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set matching TLS cert subject.
-		{false, "(" + subjectDNString + ")", fooUser, "", true, true, false, roachpb.MustMakeTenantID(123),
+		{false, "(" + subjectDNString + ")", fooUser, subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
 			true, `user "foo" is not allowed`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN empty.
-		{false, "(CN=foo)", fooUser, "", true, false, false, roachpb.MustMakeTenantID(123),
+		{false, "(CN=foo)", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
 			true, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN mismatches on OU field.
-		{false, "(" + fieldMismatchSubjectDNString + ")", fooUser, "", true, false, false, roachpb.MustMakeTenantID(123),
+		{false, "(" + fieldMismatchSubjectDNString + ")", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
 			true, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set, TLS cert DN subset of role subject DN.
-		{false, "(" + subsetSubjectDNString + ")", fooUser, "", true, false, false, roachpb.MustMakeTenantID(123),
+		{false, "(" + subsetSubjectDNString + ")", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
 			true, `certificate authentication failed for user "foo"`},
 		// Secure mode, client cert having full DN, foo user with subject role
 		// option set mismatching TLS cert subject only on CN(required for
 		// matching) having DNS as foo.
-		{false, "(" + fieldMismatchOnlyOnCommonNameString + ")dns:foo", fooUser, "", true, false, false, roachpb.MustMakeTenantID(123),
+		{false, "(" + fieldMismatchOnlyOnCommonNameString + ")dns:foo", fooUser, subjectDNString, "", true, false, false, roachpb.MustMakeTenantID(123),
 			true, `certificate authentication failed for user "foo"`},
+		{false, "(" + rootDNString + ")", username.RootUserName(), rootDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
+			true, `user "root" is not allowed`},
+		{false, "(" + nodeDNString + ")", username.NodeUserName(), nodeDNString, "", true, true, true, roachpb.MustMakeTenantID(123),
+			true, ""},
+		// tls cert dn matching root dn set, where CN != root
+		{false, "(" + subjectDNString + ")", username.RootUserName(), subjectDNString, "", true, true, false, roachpb.MustMakeTenantID(123),
+			true, `user "root" is not allowed`},
 	}
 
 	ctx := context.Background()
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d: tls:%s user:%v tenant:%v", i, tc.tlsSpec, tc.username, tc.tenantID), func(t *testing.T) {
+			defer func() {
+				security.UnsetRootSubject()
+				security.UnsetNodeSubject()
+			}()
 			err := security.SetCertPrincipalMap(strings.Split(tc.principalMap, ","))
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			var roleSubject *ldap.DN
-			if tc.isSubjectRoleOptionSet {
-				roleSubject, _ = distinguishedname.ParseDN(subjectDNString)
+			if tc.isSubjectRoleOptionOrDNSet {
+				switch tc.username {
+				case username.RootUserName():
+					err = security.SetRootSubject(tc.distinguishedNameString)
+					if err != nil {
+						t.Fatalf("could not set root subject DN, err: %v", err)
+					}
+				case username.NodeUserName():
+					err = security.SetNodeSubject(tc.distinguishedNameString)
+					if err != nil {
+						t.Fatalf("could not set node subject DN, err: %v", err)
+					}
+				default:
+					roleSubject, err = distinguishedname.ParseDN(tc.distinguishedNameString)
+					if err != nil {
+						t.Fatalf("could not set role subject, err: %v", err)
+					}
+				}
 			}
 
 			hook, err := security.UserAuthCertHook(

--- a/pkg/sql/roleoption/BUILD.bazel
+++ b/pkg/sql/roleoption/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/cli/cliflags",
         "//pkg/clusterversion",
         "//pkg/security/distinguishedname",
         "//pkg/security/username",

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -221,7 +222,9 @@ func MakeListFromKVOptions(
 					return err
 				}
 				if u.IsRootUser() {
-					return pgerror.Newf(pgcode.InvalidParameterValue, "role %q cannot have a SUBJECT", u)
+					return pgerror.Newf(pgcode.InvalidParameterValue, "role %q cannot have a SUBJECT", u,
+						"use the --%s CLI flag to configure root",
+						cliflags.RootCertDistinguishedName.Name)
 				}
 				if err := distinguishedname.ValidateDN(s); err != nil {
 					return pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)


### PR DESCRIPTION
Previous in sequence: https://github.com/cockroachdb/cockroach/pull/119958
informs #110616 
fixes #118750
fixes CRDB-35884
Epic CRDB-34126

We will be adding 2 new cli flags `root-cert-distinguished-name` and
`node-cert-distinguished-name` to provide option to have subject DN for root and
node user during server startup. This will enforce the provided certificate by
client to exactly match the value set by the above flags both for sql client and
RPC authentication. This is needed because subject role option cannot be set for
root and node users.

Post this the plan is to add a cluster setting
`server.client_cert.subject_required` which will mandate that any auth which
happens should verify certSubject with rootSubject in case of root user, with
nodeSubject in case of node user, with roleSubject otherwise.

Release note: None