### PR TITLE
workload: avoid some string format/parse roundtrips

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -242,6 +242,13 @@ func hashTableInitialData(
 				for i := 0; i < b.Length(); i++ {
 					_, _ = h.Write(colBytes.Get(i))
 				}
+			case types.TimestampFamily, types.TimestampTZFamily:
+				colTime := col.Timestamp()
+
+				for i := 0; i < b.Length(); i++ {
+					binary.LittleEndian.PutUint64(scratch[:8], uint64(colTime[i].UnixNano()))
+					_, _ = h.Write(scratch[:8])
+				}
 			default:
 				return errors.Errorf(`unhandled type %s`, col.Type())
 			}

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 )
@@ -120,6 +121,10 @@ func makeDatumFromColOffset(
 			data := col.Bytes().Get(rowIdx)
 			str := *(*string)(unsafe.Pointer(&data))
 			return alloc.NewDString(tree.DString(str)), nil
+		case types.UuidFamily:
+			u, err := uuid.FromBytes(col.Bytes().Get(rowIdx))
+			return alloc.NewDUuid(tree.DUuid{UUID: u}), err
+
 		default:
 			data := col.Bytes().Get(rowIdx)
 			str := *(*string)(unsafe.Pointer(&data))

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -125,6 +125,18 @@ func makeDatumFromColOffset(
 			str := *(*string)(unsafe.Pointer(&data))
 			return rowenc.ParseDatumStringAs(ctx, hint, str, evalCtx, semaCtx)
 		}
+	case types.TimestampFamily, types.TimestampTZFamily:
+		switch hint.Family() {
+		case types.TimestampFamily:
+			// workloads are responsible for rounding their timestamp(s) so skip
+			// MakeDTimestamp here and just directly construct it.
+			return alloc.NewDTimestamp(tree.DTimestamp{Time: col.Timestamp()[rowIdx]}), nil
+
+		case types.TimestampTZFamily:
+			// workloads are responsible for rounding their timestamp(s) so skip
+			// MakeDTimestamp here and just directly construct it.
+			return alloc.NewDTimestampTZ(tree.DTimestampTZ{Time: col.Timestamp()[rowIdx]}), nil
+		}
 	}
 	return nil, errors.Errorf(
 		`don't know how to interpret %s column as %s`, col.Type(), hint)

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -432,8 +432,8 @@ func (w *tpcc) tpccHistoryInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufal
 	historyRowCount := numHistoryPerWarehouse * w.warehouses
 	l.uuidAlloc.DeterministicV4(uint64(rowIdx), uint64(historyRowCount))
 	var rowID []byte
-	*a, rowID = a.Alloc(36, 0 /* extraCap */)
-	l.uuidAlloc.StringBytes(rowID)
+	*a, rowID = a.Alloc(uuid.Size, 0 /* extraCap */)
+	copy(rowID, l.uuidAlloc[:])
 
 	cID := (rowIdx % numCustomersPerDistrict) + 1
 	dID := ((rowIdx / numCustomersPerDistrict) % numDistrictsPerWarehouse) + 1

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -306,7 +306,7 @@ var customerTypes = []*types.T{
 	types.Bytes,
 	types.Bytes,
 	types.Bytes,
-	types.Bytes,
+	types.Timestamp,
 	types.Bytes,
 	types.Float,
 	types.Float,
@@ -360,7 +360,7 @@ func (w *tpcc) tpccCustomerInitialRowBatch(
 	cb.ColVec(9).Bytes().Set(0, randStateInitialDataOnly(&l.rng, &lo, a))
 	cb.ColVec(10).Bytes().Set(0, randZipInitialDataOnly(&l.rng, &no, a))
 	cb.ColVec(11).Bytes().Set(0, randNStringInitialDataOnly(&l.rng, &no, a, 16, 16)) // phone number
-	cb.ColVec(12).Bytes().Set(0, w.nowString)
+	cb.ColVec(12).Timestamp()[0] = w.nowTime
 	cb.ColVec(13).Bytes().Set(0, credit)
 	cb.ColVec(14).Float64()[0] = creditLimit
 	cb.ColVec(15).Float64()[0] = float64(randInt(l.rng.Rand, 0, 5000)) / float64(10000.0) // discount
@@ -412,7 +412,7 @@ var historyTypes = []*types.T{
 	types.Int,
 	types.Int,
 	types.Int,
-	types.Bytes,
+	types.Timestamp,
 	types.Float,
 	types.Bytes,
 }
@@ -446,7 +446,7 @@ func (w *tpcc) tpccHistoryInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufal
 	cb.ColVec(3).Int64()[0] = int64(wID)
 	cb.ColVec(4).Int64()[0] = int64(dID)
 	cb.ColVec(5).Int64()[0] = int64(wID)
-	cb.ColVec(6).Bytes().Set(0, w.nowString)
+	cb.ColVec(6).Timestamp()[0] = w.nowTime
 	cb.ColVec(7).Float64()[0] = 10.00
 	cb.ColVec(8).Bytes().Set(0, randAStringInitialDataOnly(&l.rng, &ao, a, 12, 24))
 }
@@ -473,7 +473,7 @@ var orderTypes = []*types.T{
 	types.Int,
 	types.Int,
 	types.Int,
-	types.Bytes,
+	types.Timestamp,
 	types.Int,
 	types.Int,
 	types.Int,
@@ -525,7 +525,7 @@ func (w *tpcc) tpccOrderInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufallo
 	cb.ColVec(1).Int64()[0] = int64(dID)
 	cb.ColVec(2).Int64()[0] = int64(wID)
 	cb.ColVec(3).Int64()[0] = int64(cID)
-	cb.ColVec(4).Bytes().Set(0, w.nowString)
+	cb.ColVec(4).Timestamp()[0] = w.nowTime
 	cb.ColVec(5).Nulls().UnsetNulls()
 	if carrierSet {
 		cb.ColVec(5).Int64()[0] = carrierID
@@ -592,7 +592,7 @@ var orderLineTypes = []*types.T{
 	types.Int,
 	types.Int,
 	types.Int,
-	types.Bytes,
+	types.Timestamp,
 	types.Int,
 	types.Float,
 	types.Bytes,
@@ -624,23 +624,20 @@ func (w *tpcc) tpccOrderLineInitialRowBatch(
 	olSupplyWIDCol := cb.ColVec(5).Int64()
 	olDeliveryD := cb.ColVec(6)
 	olDeliveryD.Nulls().UnsetNulls()
-	olDeliveryDCol := olDeliveryD.Bytes()
+	olDeliveryDCol := olDeliveryD.Timestamp()
 	olQuantityCol := cb.ColVec(7).Int64()
 	olAmountCol := cb.ColVec(8).Float64()
 	olDistInfoCol := cb.ColVec(9).Bytes()
 
-	olDeliveryDCol.Reset()
 	olDistInfoCol.Reset()
 	for rowIdx := 0; rowIdx < numOrderLines; rowIdx++ {
 		olNumber := rowIdx + 1
 
 		var amount float64
 		var deliveryDSet bool
-		var deliveryD []byte
 		if oID < 2101 {
 			amount = 0
 			deliveryDSet = true
-			deliveryD = w.nowString
 		} else {
 			amount = float64(randInt(l.rng.Rand, 1, 999999)) / 100.0
 		}
@@ -652,10 +649,9 @@ func (w *tpcc) tpccOrderLineInitialRowBatch(
 		olIIDCol[rowIdx] = randInt(l.rng.Rand, 1, 100000)
 		olSupplyWIDCol[rowIdx] = int64(wID)
 		if deliveryDSet {
-			olDeliveryDCol.Set(rowIdx, deliveryD)
+			olDeliveryDCol.Set(rowIdx, w.nowTime)
 		} else {
 			olDeliveryD.Nulls().SetNull(rowIdx)
-			olDeliveryDCol.Set(rowIdx, nil)
 		}
 		olQuantityCol[rowIdx] = 5
 		olAmountCol[rowIdx] = amount

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -41,7 +41,7 @@ type tpcc struct {
 
 	warehouses       int
 	activeWarehouses int
-	nowString        []byte
+	nowTime          time.Time
 	numConns         int
 	idleConns        int
 	isoLevel         string
@@ -224,7 +224,11 @@ var tpccMeta = workload.Meta{
 
 		// Hardcode this since it doesn't seem like anyone will want to change
 		// it and it's really noisy in the generated fixture paths.
-		g.nowString = []byte(`2006-01-02 15:04:05`)
+		var err error
+		g.nowTime, err = time.Parse(`2006-01-02 15:04:05`, `2006-01-02 15:04:05`)
+		if err != nil {
+			panic(err) // unreachable.
+		}
 		return g
 	},
 }


### PR DESCRIPTION
Previously we were formatting UUIDs and Timestamps into strings, and allocating those strings, to put them into the column vector only for import's workload reader to parse the strings back into native types as it read the vector, accounting for 5% or more of total CPU usage when IMPORT'ing from workload-generated TPCC data. Keeping these two types in native representations through the vector avoids this.