### PR TITLE
sql/importer: deflake TestExportImportBank

### DIFF
--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -131,6 +131,7 @@ func TestExportImportBank(t *testing.T) {
 			schema := bank.FromRows(1).Tables()[0].Schema
 			exportedFiles := filepath.Join(exportDir, "*")
 			db.Exec(t, fmt.Sprintf("CREATE TABLE bank2 %s", schema))
+			defer db.Exec(t, "DROP TABLE bank2")
 			db.Exec(t, fmt.Sprintf(`IMPORT INTO bank2 CSV DATA ($1) WITH delimiter = '|'%s`, nullIf), exportedFiles)
 
 			db.CheckQueryResults(t,
@@ -140,7 +141,6 @@ func TestExportImportBank(t *testing.T) {
 				`SELECT fingerprint FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE bank2]`,
 				db.QueryStr(t, `SELECT fingerprint FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE bank]`),
 			)
-			db.Exec(t, "DROP TABLE bank2")
 		})
 	}
 }


### PR DESCRIPTION
This commit fixes an issue caused by running two tests on the same database. Each test creates a table `bank2` and drops it at the end of the test. However, if the first test fails after creating the table, the table might not be successfully dropped. Therefore, the second test would fail when attempting to create the table since it already exists. This commit fixes this problem by adding a line to defer the `DROP TABLE` command right after it's created..

Fixes #121176

Release note: None