### PR TITLE
importccl: remove bulkio.import.write_import_epoch.enabled cluster setting

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/import-epoch
+++ b/pkg/ccl/backupccl/testdata/backup-restore/import-epoch
@@ -6,11 +6,6 @@ new-cluster name=s1
 ----
 
 exec-sql
-SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=true;
-----
-
-
-exec-sql
 CREATE DATABASE d;
 USE d;
 CREATE TABLE foo (i INT PRIMARY KEY, s STRING);

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -410,7 +410,6 @@ func (r *importResumer) prepareTablesForIngestion(
 	var desc *descpb.TableDescriptor
 
 	useImportEpochs := p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V24_1)
-	useImportEpochs = useImportEpochs && importEpochs.Get(&p.ExecCfg().Settings.SV)
 	for i, table := range details.Tables {
 		if !table.IsNew {
 			desc, err = prepareExistingTablesForIngestion(ctx, txn, descsCol, table.Desc, useImportEpochs)
@@ -1255,13 +1254,6 @@ var retryDuration = settings.RegisterDurationSetting(
 	"duration during which the IMPORT can be retried in face of non-permanent errors",
 	time.Minute*2,
 	settings.PositiveDuration,
-)
-
-var importEpochs = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"bulkio.import.write_import_epoch.enabled",
-	"controls whether IMPORT will write ImportEpoch's to descriptors",
-	true,
 )
 
 func getFractionCompleted(job *jobs.Job) float64 {

--- a/pkg/sql/importer/import_mvcc_test.go
+++ b/pkg/sql/importer/import_mvcc_test.go
@@ -53,7 +53,6 @@ func TestMVCCValueHeaderImportEpoch(t *testing.T) {
 
 	// Create a table where the first row ( in sort order) comes from an IMPORT
 	// while the second comes from an INSERT.
-	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.write_import_epoch.enabled=true`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (a INT8)`)
 	sqlDB.Exec(t, `INSERT INTO d.t VALUES ('2')`)
 	sqlDB.Exec(t, `IMPORT INTO d.t CSV DATA ($1)`, srv.URL)


### PR DESCRIPTION
Currently, the user can disable import from writing the import epoch to the mvcc value header. This cluster setting was added because we thought this import epoch logic could be risky:
- it could degrade import performance
- epoch based rollbacks could be incorrect and much slower


The cluster setting further complicates the rollback code, as pr #120809 shows. Since the risks of this code aren't terribly bad, it seems fine to remove the code to simplify the import rollback logic.

Epic: none

Release note: none