### PR TITLE
roachtest: increase allocbench timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -261,6 +261,7 @@ func registerAllocationBenchSpec(r registry.Registry, allocSpec allocationBenchS
 			allocSpec.nodes+1,
 			specOptions...,
 		),
+		Timeout:           time.Duration(allocSpec.samples) * time.Hour,
 		NonReleaseBlocker: true,
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),


### PR DESCRIPTION
`allocbench` runs repeated samples of the same multi-workload configuration and benchmarks allocation stats. All existing `allocbench` tests run 5 x 30 minute samples with a previous timeout of 3 hours. This timeout could occasionally be hit if the initial setup took too long.

Bump the timeout from 3 hours to 1 hour * number of samples to avoid spurious timeouts.

Resolves: #120977
Release note: None