### PR TITLE
catalog/lease: use txn time when detecting session based leasing table

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1417,7 +1417,7 @@ func (ex *connExecutor) checkDescriptorTwoVersionInvariant(ctx context.Context) 
 	if knobs := ex.server.cfg.SchemaChangerTestingKnobs; knobs != nil {
 		inRetryBackoff = knobs.TwoVersionLeaseViolation
 	}
-	regionCache, err := regions.NewCachedDatabaseRegions(ctx, ex.server.cfg.DB, ex.server.cfg.LeaseManager)
+	regionCache, err := regions.NewCachedDatabaseRegionsAt(ctx, ex.server.cfg.DB, ex.server.cfg.LeaseManager, ex.state.mu.txn.ProvisionalCommitTimestamp())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/regions/BUILD.bazel
+++ b/pkg/sql/regions/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/lease",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
Previously, the logic to detect if the session based leasing table
should be injected synthetically queries the system database version,
but did not correctly use the transaction timestamp, which could lead to
us incorrectly assuming the descriptor is upgraded at the timestamp that
the leasing count query executed at. To address this, this patch updates
the CachedDatabaseRegions to support using a fixed timestamp from the
transaction.

Fixes: #120675, #121036

Release note: None