### PR TITLE
 regionliveness: probe on replica errors for liveness on rbr system tables

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -272,24 +272,7 @@ COMMIT;`}
 		// Wait for the span configs to propagate. After we know they have
 		// propagated, we'll shut down the tenant and wait for them to get
 		// applied.
-		tdb.Exec(t, "CREATE TABLE after AS SELECT now() AS after")
-		tdb.CheckQueryResultsRetry(t, `
-  WITH progress AS (
-                    SELECT crdb_internal.pb_to_json(
-                            'progress',
-                            progress
-                           )->'AutoSpanConfigReconciliation' AS p
-                      FROM crdb_internal.system_jobs
-                     WHERE status = 'running'
-                ),
-       checkpoint AS (
-                    SELECT (p->'checkpoint'->>'wallTime')::FLOAT8 / 1e9 AS checkpoint
-                      FROM progress
-                     WHERE p IS NOT NULL
-                  )
-SELECT checkpoint > extract(epoch from after)
-  FROM checkpoint, after`,
-			[][]string{{"true"}})
+		sqlutils.WaitForSpanConfigReconciliation(t, tdb)
 		tenant.AppStopper().Stop(ctx)
 	}
 

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -16,13 +16,16 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -88,7 +91,9 @@ func runAcceptanceMultitenantMultiRegion(ctx context.Context, t test.Test, c clu
 	{
 		// Intentionally, alter settings so that the system database span config
 		// changes propagate faster, when we convert the system database to MR.
-		_, err := c.Conn(ctx, t.L(), 1).Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
+		conn := c.Conn(ctx, t.L(), 1)
+		defer conn.Close()
+		_, err := conn.Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
 		require.NoError(t, err)
 		configStmts := []string{
 			`SET CLUSTER SETTING sql.virtual_cluster.feature_access.multiregion.enabled='true'`,
@@ -99,9 +104,10 @@ func runAcceptanceMultitenantMultiRegion(ctx context.Context, t test.Test, c clu
 			"SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50 ms'",
 			`SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '1500ms'`,
 			`ALTER TENANT ALL SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '500ms'`,
+			`SET CLUSTER setting kv.replication_reports.interval = '5s';`,
 		}
 		for _, stmt := range configStmts {
-			_, err := c.Conn(ctx, t.L(), 1).Exec(stmt)
+			_, err := conn.Exec(stmt)
 			require.NoError(t, err)
 		}
 	}
@@ -150,6 +156,61 @@ func runAcceptanceMultitenantMultiRegion(ctx context.Context, t test.Test, c clu
 		mkStmt(`INSERT INTO foo VALUES($1, $2)`, 1, "bar"),
 		mkStmt(`SELECT * FROM foo LIMIT 1`).
 			withResults([][]string{{"1", "bar"}}))
+
+	// Wait for the span configs to propagate. After we know they have
+	// propagated, we'll shut down the tenant and wait for them to get
+	// applied.
+	tdb, tdbCloser := openDBAndMakeSQLRunner(t, tenants[0].pgURL)
+	defer tdbCloser()
+	t.Status("Waiting for span config reconciliation...")
+	sqlutils.WaitForSpanConfigReconciliation(t, tdb)
+	t.Status("Span config reconciliation complete")
+	t.Status("Waiting for replication changes...")
+	conn := c.Conn(ctx, t.L(), 1)
+	defer conn.Close()
+	//systemConn := sqlutils.MakeSQLRunner(conn)
+	checkStartTime := timeutil.Now()
+	count := 0
+	for timeutil.Since(checkStartTime) < time.Minute*5 {
+		res := tdb.QueryStr(t, `
+SELECT
+	locality_count
+FROM
+	(
+		SELECT
+			count(*) AS locality_count
+		FROM
+			(
+				SELECT
+					DISTINCT
+					range_id,
+					start_key,
+					split_part(
+						unnest(replica_localities),
+						',',
+						2
+					)
+				FROM
+					[SHOW RANGES FROM DATABASE system]
+				WHERE
+					(
+						start_key NOT LIKE '%Table/11/%'
+						AND start_key NOT LIKE '%Table/39/%'
+						AND start_key NOT LIKE '%Table/46/%'
+					)
+			)
+		GROUP BY
+			range_id
+	)
+WHERE
+	locality_count < 2;`)
+		if len(res) == 0 {
+			break
+		}
+		count += 1
+		time.Sleep(time.Second * 5)
+	}
+	t.Status("Replication changes complete")
 
 	// Stop all the tenants gracefully first.
 	for _, tenant := range tenants {

--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -342,6 +342,8 @@ func (l *livenessProber) GetProbeTimeout() (bool, time.Duration) {
 func IsQueryTimeoutErr(err error) bool {
 	return pgerror.GetPGCode(err) == pgcode.QueryCanceled ||
 		errors.HasType(err, (*timeutil.TimeoutError)(nil)) ||
+		errors.HasType(err, (*kvpb.ReplicaUnavailableError)(nil)) ||
+		pgerror.GetPGCode(err) == pgcode.RangeUnavailable ||
 		errors.Is(err, context.DeadlineExceeded)
 }
 

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "sql_runner.go",
         "table_gen.go",
         "table_id.go",
+        "util_mutiltregion.go",
         "zone.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/sqlutils",

--- a/pkg/testutils/sqlutils/util_mutiltregion.go
+++ b/pkg/testutils/sqlutils/util_mutiltregion.go
@@ -1,0 +1,34 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sqlutils
+
+// WaitForSpanConfigReconciliation waits for span config reconciliation to ensure
+// that MR changes are propagated.
+func WaitForSpanConfigReconciliation(t Fataler, tdb *SQLRunner) {
+	tdb.Exec(t, "CREATE TABLE after AS SELECT now() AS after")
+	tdb.CheckQueryResultsRetry(t, `
+  WITH progress AS (
+                    SELECT crdb_internal.pb_to_json(
+                            'progress',
+                            progress
+                           )->'AutoSpanConfigReconciliation' AS p
+                      FROM crdb_internal.system_jobs
+                     WHERE status = 'running'
+                ),
+       checkpoint AS (
+                    SELECT (p->'checkpoint'->>'wallTime')::FLOAT8 / 1e9 AS checkpoint
+                      FROM progress
+                     WHERE p IS NOT NULL
+                  )
+SELECT checkpoint > extract(epoch from after)
+  FROM checkpoint, after`,
+		[][]string{{"true"}})
+}


### PR DESCRIPTION
Previously, we probed for region liveness issues only after encountering
a timeout error when accessing regional-by-row tables. This approach
missed retriable replica errors (such as slow proposals), which also
indicate potential availability problems. This patch now treats
retriable replica errors as a trigger for region liveness probes,
improving the speed of issue detection. Additionally, we'll update the
multi-region multi-tenant test to ensure the timely propagation of span
configuration changes.

Fixes: #121327
Fixes: https://github.com/cockroachdb/cockroach/issues/119236

Release note: None