### PR TITLE
cacheutil: make sql cache map generic

### DIFF
--- a/pkg/sql/cacheutil/cache_test.go
+++ b/pkg/sql/cacheutil/cache_test.go
@@ -13,6 +13,7 @@ package cacheutil
 import (
 	"context"
 	"math"
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -34,7 +35,7 @@ func TestCache(t *testing.T) {
 	m := mon.NewStandaloneBudget(math.MaxInt64)
 	memoryMonitor.Start(ctx, nil, m)
 
-	cache := NewCache(memoryMonitor.MakeBoundAccount(), stopper, 2 /* numSystemTables */)
+	cache := NewCache[string, string](memoryMonitor.MakeBoundAccount(), stopper, 2 /* numSystemTables */)
 
 	isEligible := cache.ClearCacheIfStaleLocked(ctx, []descpb.DescriptorVersion{1, 0})
 	require.Equal(t, isEligible, false)
@@ -51,15 +52,21 @@ func TestCache(t *testing.T) {
 	// LoadValueOutsideOfCacheSingleFlight due to singleflight.
 	// Testing that only one call happens is hard to synchronize, we would
 	// have to add a test hook into `DoChan` to make synchronize our calls.
+	var wg sync.WaitGroup
 	for i := 0; i < 5; i++ {
+		wg.Add(1)
+
 		go func() {
+			defer wg.Done()
 			val, err := cache.LoadValueOutsideOfCacheSingleFlight(ctx, "test", func(loadCtx context.Context) (interface{}, error) {
-				return "val", nil
+				v := "val"
+				return &v, nil
 			})
 			require.NoError(t, err)
-			require.Equal(t, val, "val")
+			require.Equal(t, *val, "val")
 		}()
 	}
+	wg.Wait()
 
 	wrote := cache.MaybeWriteBackToCache(ctx, []descpb.DescriptorVersion{2, 2}, "test", "val", int64(len("test")+len("val")))
 	require.Equal(t, wrote, true)


### PR DESCRIPTION
Convert sql cache map to use generic.

Epic: None
Release note: None