### PR TITLE
storage: add TestWALFailover

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -769,7 +769,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 	}
 	defer storeEnvs.CloseAll()
 
-	walFailoverConfig := storage.WALFailover(cfg.WALFailover, storeEnvs)
+	walFailoverConfig := storage.WALFailover(cfg.WALFailover, storeEnvs, vfs.Default)
 
 	for i, spec := range cfg.Stores.Specs {
 		log.Eventf(ctx, "initializing %+v", spec)

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -128,6 +128,7 @@ go_test(
         "mvcc_stats_test.go",
         "mvcc_test.go",
         "mvcc_value_test.go",
+        "open_test.go",
         "pebble_iterator_test.go",
         "pebble_mvcc_scanner_test.go",
         "pebble_test.go",

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -220,7 +220,9 @@ func errConfigOption(err error) func(*engineConfig) error {
 	return func(*engineConfig) error { return err }
 }
 
-func makeExternalWALDir(engineCfg *engineConfig, externalDir base.ExternalPath) (wal.Dir, error) {
+func makeExternalWALDir(
+	engineCfg *engineConfig, externalDir base.ExternalPath, defaultFS vfs.FS,
+) (wal.Dir, error) {
 	// If the store is encrypted, we require that all the WAL failover dirs also
 	// be encrypted so that the user doesn't accidentally leak data unencrypted
 	// onto the filesystem.
@@ -232,7 +234,7 @@ func makeExternalWALDir(engineCfg *engineConfig, externalDir base.ExternalPath) 
 		return wal.Dir{}, errors.Newf("must provide --enterprise-encryption flag for store %q, specified WAL failover path %q is encrypted",
 			engineCfg.env.Dir, externalDir.Path)
 	}
-	env, err := fs.InitEnv(context.Background(), vfs.Default, externalDir.Path, fs.EnvConfig{
+	env, err := fs.InitEnv(context.Background(), defaultFS, externalDir.Path, fs.EnvConfig{
 		RW:                engineCfg.env.RWMode(),
 		EncryptionOptions: externalDir.EncryptionOptions,
 	})
@@ -249,7 +251,7 @@ func makeExternalWALDir(engineCfg *engineConfig, externalDir base.ExternalPath) 
 // WALFailover configures automatic failover of the engine's write-ahead log to
 // another volume in the event the WAL becomes blocked on a write that does not
 // complete within a reasonable duration.
-func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption {
+func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs, defaultFS vfs.FS) ConfigOption {
 	// The set of options available in single-store versus multi-store
 	// configurations vary. This is in part due to the need to store the multiple
 	// stores' WALs separately. When WALFailoverExplicitPath is provided, we have
@@ -265,7 +267,7 @@ func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption 
 			// We need to add the explicilt path to WALRecoveryDirs.
 			if walCfg.PrevPath.IsSet() {
 				return func(cfg *engineConfig) error {
-					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath)
+					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath, defaultFS)
 					if err != nil {
 						return err
 					}
@@ -282,13 +284,13 @@ func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs) ConfigOption 
 		case base.WALFailoverExplicitPath:
 			// The user has provided an explicit path to which we should fail over WALs.
 			return func(cfg *engineConfig) error {
-				walDir, err := makeExternalWALDir(cfg, walCfg.Path)
+				walDir, err := makeExternalWALDir(cfg, walCfg.Path, defaultFS)
 				if err != nil {
 					return err
 				}
 				cfg.opts.WALFailover = makePebbleWALFailoverOptsForDir(cfg.settings, walDir)
 				if walCfg.PrevPath.IsSet() {
-					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath)
+					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath, defaultFS)
 					if err != nil {
 						return err
 					}
@@ -476,6 +478,12 @@ func Open(
 	}
 	p, err := newPebble(ctx, cfg)
 	if err != nil {
+		// Run after-close hooks if there are any. This ensures we
+		// release any references to fs.Envs that would've been held by
+		// the engine if it had been successfully opened.
+		for _, f := range cfg.afterClose {
+			f()
+		}
 		return nil, err
 	}
 	return p, nil

--- a/pkg/storage/open_test.go
+++ b/pkg/storage/open_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWALFailover(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var allEnvs fs.Envs
+	defer func() { allEnvs.CloseAll() }()
+
+	// Create an in-memory FS to serve as the default FS (used
+	// when explicit paths are provided).
+	defaultFS := vfs.NewMem()
+
+	getEnv := func(name string) *fs.Env {
+		for _, e := range allEnvs {
+			if e.Dir == name {
+				return e
+			}
+		}
+		return nil
+	}
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "wal_failover_config"),
+		func(t *testing.T, td *datadriven.TestData) string {
+			switch td.Cmd {
+			case "mkenv":
+				dir := td.CmdArgs[0].String()
+				if e := getEnv(dir); e != nil {
+					return fmt.Sprintf("env %s already exists", e.Dir)
+				}
+				memfs := vfs.NewMem()
+				require.NoError(t, memfs.MkdirAll(dir, os.ModePerm))
+				e, err := fs.InitEnv(context.Background(), memfs, dir, fs.EnvConfig{})
+				if err != nil {
+					return fmt.Sprintf("err = %q", err)
+				}
+				allEnvs = append(allEnvs, e)
+				return ""
+			case "open":
+				var flagStr, openDir string
+				var envDirs []string
+				td.ScanArgs(t, "flag", &flagStr)
+				td.ScanArgs(t, "open", &openDir)
+				td.ScanArgs(t, "envs", &envDirs)
+
+				var cfg base.WALFailoverConfig
+				if flagStr != "" {
+					if err := cfg.Set(flagStr); err != nil {
+						return fmt.Sprintf("error parsing flag: %q", err)
+					}
+				}
+				openEnv := getEnv(openDir)
+				if openEnv == nil {
+					return fmt.Sprintf("unknown env %q", openDir)
+				}
+				var envs fs.Envs
+				for _, dir := range envDirs {
+					e := getEnv(dir)
+					if e == nil {
+						return fmt.Sprintf("unknown env %q", dir)
+					}
+					envs = append(envs, e)
+				}
+				openEnv.Ref()
+
+				// Mock a cluster version, defaulting to 24.1.
+				minVersionMajor, minVersionMinor := 24, 1
+				minVersion := clusterversion.V24_1.Version()
+				if td.MaybeScanArgs(t, "min-version", &minVersionMajor, &minVersionMinor) {
+					// TODO(jackson): Add datadriven support for scanning into int32s so we can
+					// scan directly into minVersion.
+					minVersion.Major, minVersion.Minor = int32(minVersionMajor), int32(minVersionMinor)
+				}
+				settings := cluster.MakeTestingClusterSettingsWithVersions(minVersion, minVersion, true /* initializeVersion */)
+
+				// Mock an enterpise license, or not if disable-enterprise is specified.
+				enterpriseEnabledFunc := base.CCLDistributionAndEnterpriseEnabled
+				base.CCLDistributionAndEnterpriseEnabled = func(st *cluster.Settings) bool { return !td.HasArg("disable-enterprise") }
+				defer func() { base.CCLDistributionAndEnterpriseEnabled = enterpriseEnabledFunc }()
+
+				engine, err := Open(context.Background(), openEnv, settings, WALFailover(cfg, envs, defaultFS))
+				if err != nil {
+					openEnv.Close()
+					return fmt.Sprintf("open error: %s", err)
+				}
+				var buf bytes.Buffer
+				fmt.Fprintln(&buf, "OK")
+				if failoverCfg := engine.cfg.opts.WALFailover; failoverCfg != nil {
+					fmt.Fprintf(&buf, "secondary = %s\n", failoverCfg.Secondary.Dirname)
+					dur, ok := failoverCfg.UnhealthyOperationLatencyThreshold()
+					fmt.Fprintf(&buf, "UnhealthyOperationLatencyThreshold() = (%s,%t)\n", dur, ok)
+				}
+				for _, recoveryDir := range engine.cfg.opts.WALRecoveryDirs {
+					fmt.Fprintf(&buf, "WALRecoveryDir: %s\n", recoveryDir.Dirname)
+				}
+				engine.Close()
+				return buf.String()
+			default:
+				return fmt.Sprintf("unrecognized command %q", td.Cmd)
+			}
+		})
+}

--- a/pkg/storage/testdata/wal_failover_config
+++ b/pkg/storage/testdata/wal_failover_config
@@ -160,3 +160,101 @@ open flag=disabled,prev_path=baz envs=(foo) open=foo
 ----
 OK
 WALRecoveryDir: baz
+
+# Make an env with encryption-at-rest.
+
+mkenv ear-a encrypted-at-rest
+----
+
+# Ensure that we error if an explicit path is not encrypted.
+
+open flag=path=baz envs=(ear-a) open=ear-a
+----
+open error: must provide --enterprise-encryption flag for "baz", used as WAL failover path for encrypted store "ear-a"
+
+# And succeed if it is.
+
+open flag=path=baz envs=(ear-a) open=ear-a path-encrypted
+----
+OK
+secondary = baz
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+
+# Disabling should error if no encryption flags for prev_path is provided.
+
+open flag=disabled,prev_path=baz envs=(ear-a) open=ear-a
+----
+open error: must provide --enterprise-encryption flag for "baz", used as WAL failover path for encrypted store "ear-a"
+
+# And succeed if they are.
+
+open flag=disabled,prev_path=baz envs=(ear-a) open=ear-a prev-path-encrypted
+----
+OK
+WALRecoveryDir: baz
+
+# Attempt to use 'among-stores' with an encrypted store and an unencrypted store.
+
+open flag=among-stores envs=(ear-a, foo) open=foo
+----
+open error: storage: must provide --enterprise-encryption flag for all stores or none if using WAL failover
+
+# Ensure we perform the same check when epening the encrypted store.
+
+open flag=among-stores envs=(ear-a, foo) open=ear-a
+----
+open error: storage: must provide --enterprise-encryption flag for all stores or none if using WAL failover
+
+# Using among-stores with all encrypted envs should succeed.
+
+mkenv ear-b encrypted-at-rest
+----
+
+open flag=among-stores envs=(ear-a, ear-b) open=ear-a
+----
+OK
+secondary = ear-b/auxiliary/wals-among-stores
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+
+open flag=disabled envs=(ear-a, ear-b) open=ear-a
+----
+OK
+WALRecoveryDir: ear-b/auxiliary/wals-among-stores
+
+# Open ear-a using an explicit path.
+
+open flag=path=bax envs=(ear-a) open=ear-a path-encrypted
+----
+OK
+secondary = bax
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+
+# Switching the explicit path without specifying the previous path's
+# encryption options should error.
+
+open flag=path=baz,prev_path=bax envs=(ear-a) open=ear-a path-encrypted
+----
+open error: must provide --enterprise-encryption flag for "bax", used as WAL failover path for encrypted store "ear-a"
+
+# Switching the explicit path without specifying the new path's
+# encryption options should error.
+
+open flag=path=baz,prev_path=bax envs=(ear-a) open=ear-a prev-path-encrypted
+----
+open error: must provide --enterprise-encryption flag for "baz", used as WAL failover path for encrypted store "ear-a"
+
+# Providing both should succeed.
+
+open flag=path=baz,prev_path=bax envs=(ear-a) open=ear-a path-encrypted prev-path-encrypted
+----
+OK
+secondary = baz
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+WALRecoveryDir: bax
+
+# Opening an unencrypted store with an encrypted WAL failover
+# path should error.
+
+open flag=path=bax envs=(foo) open=foo path-encrypted
+----
+open error: must provide --enterprise-encryption flag for store "foo", specified WAL failover path "bax" is encrypted

--- a/pkg/storage/testdata/wal_failover_config
+++ b/pkg/storage/testdata/wal_failover_config
@@ -1,0 +1,162 @@
+mkenv foo
+----
+
+# Open foo with default (disabled) WAL failover configuration in
+# the context of a single-store node.
+
+open flag= envs=(foo) open=foo
+----
+OK
+
+mkenv bar
+----
+
+# Open foo with default (disabled) WAL failover configuration in
+# the context of a two-store node.
+
+open flag= envs=(foo,bar) open=foo
+----
+OK
+
+# Open foo with WAL failover set to 'among-stores' in the context
+# of a single-store node. WAL failover will remain disabled.
+
+open flag=among-stores envs=(foo) open=foo
+----
+OK
+
+# Open foo with 'disabled' WAL failover in the context of a single-store
+# node. This is permitted and WAL failover will remain disbaled.
+open flag=disabled envs=(foo) open=foo
+----
+OK
+
+# Open foo with WAL failover set to 'among-stores' in the context
+# of a two-store node that has not yet finalized 24.1. The
+# UnhealthyOperationLatencyThreshold func should return false,
+# indicating that Pebble is not allowed to failover to the secondary yet.
+
+open flag=among-stores envs=(foo,bar) open=foo min-version=(23,2)
+----
+OK
+secondary = bar/auxiliary/wals-among-stores
+UnhealthyOperationLatencyThreshold() = (100ms,false)
+
+# Open foo with WAL failover set to 'among-stores' in the context
+# of a two-store node that HAS finalized 24.1. The
+# UnhealthyOperationLatencyThreshold func should return true,
+# indicating that Pebble IS allowed to failover to the secondary.
+
+open flag=among-stores envs=(foo,bar) open=foo
+----
+OK
+secondary = bar/auxiliary/wals-among-stores
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+
+# Try to open foo with WAL failover default. The engine should
+# refuse to open (the operator is required to explicitly disable
+# WAL failover).
+
+open flag= envs=(foo,bar) open=foo
+----
+open error: directory "bar/auxiliary/wals-among-stores" may contain relevant WALs
+
+# Opening with the "disabled" setting should succeed.
+
+open flag=disabled envs=(foo,bar) open=foo
+----
+OK
+WALRecoveryDir: bar/auxiliary/wals-among-stores
+
+# And now foo should be able to be opened without setting
+# the disabled flag.
+
+open flag= envs=(foo,bar) open=foo
+----
+OK
+
+# Specifying an explicit path (in enabled or disabled mode) should
+# error in multi-store configurations.
+
+open flag=path=/mnt/data/foo envs=(foo,bar) open=foo
+----
+open error: storage: cannot use explicit path --wal-failover option with multiple stores
+
+open flag=disabled,prev_path=/mnt/data/foo envs=(foo,bar) open=foo
+----
+open error: storage: cannot use explicit prev_path --wal-failover option with multiple stores
+
+# The last store should should use the first store's dir as its
+# secondary.
+
+open flag=among-stores envs=(foo,bar) open=bar
+----
+OK
+secondary = foo/auxiliary/wals-among-stores
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+
+# Disable it.
+
+open flag=disabled envs=(foo,bar) open=bar
+----
+OK
+WALRecoveryDir: foo/auxiliary/wals-among-stores
+
+# Ensure that WAL failover refuses to failover if there's no enterprise
+# license configured.
+open flag=among-stores envs=(foo,bar) open=foo disable-enterprise
+----
+OK
+secondary = bar/auxiliary/wals-among-stores
+UnhealthyOperationLatencyThreshold() = (100ms,false)
+
+open flag=disabled envs=(foo,bar) open=foo
+----
+OK
+WALRecoveryDir: bar/auxiliary/wals-among-stores
+
+# Test specifying an explicit path.
+
+open flag=path=bax envs=(foo) open=foo
+----
+OK
+secondary = bax
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+
+# Test opening foo again without specifying a WAL failover flag.
+# It should fail because the secondary may contain relevant logs.
+
+open flag= envs=(foo) open=foo
+----
+open error: directory "bax" may contain relevant WALs
+
+# Try to disable it without setting a prev_path. It should fail
+# as well.
+
+open flag=disabled envs=(foo) open=foo
+----
+open error: directory "bax" may contain relevant WALs
+
+# Changing the secondary location without specifying prev_path=bax
+# should fail.
+
+open flag=path=baz envs=(foo) open=foo
+----
+open error: directory "bax" may contain relevant WALs
+
+# Changing the secondary location WITH specifying prev_path=bax
+# should succeed.
+
+open flag=path=baz,prev_path=bax envs=(foo) open=foo
+----
+OK
+secondary = baz
+UnhealthyOperationLatencyThreshold() = (100ms,true)
+WALRecoveryDir: bax
+
+# Disabling WAL failover WITH specifying prev_path should succeed too.
+
+open flag=disabled,prev_path=baz envs=(foo) open=foo
+----
+OK
+WALRecoveryDir: baz


### PR DESCRIPTION
Add a new datadriven unit test that tests configuration of WAL failover. Additionally fix a bug where by a reference to a *fs.Env used by WAL failover could be leaked if opening the engine failed.

Epic: none
Release note: none