### PR TITLE
roachtest: fix run-operation for case where 1 spec matches

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -192,7 +192,7 @@ is chosen at random and run. The provided cluster name must already exist in roa
 this command does no setup/teardown of clusters.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("\nRunning operation %s.\n\n", args[0])
+			fmt.Printf("\nRunning operation %s on %s.\n\n", args[1], args[0])
 			cmd.SilenceUsage = true
 			return runOperation(operations.RegisterOperations, args[1], args[0])
 		},

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -476,6 +476,10 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 	if len(specs) > 1 {
 		opSpec = &specs[rand.Intn(len(specs))]
 		l.Printf("more than one operation found for filter %s, randomly selected %s to run", filter, opSpec.Name)
+	} else if len(specs) == 1 {
+		opSpec = &specs[0]
+	} else {
+		return errors.Errorf("no operations found for filter %s", filter)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Previously, we were panicking in this case because we did not handle cases where the passed-in filter only matches one operation.

Epic: none

Release note: None