### PR TITLE
backupccl: fix more places where tests rely on stable IDs

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_procedures
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_procedures
@@ -379,9 +379,10 @@ WITH to_json AS (
       system.descriptor
     WHERE id = $defaultdb_sc1_id
 )
-SELECT d->'schema'->>'functions'::string FROM to_json;
+-- Remove ID from the result, since it isn't stable.
+SELECT json_set(d, '{schema,functions,p,signatures,0,id}', '0')->'schema'->>'functions'::string FROM to_json;
 ----
-{"p": {"signatures": [{"id": 111, "isProcedure": true, "returnType": {"family": "VoidFamily", "oid": 2278}}]}}
+{"p": {"signatures": [{"id": 0, "isProcedure": true, "returnType": {"family": "VoidFamily", "oid": 2278}}]}}
 
 exec-sql
 BACKUP TABLE sc1.t INTO 'nodelocal://1/test/'

--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
@@ -405,9 +405,10 @@ WITH to_json AS (
       system.descriptor
     WHERE id = $defaultdb_sc1_db
 )
-SELECT d->'schema'->>'functions'::string FROM to_json;
+-- Remove ID from the result, since it isn't stable.
+SELECT json_set(d, '{schema,functions,f,signatures,0,id}', '0')->'schema'->>'functions'::string FROM to_json;
 ----
-{"f": {"signatures": [{"id": 111, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
+{"f": {"signatures": [{"id": 0, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
 
 exec-sql
 BACKUP TABLE sc1.t INTO 'nodelocal://1/test/'

--- a/pkg/ccl/backupccl/testdata/backup-restore/procedures
+++ b/pkg/ccl/backupccl/testdata/backup-restore/procedures
@@ -351,9 +351,10 @@ WITH to_json AS (
       system.descriptor
     WHERE id = $defaultdb_sc1_db
 )
-SELECT d->'schema'->>'functions'::string FROM to_json;
+-- Remove ID from the result, since it isn't stable.
+SELECT json_set(d, '{schema,functions,p,signatures,0,id}', '0')->'schema'->>'functions'::string FROM to_json;
 ----
-{"p": {"signatures": [{"id": 111, "isProcedure": true, "returnType": {"family": "VoidFamily", "oid": 2278}}]}}
+{"p": {"signatures": [{"id": 0, "isProcedure": true, "returnType": {"family": "VoidFamily", "oid": 2278}}]}}
 
 exec-sql
 BACKUP TABLE sc1.t INTO 'nodelocal://1/test/'

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -347,9 +347,10 @@ WITH to_json AS (
       system.descriptor
     WHERE id = $defaultdb_sc1_db
 )
-SELECT d->'schema'->>'functions'::string FROM to_json;
+-- Remove ID from the result, since it isn't stable.
+SELECT json_set(d, '{schema,functions,f,signatures,0,id}', '0')->'schema'->>'functions'::string FROM to_json;
 ----
-{"f": {"signatures": [{"id": 111, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
+{"f": {"signatures": [{"id": 0, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
 
 exec-sql
 BACKUP TABLE sc1.t INTO 'nodelocal://1/test/'

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-checks
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-checks
@@ -168,10 +168,10 @@ db1 <nil> sc1 schema false
 db1 sc1 f1 function false
 db1 sc1 t1 table false
 
-exec-sql
+exec-sql expect-error-regex=(cannot restore table "t1" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2';
 ----
-pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
+regex matches error
 
 exec-sql
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2', skip_missing_udfs;
@@ -209,10 +209,10 @@ SELECT database_name, parent_schema_name, object_name, object_type, is_full_clus
 db1 <nil> sc1 schema false
 db1 sc1 t1 table false
 
-exec-sql
+exec-sql expect-error-regex=(cannot restore table "t1" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3';
 ----
-pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
+regex matches error
 
 exec-sql
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3', skip_missing_udfs;

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-defaults
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-defaults
@@ -170,10 +170,10 @@ db1 <nil> sc1 schema false
 db1 sc1 f1 function false
 db1 sc1 t1 table false
 
-exec-sql
+exec-sql expect-error-regex=(cannot restore table "t1" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2';
 ----
-pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
+regex matches error
 
 exec-sql
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2', skip_missing_udfs;
@@ -211,10 +211,10 @@ SELECT database_name, parent_schema_name, object_name, object_type, is_full_clus
 db1 <nil> sc1 schema false
 db1 sc1 t1 table false
 
-exec-sql
+exec-sql expect-error-regex=(cannot restore table "t1" without referenced function [0-9]+ \(or "skip_missing_udfs" option\))
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3';
 ----
-pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
+regex matches error
 
 exec-sql
 RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3', skip_missing_udfs;


### PR DESCRIPTION
These tests started to become flaky since they assert exact values for descriptor IDs. These IDs are not deterministic across test runs, so this patch fixes places where the assertion is made.

Release justification: test only change
fixes https://github.com/cockroachdb/cockroach/issues/121423
Release note: None