### PR TITLE
release-23.1: util/mon: lose more references on Stop

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -628,6 +628,8 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 			next.parentMu.prevSibling = prev
 		}
 		parent.mu.numChildren--
+		// Lose the references to siblings to aid GC.
+		mm.parentMu.prevSibling, mm.parentMu.nextSibling = nil, nil
 		parent.mu.Unlock()
 	}
 	// If this monitor still has children, let's lose the reference to them as


### PR DESCRIPTION
Backport 1/1 commits from #120764.

/cc @cockroachdb/release

---

This commit makes it so that we also now lose the references from the monitor being `Stop`ped to its siblings to aid GC. This was omitted by mistake originally and _perhaps_ could make GC's job harder.

Epic: None

Release note: None

Release justification: low-risk improvement.