### PR TITLE
kvcoord: fix DistSender circuit breaker benchmark `nil` panic

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -407,7 +407,7 @@ type DistSenderRangeFeedMetrics struct {
 	Errors                 rangeFeedErrorCounters
 }
 
-func makeDistSenderMetrics() DistSenderMetrics {
+func MakeDistSenderMetrics() DistSenderMetrics {
 	m := DistSenderMetrics{
 		BatchCount:                         metric.NewCounter(metaDistSenderBatchCount),
 		PartialBatchCount:                  metric.NewCounter(metaDistSenderPartialBatchCount),
@@ -746,7 +746,7 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 		clock:         cfg.Clock,
 		nodeDescs:     cfg.NodeDescs,
 		nodeIDGetter:  nodeIDGetter,
-		metrics:       makeDistSenderMetrics(),
+		metrics:       MakeDistSenderMetrics(),
 		kvInterceptor: cfg.KVInterceptor,
 		locality:      cfg.Locality,
 		healthFunc:    cfg.HealthFunc,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -131,7 +131,7 @@ func BenchmarkDistSenderCircuitBreakersForReplica(b *testing.B) {
 	kvcoord.CircuitBreakerEnabled.Override(ctx, &st.SV, true)
 
 	cbs := kvcoord.NewDistSenderCircuitBreakers(
-		ambientCtx, stopper, st, nil, kvcoord.DistSenderMetrics{})
+		ambientCtx, stopper, st, nil, kvcoord.MakeDistSenderMetrics())
 
 	replDesc := &roachpb.ReplicaDescriptor{
 		NodeID:    1,
@@ -198,7 +198,7 @@ func benchmarkCircuitBreakersTrack(
 	kvcoord.CircuitBreakerCancellation.Override(ctx, &st.SV, cancel)
 
 	cbs := kvcoord.NewDistSenderCircuitBreakers(
-		ambientCtx, stopper, st, nil, kvcoord.DistSenderMetrics{})
+		ambientCtx, stopper, st, nil, kvcoord.MakeDistSenderMetrics())
 
 	replDesc := &roachpb.ReplicaDescriptor{
 		NodeID:    1,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -5881,7 +5881,7 @@ func TestDistSenderCrossLocalityMetrics(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%-v", tc.crossLocalityType), func(t *testing.T) {
-			metrics := makeDistSenderMetrics()
+			metrics := MakeDistSenderMetrics()
 			beforeMetrics, err := metrics.getDistSenderCounterMetrics(metricsNames)
 			if err != nil {
 				t.Error(err)

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -156,7 +156,7 @@ func TestSpanImport(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	metrics := makeDistSenderMetrics()
+	metrics := MakeDistSenderMetrics()
 	gt := grpcTransport{
 		opts: SendOptions{
 			metrics: &metrics,
@@ -190,7 +190,7 @@ func TestResponseVerifyFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	metrics := makeDistSenderMetrics()
+	metrics := MakeDistSenderMetrics()
 	gt := grpcTransport{
 		opts: SendOptions{
 			metrics: &metrics,


### PR DESCRIPTION
Resolves #121020.
Epic: none
Release note: None