### PR TITLE
server: simplify tenant auto upgrade logic

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
         "//pkg/testutils/sqlutils",
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",
-        "//pkg/util",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -171,6 +171,7 @@ func TestTenantAutoUpgrade(t *testing.T) {
 
 	expectedInitialTenantVersion := v0.Version()
 	expectedFinalTenantVersion := clusterversion.Latest.Version()
+	expectedFinalTenantVersion.Internal = 0 // tenants only upgrade to non-internal versions
 
 	tenantSettings := cluster.MakeTestingClusterSettingsWithVersions(
 		clusterversion.Latest.Version(),
@@ -189,9 +190,8 @@ func TestTenantAutoUpgrade(t *testing.T) {
 			TenantName: roachpb.TenantName(name),
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					TenantAutoUpgradeInfo:                          upgradeInfoCh,
-					AllowTenantAutoUpgradeOnInternalVersionChanges: true,
-					BinaryVersionOverride:                          v0.Version(),
+					TenantAutoUpgradeInfo: upgradeInfoCh,
+					BinaryVersionOverride: v0.Version(),
 				},
 			},
 		}

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -30,113 +30,27 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTenantAutoUpgradeRespectsAutoUpgradeEnabledSetting(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
-
-	v0 := clusterversion.MinSupported
-	ctx := context.Background()
-	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.Latest.Version(),
-		v0.Version(),
-		false, // initializeVersion
-	)
-	// Initialize the version to v0.
-	require.NoError(t, clusterversion.Initialize(ctx,
-		v0.Version(), &settings.SV))
-
-	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestControlsTenantsExplicitly,
-		Settings:          settings,
-		Knobs: base.TestingKnobs{
-			Server: &server.TestingKnobs{
-				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v0.Version(),
-			},
-			SQLEvalContext: &eval.TestingKnobs{
-				// When the host binary version is not equal to its cluster version, tenant logical version is set
-				// to the host's minimum supported binary version. We need this override to ensure that the tenant is
-				// created at v0.
-				TenantLogicalVersionKeyOverride: v0,
-			},
-		},
-	})
-	defer ts.Stopper().Stop(ctx)
-	sysDB := sqlutils.MakeSQLRunner(ts.SQLConn(t, serverutils.DBName("")))
-
-	expectedInitialTenantVersion := v0.Version()
-
-	tenantSettings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.Latest.Version(),
-		v0.Version(),
-		false, // initializeVersion
-	)
-	require.NoError(t, clusterversion.Initialize(ctx,
-		expectedInitialTenantVersion, &tenantSettings.SV))
-
-	upgradeInfoCh := make(chan struct {
-		Status    int
-		UpgradeTo roachpb.Version
-	}, 1)
-	mkTenant := func(t *testing.T, name string) (tenantDB *gosql.DB) {
-		tenantArgs := base.TestSharedProcessTenantArgs{
-			TenantName: roachpb.TenantName(name),
-			Knobs: base.TestingKnobs{
-				Server: &server.TestingKnobs{
-					TenantAutoUpgradeInfo: upgradeInfoCh,
-					BinaryVersionOverride: v0.Version(),
-				},
-			},
-		}
-		_, tenantDB, err := ts.TenantController().StartSharedProcessTenant(ctx, tenantArgs)
-		require.NoError(t, err)
-		return tenantDB
-	}
-
-	// Create a shared process tenant and its SQL server.
-	const tenantName = "marhaba-crdb"
-	tenantDB := mkTenant(t, tenantName)
-	tenantRunner := sqlutils.MakeSQLRunner(tenantDB)
-
-	// Ensure that the tenant works.
-	tenantRunner.Exec(t, "CREATE TABLE t (i INT PRIMARY KEY)")
-	tenantRunner.Exec(t, "INSERT INTO t VALUES (1), (2)")
-
-	// Disable cluster.auto_upgrade.enabled setting for the tenant to prevent auto upgrade.
-	tenantRunner.Exec(t, fmt.Sprintf("SET CLUSTER SETTING %s = false", clusterversion.AutoUpgradeEnabled.Name()))
-
-	// Upgrade the host cluster.
-	sysDB.Exec(t,
-		"SET CLUSTER SETTING version = $1",
-		clusterversion.Latest.String())
-
-	// Ensure that the tenant still works.
-	tenantRunner.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1"}, {"2"}})
-
-	// Wait for auto upgrade status to be received by the testing knob.
-	succeedsSoon := 20 * time.Second
-	for {
-		select {
-		case upgradeInfo := <-upgradeInfoCh:
-			if int(server.UpgradeDisabledByConfiguration) == upgradeInfo.Status {
-				return
-			}
-		case <-time.After(succeedsSoon):
-			t.Fatalf("failed to receive the right auto upgrade status after %d seconds", int(succeedsSoon.Seconds()))
-		}
-	}
+// autoUpgradeClusterSetting wraps data about an auto-upgrade related
+// cluster setting that should lead to the auto upgrade process not
+// being able to run while the setting is active, due to the given
+// upgrade status.
+type autoUpgradeClusterSetting struct {
+	name          string
+	value         any
+	upgradeStatus int
 }
 
-func TestTenantAutoUpgrade(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+// testTenantAutoUpgrades exercises the auto upgrade logic for
+// tenants. If a `clusterSetting` is passed, they are set on the
+// tenant before any upgrade takes place, and reset prior to the point
+// where the tenant auto upgrade should kick in.
+func testTenantAutoUpgrade(t *testing.T, clusterSetting *autoUpgradeClusterSetting) {
 	defer log.Scope(t).Close(t)
 	skip.UnderStressRace(t)
 
@@ -190,8 +104,9 @@ func TestTenantAutoUpgrade(t *testing.T) {
 			TenantName: roachpb.TenantName(name),
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					TenantAutoUpgradeInfo: upgradeInfoCh,
-					BinaryVersionOverride: v0.Version(),
+					TenantAutoUpgradeInfo:          upgradeInfoCh,
+					TenantAutoUpgradeLoopFrequency: time.Second,
+					BinaryVersionOverride:          v0.Version(),
 				},
 			},
 		}
@@ -201,13 +116,18 @@ func TestTenantAutoUpgrade(t *testing.T) {
 	}
 
 	// Create a shared process tenant and its SQL server.
-	const tenantName = "hola-crdb"
+	const tenantName = "app"
 	tenantDB := mkTenant(t, tenantName)
 	tenantRunner := sqlutils.MakeSQLRunner(tenantDB)
 
 	// Ensure that the tenant works.
 	tenantRunner.Exec(t, "CREATE TABLE t (i INT PRIMARY KEY)")
 	tenantRunner.Exec(t, "INSERT INTO t VALUES (1), (2)")
+
+	// Apply the cluster setting, if any.
+	if clusterSetting != nil {
+		tenantRunner.Exec(t, fmt.Sprintf("SET CLUSTER SETTING %s = $1", clusterSetting.name), clusterSetting.value)
+	}
 
 	// Upgrade the host cluster.
 	sysDB.Exec(t,
@@ -217,25 +137,73 @@ func TestTenantAutoUpgrade(t *testing.T) {
 	// Ensure that the tenant still works.
 	tenantRunner.CheckQueryResults(t, "SELECT * FROM t", [][]string{{"1"}, {"2"}})
 
-	var upgradeInfo struct {
-		Status    int
-		UpgradeTo roachpb.Version
-	}
-	succeedsSoon := 20 * time.Second
-	if util.RaceEnabled || skip.Stress() {
-		succeedsSoon = 60 * time.Second
-	}
-	// Wait for auto upgrade status to be received by the testing knob.
-	for {
-		select {
-		case upgradeInfo = <-upgradeInfoCh:
-			if upgradeInfo.UpgradeTo == expectedFinalTenantVersion && upgradeInfo.Status == int(server.UpgradeAllowed) {
-				return
+	waitForUpgradeInfo := func(expectedVersion roachpb.Version, expectedStatus int) {
+		succeedsSoon := 20 * time.Second
+
+		for {
+			select {
+			case upgradeInfo := <-upgradeInfoCh:
+				if upgradeInfo.UpgradeTo == expectedVersion && upgradeInfo.Status == expectedStatus {
+					return
+				}
+			case <-time.After(succeedsSoon):
+				t.Fatalf(
+					"failed to receive the auto upgrade status for version %s and status %d after %d seconds",
+					expectedVersion, expectedStatus, int(succeedsSoon.Seconds()),
+				)
 			}
-		case <-time.After(succeedsSoon):
-			t.Fatalf("failed to receive the right auto upgrade status after %d seconds", int(succeedsSoon.Seconds()))
 		}
 	}
+
+	// Reset cluster setting, if any.
+	if clusterSetting != nil {
+		// Wait for us to receive an upgrade event indicating that we are
+		// not upgrading immediately after the storage cluster due to a
+		// cluster setting configuration.
+		waitForUpgradeInfo(roachpb.Version{}, clusterSetting.upgradeStatus)
+
+		tenantRunner.Exec(t, fmt.Sprintf("RESET CLUSTER SETTING %s", clusterSetting.name))
+	}
+
+	// Wait for auto upgrade status to be received by the testing
+	// knob. If the min supported version and the `Latest` version are
+	// on the same major release, the tenant will just realize that it
+	// is already upgraded. Otherwise, the upgrade should be allowed to
+	// continue.
+	expectedVersion := expectedFinalTenantVersion
+	expectedStatus := server.UpgradeAllowed
+	if expectedFinalTenantVersion.Major == v0.Version().Major &&
+		expectedFinalTenantVersion.Minor == v0.Version().Minor {
+		expectedVersion = roachpb.Version{}
+		expectedStatus = server.UpgradeAlreadyCompleted
+	}
+	waitForUpgradeInfo(expectedVersion, int(expectedStatus))
+}
+
+func TestTenantAutoUpgradeNoClusterSettings(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDuress(t, "slow test")
+	testTenantAutoUpgrade(t, nil)
+}
+
+func TestTenantAutoUpgradeWithAutoUpgradeClusterSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDuress(t, "slow test")
+	testTenantAutoUpgrade(t, &autoUpgradeClusterSetting{
+		name:          "cluster.auto_upgrade.enabled",
+		value:         false,
+		upgradeStatus: int(server.UpgradeDisabledByConfiguration),
+	})
+}
+
+func TestTenantAutoUpgradeWithPreserveDowngradeOptionClusterSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	skip.UnderDuress(t, "slow test")
+	testTenantAutoUpgrade(t, &autoUpgradeClusterSetting{
+		name:          "cluster.preserve_downgrade_option",
+		value:         clusterversion.MinSupported.Version().String(),
+		upgradeStatus: int(server.UpgradeDisabledByConfigurationToPreserveDowngrade),
+	})
 }
 
 // TestTenantUpgrade exercises the case where a system tenant is in a

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -69,14 +69,14 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 				log.Infof(ctx, "failed attempt to upgrade cluster version: %v", err)
 				continue
 			case UpgradeDisabledByConfigurationToPreserveDowngrade:
-				log.Infof(ctx, "auto upgrade is disabled for current version (preserve_downgrade_option): %s", redact.Safe(clusterVersion))
+				log.Infof(ctx, "auto upgrade is disabled by preserve_downgrade_option")
 				// Note: we do 'continue' here (and not 'return') so that the
 				// auto-upgrade gets a chance to continue/complete if the
 				// operator resets `preserve_downgrade_option` after the node
 				// has started up already.
 				continue
 			case UpgradeDisabledByConfiguration:
-				log.Infof(ctx, "auto upgrade is disabled by (cluster.auto_upgrade.enabled)")
+				log.Infof(ctx, "auto upgrade is disabled by cluster.auto_upgrade.enabled")
 				// Note: we do 'continue' here (and not 'return') so that the
 				// auto-upgrade gets a chance to continue/complete if the
 				// operator resets `auto_upgrade.enabled` after the node

--- a/pkg/server/tenant_auto_upgrade.go
+++ b/pkg/server/tenant_auto_upgrade.go
@@ -31,31 +31,29 @@ import (
 // starts. This is to cover cases where upgrade becomes possible due to
 // an upgrade to the tenant binary version.
 func (s *SQLServer) startTenantAutoUpgradeLoop(ctx context.Context) error {
-	storageClusterVersion := s.settingsWatcher.GetStorageClusterActiveVersion().Version
 	return s.stopper.RunAsyncTask(ctx, "tenant-auto-upgrade-checker", func(ctx context.Context) {
-		firstAttempt := true
+		loopFrequency := 30 * time.Second
+		if k := s.cfg.TestingKnobs.Server; k != nil {
+			loopFrequency = k.(*TestingKnobs).TenantAutoUpgradeLoopFrequency
+		}
+
 		for {
 			select {
 			case <-s.stopper.ShouldQuiesce():
 				return
-			// Check for changes every 10 seconds to avoid triggering an upgrade
-			// on every change to the internal version of storage cluster version
-			// within a short time period.
-			case <-time.After(time.Second * 10):
-				latestStorageClusterVersion := s.settingsWatcher.GetStorageClusterActiveVersion().Version
-				// Only run upgrade if this is the first attempt (i.e. on server startup) or if the
-				// the storage cluster version changed and is at an Internal version of 0 which implies that
-				// that storage is at the "final" version for some release. First case ensures that if an upgrade is
-				// possible due to a change in a sql instance binary version, it happens. Second
-				// cases ensures that if an upgrade is possible due to a change in the storage
-				// cluster version, it happens.
-				storageClusterVersionChanged := storageClusterVersion != latestStorageClusterVersion
-				if firstAttempt ||
-					(storageClusterVersionChanged && storageClusterVersion.Internal == 0) {
-					firstAttempt = false
-					storageClusterVersion = latestStorageClusterVersion
-					if err := s.startAttemptTenantUpgrade(ctx); err != nil {
+			case <-time.After(loopFrequency):
+				storageClusterVersion := s.settingsWatcher.GetStorageClusterActiveVersion().Version
+
+				// Only attempt to upgrade if the storage cluster is at an Internal version of 0,
+				// which implies that storage is at the "final" version for some release.
+				if storageClusterVersion.Internal == 0 {
+					upgradeCompleted, err := s.startAttemptTenantUpgrade(ctx)
+					if err != nil {
 						log.Errorf(ctx, "failed to start an upgrade attempt: %v", err)
+					}
+
+					if upgradeCompleted {
+						return
 					}
 				}
 			}
@@ -63,8 +61,10 @@ func (s *SQLServer) startTenantAutoUpgradeLoop(ctx context.Context) error {
 	})
 }
 
-// startAttemptTenantUpgrade attempts to upgrade cluster version.
-func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) error {
+// startAttemptTenantUpgrade attempts to upgrade cluster
+// version. Returns whether the upgrade was completed, and any errors
+// found during the process.
+func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) (bool, error) {
 	ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
 
@@ -77,7 +77,7 @@ func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) error {
 			case <-disableCh:
 				log.Infof(ctx, "auto upgrade no longer disabled by testing")
 			case <-s.stopper.ShouldQuiesce():
-				return nil
+				return false, nil
 			}
 		}
 	}
@@ -97,7 +97,7 @@ func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) error {
 		tenantClusterVersion, err = s.settingsWatcher.GetClusterVersionFromStorage(ctx, txn)
 		return err
 	}); err != nil {
-		return errors.Wrap(err, "unable to retrieve tenant cluster version")
+		return false, errors.Wrap(err, "unable to retrieve tenant cluster version")
 	}
 
 	// Check if we should upgrade cluster version.
@@ -113,20 +113,23 @@ func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) error {
 
 	switch status {
 	case UpgradeBlockedDueToError:
-		return err
+		return false, err
 	case UpgradeDisabledByConfiguration:
-		log.Infof(ctx, "auto upgrade is disabled for current version (preserve_downgrade_option): %s", redact.Safe(tenantClusterVersion.Version))
-		return nil
+		log.Infof(ctx, "auto upgrade is disabled for current version (cluster.auto_upgrade.enabled): %s", redact.Safe(tenantClusterVersion.Version))
+		return false, nil
+	case UpgradeDisabledByConfigurationToPreserveDowngrade:
+		log.Infof(ctx, "auto upgrade is disabled for current version (cluster.preserve_downgrade_option): %s", redact.Safe(tenantClusterVersion.Version))
+		return false, nil
 	case UpgradeAlreadyCompleted:
 		log.Info(ctx, "no need to upgrade, instance already at the newest version")
-		return nil
+		return true, nil
 	case UpgradeBlockedDueToLowStorageClusterVersion:
 		log.Info(ctx, "upgrade blocked because storage binary version doesn't support upgrading to minimum tenant binary version")
-		return nil
+		return false, nil
 	case UpgradeAllowed:
 		// Fall out of the select below.
 	default:
-		return errors.AssertionFailedf("unhandled case: %d", status)
+		return false, errors.AssertionFailedf("unhandled case: %d", status)
 	}
 
 	upgradeRetryOpts := retry.Options{
@@ -144,13 +147,32 @@ func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) error {
 			sessiondata.NodeUserSessionDataOverride,
 			"SET CLUSTER SETTING version = $1;", upgradeToVersion.String(),
 		); err != nil {
-			return errors.Wrap(err, "error when finalizing tenant cluster version upgrade")
+			return false, errors.Wrap(err, "error when finalizing tenant cluster version upgrade")
 		} else {
 			log.Infof(ctx, "successfully upgraded tenant cluster version to %v", upgradeToVersion)
-			return nil
+			return false, nil
 		}
 	}
-	return nil
+	return false, nil
+}
+
+func (s *SQLServer) isAutoUpgradeEnabled(
+	currentClusterVersion roachpb.Version,
+) (bool, upgradeStatus) {
+	if autoUpgradeEnabled := s.settingsWatcher.GetAutoUpgradeEnabledSettingValue(); !autoUpgradeEnabled {
+		// Automatic upgrade is not enabled.
+		return false, UpgradeDisabledByConfiguration
+	}
+
+	if downgradeVersion := s.settingsWatcher.GetPreserveDowngradeVersionSettingValue(); downgradeVersion != "" {
+		if currentClusterVersion.String() == downgradeVersion {
+			// Automatic upgrade is blocked by the preserve downgrade
+			// setting.
+			return false, UpgradeDisabledByConfigurationToPreserveDowngrade
+		}
+	}
+
+	return true, -1
 }
 
 // tenantUpgradeStatus lets the main checking loop know if we should upgrade.
@@ -159,9 +181,8 @@ func (s *SQLServer) tenantUpgradeStatus(
 ) (st upgradeStatus, upgradeToVersion roachpb.Version, err error) {
 	storageClusterVersion := s.settingsWatcher.GetStorageClusterActiveVersion().Version
 
-	if autoUpgradeEnabled := s.settingsWatcher.GetAutoUpgradeEnabledSettingValue(); !autoUpgradeEnabled {
-		// Automatic upgrade is not enabled.
-		return UpgradeDisabledByConfiguration, roachpb.Version{}, nil
+	if enabled, status := s.isAutoUpgradeEnabled(currentClusterVersion); !enabled {
+		return status, roachpb.Version{}, nil
 	}
 
 	instances, err := s.sqlInstanceReader.GetAllInstances(ctx)
@@ -171,7 +192,6 @@ func (s *SQLServer) tenantUpgradeStatus(
 	if len(instances) == 0 {
 		return UpgradeBlockedDueToError, roachpb.Version{}, errors.Errorf("no live instances found")
 	}
-	log.Infof(ctx, "found %d instances", len(instances))
 
 	findMinBinaryVersion := func(instances []sqlinstance.InstanceInfo) roachpb.Version {
 		minVersion := instances[0].BinaryVersion

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -163,17 +163,6 @@ type TestingKnobs struct {
 		UpgradeTo roachpb.Version
 	}
 
-	// As of September 2023, only `v23.1` and master support shared process tenants. `v23.2` is not
-	// cut yet so the difference between the current binary version on master and v23.1 is only in the
-	// Internal version (both are major=23 minor=1). We only trigger shared process tenant auto upgrade
-	// on changes to major/minor versions but since we can only start shared process tenants in `v23.1`,
-	// there will not be any change to major/minor versions when upgrading from `v23.1` to master and
-	// we won't be able to test this new feature. This testing knob allows `TestTenantAutoUpgrade` to
-	// auto upgrade on changes to the Internal version.
-	// // TODO(ahmad/healthy-pod): Remove this once `v23.2` is cut and update `TestTenantAutoUpgrade`
-	// to reflect the changes.
-	AllowTenantAutoUpgradeOnInternalVersionChanges bool
-
 	// EnvironmentSampleInterval overrides base.DefaultMetricsSampleInterval when used to construct sampleEnvironmentCfg.
 	EnvironmentSampleInterval time.Duration
 }

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -163,6 +163,10 @@ type TestingKnobs struct {
 		UpgradeTo roachpb.Version
 	}
 
+	// TenantAutoUpgradeLoopFrequency indicates how often the tenant
+	// auto upgrade loop will check if the tenant can be auto-upgraded.
+	TenantAutoUpgradeLoopFrequency time.Duration
+
 	// EnvironmentSampleInterval overrides base.DefaultMetricsSampleInterval when used to construct sampleEnvironmentCfg.
 	EnvironmentSampleInterval time.Duration
 }


### PR DESCRIPTION
This commit fixes a bug in the tenant auto upgrade logic where tenants
will not attempt to auto upgrade if an auto-upgrade related cluster
setting (`cluster.auto_upgrade.enabled` or
`cluster.preserve_downgrade_option`) was active at the time the
storage cluster finished upgrading. In that case, the tenant would
never pick up the fact that it is now able to auto upgrade, and would
remain in the older cluster version (auto upgrading only if the
service is restarted).

The fix here also brings the tenant auto upgrade logic a lot closer to
the system auto upgrade counterpart. We continue to attempt an
auto-upgrade until we know we have upgraded as much as possible (to
the same version as the storage cluster).

Fixes: #121858

Release note: None