### PR TITLE
ui: use max aggregator for commit latency on changefeed dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -66,16 +66,19 @@ export default function (props: GraphDashboardProps) {
           name="cr.node.changefeed.commit_latency-p99"
           title="99th Percentile"
           downsampleMax
+          aggregateMax
         />
         <Metric
           name="cr.node.changefeed.commit_latency-p90"
           title="90th Percentile"
           downsampleMax
+          aggregateMax
         />
         <Metric
           name="cr.node.changefeed.commit_latency-p50"
           title="50th Percentile"
           downsampleMax
+          aggregateMax
         />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
Previously, the commit latency in the changefeed dashboard in the db console would be aggregated by sum across all nodes. This was confusing for users who might see unexpectedly high commit latency.

In this change, we use max aggregation for the commit latency so that users see the max commit latency from all the nodes instead of the sum. This provides more useful observability into changefeed behavior.

Fixes: #119246
Fixes: #112947
Epic: None

Release note (ui change): The "Commit Latency" chart in the changefeed dashboard now aggregates by max instead of by sum for multi-node changefeeds. This more accurately reflects the amount of time for events to be acknowledged by the downstream sink.