### PR TITLE
jobs: deflake TestRegistryLifecycle

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -89,7 +89,7 @@ func (r *Registry) maybeDumpTrace(resumerCtx context.Context, resumer Resumer, j
 	if err := r.db.Txn(dumpCtx, func(ctx context.Context, txn isql.Txn) error {
 		return WriteProtobinExecutionDetailFile(dumpCtx, resumerTraceFilename, &td, txn, jobID)
 	}); err != nil {
-		log.Warning(dumpCtx, "failed to write trace on resumer trace file")
+		log.Warningf(dumpCtx, "failed to write trace on resumer trace file: %v", err)
 	}
 }
 
@@ -468,7 +468,7 @@ func (r *Registry) runJob(
 	r.maybeClearLease(job, err)
 	r.maybeDumpTrace(ctx, resumer, job.ID())
 	if r.knobs.AfterJobStateMachine != nil {
-		r.knobs.AfterJobStateMachine()
+		r.knobs.AfterJobStateMachine(job.ID())
 	}
 	return err
 }

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -724,7 +724,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 		jobMetrics               *JobTypeMetrics
 		adopted                  *metric.Counter
 		resumed                  *metric.Counter
-		afterJobStateMachineKnob func()
+		afterJobStateMachineKnob func(id jobspb.JobID)
 		// expectImmediateRetry is true if the test should expect immediate
 		// resumption on retry, such as after pausing and resuming job.
 		expectImmediateRetry bool
@@ -899,7 +899,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 	t.Run("running", func(t *testing.T) {
 		ctx := context.Background()
 		bti := BackoffTestInfra{}
-		bti.afterJobStateMachineKnob = func() {
+		bti.afterJobStateMachineKnob = func(_ jobspb.JobID) {
 			if bti.done.Load().(bool) {
 				return
 			}
@@ -928,7 +928,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 			bti.errCh <- nil
 			<-bti.transitionCh
 		}
-		bti.afterJobStateMachineKnob = func() {
+		bti.afterJobStateMachineKnob = func(jobspb.JobID) {
 			if bti.done.Load().(bool) {
 				return
 			}
@@ -954,7 +954,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 	t.Run("revert on fail", func(t *testing.T) {
 		ctx := context.Background()
 		bti := BackoffTestInfra{}
-		bti.afterJobStateMachineKnob = func() {
+		bti.afterJobStateMachineKnob = func(jobspb.JobID) {
 			if bti.done.Load().(bool) {
 				return
 			}
@@ -1012,7 +1012,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 			bti.errCh <- nil
 			<-bti.transitionCh
 		}
-		bti.afterJobStateMachineKnob = func() {
+		bti.afterJobStateMachineKnob = func(jobspb.JobID) {
 			if bti.done.Load().(bool) {
 				return
 			}

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -65,7 +65,7 @@ type TestingKnobs struct {
 	// AfterJobStateMachine is called once the running instance of the job has
 	// returned from the state machine that transitions it from one state to
 	// another.
-	AfterJobStateMachine func()
+	AfterJobStateMachine func(jobspb.JobID)
 
 	// TimeSource replaces registry's clock.
 	TimeSource *hlc.Clock


### PR DESCRIPTION
In #116844 we added a CREATE USER statement to this tests setup. That statement produces 2 schema change jobs that could race with the coordination required for the assertions in this test to be valid.

Here we solve this by only running the AfterJobStateMachine callback for the job we care about.

Fixes #121149

Release note: None