### PR TITLE
pkg/ui: properly derive XScale in statement details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -704,9 +704,9 @@ export class StatementDetails extends React.Component<
     const duration = (v: number) => Duration(v * 1e9);
     const [chartsStart, chartsEnd] = toRoundedDateRange(this.props.timeScale);
     const xScale = {
-      graphTsStartMillis: chartsStart.valueOf,
-      graphTsEndMillis: chartsEnd.valueOf,
-    } as unknown as XScale;
+      graphTsStartMillis: chartsStart.valueOf(),
+      graphTsEndMillis: chartsEnd.valueOf(),
+    } as XScale;
 
     return (
       <>


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/121362

Epic: none

https://github.com/cockroachdb/cockroach/pull/118680 introduced code to align the timeseries charts on the statement details page to the time range set by the time picker, instead of the time range that we had available data for.

The code contained a bug where it would set the start & end of the XScale to `Moment.prototype.valueOf` instead of the result of *calling* `Moment.prototype.valueOf()`. This causes the start & end timestamps to be set to functions, instead of unix timestamps, which broke the charts.

This PR simply invokes the function.

Release note (bug fix): The timeseries graphs shown on the SQL Activity statement details page in DB Console will now render properly, after fixing a bug related to setting the time range of the charts.
