### PR TITLE
workflows: tag builds with the keyword `ci-build`

### DIFF
--- a/build/github/build.sh
+++ b/build/github/build.sh
@@ -38,6 +38,7 @@ bazel build \
     --config "$CONFIG" $EXTRA_ARGS \
     --jobs 100 \
     --build_event_binary_file=bes.bin \
+    --bes_keywords ci-build \
     $(./build/github/engflow-args.sh) \
     //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
     //pkg/cmd/cockroach-sql \


### PR DESCRIPTION
This will help identify builds for e.g. automatically pulling versions of `roachprod`.

Epic: CRDB-8308
Release note: None