### PR TITLE
release-23.2: roachtest/mixedversion: wrap original errors in test failures

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -28,7 +28,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "@com_github_pkg_errors//:errors",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/errors"
 )
 
 // Helper is the struct passed to `stepFunc`s (user-provided or
@@ -111,8 +112,8 @@ func (h *Helper) Background(
 				return err
 			}
 
-			desc := fmt.Sprintf("error in background function %s: %s", name, err)
-			return h.runner.testFailure(desc, bgLogger, nil)
+			err := errors.Wrapf(err, "error in background function %s", name)
+			return h.runner.testFailure(err, bgLogger, nil)
 		}
 
 		return nil

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -89,7 +89,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 const (


### PR DESCRIPTION
Backport 1/1 commits from #121137.

/cc @cockroachdb/release

Release justification: test only changes.

---

Previously, every test failure would be returned to the caller as a `testFailure` struct (that implements the `error` interface). That struct would display the string representation of the original error along with mixed-version state information to help with debugging.

That implementation, however, had a significant drawback: we lose all type information related to the original error that caused the test failure. Specifically, if the error that caused the test to fail is one that leads to the GitHub issue to be redirected to a different team (via `errors.Mark` or `registry.ErrorWithOwner`), that information is lost.

In this commit, we make the error returned to the caller a proper wrapper of the original error. The mixed-version state information is added as error details and they continue to be logged in the step's logger on failure.

Fixes: #120926

Release note: None