### PR TITLE
cli,server: add --virtualized[-empty] flags to init

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -263,6 +263,13 @@ func TestDockerCLI_test_init_command(t *testing.T) {
 	runTestDockerCLI(t, "test_init_command", "../cli/interactive_tests/test_init_command.tcl")
 }
 
+func TestDockerCLI_test_init_virtualized_command(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_init_virtualized_command", "../cli/interactive_tests/test_init_virtualized_command.tcl")
+}
+
 func TestDockerCLI_test_interrupt(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -139,4 +139,13 @@ listeners, if the headers are allowed.`,
 		Name:        "base-dir",
 		Description: "If set, the tenant processes will use it as a store location.",
 	}
+
+	Virtualized = FlagInfo{
+		Name:        "virtualized",
+		Description: "If set, the cluster will be initialized as a virtualized cluster.",
+	}
+	VirtualizedEmpty = FlagInfo{
+		Name:        "virtualized-empty",
+		Description: "If set, the cluster will be initialized as a virtualized cluster without an application cluster.",
+	}
 )

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -531,6 +531,12 @@ func init() {
 		_ = f.MarkHidden(cliflags.ApplicationInternalRPCPortRange.Name)
 	}
 
+	{
+		f := initCmd.Flags()
+		cliflagcfg.BoolFlag(f, &initCmdOptions.virtualized, cliflags.Virtualized)
+		cliflagcfg.BoolFlag(f, &initCmdOptions.virtualizedEmpty, cliflags.VirtualizedEmpty)
+	}
+
 	// Multi-tenancy start-sql command flags.
 	{
 		f := mtStartSQLCmd.Flags()

--- a/pkg/cli/interactive_tests/test_init_virtualized_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_virtualized_command.tcl
@@ -1,0 +1,28 @@
+#! /usr/bin/env expect -f
+#
+source [file join [file dirnam $argv0] common.tcl]
+
+# Start a server with a --join flag so the init command is required
+# (even though we have no intention of starting a second node).  Note
+# that unlike other expect-based tests, this one doesn't use a fifo
+# for --pid_file because we don't want reads from that fifo to change
+# the outcome.
+system "$argv start --insecure --pid-file=server_pid -s=path=logs/db --listen-addr=localhost --background --join=localhost:26258 >>logs/expect-cmd.log 2>&1"
+
+start_test "Check that the server has informed us and the log file that it was ready before forking off in the background"
+system "grep -q 'initial startup completed' logs/db/logs/cockroach.log"
+system "grep -q 'will now attempt to join a running cluster, or wait' logs/db/logs/cockroach.log"
+end_test
+
+start_test "Check that init --virtualized creates an application virtual cluster"
+
+system "$argv init --insecure --host=localhost --virtualized"
+
+# Start a shell and expect that we end up inside a secondary virtual
+# cluster.
+spawn $argv sql --no-line-editor
+send "SELECT crdb_internal.pretty_key(crdb_internal.table_span(1)\[1\], 0);\r"
+eexpect "/3/Table/1"
+
+stop_server $argv
+end_test

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -139,6 +139,7 @@ type initState struct {
 	initializedEngines   []storage.Engine
 	uninitializedEngines []storage.Engine
 	initialSettingsKVs   []roachpb.KeyValue
+	initType             serverpb.InitType
 }
 
 // bootstrapped is a shorthand to check if there exists at least one initialized
@@ -336,7 +337,7 @@ var errInternalBootstrapError = errors.New("unable to bootstrap due to internal 
 // nodes. In that case, they end up with more than one cluster, and nodes
 // panicking or refusing to connect to each other.
 func (s *initServer) Bootstrap(
-	ctx context.Context, _ *serverpb.BootstrapRequest,
+	ctx context.Context, r *serverpb.BootstrapRequest,
 ) (*serverpb.BootstrapResponse, error) {
 	// Bootstrap() only responds once. Everyone else gets an error, either
 	// ErrClusterInitialized (in the success case) or errInternalBootstrapError.
@@ -358,6 +359,7 @@ func (s *initServer) Bootstrap(
 		s.mu.rejectErr = errInternalBootstrapError
 		return nil, s.mu.rejectErr
 	}
+	state.initType = r.InitType
 
 	// We've successfully bootstrapped (we've initialized at least one engine).
 	// We mark ourselves as bootstrapped to prevent future bootstrap attempts.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2084,6 +2084,10 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.appRegistry,
 	)
 
+	if err := s.runIdempontentSQLForInitType(ctx, state.initType); err != nil {
+		return err
+	}
+
 	// Start the job scheduler now that the SQL Server and
 	// external storage is initialized.
 	if err := s.initJobScheduler(ctx); err != nil {
@@ -2227,6 +2231,58 @@ func (s *topLevelServer) initJobScheduler(ctx context.Context) error {
 	}
 	s.sqlServer.startJobScheduler(ctx, s.cfg.TestingKnobs)
 	return nil
+}
+
+// runIdempontentSQLForInitType runs one-time initialization steps via
+// SQL based on the given InitType.
+func (s *topLevelServer) runIdempontentSQLForInitType(
+	ctx context.Context, typ serverpb.InitType,
+) error {
+	if typ == serverpb.InitType_NONE || typ == serverpb.InitType_DEFAULT {
+		return nil
+	}
+
+	initAttempt := func() error {
+		const defaultApplicationClusterName = "application"
+		switch typ {
+		case serverpb.InitType_VIRTUALIZED:
+			ie := s.sqlServer.execCfg.InternalDB.Executor()
+			_, err := ie.Exec(ctx, "init-create-app-tenant", nil, /* txn */
+				"CREATE VIRTUAL CLUSTER IF NOT EXISTS $1", defaultApplicationClusterName)
+			if err != nil {
+				return err
+			}
+			_, err = ie.Exec(ctx, "init-default-app-tenant", nil, /* txn */
+				"ALTER VIRTUAL CLUSTER $1 START SERVICE SHARED", defaultApplicationClusterName)
+			if err != nil {
+				return err
+			}
+			fallthrough
+		case serverpb.InitType_VIRTUALIZED_EMPTY:
+			ie := s.sqlServer.execCfg.InternalDB.Executor()
+			_, err := ie.Exec(ctx, "init-default-target-cluster-setting", nil, /* txn */
+				"SET CLUSTER SETTING server.controller.default_target_cluster = $1", defaultApplicationClusterName)
+			if err != nil {
+				return err
+			}
+		default:
+			return errors.Errorf("unknown bootstrap init type: %d", typ)
+		}
+		return nil
+	}
+
+	rOpts := retry.Options{
+		MaxBackoff:     10 * time.Second,
+		InitialBackoff: time.Second,
+	}
+	for r := retry.StartWithCtx(ctx, rOpts); r.Next(); {
+		if err := initAttempt(); err != nil {
+			log.Errorf(ctx, "cluster initialization attempt failed: %s", err.Error())
+			continue
+		}
+		return nil
+	}
+	return errors.Errorf("cluster initialization failed; cluster may need to be manually configured")
 }
 
 // AcceptClients starts listening for incoming SQL clients over the network.

--- a/pkg/server/serverpb/init.proto
+++ b/pkg/server/serverpb/init.proto
@@ -12,7 +12,16 @@ syntax = "proto3";
 package cockroach.server.serverpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
-message BootstrapRequest { }
+message BootstrapRequest {
+    InitType init_type = 1;
+}
+
+enum InitType {
+    DEFAULT = 0;
+    NONE = 1;
+    VIRTUALIZED_EMPTY = 2;
+    VIRTUALIZED = 3;
+}
 message BootstrapResponse { }
 
 service Init {


### PR DESCRIPTION
This adds the ability to specify that the cluster should be initialized as a virtualized cluster.

Currently, this runs a one-time set of SQL initialization steps.

One may rightly ask why we don't run the SQL directly from the `init` command. Running the SQL command would

1) Require that the user pass new custom-flags to init if they are
   using on-standard listen options, and

2) Technically may race with the server startup unless we waiting
   until the server was listening for connections.

Fixes #120262

Release note (ops change): Cluster virtualization is now configured at cluster startup via flags (--virtualized or --virtualized-empty) passed to `cocroach init` rather than via the previously available --config-profile flag passed to `cockroach start`.