### PR TITLE
cli: conditionally allow version skipping

### DIFF
--- a/pkg/ccl/backupccl/restore_planning_test.go
+++ b/pkg/ccl/backupccl/restore_planning_test.go
@@ -156,7 +156,7 @@ func TestBackupManifestVersionCompatibility(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			settings := cluster.MakeTestingClusterSettingsWithVersions(binaryVersion, tc.minimumSupportedVersion, false)
 			require.NoError(t, clusterversion.Initialize(context.Background(), tc.clusterVersion, &settings.SV))
-			version := clusterversion.MakeVersionHandleWithOverride(&settings.SV, binaryVersion, tc.minimumSupportedVersion)
+			version := clusterversion.MakeVersionHandle(&settings.SV, binaryVersion, tc.minimumSupportedVersion)
 			manifest := []backuppb.BackupManifest{{ClusterVersion: tc.backupVersion}}
 
 			err := checkBackupManifestVersionCompatability(context.Background(), version, manifest /*unsafe=*/, false)

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlexec"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlshell"
 	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -89,18 +91,32 @@ func clearFlagChanges(cmd *cobra.Command) {
 //
 // See below for defaults.
 var serverCfg = func() server.Config {
-	st := cluster.MakeClusterSettings()
-	logcrash.SetGlobalSettings(&st.SV)
-
+	st := makeClusterSettings()
 	return server.MakeConfig(context.Background(), st)
 }()
+
+func makeClusterSettings() *cluster.Settings {
+	// Even though the code supports upgrading from multiple previous releases,
+	// skipping versions is experimental; by default, we only allow upgrading from
+	// the previous release.
+	//
+	// Version skipping can be enabled by setting COCKROACH_ALLOW_VERSION_SKIPPING=1.
+	var minSupported clusterversion.Key
+	if envutil.EnvOrDefaultBool("COCKROACH_ALLOW_VERSION_SKIPPING", false) {
+		minSupported = clusterversion.MinSupported
+	} else {
+		minSupported = clusterversion.PreviousRelease
+	}
+	st := cluster.MakeClusterSettingsWithVersions(clusterversion.Latest.Version(), minSupported.Version())
+	logcrash.SetGlobalSettings(&st.SV)
+	return st
+}
 
 // setServerContextDefaults set the default values in serverCfg.  This
 // function is called by initCLIDefaults() and thus re-called in every
 // test that exercises command-line parsing.
 func setServerContextDefaults() {
-	st := cluster.MakeClusterSettings()
-	logcrash.SetGlobalSettings(&st.SV)
+	st := makeClusterSettings()
 	serverCfg.SetDefaults(context.Background(), st)
 
 	serverCfg.TenantKVAddrs = []string{"127.0.0.1:26257"}

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -168,19 +168,12 @@ type handleImpl struct {
 
 var _ Handle = (*handleImpl)(nil)
 
-// MakeVersionHandle returns a Handle that has its latest and minimum supported
-// versions initialized to this binary's build and its minimum supported
-// versions respectively.
-func MakeVersionHandle(sv *settings.Values) Handle {
-	return MakeVersionHandleWithOverride(sv, Latest.Version(), MinSupported.Version())
-}
-
-// MakeVersionHandleWithOverride returns a Handle that has its
-// binary and minimum supported versions initialized to the provided versions.
+// MakeVersionHandle returns a Handle that has its binary and minimum supported
+// versions initialized to the provided versions.
 //
 // It's typically used in tests that want to override the default binary and
 // minimum supported versions.
-func MakeVersionHandleWithOverride(
+func MakeVersionHandle(
 	sv *settings.Values, latestVersion, minSupportedVersion roachpb.Version,
 ) Handle {
 	return newHandleImpl(version, sv, latestVersion, minSupportedVersion)

--- a/pkg/server/profiler/BUILD.bazel
+++ b/pkg/server/profiler/BUILD.bazel
@@ -46,7 +46,6 @@ go_test(
     ],
     embed = [":profiler"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/server/dumpstore",
         "//pkg/settings/cluster",
         "//pkg/util/mon",

--- a/pkg/server/profiler/activequeryprofiler_test.go
+++ b/pkg/server/profiler/activequeryprofiler_test.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/stretchr/testify/require"
@@ -89,11 +88,8 @@ func TestNewActiveQueryProfiler(t *testing.T) {
 func TestShouldDump(t *testing.T) {
 	ctx := context.Background()
 	createSettingFn := func(settingEnabled bool) *cluster.Settings {
-		s := &cluster.Settings{}
-		sv := &s.SV
-		s.Version = clusterversion.MakeVersionHandle(sv)
-		sv.Init(ctx, s.Version)
-		ActiveQueryDumpsEnabled.Override(ctx, sv, settingEnabled)
+		s := cluster.MakeClusterSettings()
+		ActiveQueryDumpsEnabled.Override(ctx, &s.SV, settingEnabled)
 		return s
 	}
 

--- a/pkg/server/profiler/cpuprofile_test.go
+++ b/pkg/server/profiler/cpuprofile_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/dumpstore"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -25,10 +24,8 @@ import (
 func TestCPUProfiler(t *testing.T) {
 	ctx := context.Background()
 	dumpStore := dumpstore.NewStore(t.TempDir(), nil, nil)
-	s := &cluster.Settings{}
+	s := cluster.MakeClusterSettings()
 	sv := &s.SV
-	s.Version = clusterversion.MakeVersionHandle(sv)
-	sv.Init(ctx, s.Version)
 	cpuProfileInterval.Override(ctx, sv, time.Hour)
 	cpuUsageCombined.Override(ctx, sv, 80)
 	pastTime := time.Date(2023, 1, 1, 1, 1, 1, 1, time.UTC)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1322,8 +1322,19 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath, upgradeBinaryPath 
 		}
 	}
 
-	// During config initialization, NumNodes is required to be 3.
+	var envVars []string
+	if strings.Contains(upgradeBinaryPath, "cockroach-short") {
+		// If we're using a cockroach-short binary, that means it was
+		// locally built, so we need to opt-out of version offsetting to
+		// better simulate a real upgrade path.
+		envVars = append(envVars, "COCKROACH_TESTING_FORCE_RELEASE_BRANCH=true")
+		// The build is made during testing, so it has metamorphic constants.
+		// We disable them here so that the test is more stable.
+		envVars = append(envVars, "COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true")
+	}
+	envVars = append(envVars, "COCKROACH_ALLOW_VERSION_SKIPPING=true")
 	opts := []testserver.TestServerOpt{
+		// During config initialization, NumNodes is required to be 3.
 		testserver.ThreeNodeOpt(),
 		testserver.StoreOnDiskOpt(),
 		testserver.CacheSizeOpt(0.1),
@@ -1332,17 +1343,7 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath, upgradeBinaryPath 
 		testserver.PollListenURLTimeoutOpt(120),
 		testserver.CockroachLogsDirOpt(logsDir),
 	}
-	if strings.Contains(upgradeBinaryPath, "cockroach-short") {
-		opts = append(opts, testserver.EnvVarOpt([]string{
-			// If we're using a cockroach-short binary, that means it was
-			// locally built, so we need to opt-out of version offsetting to
-			// better simulate a real upgrade path.
-			"COCKROACH_TESTING_FORCE_RELEASE_BRANCH=true",
-			// The build is made during testing, so it has metamorphic constants.
-			// We disable them here so that the test is more stable.
-			"COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true",
-		}))
-	}
+	testserver.EnvVarOpt(envVars)
 
 	ts, err := testserver.NewTestServer(opts...)
 	if err != nil {


### PR DESCRIPTION
This PR revives https://github.com/cockroachdb/cockroach/pull/113695, where we want to conditionally allow version skipping:

Currently the code allows upgrading from TWO previous releases (23.1 and 23.2); however, for now we only want to allow skipping a version experimentally.

This commit changes the cli code to set the minimum supported version to `PreviousRelease` by default, or to `MinSupported` when a special env var is used.

Epic: none
Release note: None