### PR TITLE
schemachange/leasing-benchmark: use valid aws zones for this test

### DIFF
--- a/pkg/cmd/roachtest/tests/multiregion_leasing.go
+++ b/pkg/cmd/roachtest/tests/multiregion_leasing.go
@@ -184,7 +184,7 @@ func registerSchemaChangeMultiRegionBenchmarkLeasing(r registry.Registry) {
 			3,
 			spec.Geo(),
 			spec.GCEZones("us-west1-b,us-east1-b,australia-southeast1-a"),
-			spec.AWSZones("us-east-2b,us-west-1a,ap-southeast-4a"),
+			spec.AWSZones("us-east-1a,us-west-2b,ap-southeast-2b"),
 		),
 		CompatibleClouds: registry.AllExceptLocal,
 		Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
Previously, this test was using zones which which weren't valid for AWS. To address this patch changes the AWS zones for
schemachange/leasing-benchmark to be valid for the machine types required.

Informs: #120621

Release note: None