### PR TITLE
cli: use 'main' for default created virtual cluster

### DIFF
--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -146,6 +146,6 @@ listeners, if the headers are allowed.`,
 	}
 	VirtualizedEmpty = FlagInfo{
 		Name:        "virtualized-empty",
-		Description: "If set, the cluster will be initialized as a virtualized cluster without an application cluster.",
+		Description: "If set, the cluster will be initialized as a virtualized cluster without main virtual cluster.",
 	}
 )

--- a/pkg/cli/interactive_tests/test_init_virtualized_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_virtualized_command.tcl
@@ -14,7 +14,7 @@ system "grep -q 'initial startup completed' logs/db/logs/cockroach.log"
 system "grep -q 'will now attempt to join a running cluster, or wait' logs/db/logs/cockroach.log"
 end_test
 
-start_test "Check that init --virtualized creates an application virtual cluster"
+start_test "Check that init --virtualized creates a main virtual cluster"
 
 system "$argv init --insecure --host=localhost --virtualized"
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2245,17 +2245,17 @@ func (s *topLevelServer) runIdempontentSQLForInitType(
 	}
 
 	initAttempt := func() error {
-		const defaultApplicationClusterName = "application"
+		const defaulVirtuallusterName = "main"
 		switch typ {
 		case serverpb.InitType_VIRTUALIZED:
 			ie := s.sqlServer.execCfg.InternalDB.Executor()
 			_, err := ie.Exec(ctx, "init-create-app-tenant", nil, /* txn */
-				"CREATE VIRTUAL CLUSTER IF NOT EXISTS $1", defaultApplicationClusterName)
+				"CREATE VIRTUAL CLUSTER IF NOT EXISTS $1", defaulVirtuallusterName)
 			if err != nil {
 				return err
 			}
 			_, err = ie.Exec(ctx, "init-default-app-tenant", nil, /* txn */
-				"ALTER VIRTUAL CLUSTER $1 START SERVICE SHARED", defaultApplicationClusterName)
+				"ALTER VIRTUAL CLUSTER $1 START SERVICE SHARED", defaulVirtuallusterName)
 			if err != nil {
 				return err
 			}
@@ -2263,7 +2263,7 @@ func (s *topLevelServer) runIdempontentSQLForInitType(
 		case serverpb.InitType_VIRTUALIZED_EMPTY:
 			ie := s.sqlServer.execCfg.InternalDB.Executor()
 			_, err := ie.Exec(ctx, "init-default-target-cluster-setting", nil, /* txn */
-				"SET CLUSTER SETTING server.controller.default_target_cluster = $1", defaultApplicationClusterName)
+				"SET CLUSTER SETTING server.controller.default_target_cluster = $1", defaulVirtuallusterName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This better communicates that in virtualized/UA mode, this is _the_ cluster that one should expect to connect to, run workloads in, inspect, and replicate if one wants to replicate their cluster, setting it apart from the internal system VC more strongly, while also avoiding confusion with _their_ application or the concept of 'application name' used elsewhere in the DB console and SQL surfaces.

Release note: none.
Epic: none.