### PR TITLE
roachprod-microbench: add kill to timeout

### DIFF
--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -340,7 +340,7 @@ func (e *executor) executeBenchmarks() error {
 		runCommand := fmt.Sprintf("./run.sh %s -test.benchmem -test.bench=^%s$ -test.run=^$ -test.v",
 			strings.Join(e.testArgs, " "), bench.name)
 		if e.timeout != "" {
-			runCommand = fmt.Sprintf("timeout %s %s", e.timeout, runCommand)
+			runCommand = fmt.Sprintf("timeout -k 30s %s %s", e.timeout, runCommand)
 		}
 		if e.shellCommand != "" {
 			runCommand = fmt.Sprintf("%s && %s", e.shellCommand, runCommand)
@@ -395,7 +395,7 @@ func (e *executor) executeBenchmarks() error {
 				fmt.Println()
 			}
 			tag := fmt.Sprintf("%d", logIndex)
-			if response.ExitStatus == 124 {
+			if response.ExitStatus == 124 || response.ExitStatus == 137 {
 				tag = fmt.Sprintf("%d-timeout", logIndex)
 			}
 			err = report.writeBenchmarkErrorLogs(response, tag)


### PR DESCRIPTION
Previously, some microbenchmark executions became completely stuck, after timing out, and did not eventually terminate with the TERM signal. This change adds the "kill after" (-k) to the timeout command to ensure the process gets killed if the original signal was not enough.

Epic: None
Release Note: None