### PR TITLE
kvserver: skip promo non-voter in add voter under deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2118,6 +2118,7 @@ func TestPromoteNonVoterInAddVoter(t *testing.T) {
 	// rebalancing to ensure all stores have the same range count initially, due
 	// to slow heartbeats.
 	skip.UnderStress(t)
+	skip.UnderDeadlock(t)
 	skip.UnderRace(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
`TestPromoteNonVoterInAddVoter` uses a 7 node test cluster and is skipped under stress/race. Also skip the test under deadlock builds to avoid timing out waiting for initial replica count balance when setting up the test.

Fixes: #121340
Release note: None