### PR TITLE
kvclient: fix error handling on proxy requests

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1532,11 +1532,17 @@ func (n *Node) maybeProxyRequest(
 	// TODO(baptist): Correctly set up the span / tracing.
 	br, pErr := n.proxySender.Send(ctx, ba)
 	if pErr == nil {
-		log.VEvent(ctx, 2, "proxy succeeded")
+		log.VEvent(ctx, 2, "proxy request completed")
 		return br
+	} else if pErr == kvcoord.ProxyFailedWithSendError {
+		log.VEventf(ctx, 2, "proxy failed with send error %v", pErr)
+		// Use the original error NLHE from local evaluation.
+		return nil
 	}
-	// Wrap the error in a ProxyFailedError. It is unwrapped on the client side
-	// and handled there.
+	// It is rare to get here on a proxy request because wrapping normally
+	// happens in DistSender.sendPartialBatch. Pessimistically wrap the error
+	// and convert this to a ProxyFailedError which may become an ambiguous
+	// error on the other side.
 	log.VEventf(ctx, 2, "proxy attempt resulted in error %v", pErr)
 	br = &kvpb.BatchResponse{}
 	br.Error = kvpb.NewError(kvpb.NewProxyFailedError(pErr.GoError()))


### PR DESCRIPTION
Previously on a proxy request, the error was extracted and wrapped into a ProxyFailedError incorrectly. It should only be moved into a ProxyFailedError if it is a non-remote error. This PR cleans up the handling of any proxy requests (requests with ProxyRangeInfo) set on them.

Epic: none
Fixes: #121168

Release note: None

Release Justification: This change prevents errors on proxy requests from incorrectly being converted to ambiguous errors on the sender.