### PR TITLE
bazelbuilder: remove `chrome` install

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20240202-060306
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20240403-181753

--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,1 +1,1 @@
-us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel-fips:20230815-175543
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel-fips:20240403-181753

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -74,18 +74,6 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key a
     google-cloud-cli-gke-gcloud-auth-plugin \
     && apt-get clean
 
-# chrome is needed for UI tests. Unfortunately it is only distributed for x86_64
-# and not for ARM. Chrome shouldn't need to be installed when we migrate away
-# from Karma for UI testing.
-RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") \
-      curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-      && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google.list \
-      && apt-get update \
-      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      google-chrome-stable ;; \
-    esac
-
 RUN apt-get purge -y \
     apt-transport-https \
     flex \

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -32,7 +32,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:1277dc9c759382ec85c06af78c2ce6f84db2e19de1a364e0a76fbf4bc6853a24",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:d16cbd2486fbca3ee35408f424ed51953e7853d0c48e0f58fe8e0a7382050dc2",
         "dockerReuse": "True",
         "Pool": "default",
     },
@@ -137,7 +137,7 @@ platform(
         "@platforms//cpu:arm64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:2ff9afdff2e838b218c8b4e80c5c1f398dc25674ba238a7bbf8364040b02fb0a",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:c631626d4988f6df1a314161d639a3503e29eab23f2d679a722b7861a47aa428",
         "dockerReuse": "True",
         "Pool": "default",
     },


### PR DESCRIPTION
This has apparently not been necessary since we removed `karma` from UI
testing.

Epic: none
Release note: None