### PR TITLE
compose: remove PG ComposeCompare test

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -49,18 +49,6 @@ func TestCompare(t *testing.T) {
 		addr string
 		init []string
 	}{
-		"postgres": {
-			addr: "postgresql://postgres@postgres:5432/postgres",
-			init: []string{
-				"drop schema if exists public cascade",
-				"create schema public",
-				"CREATE EXTENSION IF NOT EXISTS postgis",
-				"CREATE EXTENSION IF NOT EXISTS postgis_topology",
-				"CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;",
-				"CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";",
-				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
-			},
-		},
 		"cockroach1": {
 			addr: "postgresql://root@cockroach1:26257/postgres?sslmode=disable",
 			init: []string{
@@ -85,22 +73,6 @@ func TestCompare(t *testing.T) {
 		},
 	}
 	configs := map[string]testConfig{
-		"postgres": {
-			setup:           sqlsmith.Setups[sqlsmith.RandTableSetupName],
-			setupMutators:   []randgen.Mutator{randgen.PostgresCreateTableMutator},
-			opts:            []sqlsmith.SmitherOption{sqlsmith.PostgresMode()},
-			ignoreSQLErrors: true,
-			conns: []testConn{
-				{
-					name:     "cockroach1",
-					mutators: []randgen.Mutator{},
-				},
-				{
-					name:     "postgres",
-					mutators: []randgen.Mutator{randgen.PostgresMutator},
-				},
-			},
-		},
 		"mutators": {
 			setup:           sqlsmith.Setups[sqlsmith.RandTableSetupName],
 			opts:            []sqlsmith.SmitherOption{sqlsmith.CompareMode()},

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,10 +1,5 @@
 version: '3'
 services:
-  postgres:
-    image: postgis/postgis:13-3.1
-    environment:
-      - POSTGRES_INITDB_ARGS=--locale=C --encoding=UTF8
-      - POSTGRES_HOST_AUTH_METHOD=trust
   cockroach1:
     image: ubuntu:xenial-20170214
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach1
@@ -22,7 +17,6 @@ services:
     # compare.test is a binary built by the pkg/compose/prepare.sh in non-bazel builds
     command: /compare/compare.test -each ${EACH} -test.run ${TESTS} -artifacts ${ARTIFACTS}
     depends_on:
-      - postgres
       - cockroach1
       - cockroach2
     volumes:


### PR DESCRIPTION
This test does not provide us much value and is too flaky to be useful. Most of the time it fails are due to minor differences in things like names, formatting, or precision, and accommodating each of these differences is not worth it.

fixes https://github.com/cockroachdb/cockroach/issues/109400
fixes https://github.com/cockroachdb/cockroach/issues/116150
fixes https://github.com/cockroachdb/cockroach/issues/112154
Release note: None
