### PR TITLE
opt/memo: use virtual column stats for matching scalar expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2518,9 +2518,11 @@ CREATE TABLE t68254 (
   c JSONB,
   d STRING AS (b || repeat('a', a)) VIRTUAL,
   e STRING AS ((c->'foo')->>'bar') VIRTUAL,
+  f JSONB AS (c->'foo'->'bar') VIRTUAL,
   INDEX (d),
   INDEX (e),
-  INDEX (b, e)
+  INDEX (b, e),
+  INDEX (f)
 )
 
 statement ok
@@ -2553,6 +2555,7 @@ j1               {b}           5          5               1           true
 j1               {c}           5          5               1           true
 j1               {d}           5          5               1           true
 j1               {e}           5          5               1           true
+j1               {f}           5          5               1           true
 
 statement ok
 CREATE STATISTICS j2 ON d FROM t68254
@@ -2560,11 +2563,17 @@ CREATE STATISTICS j2 ON d FROM t68254
 statement ok
 CREATE STATISTICS j3 ON e FROM t68254
 
+statement ok
+CREATE STATISTICS j4 ON f FROM t68254
+
 let $hist_d
 SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t68254] WHERE statistics_name = 'j2'
 
 let $hist_e
 SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t68254] WHERE statistics_name = 'j3'
+
+let $hist_f
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t68254] WHERE statistics_name = 'j4'
 
 query TIRI colnames,nosort
 SHOW HISTOGRAM $hist_d
@@ -2583,6 +2592,66 @@ upper_bound   range_rows  distinct_range_rows  equal_rows
 '{"baz": 1}'  0           0                    1
 '{"baz": 2}'  0           0                    1
 '{"baz": 3}'  0           0                    1
+
+query TIRI colnames,nosort
+SHOW HISTOGRAM $hist_f
+----
+upper_bound   range_rows  distinct_range_rows  equal_rows
+'{"baz": 0}'  0           0                    1
+'{"baz": 1}'  0           0                    1
+'{"baz": 2}'  0           0                    1
+'{"baz": 3}'  0           0                    1
+
+query T
+EXPLAIN SELECT * FROM t68254 WHERE e IN ('{"baz": 2}', '{"baz": 3}', '{"baz": 4}')
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • index join
+    │ estimated row count: 2
+    │ table: t68254@t68254_pkey
+    │
+    └── • scan
+          estimated row count: 2 (40% of the table; stats collected <hidden> ago)
+          table: t68254@t68254_e_idx
+          spans: [/'{"baz": 2}' - /'{"baz": 2}'] [/'{"baz": 3}' - /'{"baz": 3}'] [/'{"baz": 4}' - /'{"baz": 4}']
+
+query T
+EXPLAIN SELECT * FROM t68254 WHERE f IN ('{"baz": 2}', '{"baz": 3}', '{"baz": 4}')
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • index join
+    │ estimated row count: 2
+    │ table: t68254@t68254_pkey
+    │
+    └── • scan
+          estimated row count: 2 (40% of the table; stats collected <hidden> ago)
+          table: t68254@t68254_f_idx
+          spans: [/'{"baz": 2}' - /'{"baz": 2}'] [/'{"baz": 3}' - /'{"baz": 3}'] [/'{"baz": 4}' - /'{"baz": 4}']
+
+query T
+EXPLAIN SELECT * FROM t68254 WHERE c->'foo'->'bar' > '{"baz": 0}'
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • index join
+    │ estimated row count: 3
+    │ table: t68254@t68254_pkey
+    │
+    └── • scan
+          estimated row count: 3 (60% of the table; stats collected <hidden> ago)
+          table: t68254@t68254_f_idx
+          spans: (/'{"baz": 0}' - ]
 
 # Check that we also collect stats on the hidden expression index virt column.
 statement ok
@@ -2611,6 +2680,7 @@ j4               {crdb_internal_idx_expr}  5          5               1         
 j4               {c}                       5          5               1           true
 j4               {d}                       5          5               1           true
 j4               {e}                       5          5               1           true
+j4               {f}                       5          5               1           true
 
 statement ok
 CREATE STATISTICS j5 ON crdb_internal_idx_expr FROM t68254

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -26,6 +26,14 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
+// replaceFunc is the callback function passed to norm.Factory.Replace. It is
+// copied here from norm.ReplaceFunc to avoid a circular dependency.
+type ReplaceFunc func(e opt.Expr) opt.Expr
+
+// replacer is a wrapper around norm.Factory.Replace, so that we can call it
+// without creating a circular dependency.
+type replacer func(e opt.Expr, replace ReplaceFunc) opt.Expr
+
 // Memo is a data structure for efficiently storing a forest of query plans.
 // Conceptually, the memo is composed of a numbered set of equivalency classes
 // called groups where each group contains a set of logically equivalent
@@ -116,6 +124,10 @@ type Memo struct {
 	// interner interns all expressions in the memo, ensuring that there is at
 	// most one instance of each expression in the memo.
 	interner interner
+
+	// replacer is a wrapper around norm.Factory.Replace, used by statistics
+	// builder to rewrite some expressions when calculating stats.
+	replacer replacer
 
 	// logPropsBuilder is inlined in the memo so that it can be reused each time
 	// scalar or relational properties need to be built.
@@ -256,6 +268,10 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(ctx, evalCtx, m)
+}
+
+func (m *Memo) SetReplacer(replacer replacer) {
+	m.replacer = replacer
 }
 
 // AllowUnconstrainedNonCoveringIndexScan indicates whether unconstrained

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1123,7 +1123,19 @@ func (sb *statisticsBuilder) colStatProject(
 		for i := range prj.Projections {
 			item := &prj.Projections[i]
 			if reqSynthCols.Contains(item.Col) {
-				// TODO(michae2): Check for matching virtual column expressions here.
+				// Before checking OuterCols, try to replace any virtual computed column
+				// expressions with the corresponding virtual column.
+				if sb.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats &&
+					!s.VirtualCols.Empty() {
+					element := sb.factorOutVirtualCols(
+						item.Element, &item.scalar.Shared, s.VirtualCols, prj.Memo(),
+					).(opt.ScalarExpr)
+					if element != item.Element {
+						newItem := constructProjectionsItem(element, item.Col, prj.Memo())
+						item = &newItem
+					}
+				}
+
 				reqInputCols.UnionWith(item.scalar.OuterCols)
 
 				// If the element is not a null constant, account for that
@@ -3296,7 +3308,19 @@ func (sb *statisticsBuilder) applyFilters(
 func (sb *statisticsBuilder) applyFiltersItem(
 	filter *FiltersItem, e RelExpr, relProps *props.Relational,
 ) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
-	// TODO(michae2): Check for matching virtual column expressions here.
+	// Before checking anything, try to replace any virtual computed column
+	// expressions with the corresponding virtual column.
+	if sb.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats &&
+		!relProps.Statistics().VirtualCols.Empty() {
+		cond := sb.factorOutVirtualCols(
+			filter.Condition, &filter.scalar.Shared, relProps.Statistics().VirtualCols, e.Memo(),
+		).(opt.ScalarExpr)
+		if cond != filter.Condition {
+			newFilter := constructFiltersItem(cond, e.Memo())
+			filter = &newFilter
+		}
+	}
+
 	if isEqualityWithTwoVars(filter.Condition) {
 		// Equalities are handled by applyEquivalencies.
 		return 0, opt.ColSet{}, opt.ColSet{}
@@ -4413,7 +4437,6 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 			// is able to build column equivalencies.
 			switch disjuncts[i].(type) {
 			case *EqExpr, *AndExpr:
-				// TODO(michae2): Check for matching virtual column expressions here.
 				if andFilters, ok = addEqExprConjuncts(disjuncts[i], andFilters, e.Memo()); !ok {
 					numUnappliedConjuncts++
 					continue
@@ -4512,6 +4535,15 @@ func combineOredSelectivities(selectivities []props.Selectivity) props.Selectivi
 // in cases where the Factory is not accessible.
 func constructFiltersItem(condition opt.ScalarExpr, m *Memo) FiltersItem {
 	item := FiltersItem{Condition: condition}
+	item.PopulateProps(m)
+	return item
+}
+
+// constructProjectionsItem constructs an expression for the ProjectionsItem
+// operator, with identical behavior to the Factor method of the same name, but
+// for use in cases where the Factory is not accessible.
+func constructProjectionsItem(element opt.ScalarExpr, col opt.ColumnID, m *Memo) ProjectionsItem {
+	item := ProjectionsItem{Element: element, Col: col}
 	item.PopulateProps(m)
 	return item
 }
@@ -4944,4 +4976,55 @@ func (sb *statisticsBuilder) buildStatsFromCheckConstraints(
 		}
 	}
 	return false
+}
+
+// factorOutVirtualCols replaces any subexpressions matching any virtual
+// computed column expressions with a reference to the virtual computed
+// column. This allows us to directly use statistics collected on the virtual
+// computed column instead of estimating from the expression.
+func (sb *statisticsBuilder) factorOutVirtualCols(
+	e opt.Expr, shared *props.Shared, virtualCols opt.ColSet, m *Memo,
+) opt.Expr {
+	if m.replacer == nil {
+		panic(errors.AssertionFailedf("Memo.replacer unset"))
+	}
+
+	// Optimization: build a slice of virtual computed column expressions to find,
+	// and also prune any virtual cols whose outer columns are not contained in
+	// the expression's outer columns.
+	type virtExpr struct {
+		colID opt.ColumnID
+		expr  opt.Expr
+	}
+	virtExprs := make([]virtExpr, virtualCols.Len())
+	virtualCols.ForEach(func(colID opt.ColumnID) {
+		col := sb.md.ColumnMeta(colID)
+		tab := sb.md.TableMeta(col.Table)
+		if !tab.ColsInComputedColsExpressions.Intersects(shared.OuterCols) {
+			return
+		}
+		expr, ok := tab.ComputedCols[colID]
+		if !ok {
+			panic(errors.AssertionFailedf(
+				"could not find computed column expression for column %v in table %v", colID, tab.Alias,
+			))
+		}
+		virtExprs = append(virtExprs, virtExpr{colID: colID, expr: expr})
+	})
+
+	if len(virtExprs) == 0 {
+		return e
+	}
+
+	// Replace all virtual col expressions with the corresponding virtual col.
+	var replace ReplaceFunc
+	replace = func(e opt.Expr) opt.Expr {
+		for _, ve := range virtExprs {
+			if e == ve.expr {
+				return m.MemoizeVariable(ve.colID)
+			}
+		}
+		return m.replacer(e, replace)
+	}
+	return replace(e)
 }

--- a/pkg/sql/opt/memo/testdata/stats/virtual
+++ b/pkg/sql/opt/memo/testdata/stats/virtual
@@ -302,8 +302,287 @@ project
  └── projections
       └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
 
-# TODO(michae2): We need special handling for InlineSelectVirtualColumns, so
-# skip filtering on b until we have that.
+# Push a select on the virtual column below the project.
+norm colstat=1 colstat=2
+SELECT * FROM abc WHERE b > 3
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(2)=6, null(2)=0]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── select
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── immutable
+ │    ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(2)=6, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) c:3(int)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Again, with placeholders.
+assign-placeholders-norm query-args=(3)
+SELECT * FROM abc WHERE b > $1
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=12]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── select
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── immutable
+ │    ├── stats: [rows=12, distinct(2)=6, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) c:3(int)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Push a select on the virtual column expression below the project.
+norm colstat=1 colstat=2
+SELECT * FROM abc WHERE a % 10 > 3
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(2)=6, null(2)=0]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── select
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── immutable
+ │    ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(2)=6, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) c:3(int)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Again, with placeholders.
+assign-placeholders-norm query-args=(3)
+SELECT * FROM abc WHERE a % 10 > $1
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=12]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── select
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── immutable
+ │    ├── stats: [rows=12, distinct(2)=6, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) c:3(int)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Push a select on the virtual column expression below the project.
+norm colstat=1 colstat=2
+SELECT * FROM (SELECT a FROM abc) WHERE a % 10 > 3
+----
+select
+ ├── columns: a:1(int!null)
+ ├── immutable
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(2)=6, null(2)=0]
+ │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+ │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── scan abc
+ │    ├── columns: a:1(int!null)
+ │    ├── computed column expressions
+ │    │    └── b:2
+ │    │         └── a:1 % 10 [type=int]
+ │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    └── key: (1)
+ └── filters
+      └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+
+# Again, with placeholders.
+assign-placeholders-norm query-args=(3)
+SELECT * FROM (SELECT a FROM abc) WHERE a % 10 > $1
+----
+select
+ ├── columns: a:1(int!null)
+ ├── immutable
+ ├── stats: [rows=12, distinct(2)=6, null(2)=0]
+ │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+ │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── scan abc
+ │    ├── columns: a:1(int!null)
+ │    ├── computed column expressions
+ │    │    └── b:2
+ │    │         └── a:1 % 10 [type=int]
+ │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │   virtcolstats: (2)
+ │    └── key: (1)
+ └── filters
+      └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+
+# Select using an IN set.
+norm colstat=1 colstat=2
+SELECT * FROM abc WHERE a % 10 IN (2, 4, 6)
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=6, distinct(1)=6, null(1)=0, distinct(2)=3, null(2)=0]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── select
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── immutable
+ │    ├── stats: [rows=6, distinct(1)=6, null(1)=0, distinct(2)=3, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2
+ │    │                <--- 2 --- 4 --- 6
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) c:3(int)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── (a:1 % 10) IN (2, 4, 6) [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Again, with placeholders.
+assign-placeholders-norm query-args=(2, 4, 6)
+SELECT * FROM abc WHERE a % 10 IN ($1, $2, $3)
+----
+project
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int)
+ ├── immutable
+ ├── stats: [rows=6]
+ │   virtcolstats: (2)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── select
+ │    ├── columns: a:1(int!null) c:3(int)
+ │    ├── immutable
+ │    ├── stats: [rows=6, distinct(2)=3, null(2)=0]
+ │    │   histogram(2)=  0  2  0  2  0  2
+ │    │                <--- 2 --- 4 --- 6
+ │    │   virtcolstats: (2)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(3)
+ │    ├── scan abc
+ │    │    ├── columns: a:1(int!null) c:3(int)
+ │    │    ├── computed column expressions
+ │    │    │    └── b:2
+ │    │    │         └── a:1 % 10 [type=int]
+ │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+ │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+ │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+ │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+ │    │    │   virtcolstats: (2)
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(3)
+ │    └── filters
+ │         └── (a:1 % 10) IN (2, 4, 6) [type=bool, outer=(1), immutable]
+ └── projections
+      └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
 
 # Distinct on top of the project.
 norm
@@ -333,6 +612,76 @@ distinct-on
       │    └── key: (1)
       └── projections
            └── a:1 % 10 [as=b:2, type=int, outer=(1), immutable]
+
+# Distinct on top of the project using just the virtual column expression.
+norm
+SELECT DISTINCT a % 10 FROM abc
+----
+distinct-on
+ ├── columns: "?column?":6(int!null)
+ ├── grouping columns: "?column?":6(int!null)
+ ├── immutable
+ ├── stats: [rows=10, distinct(6)=10, null(6)=0]
+ │   virtcolstats: (2)
+ ├── key: (6)
+ └── project
+      ├── columns: "?column?":6(int!null)
+      ├── immutable
+      ├── stats: [rows=20, distinct(6)=10, null(6)=0]
+      │   virtcolstats: (2)
+      ├── scan abc
+      │    ├── columns: a:1(int!null)
+      │    ├── computed column expressions
+      │    │    └── b:2
+      │    │         └── a:1 % 10 [type=int]
+      │    ├── stats: [rows=20, distinct(2)=10, null(2)=0]
+      │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+      │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+      │    │   virtcolstats: (2)
+      │    └── key: (1)
+      └── projections
+           └── a:1 % 10 [as="?column?":6, type=int, outer=(1), immutable]
+
+# Distinct on top of the project using just the virtual column expression.
+norm
+SELECT DISTINCT a % 10 FROM abc WHERE a % 10 > 3
+----
+distinct-on
+ ├── columns: "?column?":6(int!null)
+ ├── grouping columns: "?column?":6(int!null)
+ ├── immutable
+ ├── stats: [rows=6, distinct(6)=6, null(6)=0]
+ │   virtcolstats: (2)
+ ├── key: (6)
+ └── project
+      ├── columns: "?column?":6(int!null)
+      ├── immutable
+      ├── stats: [rows=12, distinct(6)=6, null(6)=0]
+      │   virtcolstats: (2)
+      ├── select
+      │    ├── columns: a:1(int!null)
+      │    ├── immutable
+      │    ├── stats: [rows=12, distinct(2)=6, null(2)=0]
+      │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2
+      │    │                <--- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+      │    │   virtcolstats: (2)
+      │    ├── key: (1)
+      │    ├── scan abc
+      │    │    ├── columns: a:1(int!null)
+      │    │    ├── computed column expressions
+      │    │    │    └── b:2
+      │    │    │         └── a:1 % 10 [type=int]
+      │    │    ├── stats: [rows=20, distinct(1)=20, null(1)=0, distinct(2)=10, null(2)=0]
+      │    │    │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1   0  1
+      │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17 --- 18 --- 19
+      │    │    │   histogram(2)=  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2  0  2
+      │    │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9
+      │    │    │   virtcolstats: (2)
+      │    │    └── key: (1)
+      │    └── filters
+      │         └── (a:1 % 10) > 3 [type=bool, outer=(1), immutable]
+      └── projections
+           └── a:1 % 10 [as="?column?":6, type=int, outer=(1), immutable]
 
 # Push a join below the project.
 opt colstat=1 colstat=2 colstat=6 colstat=7

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -136,6 +136,9 @@ func (f *Factory) Init(ctx context.Context, evalCtx *eval.Context, catalog cat.C
 		mem = &memo.Memo{}
 	}
 	mem.Init(ctx, evalCtx)
+	mem.SetReplacer(func(e opt.Expr, replace memo.ReplaceFunc) opt.Expr {
+		return f.Replace(e, ReplaceFunc(replace))
+	})
 
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.


### PR DESCRIPTION
As of #120668 we now use statistics on virtual computed columns in
statistics builder. Simple queries that synthesize virtual columns in
Project expressions already benefit, because they use the virtual column
ID when synthesizing the virtual column.

Other expressions, however, do not directly use the virtual column ID
when synthesizing a virtual column. This includes Select expressions,
joins, constrained scans, and some Project expressions.

For example, consider a query like the following:

```
CREATE TABLE ab (a INT PRIMARY KEY, b INT AS (a % 10) VIRTUAL, INDEX (b));
SELECT * FROM ab WHERE a % 10 > 3;
```

Even though the filter condition is in terms of `a`, we'd like to use
the statistics on virtual computed column `b` since the expression
matches.

In order to do this, we replace `a % 10` with `b` in a copy of the
filter condition before doing any stats calculations. Then we perform
our normal stats calculations, using `b`.

Fixes: #68254
Fixes: #110146

Epic: CRDB-8949

Release note: None