### PR TITLE
stress: reduce default `--runs_per_test` to 25

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -23,7 +23,7 @@ fi
 
 status=0
 bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
-      --runs_per_test ${RUNS_PER_TEST=30} --verbose_failures --build_event_binary_file=artifacts/eventstream \
+      --runs_per_test ${RUNS_PER_TEST=25} --verbose_failures --build_event_binary_file=artifacts/eventstream \
       --profile=artifacts/profile.json.gz \
       ${EXTRA_TEST_ARGS:+$EXTRA_TEST_ARGS} \
       $BES_KEYWORDS_ARGS \


### PR DESCRIPTION
The nightlies are taking longer to run since the branch cut, so this should speed things up slightly.

Epic: CRDB-8308
Release note: None