### PR TITLE
opt: push Offset into IndexJoin

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1466,16 +1466,16 @@ EXPLAIN (VERBOSE) SELECT * FROM noncover ORDER BY c LIMIT 5 OFFSET 5
 distribution: local
 vectorized: true
 ·
-• limit
+• index join
 │ columns: (a, b, c, d)
-│ offset: 5
+│ ordering: +c
+│ estimated row count: 5 (missing stats)
+│ table: noncover@noncover_pkey
+│ key columns: a
 │
-└── • index join
-    │ columns: (a, b, c, d)
-    │ ordering: +c
-    │ estimated row count: 10 (missing stats)
-    │ table: noncover@noncover_pkey
-    │ key columns: a
+└── • limit
+    │ columns: (a, c)
+    │ offset: 5
     │
     └── • scan
           columns: (a, c)

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -37,8 +37,6 @@
 
 # PushLimitIntoIndexJoin pushes a limit through an index join. Since index
 # lookup can be expensive, it's always better to discard rows beforehand.
-#
-# TODO(radu): we can similarly push Offset too.
 [PushLimitIntoIndexJoin, Explore]
 (Limit
     (IndexJoin $input:* $indexJoinPrivate:*) &
@@ -53,6 +51,25 @@
 =>
 (IndexJoin
     (Limit $input $limitExpr (PruneOrdering $ordering $cols))
+    $indexJoinPrivate
+)
+
+# PushOffsetIntoIndexJoin pushes an offset through an index join. Since an index
+# lookup can be expensive, it's always better to discard rows beforehand.
+[PushOffsetIntoIndexJoin, Explore]
+(Offset
+    (IndexJoin $input:* $indexJoinPrivate:*) &
+        (IndexJoinPreservesRows $indexJoinPrivate)
+    $offsetExpr:(Const $offset:* & (IsPositiveInt $offset))
+    $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $cols:(OutputCols $input)
+        )
+)
+=>
+(IndexJoin
+    (Offset $input $offsetExpr (PruneOrdering $ordering $cols))
     $indexJoinPrivate
 )
 

--- a/pkg/sql/opt/xform/testdata/coster/limit
+++ b/pkg/sql/opt/xform/testdata/coster/limit
@@ -17,50 +17,50 @@ SELECT * FROM a
 WHERE y = 10 ORDER BY s, x DESC
 LIMIT 20 OFFSET 1000
 ----
-offset
+index-join a
  ├── columns: x:1!null y:2!null z:3 s:4!null
- ├── internal-ordering: +4,-1 opt(2)
  ├── cardinality: [0 - 20]
  ├── stats: [rows=1]
- ├── cost: 89.9929301
+ ├── cost: 35.4529295
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3,4)
  ├── ordering: +4,-1 opt(2) [actual: +4,-1]
- ├── index-join a
- │    ├── columns: x:1!null y:2!null z:3 s:4!null
- │    ├── cardinality: [0 - 1020]
- │    ├── stats: [rows=10, distinct(4)=9.56179, null(4)=0]
- │    ├── cost: 89.9729301
- │    ├── key: (1)
- │    ├── fd: ()-->(2), (1)-->(3,4)
- │    ├── ordering: +4,-1 opt(2) [actual: +4,-1]
- │    └── limit
- │         ├── columns: x:1!null y:2!null s:4!null
- │         ├── internal-ordering: +4,-1 opt(2)
- │         ├── cardinality: [0 - 1020]
- │         ├── stats: [rows=10, distinct(4)=9.56179, null(4)=0]
- │         ├── cost: 29.3629295
- │         ├── key: (1)
- │         ├── fd: ()-->(2), (1)-->(4)
- │         ├── ordering: +4,-1 opt(2) [actual: +4,-1]
- │         ├── sort (segmented)
- │         │    ├── columns: x:1!null y:2!null s:4!null
- │         │    ├── stats: [rows=10, distinct(2)=1, null(2)=0, distinct(4)=9.56179, null(4)=0]
- │         │    ├── cost: 29.2529295
- │         │    ├── key: (1)
- │         │    ├── fd: ()-->(2), (1)-->(4)
- │         │    ├── ordering: +4,-1 opt(2) [actual: +4,-1]
- │         │    ├── limit hint: 1020.00
- │         │    └── scan a@a_y_s_idx
- │         │         ├── columns: x:1!null y:2!null s:4!null
- │         │         ├── constraint: /2/4/1: [/10 - /10]
- │         │         ├── stats: [rows=10, distinct(2)=1, null(2)=0, distinct(4)=9.56179, null(4)=0]
- │         │         ├── cost: 28.6200001
- │         │         ├── key: (1)
- │         │         ├── fd: ()-->(2), (1)-->(4)
- │         │         └── ordering: +4 opt(2) [actual: +4]
- │         └── 1020
- └── 1000
+ └── offset
+      ├── columns: x:1!null y:2!null s:4!null
+      ├── internal-ordering: +4,-1 opt(2)
+      ├── cardinality: [0 - 20]
+      ├── stats: [rows=1]
+      ├── cost: 29.3829295
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(4)
+      ├── ordering: +4,-1 opt(2) [actual: +4,-1]
+      ├── limit
+      │    ├── columns: x:1!null y:2!null s:4!null
+      │    ├── internal-ordering: +4,-1 opt(2)
+      │    ├── cardinality: [0 - 1020]
+      │    ├── stats: [rows=10, distinct(4)=9.56179, null(4)=0]
+      │    ├── cost: 29.3629295
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(4)
+      │    ├── ordering: +4,-1 opt(2) [actual: +4,-1]
+      │    ├── sort (segmented)
+      │    │    ├── columns: x:1!null y:2!null s:4!null
+      │    │    ├── stats: [rows=10, distinct(2)=1, null(2)=0, distinct(4)=9.56179, null(4)=0]
+      │    │    ├── cost: 29.2529295
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(2), (1)-->(4)
+      │    │    ├── ordering: +4,-1 opt(2) [actual: +4,-1]
+      │    │    ├── limit hint: 1020.00
+      │    │    └── scan a@a_y_s_idx
+      │    │         ├── columns: x:1!null y:2!null s:4!null
+      │    │         ├── constraint: /2/4/1: [/10 - /10]
+      │    │         ├── stats: [rows=10, distinct(2)=1, null(2)=0, distinct(4)=9.56179, null(4)=0]
+      │    │         ├── cost: 28.6200001
+      │    │         ├── key: (1)
+      │    │         ├── fd: ()-->(2), (1)-->(4)
+      │    │         └── ordering: +4 opt(2) [actual: +4]
+      │    └── 1020
+      └── 1000
 
 exec-ddl
 ALTER TABLE a INJECT STATISTICS '[

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -816,6 +816,110 @@ Final best expression
         └── 5
 
 # --------------------------------------------------
+# PushOffsetIntoIndexJoin
+# --------------------------------------------------
+
+opt expect=PushOffsetIntoIndexJoin
+SELECT * FROM kuv WHERE k = 1 OR k = 2 ORDER BY u OFFSET 5
+----
+index-join kuv
+ ├── columns: k:1!null u:2 v:3
+ ├── ordering: +2
+ └── offset
+      ├── columns: k:1!null u:2 rowid:4!null
+      ├── internal-ordering: +2
+      ├── key: (4)
+      ├── fd: (4)-->(1,2)
+      ├── ordering: +2
+      ├── sort
+      │    ├── columns: k:1!null u:2 rowid:4!null
+      │    ├── key: (4)
+      │    ├── fd: (4)-->(1,2)
+      │    ├── ordering: +2
+      │    └── scan kuv@kuv_k_u_idx
+      │         ├── columns: k:1!null u:2 rowid:4!null
+      │         ├── constraint: /1/2/4: [/1 - /2]
+      │         ├── key: (4)
+      │         └── fd: (4)-->(1,2)
+      └── 5
+
+# Both LIMIT and OFFSET can be pushed below a join.
+opt expect=(PushLimitIntoIndexJoin,PushOffsetIntoIndexJoin)
+SELECT * FROM kuv WHERE k = 1 OR k = 2 ORDER BY u LIMIT 10 OFFSET 5
+----
+index-join kuv
+ ├── columns: k:1!null u:2 v:3
+ ├── cardinality: [0 - 10]
+ ├── ordering: +2
+ └── offset
+      ├── columns: k:1!null u:2 rowid:4!null
+      ├── internal-ordering: +2
+      ├── cardinality: [0 - 10]
+      ├── key: (4)
+      ├── fd: (4)-->(1,2)
+      ├── ordering: +2
+      ├── top-k
+      │    ├── columns: k:1!null u:2 rowid:4!null
+      │    ├── internal-ordering: +2
+      │    ├── k: 15
+      │    ├── cardinality: [0 - 15]
+      │    ├── key: (4)
+      │    ├── fd: (4)-->(1,2)
+      │    ├── ordering: +2
+      │    └── scan kuv@kuv_k_u_idx
+      │         ├── columns: k:1!null u:2 rowid:4!null
+      │         ├── constraint: /1/2/4: [/1 - /2]
+      │         ├── key: (4)
+      │         └── fd: (4)-->(1,2)
+      └── 5
+
+# Ensure that the offset is not pushed down when the ordering requires columns
+# produced by the IndexJoin.
+opt expect-not=PushOffsetIntoIndexJoin
+SELECT * FROM kuv WHERE u > 1 AND u < 10 ORDER BY u, v OFFSET 5
+----
+offset
+ ├── columns: k:1 u:2!null v:3
+ ├── internal-ordering: +2,+3
+ ├── ordering: +2,+3
+ ├── sort
+ │    ├── columns: k:1 u:2!null v:3
+ │    ├── ordering: +2,+3
+ │    └── select
+ │         ├── columns: k:1 u:2!null v:3
+ │         ├── scan kuv
+ │         │    └── columns: k:1 u:2 v:3
+ │         └── filters
+ │              └── (u:2 > 1) AND (u:2 < 10) [outer=(2), constraints=(/2: [/2 - /9]; tight)]
+ └── 5
+
+# Ensure that the offset is not pushed down when using SKIP LOCKED.
+opt expect-not=PushOffsetIntoIndexJoin
+SELECT * FROM kuv WHERE k = 1 ORDER BY u OFFSET 5 FOR UPDATE SKIP LOCKED
+----
+offset
+ ├── columns: k:1!null u:2 v:3
+ ├── internal-ordering: +2 opt(1)
+ ├── volatile
+ ├── fd: ()-->(1)
+ ├── ordering: +2 opt(1) [actual: +2]
+ ├── index-join kuv
+ │    ├── columns: k:1!null u:2 v:3
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── fd: ()-->(1)
+ │    ├── ordering: +2 opt(1) [actual: +2]
+ │    └── scan kuv@kuv_k_u_idx
+ │         ├── columns: k:1!null u:2 rowid:4!null
+ │         ├── constraint: /1/2/4: [/1 - /1]
+ │         ├── locking: for-update,skip-locked
+ │         ├── volatile
+ │         ├── key: (4)
+ │         ├── fd: ()-->(1), (4)-->(2)
+ │         └── ordering: +2 opt(1) [actual: +2]
+ └── 5
+
+# --------------------------------------------------
 # PushLimitIntoOffset + GenerateLimitedScans
 # --------------------------------------------------
 
@@ -825,51 +929,51 @@ Final best expression
 opt
 SELECT * from a ORDER BY s LIMIT 10 OFFSET 10
 ----
-offset
+index-join a
  ├── columns: k:1!null i:2 f:3 s:4 j:5
- ├── internal-ordering: +4
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── ordering: +4
- ├── index-join a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5
- │    ├── cardinality: [0 - 20]
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    ├── ordering: +4
- │    └── scan a@s_idx
- │         ├── columns: k:1!null i:2 f:3 s:4
- │         ├── limit: 20
- │         ├── key: (1)
- │         ├── fd: (1)-->(2-4)
- │         └── ordering: +4
- └── 10
+ └── offset
+      ├── columns: k:1!null i:2 f:3 s:4
+      ├── internal-ordering: +4
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2-4)
+      ├── ordering: +4
+      ├── scan a@s_idx
+      │    ├── columns: k:1!null i:2 f:3 s:4
+      │    ├── limit: 20
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-4)
+      │    └── ordering: +4
+      └── 10
 
 # The right index is used for the limited scan based on the order.
 opt
 SELECT * from a ORDER BY s DESC LIMIT 10 OFFSET 10
 ----
-offset
+index-join a
  ├── columns: k:1!null i:2 f:3 s:4 j:5
- ├── internal-ordering: -4
  ├── cardinality: [0 - 10]
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  ├── ordering: -4
- ├── index-join a
- │    ├── columns: k:1!null i:2 f:3 s:4 j:5
- │    ├── cardinality: [0 - 20]
- │    ├── key: (1)
- │    ├── fd: (1)-->(2-5)
- │    ├── ordering: -4
- │    └── scan a@si_idx
- │         ├── columns: k:1!null i:2 s:4 j:5
- │         ├── limit: 20
- │         ├── key: (1)
- │         ├── fd: (1)-->(2,4,5)
- │         └── ordering: -4
- └── 10
+ └── offset
+      ├── columns: k:1!null i:2 s:4 j:5
+      ├── internal-ordering: -4
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2,4,5)
+      ├── ordering: -4
+      ├── scan a@si_idx
+      │    ├── columns: k:1!null i:2 s:4 j:5
+      │    ├── limit: 20
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,4,5)
+      │    └── ordering: -4
+      └── 10
 
 # PushLimitIntoIndexJoin propagates row-level locking information.
 opt


### PR DESCRIPTION
The `PushOffsetIntoIndexJoin` rule has been added that pushes Offset
expressions below IndexJoin expressions. It is very similar to
`PushLimitIntoIndexJoin`.

Fixes #121157

Release note (performance improvement): The optimizer now generates more
efficient query plans for some queries with `OFFSET` clauses.
