### PR TITLE
sql: miscellaneous cleanup around OUT parameters

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
@@ -262,3 +262,96 @@ NOTICE: new value of i: 4
 NOTICE: returning
 
 subtest end
+
+# TODO(120818): uncomment these tests.
+# statement ok
+# CREATE PROCEDURE p_inner(OUT p_param INT) AS $$ SELECT 1; $$ LANGUAGE SQL;
+#
+# statement ok
+# CREATE FUNCTION f(OUT f_param INT) AS $$ BEGIN CALL p_inner(NULL); END; $$ LANGUAGE PLpgSQL;
+#
+# statement error pgcode 42601 procedure parameter "param" is an output parameter but corresponding argument is not writable
+# SELECT f();
+#
+# statement ok
+# CREATE OR REPLACE FUNCTION f(OUT f_param INT) AS $$ BEGIN CALL p_inner(f_param); END; $$ LANGUAGE PLpgSQL;
+#
+# query I colnames
+# SELECT f();
+# ----
+# f
+# 1
+#
+# query I colnames
+# SELECT * FROM f();
+# ----
+# f_param
+# 1
+#
+# statement ok
+# CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+# DECLARE
+#   v INT;
+# BEGIN
+#   CALL p_inner(v);
+#   RETURN v;
+# END; $$ LANGUAGE PLpgSQL;
+#
+# query I colnames
+# SELECT f();
+# ----
+# f
+# 1
+#
+# query I colnames
+# SELECT * FROM f();
+# ----
+# f
+# 1
+#
+# statement ok
+# DROP FUNCTION f;
+#
+# statement ok
+# CREATE PROCEDURE p_outer(OUT p_outer_param INT) AS $$ BEGIN CALL p_inner(p_outer_param); END; $$ LANGUAGE PLpgSQL;
+#
+# query I colnames
+# CALL p_outer(NULL);
+# ----
+# p_outer_param
+# 1
+#
+# statement ok
+# CREATE OR REPLACE PROCEDURE p_outer(OUT p_outer_param INT) AS $$
+# DECLARE
+#   v INT;
+# BEGIN
+#   CALL p_inner(v);
+# END; $$ LANGUAGE PLpgSQL;
+#
+# query I colnames
+# CALL p_outer(NULL);
+# ----
+# p_outer_param
+# NULL
+#
+# statement ok
+# CREATE OR REPLACE PROCEDURE p_outer(OUT p_outer_param INT) AS $$
+# DECLARE
+#   v INT;
+# BEGIN
+#   CALL p_inner(v);
+#   SELECT v INTO p_outer_param;
+# END; $$ LANGUAGE PLpgSQL;
+#
+# query I colnames
+# CALL p_outer(NULL);
+# ----
+# p_outer_param
+# 1
+#
+# statement ok
+# DROP PROCEDURE p_outer;
+#
+# statement ok
+# DROP PROCEDURE p_inner;

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_params
@@ -69,7 +69,7 @@ SELECT f(3);
 ----
 NOTICE: 2
 
-# TODO(100405): figure out why this causes an internal error.
+# TODO(120942): figure out why this causes an internal error.
 # query II colnames
 # SELECT * FROM f(3);
 # ----
@@ -129,7 +129,7 @@ NOTICE: 1 <NULL>
 NOTICE: 3 <NULL>
 NOTICE: 3 4
 
-# TODO(100405): figure this out.
+# TODO(120942): figure this out.
 # query II colnames
 # SELECT * FROM f(1);
 # ----

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -950,8 +950,6 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 	if s.types == nil || len(s.types.scalarTypes) == 0 {
 		paramCnt = 0
 	}
-	// TODO(100405): Add support for non-default param classes. Currently, only IN
-	// parameters are supported.
 	// TODO(100962): Set a param default value sometimes.
 	params := make(tree.RoutineParams, paramCnt)
 	paramTypes := make(tree.ParamTypes, paramCnt)
@@ -966,9 +964,12 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 			ptyp = s.randType()
 		}
 		pname := fmt.Sprintf("p%d", i)
+		// TODO(88947): choose VARIADIC once supported too.
+		const numSupportedParamClasses = 4
 		params[i] = tree.RoutineParam{
-			Name: tree.Name(pname),
-			Type: ptyp,
+			Name:  tree.Name(pname),
+			Type:  ptyp,
+			Class: tree.RoutineParamClass(s.rnd.Intn(numSupportedParamClasses)),
 		}
 		paramTypes[i] = tree.ParamType{
 			Name: pname,

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -406,3 +406,26 @@ statement error pgcode 42P13 null input attribute not allowed in procedure defin
 CREATE PROCEDURE pv() AS 'SELECT 1' STRICT LANGUAGE SQL;
 
 subtest end
+
+statement error pgcode 42809 sum is not a procedure
+CALL sum(1);
+
+statement error pgcode 42809 first_value\(int\) is not a procedure
+CALL first_value(1);
+
+statement error pgcode 42809 addgeometrycolumn is not a procedure
+CALL addgeometrycolumn(null, null, null, null, null);
+
+statement ok
+CREATE PROCEDURE p_inner(OUT param INTEGER) AS $$ SELECT 1; $$ LANGUAGE SQL;
+
+skipif config local-mixed-23.2
+statement error pgcode 0A000 calling procedures with output arguments is not supported in SQL functions
+CREATE FUNCTION f() RETURNS INT AS $$ CALL p_inner(NULL); $$ LANGUAGE SQL;
+
+skipif config local-mixed-23.2
+statement error pgcode 0A000 calling procedures with output arguments is not supported in SQL functions
+CREATE PROCEDURE p_outer(OUT param INTEGER) AS $$ CALL p_inner(NULL); $$ LANGUAGE SQL;
+
+statement ok
+DROP PROCEDURE p_inner;

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -501,7 +501,7 @@ CREATE TYPE typ AS (a INT, b INT);
 statement ok
 CREATE PROCEDURE p_udt(OUT typ) AS $$ SELECT (1, 2); $$ LANGUAGE SQL;
 
-# TODO(100405): this currently results in an internal error.
+# TODO(120942): this currently results in an internal error.
 # query T colnames
 # CALL p_udt(NULL);
 # ----

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -146,6 +146,10 @@ type Builder struct {
 	// UDF.
 	insideUDF bool
 
+	// insideSQLRoutine is true when the current expressions are being built
+	// within a SQL UDF or a SQL procedure.
+	insideSQLRoutine bool
+
 	// insideDataSource is true when we are processing a data source.
 	insideDataSource bool
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1392,7 +1392,7 @@ func (expr *FuncExpr) TypeCheck(
 		}
 	} else {
 		// Make sure the window function builtins are used as window function applications.
-		if funcCls == WindowClass {
+		if !expr.InCall && funcCls == WindowClass {
 			return nil, pgerror.Newf(pgcode.WrongObjectType,
 				"window function %s() requires an OVER clause", &expr.Func)
 		}


### PR DESCRIPTION
This commit adjusts the code slightly so that in case a user attempts to CALL not a procedure (but a special function like an aggregate, a window function, or our custom SQL function) we return the same error as postgres (previously we would return an internal error in some cases).

Additionally, it disables calling procedures with output parameters from SQL UDFs and SPs - this feature is currently unsupported in postgres. Note that calling procedures with output parameters from PLpgSQL is supported by PG but not yet supported by us (this commit includes some commented out unit tests for that).

Furthermore, this commit updates sqlsmith to generate all supported parameter types as well as adjusts a few TODOs to reference a different issue number (where we currently hit an internal error) in order to remove remaining references of the OUT parameter issue.

Fixes: #100405.
Fixes: #120932.
Fixes: #120989.

Release note: None