### PR TITLE
workflows: run `examples-orms` on non-FIPS machines

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   examples_orms:
-    runs-on: [self-hosted, basic_big_runner_group_fips]
+    runs-on: [self-hosted, basic_big_runner_group]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This was an accident.

Epic: CRDB-8308
Release note: None
