### PR TITLE
sql: alter sequence options no min, no max and as type to replicate postgreSQL

### DIFF
--- a/pkg/sql/catalog/schemaexpr/sequence_options.go
+++ b/pkg/sql/catalog/schemaexpr/sequence_options.go
@@ -72,57 +72,6 @@ func getSequenceIntegerBounds(
 	)
 }
 
-func setSequenceIntegerBounds(
-	opts *descpb.TableDescriptor_SequenceOpts,
-	integerType *types.T,
-	isAscending bool,
-	setMinValue bool,
-	setMaxValue bool,
-) error {
-	var minValue int64 = math.MinInt64
-	var maxValue int64 = math.MaxInt64
-
-	if isAscending {
-		minValue = 1
-
-		switch integerType {
-		case types.Int2:
-			maxValue = math.MaxInt16
-		case types.Int4:
-			maxValue = math.MaxInt32
-		case types.Int:
-			// Do nothing, it's the default.
-		default:
-			return errors.AssertionFailedf(
-				"CREATE SEQUENCE option AS received type %s, must be integer",
-				integerType,
-			)
-		}
-	} else {
-		maxValue = -1
-		switch integerType {
-		case types.Int2:
-			minValue = math.MinInt16
-		case types.Int4:
-			minValue = math.MinInt32
-		case types.Int:
-			// Do nothing, it's the default.
-		default:
-			return errors.AssertionFailedf(
-				"CREATE SEQUENCE option AS received type %s, must be integer",
-				integerType,
-			)
-		}
-	}
-	if setMinValue {
-		opts.MinValue = minValue
-	}
-	if setMaxValue {
-		opts.MaxValue = maxValue
-	}
-	return nil
-}
-
 // AssignSequenceOptions moves options from the AST node to the sequence options descriptor,
 // starting with defaults and overriding them with user-provided options.
 func AssignSequenceOptions(
@@ -132,7 +81,6 @@ func AssignSequenceOptions(
 	setDefaults bool,
 	existingType *types.T,
 ) error {
-	wasAscending := opts.Increment > 0
 
 	// Set the default integer type of a sequence.
 	integerType := parser.NakedIntTypeFromDefaultIntSize(defaultIntSize)
@@ -171,32 +119,20 @@ func AssignSequenceOptions(
 		opts.CacheSize = 1
 	}
 
-	// Set default MINVALUE and MAXVALUE if AS option value for integer type is specified.
-	if opts.AsIntegerType != "" {
-		// We change MINVALUE and MAXVALUE if it is the originally set to the default during ALTER.
-		setMinValue := setDefaults
-		setMaxValue := setDefaults
-		if !setDefaults && existingType != nil {
-			existingLowerIntBound, existingUpperIntBound, err := getSequenceIntegerBounds(existingType)
-			if err != nil {
-				return err
-			}
-			if (wasAscending && opts.MinValue == 1) || (!wasAscending && opts.MinValue == existingLowerIntBound) {
-				setMinValue = true
-			}
-			if (wasAscending && opts.MaxValue == existingUpperIntBound) || (!wasAscending && opts.MaxValue == -1) {
-				setMaxValue = true
-			}
+	// Set Minvalue and Maxvalue to new types bounds if at current bounds.
+	if !setDefaults && existingType != nil && opts.AsIntegerType != "" {
+		existingLowerIntBound, existingUpperIntBound, err := getSequenceIntegerBounds(existingType)
+		if err != nil {
+			return err
+		}
+		// If Minvalue is bounded to the existing type, set it to the bounds of the new type.
+		if opts.MinValue == existingLowerIntBound {
+			opts.MinValue = lowerIntBound
 		}
 
-		if err := setSequenceIntegerBounds(
-			opts,
-			integerType,
-			isAscending,
-			setMinValue,
-			setMaxValue,
-		); err != nil {
-			return err
+		// If MaxValue is bounded to the existing type, set it to the bounds of the new type.
+		if opts.MaxValue == existingUpperIntBound {
+			opts.MaxValue = upperIntBound
 		}
 	}
 
@@ -235,12 +171,24 @@ func AssignSequenceOptions(
 			// Do nothing; this has already been set.
 		case tree.SeqOptMinValue:
 			// A value of nil represents the user explicitly saying `NO MINVALUE`.
-			if option.IntVal != nil {
+			if option.IntVal == nil {
+				if isAscending {
+					opts.MinValue = 1
+				} else {
+					opts.MinValue = lowerIntBound
+				}
+			} else {
 				opts.MinValue = *option.IntVal
 			}
 		case tree.SeqOptMaxValue:
 			// A value of nil represents the user explicitly saying `NO MAXVALUE`.
-			if option.IntVal != nil {
+			if option.IntVal == nil {
+				if isAscending {
+					opts.MaxValue = upperIntBound
+				} else {
+					opts.MaxValue = -1
+				}
+			} else {
 				opts.MaxValue = *option.IntVal
 			}
 		case tree.SeqOptStart:
@@ -253,7 +201,7 @@ func AssignSequenceOptions(
 		}
 	}
 
-	if setDefaults || (wasAscending && opts.Start == 1) || (!wasAscending && opts.Start == -1) {
+	if setDefaults {
 		// If start option not specified, set it to MinValue (for ascending sequences)
 		// or MaxValue (for descending sequences).
 		// We only do this if we're setting it for the first time, or the sequence was

--- a/pkg/sql/logictest/testdata/logic_test/alter_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_sequence
@@ -222,7 +222,7 @@ ALTER SEQUENCE reverse_direction_seqas AS smallint INCREMENT -1
 query T
 SELECT create_statement FROM [SHOW CREATE SEQUENCE reverse_direction_seqas]
 ----
-CREATE SEQUENCE public.reverse_direction_seqas AS INT2 MINVALUE -32768 MAXVALUE -1 INCREMENT -1 START -1
+CREATE SEQUENCE public.reverse_direction_seqas AS INT2 MINVALUE 1 MAXVALUE 32767 INCREMENT -1 START 1
 
 statement ok
 ALTER SEQUENCE reverse_direction_seqas AS int INCREMENT 1
@@ -286,3 +286,112 @@ CREATE SEQUENCE restart_max_err_seqas MAXVALUE 100
 
 statement error RESTART value \(1000\) cannot be greater than MAXVALUE \(100\)
 ALTER SEQUENCE restart_max_err_seqas RESTART 1000
+
+
+statement ok
+CREATE SEQUENCE set_no_maxvalue MAXVALUE 3
+
+query III
+select nextval('set_no_maxvalue'),nextval('set_no_maxvalue'),nextval('set_no_maxvalue')
+----
+1  2  3
+
+statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "set_no_maxvalue" \(3\)
+select nextval('set_no_maxvalue')
+
+statement ok
+ALTER SEQUENCE set_no_maxvalue NO MAXVALUE
+
+query I
+select nextval('set_no_maxvalue')
+----
+4
+
+statement ok
+CREATE SEQUENCE set_no_minvalue INCREMENT -1 MINVALUE -3;
+
+query III
+select nextval('set_no_minvalue'),nextval('set_no_minvalue'),nextval('set_no_minvalue')
+----
+-1  -2  -3
+
+statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "set_no_minvalue" \(-3\)
+select nextval('set_no_minvalue')
+
+statement ok
+ALTER SEQUENCE set_no_minvalue NO MINVALUE
+
+query I
+select nextval('set_no_minvalue')
+----
+-4
+
+
+statement ok
+CREATE SEQUENCE seq_inverse_no_change;
+
+statement ok
+ALTER SEQUENCE seq_inverse_no_change INCREMENT BY -1;
+
+query TT colnames
+SHOW CREATE SEQUENCE seq_inverse_no_change;
+----
+table_name             create_statement
+seq_inverse_no_change  CREATE SEQUENCE public.seq_inverse_no_change MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT -1 START 1
+
+statement ok
+ALTER SEQUENCE seq_inverse_no_change INCREMENT BY 1;
+
+query TT colnames
+SHOW CREATE SEQUENCE seq_inverse_no_change;
+----
+table_name             create_statement
+seq_inverse_no_change  CREATE SEQUENCE public.seq_inverse_no_change MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+
+
+statement ok
+CREATE SEQUENCE seq_change_type_bounds MINVALUE -9223372036854775808 MAXVALUE 9223372036854775807 START 0
+
+statement ok
+ALTER SEQUENCE seq_change_type_bounds AS smallint;
+
+query TT colnames
+SHOW CREATE SEQUENCE seq_change_type_bounds;
+----
+table_name              create_statement
+seq_change_type_bounds  CREATE SEQUENCE public.seq_change_type_bounds AS INT2 MINVALUE -32768 MAXVALUE 32767 INCREMENT 1 START 0
+
+statement ok
+ALTER SEQUENCE seq_change_type_bounds AS integer;
+
+query TT colnames
+SHOW CREATE SEQUENCE seq_change_type_bounds;
+----
+table_name              create_statement
+seq_change_type_bounds  CREATE SEQUENCE public.seq_change_type_bounds AS INT8 MINVALUE -9223372036854775808 MAXVALUE 9223372036854775807 INCREMENT 1 START 0
+
+
+statement ok
+CREATE SEQUENCE seq_alter_no_min_max_asc INCREMENT 1 START 5 MINVALUE -10 MAXVALUE 10;
+
+statement ok
+ALTER SEQUENCE seq_alter_no_min_max_asc NO MINVALUE NO MAXVALUE;
+
+query TT colnames
+SHOW CREATE SEQUENCE seq_alter_no_min_max_asc;
+----
+table_name                create_statement
+seq_alter_no_min_max_asc  CREATE SEQUENCE public.seq_alter_no_min_max_asc MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 5
+
+
+statement ok
+CREATE SEQUENCE seq_alter_no_min_max_des INCREMENT -1 START -5 MINVALUE -10 MAXVALUE 10 ;
+
+statement ok
+ALTER SEQUENCE seq_alter_no_min_max_des NO MINVALUE NO MAXVALUE ;
+
+query TT colnames
+SHOW CREATE SEQUENCE seq_alter_no_min_max_des
+----
+table_name                create_statement
+seq_alter_no_min_max_des  CREATE SEQUENCE public.seq_alter_no_min_max_des MINVALUE -9223372036854775808 MAXVALUE -1 INCREMENT -1 START -5


### PR DESCRIPTION
This commit changes 'NO MINVALUE' and 'NO MAXVALUE' sequence options
to replicate postgreSQL behavior.
If the sequence is ascending then the NO MAXVALUE is the largest value
for it int type and NO MINVALUE is 1.
If the sequence is descending then the NO MAXVALUE is -1 and NO MINVALUE
is the smallest value for its int type.
This commit also addresses how MINVALUE and MAXVALUE are automatically
changed when altering the seq int type. If either is equal to the
current types limit, then it is will automatically adjsut to the
changes types limits. Otherwise it will not change.

Epic: None

Release note (bug fix): Sequence options for 'NO MINVALUE' and 'NO
MAXVALUE' now replicate postgreSQL.

Sequence MINVALUE and MAXVALUE automatical adjust to new types bounds
mirroring behavior of postgreSQL.