### PR TITLE
backupccl: add backup.restore_span.max_file_count cluster setting

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -97,6 +97,7 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 												nil,
 												introducedSpanFrontier,
 												0,
+												defaultMaxFileCount,
 												false)
 											require.NoError(b, err)
 											defer filter.close()

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -471,6 +471,7 @@ func runGenerativeSplitAndScatter(
 			spec.HighWater,
 			introducedSpanFrontier,
 			spec.TargetSize,
+			spec.MaxFileCount,
 			spec.UseFrontierCheckpointing)
 		if err != nil {
 			return errors.Wrap(err, "failed to make span covering filter")

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -174,6 +174,7 @@ func distRestore(
 			HighWater:                   md.spanFilter.highWaterMark,
 			UserProto:                   execCtx.User().EncodeProto(),
 			TargetSize:                  md.spanFilter.targetSize,
+			MaxFileCount:                int64(md.spanFilter.maxFileCount),
 			ChunkSize:                   int64(chunkSize),
 			NumEntries:                  int64(md.numImportSpans),
 			NumNodes:                    int64(numNodes),

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -64,6 +64,16 @@ var targetOnlineRestoreSpanSize = settings.RegisterByteSizeSetting(
 	16<<30,
 )
 
+var maxFileCount = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"backup.restore_span.max_file_count",
+	"the maximum number of backup files an extending restore span may contain",
+	defaultMaxFileCount,
+	settings.PositiveInt,
+)
+
+const defaultMaxFileCount = 200
+
 // backupManifestFileIterator exposes methods that can be used to iterate over
 // the `BackupManifest_Files` field of a manifest.
 type backupManifestFileIterator interface {
@@ -138,6 +148,7 @@ type spanCoveringFilter struct {
 	introducedSpanFrontier   spanUtils.Frontier
 	useFrontierCheckpointing bool
 	targetSize               int64
+	maxFileCount             int
 }
 
 func makeSpanCoveringFilter(
@@ -146,15 +157,24 @@ func makeSpanCoveringFilter(
 	highWater roachpb.Key,
 	introducedSpanFrontier spanUtils.Frontier,
 	targetSize int64,
+	maxFileCount int64,
 	useFrontierCheckpointing bool,
 ) (spanCoveringFilter, error) {
 	f, err := loadCheckpointFrontier(requiredSpans, checkpointedSpans)
 	if err != nil {
 		return spanCoveringFilter{}, err
 	}
+	if maxFileCount == 0 {
+		// A 0 valued maxFileCount may get passed in a mixed version cluster:
+		// specifically, when the job coordinator is on an older version and the
+		// generative split and scatter processor is on a newer version. In this
+		// case, ensure the maxFileCount is set to default.
+		maxFileCount = defaultMaxFileCount
+	}
 	sh := spanCoveringFilter{
 		introducedSpanFrontier:   introducedSpanFrontier,
 		targetSize:               targetSize,
+		maxFileCount:             int(maxFileCount),
 		highWaterMark:            highWater,
 		useFrontierCheckpointing: useFrontierCheckpointing,
 		checkpointFrontier:       f,
@@ -429,16 +449,12 @@ func generateAndSendImportSpans(
 					lastCovSpanCount = newCovFilesCount
 				} else {
 					// We have room to add to the last span if doing so would remain below
-					// both the target byte size and 200 total files. We limit the number
+					// both the target byte size and maxFileCount total files. We limit the number
 					// of files since we default to running multiple concurrent workers so
 					// we want to bound sum total open files across all of them to <= 1k.
 					// We bound the span byte size to improve work distribution and make
 					// the progress more granular.
-					// We waive the file count limit if the target size is >8GB, as a size
-					// this large clearly indicates we want lots of files (such as during
-					// online restores where we don't open them).
-					fileCountOK := lastCovSpanCount+newCovFilesCount <= 200 || filter.targetSize > 8<<30
-					fits := lastCovSpanSize+newCovFilesSize <= filter.targetSize && fileCountOK
+					fits := lastCovSpanSize+newCovFilesSize <= filter.targetSize && lastCovSpanCount+newCovFilesCount <= filter.maxFileCount
 
 					if (newCovFilesCount == 0 || fits) && !firstInSpan {
 						// If there are no new files that cover this span or if we can add the

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -292,6 +292,7 @@ func makeImportSpans(
 		highWaterMark,
 		introducedSpanFrontier,
 		targetSize,
+		defaultMaxFileCount,
 		highWaterMark == nil)
 	if err != nil {
 		return nil, err
@@ -693,6 +694,7 @@ func TestCheckpointFilter(t *testing.T) {
 			nil,
 			nil,
 			0,
+			defaultMaxFileCount,
 			true)
 		require.NoError(t, err)
 		defer f.close()

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -458,7 +458,8 @@ message GenerativeSplitAndScatterSpec {
   // ExclusiveFileSpanComparison is true if the backup can safely use
   // exclusive file span comparison.
   optional bool exclusive_file_span_comparison = 22 [(gogoproto.nullable) = false];
-
+  // MaxFileCount is the max number of files in an extending restore span entry.
+  optional int64 max_file_count = 23[(gogoproto.nullable) = false];
   reserved 19;
 }
 


### PR DESCRIPTION
As of #119840, restore limits the number of files to an extending restore span entry to 200. When this file cap is less than the number of inc layers, restore slows signficantly, as the restore span entries become much smaller. This patch introduces a cluster setting which allows the user to raise this file cap.

Informs: #120186

Release note: none