### PR TITLE
backupccl: skip `TestRestorePauseOnError`

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9166,6 +9166,8 @@ func TestRestorePauseOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
+	skip.WithIssue(t, 121342)
+
 	defer jobs.TestingSetProgressThresholds()()
 
 	baseDir := "testdata"


### PR DESCRIPTION
Flaky. See #121342

Epic: None
Release note: None