### PR TITLE
changefeedccl: skip `TestChangefeedWithSimpleDistributionStrategy`

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -496,6 +496,8 @@ func TestChangefeedWithSimpleDistributionStrategy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 120870)
+
 	// The test is slow and will time out under deadlock/race/stress.
 	skip.UnderShort(t)
 	skip.UnderDuress(t)


### PR DESCRIPTION
This test is flaky.

See #120870

Epic: none
Release note: None