### PR TITLE
kv: use response keys of ranged writes for lock tracking

### DIFF
--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -513,7 +513,7 @@ func (ba *BatchRequest) RefreshSpanIterate(br *BatchResponse, fn func(roachpb.Sp
 		if br != nil {
 			resp = br.Responses[i].GetInner()
 		}
-		if ba.WaitPolicy == lock.WaitPolicy_SkipLocked && CanSkipLocked(req) {
+		if ba.WaitPolicy == lock.WaitPolicy_SkipLocked && CanSkipLocked(req) && resp != nil {
 			if ba.IndexFetchSpec != nil {
 				return errors.AssertionFailedf("unexpectedly IndexFetchSpec is set with SKIP LOCKED wait policy")
 			}
@@ -574,7 +574,7 @@ func ActualSpan(req Request, resp Response) (roachpb.Span, bool) {
 // COL_BATCH_RESPONSE scan format.
 func ResponseKeyIterate(req Request, resp Response, fn func(roachpb.Key)) error {
 	if resp == nil {
-		return nil
+		return errors.Errorf("cannot iterate over response keys of %s request with nil response", req.Method())
 	}
 	switch v := resp.(type) {
 	case *GetResponse:

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -474,25 +474,47 @@ func (br *BatchResponse) String() string {
 	return strings.Join(str, ", ")
 }
 
-// LockSpanIterate calls the passed method with the key ranges of the
-// transactional locks contained in the batch. Usually the key spans
-// contained in the requests are used, but when a response contains a
-// ResumeSpan the ResumeSpan is subtracted from the request span to
-// provide a more minimal span of keys affected by the request.
-func (ba *BatchRequest) LockSpanIterate(br *BatchResponse, fn func(roachpb.Span, lock.Durability)) {
+// LockSpanIterate calls LockSpanIterate for each request in the batch.
+func (ba *BatchRequest) LockSpanIterate(
+	br *BatchResponse, fn func(roachpb.Span, lock.Durability),
+) error {
 	for i, arg := range ba.Requests {
 		req := arg.GetInner()
-		if !IsLocking(req) {
-			continue
-		}
 		var resp Response
 		if br != nil {
 			resp = br.Responses[i].GetInner()
 		}
-		if span, ok := ActualSpan(req, resp); ok {
-			fn(span, LockingDurability(req))
+		if err := LockSpanIterate(req, resp, fn); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+// LockSpanIterate calls the passed function with the keys or key spans of the
+// transactional locks acquired by the request. Usually the full key span that
+// is addressed by the request is used. However, a more minimal span of keys can
+// be provided in the following cases:
+//   - the request operates over a range of keys but the response includes the
+//     specific set of keys that were locked. In these cases, the provided
+//     function is called with each individual locked key.
+//   - the request operates over a range of keys but the response contains a
+//     ResumeSpan signifying the key spans not reached by the request. In these
+//     cases, the ResumeSpan is subtracted from the request span.
+func LockSpanIterate(req Request, resp Response, fn func(roachpb.Span, lock.Durability)) error {
+	if !IsLocking(req) {
+		return nil
+	}
+	dur := LockingDurability(req)
+	if canIterateResponseKeys(req, resp) {
+		return ResponseKeyIterate(req, resp, func(key roachpb.Key) {
+			fn(roachpb.Span{Key: key}, dur)
+		})
+	}
+	if span, ok := actualSpan(req, resp); ok {
+		fn(span, dur)
+	}
+	return nil
 }
 
 // RefreshSpanIterate calls the passed function with the key spans of
@@ -536,7 +558,7 @@ func (ba *BatchRequest) RefreshSpanIterate(br *BatchResponse, fn func(roachpb.Sp
 			}
 		} else {
 			// Otherwise, call the function with the span which was operated on.
-			if span, ok := ActualSpan(req, resp); ok {
+			if span, ok := actualSpan(req, resp); ok {
 				fn(span)
 			}
 		}
@@ -544,10 +566,10 @@ func (ba *BatchRequest) RefreshSpanIterate(br *BatchResponse, fn func(roachpb.Sp
 	return nil
 }
 
-// ActualSpan returns the actual request span which was operated on,
+// actualSpan returns the actual request span which was operated on,
 // according to the existence of a resume span in the response. If
 // nothing was operated on, returns false.
-func ActualSpan(req Request, resp Response) (roachpb.Span, bool) {
+func actualSpan(req Request, resp Response) (roachpb.Span, bool) {
 	h := req.Header()
 	if resp != nil {
 		resumeSpan := resp.Header().ResumeSpan
@@ -565,6 +587,25 @@ func ActualSpan(req Request, resp Response) (roachpb.Span, bool) {
 		}
 	}
 	return h.Span(), true
+}
+
+// canIterateResponseKeys returns whether the response to the given request
+// contains keys that can be iterated over using ResponseKeyIterate.
+func canIterateResponseKeys(req Request, resp Response) bool {
+	if resp == nil {
+		return false
+	}
+	switch v := req.(type) {
+	case *GetRequest:
+		return true
+	case *ScanRequest:
+		return v.ScanFormat != COL_BATCH_RESPONSE
+	case *ReverseScanRequest:
+		return v.ScanFormat != COL_BATCH_RESPONSE
+	case *DeleteRangeRequest:
+		return v.ReturnKeys
+	}
+	return false
 }
 
 // ResponseKeyIterate calls the passed function with the keys returned

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -642,6 +642,14 @@ func ResponseKeyIterate(req Request, resp Response, fn func(roachpb.Key)) error 
 				return errors.AssertionFailedf("unexpectedly non-empty ColBatches")
 			}
 		}
+	case *DeleteRangeResponse:
+		if !req.(*DeleteRangeRequest).ReturnKeys {
+			return errors.AssertionFailedf("cannot iterate over response keys of DeleteRange " +
+				"request when ReturnKeys=false")
+		}
+		for _, k := range v.Keys {
+			fn(k)
+		}
 	default:
 		return errors.Errorf("cannot iterate over response keys of %s request", req.Method())
 	}

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -472,6 +472,24 @@ func TestResponseKeyIterate(t *testing.T) {
 			expErr: "unexpectedly called ResponseKeyIterate on a ReverseScanRequest with COL_BATCH_RESPONSE scan format",
 		},
 		{
+			name:    "delete-range, no response keys",
+			req:     &DeleteRangeRequest{RequestHeader: rangeHeader, ReturnKeys: true},
+			resp:    &DeleteRangeResponse{Keys: nil},
+			expKeys: nil,
+		},
+		{
+			name:    "delete-range, some response keys",
+			req:     &DeleteRangeRequest{RequestHeader: rangeHeader, ReturnKeys: true},
+			resp:    &DeleteRangeResponse{Keys: []roachpb.Key{keyB, keyC}},
+			expKeys: []roachpb.Key{keyB, keyC},
+		},
+		{
+			name:   "delete-range, return keys disabled",
+			req:    &DeleteRangeRequest{RequestHeader: rangeHeader, ReturnKeys: false},
+			resp:   &DeleteRangeResponse{},
+			expErr: "cannot iterate over response keys of DeleteRange request when ReturnKeys=false",
+		},
+		{
 			name:   "put",
 			req:    &PutRequest{},
 			resp:   &PutResponse{},
@@ -500,12 +518,6 @@ func TestResponseKeyIterate(t *testing.T) {
 			req:    &DeleteRequest{},
 			resp:   &DeleteResponse{},
 			expErr: "cannot iterate over response keys of Delete request",
-		},
-		{
-			name:   "delete-range",
-			req:    &DeleteRangeRequest{},
-			resp:   &DeleteRangeResponse{},
-			expErr: "cannot iterate over response keys of DeleteRange request",
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -414,6 +414,12 @@ func TestResponseKeyIterate(t *testing.T) {
 			expKeys: []roachpb.Key{keyA},
 		},
 		{
+			name:   "get, no response",
+			req:    &GetRequest{RequestHeader: pointHeader},
+			resp:   nil,
+			expErr: "cannot iterate over response keys of Get request with nil response",
+		},
+		{
 			name:    "scan, missing",
 			req:     &ScanRequest{RequestHeader: rangeHeader, ScanFormat: KEY_VALUES},
 			resp:    &ScanResponse{},

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -127,7 +127,7 @@ func (r *Replica) updateTimestampCache(
 		header := req.Header()
 		start, end := header.Key, header.EndKey
 
-		if ba.WaitPolicy == lock.WaitPolicy_SkipLocked && kvpb.CanSkipLocked(req) {
+		if ba.WaitPolicy == lock.WaitPolicy_SkipLocked && kvpb.CanSkipLocked(req) && resp != nil {
 			if ba.IndexFetchSpec != nil {
 				log.Errorf(ctx, "%v", errors.AssertionFailedf("unexpectedly IndexFetchSpec is set with SKIP LOCKED wait policy"))
 			}


### PR DESCRIPTION
Informs #117978.

This PR updates the `txnPipeliner` to use the response keys from `Get`, `Scan`, `ReverseScan`, and `DeleteRange` requests to track pipelined and non-pipelined lock acquisitions / intent writes, instead of assuming that the requests could have left intents anywhere in their request span. This more precise tracking avoid broad ranged intent resolution when more narrow intent resolution is possible. It will also be used by #117978 to track in-flight replicated lock acquisition.

This is a WIP. Some tests need to be updated.

Release note: None