### PR TITLE
dev: add `dev ui crdb-api-client` command

### DIFF
--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -336,8 +336,14 @@ func (d *dev) generateJs(cmd *cobra.Command) error {
 
 	// Copy the eslint-plugin output tree back out of the sandbox, since eslint
 	// plugins in editors default to only searching in ./node_modules for plugins.
-	return d.os.CopyAll(
+	err = d.os.CopyAll(
 		filepath.Join(bazelBin, eslintPluginDist),
 		filepath.Join(workspace, eslintPluginDist),
 	)
+	if err != nil {
+		return err
+	}
+
+	// Generate crdb-api-client package.
+	return makeUICrdbApiClientCmd(d).RunE(cmd, []string{})
 }

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -57,6 +57,7 @@ ls crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/node_modules/@cockroach
 ls crdb-checkout/pkg/ui/workspaces/cluster-ui/node_modules/@cockroachlabs
 ls crdb-checkout/pkg/ui/workspaces/db-console/node_modules/@cockroachlabs
 ls crdb-checkout/pkg/ui/workspaces/e2e-tests/node_modules/@cockroachlabs
+ls crdb-checkout/pkg/ui/workspaces/crdb-api-client/node_modules/@cockroachlabs
 bazel build //pkg/cmd/cockroach:cockroach --verbose_failures --sandbox_debug --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -153,6 +153,9 @@ rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/index.js
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/index.ts
 
 exec
 dev ui clean --all
@@ -166,6 +169,9 @@ rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/index.js
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/index.ts
 rm -rf crdb-checkout/pkg/ui/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/node_modules
@@ -173,6 +179,7 @@ rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/e2e-tests/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/node_modules
+rm -rf crdb-checkout/pkg/ui/workspaces/crdb-api-client/node_modules
 
 exec
 dev ui e2e

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -43,6 +43,7 @@ func makeUICmd(d *dev) *cobra.Command {
 	uiCmd.AddCommand(makeUIE2eCmd(d))
 	uiCmd.AddCommand(makeMirrorDepsCmd(d))
 	uiCmd.AddCommand(makeUIStorybookCmd(d))
+	uiCmd.AddCommand(makeUICrdbApiClientCmd(d))
 
 	return uiCmd
 }
@@ -65,6 +66,8 @@ type UIDirectories struct {
 	protoOss string
 	// protoCcl is the absolute path to ./pkg/ui/workspaces/db-console/ccl/src/js/.
 	protoCcl string
+	// crdbJsProto is the absolute path to ./pkg/ui/workspaces/crdb-js-proto/.
+	crdbApiClient string
 }
 
 // getUIDirs computes the absolute path to the root of each UI sub-project.
@@ -75,14 +78,15 @@ func getUIDirs(d *dev) (*UIDirectories, error) {
 	}
 
 	return &UIDirectories{
-		workspace:    workspace,
-		root:         filepath.Join(workspace, "./pkg/ui"),
-		clusterUI:    filepath.Join(workspace, "./pkg/ui/workspaces/cluster-ui"),
-		dbConsole:    filepath.Join(workspace, "./pkg/ui/workspaces/db-console"),
-		e2eTests:     filepath.Join(workspace, "./pkg/ui/workspaces/e2e-tests"),
-		eslintPlugin: filepath.Join(workspace, "./pkg/ui/workspaces/eslint-plugin-crdb"),
-		protoOss:     filepath.Join(workspace, "./pkg/ui/workspaces/db-console/src/js"),
-		protoCcl:     filepath.Join(workspace, "./pkg/ui/workspaces/db-console/ccl/src/js"),
+		workspace:     workspace,
+		root:          filepath.Join(workspace, "./pkg/ui"),
+		clusterUI:     filepath.Join(workspace, "./pkg/ui/workspaces/cluster-ui"),
+		dbConsole:     filepath.Join(workspace, "./pkg/ui/workspaces/db-console"),
+		e2eTests:      filepath.Join(workspace, "./pkg/ui/workspaces/e2e-tests"),
+		eslintPlugin:  filepath.Join(workspace, "./pkg/ui/workspaces/eslint-plugin-crdb"),
+		protoOss:      filepath.Join(workspace, "./pkg/ui/workspaces/db-console/src/js"),
+		protoCcl:      filepath.Join(workspace, "./pkg/ui/workspaces/db-console/ccl/src/js"),
+		crdbApiClient: filepath.Join(workspace, "./pkg/ui/workspaces/crdb-api-client"),
 	}, nil
 }
 
@@ -128,6 +132,7 @@ func (d *dev) assertNoLinkedNpmDeps(targets []buildTarget) error {
 		uiDirs.clusterUI,
 		uiDirs.dbConsole,
 		uiDirs.e2eTests,
+		uiDirs.crdbApiClient,
 	}
 
 	type LinkedPackage struct {
@@ -547,6 +552,74 @@ func makeUIStorybookCmd(d *dev) *cobra.Command {
 	return storybookCmd
 }
 
+// makeUICrdbApiClientCmd initializes the 'ui crdb-api-client' subcommand. which
+// generates JS protobuf client package and hoists it to source tree.
+func makeUICrdbApiClientCmd(d *dev) *cobra.Command {
+	return &cobra.Command{
+		Use:   "crdb-api-client",
+		Short: "Build crdb-api-client library",
+		Long:  ``,
+		Args:  cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, commandLine []string) error {
+			// Create a context that cancels when OS signals come in.
+			ctx, stop := signal.NotifyContext(d.cli.Context(), os.Interrupt, os.Kill)
+			defer stop()
+			bazelBin, err := d.getBazelBin(d.cli.Context(), []string{})
+			if err != nil {
+				return err
+			}
+			dstDirs, err := getUIDirs(d)
+			if err != nil {
+				return err
+			}
+
+			// Ensure node dependencies are up-to-date.
+			err = d.exec.CommandContextInheritingStdStreams(
+				ctx,
+				"pnpm",
+				"--dir",
+				dstDirs.root,
+				"install",
+			)
+			if err != nil {
+				log.Fatalf("failed to fetch node dependencies: %v", err)
+			}
+
+			args := []string{
+				"build",
+				"//pkg/ui/workspaces/crdb-api-client:crdb-api-client",
+			}
+
+			logCommand("bazel", args...)
+			err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+			if err != nil {
+				log.Fatalf("failed to build crdb-api-client target: %v", err)
+				return err
+			}
+
+			// Hoist generated output files back to source tree.
+			crdbApiClientSrc := filepath.Join(bazelBin, "pkg", "ui", "workspaces", "crdb-api-client", "crdb-api-client")
+			crdbApiClientPaths := []string{"dist", "index.js", "index.ts"}
+
+			for _, relPath := range crdbApiClientPaths {
+				err = d.os.RemoveAll(filepath.Join(dstDirs.crdbApiClient, relPath))
+				if err != nil {
+					return err
+				}
+				err = d.os.CopyAll(
+					filepath.Join(crdbApiClientSrc, relPath),
+					filepath.Join(dstDirs.crdbApiClient, relPath),
+				)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
 func makeUILintCmd(d *dev) *cobra.Command {
 	const (
 		verboseFlag = "verbose"
@@ -624,6 +697,9 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 				filepath.Join(uiDirs.dbConsole, "dist"),
 				filepath.Join(uiDirs.clusterUI, "dist"),
 				filepath.Join(uiDirs.eslintPlugin, "dist"),
+				filepath.Join(uiDirs.crdbApiClient, "dist"),
+				filepath.Join(uiDirs.crdbApiClient, "index.js"),
+				filepath.Join(uiDirs.crdbApiClient, "index.ts"),
 			}
 			if all {
 				workspace, err := d.getWorkspace(d.cli.Context())
@@ -640,6 +716,7 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 					filepath.Join(uiDirs.clusterUI, "node_modules"),
 					filepath.Join(uiDirs.e2eTests, "node_modules"),
 					filepath.Join(uiDirs.eslintPlugin, "node_modules"),
+					filepath.Join(uiDirs.crdbApiClient, "node_modules"),
 				)
 			}
 

--- a/pkg/ui/workspaces/crdb-api-client/.gitignore
+++ b/pkg/ui/workspaces/crdb-api-client/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+index.*

--- a/pkg/ui/workspaces/crdb-api-client/BUILD.bazel
+++ b/pkg/ui/workspaces/crdb-api-client/BUILD.bazel
@@ -3,7 +3,6 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//docs/generated/http:defs.bzl", "PROTOBUF_TARGETS")
 load("//pkg/ui/workspaces/db-console/src/js:defs.bzl", "proto_sources")
 


### PR DESCRIPTION
This change adds a new `dev` command to generate
JS proto files for `crdb-api-client` JS library and move generated files back to source tree to allow later use it as a dependency in `db-console` and publish to NPM registry.

Release note: None

Epic: https://cockroachlabs.atlassian.net/browse/CC-26102