### PR TITLE
kvcoord: don't untrip DistSender circuit breaker on shutdown

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
@@ -667,6 +667,14 @@ func (r *ReplicaCircuitBreaker) launchProbe(report func(error), done func()) {
 
 			// Probe the replica.
 			err := r.sendProbe(ctx, transport)
+
+			// If the context (with no timeout) failed, we're shutting down. Just exit
+			// the probe without reporting the result (which could trip the breaker).
+			if ctx.Err() != nil {
+				return
+			}
+
+			// Report the probe result.
 			report(err)
 			if err == nil {
 				// On a successful probe, record the success and stop probing.
@@ -739,9 +747,9 @@ func (r *ReplicaCircuitBreaker) launchProbe(report func(error), done func()) {
 //     these replicas.
 func (r *ReplicaCircuitBreaker) sendProbe(ctx context.Context, transport Transport) error {
 	// We don't use timeutil.RunWithTimeout() because we need to be able to
-	// differentiate which context failed.
+	// differentiate whether the context timed out.
 	timeout := CircuitBreakerProbeTimeout.Get(&r.d.settings.SV)
-	sendCtx, cancel := context.WithTimeout(ctx, timeout) // nolint:context
+	ctx, cancel := context.WithTimeout(ctx, timeout) // nolint:context
 	defer cancel()
 
 	transport.Reset()
@@ -756,19 +764,15 @@ func (r *ReplicaCircuitBreaker) sendProbe(ctx context.Context, transport Transpo
 	})
 
 	log.VEventf(ctx, 2, "sending probe to %s: %s", r.id(), ba)
-	br, err := transport.SendNext(sendCtx, ba)
+	br, err := transport.SendNext(ctx, ba)
 	log.VEventf(ctx, 2, "probe result from %s: br=%v err=%v", r.id(), br, err)
 
 	// Handle local send errors.
 	if err != nil {
-		// If the given context was cancelled, we're shutting down. Stop probing.
-		if ctx.Err() != nil {
-			return nil
-		}
-
-		// If the send context timed out, fail.
-		if ctxErr := sendCtx.Err(); ctxErr != nil {
-			return errors.Wrapf(ctxErr, "probe timed out")
+		// If the context timed out, fail. The caller will handle the case where
+		// we're shutting down.
+		if err := ctx.Err(); err != nil {
+			return errors.Wrapf(err, "probe timed out")
 		}
 
 		// Any other local error is likely a networking/gRPC issue. This includes if


### PR DESCRIPTION
Previously, if the node shuts down while a circuit breaker probe is in flight, this could cause the breaker to untrip. It shouldn't.

Epic: none
Release note: None