### PR TITLE
sql/randgen: avoid violating unique constraints

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -195,7 +195,7 @@ func makeConstDatum(s *Smither, typ *types.T) tree.Datum {
 	if s.unlikelyRandomNulls {
 		nullChance = 20 // A one out of 20 chance of generating a NULL.
 	}
-	datum = randgen.RandDatumWithNullChance(s.rnd, typ, nullChance, s.favorCommonData, false /* targetColumnIsUnique */)
+	datum = randgen.RandDatumWithNullChance(s.rnd, typ, nullChance, s.favorCommonData)
 	if f := datum.ResolvedType().Family(); f != types.UnknownFamily && s.simpleDatums {
 		datum = randgen.RandDatumSimple(s.rnd, typ)
 	}

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -45,8 +45,7 @@ import (
 // regardless of the null flag.
 func RandDatum(rng *rand.Rand, typ *types.T, nullOk bool) tree.Datum {
 	nullChance := NullChance(nullOk)
-	return RandDatumWithNullChance(rng, typ, nullChance,
-		false /* favorCommonData */, false /* targetColumnIsUnique */)
+	return RandDatumWithNullChance(rng, typ, nullChance, false /* favorCommonData */, false /* targetColumnIsUnique */)
 }
 
 // NullChance returns `n` representing a 1 out of `n` probability of generating
@@ -266,11 +265,10 @@ func RandDatumWithNullChance(
 		return tree.DNull
 	case types.ArrayFamily:
 		return RandArrayWithCommonDataChance(rng, typ, 0, /* nullChance */
-			favorCommonData, targetColumnIsUnique)
+			favorCommonData)
 	case types.AnyFamily:
 		return RandDatumWithNullChance(rng, RandType(rng), nullChance,
-			favorCommonData, targetColumnIsUnique,
-		)
+			favorCommonData, targetColumnIsUnique)
 	case types.EnumFamily:
 		// If the input type is not hydrated with metadata, or doesn't contain
 		// any enum values, then return NULL.
@@ -302,7 +300,7 @@ func RandDatumWithNullChance(
 // of being null.
 func RandArray(rng *rand.Rand, typ *types.T, nullChance int) tree.Datum {
 	return RandArrayWithCommonDataChance(rng, typ, nullChance,
-		false /* favorCommonData */, false /* targetColumnIsUnique */)
+		false /* favorCommonData */)
 }
 
 // RandArrayWithCommonDataChance generates a random DArray where the contents

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -284,7 +284,7 @@ var opWeights = []int{
 	createIndex:                       1,
 	createSchema:                      1,
 	createSequence:                    1,
-	createTable:                       1,
+	createTable:                       300,
 	createTableAs:                     1,
 	createTypeEnum:                    1,
 	createView:                        1,


### PR DESCRIPTION
This patch prevents the ability to generate expressions that can violate unqiue constraints. For example, a unique index expression of (col + 'NaN'::DECIMAL) easily violates the constraint set on it after two inserts.

Epic: none
Fixes:

Release note: None