### PR TITLE
importer,workload: reduce allocs

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/bitarray",
+        "//pkg/util/bufalloc",
         "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",

--- a/pkg/sql/importer/bench_test.go
+++ b/pkg/sql/importer/bench_test.go
@@ -116,6 +116,7 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 					kv := &kvBatch.KVs[i]
 					bytes += len(kv.Key) + len(kv.Value.RawBytes)
 				}
+				kvBatch.Close()
 			}
 			if err := g.Wait(); err != nil {
 				b.Fatal(err)

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -589,6 +589,7 @@ func ingestKvs(
 				_ = indexAdder.Flush(ctx)
 				pushProgress(ctx)
 			}
+			kvBatch.Close() // return slice to this converter's pool.
 		}
 		return nil
 	})

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -1401,7 +1401,7 @@ func (m *pgDumpReader) readFile(
 				kv := roachpb.KeyValue{Key: key}
 				kv.Value.SetInt(val)
 				m.kvCh <- row.KVBatch{
-					Source: inputIdx, KVs: []roachpb.KeyValue{kv}, Progress: input.ReadFraction(),
+					Source: inputIdx, KVSlice: &row.KVSlice{KVs: []roachpb.KeyValue{kv}}, Progress: input.ReadFraction(),
 				}
 			case "addgeometrycolumn":
 				// handled during schema extraction.

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/bufalloc",
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/sql/row/expr_walker.go
+++ b/pkg/sql/row/expr_walker.go
@@ -279,7 +279,7 @@ func importGenUUID(
 		c.randSource = makeImportRand(c)
 	}
 	gen := c.randSource.Int63(c)
-	id := uuid.MakeV4()
+	id := uuid.UUID{}
 	id.DeterministicV4(uint64(gen), uint64(1<<63))
 	return tree.NewDUuid(tree.DUuid{UUID: id}), nil
 }

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -87,6 +87,7 @@ type RowHelper struct {
 	maxRowSizeLog, maxRowSizeErr uint32
 	internal                     bool
 	metrics                      *rowinfra.Metrics
+	alloc                        rowenc.IndexEntryAlloc
 }
 
 func NewRowHelper(
@@ -199,7 +200,7 @@ func (rh *RowHelper) encodeSecondaryIndexes(
 	for i := range rh.Indexes {
 		index := rh.Indexes[i]
 		if !ignoreIndexes.Contains(int(index.GetID())) {
-			entries, err := rowenc.EncodeSecondaryIndex(ctx, rh.Codec, rh.TableDesc, index, colIDtoRowIndex, values, includeEmpty)
+			entries, err := rowenc.EncodeSecondaryIndexAlloc(ctx, rh.Codec, rh.TableDesc, index, colIDtoRowIndex, values, includeEmpty, &rh.alloc)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -35,6 +36,7 @@ type Inserter struct {
 	key      roachpb.Key
 	valueBuf []byte
 	value    roachpb.Value
+	alloc    bufalloc.ByteAllocator
 }
 
 // MakeInserter creates a Inserter for the given table.
@@ -162,7 +164,7 @@ func (ri *Inserter) InsertRow(
 		&ri.Helper, primaryIndexKey, ri.InsertCols,
 		values, ri.InsertColIDtoRowIndex,
 		ri.InsertColIDtoRowIndex,
-		&ri.key, &ri.value, ri.valueBuf, putFn, overwrite, traceKV)
+		&ri.key, &ri.value, ri.valueBuf, putFn, overwrite, traceKV, &ri.alloc)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -247,7 +247,13 @@ type DatumRowConverter struct {
 	FractionFn     func() float32
 	kvInserter     KVInserter
 
-	alloc tree.DatumAlloc
+	alloc      tree.DatumAlloc
+	allocPools struct {
+		strings []string
+		ints    []tree.DInt
+		dec     []tree.DDecimal
+		uuids   []tree.DUuid
+	}
 
 	db *kv.DB
 }
@@ -352,7 +358,16 @@ func NewDatumRowConverter(
 		c.KvBatch.KVs = append(c.KvBatch.KVs, kv)
 		c.KvBatch.MemSize += int64(cap(kv.Key) + cap(kv.Value.RawBytes))
 	}
+	// The ones below will reuse after each reset, but for types that don't get
+	// reused we want a large alloc size. We don't worry about lifetime/aliasing
+	// with a large alloc since we know they're all being fed straight to encoding
+	// and then freed at the same time.
 	c.alloc.AllocSize = 256
+	c.allocPools.strings = make([]string, 32)
+	c.allocPools.ints = make([]tree.DInt, 32)
+	c.allocPools.dec = make([]tree.DDecimal, 32)
+	c.allocPools.uuids = make([]tree.DUuid, 32)
+	c.resetAllocBufs()
 
 	var targetCols []catalog.Column
 	var err error
@@ -528,6 +543,9 @@ const rowIDBits = 64 - builtinconstants.UniqueIntNodeIDBits
 // Row inserts kv operations into the current kv batch, and triggers a SendBatch
 // if necessary.
 func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex int64) error {
+	// Our datums don't live past the encoding into a KV so we can reset the alloc
+	// pool with the same backing slice to reuse them rather than allocating new
+	// datums for every call.
 	getCellInfoAnnotation(c.EvalCtx.Annotations).reset(sourceID, rowIndex)
 	for i, col := range c.cols {
 		if col.HasDefault() {
@@ -600,7 +618,15 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 			return err
 		}
 	}
+	c.resetAllocBufs()
 	return nil
+}
+
+func (c *DatumRowConverter) resetAllocBufs() {
+	c.alloc.ResetStrings(c.allocPools.strings)
+	c.alloc.ResetInts(c.allocPools.ints)
+	c.alloc.ResetDecimals(c.allocPools.dec)
+	c.alloc.ResetUUIDs(c.allocPools.uuids)
 }
 
 // SendBatch streams kv operations from the current KvBatch to the destination

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/unique"
 	"github.com/cockroachdb/errors"
@@ -53,6 +54,7 @@ type Updater struct {
 	value           roachpb.Value
 	oldIndexEntries [][]rowenc.IndexEntry
 	newIndexEntries [][]rowenc.IndexEntry
+	alloc           bufalloc.ByteAllocator
 }
 
 type rowUpdaterType int
@@ -371,7 +373,7 @@ func (ru *Updater) UpdateRow(
 		&ru.Helper, primaryIndexKey, ru.FetchCols,
 		ru.newValues, ru.FetchColIDtoRowIndex,
 		ru.UpdateColIDtoRowIndex,
-		&ru.key, &ru.value, ru.valueBuf, insertPutFn, true /* overwrite */, traceKV)
+		&ru.key, &ru.value, ru.valueBuf, insertPutFn, true /* overwrite */, traceKV, &ru.alloc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/errors"
 )
 
@@ -100,6 +101,7 @@ func prepareInsertOrUpdateBatch(
 	rawValueBuf []byte,
 	putFn func(ctx context.Context, b Putter, key *roachpb.Key, value *roachpb.Value, traceKV bool),
 	overwrite, traceKV bool,
+	alloc *bufalloc.ByteAllocator,
 ) ([]byte, error) {
 	families := helper.TableDesc.GetFamilies()
 	for i := range families {
@@ -210,7 +212,7 @@ func prepareInsertOrUpdateBatch(
 			// Copy the contents of rawValueBuf into the roachpb.Value. This is
 			// a deep copy so rawValueBuf can be re-used by other calls to the
 			// function.
-			kvValue.SetTuple(rawValueBuf)
+			kvValue.SetTupleAlloc(rawValueBuf, alloc)
 			if err := helper.CheckRowSize(ctx, kvKey, kvValue.RawBytes, family.ID); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -105,7 +105,7 @@ func performCast(
 	if err != nil {
 		return nil, err
 	}
-	return tree.AdjustValueToType(t, d)
+	return tree.AdjustValueToType(t, d, nil)
 }
 
 var (

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -339,7 +339,7 @@ func (expr *NumVal) ResolveAsType(
 				return nil, err
 			}
 		}
-		return AdjustValueToType(typ, &expr.resInt64)
+		return AdjustValueToType(typ, &expr.resInt64, nil)
 	case types.FloatFamily:
 		if !expr.resAsFloat {
 			if strings.EqualFold(expr.origString, "NaN") {

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1064,6 +1064,10 @@ func AsDDecimal(e Expr) (*DDecimal, bool) {
 	return nil, false
 }
 
+func NewDDecimal(d DDecimal) *DDecimal {
+	return &d
+}
+
 // ParseDDecimal parses and returns the *DDecimal Datum value represented by the
 // provided string, or an error if parsing is unsuccessful.
 func ParseDDecimal(s string) (*DDecimal, error) {
@@ -6430,7 +6434,10 @@ func AdjustValueToType(typ *types.T, inVal Datum, alloc *DatumAlloc) (outVal Dat
 			if err != nil {
 				return nil, errors.Wrapf(err, "type %s", typ.SQLString())
 			}
-			return &outDec, nil
+			if alloc != nil {
+				return alloc.NewDDecimal(outDec), nil
+			}
+			return NewDDecimal(outDec), nil
 		}
 	case types.ArrayFamily:
 		if inArr, ok := inVal.(*DArray); ok {

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -6463,7 +6463,12 @@ func AdjustValueToType(typ *types.T, inVal Datum, alloc *DatumAlloc) (outVal Dat
 		}
 	case types.TimestampFamily:
 		if in, ok := inVal.(*DTimestamp); ok {
-			return in.Round(TimeFamilyPrecisionToRoundDuration(typ.Precision()))
+			p := TimeFamilyPrecisionToRoundDuration(typ.Precision())
+			// If we don't need to round, skip calling it an allocating a new Datum.
+			if in.Time.Round(p).Equal(in.Time) {
+				return in, nil
+			}
+			return in.Round(p)
 		}
 	case types.TimestampTZFamily:
 		if in, ok := inVal.(*DTimestampTZ); ok {

--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -491,3 +491,31 @@ func (a *DatumAlloc) NewDOid(v DOid) Datum {
 	*buf = (*buf)[1:]
 	return r
 }
+
+// ResetStrings can be used to reset the backing buffer of strings to the passed
+// buffer; this can be used -- with care -- to reuse a backing buffer when the
+// lifetimes of datums allocated from it are managed.
+func (s *DatumAlloc) ResetStrings(buf []string) {
+	s.stringAlloc = buf
+}
+
+// ResetInts can be used to reset the backing buffer of ints to the passed
+// buffer; this can be used -- with care -- to reuse a backing buffer when the
+// lifetimes of datums allocated from it are managed.
+func (s *DatumAlloc) ResetInts(buf []DInt) {
+	s.dintAlloc = buf
+}
+
+// ResetDecimals can be used to reset the backing buffer of decimals to the
+// passed buffer; this can be used -- with care -- to reuse a backing buffer
+// when the lifetimes of datums allocated from it are managed.
+func (s *DatumAlloc) ResetDecimals(buf []DDecimal) {
+	s.ddecimalAlloc = buf
+}
+
+// ResetUUIDs can be used to reset the backing buffer of uuids to the passed
+// buffer; this can be used -- with care -- to reuse a backing buffer when the
+// lifetimes of datums allocated from it are managed.
+func (s *DatumAlloc) ResetUUIDs(buf []DUuid) {
+	s.duuidAlloc = buf
+}

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -120,7 +120,7 @@ func ParseAndRequireString(
 	if err != nil {
 		return d, dependsOnContext, err
 	}
-	d, err = AdjustValueToType(t, d)
+	d, err = AdjustValueToType(t, d, nil)
 	return d, dependsOnContext, err
 }
 


### PR DESCRIPTION
See commits.
```
benchstat before.txt after.txt
goos: darwin
goarch: arm64
                       │ before.txt │             after.txt             │
                       │   sec/op   │   sec/op     vs base              │
ConvertToKVs_TPCC01-10   2.025 ± 1%   1.988 ± 17%       ~ (p=0.065 n=6)
ConvertToKVs_TPCC10-10   18.72 ± 3%   18.22 ±  3%  -2.63% (p=0.002 n=6)
geomean                  6.156        6.019        -2.23%

                       │  before.txt  │              after.txt              │
                       │     B/s      │      B/s       vs base              │
ConvertToKVs_TPCC01-10   66.53Mi ± 1%   67.77Mi ± 14%       ~ (p=0.065 n=6)
ConvertToKVs_TPCC10-10   66.21Mi ± 3%   68.00Mi ±  3%  +2.70% (p=0.002 n=6)
geomean                  66.37Mi        67.88Mi        +2.28%

                       │   before.txt   │              after.txt               │
                       │      B/op      │     B/op       vs base               │
ConvertToKVs_TPCC01-10   1277.9Mi ± 18%   950.9Mi ± 24%  -25.59% (p=0.002 n=6)
ConvertToKVs_TPCC10-10   12.366Gi ±  4%   8.967Gi ±  4%  -27.49% (p=0.002 n=6)
geomean                   3.928Gi         2.886Gi        -26.54%

                       │ before.txt  │             after.txt              │
                       │  allocs/op  │  allocs/op   vs base               │
ConvertToKVs_TPCC01-10   22.65M ± 7%   18.22M ± 8%  -19.53% (p=0.002 n=6)
ConvertToKVs_TPCC10-10   212.5M ± 2%   172.8M ± 2%  -18.69% (p=0.002 n=6)
geomean                  69.37M        56.11M       -19.11%
```