### PR TITLE
sql_test: deflake TestIndexBackfillFractionTracking

### DIFF
--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -671,10 +671,11 @@ func splitIndex(
 			return err
 		}
 
-		holder, err := tc.FindRangeLeaseHolder(rangeDesc, nil)
+		li, _, err := tc.FindRangeLeaseEx(ctx, rangeDesc, nil)
 		if err != nil {
 			return err
 		}
+		holder := li.CurrentOrProspective().Replica
 
 		_, rightRange, err := tc.Server(int(holder.NodeID) - 1).SplitRange(pik)
 		if err != nil {

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -153,6 +153,21 @@ type TestClusterInterface interface {
 		hint *roachpb.ReplicationTarget,
 	) (roachpb.ReplicationTarget, error)
 
+	// FindRangeLeaseEx returns information about a range's lease. As opposed to
+	// FindRangeLeaseHolder, it doesn't check the validity of the lease; instead it
+	// returns a timestamp from a node's clock.
+	//
+	// If hint is not nil, the respective node will be queried. If that node doesn't
+	// have a replica able to serve a LeaseInfoRequest, an error will be returned.
+	// If hint is nil, the first node is queried. In either case, if the returned
+	// lease is not valid, it's possible that the returned lease information is
+	// stale - i.e. there might be a newer lease unbeknownst to the queried node.
+	FindRangeLeaseEx(
+		ctx context.Context,
+		rangeDesc roachpb.RangeDescriptor,
+		hint *roachpb.ReplicationTarget,
+	) (_ roachpb.LeaseInfo, now hlc.ClockTimestamp, _ error)
+
 	// TransferRangeLease transfers the lease for a range from whoever has it to
 	// a particular store. That store must already have a replica of the range. If
 	// that replica already has the (active) lease, this method is a no-op.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1277,15 +1277,7 @@ func (tc *TestCluster) FindRangeLease(
 	return l.CurrentOrProspective(), now, err
 }
 
-// FindRangeLeaseEx returns information about a range's lease. As opposed to
-// FindRangeLeaseHolder, it doesn't check the validity of the lease; instead it
-// returns a timestamp from a node's clock.
-//
-// If hint is not nil, the respective node will be queried. If that node doesn't
-// have a replica able to serve a LeaseInfoRequest, an error will be returned.
-// If hint is nil, the first node is queried. In either case, if the returned
-// lease is not valid, it's possible that the returned lease information is
-// stale - i.e. there might be a newer lease unbeknownst to the queried node.
+// FindRangeLeaseEx is part of TestClusterInterface.
 func (tc *TestCluster) FindRangeLeaseEx(
 	ctx context.Context, rangeDesc roachpb.RangeDescriptor, hint *roachpb.ReplicationTarget,
 ) (_ roachpb.LeaseInfo, now hlc.ClockTimestamp, _ error) {


### PR DESCRIPTION
TestIndexBackfillFractionTracking performs some splits, followed by index backfills. When running under race, the lease of the RHS, installed by the split, can expire and cause the `no valid lease` error.

This patch uses `FindRangeLeaseEx` instead of `FindRangeLeaseHolder` to find the lease; the former doesn't check the validity of the lease; instead it returns a timestamp from a node's clock.

We've seen this before in #9721.

Fixes: #120627

Release note: None