### PR TITLE
workload/schemachange: correct error code for referencing dropping enum

### DIFF
--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -331,7 +331,7 @@ func (g ByNameGetter) Type(
 		tn := tree.MakeTableNameWithSchema(
 			tree.Name(db.GetName()), tree.Name(sc.GetName()), tree.Name(name),
 		)
-		return nil, sqlerrors.NewUndefinedRelationError(&tn)
+		return nil, sqlerrors.NewUndefinedTypeError(&tn)
 	}
 	if tbl, ok := desc.(catalog.TableDescriptor); ok {
 		// A given table name can resolve to either a type descriptor or a table

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -964,8 +964,8 @@ func (l *internalLookupCtx) getTableByID(id descpb.ID) (catalog.TableDescriptor,
 func (l *internalLookupCtx) getTypeByID(id descpb.ID) (catalog.TypeDescriptor, error) {
 	typ, ok := l.typDescs[id]
 	if !ok {
-		return nil, sqlerrors.NewUndefinedRelationError(
-			tree.NewUnqualifiedTableName(tree.Name(fmt.Sprintf("[%d]", id))))
+		return nil, sqlerrors.NewUndefinedTypeError(
+			tree.NewUnqualifiedTypeName(fmt.Sprintf("[%d]", id)))
 	}
 	return typ, nil
 }

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4021,7 +4021,7 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 		// 4. Reference a UDT that does not exist.
 		{pgcode.UndefinedObject, `CREATE FUNCTION { UniqueName } (IN p1 "ThisTypeDoesNotExist") RETURNS VOID LANGUAGE SQL AS $$ SELECT NULL $$`},
 		// 5. Reference an Enum that's in the process of being dropped
-		{pgcode.UndefinedTable, `CREATE FUNCTION { UniqueName } (IN p1 { NonPublicEnum }) RETURNS VOID LANGUAGE SQL AS $$ SELECT NULL $$`},
+		{pgcode.UndefinedObject, `CREATE FUNCTION { UniqueName } (IN p1 { NonPublicEnum }) RETURNS VOID LANGUAGE SQL AS $$ SELECT NULL $$`},
 		// 6. Reference an Enum value that's in the process of being dropped
 		{pgcode.InvalidParameterValue, `CREATE FUNCTION { UniqueName } () RETURNS VOID LANGUAGE SQL AS $$ SELECT { DroppingEnumMember } $$`},
 	}, placeholderMap)


### PR DESCRIPTION
This patch changes the error code expected for referencing an enum that's in the process of being dropped to the proper one.

Epic: none

Release note: None