### PR TITLE
sql: improve setseed builtin

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3295,7 +3295,7 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.extraTxnState.rowsWrittenLogged = false
 	ex.extraTxnState.rowsReadLogged = false
 	if txnExecStatsSampleRate := collectTxnStatsSampleRate.Get(&ex.server.GetExecutorConfig().Settings.SV); txnExecStatsSampleRate > 0 {
-		ex.extraTxnState.shouldCollectTxnExecutionStats = txnExecStatsSampleRate > ex.rng.Float64()
+		ex.extraTxnState.shouldCollectTxnExecutionStats = txnExecStatsSampleRate > ex.rng.internal.Float64()
 	}
 
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pprofutil",
-        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/util/tochar",
         "//pkg/util/tracing",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -363,8 +362,6 @@ func (ds *ServerImpl) setupFlow(
 			RangeStatsFetcher:         ds.ServerConfig.RangeStatsFetcher,
 			ULIDEntropy:               ulid.Monotonic(crypto_rand.Reader, 0),
 		}
-		rng, _ := randutil.NewPseudoRand()
-		evalCtx.RNG = rng
 		// Most processors will override this Context with their own context in
 		// ProcessorBase. StartInternal().
 		evalCtx.SetDeprecatedContext(ctx)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -175,6 +175,15 @@ SELECT i, random() FROM ROWS FROM (generate_series(1, 5)) AS i ORDER by i
 4  0.43716650508717286
 5  0.16686635296305902
 
+# Subqueries need to use the same RNG.
+statement ok
+SELECT setseed(0.1)
+
+query RR
+WITH cte(col) AS (SELECT random()) SELECT col, random() FROM cte
+----
+0.8090535001228529  0.33363615433097443
+
 # Concatenating 'empty' because the empty string doesn't work in these tests.
 query T
 SELECT concat() || 'empty'

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -57,7 +57,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -557,8 +556,6 @@ func internalExtendedEvalCtx(
 		statsProvider:   sqlStatsProvider,
 		jobs:            newTxnJobsCollection(),
 	}
-	rng, _ := randutil.NewPseudoRand()
-	ret.RNG = rng
 	ret.SetDeprecatedContext(ctx)
 	ret.copyFromExecCfg(execCfg)
 	return ret

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -66,7 +66,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ulid"
@@ -2648,8 +2647,6 @@ func createSchemaChangeEvalCtx(
 			ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 	}
-	rng, _ := randutil.NewPseudoRand()
-	evalCtx.RNG = rng
 	// TODO(andrei): This is wrong (just like on the main code path on
 	// setupFlow). Each processor should override Ctx with its own context.
 	evalCtx.SetDeprecatedContext(ctx)

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/mon",
-        "//pkg/util/randutil",
         "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 )
 
@@ -65,8 +64,6 @@ func newEvalCtx(ctx context.Context, d Dependencies) *eval.Context {
 		DescIDGenerator:      d.DescIDGenerator(),
 		ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 	}
-	rng, _ := randutil.NewPseudoRand()
-	evalCtx.RNG = rng
 	evalCtx.SetDeprecatedContext(ctx)
 	return evalCtx
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2090,7 +2090,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Float),
 			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDFloat(tree.DFloat(evalCtx.RNG.Float64())), nil
+				return tree.NewDFloat(tree.DFloat(evalCtx.GetRNG().Float64())), nil
 			},
 			Info: "Returns a random floating-point number between 0 (inclusive) and 1 (exclusive). " +
 				"Note that the value contains at most 53 bits of randomness.",
@@ -2108,7 +2108,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				if seed < -1.0 || seed > 1.0 {
 					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "setseed parameter %f is out of allowed range [-1,1]", seed)
 				}
-				evalCtx.RNG.Seed(int64(math.Float64bits(float64(seed))))
+				evalCtx.GetRNG().Seed(int64(math.Float64bits(float64(seed))))
 				return tree.DVoidDatum, nil
 			},
 			Info: "Sets the seed for subsequent random() calls in this session (value between -1.0 and 1.0, inclusive). " +

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -85,6 +85,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/json",
         "//pkg/util/mon",
+        "//pkg/util/randutil",
         "//pkg/util/rangedesc",
         "//pkg/util/ring",
         "//pkg/util/timeofday",


### PR DESCRIPTION
This commit improves https://github.com/cockroachdb/cockroach/commit/b51da9ebe2d1c2e4b7ecf810edb5c88cdc991adb in
a couple of ways.

First, it makes the allocation of the RNG lazy, whenever either random()
or setseed() is called for the first time.

Here is the impact on `flowinfra/BenchmarkInfrastructure`:
```
name                         old time/op    new time/op    delta
Infrastructure/n1/r1-24        37.0µs ± 1%    23.0µs ± 2%  -37.74%  (p=0.000 n=10+10)
Infrastructure/n1/r100-24      87.7µs ± 1%    75.7µs ± 2%  -13.76%  (p=0.000 n=8+10)
Infrastructure/n1/r10000-24    5.03ms ± 2%    5.06ms ± 1%     ~     (p=0.165 n=10+10)
Infrastructure/n3/r1-24         749µs ± 4%     714µs ± 4%   -4.57%  (p=0.000 n=10+10)
Infrastructure/n3/r100-24      1.01ms ± 3%    0.96ms ± 4%   -5.09%  (p=0.000 n=10+10)
Infrastructure/n3/r10000-24    19.4ms ± 1%    19.6ms ± 1%     ~     (p=0.247 n=10+10)

name                         old alloc/op   new alloc/op   delta
Infrastructure/n1/r1-24        28.2kB ± 2%    22.3kB ± 1%  -20.77%  (p=0.000 n=9+8)
Infrastructure/n1/r100-24      74.2kB ± 0%    68.4kB ± 0%   -7.81%  (p=0.000 n=8+8)
Infrastructure/n1/r10000-24    4.58MB ± 0%    4.57MB ± 0%     ~     (p=0.161 n=8+8)
Infrastructure/n3/r1-24         168kB ± 1%     153kB ± 9%   -8.85%  (p=0.000 n=8+9)
Infrastructure/n3/r100-24       401kB ± 0%     383kB ± 1%   -4.47%  (p=0.000 n=8+9)
Infrastructure/n3/r10000-24    21.9MB ± 0%    22.0MB ± 2%     ~     (p=0.481 n=8+9)

name                         old allocs/op  new allocs/op  delta
Infrastructure/n1/r1-24           122 ± 3%       116 ± 1%   -4.64%  (p=0.000 n=9+8)
Infrastructure/n1/r100-24         236 ± 0%       230 ± 0%   -2.28%  (p=0.000 n=8+8)
Infrastructure/n1/r10000-24     10.4k ± 0%     10.4k ± 0%     ~     (p=0.151 n=8+8)
Infrastructure/n3/r1-24         1.52k ± 1%     1.50k ± 2%   -1.47%  (p=0.005 n=8+8)
Infrastructure/n3/r100-24       2.20k ± 0%     2.17k ± 1%   -1.16%  (p=0.000 n=8+9)
Infrastructure/n3/r10000-24     54.0k ± 0%     54.6k ± 5%     ~     (p=0.743 n=8+9)
```

Second, it fixes the logic so that all consequent statements on the same
session do use the right seed - previously, subqueries would use
a separate RNG created in `initEvalCtx`.

This refactor also allows us to only set the RNG field on the eval
context on the main code path.

Epic: None

Release note: None