### PR TITLE
rangefeed: don't set default txn push interval when pusher nil

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -122,11 +122,22 @@ type Config struct {
 // SetDefaults initializes unset fields in Config to values
 // suitable for use by a Processor.
 func (sc *Config) SetDefaults() {
-	if sc.PushTxnsInterval == 0 {
-		sc.PushTxnsInterval = DefaultPushTxnsInterval
-	}
-	if sc.PushTxnsAge == 0 {
-		sc.PushTxnsAge = defaultPushTxnsAge
+	// Some tests don't set the TxnPusher, so we avoid setting a default push txn
+	// interval in such cases #121429.
+	if sc.TxnPusher == nil {
+		if sc.PushTxnsInterval != 0 {
+			panic("nil TxnPusher with non-zero PushTxnsInterval")
+		}
+		if sc.PushTxnsAge != 0 {
+			panic("nil TxnPusher with non-zero PushTxnsAge")
+		}
+	} else {
+		if sc.PushTxnsInterval == 0 {
+			sc.PushTxnsInterval = DefaultPushTxnsInterval
+		}
+		if sc.PushTxnsAge == 0 {
+			sc.PushTxnsAge = defaultPushTxnsAge
+		}
 	}
 }
 


### PR DESCRIPTION
In 8eb7ca9, we reverted the change to remove the legacy rangefeed processor but omitted updating the `SetDefaults` config function. In-between removing the legacy rangefeed processor and subsequently reverting its removal, we updated the `SetDefaults` function to always set the default txn push interval (6fcbdfc).

This causes a NPE when dereferencing the txn pusher, which occurs during some benchmark testing.

Re-introduce the txn pusher nil check when setting the default processor push txn interval.

Fixes: #121429
Release note: None