### PR TITLE
roachtest: deflake kv/restart/nodes=12

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -1012,6 +1012,11 @@ func registerKVRestartImpact(r registry.Registry) {
 
 			// Begin the monitoring goroutine to track QPS every 5 seconds.
 			m.Go(func(ctx context.Context) error {
+				// Wait until 10s after the workload began to begin asserting on QPS.
+				if dur := timeutil.Since(workloadStartTime); dur < 10*time.Second {
+					time.Sleep(10*time.Second - dur)
+				}
+
 				t.Status(fmt.Sprintf("verify QPS is at least %d during the test, expecting %d", int(passingQPS), int(expectedQPS)))
 				lastPrint := timeutil.Now()
 				defer t.WorkerStatus()


### PR DESCRIPTION
Deflake the kv/restart/nodes=12 roachtest by waiting 10 seconds before beginning to assert on QPS.

Epic: none
Close #121414
Release note: None