### PR TITLE
sql: make SHOW JOBS more readable by humans

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -793,7 +793,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	asOf1 := strings.TrimPrefix(matches[1], "/full")
 
 	sqlDB.CheckQueryResults(
-		t, "SELECT description FROM [SHOW JOBS] WHERE job_type != 'MIGRATION' AND status != 'failed'",
+		t, "SELECT description FROM crdb_internal.jobs WHERE job_type = 'BACKUP' AND status != 'failed'",
 		[][]string{
 			{fmt.Sprintf("BACKUP TO ('%s', '%s', '%s')", backups[0].(string), backups[1].(string),
 				backups[2].(string))},
@@ -810,7 +810,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 				collections[1], collections[2])},
 		},
 	)
-	sqlDB.CheckQueryResults(t, "SELECT description FROM [SHOW JOBS] WHERE status = 'failed'",
+	sqlDB.CheckQueryResults(t, "SELECT description FROM crdb_internal.jobs WHERE job_type = 'BACKUP' AND status = 'failed'",
 		[][]string{{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir", collections[0],
 			collections[1], collections[2])}})
 
@@ -852,7 +852,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	resolvedAsOfCollectionURIs := getResolvedCollectionURIs(collections, asOf1)
 
 	sqlDB.CheckQueryResults(
-		t, "SELECT description FROM [SHOW JOBS] WHERE job_type='RESTORE' ORDER BY created",
+		t, "SELECT description FROM crdb_internal.jobs WHERE job_type='RESTORE' ORDER BY created",
 		[][]string{
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				backups[0].(string), backups[1].(string), backups[2].(string))},
@@ -5771,7 +5771,7 @@ func TestBackupRestoreShowJob(t *testing.T) {
 	// TODO (lucy): Update this if/when we decide to change how these jobs queued by
 	// the startup migration are handled.
 	sqlDB.CheckQueryResults(
-		t, "SELECT description FROM [SHOW JOBS] WHERE job_type != 'MIGRATION' AND description != 'updating privileges' ORDER BY description",
+		t, "SELECT description FROM crdb_internal.jobs WHERE job_type = 'BACKUP' OR job_type = 'RESTORE' ORDER BY description",
 		[][]string{
 			{"BACKUP DATABASE data TO 'nodelocal://1/foo' WITH OPTIONS (revision_history = true)"},
 			{"RESTORE TABLE data.bank FROM 'nodelocal://1/foo' WITH OPTIONS (into_db = 'data 2', skip_missing_foreign_keys)"},

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5620,7 +5620,7 @@ func TestChangefeedDescription(t *testing.T) {
 
 			var description string
 			sqlDB.QueryRow(t,
-				`SELECT description FROM [SHOW JOBS] WHERE job_id = $1`, jobID,
+				`SELECT description FROM [SHOW JOB $1]`, jobID,
 			).Scan(&description)
 
 			require.Equal(t, tc.descr, description)

--- a/pkg/ccl/streamingccl/streamingest/testdata/simple
+++ b/pkg/ccl/streamingccl/streamingest/testdata/simple
@@ -21,7 +21,7 @@ CREATE FUNCTION strip_host(s string) returns string language sql AS $$ select co
 ----
 
 query-sql as=destination-system
-SELECT strip_host(description) FROM [SHOW JOBS] WHERE job_type='REPLICATION STREAM INGESTION'
+SELECT strip_host(description) FROM [SHOW JOBS SELECT id FROM system.jobs WHERE job_type='REPLICATION STREAM INGESTION']
 ----
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF source ON ('postgres://root@?redacted')
 

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -699,7 +699,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	defer testCluster.Stopper().Stop(context.Background())
 
 	endpoint := fmt.Sprintf("combinedstmts?start=%d&end=%d", aggregatedTs-3600, oneMinAfterAggregatedTs)
-	findJobQuery := "SELECT status FROM [SHOW JOBS] WHERE statement = 'CREATE INDEX idx_age ON football.public.players (age) STORING (name)';"
+	findJobQuery := "SELECT status FROM crdb_internal.jobs WHERE statement = 'CREATE INDEX idx_age ON football.public.players (age) STORING (name)';"
 	testAppName := "TestCombinedStatementsWithFullScans"
 
 	firstServerProto := testCluster.Server(0).ApplicationLayer()

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -387,7 +387,7 @@ func TestFormat(t *testing.T) {
 			// "updating view reference" job.
 			query := fmt.Sprintf(
 				`SELECT description
-FROM [SHOW JOBS]
+FROM [SHOW JOBS SELECT id FROM system.jobs]
 WHERE job_type IN ('SCHEMA CHANGE', 'NEW SCHEMA CHANGE')
 AND description LIKE 'CREATE%%%s%%'`,
 				name,

--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -22,9 +22,13 @@ import (
 
 func constructSelectQuery(n *tree.ShowJobs) string {
 	var baseQuery strings.Builder
-	baseQuery.WriteString(`SELECT job_id, job_type, description, `)
-	if n.Jobs != nil {
-		baseQuery.WriteString(`statement, `)
+	baseQuery.WriteString(`SELECT job_id, job_type, `)
+	if n.Jobs == nil {
+		baseQuery.WriteString(`CASE WHEN length(description) > 70 THEN `)
+		baseQuery.WriteString(`concat(substr(description, 0, 60)||' … '||right(description, 7)) `)
+		baseQuery.WriteString(`ELSE description END as description, `)
+	} else {
+		baseQuery.WriteString(`description, statement, `)
 	}
 	baseQuery.WriteString(`user_name, status, running_status, `)
 	baseQuery.WriteString(`date_trunc('second', created) as created, date_trunc('second', started) as started, `)

--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -27,7 +27,8 @@ func constructSelectQuery(n *tree.ShowJobs) string {
 		baseQuery.WriteString(`statement, `)
 	}
 	baseQuery.WriteString(`user_name, status, running_status, `)
-	baseQuery.WriteString(`created, started, finished, modified, `)
+	baseQuery.WriteString(`date_trunc('second', created) as created, date_trunc('second', started) as started, `)
+	baseQuery.WriteString(`date_trunc('second', finished) as finished, date_trunc('second', modified) as modified, `)
 	baseQuery.WriteString(`fraction_completed, error, coordinator_id`)
 
 	if n.Jobs != nil {

--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -22,12 +22,17 @@ import (
 
 func constructSelectQuery(n *tree.ShowJobs) string {
 	var baseQuery strings.Builder
-	baseQuery.WriteString(`
-SELECT job_id, job_type, description, statement, user_name, status,
-       running_status, created, started, finished, modified,
-       fraction_completed, error, coordinator_id, trace_id, last_run,
-       next_run, num_runs, execution_errors
-`)
+	baseQuery.WriteString(`SELECT job_id, job_type, description, `)
+	if n.Jobs != nil {
+		baseQuery.WriteString(`statement, `)
+	}
+	baseQuery.WriteString(`user_name, status, running_status, `)
+	baseQuery.WriteString(`created, started, finished, modified, `)
+	baseQuery.WriteString(`fraction_completed, error, coordinator_id`)
+
+	if n.Jobs != nil {
+		baseQuery.WriteString(`, trace_id, execution_errors`)
+	}
 
 	// Check if there are any SHOW JOBS options that we need to add columns for.
 	if n.Options != nil {

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2106,7 +2106,7 @@ func TestFailedImportGC(t *testing.T) {
 	close(blockGC)
 	// Ensure that a GC job was created, and wait for it to finish.
 	doneGCQuery := fmt.Sprintf(
-		"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = '%s' AND running_status = '%s' AND created > %s",
+		"SELECT count(*) FROM crdb_internal.jobs WHERE job_type = '%s' AND running_status = '%s' AND created > %s",
 		"SCHEMA CHANGE GC", sql.RunningStatusWaitingForMVCCGC, beforeImport.String(),
 	)
 	sqlDB.CheckQueryResultsRetry(t, doneGCQuery, [][]string{{"1"}})
@@ -6448,16 +6448,16 @@ func TestImportPgDumpSchemas(t *testing.T) {
 
 		// Ensure that a GC job was created, and wait for it to finish.
 		doneGCQuery := fmt.Sprintf(
-			"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = '%s' AND running_status = '%s' AND created > %s",
+			"SELECT count(*) FROM crdb_internal.jobs WHERE job_type = '%s' AND running_status = '%s' AND created > %s",
 			"SCHEMA CHANGE GC", sql.RunningStatusWaitingForMVCCGC, beforeImport.String(),
 		)
 
 		doneSchemaDropQuery := fmt.Sprintf(
-			"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = '%s' AND status = '%s' AND description"+
+			"SELECT count(*) FROM crdb_internal.jobs WHERE job_type = '%s' AND status = '%s' AND description"+
 				" LIKE '%s'", "SCHEMA CHANGE", jobs.StatusSucceeded, "dropping schemas%")
 
 		doneDatabaseUpdateQuery := fmt.Sprintf(
-			"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = '%s' AND status = '%s' AND description"+
+			"SELECT count(*) FROM crdb_internal.jobs WHERE job_type = '%s' AND status = '%s' AND description"+
 				" LIKE '%s'", "SCHEMA CHANGE", jobs.StatusSucceeded, "updating parent database%")
 
 		sqlDB.CheckQueryResultsRetry(t, doneGCQuery, [][]string{{"1"}})

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -232,7 +232,7 @@ statement ok
 DROP INDEX expr_idx;
 
 query T colnames
-SELECT description FROM [show jobs] ORDER BY created DESC LIMIT 2;
+SELECT description FROM crdb_internal.jobs ORDER BY created DESC LIMIT 2;
 ----
 description
 GC for DROP INDEX test.public.tbl@expr_idx

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -744,14 +744,14 @@ SELECT status,
        regexp_replace(description, 'ROLL BACK JOB \d+.*', 'ROLL BACK JOB') as desc
   FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE' ORDER BY job_id DESC LIMIT 1
 ----
-failed  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5; ALTER TABLE test.public.customers ADD COLUMN j INT8 DEFAULT 4; ALTER TABLE test.public.customers ADD COLUMN l INT8 DEFAULT 3; ALTER TABLE test.public.customers ADD COLUMN m CHAR; ALTER TABLE test.public.customers ADD COLUMN n CHAR DEFAULT 'a'; CREATE INDEX j_idx ON test.public.customers (j); CREATE INDEX l_idx ON test.public.customers (l); CREATE INDEX m_idx ON test.public.customers (m); CREATE UNIQUE INDEX i_idx ON test.public.customers (i); CREATE UNIQUE INDEX n_idx ON test.public.customers (n)
+failed  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT … ers (n)
 
 query TT
 SELECT status,
        regexp_replace(description, 'ROLL BACK JOB \d+.*', 'ROLL BACK JOB') as descr
   FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for ROLL%' ORDER BY job_id DESC LIMIT 1
 ----
-running  GC for ROLLBACK of ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5; ALTER TABLE test.public.customers ADD COLUMN j INT8 DEFAULT 4; ALTER TABLE test.public.customers ADD COLUMN l INT8 DEFAULT 3; ALTER TABLE test.public.customers ADD COLUMN m CHAR; ALTER TABLE test.public.customers ADD COLUMN n CHAR DEFAULT 'a'; CREATE INDEX j_idx ON test.public.customers (j); CREATE INDEX l_idx ON test.public.customers (l); CREATE INDEX m_idx ON test.public.customers (m); CREATE UNIQUE INDEX i_idx ON test.public.customers (i); CREATE UNIQUE INDEX n_idx ON test.public.customers (n)
+running  GC for ROLLBACK of ALTER TABLE test.public.customers ADD CO … ers (n)
 
 subtest add_multiple_computed_elements
 
@@ -781,7 +781,7 @@ query TT
 SELECT status, description FROM [SHOW JOBS]
 WHERE job_type = 'SCHEMA CHANGE' ORDER BY job_id DESC LIMIT 1
 ----
-succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT 5; ALTER TABLE test.public.customers ADD COLUMN j INT8 AS (i - 1) STORED; ALTER TABLE test.public.customers ADD COLUMN d INT8 DEFAULT 15, ADD COLUMN e INT8 AS (d + (i - 1)) STORED
+succeeded  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT …  STORED
 
 # VALIDATE CONSTRAINT will not hang when executed in the same txn as
 # a schema change in the same txn #32118

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -573,10 +573,10 @@ SELECT * FROM [SHOW COMPACT TRACE FOR SESSION] LIMIT 0
 ----
 age  message  tag  operation
 
-query ITTTTTTTTTTRTIITTIT colnames
+query ITTTTTTTTTRTI colnames
 SELECT * FROM [SHOW JOBS] LIMIT 0
 ----
-job_id  job_type  description  statement  user_name  status  running_status  created  started  finished  modified  fraction_completed  error  coordinator_id  trace_id  last_run  next_run  num_runs  execution_errors
+job_id  job_type  description  user_name  status  running_status  created  started  finished  modified  fraction_completed  error  coordinator_id
 
 query TT colnames
 SELECT * FROM [SHOW SYNTAX 'select 1; select 2']

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -121,7 +121,7 @@ distribution: local
 vectorized: true
 ·
 • sort
-│ order: -column24,-started
+│ order: -column29,-started
 │
 └── • render
     │

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -366,7 +366,7 @@ func TestDeleteFailedJob(t *testing.T) {
 	// SHOW AUTOMATIC JOBS.
 	// Note: if this test fails, it will likely show up by using stressrace.
 	if res := sqlDB.QueryStr(t,
-		`SELECT statement, status, error FROM [SHOW AUTOMATIC JOBS] WHERE status = $1`,
+		`SELECT job_id, status, error FROM [SHOW AUTOMATIC JOBS] WHERE status = $1`,
 		jobs.StatusFailed,
 	); len(res) != 0 {
 		t.Fatalf("job should have been deleted but found: %v", res)

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -1107,7 +1107,8 @@ func TestMakeTTLJobDescription(t *testing.T) {
 			createTable := getCreateTable(testCase.tableSelectBatchSize)
 			th.sqlDB.Exec(t, createTable)
 			th.waitForScheduledJob(t, jobs.StatusSucceeded, "")
-			rows := th.sqlDB.QueryStr(t, "SELECT description FROM [SHOW JOBS] WHERE job_type = 'ROW LEVEL TTL'")
+			rows := th.sqlDB.QueryStr(t, "SELECT description FROM [SHOW JOBS SELECT id FROM system.jobs WHERE job_type = 'ROW LEVEL TTL']")
+			t.Log(rows)
 			require.Len(t, rows, 1)
 			row := rows[0]
 			require.Contains(t, row[0], fmt.Sprintf("LIMIT %d", testCase.jobSelectBatchSize))


### PR DESCRIPTION
See commits.

Release note (breaking change): Some internal information columns have been removed from SHOW JOBS and job descriptions are abbreviated unless a specific job or set of jobs is shown (see prior release notes for details)