### PR TITLE
coldata: batch-allocate columns of the same type

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -1225,6 +1225,22 @@ func BenchmarkWideTable(b *testing.B) {
 	})
 }
 
+func BenchmarkScanWideTable(b *testing.B) {
+	skip.UnderShort(b)
+	defer log.Scope(b).Close(b)
+	ForEachDB(b, func(b *testing.B, db *sqlutils.SQLRunner) {
+		db.Exec(b, wideTableSchema)
+		var buf bytes.Buffer
+		s := rand.New(rand.NewSource(5432))
+		insertIntoWideTable(b, buf, 0, 10000, 10, s, db)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			db.Exec(b, "SELECT * FROM bench.widetable WHERE f4 < 10")
+		}
+	})
+}
+
 func BenchmarkWideTableIgnoreColumns(b *testing.B) {
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
@@ -1235,7 +1251,6 @@ func BenchmarkWideTableIgnoreColumns(b *testing.B) {
 		insertIntoWideTable(b, buf, 0, 10000, 10, s, db)
 
 		b.ResetTimer()
-
 		for i := 0; i < b.N; i++ {
 			db.Exec(b, "SELECT count(*) FROM bench.widetable WHERE f4 < 10")
 		}

--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     ],
     embed = [":coldata"],
     deps = [
+        "//pkg/col/coldataext",
         "//pkg/col/coldatatestutils",
         "//pkg/sql/colconv",
         "//pkg/sql/types",

--- a/pkg/col/coldata/batch_test.go
+++ b/pkg/col/coldata/batch_test.go
@@ -11,11 +11,13 @@
 package coldata_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -183,5 +185,41 @@ func TestBatchString(t *testing.T) {
 		copy(b.Selection(), tc.sel)
 		b.SetLength(tc.length)
 		assert.Equal(t, getExpected(tc.length, tc.sel), b.String())
+	}
+}
+
+func BenchmarkNewMemBatchWithCapacity(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+
+	getAllTypes := func(numRepeats int) []*types.T {
+		allTypes := []*types.T{
+			types.Bool, types.Bytes, types.Int2, types.Int4, types.Int,
+			types.Float, types.Decimal, types.TimestampTZ, types.Interval,
+			types.Json, types.TSQuery,
+		}
+		var res []*types.T
+		for i := 0; i < numRepeats; i++ {
+			res = append(res, allTypes...)
+		}
+		return res
+	}
+
+	factory := coldataext.NewExtendedColumnFactoryNoEvalCtx()
+	for _, length := range []int{1, 32, coldata.DefaultColdataBatchSize} {
+		for _, tc := range []struct {
+			name string
+			typs []*types.T
+		}{
+			{"oneInt", types.OneIntCol},
+			{"threeInts", types.ThreeIntCols},
+			{"allOnce", getAllTypes(1)},
+			{"allThrice", getAllTypes(3)},
+		} {
+			b.Run(fmt.Sprintf("%s/len=%d", tc.name, length), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					_ = coldata.NewMemBatchWithCapacity(tc.typs, length, factory)
+				}
+			})
+		}
 	}
 }

--- a/pkg/col/coldata/datum_vec.go
+++ b/pkg/col/coldata/datum_vec.go
@@ -57,4 +57,6 @@ type DatumVec interface {
 	Size(startIdx int) int64
 	// SetEvalCtx updates the vector with the provided *eval.Context.
 	SetEvalCtx(evalCtx interface{})
+	// SetType updates the vector with its type.
+	SetType(t interface{})
 }

--- a/pkg/col/coldata/nulls.go
+++ b/pkg/col/coldata/nulls.go
@@ -47,16 +47,25 @@ type Nulls struct {
 
 // NewNulls returns a new nulls vector, initialized with a length.
 func NewNulls(len int) Nulls {
-	if len > 0 {
-		n := Nulls{
-			nulls: make([]byte, (len-1)/8+1),
-		}
-		n.UnsetNulls()
-		return n
+	return newNulls(make([]byte, nullsStorageCap(len)))
+}
+
+//gcassert:inline
+func newNulls(nulls []byte) Nulls {
+	n := Nulls{nulls: nulls}
+	n.UnsetNulls()
+	return n
+}
+
+// nullsStorageCap returns the length of the byte slice that is needed to
+// maintain the Nulls bitmap for n elements.
+//
+//gcassert:inline
+func nullsStorageCap(n int) int {
+	if n <= 0 {
+		return 0
 	}
-	return Nulls{
-		nulls: make([]byte, 0),
-	}
+	return (n-1)/8 + 1
 }
 
 // MaybeHasNulls returns true if the column possibly has any null values, and

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -239,3 +239,8 @@ func convertToDatum(v coldata.Datum) tree.Datum {
 func (dv *datumVec) SetEvalCtx(evalCtx interface{}) {
 	dv.evalCtx = evalCtx.(*eval.Context)
 }
+
+// SetType implements coldata.DatumVec interface.
+func (dv *datumVec) SetType(t interface{}) {
+	dv.t = t.(*types.T)
+}


### PR DESCRIPTION
This commit improves `NewMemBatchWithCapacity` method to batch-allocate underlying storage for columns of the same type. If we see multiple vectors use the same canonical type, we can allocate a huge backing slice that is divided between columns. Similar idea is applied to how we allocate nulls. This can noticeably reduce the number (but not the size) of allocations.

Kudos to Marcus for the idea.

Macro-benchmark:
```
name                                           old time/op    new time/op    delta
ScanWideTable/Cockroach-24                       7.56ms ± 1%    7.52ms ± 1%   -0.49%  (p=0.035 n=10+10)
ScanWideTable/SharedProcessTenantCockroach-24    7.64ms ± 1%    7.56ms ± 1%   -1.06%  (p=0.000 n=10+10)
ScanWideTable/MultinodeCockroach-24              8.13ms ± 1%    8.04ms ± 1%   -1.15%  (p=0.002 n=10+10)

name                                           old alloc/op   new alloc/op   delta
ScanWideTable/Cockroach-24                       3.04MB ± 0%    3.04MB ± 0%   +0.08%  (p=0.000 n=10+9)
ScanWideTable/SharedProcessTenantCockroach-24    3.05MB ± 0%    3.05MB ± 0%   +0.11%  (p=0.000 n=10+10)
ScanWideTable/MultinodeCockroach-24              3.32MB ± 0%    3.33MB ± 1%     ~     (p=0.481 n=10+10)

name                                           old allocs/op  new allocs/op  delta
ScanWideTable/Cockroach-24                        1.17k ± 0%     0.77k ± 0%  -33.83%  (p=0.000 n=10+10)
ScanWideTable/SharedProcessTenantCockroach-24     1.22k ± 1%     0.82k ± 1%  -32.57%  (p=0.000 n=10+10)
ScanWideTable/MultinodeCockroach-24               2.97k ± 1%     2.43k ± 1%  -18.15%  (p=0.000 n=9+9)
```
Micro-benchmark:
```
NewMemBatchWithCapacity/oneInt/len=1-24           204ns ± 6%     215ns ± 7%   +5.60%  (p=0.005 n=10+10)
NewMemBatchWithCapacity/threeInts/len=1-24        409ns ± 3%     422ns ± 6%     ~     (p=0.082 n=9+10)
NewMemBatchWithCapacity/allOnce/len=1-24         1.39µs ± 8%    1.33µs ±11%     ~     (p=0.072 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1-24       3.96µs ± 9%    4.43µs ± 7%  +11.79%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=32-24          300ns ±10%     365ns ±10%  +21.58%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/threeInts/len=32-24       596ns ±10%     665ns ± 9%  +11.65%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=32-24        2.91µs ± 6%    2.59µs ±11%  -11.01%  (p=0.000 n=8+10)
NewMemBatchWithCapacity/allThrice/len=32-24      7.98µs ±13%    7.99µs ±23%     ~     (p=0.796 n=10+10)
NewMemBatchWithCapacity/oneInt/len=1024-24       3.28µs ±16%    4.12µs ±27%  +25.60%  (p=0.001 n=10+10)
NewMemBatchWithCapacity/threeInts/len=1024-24    7.39µs ±11%    5.98µs ±24%  -19.07%  (p=0.002 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1024-24      36.9µs ± 9%    31.2µs ±13%  -15.39%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1024-24    91.6µs ±19%    87.6µs ±23%     ~     (p=0.631 n=10+10)

name                                           old alloc/op   new alloc/op   delta
NewMemBatchWithCapacity/oneInt/len=1-24            208B ± 0%      208B ± 0%     ~     (all equal)
NewMemBatchWithCapacity/threeInts/len=1-24         448B ± 0%      480B ± 0%   +7.14%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1-24         2.28kB ± 0%    2.27kB ± 0%   -0.35%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1-24       6.71kB ± 0%    6.68kB ± 0%   -0.48%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=32-24           700B ± 0%      700B ± 0%     ~     (all equal)
NewMemBatchWithCapacity/threeInts/len=32-24      1.43kB ± 0%    1.48kB ± 0%   +3.64%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=32-24        8.48kB ± 0%    8.48kB ± 0%   +0.05%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=32-24      24.8kB ± 0%    24.8kB ± 0%   -0.08%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=1024-24       16.7kB ± 0%    16.7kB ± 0%     ~     (all equal)
NewMemBatchWithCapacity/threeInts/len=1024-24    33.5kB ± 0%    33.6kB ± 0%   +0.14%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1024-24       204kB ± 0%     204kB ± 0%     ~     (all equal)
NewMemBatchWithCapacity/allThrice/len=1024-24     595kB ± 0%     581kB ± 0%   -2.29%  (p=0.000 n=10+10)

name                                           old allocs/op  new allocs/op  delta
NewMemBatchWithCapacity/oneInt/len=1-24            7.00 ± 0%      7.00 ± 0%     ~     (all equal)
NewMemBatchWithCapacity/threeInts/len=1-24         13.0 ± 0%      10.0 ± 0%  -23.08%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1-24           37.0 ± 0%      27.0 ± 0%  -27.03%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1-24          103 ± 0%        44 ± 0%  -57.28%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=32-24           7.00 ± 0%      7.00 ± 0%     ~     (all equal)
NewMemBatchWithCapacity/threeInts/len=32-24        13.0 ± 0%      10.0 ± 0%  -23.08%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=32-24          37.0 ± 0%      27.0 ± 0%  -27.03%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=32-24         103 ± 0%        44 ± 0%  -57.28%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/oneInt/len=1024-24         7.00 ± 0%      7.00 ± 0%     ~     (all equal)
NewMemBatchWithCapacity/threeInts/len=1024-24      13.0 ± 0%      10.0 ± 0%  -23.08%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allOnce/len=1024-24        37.0 ± 0%      27.0 ± 0%  -27.03%  (p=0.000 n=10+10)
NewMemBatchWithCapacity/allThrice/len=1024-24       103 ± 0%        44 ± 0%  -57.28%  (p=0.000 n=10+10)
```
Note that there is some slowdown when allocating columns of small capacity, but the absolute speed is still pretty high. My hypothesis is that reduced number of objects would reduce impact of GC which should counteract this slowdown, making this change neutral or beneficial overall (depending on the type schema and column capacity).

Informs: #117546.
Epic: CRDB-35243

Release note: None