### PR TITLE
workload/schemachange: support UDFs invoking other UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -29,6 +29,29 @@ SELECT * FROM udfCallNest_3(1, 2)
 ----
 512
 
+# Get the dependency graph from pg_depend between functions.
+query TT rowsort
+SELECT
+	src_p.proname as from, dst_p.proname as to
+FROM
+	pg_depend AS d, pg_proc AS src_p, pg_proc AS dst_p
+WHERE
+	d.classid = 'pg_catalog.pg_proc'::REGCLASS::INT8
+	AND d.refclassid = 'pg_catalog.pg_proc'::REGCLASS::INT8
+	AND d.objid = src_p.oid
+	AND d.refobjid = dst_p.oid;
+----
+udfcallnest          udfcall
+udfcallnest_2        udfcall
+udfcallnest_2        udfcallnest
+udfcallnest_3        udfcall
+udfcallnest_3        udfcallnest_2
+udfcallnest_3        udfcallnest
+upper_hello          lower_hello
+concat_hello         lower_hello
+concat_hello         upper_hello
+nested_udf_for_from  upper_hello
+
 # Validate recursion doesn't work today.
 statement error pgcode 42883 unknown function: recursion_check\(\)
 CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;

--- a/pkg/workload/schemachange/query_util.go
+++ b/pkg/workload/schemachange/query_util.go
@@ -100,6 +100,14 @@ const (
 	functionDescsQuery = `SELECT id, schema_id, name, descriptor->'function' AS descriptor FROM descriptors WHERE descriptor ? 'function'`
 
 	regionsFromClusterQuery = `SELECT * FROM [SHOW REGIONS FROM CLUSTER]`
+
+	functionDepsQuery = `SELECT
+	objid AS from_oid, refobjid AS to_oid
+FROM
+	pg_depend AS d
+WHERE
+	d.classid = 'pg_catalog.pg_proc'::REGCLASS::INT8
+	AND d.refclassid = 'pg_catalog.pg_proc'::REGCLASS::INT8`
 )
 
 func regionsFromDatabaseQuery(database string) string {


### PR DESCRIPTION
This patch adds support for the schema change workload to create UDF's which invoke other UDF's, which will need the following:

1. Extend pg_depend to support tracking UDF references to other UDFs. This is an extension from Postgres behaviour where classid will refer to the pg_proc table.
2. Update the schema changer workload to create include UDF references when creating functions
3. Modify the schema changer workload to ensure that DROP / RENAME FUNCTION operations on these functions check for references to other functions, which will cause the operation to fail.
4. Modify the schema changer workload to ensure that DROP SCHEMA with the legacy schema changer will properly block operations if references exist from a different schema.

Fixes: #120671
