### PR TITLE
sql/schemachanger: add fallback for temp sequences

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -120,7 +120,7 @@ func getSchemaForCreateTable(
 	// schema for PostgreSQL.
 	if tableName.Schema() == catconstants.PublicSchemaName {
 		if _, ok := types.PublicSchemaAliases[tableName.Object()]; ok {
-			return nil, sqlerrors.NewTypeAlreadyExistsError(tableName.String())
+			return nil, sqlerrors.NewTypeAlreadyExistsError(tableName.Object())
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2463,3 +2463,43 @@ SELECT column_name from [SHOW COLUMNS FROM sq_119108]
 value
 
 subtest end
+
+subtest geo_types
+
+onlyif config local-legacy-schema-changer
+onlyif config local-mixed-23.1
+onlyif config local-mixed-23.2
+statement error type "geography" already exists
+CREATE SEQUENCE geography
+
+onlyif config local-legacy-schema-changer
+onlyif config local-mixed-23.1
+onlyif config local-legacy-schema-changer local-mixed-23.1 local-mixed-23.2
+statement error type "geometry" already exists
+CREATE SEQUENCE geometry
+
+onlyif config local-legacy-schema-changer local-mixed-23.1 local-mixed-23.2
+onlyif config local-mixed-23.1
+onlyif config local-legacy-schema-changer local-mixed-23.1 local-mixed-23.2
+statement error type "box2d" already exists
+CREATE SEQUENCE box2d
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error geography is a built-in type and cannot be modified
+CREATE SEQUENCE geography
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error geometry is a built-in type and cannot be modified
+CREATE SEQUENCE geometry
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error box2d is a built-in type and cannot be modified
+CREATE SEQUENCE box2d
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2503,3 +2503,21 @@ statement error box2d is a built-in type and cannot be modified
 CREATE SEQUENCE box2d
 
 subtest end
+
+subtest temp_sequence
+
+statement error temporary tables are only supported experimentally
+CREATE TEMP SEQUENCE temp_seq
+
+statement ok
+SET experimental_enable_temp_tables = true
+
+statement ok
+CREATE TEMP SEQUENCE temp_seq
+
+query TT
+SELECT substring(sequence_schema FOR 7), sequence_name FROM [SHOW SEQUENCES] WHERE sequence_name = 'temp_seq'
+----
+pg_temp  temp_seq
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1035,6 +1035,13 @@ func (b *builderState) resolveRelation(
 		if t.IsTemporary() {
 			panic(scerrors.NotImplementedErrorf(nil /* n */, "dropping a temporary table"))
 		}
+	} else if typ, isType := rel.(catalog.TypeDescriptor); isType {
+		if typ.GetKind() == descpb.TypeDescriptor_ALIAS && typ.GetID() == descpb.InvalidID {
+			// This case handles the types in types.PublicSchemaAliases -- BOX2D,
+			// GEOGRAPHY, and GEOMETRY.
+			panic(pgerror.Newf(pgcode.WrongObjectType,
+				"%s is a built-in type and cannot be modified", tree.ErrNameString(typ.GetName())))
+		}
 	}
 
 	// If we own the schema then we can manipulate the underlying relation,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt",
     visibility = ["//pkg/sql/schemachanger/scbuild:__subpackages__"],
     deps = [
+        "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/geo/geoindex",


### PR DESCRIPTION
The new schema changer doesn't yet support temporary objects, so we need
to fallback to the old one.

This PR is stacked on top of https://github.com/cockroachdb/cockroach/pull/121376. Only the last commit needs to be reviewed.
informs https://github.com/cockroachdb/cockroach/issues/121377
Release note: None