### PR TITLE
batcheval: move test to `large` RBE pool

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -132,10 +132,7 @@ go_test(
         "transaction_test.go",
     ],
     embed = [":batcheval"],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
-        "//conditions:default": {"test.Pool": "default"},
-    }),
+    exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None