### PR TITLE
sql: explicitly pass context to misc forEach* functions

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -721,7 +721,7 @@ func resolveMemberOfWithAdminOption(
 			isAdmin bool
 		}
 		memberToRoles := make(map[username.SQLUsername][]membership)
-		if err := forEachRoleMembership(ctx, txn, func(role, member username.SQLUsername, isAdmin bool) error {
+		if err := forEachRoleMembership(ctx, txn, func(ctx context.Context, role, member username.SQLUsername, isAdmin bool) error {
 			memberToRoles[member] = append(memberToRoles[member], membership{role, isAdmin})
 			return nil
 		}); err != nil {

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -125,7 +125,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 
 	// First check all the databases.
 	if err := forEachDatabaseDesc(params.ctx, params.p, nil /*nil prefix = all databases*/, true, /* requiresPrivileges */
-		func(db catalog.DatabaseDescriptor) error {
+		func(ctx context.Context, db catalog.DatabaseDescriptor) error {
 			if _, ok := userNames[db.GetPrivileges().Owner()]; ok {
 				userNames[db.GetPrivileges().Owner()] = append(
 					userNames[db.GetPrivileges().Owner()],

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -46,7 +46,7 @@ func postgisColumnsTablePopulator(
 			p,
 			dbContext,
 			hideVirtual,
-			func(db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor) error {
+			func(ctx context.Context, db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor) error {
 				if !table.IsPhysicalTable() {
 					return nil
 				}


### PR DESCRIPTION
This commit attempts to prevent future bugs (and maybe fixes one or two existing ones) where the context is captured by the anonymous function that is itself captured by `forEach*` function. The problem is that the context passed to `populate` and `generate` function of the virtual tables could be different from the one that is later used when next'ing the generator. By passing the context explicitly it should be less likely that the incorrect context object is used in the anonymous functions.

Informs: #120815.
Epic: None

Release note: None