### PR TITLE
builtins: implement inet_server_addr and port

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3426,6 +3426,10 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="has_type_privilege"></a><code>has_type_privilege(user: oid, type: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for type.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="inet_server_addr"></a><code>inet_server_addr() &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Returns the gateway’s address</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="inet_server_port"></a><code>inet_server_port() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the gateway’s port</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="information_schema._pg_numeric_precision"></a><code>information_schema._pg_numeric_precision(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the precision of the given type with type modifier</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="information_schema._pg_numeric_precision_radix"></a><code>information_schema._pg_numeric_precision_radix(typid: oid, typmod: int4) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the radix of the given type with type modifier</p>

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -890,6 +890,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			}
 			return clientsecopts.MakeURLForServer(ccopts, sparams, user)
 		},
+		SQLAddr:          cfg.SQLAddr,
 		LogicalClusterID: cfg.rpcContext.LogicalClusterID.Get,
 		NodeID:           cfg.nodeIDContainer,
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1188,6 +1188,8 @@ type NodeInfo struct {
 	AdminURL func() *url.URL
 	// PGURL is the SQL connection URL for this server.
 	PGURL func(*url.Userinfo) (*pgurl.URL, error)
+	// SQLAddr is the bound SQL address.
+	SQLAddr string
 }
 
 // limitedMetricsRecorder is a limited portion of the status.MetricsRecorder

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2535,7 +2535,7 @@ SELECT pg_catalog.inet_client_addr(), pg_catalog.inet_client_port(), pg_catalog.
 FROM pg_class
 WHERE relname = 'pg_constraint'
 ----
-::/0  0  ::/0  0
+::/0  0  127.0.0.1  0
 
 query TTTT
 SELECT quote_ident('foo'), quote_ident('select'), quote_ident('int8'), quote_ident('numeric')

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -135,6 +135,7 @@ func (evalCtx *extendedEvalContext) copyFromExecCfg(execCfg *ExecutorConfig) {
 	evalCtx.ClusterID = execCfg.NodeInfo.LogicalClusterID()
 	evalCtx.ClusterName = execCfg.RPCContext.ClusterName()
 	evalCtx.NodeID = execCfg.NodeInfo.NodeID
+	evalCtx.SQLAddr = execCfg.NodeInfo.SQLAddr
 	evalCtx.Locality = execCfg.Locality
 	evalCtx.OriginalLocality = execCfg.Locality
 	evalCtx.NodesStatusServer = execCfg.NodesStatusServer
@@ -453,6 +454,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.ClusterID = execCfg.NodeInfo.LogicalClusterID()
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()
 	p.extendedEvalCtx.NodeID = execCfg.NodeInfo.NodeID
+	p.extendedEvalCtx.SQLAddr = execCfg.NodeInfo.SQLAddr
 	p.extendedEvalCtx.Locality = execCfg.Locality
 	p.extendedEvalCtx.OriginalLocality = execCfg.Locality
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2642,6 +2642,7 @@ func createSchemaChangeEvalCtx(
 			ClusterID:            execCfg.NodeInfo.LogicalClusterID(),
 			ClusterName:          execCfg.RPCContext.ClusterName(),
 			NodeID:               execCfg.NodeInfo.NodeID,
+			SQLAddr:              execCfg.NodeInfo.SQLAddr,
 			Codec:                execCfg.Codec,
 			Locality:             execCfg.Locality,
 			OriginalLocality:     execCfg.Locality,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -13,6 +13,7 @@ package builtins
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -1968,26 +1969,46 @@ var pgBuiltins = map[string]builtinDefinition{
 		},
 	),
 
-	"inet_server_addr": makeBuiltin(defProps(),
+	"inet_server_addr": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipaddr.IPAddr{}}), nil
+			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if evalCtx.SQLAddr == "" {
+					return tree.DNull, nil
+				}
+				host, _, err := net.SplitHostPort(evalCtx.SQLAddr)
+				if err != nil {
+					return nil, err
+				}
+				return tree.ParseDIPAddrFromINetString(host)
 			},
-			Info:       notUsableInfo,
+			Info:       "Returns the gateway's address",
 			Volatility: volatility.Stable,
 		},
 	),
 
-	"inet_server_port": makeBuiltin(defProps(),
+	"inet_server_port": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.DZero, nil
+			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if evalCtx.SQLAddr == "" {
+					return tree.DNull, nil
+				}
+				_, portStr, err := net.SplitHostPort(evalCtx.SQLAddr)
+				if err != nil {
+					return nil, err
+				}
+				port, err := strconv.Atoi(portStr)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(port)), nil
 			},
-			Info:       notUsableInfo,
+			Info:       "Returns the gateway's port",
 			Volatility: volatility.Stable,
 		},
 	),

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -104,6 +104,8 @@ type Context struct {
 	//   [region=us,dc=east]
 	// The region entry in this variable is the gateway region.
 	Locality roachpb.Locality
+	// SQLAddr is the bound SQL address of this instance.
+	SQLAddr string
 
 	// OriginalLocality is the initial Locality at the time the connection was
 	// established. Since Locality may be overridden in some paths, this provides


### PR DESCRIPTION
These are useful when connecting via a load-balancer to tell which node one ended up connecting to, and are supported by PG as well.

Release note (sql change): the inet_server_addr and inet_server_port builtins now return the gateway's address and port instead of zero.
Epic: none.