### PR TITLE
ui: add licensing notification to Db Console

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -757,7 +757,7 @@ Binary built without web UI.
 			respBytes, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			expected := fmt.Sprintf(
-				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0}`,
+				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0,"IsManaged":false}`,
 				build.GetInfo().Tag,
 				build.BinaryVersionPrefix(),
 				1,
@@ -785,7 +785,7 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0}`,
+					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0,"IsManaged":false}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,
@@ -794,7 +794,7 @@ Binary built without web UI.
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0}`,
+					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0,"IsManaged":false}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -96,6 +96,7 @@ type indexHTMLArgs struct {
 
 	LicenseType               string
 	SecondsUntilLicenseExpiry int64
+	IsManaged                 bool
 }
 
 // OIDCUIConf is a variable that stores data required by the
@@ -183,6 +184,9 @@ func Handler(cfg Config) http.Handler {
 
 			LicenseType:               licenseType,
 			SecondsUntilLicenseExpiry: licenseTTL,
+			// log.RedactionPolicyManaged is set to true only when cluster is running under
+			// managed service control.
+			IsManaged: log.RedactionPolicyManaged,
 		}
 		if cfg.NodeID != nil {
 			args.NodeID = cfg.NodeID.String()

--- a/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
@@ -24,6 +24,7 @@ export interface DataFromServer {
   FeatureFlags: FeatureFlags;
   LicenseType: string;
   SecondsUntilLicenseExpiry: number;
+  IsManaged: boolean;
 }
 
 // Tell TypeScript about `window.dataFromServer`, which is set in a script

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -709,51 +709,9 @@ export const daysUntilLicenseExpiresSelector = createSelector(
   },
 );
 
-export const showLicenseTTLLocalSetting = new LocalSetting(
-  "show_license_ttl",
-  localSettingsSelector,
-  { show: true },
-);
-
-export const showLicenseTTLAlertSelector = createSelector(
-  showLicenseTTLLocalSetting.selector,
-  daysUntilLicenseExpiresSelector,
-  licenseTypeSelector,
-  (showLicenseTTL, daysUntilLicenseExpired, licenseType): Alert => {
-    if (!showLicenseTTL.show) {
-      return;
-    }
-    if (licenseType === "None") {
-      return;
-    }
-    const daysToShowAlert = 14;
-    let title: string;
-    let level: AlertLevel;
-
-    if (daysUntilLicenseExpired > daysToShowAlert) {
-      return;
-    } else if (daysUntilLicenseExpired < 0) {
-      title = `License expired ${Math.abs(daysUntilLicenseExpired)} days ago`;
-      level = AlertLevel.CRITICAL;
-    } else if (daysUntilLicenseExpired === 0) {
-      title = `License expired`;
-      level = AlertLevel.CRITICAL;
-    } else if (daysUntilLicenseExpired <= daysToShowAlert) {
-      title = `License expires in ${daysUntilLicenseExpired} days`;
-      level = AlertLevel.WARNING;
-    }
-    return {
-      level: level,
-      title: title,
-      showAsAlert: true,
-      autoClose: false,
-      closable: true,
-      dismiss: (dispatch: Dispatch<Action>) => {
-        dispatch(showLicenseTTLLocalSetting.set({ show: false }));
-        return Promise.resolve();
-      },
-    };
-  },
+export const isManagedClusterSelector = createSelector(
+  getDataFromServer,
+  data => data.IsManaged,
 );
 
 /**
@@ -770,7 +728,6 @@ export const bannerAlertsSelector = createSelector(
   terminateSessionAlertSelector,
   terminateQueryAlertSelector,
   dataFromServerAlertSelector,
-  showLicenseTTLAlertSelector,
   (...alerts: Alert[]): Alert[] => {
     return _.without(alerts, null, undefined);
   },

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -68,6 +68,7 @@ const emptyDataFromServer: DataFromServer = {
   Version: "",
   LicenseType: "OSS",
   SecondsUntilLicenseExpiry: 0,
+  IsManaged: false,
 };
 
 export const featureFlagSelector = createSelector(

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -24,6 +24,7 @@ export interface DataFromServer {
   FeatureFlags: FeatureFlags;
   LicenseType: string;
   SecondsUntilLicenseExpiry: number;
+  IsManaged: boolean;
 }
 // Tell TypeScript about `window.dataFromServer`, which is set in a script
 // tag in index.html, the contents of which are generated in a Go template

--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -60,6 +60,7 @@ export let privileges: string;
 export let showSessions: string;
 export let sessionsTable: string;
 export let upgradeTroubleshooting: string;
+export let licensingFaqs: string;
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion =
@@ -137,6 +138,7 @@ export const recomputeDocsURLs = () => {
   upgradeTroubleshooting = docsURL(
     "upgrade-cockroach-version.html#troubleshooting",
   );
+  licensingFaqs = docsURL("licensing-faqs#renew-an-expired-license");
 };
 
 recomputeDocsURLs();

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -40,6 +40,7 @@ import "./layout.styl";
 import "./layoutPanel.styl";
 import { getDataFromServer } from "src/util/dataFromServer";
 import TenantDropdown from "../../components/tenantDropdown/tenantDropdown";
+import { LicenseNotification } from "../licenseNotification/licenseNotification";
 
 export interface LayoutProps {
   clusterName: string;
@@ -85,6 +86,7 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
                 <CockroachLabsLockupIcon height={26} />
               </Left>
               <Right>
+                <LicenseNotification />
                 <LoginIndicator />
               </Right>
             </GlobalNavigation>

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/licenseNotification/licenseNotification.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/licenseNotification/licenseNotification.module.styl
@@ -1,0 +1,45 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require "~src/components/core/index.styl"
+
+.container
+  display flex
+  flex-direction row
+  font-family $font-family--base
+  align-items center
+  cursor default
+  font-size 14px
+  line-height 22px
+  margin-right 24px
+  .icon
+    width 16px
+    height 16px
+    display flex
+    justify-content center
+    align-items center
+    border-radius 16px
+    margin-right 8px
+  b
+    font-family $font-family--semi-bold
+
+
+a.tooltip-link
+  color white
+  font-weight bold
+  border-bottom-width 1px
+  border-bottom-style dashed
+  border-bottom-color inherit
+
+.content
+  border-bottom-width 1px
+  border-bottom-style dashed
+  border-bottom-color inherit
+

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/licenseNotification/licenseNotification.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/licenseNotification/licenseNotification.tsx
@@ -1,0 +1,126 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Tooltip } from "antd";
+import "antd/lib/tooltip/style";
+import { useSelector } from "react-redux";
+import classNames from "classnames/bind";
+import {
+  daysUntilLicenseExpiresSelector,
+  isManagedClusterSelector,
+  licenseTypeSelector,
+} from "src/redux/alerts";
+import moment from "moment";
+import ErrorIcon from "assets/error-circle.svg";
+import InfoIcon from "assets/info-filled-circle.svg";
+import WarningIcon from "assets/warning.svg";
+import styles from "./licenseNotification.module.styl";
+import { licensingFaqs } from "src/util/docs";
+
+const cn = classNames.bind(styles);
+
+export const LicenseNotification = () => {
+  const daysToWarn = 30; // Equal to trial period
+  const daysUntilLicenseExpires = useSelector(daysUntilLicenseExpiresSelector);
+  const licenseType = useSelector(licenseTypeSelector);
+  const isManagedCluster = useSelector(isManagedClusterSelector);
+
+  if (licenseType === "None") {
+    return null;
+  }
+  // Do not show notification for clusters that run as part of managed service.
+  if (isManagedCluster) {
+    return null;
+  }
+  let Icon: string;
+  let title: React.ReactNode;
+  let tooltipContent: JSX.Element;
+
+  const learnMore = (
+    <a
+      href={licensingFaqs}
+      target="_blank"
+      rel="noreferrer"
+      className={cn("tooltip-link")}
+    >
+      Learn more
+    </a>
+  );
+  const expirationDateFormatted = moment()
+    .add(daysUntilLicenseExpires, "days")
+    .format("MMMM Do, YYYY");
+
+  if (daysUntilLicenseExpires > daysToWarn) {
+    title = (
+      <span>
+        License expires in <b>{Math.abs(daysUntilLicenseExpires)} days</b>
+      </span>
+    );
+    Icon = InfoIcon;
+    tooltipContent = (
+      <span>
+        You are using an {licenseType} license of CockroachDB. To avoid service
+        disruption, please renew before the expiration date of{" "}
+        {expirationDateFormatted}. {learnMore}
+      </span>
+    );
+  } else if (daysUntilLicenseExpires === 0) {
+    title = (
+      <span>License expires in {Math.abs(daysUntilLicenseExpires)} days.</span>
+    );
+    Icon = WarningIcon;
+    tooltipContent = (
+      <span>
+        Your {licenseType} license of CockroachDB expired today. To re-enable
+        Enterprise features, please renew your license. {learnMore}
+      </span>
+    );
+  } else if (daysUntilLicenseExpires <= 0) {
+    title = (
+      <span>
+        <b>License expired</b> {Math.abs(daysUntilLicenseExpires)} days ago
+      </span>
+    );
+    Icon = ErrorIcon;
+    tooltipContent = (
+      <span>
+        Your {licenseType} license of CockroachDB expired on{" "}
+        {expirationDateFormatted}. To re-enable Enterprise features, please
+        renew your license. {learnMore}
+      </span>
+    );
+  } else if (daysUntilLicenseExpires <= daysToWarn) {
+    title = (
+      <span>
+        License expires in <b>{daysUntilLicenseExpires} days</b>
+      </span>
+    );
+    Icon = WarningIcon;
+    tooltipContent = (
+      <span>
+        You are using an {licenseType} license of CockroachDB. To avoid service
+        disruption, please renew before the expiration date of{" "}
+        {expirationDateFormatted}. {learnMore}
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip
+      placement="bottom"
+      title={tooltipContent}
+      className={cn("container")}
+    >
+      <img src={Icon} className={cn("icon")} />
+      <span className={cn("content")}>{title}</span>
+    </Tooltip>
+  );
+};

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -170,7 +170,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/util/caller",
         "//pkg/util/ctxgroup",
-        "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log/channel",
         "//pkg/util/log/logconfig",

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -54,6 +54,8 @@ var debugLog *loggerT
 // in support escalations.
 const redactionPolicyManagedEnvVar = "COCKROACH_REDACTION_POLICY_MANAGED"
 
+var RedactionPolicyManaged = envutil.EnvOrDefaultBool(redactionPolicyManagedEnvVar, false)
+
 func init() {
 	logflags.InitFlags(
 		&logging.showLogs,
@@ -145,7 +147,7 @@ func ApplyConfig(config logconfig.Config) (logShutdownFn func(), err error) {
 	logging.allSinkInfos.clear()
 
 	// Indicate whether we're running in a managed environment. Impacts redaction policies.
-	logging.setManagedRedactionPolicy(envutil.EnvOrDefaultBool(redactionPolicyManagedEnvVar, false))
+	logging.setManagedRedactionPolicy(RedactionPolicyManaged)
 
 	// If capture of internal fd2 writes is enabled, set it up here.
 	if config.CaptureFd2.Enable {


### PR DESCRIPTION
Before, there was a change which added alert pop up to notify users about remaining days before license expires. Instead, it requires to show this information permanently for clusters with Enterprise of Trial licenses.
This change:
- removes pop up alert with licensing
- adds notification message on top panes (left to user's name) which indicates how many days left before license expires. Also it shows as a warning if less than 30 days remains, and with "danger" icon - if license expired.

Release note: show notification message about license expiration for clusters with enterprise or trial license.

Resolves: #98589

License expires today:
<img width="380" alt="Screenshot 2024-03-21 at 13 20 35" src="https://github.com/cockroachdb/cockroach/assets/3106437/15875f1e-b37b-43e8-8aee-a0380fc570a4">

License expires in 30 days:
<img width="408" alt="Screenshot 2024-03-21 at 13 18 31" src="https://github.com/cockroachdb/cockroach/assets/3106437/199257de-de19-438c-b607-92ffd1a635a5">

License expires in 365 days:
<img width="450" alt="Screenshot 2024-03-21 at 13 17 05" src="https://github.com/cockroachdb/cockroach/assets/3106437/4c722a1a-f431-4b01-b68b-df8a0d0b2aa4">

License expired many days ago:
<img width="603" alt="Screenshot 2024-03-21 at 13 15 15" src="https://github.com/cockroachdb/cockroach/assets/3106437/c32f09cb-54ef-4e8e-a3f0-9e20b19f5430">
