### PR TITLE
backupccl: integrate the file sink sst with admission control

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -128,6 +128,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util",
+        "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/bulk",
         "//pkg/util/ctxgroup",

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -110,6 +111,13 @@ var (
 	)
 
 	testingDiscardBackupData = envutil.EnvOrDefaultBool("COCKROACH_BACKUP_TESTING_DISCARD_DATA", false)
+
+	fileSSTSinkElasticCPUControlEnabled = settings.RegisterBoolSetting(
+		settings.ApplicationLevel,
+		"bulkio.backup.file_sst_sink_elastic_control.enabled",
+		"determines whether the file sst sink integrates with elastic CPU control",
+		true,
+	)
 )
 
 const (
@@ -455,9 +463,29 @@ func runBackupProcessor(
 		todo <- chunk
 	}
 
+	// Passing a nil pacer is effectively a noop if CPU control is disabled.
+	var pacer *admission.Pacer = nil
+	if fileSSTSinkElasticCPUControlEnabled.Get(&clusterSettings.SV) {
+		tenantID, ok := roachpb.ClientTenantFromContext(ctx)
+		if !ok {
+			tenantID = roachpb.SystemTenantID
+		}
+		pacer = flowCtx.Cfg.AdmissionPacerFactory.NewPacer(
+			100*time.Millisecond,
+			admission.WorkInfo{
+				TenantID:        tenantID,
+				Priority:        admissionpb.BulkNormalPri,
+				CreateTime:      timeutil.Now().UnixNano(),
+				BypassAdmission: false,
+			},
+		)
+	}
+	// It is safe to close a nil pacer.
+	defer pacer.Close()
+
 	return ctxgroup.GroupWorkers(ctx, numSenders, func(ctx context.Context, _ int) error {
 		readTime := spec.BackupEndTime.GoTime()
-		sink := makeFileSSTSink(sinkConf, storage)
+		sink := makeFileSSTSink(sinkConf, storage, pacer)
 		defer func() {
 			if err := sink.flush(ctx); err != nil {
 				log.Warningf(ctx, "failed to flush SST sink: %s", err)

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -40,8 +41,9 @@ type sstSinkConf struct {
 }
 
 type fileSSTSink struct {
-	dest cloud.ExternalStorage
-	conf sstSinkConf
+	dest  cloud.ExternalStorage
+	conf  sstSinkConf
+	pacer *admission.Pacer
 
 	sst     storage.SSTWriter
 	ctx     context.Context
@@ -76,8 +78,10 @@ type fileSSTSink struct {
 	}
 }
 
-func makeFileSSTSink(conf sstSinkConf, dest cloud.ExternalStorage) *fileSSTSink {
-	return &fileSSTSink{conf: conf, dest: dest}
+func makeFileSSTSink(
+	conf sstSinkConf, dest cloud.ExternalStorage, pacer *admission.Pacer,
+) *fileSSTSink {
+	return &fileSSTSink{conf: conf, dest: dest, pacer: pacer}
 }
 
 func (s *fileSSTSink) Close() error {
@@ -248,7 +252,7 @@ func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
 	//
 	// TODO(msbutler): investigate using single a single iterator that surfaces
 	// all point keys first and then all range keys
-	if err := s.copyPointKeys(resp.dataSST); err != nil {
+	if err := s.copyPointKeys(ctx, resp.dataSST); err != nil {
 		return err
 	}
 	if err := s.copyRangeKeys(resp.dataSST); err != nil {
@@ -290,7 +294,7 @@ func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
 	return nil
 }
 
-func (s *fileSSTSink) copyPointKeys(dataSST []byte) error {
+func (s *fileSSTSink) copyPointKeys(ctx context.Context, dataSST []byte) error {
 	iterOpts := storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsOnly,
 		LowerBound: keys.LocalMax,
@@ -303,6 +307,9 @@ func (s *fileSSTSink) copyPointKeys(dataSST []byte) error {
 	defer iter.Close()
 
 	for iter.SeekGE(storage.MVCCKey{Key: keys.MinKey}); ; iter.Next() {
+		if err := s.pacer.Pace(ctx); err != nil {
+			return err
+		}
 		if valid, err := iter.Valid(); !valid || err != nil {
 			if err != nil {
 				return err

--- a/pkg/ccl/backupccl/file_sst_sink_test.go
+++ b/pkg/ccl/backupccl/file_sst_sink_test.go
@@ -567,7 +567,7 @@ func TestFileSSTSinkCopyPointKeys(t *testing.T) {
 					withKVs(kvs).
 					withRangeKeys([]rangeKeyAndTS{{"a", "z", 10}}).
 					build()
-				err := sink.copyPointKeys(es.dataSST)
+				err := sink.copyPointKeys(ctx, es.dataSST)
 				if input.expectErr != "" {
 					// Do not compare resulting SSTs if we expect errors.
 					require.ErrorContains(t, err, input.expectErr)
@@ -927,7 +927,7 @@ func fileSSTSinkTestSetUp(
 		settings: &settings.SV,
 	}
 
-	sink := makeFileSSTSink(sinkConf, store)
+	sink := makeFileSSTSink(sinkConf, store, nil /* pacer */)
 	return sink, store
 }
 


### PR DESCRIPTION
This PR includes the first commit of a previously unmerged PR: https://github.com/cockroachdb/cockroach/pull/108231. In https://github.com/cockroachdb/cockroach/issues/107770, we found these changes to be helpful but did not fully resolve the issue. It is worthwhile to merge these changes while we find more places to integrate AC for aws specific elastic backup.

This PR intentionally skips 9c9cce182f29235b6e2d67a9f94602937e26a0f7 since it requires an AWS sdk change and should be left for a follow up PR.

____

[backupccl: integrate the file sst sink with admission control](https://github.com/cockroachdb/cockroach/commit/317a6e178ba5aefde74a54f550b060a139978945) 

It's a tight loop, and we've seen it show up prominently in CPU profiles
during backups.

Informs https://github.com/cockroachdb/cockroach/issues/107770.

Release note: None
