### PR TITLE
release-23.2: sql: Allow dropping enum value when referenced by UDF

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -754,6 +754,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",
+        "//pkg/ccl",
         "//pkg/ccl/changefeedccl/schemafeed/schematestutils",
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/clusterversion",

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -272,7 +272,7 @@ var opWeights = []int{
 	dropSequence:                      1,
 	dropTable:                         1,
 	dropView:                          1,
-	alterTypeDropValue:                0, // Disabled and tracked with #114844, #113859, and #115612.
+	alterTypeDropValue:                1,
 	dropSchema:                        1,
 	alterDatabasePrimaryRegion:        0, // Disabled and tracked with #83831
 	alterTableRenameColumn:            1,


### PR DESCRIPTION
Backport 2/2 commits from #118780.
fixes https://github.com/cockroachdb/cockroach/issues/120930

/cc @cockroachdb/release

---

This PR extends the current validation code executed
while dropping an enum value to also check for the value
being referenced in a UDF. Additionally, we re-enable
testing for `alterTypeDropValue` within the random
schema change workload.

Prior to dropping an enum value, we confirm that the value
is unused in tables, constraints, indices etc. However,
when we added support for UDFs, we did not extend the
scope of this to also check for an enum value being
referenced in a UDF. This introduced a bug where we were
unable to drop an unused enum value if some other value
from within the enum was  being referenced by a UDF.
For example, if an enum 'e' contained values {'1', '2', '3'},
with the value '1' being referenced in a UDF, we were
unable to drop the values '2' and '3' as well.
This PR fixes this bug by expanding the usage check for
enum values to also include UDFs. With this fix, we can drop
an enum value as long as the value itself is unreferenced.

The **first commit** address this bug and and  refactors some of
the common code into its own methods to avoid code duplication. 
It extends the existing test suite to test for multiple scenarios 
when an enum value is dropped. 

The **second commit** re-enables testing for `alterTypeDropValue`
within the random schema workload. This was disabled
due to the bug which is being addressed in the first commit.

Epic: none

Fixes: https://github.com/cockroachdb/cockroach/issues/115612, https://github.com/cockroachdb/cockroach/issues/114844

Release note (bug fix): Fix an existing bug where we are
unable to drop an unused value from an enum if the enum is being
referenced in a UDF. With this bug fix, we can drop a value
from an enum as long as the value is not being referenced
by a UDF. Note, the enum can still be referenced by a UDF.
We only allow a value to be dropped if the value is not being
referenced by any other data element including UDFs.

Release justification: a low risk bug fix for an issue would prevent users from being able to modify enums used by UDFs