### PR TITLE
rangefeed: skip BenchmarkMemoryAccounting for now

### DIFF
--- a/pkg/kv/kvserver/rangefeed/event_size_test.go
+++ b/pkg/kv/kvserver/rangefeed/event_size_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -546,6 +547,7 @@ func TestBasicEventSizeCalculation(t *testing.T) {
 // BenchmarkMemoryAccounting benchmarks the memory accounting of the event
 // struct.
 func BenchmarkMemoryAccounting(b *testing.B) {
+	skip.WithIssue(b, 121087)
 	b.Run("memory_calculation", func(b *testing.B) {
 		b.ReportAllocs()
 		rand, _ := randutil.NewTestRand()


### PR DESCRIPTION
This patch skips BenchmarkMemoryAccounting. Occassionally,
generateRandomizedEventAndSend may produce an empty event, leading to incorrect
handling in switch cases as we do not expect empty event in production. We
previously introduced benchmark to measure overhead of other memory accounting
methods I was exploring. It seems unnecessary now that we are going for a more
straightforward way. I will improve the testing in #120902.

Epic: none
Release note: none