### PR TITLE
execbuilder: only apply implicit for-update locking to mutation input

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -98,11 +99,10 @@ type Builder struct {
 
 	allowInsertFastPath bool
 
-	// forceForUpdateLocking is conditionally passed through to factory methods
-	// for scan operators that serve as the input for mutation operators. When
-	// set to true, it ensures that a FOR UPDATE row-level locking mode is used
-	// by scans. See forUpdateLocking.
-	forceForUpdateLocking bool
+	// forceForUpdateLocking is a set of opt catalog table IDs that serve as input
+	// for mutation operators, and should be locked using forUpdateLocking to
+	// reduce query retries.
+	forceForUpdateLocking intsets.Fast
 
 	// planLazySubqueries is true if the builder should plan subqueries that are
 	// lazily evaluated as routines instead of a subquery which is evaluated

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -859,3 +859,43 @@ vectorized: true
 # Reset for rest of test.
 statement ok
 SET enable_implicit_select_for_update = true
+
+# Test that implicit SELECT FOR UPDATE doesn't spread to subqueries.
+statement ok
+CREATE TABLE t121322_ab (a int PRIMARY KEY, b int, INDEX (b))
+
+statement ok
+CREATE TABLE t121322_c (c int PRIMARY KEY)
+
+query T
+EXPLAIN UPDATE t121322_ab SET b = (SELECT sum(c) FROM t121322_c) WHERE a = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: t121322_ab
+│   │ set: b
+│   │ auto commit
+│   │
+│   └── • render
+│       │
+│       └── • scan
+│             missing stats
+│             table: t121322_ab@t121322_ab_pkey
+│             spans: [/1 - /1]
+│             locking strength: for update
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT sum(c) FROM t121322_c)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • scan
+              missing stats
+              table: t121322_c@t121322_c_pkey
+              spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -947,3 +947,46 @@ count         Put /Table/120/1/2/0 -> /TUPLE/2:2:Int/2
 count         Del /Table/120/2/3/0
 count         CPut /Table/120/2/2/0 -> /BYTES/0x8a (expecting does not exist)
 sql query     execution failed after 0 rows: duplicate key value violates unique constraint "woo"
+
+# Test that implicit SELECT FOR UPDATE doesn't spread to subqueries.
+statement ok
+CREATE TABLE t121322_ab (a int PRIMARY KEY, b int, INDEX (b))
+
+statement ok
+CREATE TABLE t121322_c (c int PRIMARY KEY)
+
+query T
+EXPLAIN UPSERT INTO t121322_ab SELECT 1, (SELECT sum(c) FROM t121322_c)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • upsert
+│   │ into: t121322_ab(a, b)
+│   │ auto commit
+│   │ arbiter indexes: t121322_ab_pkey
+│   │
+│   └── • cross join (left outer)
+│       │
+│       ├── • values
+│       │     size: 2 columns, 1 row
+│       │
+│       └── • scan
+│             missing stats
+│             table: t121322_ab@t121322_ab_pkey
+│             spans: [/1 - /1]
+│             locking strength: for update
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT sum(c) FROM t121322_c)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │
+        └── • scan
+              missing stats
+              table: t121322_c@t121322_c_pkey
+              spans: FULL SCAN


### PR DESCRIPTION
In `shouldApplyImplicitLockingToMutationInput` we match only certain plan shapes of UPDATE and UPSERT, to make certain that implicit for-update locking will not be a pessimization. Then in `buildMutationInput` we were enabling implicit for-update locking for _all_ operations underneath the input of the mutation.

This was causing subqueries in projections to also have implicit for-update locking, for example in queries like:

```sql
UPDATE ab SET b = (SELECT sum(c) FROM c) WHERE a = 1;
```

In order to restrict implicit for-update locking to the mutation target table, this commit changes `shouldApplyImplicitLockingToMutationInput` to return the TableID of the input scan. We now only apply implicit for-update locking to these tables.

Fixes: #121322

Release note (bug fix): Fix a bug where UPDATE and UPSERT queries with a subquery were sometimes inappropriately using implicit FOR-UPDATE locking within the subquery. This bug has existing since implicit FOR-UPDATE locking was introduced in 20.1.0.