### PR TITLE
drtprod: add push-hosts helper

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -47,6 +47,24 @@ case $1 in
       set -- sql --secure "$@"
     fi
     ;;
+  # TODO(dt): build this into roachprod.
+  "push-hosts")
+    if [ "$#" -ne 3 ]; then
+      echo "usage: drtprod $1 <destination> <cluster>"
+      exit 1
+    fi
+    shift
+    dest=$1
+    shift
+    # TODO(dt): support just pushing ips for all clusters.
+    cluster=$1
+    shift
+    ips="$($0 ip $cluster)"
+    pgurls="$($0 pgurl --secure $cluster)"
+    $0 ssh $dest -- "echo '${ips}' > $cluster.ips.txt"
+    $0 ssh $dest -- "echo '${pgurls}' > $cluster.pgurls.txt"
+    exit 0
+    ;;
   "dns")
     if [ "$#" -lt 2 ]; then
       echo "usage: drtprod $1 <cluster> [create]"


### PR DESCRIPTION
It is much easier to craft workload commands in terms of an IP file and then just push the IP file if/when it changes rather than crafting a new command every time.

Release note: none.
Epic: none.