### PR TITLE
kvclient: add a testing knob to stress proxy code

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -179,6 +179,10 @@ func TestMultiRegionDataDriven(t *testing.T) {
 									}
 								},
 							},
+							// NB: This test is asserting on whether it reads from the leaseholder
+							// or the follower first, so it has to route to leaseholder when
+							// requested.
+							KVClient: &kvcoord.ClientTestingKnobs{RouteToLeaseholderFirst: true},
 						},
 					}
 				}

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "//pkg/base",
         "//pkg/config/zonepb",
         "//pkg/keys",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/concurrency/isolation",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -452,6 +452,10 @@ func TestSendRPCOrder(t *testing.T) {
 		TransportFactory:  transportFactory,
 		RangeDescriptorDB: mockRangeDescriptorDBForDescs(descriptor),
 		Settings:          cluster.MakeTestingClusterSettings(),
+		// This test is checking how the different locality settings impact the
+		// choice of routing and number of requests. It needs to route to the
+		// leaseholder first to prevent extra calls.
+		TestingKnobs: ClientTestingKnobs{RouteToLeaseholderFirst: true},
 	}
 
 	for _, tc := range testCases {
@@ -1183,6 +1187,9 @@ func TestDistSenderMovesOnFromReplicaWithStaleLease(t *testing.T) {
 		TransportFactory:  adaptSimpleTransport(sendFn),
 		RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
+		// This test is counting the number of batch requests sent, so route to
+		// the leaseholder first to avoid spurious calls.
+		TestingKnobs: ClientTestingKnobs{RouteToLeaseholderFirst: true},
 	}
 	ds := NewDistSender(cfg)
 
@@ -1302,6 +1309,9 @@ func TestDistSenderIgnoresNLHEBasedOnOldRangeGeneration(t *testing.T) {
 				TransportFactory:  adaptSimpleTransport(sendFn),
 				RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
 				Settings:          cluster.MakeTestingClusterSettings(),
+				// This test is asserting on the number of requests sent, so it
+				// has to route to the leaseholder first.
+				TestingKnobs: ClientTestingKnobs{RouteToLeaseholderFirst: true},
 			}
 			ds := NewDistSender(cfg)
 
@@ -4012,6 +4022,9 @@ func TestCanSendToFollower(t *testing.T) {
 			MaxBackoff:     time.Microsecond,
 		},
 		Settings: cluster.MakeTestingClusterSettings(),
+		// This test is looking at the exact nodes the requests are sent to. If
+		// we send to a follower first, the sentTo node is incorrect.
+		TestingKnobs: ClientTestingKnobs{RouteToLeaseholderFirst: true},
 	}
 	for i, c := range []struct {
 		canSendToFollower bool

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -49,6 +49,15 @@ type ClientTestingKnobs struct {
 	// only applies to requests sent with the LEASEHOLDER routing policy.
 	DontReorderReplicas bool
 
+	// RouteToLeaseholderFirst, if set, the DistSender will move the leaseholder
+	// to the first replica in the transport list when the policy is
+	// RoutingPolicy_LEASEHOLDER. The leaseholder may still be the first replica
+	// it sends the request to if it is also the closest replica. Requests that
+	// are targeted for the leaseholder will instead be proxied to it. This
+	// parameter is typically not set for tests and instead is controlled by
+	// metamorphicRouteToLeaseholderFirst.
+	RouteToLeaseholderFirst bool
+
 	// CommitWaitFilter allows tests to instrument the beginning of a transaction
 	// commit wait sleep.
 	CommitWaitFilter func()

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -754,6 +754,11 @@ func TestReplicaCircuitBreaker_Partial_Retry(t *testing.T) {
 				Server: &server.TestingKnobs{
 					WallClock: manualClock,
 				},
+				// This test is requiring clients to go to the leaseholder first
+				// to get URE errors in the case of a partial partition. If this
+				// is not set, the test fails because it is counting the number
+				// of URE errors it encounters.
+				KVClient: &kvcoord.ClientTestingKnobs{RouteToLeaseholderFirst: true},
 			},
 			Settings: st,
 			RaftConfig: base.RaftConfig{


### PR DESCRIPTION
Previously we built proxy requests to always be a "second choice" if the leaseholder wasn't available, but it wasn't used in any of the existing tests. With this change, we metamorphically test proxying of requests in almost all unit tests other than the ones that are very particular about the order they want to test things.

Epic: none

Release note: None