### PR TITLE
kvnemesis: use `heavy` pool

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -72,7 +72,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvnemesis"],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = {"test.Pool": "heavy"},
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",


### PR DESCRIPTION
Closes #120738.

Epic: CRDB-8308
Release note: None