### PR TITLE
kvserver: deflake TestStoreRangeMergeRaftSnapshot

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3884,15 +3884,11 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		}
 		keySpans := rditer.MakeReplicatedKeySpans(inSnap.Desc)
 		sstFileWriters := map[string]sstFileWriter{}
-		for i, span := range keySpans {
+		for _, span := range keySpans {
 			file := &storage.MemObject{}
 			writer := storage.MakeIngestionSSTWriter(ctx, st, file)
-			// If UseExciseForSnapshots is enabled, the snapshot won't write the last
-			// ClearRange in the sstable.
-			if i < len(keySpans)-1 || !storage.UseExciseForSnapshots.Get(&st.SV) {
-				if err := writer.ClearRawRange(span.Key, span.EndKey, true, true); err != nil {
-					return err
-				}
+			if err := writer.ClearRawRange(span.Key, span.EndKey, true /* pointKeys */, true /* rangeKeys */); err != nil {
+				return err
 			}
 			sstFileWriters[string(span.Key)] = sstFileWriter{
 				span:   span,


### PR DESCRIPTION
We no longer skip range tombstones when excises are turned on for local raft snapshots.

Related commit: 935708231ac7ea29794028c17d43f21b2c00d60d

Fixes #121227.

Release note: None