### PR TITLE
storage: support disk stall tracing

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2425,7 +2425,7 @@ Note that the measurement does not include the duration for replicating the eval
 		Measurement: "Time",
 		Help:        "Weighted time spent reading from or writing to the store's disk since this process started (as reported by the OS)",
 	}
-	metaIopsInProgress = metric.Metadata{
+	metaDiskIopsInProgress = metric.Metadata{
 		Name:        "storage.disk.iopsinprogress",
 		Unit:        metric.Unit_COUNT,
 		Measurement: "Operations",
@@ -2840,7 +2840,7 @@ type StoreMetrics struct {
 	DiskWriteTime      *metric.Gauge
 	DiskIOTime         *metric.Gauge
 	DiskWeightedIOTime *metric.Gauge
-	IopsInProgress     *metric.Gauge
+	DiskIopsInProgress *metric.Gauge
 }
 
 type tenantMetricsRef struct {
@@ -3592,7 +3592,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		DiskWriteTime:      metric.NewGauge(metaDiskWriteTime),
 		DiskIOTime:         metric.NewGauge(metaDiskIOTime),
 		DiskWeightedIOTime: metric.NewGauge(metaDiskWeightedIOTime),
-		IopsInProgress:     metric.NewGauge(metaIopsInProgress),
+		DiskIopsInProgress: metric.NewGauge(metaDiskIopsInProgress),
 
 		// Estimated MVCC stats in split.
 		SplitsWithEstimatedStats:     metric.NewCounter(metaSplitEstimatedStats),
@@ -3815,7 +3815,7 @@ func (sm *StoreMetrics) updateDiskStats(stats disk.Stats) {
 	sm.DiskWriteTime.Update(int64(stats.WritesDuration))
 	sm.DiskIOTime.Update(int64(stats.CumulativeDuration))
 	sm.DiskWeightedIOTime.Update(int64(stats.WeightedIODuration))
-	sm.IopsInProgress.Update(int64(stats.InProgressCount))
+	sm.DiskIopsInProgress.Update(int64(stats.InProgressCount))
 }
 
 func (sm *StoreMetrics) handleMetricsResult(ctx context.Context, metric result.Metrics) {

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -59,6 +59,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/fetchpb",
+        "//pkg/storage/disk",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/storage/pebbleiter",

--- a/pkg/storage/disk/BUILD.bazel
+++ b/pkg/storage/disk/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "linux_parse.go",
         "monitor.go",
+        "monitor_tracer.go",
         "platform_default.go",
         "platform_linux.go",
         "stats.go",
@@ -35,22 +36,15 @@ go_test(
     srcs = [
         "linux_parse_test.go",
         "monitor_test.go",
+        "monitor_tracer_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":disk"],
     deps = [
         "//pkg/util/leaktest",
         "//pkg/util/log",
-        "//pkg/util/syncutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
-    ] + select({
-        "@io_bazel_rules_go//go/platform:android": [
-            "@com_github_cockroachdb_datadriven//:datadriven",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "@com_github_cockroachdb_datadriven//:datadriven",
-        ],
-        "//conditions:default": [],
-    }),
+    ],
 )

--- a/pkg/storage/disk/linux_parse.go
+++ b/pkg/storage/disk/linux_parse.go
@@ -50,7 +50,7 @@ import (
 //	12  I/Os currently in progress
 //	13  time spent doing I/Os (ms)
 //	14  weighted time spent doing I/Os (ms)
-func parseDiskStats(contents []byte, disks []*monitoredDisk) error {
+func parseDiskStats(contents []byte, disks []*monitoredDisk, measuredAt time.Time) error {
 	for lineNum := 0; len(contents) > 0; lineNum++ {
 		lineBytes, rest := splitLine(contents)
 		line := unsafe.String(&lineBytes[0], len(lineBytes))
@@ -153,7 +153,7 @@ func parseDiskStats(contents []byte, disks []*monitoredDisk) error {
 		} else if ok {
 			stats.FlushesDuration = time.Duration(millis) * time.Millisecond
 		}
-		disks[diskIdx].recordStats(stats)
+		disks[diskIdx].recordStats(measuredAt, stats)
 	}
 	return nil
 }

--- a/pkg/storage/disk/linux_parse_test.go
+++ b/pkg/storage/disk/linux_parse_test.go
@@ -53,7 +53,8 @@ func TestLinux_CollectDiskStats(t *testing.T) {
 				v, err = strconv.ParseUint(cmdArg.Vals[1], 10, 32)
 				require.NoError(t, err)
 				deviceID.minor = uint32(v)
-				disks = append(disks, &monitoredDisk{deviceID: deviceID})
+				tracer := newMonitorTracer(1000)
+				disks = append(disks, &monitoredDisk{deviceID: deviceID, tracer: tracer})
 			}
 			slices.SortFunc(disks, func(a, b *monitoredDisk) int { return compareDeviceIDs(a.deviceID, b.deviceID) })
 
@@ -69,11 +70,15 @@ func TestLinux_CollectDiskStats(t *testing.T) {
 				return err.Error()
 			}
 			for i := range disks {
+				monitor := Monitor{disks[i]}
+				stats, err := monitor.CumulativeStats()
+				require.NoError(t, err)
+
 				if i > 0 {
 					fmt.Fprintln(&buf)
 				}
 				fmt.Fprintf(&buf, "%s: ", disks[i].deviceID)
-				fmt.Fprint(&buf, disks[i].stats.lastMeasurement.String())
+				fmt.Fprint(&buf, stats.String())
 			}
 			return buf.String()
 		default:

--- a/pkg/storage/disk/monitor_tracer.go
+++ b/pkg/storage/disk/monitor_tracer.go
@@ -1,0 +1,180 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package disk
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+type traceEvent struct {
+	time  time.Time
+	stats Stats
+	err   error
+}
+
+// String implements fmt.Stringer.
+func (t traceEvent) String() string {
+	if t.err != nil {
+		return fmt.Sprintf("%s\t\t%s", t.time.Format(time.RFC3339Nano), t.err.Error())
+	}
+	s := t.stats
+	statString := fmt.Sprintf("%s\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%s",
+		s.DeviceName, s.ReadsCount, s.ReadsMerged, s.ReadsSectors, s.ReadsDuration,
+		s.WritesCount, s.WritesMerged, s.WritesSectors, s.WritesDuration,
+		s.InProgressCount, s.CumulativeDuration, s.WeightedIODuration,
+		s.DiscardsCount, s.DiscardsMerged, s.DiscardsSectors, s.DiscardsDuration,
+		s.FlushesCount, s.FlushesDuration)
+	return fmt.Sprintf("%s\t%s\tnil", t.time.Format(time.RFC3339Nano), statString)
+}
+
+// monitorTracer manages a ring buffer containing a history of disk stats.
+// The tracer is designed such that higher-level components can apply
+// aggregation functions to compute statistics over rolling windows and output
+// detailed traces when failures are detected.
+type monitorTracer struct {
+	capacity int
+
+	mu struct {
+		syncutil.Mutex
+		trace []traceEvent
+		start int
+		end   int
+		size  int
+	}
+}
+
+func newMonitorTracer(capacity int) *monitorTracer {
+	return &monitorTracer{
+		capacity: capacity,
+		mu: struct {
+			syncutil.Mutex
+			trace []traceEvent
+			start int
+			end   int
+			size  int
+		}{
+			trace: make([]traceEvent, capacity),
+			start: 0,
+			end:   0,
+			size:  0,
+		},
+	}
+}
+
+// RecordEvent appends a traceEvent to the internal ring buffer. The
+// implementation assumes that the event time specified during consecutive calls
+// are strictly increasing.
+func (m *monitorTracer) RecordEvent(event traceEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.trace[m.mu.end] = event
+	m.mu.end = (m.mu.end + 1) % m.capacity
+	if m.mu.size == m.capacity {
+		m.mu.start = (m.mu.start + 1) % m.capacity
+	} else {
+		m.mu.size++
+	}
+}
+
+// Find retrieves the traceEvent that occurred before and closest to a specified
+// time, t. If no events occurred before t, an error is thrown.
+func (m *monitorTracer) Find(t time.Time) (traceEvent, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	offset, err := m.floorSearchLocked(t)
+	if err != nil {
+		return traceEvent{}, err
+	}
+	eventIdx := (m.mu.start + offset) % m.capacity
+	return m.mu.trace[eventIdx], nil
+}
+
+// Latest retrieves stats from the last traceEvent that was queued. If the trace
+// is empty we throw an error.
+func (m *monitorTracer) Latest() (traceEvent, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.mu.size == 0 {
+		return traceEvent{}, errors.Errorf("trace is empty")
+	}
+	// Since m.mu.end points to the next index to write at, we add m.capacity to
+	// prevent an arithmetic modulus error in case m.mu.end is zero.
+	latestIdx := (m.mu.end - 1 + m.capacity) % m.capacity
+	return m.mu.trace[latestIdx], nil
+}
+
+// String implements fmt.Stringer.
+func (m *monitorTracer) String() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.mu.size == 0 {
+		return ""
+	}
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
+	fmt.Fprintln(w, "Time\t"+
+		"Device Name\tReads Completed\tReads Merged\tSectors Read\tRead Duration\t"+
+		"Writes Completed\tWrites Merged\tSectors Written\tWrite Duration\t"+
+		"IO in Progress\tIO Duration\tWeighted IO Duration\t"+
+		"Discards Completed\tDiscards Merged\tSectors Discarded\tDiscard Duration\t"+
+		"Flushes Completed\tFlush Duration\tError")
+	prevStats := m.mu.trace[m.mu.start].stats
+	for i := 1; i < m.mu.size; i++ {
+		event := m.mu.trace[(m.mu.start+i)%m.capacity]
+		delta := event.stats.delta(&prevStats)
+		if event.err == nil {
+			prevStats = event.stats
+		}
+		deltaEvent := traceEvent{
+			time:  event.time,
+			stats: delta,
+			err:   event.err,
+		}
+		fmt.Fprintln(w, deltaEvent)
+	}
+	_ = w.Flush()
+
+	return buf.String()
+}
+
+// floorSearchLocked retrieves the offset from the trace's start for the traceEvent
+// that occurred before or at a specified time, t. If no events occurred before
+// t, an error is thrown. Note that it is the responsibility of the caller to
+// acquire the tracer mutex and the returned offset may become invalid after the
+// mutex is released.
+func (m *monitorTracer) floorSearchLocked(t time.Time) (int, error) {
+	if m.mu.size == 0 {
+		return -1, errors.Errorf("trace is empty")
+	}
+	// Apply binary search to find the offset of the traceEvent that occurred at
+	// or after time t.
+	offset, found := sort.Find(m.mu.size, func(i int) int {
+		idx := (m.mu.start + i) % m.capacity
+		return t.Compare(m.mu.trace[idx].time)
+	})
+	if found {
+		return offset, nil
+	}
+	if offset == 0 {
+		return -1, errors.Errorf("no event found in trace before or at time %s", t)
+	}
+	// Decrement offset since it currently points to the first traceEvent that
+	// occurred after time t.
+	return offset - 1, nil
+}

--- a/pkg/storage/disk/monitor_tracer_test.go
+++ b/pkg/storage/disk/monitor_tracer_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package disk
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func parseStats(fields []string) (Stats, error) {
+	stats := Stats{DeviceName: fields[0]}
+	var err error
+	if stats.ReadsCount, err = strconv.Atoi(fields[1]); err != nil {
+		return Stats{}, err
+	}
+	if stats.ReadsMerged, err = strconv.Atoi(fields[2]); err != nil {
+		return Stats{}, err
+	}
+	if stats.ReadsSectors, err = strconv.Atoi(fields[3]); err != nil {
+		return Stats{}, err
+	}
+	if stats.ReadsDuration, err = time.ParseDuration(fields[4]); err != nil {
+		return Stats{}, err
+	}
+	if stats.WritesCount, err = strconv.Atoi(fields[5]); err != nil {
+		return Stats{}, err
+	}
+	if stats.WritesMerged, err = strconv.Atoi(fields[6]); err != nil {
+		return Stats{}, err
+	}
+	if stats.WritesSectors, err = strconv.Atoi(fields[7]); err != nil {
+		return Stats{}, err
+	}
+	if stats.WritesDuration, err = time.ParseDuration(fields[8]); err != nil {
+		return Stats{}, err
+	}
+	if stats.InProgressCount, err = strconv.Atoi(fields[9]); err != nil {
+		return Stats{}, err
+	}
+	if stats.CumulativeDuration, err = time.ParseDuration(fields[10]); err != nil {
+		return Stats{}, err
+	}
+	if stats.WeightedIODuration, err = time.ParseDuration(fields[11]); err != nil {
+		return Stats{}, err
+	}
+	return stats, nil
+}
+
+func TestMonitorTracer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var buf bytes.Buffer
+	var tracer *monitorTracer
+	datadriven.RunTest(t, "testdata/tracer", func(t *testing.T, td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "record":
+			var capacity int
+			td.ScanArgs(t, "capacity", &capacity)
+			tracer = newMonitorTracer(capacity)
+
+			if !strings.Contains(td.Input, "\n") {
+				return ""
+			}
+			for _, line := range strings.Split(td.Input, "\n") {
+				fields := strings.Fields(line)
+				require.Equal(t, 13, len(fields))
+				eventTime, err := time.Parse(time.RFC3339, fields[0])
+				require.NoError(t, err)
+				eventStats, err := parseStats(fields[1:13])
+				require.NoError(t, err)
+				event := traceEvent{
+					time:  eventTime,
+					stats: eventStats,
+					err:   nil,
+				}
+				tracer.RecordEvent(event)
+			}
+			return ""
+		case "find":
+			var timeString string
+			td.ScanArgs(t, "time", &timeString)
+			lowerBoundTime, err := time.Parse(time.RFC3339, timeString)
+			require.NoError(t, err)
+
+			event, err := tracer.Find(lowerBoundTime)
+			buf.Reset()
+			if err != nil {
+				fmt.Fprint(&buf, err.Error())
+			} else {
+				fmt.Fprintf(&buf, "%q", event)
+			}
+			return buf.String()
+		case "latest":
+			event, err := tracer.Latest()
+			buf.Reset()
+			if err != nil {
+				fmt.Fprint(&buf, err.Error())
+			} else {
+				fmt.Fprintf(&buf, "%q", event)
+			}
+			return buf.String()
+		case "trace":
+			buf.Reset()
+			fmt.Fprint(&buf, tracer)
+			return buf.String()
+		default:
+			panic(fmt.Sprintf("unrecognized command %q", td.Cmd))
+		}
+	})
+}

--- a/pkg/storage/disk/platform_linux.go
+++ b/pkg/storage/disk/platform_linux.go
@@ -18,6 +18,7 @@ import (
 	"io/fs"
 
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/sys/unix"
@@ -53,7 +54,7 @@ func (s *linuxStatsCollector) collect(disks []*monitoredDisk) error {
 		// single read. Reallocate (doubling) the buffer and continue.
 		s.buf = make([]byte, len(s.buf)*2)
 	}
-	return parseDiskStats(s.buf[:n], disks)
+	return parseDiskStats(s.buf[:n], disks, timeutil.Now())
 }
 
 func newStatsCollector(fs vfs.FS) (*linuxStatsCollector, error) {

--- a/pkg/storage/disk/testdata/tracer
+++ b/pkg/storage/disk/testdata/tracer
@@ -1,0 +1,62 @@
+# Query empty trace.
+
+record capacity=3
+----
+
+find time=2024-03-27T12:00:00.5Z
+----
+trace is empty
+
+latest
+----
+trace is empty
+
+trace
+----
+
+# Query trace with space remaining in buffer.
+
+record capacity=3
+2024-03-27T12:00:00.0Z sda 10 0 100 2ms 0 0 0 0s 0 15ms 2ms
+2024-03-27T12:00:00.5Z sda 12 0 120 5ms 0 0 0 0s 0 25ms 5ms
+----
+
+latest
+----
+"2024-03-27T12:00:00.5Z\tsda\t12\t0\t120\t5ms\t0\t0\t0\t0s\t0\t25ms\t5ms\t0\t0\t0\t0s\t0\t0s\tnil"
+
+trace
+----
+Time                    Device Name  Reads Completed  Reads Merged  Sectors Read  Read Duration  Writes Completed  Writes Merged  Sectors Written  Write Duration  IO in Progress  IO Duration  Weighted IO Duration  Discards Completed  Discards Merged  Sectors Discarded  Discard Duration  Flushes Completed  Flush Duration  Error
+2024-03-27T12:00:00.5Z  sda          2                0             20            3ms            0                 0              0                0s              0               10ms         3ms                   0                   0                0                  0s                0                  0s              nil
+
+# Query trace with event overflow.
+
+record capacity=3
+2024-03-27T12:00:00.0Z sda 10 0 100 2ms 0 0 0 0s 0 15ms 2ms
+2024-03-27T12:00:00.1Z sda 12 0 120 5ms 0 0 0 0s 0 25ms 5ms
+2024-03-27T12:00:00.2Z sda 14 0 150 7ms 0 0 0 0s 0 35ms 7ms
+2024-03-27T12:00:00.3Z sda 14 0 150 7ms 10 0 20 5ms 2 45ms 9ms
+----
+
+find time=2024-03-27T12:00:00.5Z
+----
+"2024-03-27T12:00:00.3Z\tsda\t14\t0\t150\t7ms\t10\t0\t20\t5ms\t2\t45ms\t9ms\t0\t0\t0\t0s\t0\t0s\tnil"
+
+find time=2024-03-27T12:00:00.15Z
+----
+"2024-03-27T12:00:00.1Z\tsda\t12\t0\t120\t5ms\t0\t0\t0\t0s\t0\t25ms\t5ms\t0\t0\t0\t0s\t0\t0s\tnil"
+
+find time=2024-03-27T12:00:00.0Z
+----
+no event found in trace before or at time 2024-03-27 12:00:00 +0000 UTC
+
+latest
+----
+"2024-03-27T12:00:00.3Z\tsda\t14\t0\t150\t7ms\t10\t0\t20\t5ms\t2\t45ms\t9ms\t0\t0\t0\t0s\t0\t0s\tnil"
+
+trace
+----
+Time                    Device Name  Reads Completed  Reads Merged  Sectors Read  Read Duration  Writes Completed  Writes Merged  Sectors Written  Write Duration  IO in Progress  IO Duration  Weighted IO Duration  Discards Completed  Discards Merged  Sectors Discarded  Discard Duration  Flushes Completed  Flush Duration  Error
+2024-03-27T12:00:00.2Z  sda          2                0             30            2ms            0                 0              0                0s              0               10ms         2ms                   0                   0                0                  0s                0                  0s              nil
+2024-03-27T12:00:00.3Z  sda          0                0             0             0s             10                0              20               5ms             2               10ms         2ms                   0                   0                0                  0s                0                  0s              nil

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/disk"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -440,6 +441,14 @@ func makePebbleWALFailoverOptsForDir(
 func PebbleOptions(pebbleOptions string, parseHooks *pebble.ParseHooks) ConfigOption {
 	return func(cfg *engineConfig) error {
 		return cfg.opts.Parse(pebbleOptions, parseHooks)
+	}
+}
+
+// DiskMonitor configures a monitor to track disk stats.
+func DiskMonitor(diskMonitor *disk.Monitor) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.diskMonitor = diskMonitor
+		return nil
 	}
 }
 

--- a/pkg/util/search/search.go
+++ b/pkg/util/search/search.go
@@ -12,8 +12,8 @@ package search
 
 import "github.com/cockroachdb/errors"
 
-// A Predicate is a funcation that returns whether a given search value "passes"
-// or not. It assumes that that within the search domain of [min, max) provided
+// A Predicate is a function that returns whether a given search value "passes"
+// or not. It assumes that within the search domain of [min, max) provided
 // to a Searcher, f(i) == true implies f(i-1) == true and f(i) == false implies
 // f(i+1) == false. A Predicate can be called multiple times, so it should be
 // a pure function.


### PR DESCRIPTION
Currently, in the event of a disk stall we don't have visibility into the sequence of disk events that led up to the failure due to the 10s frequency at which we export disk metrics. This commit adds support for storing a history of disk events from the previous 30s and in the event of a stall, logs a trace.

Fixes: #120506.
Informs: #89786.

Epic: None.
Release note: None.