### PR TITLE
server: clean up formatting of store props logged on start

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -902,6 +902,29 @@ func (v Value) PrettyPrint() (ret string) {
 	return buf.String()
 }
 
+// SafeFormat implements the redact.SafeFormatter interface.
+func (sp StoreProperties) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.SafeString(redact.SafeString(sp.Dir))
+	w.SafeString(":")
+	if sp.ReadOnly {
+		w.SafeString(" ro")
+	} else {
+		w.SafeString(" rw")
+	}
+	w.Printf(" encrypted=%t", sp.Encrypted)
+	if sp.WalFailoverPath != nil {
+		w.Printf(" wal_failover_path=%s", redact.SafeString(*sp.WalFailoverPath))
+	}
+	if sp.FileStoreProperties != nil {
+		w.SafeString(" fs:{")
+		w.Printf("bdev=%s", redact.SafeString(sp.FileStoreProperties.BlockDevice))
+		w.Printf(" fstype=%s", redact.SafeString(sp.FileStoreProperties.FsType))
+		w.Printf(" mountpoint=%s", redact.SafeString(sp.FileStoreProperties.MountPoint))
+		w.Printf(" mountopts=%s", redact.SafeString(sp.FileStoreProperties.MountOptions))
+		w.SafeString("}")
+	}
+}
+
 // Kind returns the kind of commit trigger as a string.
 func (ct InternalCommitTrigger) Kind() redact.SafeString {
 	switch {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -861,7 +861,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 		// TODO(jackson): Refactor to either reference count references to the env,
 		// or leave ownership with the caller of Open.
 		storeEnvs[i] = nil
-		detail(redact.Sprintf("store %d: %+v", i, eng.Properties()))
+		detail(redact.Sprintf("store %d: %s", i, eng.Properties()))
 		engines = append(engines, eng)
 	}
 


### PR DESCRIPTION
On start Cockroach logs some information about the stores it initialized. Previously, the store properties were included through logging the roachpb.StoreProperties struct with a +v format specifier. Since the WAL failover path is a pointer to a string, the address of the string was printed rather than its contents. This commit implements redact.SafeFormatter for the roachpb.StoreProperties type and uses it to fix this bug.

Epic: none
Release note: none