### PR TITLE
storage: increase default for MaxConcurrentDownloads

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -144,6 +144,19 @@ func getMaxConcurrentCompactions() int {
 	return n
 }
 
+// getMaxConcurrentDownloads returns the default max concurrent download
+// compactions. It is installed as the default value of of
+// Options.MaxConcurrentDownloads.
+//
+// TODO(ssd): The current implementation is not based on any data.
+func getMaxConcurrentDownloads() int {
+	const (
+		maxConcurrentDownloads = 3
+		minConcurrentDownloads = 1
+	)
+	return max(min(runtime.GOMAXPROCS(0)-1, maxConcurrentDownloads), minConcurrentDownloads)
+}
+
 // l0SubLevelCompactionConcurrency is the sub-level threshold at which to
 // allow an increase in compaction concurrency. The maximum is still
 // controlled by pebble.Options.MaxConcurrentCompactions. The default of 2

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -144,19 +144,6 @@ func getMaxConcurrentCompactions() int {
 	return n
 }
 
-// getMaxConcurrentDownloads returns the default max concurrent download
-// compactions. It is installed as the default value of of
-// Options.MaxConcurrentDownloads.
-//
-// TODO(ssd): The current implementation is not based on any data.
-func getMaxConcurrentDownloads() int {
-	const (
-		maxConcurrentDownloads = 3
-		minConcurrentDownloads = 1
-	)
-	return max(min(runtime.GOMAXPROCS(0)-1, maxConcurrentDownloads), minConcurrentDownloads)
-}
-
 // l0SubLevelCompactionConcurrency is the sub-level threshold at which to
 // allow an increase in compaction concurrency. The maximum is still
 // controlled by pebble.Options.MaxConcurrentCompactions. The default of 2

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -204,6 +204,15 @@ func MaxConcurrentCompactions(n int) ConfigOption {
 	}
 }
 
+// MaxConcurrentDownloads configures the maximum number of concurrent
+// download compactions an Engine will execute.
+func MaxConcurrentDownloads(n int) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.opts.MaxConcurrentDownloads = func() int { return n }
+		return nil
+	}
+}
+
 // LBaseMaxBytes configures the maximum number of bytes for LBase.
 func LBaseMaxBytes(v int64) ConfigOption {
 	return func(cfg *engineConfig) error {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -747,6 +747,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		// allow overriding the max at runtime through
 		// Engine.SetCompactionConcurrency.
 		MaxConcurrentCompactions:    getMaxConcurrentCompactions,
+		MaxConcurrentDownloads:      getMaxConcurrentDownloads,
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
 		Merger:                      MVCCMerger,


### PR DESCRIPTION
Since cockroachdb/pebble#3445 the concurrency configuration for download compactions is now independent from normal compactions. As a result, our default configuration was only allowing a single download compaction at a time. This has a rather dramatic impact on overall download phase throughput for online restore.

This reclaims some of our throughput but we still have a problem somewhere as our roachtests now take 2-3 times as long (although with this they at least pass before the 1 hour timeout).

Fixes #121265
Fixes #121266

Release note: None