### PR TITLE
Alter column with USING expression idential to new type cast can be trivial

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3850,3 +3850,10 @@ CREATE TABLE t_identity_drop_dependency(id INT PRIMARY KEY DEFAULT nextval('publ
 
 statement error pgcode 2BP01 pq: cannot drop table t_identity_drop because other objects depend on it
 ALTER TABLE t_identity_drop ALTER COLUMN b DROP IDENTITY;
+
+statement ok
+CREATE TABLE alter_col_redun_using(val int NOT NULL);
+
+# The using statement is the same as if it were not included.
+statement ok
+ALTER TABLE alter_col_redun_using ALTER val TYPE bigint USING val::bigint;


### PR DESCRIPTION
Alter column with USING expression idential to new type cast can be trivial

This pr is created as a blocking issue for django-cockroachdb found here: https://github.com/cockroachdb/cockroach/issues/82416#issuecomment-2029803229