### PR TITLE
schemachanger: handle CREATE SEQUENCE name conflicts with geo type

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -120,7 +120,7 @@ func getSchemaForCreateTable(
 	// schema for PostgreSQL.
 	if tableName.Schema() == catconstants.PublicSchemaName {
 		if _, ok := types.PublicSchemaAliases[tableName.Object()]; ok {
-			return nil, sqlerrors.NewTypeAlreadyExistsError(tableName.String())
+			return nil, sqlerrors.NewTypeAlreadyExistsError(tableName.Object())
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2463,3 +2463,43 @@ SELECT column_name from [SHOW COLUMNS FROM sq_119108]
 value
 
 subtest end
+
+subtest geo_types
+
+onlyif config local-legacy-schema-changer
+onlyif config local-mixed-23.1
+onlyif config local-mixed-23.2
+statement error type "geography" already exists
+CREATE SEQUENCE geography
+
+onlyif config local-legacy-schema-changer
+onlyif config local-mixed-23.1
+onlyif config local-legacy-schema-changer local-mixed-23.1 local-mixed-23.2
+statement error type "geometry" already exists
+CREATE SEQUENCE geometry
+
+onlyif config local-legacy-schema-changer local-mixed-23.1 local-mixed-23.2
+onlyif config local-mixed-23.1
+onlyif config local-legacy-schema-changer local-mixed-23.1 local-mixed-23.2
+statement error type "box2d" already exists
+CREATE SEQUENCE box2d
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error geography is a built-in type and cannot be modified
+CREATE SEQUENCE geography
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error geometry is a built-in type and cannot be modified
+CREATE SEQUENCE geometry
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error box2d is a built-in type and cannot be modified
+CREATE SEQUENCE box2d
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1035,6 +1035,13 @@ func (b *builderState) resolveRelation(
 		if t.IsTemporary() {
 			panic(scerrors.NotImplementedErrorf(nil /* n */, "dropping a temporary table"))
 		}
+	} else if typ, isType := rel.(catalog.TypeDescriptor); isType {
+		if typ.GetKind() == descpb.TypeDescriptor_ALIAS && typ.GetID() == descpb.InvalidID {
+			// This case handles the types in types.PublicSchemaAliases -- BOX2D,
+			// GEOGRAPHY, and GEOMETRY.
+			panic(pgerror.Newf(pgcode.WrongObjectType,
+				"%s is a built-in type and cannot be modified", tree.ErrNameString(typ.GetName())))
+		}
 	}
 
 	// If we own the schema then we can manipulate the underlying relation,


### PR DESCRIPTION
Previously, a statement like `CREATE TYPE geography` would cause an internal error. The legacy schema changer has an explicit check for this, which was not in the new schema changer.

fixes https://github.com/cockroachdb/cockroach/issues/121259
Release note: None