### PR TITLE
kvserver: clean up version logic

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4909,8 +4909,8 @@ func TestRangeMigration(t *testing.T) {
 
 	// We're going to be transitioning from startV to endV. Think a cluster of
 	// binaries running vX, but with active version vX-1.
-	startV := roachpb.Version{Major: 41}
-	endV := roachpb.Version{Major: 42}
+	startV := clusterversion.PreviousRelease.Version()
+	endV := clusterversion.Latest.Version()
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{


### PR DESCRIPTION
Previously the test TestRangeMigration was using artifical versions. This no longer works after #112456. This commit cleans up the test to validate upgrades work from `PreviousRelease` to `Latest`

Epic: none

Release note: None