### PR TITLE
server: remove compaction limit tuning from online restore

### DIFF
--- a/pkg/server/span_download.go
+++ b/pkg/server/span_download.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -87,18 +86,10 @@ func (s *systemStatusServer) localDownloadSpan(
 	ctx context.Context, req *serverpb.DownloadSpanRequest,
 ) error {
 	return s.stores.VisitStores(func(store *kvserver.Store) error {
-		downloadSpansCh, stopTuningCh := make(chan roachpb.Span), make(chan struct{})
+		downloadSpansCh := make(chan roachpb.Span)
 		return ctxgroup.GoAndWait(ctx,
-			// Tune download concurrency until stopTuningCh closes.
-			func(ctx context.Context) error {
-				t := time.NewTicker(time.Second * 15)
-				defer t.Stop()
-				return tuneDownloadCurrency(ctx, t.C, stopTuningCh, store.StateEngine(),
-					s.sqlServer.cfg.RuntimeStatSampler.GetCPUCombinedPercentNorm)
-			},
 			// Download until downloadSpansCh closes, then close stopTuningCh.
 			func(ctx context.Context) error {
-				defer close(stopTuningCh)
 				return downloadSpans(ctx, store.StateEngine(), downloadSpansCh, req.ViaBackingFileDownload)
 			},
 			// Send spans to downloadSpansCh.
@@ -137,63 +128,4 @@ func downloadSpans(ctx context.Context, e storage.Engine, spans chan roachpb.Spa
 		log.Infof(ctx, "finished downloading %d spans", len(spans))
 		return nil
 	})
-}
-
-// tuneDownloadCurrency periodically adjusts download concurrency up or down on
-// the passed engine based on the cpu load value read from the passed func until
-// the passed done ch closes or is signaled.
-func tuneDownloadCurrency(
-	ctx context.Context,
-	tick <-chan time.Time,
-	done <-chan struct{},
-	eng storage.Engine,
-	readCPU func() float64,
-) error {
-	var added int64
-	// Remove any additional concurrency we've added when we exit.
-	//
-	// TODO(dt,radu): Ideally we'd adjust a separate limit that applies only
-	// to download compactions, so that this does not fight with manual calls
-	// to SetConcurrentCompactions.
-	defer func() {
-		if added != 0 {
-			adjusted := eng.AdjustCompactionConcurrency(-added)
-			log.Infof(ctx, "downloads complete; reset compaction concurrency to %d", adjusted)
-		}
-	}()
-
-	const maxAddedConcurrency, lowCPU, highCPU, initialIncrease = 16, 0.65, 0.8, 8
-
-	// Begin by bumping up the concurrency by 8, then start watching the CPU
-	// usage and adjusting up or down based on CPU until downloading finishes.
-	eng.AdjustCompactionConcurrency(initialIncrease)
-	added += initialIncrease
-
-	ctxDone := ctx.Done()
-
-	for {
-		select {
-		case <-ctxDone:
-			return ctx.Err()
-		case <-done:
-			return nil
-		case <-tick:
-			cpu := readCPU()
-			if cpu > highCPU && added > 0 {
-				// If CPU is high and we have added any additional concurrency, we
-				// should reduce our added concurrency to make sure CPU is available
-				// for the execution of foreground traffic.
-				adjusted := eng.AdjustCompactionConcurrency(-1)
-				added--
-				log.Infof(ctx, "decreasing additional compaction concurrency to %d (%d total) due cpu usage %.0f%% > %.0f%%", added, adjusted, cpu*100, highCPU*100)
-			} else if cpu < lowCPU {
-				// If CPU is low, we should use it to do additional downloading.
-				if added < maxAddedConcurrency {
-					adjusted := eng.AdjustCompactionConcurrency(1)
-					added++
-					log.Infof(ctx, "increasing additional compaction concurrency to %d (%d total) due cpu usage %.0f%% < %.0f%%", added, adjusted, cpu*100, lowCPU*100)
-				}
-			}
-		}
-	}
 }


### PR DESCRIPTION
Release note: none.
Epic: none.