### PR TITLE
logictest: revert incorrect test assertion update

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -194,8 +194,8 @@ ORDER BY start_key
 /Table/106  14400
 /Table/107  14400
 /Table/110  90001
-/Table/111  90001
-/Table/112  14400
+/Table/111  1
+/Table/112  1
 
 subtest transactional_schemachanges
 


### PR DESCRIPTION
1fcff46 incorrectly updated the test expectations, likely because the --rewrite flag was used on an assertion that has the `retry` directive.

This commit undoes that change.

fixes https://github.com/cockroachdb/cockroach/issues/121351
Release note: None