### PR TITLE
release-23.2: tests: skip some tests under `race`

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -262,7 +262,9 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStress(t, "1μs staleness reads may actually succeed due to the slow environment")
+	const msg = "1μs staleness reads may actually succeed due to the slow environment"
+	skip.UnderStress(t, msg)
+	skip.UnderRace(t, msg)
 	defer ccl.TestingEnableEnterprise()()
 
 	ctx := context.Background()

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/testgen/template.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/testgen/template.go
@@ -35,8 +35,8 @@ import (
 
 func TestTenantUpgradeInterlock_{{$variantValue}}_{{$testName}}(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	// Times out under stress race.
-	skip.UnderStressRace(t)
+	// Times out under race.
+	skip.UnderRace(t)
 	// Test target takes 100s+ to run.
 	skip.UnderShort(t)
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -84,6 +85,8 @@ func TestDataDriven(t *testing.T) {
 	t.Cleanup(func() {
 		scope.Close(t)
 	})
+
+	skip.UnderRace(t, "very long-running test under race")
 
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -679,7 +679,7 @@ func TestStreamingAutoReplan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "multi cluster/node config exhausts hardware")
+	skip.UnderRace(t, "multi cluster/node config exhausts hardware")
 
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -235,6 +236,8 @@ func TestStoreResolveMetrics(t *testing.T) {
 func TestStoreMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "does not complete under race")
 
 	ctx := context.Background()
 	const numServers int = 3

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6532,9 +6532,9 @@ func TestRaftLeaderRemovesItself(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive, so skip under deadlock detector and stressrace.
+	// Timing-sensitive, so skip under deadlock detector and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -750,7 +750,7 @@ type circuitBreakerTest struct {
 }
 
 func setupCircuitBreakerTest(t *testing.T) *circuitBreakerTest {
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 	manualClock := hlc.NewHybridManualClock()
 	var rangeID int64             // atomic
 	slowThresh := &atomic.Value{} // supports .SetSlowThreshold(x)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4062,7 +4062,7 @@ func RunLogicTest(
 	// with less concurrency in the nightly stress runs. If you see problems
 	// please make adjustments there.
 	// As of 6/4/2019, the logic tests never complete under race.
-	skip.UnderStressRace(t, "logic tests and race detector don't mix: #37993")
+	skip.UnderRace(t, "logic tests and race detector don't mix: #37993")
 
 	// This test relies on repeated sequential storage.EventuallyFileOnlySnapshot
 	// acquisitions. Reduce the max wait time for each acquisition to speed up

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -230,11 +230,6 @@ func TestParallel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	skip.UnderRace(t, "takes >1 min under race")
-	// Note: there is special code in teamcity-trigger/main.go to run this package
-	// with less concurrency in the nightly stress runs. If you see problems
-	// please make adjustments there.
-	// As of 6/4/2019, the logic tests never complete under race.
-	skip.UnderStressRace(t, "logic tests and race detector don't mix: #37993")
 
 	glob := *paralleltestdata
 	paths, err := filepath.Glob(glob)


### PR DESCRIPTION
Backport 1/1 commits from #117894.

/cc @cockroachdb/release

Release justification: test only change

---

Some of these are skipped only under `StressRace` but not simply under `race` as they should have been.

Additionally, two tests: `spanconfigsqltranslatorccl.TestDataDriven` and `kvserver.TestStoreMetrics` are so long running that they stall or fail to complete under `race`, which has gone unnoticed before.

Epic: CRDB-8308
Release note: None
