### PR TITLE
roachprod: add faster restarts, prettier multi-node sql printing

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -199,6 +199,8 @@ func initFlags() {
 		"encrypt", startOpts.EncryptedStores, "start nodes with encryption at rest turned on")
 	startCmd.Flags().BoolVar(&startOpts.SkipInit,
 		"skip-init", startOpts.SkipInit, "skip initializing the cluster")
+	startCmd.Flags().BoolVar(&startOpts.IsRestart,
+		"restart", startOpts.IsRestart, "restart an existing cluster (skips serial start and init)")
 	startCmd.Flags().IntVar(&startOpts.InitTarget,
 		"init-target", startOpts.InitTarget, "node on which to run initialization")
 	startCmd.Flags().IntVar(&startOpts.StoreCount,

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -17,17 +17,18 @@ case $1 in
       set -- start "--restart" "$@"
     fi
     if [[ "$*" != *"--secure"* ]]; then
-      echo "--secure is implied when starting DRT clusters, adding it"
-      set -- "$@" "--secure"
+      shift
+      set -- start "--secure" "$@"
     fi
     if [[ "$*" != *"--sql-port 26257"* ]]; then
-     echo "--sql-port 26257 is implied when starting DRT clusters, adding it"
-      set -- "$@" "--sql-port" "26257"
+      shift
+      set -- start "--sql-port" "26257" "$@"
     fi
     ;;
   "sql")
     if [[ "$*" != *"--secure"* ]]; then
-      set -- "$@" "--secure"
+      shift
+      set -- sql --secure "$@"
     fi
     ;;
   "dns")

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -11,6 +11,11 @@ export ROACHPROD_DNS="drt.crdb.io"
 
 case $1 in
   "start")
+    if [[ "$*" != *"--restart"* ]]; then
+      # implied for long-lived DRT clusters; avoid on init w/ --restart=false.
+      shift
+      set -- start "--restart" "$@"
+    fi
     if [[ "$*" != *"--secure"* ]]; then
       echo "--secure is implied when starting DRT clusters, adding it"
       set -- "$@" "--secure"


### PR DESCRIPTION
A couple minor quality-of-life improvements motivated by working on long-lived, multi-node DRT clusters.