### PR TITLE
sql: deflake crdb_internal.check_consistency use in logic tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4037,7 +4037,7 @@ statement error start key must be less than end key
 SELECT crdb_internal.check_consistency(true, crdb_internal.tenant_span()[2], crdb_internal.tenant_span()[2])
 
 query TT
-SELECT status, regexp_replace(detail, '[0-9]+', '', 'g')
+SELECT status, regexp_replace(detail, '[0-9-]+', '', 'g')
 FROM crdb_internal.check_consistency(true, crdb_internal.tenant_span()[1], crdb_internal.tenant_span()[2])
 ORDER BY range_id
 LIMIT 1


### PR DESCRIPTION
Fixes #121099.

`crdb_internal.check_consistency(true, ...)` is only looking at the MVCCStats and is not performing a full recomputation. The MVCCStats are allowed to have negative values if they were estimated. Mask out the negative sign.

Release note: None