### PR TITLE
kvclient: remove auth short-circuit

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2222,6 +2222,12 @@ func noMoreReplicasErr(ambiguousErr, replicaUnavailableErr, lastAttemptErr error
 		return replicaUnavailableErr
 	}
 
+	// Authentication and authorization errors should be propagated up rather than
+	// wrapped in a SendError and retried as they are likely to be fatal if they
+	// are returned from multiple servers.
+	if grpcutil.IsAuthError(lastAttemptErr) {
+		return lastAttemptErr
+	}
 	// TODO(bdarnell): The error from the last attempt is not necessarily the best
 	// one to return; we may want to remember the "best" error we've seen (for
 	// example, a NotLeaseHolderError conveys more information than a
@@ -2496,14 +2502,6 @@ func (ds *DistSender) sendToReplicas(
 
 		} else if err != nil {
 			log.VErrEventf(ctx, 2, "RPC error: %s", err)
-			if grpcutil.IsAuthError(err) {
-				// Authentication or authorization error. Propagate.
-				if ambiguousError != nil {
-					return nil, kvpb.NewAmbiguousResultErrorf("error=%v [propagate] (last error: %v)",
-						ambiguousError, err)
-				}
-				return nil, err
-			}
 
 			// For most connection errors, we cannot tell whether or not the request
 			// may have succeeded on the remote server (exceptions are captured in the

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -1353,12 +1353,11 @@ func TestDistSenderRetryOnTransportErrors(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	for _, spec := range []struct {
-		errorCode   codes.Code
-		shouldRetry bool
+		errorCode codes.Code
 	}{
-		{codes.FailedPrecondition, true},
-		{codes.PermissionDenied, false},
-		{codes.Unauthenticated, false},
+		{codes.FailedPrecondition},
+		{codes.PermissionDenied},
+		{codes.Unauthenticated},
 	} {
 		t.Run(fmt.Sprintf("retry_after_%v", spec.errorCode), func(t *testing.T) {
 			clock := hlc.NewClockForTesting(nil)
@@ -1424,13 +1423,8 @@ func TestDistSenderRetryOnTransportErrors(t *testing.T) {
 
 			get := kvpb.NewGet(roachpb.Key("a"))
 			_, pErr := kv.SendWrapped(ctx, ds, get)
-			if spec.shouldRetry {
-				require.True(t, secondReplicaTried, "Second replica was not retried")
-				require.Nil(t, pErr, "Call should not fail")
-			} else {
-				require.False(t, secondReplicaTried, "DistSender did not abort retry loop")
-				require.NotNil(t, pErr, "Call should fail")
-			}
+			require.True(t, secondReplicaTried, "Second replica was not retried")
+			require.Nil(t, pErr, "Call should not fail")
 		})
 	}
 }


### PR DESCRIPTION
Previously DistSender would short circuit attempting replicas if there was an auth failure. THe assumption was that the only reason for an auth error was due to the client having bad information and attempts against any other replicas would fail with the same error. This is an incorrect assumption for several reasons.

1) The auth error was caused by a server side certificate expiration. 
2) The receiver may have stale information.
  a) The receiver didn't know this node had yet joined.
	b) The receiver was using stale tenant authorization information.
3) The receiver needed to make an extra request to complete this batch
	 request and that request encountered an auth error which was part of
	 the returned error.
4) The receiver proxied the request and received an auth error on the
	 other side of the connection.
5) The remote server is removed from the cluster and can't validate our
	 auth information.

There may be other reasons as well either today or in the future. We still want to terminate the loop after one pass through the replicas, but we can't short circuit on the first auth error.

Epic: none

Release note: None