### PR TITLE
release-23.2: util/mon: remove somewhat redundant numChildren field

### DIFF
--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -30,3 +30,4 @@ util
 util/admission
 util/hlc
 util/intsets
+util/mon


### PR DESCRIPTION
This commit is a reduced version of 33b1b611d666d9420e543495fdce2ef341a88dbc. It is being backported in order to avoid any possible downsides of using COCKROACH_ENABLE_MONITOR_TREE env var which, if disabled, makes it so that we don't increment `numChildren` but keep decrementing it.

This is effectively a philosophical fix of an issue that shouldn't manifest itself in any way.

Kudos to Nathan for identifying this.

Epic: None

Release note: None

Release justification: low-risk improvement.