### PR TITLE
sql: disable split queues for multitenant admin tests

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -174,11 +174,6 @@ func (s *Store) SetReplicaGCQueueActive(active bool) {
 	s.setReplicaGCQueueActive(active)
 }
 
-// SetSplitQueueActive enables or disables the split queue.
-func (s *Store) SetSplitQueueActive(active bool) {
-	s.setSplitQueueActive(active)
-}
-
 // SetMergeQueueActive enables or disables the merge queue.
 func (s *Store) SetMergeQueueActive(active bool) {
 	s.setMergeQueueActive(active)

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -129,7 +129,7 @@ func (s *Store) setReplicaGCQueueActive(active bool) {
 func (s *Store) SetReplicateQueueActive(active bool) {
 	s.replicateQueue.SetDisabled(!active)
 }
-func (s *Store) setSplitQueueActive(active bool) {
+func (s *Store) SetSplitQueueActive(active bool) {
 	s.splitQueue.SetDisabled(!active)
 }
 func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1699,7 +1699,7 @@ func NewStore(
 		s.SetReplicateQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableSplitQueue {
-		s.setSplitQueueActive(false)
+		s.SetSplitQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableTimeSeriesMaintenanceQueue {
 		s.setTimeSeriesMaintenanceQueueActive(false)

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -737,6 +737,7 @@ func TestRelocateVoters(t *testing.T) {
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
 					testCluster.ToggleReplicateQueues(false)
+					testCluster.ToggleSplitQueues(false)
 					replicaState := getReplicaState(
 						t,
 						ctx,
@@ -816,6 +817,7 @@ func TestExperimentalRelocateVoters(t *testing.T) {
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
 					testCluster.ToggleReplicateQueues(false)
+					testCluster.ToggleSplitQueues(false)
 					replicaState := getReplicaState(
 						t,
 						ctx,
@@ -908,6 +910,7 @@ func TestRelocateNonVoters(t *testing.T) {
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
 					testCluster.ToggleReplicateQueues(false)
+					testCluster.ToggleSplitQueues(false)
 					replicaState := getReplicaState(
 						t,
 						ctx,
@@ -981,6 +984,7 @@ func TestExperimentalRelocateNonVoters(t *testing.T) {
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
 					testCluster.ToggleReplicateQueues(false)
+					testCluster.ToggleSplitQueues(false)
 					replicaState := getReplicaState(
 						t,
 						ctx,

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -253,6 +253,10 @@ type TestClusterInterface interface {
 	// ToggleReplicateQueues activates or deactivates the replication queues on all
 	// the stores on all the nodes.
 	ToggleReplicateQueues(active bool)
+
+	// TogglesplitQueues activates or deactivates the split queues on all
+	// the stores on all the nodes.
+	ToggleSplitQueues(active bool)
 }
 
 // SplitPoint describes a split point that is passed to SplitTable.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1613,6 +1613,16 @@ func (tc *TestCluster) ToggleReplicateQueues(active bool) {
 	}
 }
 
+// ToggleSplitQueues implements TestClusterInterface.
+func (tc *TestCluster) ToggleSplitQueues(active bool) {
+	for _, s := range tc.Servers {
+		_ = s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
+			store.SetSplitQueueActive(active)
+			return nil
+		})
+	}
+}
+
 // ReadIntFromStores reads the current integer value at the given key
 // from all configured engines on un-stopped servers, filling in zeros
 // when the value is not found.


### PR DESCRIPTION
These tests need exact control over replicas to test relocating ranges.
The recent change in ec14795 made it so split points are added to system
tables when applying the ExcludeDataFromBackup flag. This test doesn't
care about those splits, so we can just disable the queue.

fixes https://github.com/cockroachdb/cockroach/issues/120772
fixes https://github.com/cockroachdb/cockroach/issues/120847
Release note: None