### PR TITLE
kvserver: deflake TestStrictGCEnforcement

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4076,6 +4076,13 @@ func TestStrictGCEnforcement(t *testing.T) {
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					// We don't strictly enforce the GC TTL if the protected timestamp
+					// state cached on the replica is older than the lease's start time.
+					// We disable the lease queue to prevent flakes right around lease
+					// transfers. See getImpliedGCThresholdRLocked for more details.
+					DisableLeaseQueue: true,
+				},
 				SpanConfig: &spanconfig.TestingKnobs{
 					KVSubscriberRangeFeedKnobs: &rangefeedcache.TestingKnobs{
 						OnTimestampAdvance: func(timestamp hlc.Timestamp) {


### PR DESCRIPTION
We don't do strict GC enforcement right around lease transfers if the protected timestamp state isn't caught up to the lease's start time. This test was susceptible to flake around lease transfers, so we disable them.

Closes #120678

Release note: None