### PR TITLE
roachprod: remove AZ overrides for aws provider

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -285,30 +285,19 @@ var defaultConfig = func() (cfg *awsConfig) {
 	return cfg
 }()
 
-// defaultCreateZones is the list of availability zones used by default for
-// cluster creation. If the geo flag is specified, nodes are distributed between
-// zones.
-// NOTE: a number of AWS roachtests are dependent on us-east-2 for loading fixtures,
-// out of s3://cockroach-fixtures-us-east-2. AWS doesn't support multi-regional buckets, thus resulting in material
-// egress cost if the test loads from a different region. See https://github.com/cockroachdb/cockroach/issues/105968.
-var defaultCreateZones = []string{
-	// N.B. us-east-2a is the default zone for non-geo distributed clusters. It appears to have a higher on-demand
-	// capacity of c7g.8xlarge (graviton3) than us-east-2b.
+// defaultZones is the list of availability zones used by default for
+// cluster creation. If the geo flag is specified, nodes are
+// distributed between zones.
+//
+// NOTE: a number of AWS roachtests are dependent on us-east-2 for
+// loading fixtures, out of s3://cockroach-fixtures-us-east-2. AWS
+// doesn't support multi-regional buckets, thus resulting in material
+// egress cost if the test loads from a different region. See
+// https://github.com/cockroachdb/cockroach/issues/105968.
+var defaultZones = []string{
 	"us-east-2a",
 	"us-west-2b",
 	"eu-west-2b",
-}
-
-// Overrides defaultCreateZones for specific machine types.
-// This is a workaround for,
-// "We currently do not have sufficient c6id.4xlarge capacity in the Availability Zone you requested (us-east-2a).
-// Our system will be working on provisioning additional capacity. You can currently get c6id.4xlarge capacity by
-// not specifying an Availability Zone in your request or choosing us-east-2b, us-east-2c."
-// N.B. we implicitly specify AZ to select an AMI in that zone, hence we fall back to instance-specific overrides.
-var overrideDefaultCreateZones = map[string][]string{
-	"c6id.4xlarge":  {"us-east-2c", "us-west-2b", "eu-west-2b"},
-	"c6id.8xlarge":  {"us-east-2c", "us-west-2b", "eu-west-2b"},
-	"c6id.24xlarge": {"us-east-2b", "us-west-2b", "eu-west-2b"},
 }
 
 type Tag struct {
@@ -372,7 +361,7 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		fmt.Sprintf("aws availability zones to use for cluster creation. If zones are formatted\n"+
 			"as AZ:N where N is an integer, the zone will be repeated N times. If > 1\n"+
 			"zone specified, the cluster will be spread out evenly by zone regardless\n"+
-			"of geo (default [%s])", strings.Join(defaultCreateZones, ",")))
+			"of geo (default [%s])", strings.Join(defaultZones, ",")))
 	flags.StringVar(&o.ImageAMI, ProviderName+"-image-ami",
 		o.ImageAMI, "Override image AMI to use.  See https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-images.html")
 	flags.BoolVar(&o.UseMultipleDisks, ProviderName+"-enable-multiple-stores",
@@ -543,13 +532,8 @@ func (p *Provider) Create(
 		return err
 	}
 
-	useDefaultZones := len(expandedZones) == 0
-	if useDefaultZones {
-		expandedZones = defaultCreateZones
-		if defaultAZOverride, ok := overrideDefaultCreateZones[machineType]; ok {
-			expandedZones = defaultAZOverride
-			l.Printf("WARNING: using default zones override %q for machine type %q", strings.Join(expandedZones, ","), machineType)
-		}
+	if len(expandedZones) == 0 {
+		expandedZones = defaultZones
 	}
 
 	// We need to make sure that the SSH keys have been distributed to all regions.
@@ -566,7 +550,14 @@ func (p *Provider) Create(
 	}
 
 	var zones []string // contains an az corresponding to each entry in names
-	if !opts.GeoDistributed && (useDefaultZones || len(expandedZones) == 1) {
+	if opts.GeoDistributed {
+		// Distribute the nodes amongst availability zones if geo distributed.
+		nodeZones := vm.ZonePlacement(len(expandedZones), len(names))
+		zones = make([]string, len(nodeZones))
+		for i, z := range nodeZones {
+			zones[i] = expandedZones[z]
+		}
+	} else {
 		// Only use one zone in the region if we're not creating a geo cluster.
 		regionZones, err := p.regionZones(regions[0], expandedZones)
 		if err != nil {
@@ -576,13 +567,6 @@ func (p *Provider) Create(
 		zone := regionZones[rand.Intn(len(regionZones))]
 		for range names {
 			zones = append(zones, zone)
-		}
-	} else {
-		// Distribute the nodes amongst availability zones if geo distributed.
-		nodeZones := vm.ZonePlacement(len(expandedZones), len(names))
-		zones = make([]string, len(nodeZones))
-		for i, z := range nodeZones {
-			zones[i] = expandedZones[z]
 		}
 	}
 


### PR DESCRIPTION
We previously had logic that would apply an override to the AZ for certain machine types. While this might have helped for a while, we are now seeing an increase in cluster creation errors due to AZ unavailability, including in cases where AWS indicates that resources are unavailable in the overriden AZ but _are_ available in the default AZ[^1].

In this commit, we remove that logic and rely on AZ randomization, mirroring what is done in the `gce` provider (#120714).

[^1]: for an example, see https://github.com/cockroachdb/cockroach/issues/120621#issuecomment-2011268739

Epic: none

Release note: None