### PR TITLE
roachtest: adjust WAL failover disk stall roachtest's logging config

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -81,7 +81,7 @@ func runDiskStalledWALFailover(
 	startOpts.RoachprodOpts.ExtraArgs = []string{
 		// Adopt buffering of the file logging to ensure that we don't block on
 		// flushing logs to the stalled device.
-		"--log", fmt.Sprintf(`{sinks: {stderr: {filter: INFO}}, file-defaults: {dir: "%s", buffered-writes: false, buffering: {max-staleness: 1s, flush-trigger-size: 256KiB, max-buffer-size: 50MiB}}}`, s.LogDir()),
+		"--log", fmt.Sprintf(`{file-defaults: {dir: "%s", buffered-writes: false, buffering: {max-staleness: 1s, flush-trigger-size: 256KiB, max-buffer-size: 50MiB}}}`, s.LogDir()),
 		"--wal-failover=" + failoverFlag,
 	}
 	c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))


### PR DESCRIPTION
The previous logging config outputted all logs to stderr too, which is not buffered and could become blocked on the stalled disk.

Epic: none
Release note: none