### PR TITLE
roachprod: add auth-mode arg to pgurl

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_fatih_color//:color",
         "@com_github_spf13_cobra//:cobra",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_term//:term",
         "@org_golang_x_text//language",
         "@org_golang_x_text//message",

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 	"golang.org/x/term"
 )
 
@@ -54,6 +55,7 @@ var (
 	tag                   string
 	external              = false
 	pgurlCertsDir         string
+	authMode              string
 	adminurlPath          = ""
 	adminurlIPs           = false
 	urlOpen               = false
@@ -86,6 +88,12 @@ var (
 	grafanaTags         []string
 	grafanaDashboardUID string
 	grafanaTimeRange    []int64
+
+	pgAuthModes = map[string]install.PGAuthMode{
+		"root":          install.AuthRootCert,
+		"user-password": install.AuthUserPassword,
+		"user-cert":     install.AuthUserCert,
+	}
 )
 
 func initFlags() {
@@ -173,7 +181,8 @@ func initFlags() {
 		"external", false, "return pgurls for external connections")
 	pgurlCmd.Flags().StringVar(&pgurlCertsDir,
 		"certs-dir", install.CockroachNodeCertsDir, "cert dir to use for secure connections")
-
+	pgurlCmd.Flags().StringVar(&authMode,
+		"auth-mode", "root", fmt.Sprintf("form of authentication to use, valid auth-modes: %v", maps.Keys(pgAuthModes)))
 	pprofCmd.Flags().DurationVar(&pprofOpts.Duration,
 		"duration", 30*time.Second, "Duration of profile to capture")
 	pprofCmd.Flags().BoolVar(&pprofOpts.Heap,


### PR DESCRIPTION
This change adds an --auth-mode arg to roachprod pgurl to specify the form authentication. Before, the only option was root user.

Fixes: none
Epic: none
Release note: none