### PR TITLE
catalog/lease: fix flake in TestNameCacheEntryDoesntReturnExpiredLease

### DIFF
--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -487,6 +487,11 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 		t.Fatal(err)
 	}
 
+	// Disable stats collection so that the descriptor isn't modified.
+	if _, err := db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false"); err != nil {
+		t.Fatal(err)
+	}
+
 	// Populate the name cache.
 	if _, err := db.Exec("SELECT * FROM t.test;"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Previously, TestNameCacheEntryDoesntReturnExpiredLease would flake because of the automatic stats collection would periodically end up renewing the lease on our table after a fake expiration. To address this, this patch disables stats collection for this test.

Fixes: #121314

Release note: None