### PR TITLE
roachtest: bump tpcc/mixed-headroom timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -543,7 +543,7 @@ func registerTPCC(r registry.Registry) {
 		// migrations while TPCC runs. It simulates a real production
 		// deployment in the middle of the migration into a new cluster version.
 		Name:    "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
-		Timeout: 6 * time.Hour,
+		Timeout: 7 * time.Hour,
 		Owner:   registry.OwnerTestEng,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.


### PR DESCRIPTION
In the "worst case" scenario of the test performing 4 upgrades, this test can take a little longer. In a recent failure, the test timed out while running the very last step of the test. We increase the timeout by one hour to account for similar test plans in the future.

Fixes: #120803

Release note: None