### PR TITLE
rangefeed: improve testing for event.MemUsage

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -56,6 +56,17 @@ func writeValueOpWithKV(key roachpb.Key, ts hlc.Timestamp, val []byte) enginepb.
 	})
 }
 
+func writeValueOpWithPrevValue(
+	key roachpb.Key, ts hlc.Timestamp, val, prevValue []byte,
+) enginepb.MVCCLogicalOp {
+	return makeLogicalOp(&enginepb.MVCCWriteValueOp{
+		Key:       key,
+		Timestamp: ts,
+		Value:     val,
+		PrevValue: prevValue,
+	})
+}
+
 func writeValueOp(ts hlc.Timestamp) enginepb.MVCCLogicalOp {
 	return writeValueOpWithKV(roachpb.Key("a"), ts, []byte("val"))
 }
@@ -102,6 +113,19 @@ func commitIntentOpWithKV(
 		Key:              key,
 		Timestamp:        ts,
 		Value:            val,
+		OmitInRangefeeds: omitInRangefeeds,
+	})
+}
+
+func commitIntentOpWithPrevValue(
+	txnID uuid.UUID, key roachpb.Key, ts hlc.Timestamp, val, prevValue []byte, omitInRangefeeds bool,
+) enginepb.MVCCLogicalOp {
+	return makeLogicalOp(&enginepb.MVCCCommitIntentOp{
+		TxnID:            txnID,
+		Key:              key,
+		Timestamp:        ts,
+		Value:            val,
+		PrevValue:        prevValue,
 		OmitInRangefeeds: omitInRangefeeds,
 	})
 }


### PR DESCRIPTION
Previously, it can be easy to overlook memory accounting when adding new fields
to event and RangefeedEvent. This patch adds a test designed to fail when new
fields are added. It serves as a reminder to verify and update memory accounting
as needed. Special attention is required for fields that can point to a larger
underlying memory usage (ex. slices, maps, pointers, strings, nested structs).
For simpler fields, directly updating expected test values is sufficient. In
addition, this patch removes a previously added benchmark to assess memory
accounting overhead. This is no longer needed now that we are going with a more
straightforward approach.

Fixes: https://github.com/cockroachdb/cockroach/issues/120902
Release note: None