### PR TITLE
release-23.1: util/mon: remove somewhat redundant numChildren field

### DIFF
--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -27,3 +27,4 @@ util
 util/admission
 util/hlc
 util/intsets
+util/mon

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -206,10 +206,6 @@ type BytesMonitor struct {
 		// current monitor's lock.
 		head *BytesMonitor
 
-		// numChildren is the number of children of this BytesMonitor (i.e. the
-		// number of nodes in the linked list).
-		numChildren int
-
 		// stopped indicates whether this monitor has been stopped.
 		stopped bool
 	}
@@ -341,7 +337,10 @@ func (mm *BytesMonitor) traverseTree(level int, monitorStateCb func(MonitorState
 	// Note that we cannot call traverseTree on the children while holding mm's
 	// lock since it could lead to deadlocks. Instead, we store all children as
 	// of right now, and then export them after unlocking ourselves.
-	children := make([]*BytesMonitor, 0, mm.mu.numChildren)
+	//
+	//gcassert:noescape
+	var childrenAlloc [8]*BytesMonitor
+	children := childrenAlloc[:0]
 	for c := mm.mu.head; c != nil; c = c.parentMu.nextSibling {
 		children = append(children, c)
 	}
@@ -509,7 +508,6 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 				mm.parentMu.nextSibling = s
 			}
 			pool.mu.head = mm
-			pool.mu.numChildren++
 			pool.mu.Unlock()
 		}
 		effectiveLimit = pool.limit
@@ -627,7 +625,6 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 		if next != nil {
 			next.parentMu.prevSibling = prev
 		}
-		parent.mu.numChildren--
 		// Lose the references to siblings to aid GC.
 		mm.parentMu.prevSibling, mm.parentMu.nextSibling = nil, nil
 		parent.mu.Unlock()


### PR DESCRIPTION
Backport of #120913.

This commit is a reduced version of 33b1b611d666d9420e543495fdce2ef341a88dbc. It is being backported in order to avoid any possible downsides of using COCKROACH_ENABLE_MONITOR_TREE env var which, if disabled, makes it so that we don't increment `numChildren` but keep decrementing it.

This is effectively a philosophical fix of an issue that shouldn't manifest itself in any way.

Kudos to Nathan for identifying this.

Epic: None

Release note: None

Release justification: low-risk improvement.