### PR TITLE
ui: add goroutine scheduling latency graph to runtime dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -88,6 +88,28 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Goroutine Scheduling Latency: 99th percentile"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`P99 scheduling latency for goroutines`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {nodeIDs.map(nid => (
+          <>
+            <Metric
+              key={nid}
+              name="cr.node.go.scheduler_latency-p99"
+              title={nodeDisplayName(nodeDisplayNameByID, nid)}
+              sources={[nid]}
+              downsampleMax
+            />
+          </>
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Runnable Goroutines per CPU"
       sources={nodeSources}
       tenantSource={tenantSource}


### PR DESCRIPTION
#### ui: add goroutine scheduling latency graph to runtime dashboard

Epic: None

Release note (ui change): The "Goroutine Scheduling Latency" graph has
been added to the Runtime page in Metrics.
