### PR TITLE
dbconsole: remove internal cols from jobs table

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.spec.tsx
@@ -78,9 +78,7 @@ describe("Jobs", () => {
       "Job ID",
       "User Name",
       "Creation Time (UTC)",
-      "Last Execution Time (UTC)",
       "Last Modified Time (UTC)",
-      "Execution Count",
     ];
 
     for (const columnTitle of expectedColumnTitles) {

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
@@ -55,9 +55,7 @@ export const jobsColumnLabels: any = {
   users: "User Name",
   creationTime: "Creation Time",
   lastModifiedTime: "Last Modified Time",
-  lastExecutionTime: "Last Execution Time",
   finishedTime: "Completed Time",
-  executionCount: "Execution Count",
   highWaterTimestamp: "High-water Timestamp",
   coordinatorID: "Coordinator Node",
 };
@@ -225,43 +223,6 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
         />
       ),
       sort: job => TimestampToMoment(job?.finished).valueOf(),
-      showByDefault: true,
-    },
-    {
-      name: "lastExecutionTime",
-      title: (
-        <Tooltip
-          placement="bottom"
-          style="tableTitle"
-          content={<p>Date and time of the last attempted job execution.</p>}
-        >
-          <>
-            {jobsColumnLabels.lastExecutionTime} <Timezone />
-          </>
-        </Tooltip>
-      ),
-      cell: job => (
-        <Timestamp
-          time={TimestampToMoment(job?.last_run, null)}
-          format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT}
-        />
-      ),
-      sort: job => TimestampToMoment(job?.last_run).valueOf(),
-      showByDefault: true,
-    },
-    {
-      name: "executionCount",
-      title: (
-        <Tooltip
-          placement="bottom"
-          style="tableTitle"
-          content={<p>Number of times the job was executed.</p>}
-        >
-          {jobsColumnLabels.executionCount}
-        </Tooltip>
-      ),
-      cell: job => String(job.num_runs),
-      sort: job => job.num_runs?.toNumber(),
       showByDefault: true,
     },
     {


### PR DESCRIPTION
These are internal jobs system state that few jobs use. These values are visible on the per-job detail page if one is interested but are just noise on the table, and drawing attention to them can be misleading as most jobs do retries themselves causing these numbers to be incorrect/irrelevant at best.

Release note (ui change): the jobs table page no longer includes two columns related to a deprecated internal implementation detail (last execution time and execution count).

Epic: none.