### PR TITLE
mixedversion: enable experimental cluster settings

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -100,6 +100,13 @@ func CurrentVersion() *Version {
 // MustParseVersion parses the version string given (with or without
 // leading 'v') and returns the corresponding `Version` object.
 func MustParseVersion(v string) *Version {
+	// The current version is rendered differently (see String()
+	// implementation). If the user passed that string representation,
+	// return the current version object.
+	if currentVersion := CurrentVersion(); v == currentVersion.String() {
+		return currentVersion
+	}
+
 	versionStr := v
 	if !strings.HasPrefix(v, "v") {
 		versionStr = "v" + v

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -181,6 +181,21 @@ var planMutators = []mutator{
 		[]bool{true, false},
 		clusterSettingMinimumVersion("v23.1.0"),
 	),
+	newClusterSettingMutator(
+		"storage.ingest_split.enabled",
+		[]bool{true, false},
+		clusterSettingMinimumVersion("v23.2.0"),
+	),
+	newClusterSettingMutator(
+		"kv.snapshot_receiver.excise.enabled",
+		[]bool{true, false},
+		clusterSettingMinimumVersion("v23.2.0"),
+	),
+	newClusterSettingMutator(
+		"storage.sstable.compression_algorithm",
+		[]string{"snappy", "zstd"},
+		clusterSettingMinimumVersion("v24.1.0-alpha.0"),
+	),
 }
 
 // Plan returns the TestPlan used to upgrade the cluster from the


### PR DESCRIPTION
This adds a few experimental cluster settings to the settings that can
be changed during `mixedversion` tests. Once these settings have been
running for a sufficient amount of time, we can delete the mutators
added in this commit.

The list of cluster settings was extracted from the corresponding DRT
document[^1].

[^1]: https://docs.google.com/document/d/1IlKgR6Yi-jB8-ntdlObTADjVmgucIoD2XPBTb31vMv8/edit#

Epic: none

Release note: None