### PR TITLE
ui: add WAL fsync latency to storage dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -70,6 +70,40 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="WAL Fsync Latency"
+      sources={storeSources}
+      isKvGraph={true}
+      tenantSource={tenantSource}
+      tooltip={`The latency for fsyncs to the storage engine's write-ahead log.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {_.map(nodeIDs, nid => (
+          <>
+            <Metric
+              key={nid}
+              name="cr.store.storage.wal.fsync.latency-p99.9"
+              title={"p99.9 " + getNodeNameById(nid)}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            />
+            <Metric
+              key={nid}
+              name="cr.store.storage.wal.fsync.latency-p99.99"
+              title={"p99.99 " + getNodeNameById(nid)}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            />
+            <Metric
+              key={nid}
+              name="cr.store.storage.wal.fsync.latency-max"
+              title={"p100 " + getNodeNameById(nid)}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            />
+          </>
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Log Commit Latency: 99th Percentile"
       sources={storeSources}
       isKvGraph={true}


### PR DESCRIPTION
Running kv0 locally
<img width="884" alt="Screenshot 2024-03-22 at 5 31 31 PM" src="https://github.com/cockroachdb/cockroach/assets/54990988/88b0de08-edc1-48b1-8c65-d26d7f154fa3">

Fixes #119792

Epic: none


Release note: None