### PR TITLE
roachtest: fix c2c/MultiRegion/SameRegions/kv0

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -534,7 +534,7 @@ func (rd *replicationDriver) setupC2C(
 	deprecatedCreateTenantAdminRole(t, "src-system", srcSQL)
 	deprecatedCreateTenantAdminRole(t, "dst-system", destSQL)
 
-	srcTenantID, destTenantID := 2, 2
+	srcTenantID, destTenantID := 3, 3
 	srcTenantName := "src-tenant"
 	destTenantName := "destination-tenant"
 


### PR DESCRIPTION
We changed how tenant IDs are allocated. Unfortunately we hard-code the ID here.

Fixes #120399
Release Note: none