### PR TITLE
workload/schemachanger: Stabilize UDFs calling UDFs within the workload

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -278,11 +278,13 @@ DROP FUNCTION f_called_by_b;
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
-statement ok
-CREATE TABLE t1_with_b_2_ref(j int default f_called_by_b() CHECK (f_called_by_b() > 0));
-CREATE SCHEMA altSchema;
 
 statement ok
+CREATE SCHEMA altSchema;
+CREATE FUNCTION altSchema.f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE TABLE t1_with_b_2_ref(j int default altSchema.f_called_by_b() CHECK (altSchema.f_called_by_b() > 0));
+
+statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions \(\[test.public.f_called_by_b2\]\) still depend on it
 ALTER FUNCTION f_called_by_b SET SCHEMA altSchema;
 
 skipif config local-legacy-schema-changer
@@ -290,11 +292,10 @@ statement ok
 DROP SCHEMA altSchema CASCADE;
 
 onlyif config local-legacy-schema-changer
-statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other object \(\[test.public.f_called_by_b2, test.public.t1_with_b_2_ref\]\) still depend on it
+statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other object \(\[test.public.t1_with_b_2_ref\]\) still depend on it
 DROP SCHEMA altSchema CASCADE;
 
-skipif config local-legacy-schema-changer
-statement error pgcode 42883 unknown function: f_called_by_b2()
+statement ok
 SELECT * FROM  f_called_by_b2();
 
 skipif config local-legacy-schema-changer

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -61,6 +61,14 @@ statement error pgcode 0A000 cannot rename function \"lower_hello\" because othe
 ALTER FUNCTION lower_hello rename to lower_hello_new
 
 statement ok
+CREATE SCHEMA sc2;
+
+# Validate that function schema changes are blocked.
+statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+ALTER FUNCTION lower_hello SET SCHEMA sc2;
+
+
+statement ok
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
   SELECT 1;
 $$

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1310,7 +1310,7 @@ func (og *operationGenerator) schemaContainsHasReferredFunctions(
 		{"pg_depends_from_diff_schema", `
 			SELECT refobjid FROM pg_depend as d, functions as src_function, functions as dst_function
 			WHERE src_function.schema_id <>  $1::REGNAMESPACE::INT8 AND dst_function.schema_id=$1::REGNAMESPACE::INT8 AND
-			d.refobjid=(src_function.id+100000) AND d.objid=(dst_function.id) AND
+			d.objid=(src_function.id+100000) AND d.refobjid=(dst_function.id+100000) AND
 			d.classid = 'pg_catalog.pg_proc'::REGCLASS::INT8 AND d.refclassid = 'pg_catalog.pg_proc'::REGCLASS::INT8`},
 	}
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4270,7 +4270,10 @@ func (og *operationGenerator) alterFunctionSetSchema(
 		{"descriptors", descJSONQuery},
 		{"functions", functionDescsQuery},
 	}, `SELECT
-			quote_ident(schema_id::REGNAMESPACE::TEXT) || '.' || quote_ident(name) || '(' || array_to_string(funcargs, ', ') || ')'
+				quote_ident(schema_id::REGNAMESPACE::TEXT) AS schema,
+				quote_ident(name) AS name,
+				quote_ident(schema_id::REGNAMESPACE::TEXT) || '.' || quote_ident(name) || '(' || array_to_string(funcargs, ', ') || ')' AS qualified_name,
+				(id + 100000) as func_oid
 			FROM functions
 			JOIN LATERAL (
 				SELECT
@@ -4280,16 +4283,40 @@ func (og *operationGenerator) alterFunctionSetSchema(
 					SELECT unnest(proargtypes) AS oid FROM pg_catalog.pg_proc WHERE oid = (id + 100000)
 				) args ON args.oid = pg_type.oid
 			) funcargs ON TRUE
-			`,
-	)
+	`)
 
 	schemasQuery := With([]CTE{
 		{"descriptors", descJSONQuery},
 	}, `SELECT quote_ident(name) FROM descriptors WHERE descriptor ? 'schema'`)
 
-	functions, err := Collect(ctx, og, tx, pgx.RowTo[string], functionsQuery)
+	functions, err := Collect(ctx, og, tx, pgx.RowToMap, functionsQuery)
 	if err != nil {
 		return nil, err
+	}
+
+	functionDeps, err := Collect(ctx, og, tx, pgx.RowToMap,
+		With([]CTE{
+			{"function_deps", functionDepsQuery},
+		},
+			`SELECT DISTINCT to_oid::INT8 FROM function_deps;`,
+		))
+	if err != nil {
+		return nil, err
+	}
+
+	functionDepsMap := make(map[int64]struct{})
+	for _, f := range functionDeps {
+		functionDepsMap[f["to_oid"].(int64)] = struct{}{}
+	}
+
+	functionWithDeps := make([]map[string]any, 0, len(functions))
+	functionWithoutDeps := make([]map[string]any, 0, len(functions))
+	for _, f := range functions {
+		if _, ok := functionDepsMap[f["func_oid"].(int64)]; ok {
+			functionWithDeps = append(functionWithDeps, f)
+		} else {
+			functionWithoutDeps = append(functionWithoutDeps, f)
+		}
 	}
 
 	schemas, err := Collect(ctx, og, tx, pgx.RowTo[string], schemasQuery)
@@ -4299,12 +4326,17 @@ func (og *operationGenerator) alterFunctionSetSchema(
 
 	stmt, expectedCode, err := Generate[*tree.AlterRoutineSetSchema](og.params.rng, og.produceError(), []GenerationCase{
 		{pgcode.UndefinedFunction, `ALTER FUNCTION "NoSuchFunction" SET SCHEMA "IrrelevantSchema"`},
-		{pgcode.InvalidSchemaName, `ALTER FUNCTION { Function } SET SCHEMA "NoSuchSchema"`},
+		{pgcode.InvalidSchemaName, `ALTER FUNCTION { (FunctionWithDeps).qualified_name  } SET SCHEMA "NoSuchSchema"`},
+		{pgcode.InvalidSchemaName, `ALTER FUNCTION { (FunctionWithoutDeps).qualified_name  } SET SCHEMA "NoSuchSchema"`},
 		// NB: It's considered valid to set a function's schema to the schema it already exists within.
-		{pgcode.SuccessfulCompletion, `ALTER FUNCTION { Function } SET SCHEMA { Schema }`},
+		{pgcode.SuccessfulCompletion, `ALTER FUNCTION { (FunctionWithoutDeps).qualified_name  } SET SCHEMA { Schema }`},
+		{pgcode.FeatureNotSupported, `ALTER FUNCTION { (FunctionWithDeps).qualified_name  } SET SCHEMA { Schema }`},
 	}, template.FuncMap{
-		"Function": func() (string, error) {
-			return PickOne(og.params.rng, functions)
+		"FunctionWithDeps": func() (map[string]any, error) {
+			return PickOne(og.params.rng, functionWithDeps)
+		},
+		"FunctionWithoutDeps": func() (map[string]any, error) {
+			return PickOne(og.params.rng, functionWithoutDeps)
 		},
 		"Schema": func() (string, error) {
 			return PickOne(og.params.rng, schemas)

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3939,7 +3939,8 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 	array_to_string(proargnames, ',') AS args
 FROM
 	functions
-	INNER JOIN pg_catalog.pg_proc ON oid = (id + 100000);`)
+	INNER JOIN pg_catalog.pg_proc ON oid = (id + 100000)
+	WHERE COALESCE((descriptor->'state')::STRING, 'PUBLIC') = 'PUBLIC'::STRING;`)
 	enums, err := Collect(ctx, og, tx, pgx.RowToMap, enumQuery)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This patch addresses the following issues with our UDFs invoking other UDFs support:

1. Previously the randomized CREATE FUNCTION could incorrectly select UDFs that were marked as dropped, these are now properly skipped
2. When DROP SCHEMA was invoked we would check if the schema contained any UDF invoked by any other UDF in a different schema. This should block the DROP SCHEMA operation in the legacy schema changer. Unfortunately, the check using for checking dependencies had bugs and never worked properly.
3. ALTER FUNCTION ... SET SCHEMA should have a block to prevent setting schema if any UDF references exist. Both a unit test and checking inside the randomize workload are added.

Fixes: #121407