### PR TITLE
sqlstats: remove allocation of anonymous function

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -93,11 +93,7 @@ func (s *StatsCollector) EndTransaction(
 
 	var discardedStats uint64
 	discardedStats += s.flushTarget.MergeApplicationStatementStats(
-		ctx,
-		s.ApplicationStats,
-		func(statistics *appstatspb.CollectedStatementStatistics) {
-			statistics.Key.TransactionFingerprintID = transactionFingerprintID
-		},
+		ctx, s.ApplicationStats, transactionFingerprintID,
 	)
 
 	discardedStats += s.flushTarget.MergeApplicationTransactionStats(

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -699,15 +699,13 @@ func (s *Container) freeLocked(ctx context.Context) {
 func (s *Container) MergeApplicationStatementStats(
 	ctx context.Context,
 	other sqlstats.ApplicationStats,
-	transformer func(*appstatspb.CollectedStatementStatistics),
+	transactionFingerprintID appstatspb.TransactionFingerprintID,
 ) (discardedStats uint64) {
 	if err := other.IterateStatementStats(
 		ctx,
 		sqlstats.IteratorOptions{},
 		func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
-			if transformer != nil {
-				transformer(statistics)
-			}
+			statistics.Key.TransactionFingerprintID = transactionFingerprintID
 			key := stmtKey{
 				sampledPlanKey: sampledPlanKey{
 					stmtNoConstants: statistics.Key.Query,

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -76,14 +76,13 @@ type ApplicationStats interface {
 
 	// MergeApplicationStatementStats merges the other application's statement
 	// statistics into the current ApplicationStats. It returns how many number
-	// of statistics were being discarded due to memory constraint. If the
-	// transformer is non-nil, then it is applied to other's statement statistics
-	// before other's statement statistics are merged into the current
-	// ApplicationStats.
+	// of statistics were being discarded due to memory constraint. The
+	// TransactionFingerprintID of all other's statement statistics keys is
+	// updated to the provided one.
 	MergeApplicationStatementStats(
 		ctx context.Context,
 		other ApplicationStats,
-		transformer func(statistics *appstatspb.CollectedStatementStatistics),
+		transactionFingerprintID appstatspb.TransactionFingerprintID,
 	) uint64
 
 	// MergeApplicationTransactionStats merges the other application's transaction


### PR DESCRIPTION
We can inline the "transformer" implementation that was previously passed into `MergeApplicationStatementStats` in order to avoid allocating an anonymous function.

Epic: None

Release note: None