### PR TITLE
optbuilder: fix recently introduced nil pointer in error case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -416,6 +416,12 @@ CALL first_value(1);
 statement error pgcode 42809 addgeometrycolumn is not a procedure
 CALL addgeometrycolumn(null, null, null, null, null);
 
+let $funcOID
+SELECT oid FROM pg_proc WHERE proname = 'count_rows';
+
+statement error pgcode 42809 count_rows is not a procedure
+CALL [ FUNCTION $funcOID ] ();
+
 statement ok
 CREATE PROCEDURE p_inner(OUT param INTEGER) AS $$ SELECT 1; $$ LANGUAGE SQL;
 

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -126,7 +126,7 @@ func (b *Builder) buildProcedure(c *tree.Call, inScope *scope) *scope {
 	f, ok := typedExpr.(*tree.FuncExpr)
 	if !ok {
 		panic(pgerror.Newf(pgcode.WrongObjectType,
-			"%s is not a procedure", c.Proc.Func.ReferenceByName.String(),
+			"%s is not a procedure", c.Proc.Func.String(),
 		))
 	}
 


### PR DESCRIPTION
This commit fixes a recently introduced nil pointer internal error when attempting to CALL not a procedure that is specified not by its name. `ResolvableFunctionReference` might not have `ReferenceByName`, so this commit switches to using `FunctionReference` that is always set.

Fixes: #121095.

Release note: None