### PR TITLE
workflows: some small improvements

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -284,7 +284,7 @@ jobs:
       - run: ./build/github/get-engflow-keys.sh
       - run: ./build/github/prepare-summarize-build.sh
       - name: build
-        run: bazel build //pkg/cmd/cockroach //pkg/cmd/cockroach-short //pkg/cmd/cockroach-sql //pkg/cmd/cockroach-oss --config crosswindows --jobs 100 --remote_download_minimal --build_event_binary_file=bes.bin --enable_runfiles $(./build/github/engflow-args.sh)
+        run: ./build/github/build.sh crosswindows
       - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -50,7 +50,7 @@ if files_unchanged_from_upstream go.mod go.sum DEPS.bzl $(find_relevant ./pkg/cm
   echo "Skipping //pkg/cmd/mirror/go:mirror (relevant files are unchanged from upstream)."
   echo "Skipping //pkg/cmd/generate-staticcheck (relevant files are unchanged from upstream)."
 else
-  CONTENTS=$(bazel run //pkg/cmd/mirror/go:mirror)
+  CONTENTS=$(bazel run //pkg/cmd/mirror/go:mirror ${EXTRA_BAZEL_ARGS:-})
   echo "$CONTENTS" > DEPS.bzl
   bazel run pkg/cmd/generate-staticcheck --run_under="cd $PWD && " ${EXTRA_BAZEL_ARGS:-}
 fi


### PR DESCRIPTION
1. Remember to use RBE for the build of `mirror` in `check-generated-code`.
2. Use the `build.sh` script for Windows builds.

Epic: CRDB-8308
Release note: None