### PR TITLE
storage: clean up engine options

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -784,30 +784,6 @@ func maxInflightBytesFrom(maxInflightMsgs int, maxSizePerMsg uint64) uint64 {
 	return math.MaxUint64
 }
 
-// StorageConfig contains storage configs for all storage engine.
-type StorageConfig struct {
-	Attrs roachpb.Attributes
-	// Dir is the data directory for the Pebble instance.
-	Dir string
-	// If true, creating the instance fails if the target directory does not hold
-	// an initialized instance.
-	//
-	// Makes no sense for in-memory instances.
-	MustExist bool
-	// MaxSize is used for calculating free space and making rebalancing
-	// decisions. Zero indicates that there is no maximum size.
-	MaxSize int64
-	// BallastSize is the amount reserved by a ballast file for manual
-	// out-of-disk recovery.
-	BallastSize int64
-	// Settings instance for cluster-wide knobs. Must not be nil.
-	Settings *cluster.Settings
-	// EncryptionOptions is a serialized protobuf set by Go CCL code describing
-	// the encryption-at-rest configuration. If encryption-at-rest has ever been
-	// enabled on the store, this field must be set.
-	EncryptionOptions []byte
-}
-
 const (
 	// DefaultTempStorageMaxSizeBytes is the default maximum budget
 	// for temp storage.

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -59,7 +59,7 @@ type initialState interface {
 var previousReleaseFormatMajorVersion = pebbleFormatVersion(clusterversion.PreviousRelease.Version())
 
 var previousReleaseFormatMajorVersionOpt ConfigOption = func(cfg *engineConfig) error {
-	cfg.PebbleConfig.Opts.FormatMajorVersion = previousReleaseFormatMajorVersion
+	cfg.opts.FormatMajorVersion = previousReleaseFormatMajorVersion
 	return nil
 }
 

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -2024,7 +2024,7 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 	ctx := context.Background()
 	eng, err := Open(ctx, InMemory(), st, CacheSize(testCacheSize),
 		func(cfg *engineConfig) error {
-			cfg.Opts.DisableAutomaticCompactions = true
+			cfg.opts.DisableAutomaticCompactions = true
 			return nil
 		})
 	require.NoError(b, err)

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1386,7 +1386,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 
 	ingest := func(it EngineIterator, valid bool, err error, count int) {
 		memFile := &MemObject{}
-		sst := MakeIngestionSSTWriter(ctx, db2.settings, memFile)
+		sst := MakeIngestionSSTWriter(ctx, db2.cfg.settings, memFile)
 		defer sst.Close()
 
 		for i := 0; i < count; i++ {

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4097,8 +4097,8 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 	eng, err := Open(
 		context.Background(), InMemory(), cluster.MakeTestingClusterSettings(),
 		func(cfg *engineConfig) error {
-			cfg.Opts.LBaseMaxBytes = int64(100 + rng.Intn(16384))
-			log.Infof(ctx, "lbase: %d", cfg.Opts.LBaseMaxBytes)
+			cfg.opts.LBaseMaxBytes = int64(100 + rng.Intn(16384))
+			log.Infof(ctx, "lbase: %d", cfg.opts.LBaseMaxBytes)
 			return nil
 		})
 	require.NoError(t, err)

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -46,28 +46,28 @@ func CombineOptions(opts ...ConfigOption) ConfigOption {
 // MustExist configures an engine to error on Open if the target directory
 // does not contain an initialized store.
 var MustExist ConfigOption = func(cfg *engineConfig) error {
-	cfg.MustExist = true
+	cfg.mustExist = true
 	return nil
 }
 
 // DisableAutomaticCompactions configures an engine to be opened with disabled
 // automatic compactions. Used primarily for debugCompactCmd.
 var DisableAutomaticCompactions ConfigOption = func(cfg *engineConfig) error {
-	cfg.Opts.DisableAutomaticCompactions = true
+	cfg.opts.DisableAutomaticCompactions = true
 	return nil
 }
 
 // ForceWriterParallelism configures an engine to be opened with disabled
 // automatic compactions. Used primarily for debugCompactCmd.
 var ForceWriterParallelism ConfigOption = func(cfg *engineConfig) error {
-	cfg.Opts.Experimental.ForceWriterParallelism = true
+	cfg.opts.Experimental.ForceWriterParallelism = true
 	return nil
 }
 
 // ForTesting configures the engine for use in testing. It may randomize some
 // config options to improve test coverage.
 var ForTesting ConfigOption = func(cfg *engineConfig) error {
-	cfg.onClose = append(cfg.onClose, func(p *Pebble) {
+	cfg.beforeClose = append(cfg.beforeClose, func(p *Pebble) {
 		m := p.db.Metrics()
 		if m.Keys.MissizedTombstonesCount > 0 {
 			// A missized tombstone is a Pebble DELSIZED tombstone that encodes
@@ -84,7 +84,7 @@ var ForTesting ConfigOption = func(cfg *engineConfig) error {
 // Attributes configures the engine's attributes.
 func Attributes(attrs roachpb.Attributes) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Attrs = attrs
+		cfg.attrs = attrs
 		return nil
 	}
 }
@@ -93,7 +93,7 @@ func Attributes(attrs roachpb.Attributes) ConfigOption {
 // calculating free space and making rebalancing decisions.
 func MaxSize(size int64) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.MaxSize = size
+		cfg.maxSize = size
 		return nil
 	}
 }
@@ -101,9 +101,9 @@ func MaxSize(size int64) ConfigOption {
 // BlockSize sets the engine block size, primarily for testing purposes.
 func BlockSize(size int) ConfigOption {
 	return func(cfg *engineConfig) error {
-		for i := range cfg.Opts.Levels {
-			cfg.Opts.Levels[i].BlockSize = size
-			cfg.Opts.Levels[i].IndexBlockSize = size
+		for i := range cfg.opts.Levels {
+			cfg.opts.Levels[i].BlockSize = size
+			cfg.opts.Levels[i].IndexBlockSize = size
 		}
 		return nil
 	}
@@ -113,8 +113,8 @@ func BlockSize(size int) ConfigOption {
 // primarily for testing purposes.
 func TargetFileSize(size int64) ConfigOption {
 	return func(cfg *engineConfig) error {
-		for i := range cfg.Opts.Levels {
-			cfg.Opts.Levels[i].TargetFileSize = size
+		for i := range cfg.opts.Levels {
+			cfg.opts.Levels[i].TargetFileSize = size
 		}
 		return nil
 	}
@@ -126,7 +126,7 @@ func TargetFileSize(size int64) ConfigOption {
 // of 1 or more.
 func MaxWriterConcurrency(concurrency int) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Opts.Experimental.MaxWriterConcurrency = concurrency
+		cfg.opts.Experimental.MaxWriterConcurrency = concurrency
 		return nil
 	}
 }
@@ -134,7 +134,7 @@ func MaxWriterConcurrency(concurrency int) ConfigOption {
 // MaxOpenFiles sets the maximum number of files an engine should open.
 func MaxOpenFiles(count int) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Opts.MaxOpenFiles = count
+		cfg.opts.MaxOpenFiles = count
 		return nil
 	}
 
@@ -152,8 +152,8 @@ func CacheSize(size int64) ConfigOption {
 // the same caches.
 func Caches(cache *pebble.Cache, tableCache *pebble.TableCache) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Opts.Cache = cache
-		cfg.Opts.TableCache = tableCache
+		cfg.opts.Cache = cache
+		cfg.opts.TableCache = tableCache
 		return nil
 	}
 }
@@ -162,7 +162,7 @@ func Caches(cache *pebble.Cache, tableCache *pebble.TableCache) ConfigOption {
 // out-of-disk recovery.
 func BallastSize(size int64) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.BallastSize = size
+		cfg.ballastSize = size
 		return nil
 	}
 }
@@ -170,9 +170,9 @@ func BallastSize(size int64) ConfigOption {
 // SharedStorage enables use of shared storage (experimental).
 func SharedStorage(sharedStorage cloud.ExternalStorage) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.SharedStorage = sharedStorage
-		if cfg.SharedStorage != nil && cfg.Opts.FormatMajorVersion < pebble.FormatMinForSharedObjects {
-			cfg.Opts.FormatMajorVersion = pebble.FormatMinForSharedObjects
+		cfg.sharedStorage = sharedStorage
+		if cfg.sharedStorage != nil && cfg.opts.FormatMajorVersion < pebble.FormatMinForSharedObjects {
+			cfg.opts.FormatMajorVersion = pebble.FormatMinForSharedObjects
 		}
 		return nil
 	}
@@ -181,7 +181,7 @@ func SharedStorage(sharedStorage cloud.ExternalStorage) ConfigOption {
 // SecondaryCache enables use of a secondary cache to store shared objects.
 func SecondaryCache(size int64) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Opts.Experimental.SecondaryCacheSizeBytes = size
+		cfg.opts.Experimental.SecondaryCacheSizeBytes = size
 		return nil
 	}
 }
@@ -189,7 +189,7 @@ func SecondaryCache(size int64) ConfigOption {
 // RemoteStorageFactory enables use of remote storage (experimental).
 func RemoteStorageFactory(accessor *cloud.EarlyBootExternalStorageAccessor) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.RemoteStorageFactory = accessor
+		cfg.remoteStorageFactory = accessor
 		return nil
 	}
 }
@@ -198,7 +198,7 @@ func RemoteStorageFactory(accessor *cloud.EarlyBootExternalStorageAccessor) Conf
 // compactions an Engine will execute.
 func MaxConcurrentCompactions(n int) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Opts.MaxConcurrentCompactions = func() int { return n }
+		cfg.opts.MaxConcurrentCompactions = func() int { return n }
 		return nil
 	}
 }
@@ -206,7 +206,7 @@ func MaxConcurrentCompactions(n int) ConfigOption {
 // LBaseMaxBytes configures the maximum number of bytes for LBase.
 func LBaseMaxBytes(v int64) ConfigOption {
 	return func(cfg *engineConfig) error {
-		cfg.Opts.LBaseMaxBytes = v
+		cfg.opts.LBaseMaxBytes = v
 		return nil
 	}
 }
@@ -223,22 +223,22 @@ func makeExternalWALDir(engineCfg *engineConfig, externalDir base.ExternalPath) 
 	// If the store is encrypted, we require that all the WAL failover dirs also
 	// be encrypted so that the user doesn't accidentally leak data unencrypted
 	// onto the filesystem.
-	if engineCfg.Env.Encryption != nil && len(externalDir.EncryptionOptions) == 0 {
+	if engineCfg.env.Encryption != nil && len(externalDir.EncryptionOptions) == 0 {
 		return wal.Dir{}, errors.Newf("must provide --enterprise-encryption flag for %q, used as WAL failover path for encrypted store %q",
-			externalDir.Path, engineCfg.Env.Dir)
+			externalDir.Path, engineCfg.env.Dir)
 	}
-	if engineCfg.Env.Encryption == nil && len(externalDir.EncryptionOptions) != 0 {
+	if engineCfg.env.Encryption == nil && len(externalDir.EncryptionOptions) != 0 {
 		return wal.Dir{}, errors.Newf("must provide --enterprise-encryption flag for store %q, specified WAL failover path %q is encrypted",
-			engineCfg.Env.Dir, externalDir.Path)
+			engineCfg.env.Dir, externalDir.Path)
 	}
 	env, err := fs.InitEnv(context.Background(), vfs.Default, externalDir.Path, fs.EnvConfig{
-		RW:                engineCfg.Env.RWMode(),
+		RW:                engineCfg.env.RWMode(),
 		EncryptionOptions: externalDir.EncryptionOptions,
 	})
 	if err != nil {
 		return wal.Dir{}, err
 	}
-	engineCfg.onClose = append(engineCfg.onClose, func(*Pebble) { env.Close() })
+	engineCfg.afterClose = append(engineCfg.afterClose, env.Close)
 	return wal.Dir{
 		FS:      env,
 		Dirname: externalDir.Path,
@@ -268,7 +268,7 @@ func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption 
 					if err != nil {
 						return err
 					}
-					cfg.Opts.WALRecoveryDirs = append(cfg.Opts.WALRecoveryDirs, walDir)
+					cfg.opts.WALRecoveryDirs = append(cfg.opts.WALRecoveryDirs, walDir)
 					return nil
 				}
 			}
@@ -285,13 +285,13 @@ func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption 
 				if err != nil {
 					return err
 				}
-				cfg.Opts.WALFailover = makePebbleWALFailoverOptsForDir(cfg.Settings, walDir)
+				cfg.opts.WALFailover = makePebbleWALFailoverOptsForDir(cfg.settings, walDir)
 				if walCfg.PrevPath.IsSet() {
 					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath)
 					if err != nil {
 						return err
 					}
-					cfg.Opts.WALRecoveryDirs = append(cfg.Opts.WALRecoveryDirs, walDir)
+					cfg.opts.WALRecoveryDirs = append(cfg.opts.WALRecoveryDirs, walDir)
 				}
 				return nil
 			}
@@ -365,19 +365,16 @@ func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption 
 	}
 	return func(cfg *engineConfig) error {
 		// Find the Env being opened in the slice of sorted envs.
-		idx, ok := indexOfEnv(cfg.Env)
+		idx, ok := indexOfEnv(cfg.env)
 		if !ok {
-			panic(errors.AssertionFailedf("storage: opening a store with an unrecognized filesystem Env (dir=%s)", cfg.Env.Dir))
+			panic(errors.AssertionFailedf("storage: opening a store with an unrecognized filesystem Env (dir=%s)", cfg.env.Dir))
 		}
 		failoverIdx := (idx + 1) % len(sortedEnvs)
 		secondaryEnv := sortedEnvs[failoverIdx]
 		// Ref once to ensure the secondary Env isn't closed before this Engine has
 		// been closed if the secondary's corresponding Engine is closed first.
 		secondaryEnv.Ref()
-		cfg.onClose = append(cfg.onClose, func(p *Pebble) {
-			// Release the reference.
-			secondaryEnv.Close()
-		})
+		cfg.afterClose = append(cfg.afterClose, secondaryEnv.Close)
 
 		secondary := wal.Dir{
 			FS: secondaryEnv,
@@ -385,11 +382,11 @@ func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption 
 			Dirname: secondaryEnv.PathJoin(secondaryEnv.Dir, base.AuxiliaryDir, "wals-among-stores"),
 		}
 		if walCfg.Mode == base.WALFailoverAmongStores {
-			cfg.Opts.WALFailover = makePebbleWALFailoverOptsForDir(cfg.Settings, secondary)
+			cfg.opts.WALFailover = makePebbleWALFailoverOptsForDir(cfg.settings, secondary)
 			return nil
 		}
 		// mode == WALFailoverDisabled
-		cfg.Opts.WALRecoveryDirs = append(cfg.Opts.WALRecoveryDirs, secondary)
+		cfg.opts.WALRecoveryDirs = append(cfg.opts.WALRecoveryDirs, secondary)
 		return nil
 	}
 }
@@ -425,7 +422,7 @@ func makePebbleWALFailoverOptsForDir(
 // flush_split_bytes=4096
 func PebbleOptions(pebbleOptions string, parseHooks *pebble.ParseHooks) ConfigOption {
 	return func(cfg *engineConfig) error {
-		return cfg.Opts.Parse(pebbleOptions, parseHooks)
+		return cfg.opts.Parse(pebbleOptions, parseHooks)
 	}
 }
 
@@ -442,15 +439,6 @@ func If(enable bool, opt ConfigOption) ConfigOption {
 // TODO(jackson): Update callers to use fs.InMemory directly.
 var InMemory = fs.InMemory
 
-type engineConfig struct {
-	PebbleConfig
-	// cacheSize is stored separately so that we can avoid constructing the
-	// PebbleConfig.Opts.Cache until the call to Open. A Cache is created with
-	// a ref count of 1, so creating the Cache during execution of
-	// ConfigOption makes it too easy to leak a cache.
-	cacheSize *int64
-}
-
 // Open opens a new Pebble storage engine, reading and writing data to the
 // provided fs.Env, configured with the provided options.
 //
@@ -461,23 +449,25 @@ type engineConfig struct {
 func Open(
 	ctx context.Context, env *fs.Env, settings *cluster.Settings, opts ...ConfigOption,
 ) (*Pebble, error) {
+	if settings == nil {
+		return nil, errors.AssertionFailedf("Open requires non-nil *cluster.Settings")
+	}
 	var cfg engineConfig
-	cfg.Dir = env.Dir
-	cfg.Env = env
-	cfg.Settings = settings
-	cfg.Opts = DefaultPebbleOptions()
-	cfg.Opts.FS = env
-	cfg.Opts.ReadOnly = env.IsReadOnly()
+	cfg.env = env
+	cfg.settings = settings
+	cfg.opts = DefaultPebbleOptions()
+	cfg.opts.FS = env
+	cfg.opts.ReadOnly = env.IsReadOnly()
 	for _, opt := range opts {
 		if err := opt(&cfg); err != nil {
 			return nil, err
 		}
 	}
-	if cfg.cacheSize != nil && cfg.Opts.Cache == nil {
-		cfg.Opts.Cache = pebble.NewCache(*cfg.cacheSize)
-		defer cfg.Opts.Cache.Unref()
+	if cfg.cacheSize != nil && cfg.opts.Cache == nil {
+		cfg.opts.Cache = pebble.NewCache(*cfg.cacheSize)
+		defer cfg.opts.Cache.Unref()
 	}
-	p, err := newPebble(ctx, cfg.PebbleConfig)
+	p, err := newPebble(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -525,7 +525,7 @@ func TestPebbleKeyValidationFunc(t *testing.T) {
 	// Fatalf.
 	l := &nonFatalLogger{t: t}
 	opt := func(cfg *engineConfig) error {
-		cfg.Opts.LoggerAndTracer = l
+		cfg.opts.LoggerAndTracer = l
 		return nil
 	}
 	engine := createTestPebbleEngine(opt).(*Pebble)
@@ -639,10 +639,10 @@ func TestPebbleMVCCTimeIntervalCollectorAndFilter(t *testing.T) {
 	// Set up an engine with tiny blocks, so each point key gets its own block,
 	// and disable compactions to keep SSTs separate.
 	overrideOptions := func(cfg *engineConfig) error {
-		cfg.Opts.DisableAutomaticCompactions = true
-		for i := range cfg.Opts.Levels {
-			cfg.Opts.Levels[i].BlockSize = 1
-			cfg.Opts.Levels[i].IndexBlockSize = 1
+		cfg.opts.DisableAutomaticCompactions = true
+		for i := range cfg.opts.Levels {
+			cfg.opts.Levels[i].BlockSize = 1
+			cfg.opts.Levels[i].IndexBlockSize = 1
 		}
 		return nil
 	}
@@ -780,10 +780,10 @@ func TestPebbleMVCCTimeIntervalWithClears(t *testing.T) {
 	// separate SSTs when the clearing SST does not satisfy the filter. We
 	// disable compactions to keep SSTs separate.
 	overrideOptions := func(cfg *engineConfig) error {
-		cfg.Opts.DisableAutomaticCompactions = true
-		for i := range cfg.Opts.Levels {
-			cfg.Opts.Levels[i].BlockSize = 65536
-			cfg.Opts.Levels[i].IndexBlockSize = 65536
+		cfg.opts.DisableAutomaticCompactions = true
+		for i := range cfg.opts.Levels {
+			cfg.opts.Levels[i].BlockSize = 65536
+			cfg.opts.Levels[i].IndexBlockSize = 65536
 		}
 		return nil
 	}
@@ -893,10 +893,10 @@ func TestPebbleMVCCTimeIntervalWithRangeClears(t *testing.T) {
 	// Set up an engine with tiny blocks, so each point key gets its own block,
 	// and disable compactions to keep SSTs separate.
 	overrideOptions := func(cfg *engineConfig) error {
-		cfg.Opts.DisableAutomaticCompactions = true
-		for i := range cfg.Opts.Levels {
-			cfg.Opts.Levels[i].BlockSize = 1
-			cfg.Opts.Levels[i].IndexBlockSize = 1
+		cfg.opts.DisableAutomaticCompactions = true
+		for i := range cfg.opts.Levels {
+			cfg.opts.Levels[i].BlockSize = 1
+			cfg.opts.Levels[i].IndexBlockSize = 1
 		}
 		return nil
 	}

--- a/pkg/storage/store_properties.go
+++ b/pkg/storage/store_properties.go
@@ -19,23 +19,23 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func computeStoreProperties(ctx context.Context, cfg PebbleConfig) roachpb.StoreProperties {
+func computeStoreProperties(ctx context.Context, cfg engineConfig) roachpb.StoreProperties {
 	props := roachpb.StoreProperties{
-		Dir:       cfg.Dir,
-		ReadOnly:  cfg.Env.IsReadOnly(),
-		Encrypted: cfg.Env.Encryption != nil,
+		Dir:       cfg.env.Dir,
+		ReadOnly:  cfg.env.IsReadOnly(),
+		Encrypted: cfg.env.Encryption != nil,
 	}
-	if cfg.Opts.WALFailover != nil {
+	if cfg.opts.WALFailover != nil {
 		props.WalFailoverPath = new(string)
-		*props.WalFailoverPath = cfg.Opts.WALFailover.Secondary.Dirname
+		*props.WalFailoverPath = cfg.opts.WALFailover.Secondary.Dirname
 	}
 
 	// In-memory store?
-	if cfg.Dir == "" {
+	if cfg.env.Dir == "" {
 		return props
 	}
 
-	fsprops := getFileSystemProperties(ctx, cfg.Dir)
+	fsprops := getFileSystemProperties(ctx, cfg.env.Dir)
 	props.FileStoreProperties = &fsprops
 	return props
 }

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -91,10 +91,10 @@ func newPebbleTempEngine(
 			// caller-provided key is used as-is (with the prefix prepended). See
 			// pebbleMap.makeKey and pebbleMap.makeKeyWithSequence on how this works.
 			// Use the default bytes.Compare-like comparer.
-			cfg.Opts.Comparer = pebble.DefaultComparer
-			cfg.Opts.DisableWAL = true
-			cfg.Opts.Experimental.KeyValidationFunc = nil
-			cfg.Opts.BlockPropertyCollectors = nil
+			cfg.opts.Comparer = pebble.DefaultComparer
+			cfg.opts.DisableWAL = true
+			cfg.opts.Experimental.KeyValidationFunc = nil
+			cfg.opts.BlockPropertyCollectors = nil
 			return nil
 		},
 	)


### PR DESCRIPTION
This commit refactors the various configuration structs that carry engine configuraton. Previously, there was engineConfig, PebbleConfig and base.StorageConfig. Now these three are consolidated into engineConfig which is then embedded onto the Pebble struct. Some fields that are were on Pebble but duplicated on the fs.Env have been removed from Pebble. Additionally the onClose slice has been split into beforeClose and afterClose, because the funcs registered had different expectations around when they would be called.

Epic: none
Release note: none