### PR TITLE
roachtest: disable MVCC stats recomputation during split for large-range roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -634,6 +634,11 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='512MiB'`); err != nil {
 				return err
 			}
+			// This test splits an exceptionally large range. Disable MVCC stats
+			// re-computation to ensure the splits happen in a timely manner.
+			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.split.mvcc_stats_recomputation.enabled = 'false'`); err != nil {
+				return err
+			}
 			// Set the range size to a multiple of what we expect the size of the
 			// bank table to be. This should result in the table fitting
 			// inside a single range.


### PR DESCRIPTION
The splits/largerange/size=32GiB,nodes=6 roachtest splits a 32-GB range iteratively. Re-computing stats for each of those splits takes a long time, so we disable stats re-computation for the test.

Fixes: #120885

Release note: None