### PR TITLE
base,testutils,kvserver: disable lease queue in replication manual 

### DIFF
--- a/pkg/base/test_cluster_replication_mode.go
+++ b/pkg/base/test_cluster_replication_mode.go
@@ -22,9 +22,9 @@ const (
 	// If ReplicationAuto is used, StartTestCluster() blocks until the initial
 	// ranges are fully replicated.
 	ReplicationAuto TestClusterReplicationMode = iota
-	// ReplicationManual means that the split, merge and replication queues of all
-	// servers are stopped, and the test must manually control splitting, merging
-	// and replication through the TestServer.
+	// ReplicationManual means that the lease, split, merge and replication
+	// queues of all servers are stopped, and the test must manually control
+	// splitting, merging and replication through the TestServer.
 	// Note that the server starts with a number of system ranges,
 	// all with a single replica on node 1.
 	ReplicationManual

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -281,7 +281,7 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 
 	for i := 0; i < len(tcAfter.Servers); i++ {
 		require.NoError(t, tcAfter.Servers[i].GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.SetReplicateQueueActive(true)
+			store.TestingSetReplicateQueueActive(true)
 			return nil
 		}), "Failed to activate replication queue")
 	}

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -800,8 +800,8 @@ func TestLeasePreferencesRebalance(t *testing.T) {
 		return nil
 	})
 
-	tc.GetFirstStoreFromServer(t, 1).SetReplicateQueueActive(true)
-	tc.GetFirstStoreFromServer(t, 1).SetLeaseQueueActive(true)
+	tc.GetFirstStoreFromServer(t, 1).TestingSetReplicateQueueActive(true)
+	tc.GetFirstStoreFromServer(t, 1).TestingSetLeaseQueueActive(true)
 	require.NoError(t, tc.GetFirstStoreFromServer(t, 1).ForceReplicationScanAndProcess())
 	require.NoError(t, tc.GetFirstStoreFromServer(t, 1).ForceLeaseQueueProcess())
 

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -296,7 +296,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		})
 
 		s, repl := getFirstStoreReplica(t, tc.Server(1), tablePrefix)
-		s.SetReplicateQueueActive(false)
+		s.TestingSetReplicateQueueActive(false)
 		require.Len(t, repl.Desc().Replicas().Descriptors(), 1)
 		// We really need to make sure that the split queue has hit this range,
 		// otherwise we'll fail to backpressure.

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1501,7 +1501,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 			if tc.splitOngoing {
 				atomic.StoreInt32(&activateSplitFilter, 1)
 				if err := s.Stopper().RunAsyncTask(ctx, "force split", func(_ context.Context) {
-					store.SetSplitQueueActive(true)
+					store.TestingSetSplitQueueActive(true)
 					if err := store.ForceSplitScanAndProcess(); err != nil {
 						log.Fatalf(ctx, "%v", err)
 					}
@@ -1510,7 +1510,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				}
 				<-splitPending
 			} else if tc.splitImpossible {
-				store.SetSplitQueueActive(true)
+				store.TestingSetSplitQueueActive(true)
 				if err := store.ForceSplitScanAndProcess(); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -166,28 +166,28 @@ func (s *Store) LeaseQueuePurgatoryLength() int {
 
 // SetRaftLogQueueActive enables or disables the raft log queue.
 func (s *Store) SetRaftLogQueueActive(active bool) {
-	s.setRaftLogQueueActive(active)
+	s.testingSetRaftLogQueueActive(active)
 }
 
 // SetReplicaGCQueueActive enables or disables the replica GC queue.
 func (s *Store) SetReplicaGCQueueActive(active bool) {
-	s.setReplicaGCQueueActive(active)
+	s.testingSetReplicaGCQueueActive(active)
 }
 
 // SetMergeQueueActive enables or disables the merge queue.
 func (s *Store) SetMergeQueueActive(active bool) {
-	s.setMergeQueueActive(active)
+	s.testingSetMergeQueueActive(active)
 }
 
 // SetRaftSnapshotQueueActive enables or disables the raft snapshot queue.
 func (s *Store) SetRaftSnapshotQueueActive(active bool) {
-	s.setRaftSnapshotQueueActive(active)
+	s.testingSetRaftSnapshotQueueActive(active)
 }
 
 // SetReplicaScannerActive enables or disables the scanner. Note that while
 // inactive, removals are still processed.
 func (s *Store) SetReplicaScannerActive(active bool) {
-	s.setScannerActive(active)
+	s.testingSetScannerActive(active)
 }
 
 // EnqueueRaftUpdateCheck enqueues the replica for a Raft update check, forcing

--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -412,7 +412,7 @@ func TestLeaseQueueProactiveEnqueueOnPreferences(t *testing.T) {
 func toggleLeaseQueues(tc *testcluster.TestCluster, active bool) {
 	for _, s := range tc.Servers {
 		_ = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.SetLeaseQueueActive(active)
+			store.TestingSetLeaseQueueActive(active)
 			return nil
 		})
 	}

--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -23,11 +23,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/plan"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -35,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	proto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -402,5 +406,120 @@ func TestLeaseQueueProactiveEnqueueOnPreferences(t *testing.T) {
 			}
 			return nil
 		})
+	})
+}
+
+func toggleLeaseQueues(tc *testcluster.TestCluster, active bool) {
+	for _, s := range tc.Servers {
+		_ = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
+			store.SetLeaseQueueActive(active)
+			return nil
+		})
+	}
+}
+
+// TestLeaseQueueAcquiresInvalidLeases asserts that following a restart, leases
+// are invalidated and that the lease queue acquires invalid leases when
+// enabled.
+func TestLeaseQueueAcquiresInvalidLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
+
+	lisReg := listenerutil.NewListenerRegistry()
+	defer lisReg.Close()
+
+	zcfg := zonepb.DefaultZoneConfig()
+	zcfg.NumReplicas = proto.Int32(1)
+	tc := testcluster.StartTestCluster(t, 1,
+		base.TestClusterArgs{
+			// Disable the replication queue initially, to assert on the lease
+			// statuses pre and post enabling the replicate queue.
+			ReplicationMode:     base.ReplicationManual,
+			ReusableListenerReg: lisReg,
+			ServerArgs: base.TestServerArgs{
+				Settings:          st,
+				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+				ScanMinIdleTime:   time.Millisecond,
+				ScanMaxIdleTime:   time.Millisecond,
+				Knobs: base.TestingKnobs{
+					Server: &server.TestingKnobs{
+						StickyVFSRegistry:         fs.NewStickyRegistry(),
+						DefaultZoneConfigOverride: &zcfg,
+					},
+				},
+			},
+		},
+	)
+	defer tc.Stopper().Stop(ctx)
+	db := tc.Conns[0]
+	// Disable consistency checker and sql stats collection that may acquire a
+	// lease by querying a range.
+	_, err := db.Exec("set cluster setting server.consistency_check.interval = '0s'")
+	require.NoError(t, err)
+	_, err = db.Exec("set cluster setting sql.stats.automatic_collection.enabled = false")
+	require.NoError(t, err)
+
+	// Create ranges to assert on their lease status post restart and after
+	// replicate queue processing.
+	ranges := 30
+	scratchRangeKeys := make([]roachpb.Key, ranges)
+	splitKey := tc.ScratchRange(t)
+	for i := range scratchRangeKeys {
+		_, _ = tc.SplitRangeOrFatal(t, splitKey)
+		scratchRangeKeys[i] = splitKey
+		splitKey = splitKey.Next()
+	}
+
+	invalidLeases := func() []kvserverpb.LeaseStatus {
+		invalid := []kvserverpb.LeaseStatus{}
+		for _, key := range scratchRangeKeys {
+			// Assert that the lease is invalid after restart.
+			repl := tc.GetRaftLeader(t, roachpb.RKey(key))
+			if leaseStatus := repl.CurrentLeaseStatus(ctx); !leaseStatus.IsValid() {
+				invalid = append(invalid, leaseStatus)
+			}
+		}
+		return invalid
+	}
+
+	// Assert that the leases are valid initially.
+	require.Len(t, invalidLeases(), 0)
+
+	// Restart the servers to invalidate the leases.
+	for i := range tc.Servers {
+		tc.StopServer(i)
+		err = tc.RestartServerWithInspect(i, nil)
+		require.NoError(t, err)
+	}
+
+	forceProcess := func() {
+		// Speed up the queue processing.
+		for _, s := range tc.Servers {
+			err := s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
+				return store.ForceLeaseQueueProcess()
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	// NB: The cosnsistency checker and sql stats collector both will attempt a
+	// lease acquisition when processing a range, if it the lease is currently
+	// invalid. They are disabled in this test. We do not assert on the number
+	// of invalid leases prior to enabling the lease queue here to avoid
+	// test flakiness if this changes in the future or for some other reason.
+	// Instead, we are only concerned that no invalid leases remain.
+	toggleLeaseQueues(tc, true /* active */)
+	testutils.SucceedsSoon(t, func() error {
+		forceProcess()
+		// Assert that there are now no invalid leases.
+		invalid := invalidLeases()
+		if len(invalid) > 0 {
+			return errors.Newf("The number of invalid leases are greater than 0, %+v", invalid)
+		}
+		return nil
 	})
 }

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -108,42 +108,42 @@ func (s *Store) ForceLeaseQueueProcess() error {
 // The methods below can be used to control a store's queues. Stopping a queue
 // is only meant to happen in tests.
 
-func (s *Store) setGCQueueActive(active bool) {
+func (s *Store) testingSetGCQueueActive(active bool) {
 	s.mvccGCQueue.SetDisabled(!active)
 }
 
-// SetLeaseQueueActive controls activating the lease queue. Only intended for
+// TestingSetLeaseQueueActive controls activating the lease queue. Only intended for
 // tests.
-func (s *Store) SetLeaseQueueActive(active bool) {
+func (s *Store) TestingSetLeaseQueueActive(active bool) {
 	s.leaseQueue.SetDisabled(!active)
 }
-func (s *Store) setMergeQueueActive(active bool) {
+func (s *Store) testingSetMergeQueueActive(active bool) {
 	s.mergeQueue.SetDisabled(!active)
 }
-func (s *Store) setRaftLogQueueActive(active bool) {
+func (s *Store) testingSetRaftLogQueueActive(active bool) {
 	s.raftLogQueue.SetDisabled(!active)
 }
-func (s *Store) setReplicaGCQueueActive(active bool) {
+func (s *Store) testingSetReplicaGCQueueActive(active bool) {
 	s.replicaGCQueue.SetDisabled(!active)
 }
 
-// SetReplicateQueueActive controls the replication queue. Only
+// TestingSetReplicateQueueActive controls the replication queue. Only
 // intended for tests.
-func (s *Store) SetReplicateQueueActive(active bool) {
+func (s *Store) TestingSetReplicateQueueActive(active bool) {
 	s.replicateQueue.SetDisabled(!active)
 }
-func (s *Store) SetSplitQueueActive(active bool) {
+func (s *Store) TestingSetSplitQueueActive(active bool) {
 	s.splitQueue.SetDisabled(!active)
 }
-func (s *Store) setTimeSeriesMaintenanceQueueActive(active bool) {
+func (s *Store) testingSetTimeSeriesMaintenanceQueueActive(active bool) {
 	s.tsMaintenanceQueue.SetDisabled(!active)
 }
-func (s *Store) setRaftSnapshotQueueActive(active bool) {
+func (s *Store) testingSetRaftSnapshotQueueActive(active bool) {
 	s.raftSnapshotQueue.SetDisabled(!active)
 }
-func (s *Store) setConsistencyQueueActive(active bool) {
+func (s *Store) testingSetConsistencyQueueActive(active bool) {
 	s.consistencyQueue.SetDisabled(!active)
 }
-func (s *Store) setScannerActive(active bool) {
+func (s *Store) testingSetScannerActive(active bool) {
 	s.scanner.SetDisabled(!active)
 }

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -111,7 +111,10 @@ func (s *Store) ForceLeaseQueueProcess() error {
 func (s *Store) setGCQueueActive(active bool) {
 	s.mvccGCQueue.SetDisabled(!active)
 }
-func (s *Store) setLeaseQueueActive(active bool) {
+
+// SetLeaseQueueActive controls activating the lease queue. Only intended for
+// tests.
+func (s *Store) SetLeaseQueueActive(active bool) {
 	s.leaseQueue.SetDisabled(!active)
 }
 func (s *Store) setMergeQueueActive(active bool) {

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1268,7 +1268,7 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
 	{
 		require.Equal(t, int64(0), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
-		store.SetReplicateQueueActive(true)
+		store.TestingSetReplicateQueueActive(true)
 		trace, processErr, err := store.Enqueue(
 			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
 		)
@@ -1289,14 +1289,14 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 			return nil
 		})
 		// It has done everything it needs to do now, disable before the next test section.
-		store.SetReplicateQueueActive(false)
+		store.TestingSetReplicateQueueActive(false)
 	}
 
 	// Create a VOTER_OUTGOING, i.e. a joint configuration.
 	ltk.withStopAfterJointConfig(func() {
 		desc := tc.RemoveVotersOrFatal(t, scratchStartKey, tc.Target(2))
 		require.True(t, desc.Replicas().InAtomicReplicationChange(), desc)
-		store.SetReplicateQueueActive(true)
+		store.TestingSetReplicateQueueActive(true)
 		trace, processErr, err := store.Enqueue(
 			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
 		)
@@ -1312,7 +1312,7 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 			}
 			return nil
 		})
-		store.SetReplicateQueueActive(false)
+		store.TestingSetReplicateQueueActive(false)
 	})
 }
 

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1736,7 +1736,7 @@ func filterRangeLog(
 func toggleReplicationQueues(tc *testcluster.TestCluster, active bool) {
 	for _, s := range tc.Servers {
 		_ = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.SetReplicateQueueActive(active)
+			store.TestingSetReplicateQueueActive(active)
 			return nil
 		})
 	}
@@ -1754,7 +1754,7 @@ func forceScanOnAllReplicationQueues(tc *testcluster.TestCluster) (err error) {
 func toggleSplitQueues(tc *testcluster.TestCluster, active bool) {
 	for _, s := range tc.Servers {
 		_ = s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.SetSplitQueueActive(active)
+			store.TestingSetSplitQueueActive(active)
 			return nil
 		})
 	}

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -44,9 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
-	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -2085,112 +2083,6 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 			return errors.Errorf("unable to transfer")
 		}
 		return errors.Errorf("Repeat check for correct leaseholder")
-	})
-}
-
-// TestReplicateQueueAcquiresInvalidLeases asserts that following a restart,
-// leases are invalidated and that the replicate queue acquires invalid leases
-// when enabled.
-func TestReplicateQueueAcquiresInvalidLeases(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
-
-	lisReg := listenerutil.NewListenerRegistry()
-	defer lisReg.Close()
-
-	zcfg := zonepb.DefaultZoneConfig()
-	zcfg.NumReplicas = proto.Int32(1)
-	tc := testcluster.StartTestCluster(t, 1,
-		base.TestClusterArgs{
-			// Disable the replication queue initially, to assert on the lease
-			// statuses pre and post enabling the replicate queue.
-			ReplicationMode:     base.ReplicationManual,
-			ReusableListenerReg: lisReg,
-			ServerArgs: base.TestServerArgs{
-				Settings:          st,
-				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-				ScanMinIdleTime:   time.Millisecond,
-				ScanMaxIdleTime:   time.Millisecond,
-				Knobs: base.TestingKnobs{
-					Server: &server.TestingKnobs{
-						StickyVFSRegistry:         fs.NewStickyRegistry(),
-						DefaultZoneConfigOverride: &zcfg,
-					},
-				},
-			},
-		},
-	)
-	defer tc.Stopper().Stop(ctx)
-	db := tc.Conns[0]
-	// Disable consistency checker and sql stats collection that may acquire a
-	// lease by querying a range.
-	_, err := db.Exec("set cluster setting server.consistency_check.interval = '0s'")
-	require.NoError(t, err)
-	_, err = db.Exec("set cluster setting sql.stats.automatic_collection.enabled = false")
-	require.NoError(t, err)
-
-	// Create ranges to assert on their lease status post restart and after
-	// replicate queue processing.
-	ranges := 30
-	scratchRangeKeys := make([]roachpb.Key, ranges)
-	splitKey := tc.ScratchRange(t)
-	for i := range scratchRangeKeys {
-		_, _ = tc.SplitRangeOrFatal(t, splitKey)
-		scratchRangeKeys[i] = splitKey
-		splitKey = splitKey.Next()
-	}
-
-	invalidLeases := func() []kvserverpb.LeaseStatus {
-		invalid := []kvserverpb.LeaseStatus{}
-		for _, key := range scratchRangeKeys {
-			// Assert that the lease is invalid after restart.
-			repl := tc.GetRaftLeader(t, roachpb.RKey(key))
-			if leaseStatus := repl.CurrentLeaseStatus(ctx); !leaseStatus.IsValid() {
-				invalid = append(invalid, leaseStatus)
-			}
-		}
-		return invalid
-	}
-
-	// Assert that the leases are valid initially.
-	require.Len(t, invalidLeases(), 0)
-
-	// Restart the servers to invalidate the leases.
-	for i := range tc.Servers {
-		tc.StopServer(i)
-		err = tc.RestartServerWithInspect(i, nil)
-		require.NoError(t, err)
-	}
-
-	forceProcess := func() {
-		// Speed up the queue processing.
-		for _, s := range tc.Servers {
-			err := s.GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-				return store.ForceReplicationScanAndProcess()
-			})
-			require.NoError(t, err)
-		}
-	}
-
-	// NB: The cosnsistency checker and sql stats collector both will attempt a
-	// lease acquisition when processing a range, if it the lease is currently
-	// invalid. They are disabled in this test. We do not assert on the number
-	// of invalid leases prior to enabling the replicate queue here to avoid
-	// test flakiness if this changes in the future or for some other reason.
-	// Instead, we are only concerned that no invalid leases remain.
-	toggleReplicationQueues(tc, true /* active */)
-	testutils.SucceedsSoon(t, func() error {
-		forceProcess()
-		// Assert that there are now no invalid leases.
-		invalid := invalidLeases()
-		if len(invalid) > 0 {
-			return errors.Newf("The number of invalid leases are greater than 0, %+v", invalid)
-		}
-		return nil
 	})
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1681,37 +1681,37 @@ func NewStore(
 	}
 
 	if cfg.TestingKnobs.DisableGCQueue {
-		s.setGCQueueActive(false)
+		s.testingSetGCQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableLeaseQueue {
-		s.SetLeaseQueueActive(false)
+		s.TestingSetLeaseQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableMergeQueue {
-		s.setMergeQueueActive(false)
+		s.testingSetMergeQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableRaftLogQueue {
-		s.setRaftLogQueueActive(false)
+		s.testingSetRaftLogQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableReplicaGCQueue {
-		s.setReplicaGCQueueActive(false)
+		s.testingSetReplicaGCQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableReplicateQueue {
-		s.SetReplicateQueueActive(false)
+		s.TestingSetReplicateQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableSplitQueue {
-		s.SetSplitQueueActive(false)
+		s.TestingSetSplitQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableTimeSeriesMaintenanceQueue {
-		s.setTimeSeriesMaintenanceQueueActive(false)
+		s.testingSetTimeSeriesMaintenanceQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableRaftSnapshotQueue {
-		s.setRaftSnapshotQueueActive(false)
+		s.testingSetRaftSnapshotQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableConsistencyQueue {
-		s.setConsistencyQueueActive(false)
+		s.testingSetConsistencyQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableScanner {
-		s.setScannerActive(false)
+		s.testingSetScannerActive(false)
 	}
 
 	return s

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1684,7 +1684,7 @@ func NewStore(
 		s.setGCQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableLeaseQueue {
-		s.setLeaseQueueActive(false)
+		s.SetLeaseQueueActive(false)
 	}
 	if cfg.TestingKnobs.DisableMergeQueue {
 		s.setMergeQueueActive(false)

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1608,7 +1608,7 @@ func (tc *TestCluster) ReplicationMode() base.TestClusterReplicationMode {
 func (tc *TestCluster) ToggleReplicateQueues(active bool) {
 	for _, s := range tc.Servers {
 		_ = s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.SetReplicateQueueActive(active)
+			store.TestingSetReplicateQueueActive(active)
 			return nil
 		})
 	}
@@ -1618,7 +1618,7 @@ func (tc *TestCluster) ToggleReplicateQueues(active bool) {
 func (tc *TestCluster) ToggleSplitQueues(active bool) {
 	for _, s := range tc.Servers {
 		_ = s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
-			store.SetSplitQueueActive(active)
+			store.TestingSetSplitQueueActive(active)
 			return nil
 		})
 	}

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -581,6 +581,7 @@ func (tc *TestCluster) AddServer(
 		if stk := serverArgs.Knobs.Store; stk != nil {
 			stkCopy = *stk.(*kvserver.StoreTestingKnobs)
 		}
+		stkCopy.DisableLeaseQueue = true
 		stkCopy.DisableSplitQueue = true
 		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true


### PR DESCRIPTION
A replica lease queue was introduced in https://github.com/cockroachdb/cockroach/pull/119155, which processes lease
transfers for replicas. Previously, the replicate queue handled lease
transfers. The linked change omitted updating the `ReplicationManual`
test cluster mode to disable the lease queue, resulting in unexpected
lease transfers in some tests.

Disable the lease queue under `ReplicationManual` replication mode. Misc
tests are also updated to disable/enable the lease queue appropriately.

Epic: None
Touches: https://github.com/cockroachdb/cockroach/issues/120605
Release note: None