### PR TITLE
lint: fix `gcassert`

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -5271,10 +5271,10 @@ def go_deps():
         name = "com_github_jordanlewis_gcassert",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/jordanlewis/gcassert",
-        sha256 = "b5fa1cbfe72d124fd9b62877256b7e90920f4c046d3de34a7e602cda27d71ae7",
-        strip_prefix = "github.com/jordanlewis/gcassert@v0.0.0-20240302143610-f3d7b199b629",
+        sha256 = "6e545deff1a580bfc31b2fae0b755a35e2b9c4c7e285ff4fe3eddc725a3ee101",
+        strip_prefix = "github.com/jordanlewis/gcassert@v0.0.0-20240401195008-3141cbd028c0",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jordanlewis/gcassert/com_github_jordanlewis_gcassert-v0.0.0-20240302143610-f3d7b199b629.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jordanlewis/gcassert/com_github_jordanlewis_gcassert-v0.0.0-20240401195008-3141cbd028c0.zip",
         ],
     )
     go_repository(

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -678,7 +678,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/joho/godotenv/com_github_joho_godotenv-v1.3.0.zip": "acef5a394fbd1193f52d0d19690b0bfe82728d18dd3bf67730dc5031c22d563f",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jonboulle/clockwork/com_github_jonboulle_clockwork-v0.1.0.zip": "930d355d1ced60a668bcbca6154bb5671120ba11a34119505d1c0677f7bbbf97",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jordan-wright/email/com_github_jordan_wright_email-v4.0.1-0.20210109023952-943e75fe5223+incompatible.zip": "6d35fa83ea02cfacd0e1ba9c9061381b963215cef84c8bf83ad5944cb304c390",
-    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jordanlewis/gcassert/com_github_jordanlewis_gcassert-v0.0.0-20240302143610-f3d7b199b629.zip": "b5fa1cbfe72d124fd9b62877256b7e90920f4c046d3de34a7e602cda27d71ae7",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jordanlewis/gcassert/com_github_jordanlewis_gcassert-v0.0.0-20240401195008-3141cbd028c0.zip": "6e545deff1a580bfc31b2fae0b755a35e2b9c4c7e285ff4fe3eddc725a3ee101",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/josharian/intern/com_github_josharian_intern-v1.0.0.zip": "5679bfd11c14adccdb45bd1a0f9cf4b445b95caeed6fb507ba96ecced11c248d",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/jpillora/backoff/com_github_jpillora_backoff-v1.0.0.zip": "f856692c725143c49b9cceabfbca8bc93d3dbde84a0aaa53fb26ed3774c220cc",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/json-iterator/go/com_github_json_iterator_go-v1.1.12.zip": "d001ea57081afd0e378467c8f4a9b6a51259996bb8bb763f78107eaf12f99501",

--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,7 @@ require (
 	github.com/jackc/pgx/v5 v5.4.2
 	github.com/jaegertracing/jaeger v1.18.1
 	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
-	github.com/jordanlewis/gcassert v0.0.0-20240302143610-f3d7b199b629
+	github.com/jordanlewis/gcassert v0.0.0-20240401195008-3141cbd028c0
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/kisielk/errcheck v1.6.1-0.20210625163953-8ddee489636a
 	github.com/kisielk/gotool v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1491,8 +1491,8 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible h1:jdpOPRN1zP63Td1hDQbZW73xKmzDvZHzVdNYxhnTMDA=
 github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible/go.mod h1:1c7szIrayyPPB/987hsnvNzLushdWf4o/79s3P08L8A=
-github.com/jordanlewis/gcassert v0.0.0-20240302143610-f3d7b199b629 h1:wKRbFlBR3btLZSfHhb+FM0mzAeBdxuJ8TLL2vbHsPYc=
-github.com/jordanlewis/gcassert v0.0.0-20240302143610-f3d7b199b629/go.mod h1:ZybsQk6DWyN5t7An1MuPm1gtSZ1xDaTXS9ZjIOxvQrk=
+github.com/jordanlewis/gcassert v0.0.0-20240401195008-3141cbd028c0 h1:LLHq/gxkTqoCGQNTbN4sicZzVtmBZlD1Lccgtw8Kgag=
+github.com/jordanlewis/gcassert v0.0.0-20240401195008-3141cbd028c0/go.mod h1:ZybsQk6DWyN5t7An1MuPm1gtSZ1xDaTXS9ZjIOxvQrk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2285,7 +2285,7 @@ func TestLint(t *testing.T) {
 			if path == "" {
 				continue
 			}
-			gcassertPaths = append(gcassertPaths, filepath.Join(crdbDir, "pkg", path))
+			gcassertPaths = append(gcassertPaths, fmt.Sprintf("./pkg/%s", path))
 		}
 
 		// Ensure that all packages that have '//gcassert' or '// gcassert'
@@ -2319,7 +2319,7 @@ func TestLint(t *testing.T) {
 				// and we want to extract the package path.
 				filePath := s[:strings.Index(s, ":")]                  // up to the line number
 				pkgPath := filePath[:strings.LastIndex(filePath, "/")] // up to the file name
-				gcassertPath := filepath.Join(crdbDir, "pkg", pkgPath)
+				gcassertPath := fmt.Sprintf("./pkg/%s", pkgPath)
 				for i := range gcassertPaths {
 					if gcassertPath == gcassertPaths[i] {
 						return
@@ -2338,10 +2338,10 @@ func TestLint(t *testing.T) {
 		})
 
 		var buf strings.Builder
-		output := buf.String()
 		if err := gcassert.GCAssertCwd(&buf, crdbDir, gcassertPaths...); err != nil {
 			t.Fatalf("failed gcassert (%+v):\n%s", err, buf.String())
 		}
+		output := buf.String()
 		if len(output) > 0 {
 			t.Fatalf("failed gcassert:\n%s", output)
 		}


### PR DESCRIPTION
This test was not running correctly. First of all there was some upstream issue with the `cwd` logic which I fixed in jordanlewis/gcassert#16. Additionally the `strings.Builder.String()` call was in the wrong place and I updated the code to use relative paths to the `cwd`.

Closes #121312.

Epic: none
Release note: None