### PR TITLE
util/span: disable btree frontier

### DIFF
--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -109,7 +109,7 @@ func (r OpResult) asBool() bool {
 type Operation func(roachpb.Span, hlc.Timestamp) (done OpResult)
 
 var useBtreeFrontier = envutil.EnvOrDefaultBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED",
-	util.ConstantWithMetamorphicTestBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED", true))
+	util.ConstantWithMetamorphicTestBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED", false))
 
 func enableBtreeFrontier(enabled bool) func() {
 	old := useBtreeFrontier


### PR DESCRIPTION
A recent discover of a bug here that evaded detection even with it enabled on master for the whole development cycle has led to a reconsideration.

Reverting to the LLBR frontier for now and following up with more robust testing of the btree frontier before enabling it seems wise. We can add easier knobs to enable it (cluster settings passed by callers) and even consider enabling it by default in a patch release but at this time it seems prudent to flip the default until we expand test coverage.

Release note: none.
Epic: none.