### PR TITLE
sql: treat memory monitor errors as retriable

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -254,7 +254,7 @@ func IsPermanentSchemaChangeError(err error) bool {
 	}
 
 	switch pgerror.GetPGCode(err) {
-	case pgcode.SerializationFailure, pgcode.InternalConnectionFailure:
+	case pgcode.SerializationFailure, pgcode.InternalConnectionFailure, pgcode.OutOfMemory:
 		return false
 
 	case pgcode.Internal, pgcode.RangeUnavailable:


### PR DESCRIPTION
Release note (bug fix): Memory exhaustion errors which can occur during schema changes are no longer considered to be permanent failures. These schema changes will now be retried rather than reverted.

This is just rebase of a PR by @ajwerner: https://github.com/cockroachdb/cockroach/pull/71816, with a minor change to improve test reliability.

Fixes: #120807