### PR TITLE
backupccl: fix race condition in online restore worker

### DIFF
--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -94,7 +94,7 @@ func sendAddRemoteSSTs(
 
 	restoreWorkers := int(onlineRestoreLinkWorkers.Get(&execCtx.ExecCfg().Settings.SV))
 	for i := 0; i < restoreWorkers; i++ {
-		grp.GoCtx(sendAddRemoteSSTWorker(execCtx, restoreSpanEntriesCh, requestFinishedCh, kr, fromSystemTenant, &approxRows, &approxDataSize))
+		grp.GoCtx(sendAddRemoteSSTWorker(execCtx, restoreSpanEntriesCh, requestFinishedCh, *kr, fromSystemTenant, &approxRows, &approxDataSize))
 	}
 
 	if err := grp.Wait(); err != nil {
@@ -145,7 +145,7 @@ func sendAddRemoteSSTWorker(
 	execCtx sql.JobExecContext,
 	restoreSpanEntriesCh <-chan execinfrapb.RestoreSpanEntry,
 	requestFinishedCh chan<- struct{},
-	kr *KeyRewriter,
+	kr KeyRewriter,
 	fromSystemTenant bool,
 	approxRows *int64,
 	approxDataSize *int64,
@@ -222,7 +222,7 @@ func sendAddRemoteSSTWorker(
 				}
 				// Clone the key because rewriteSpan could modify the keys in place, but
 				// we reuse backup files across restore span entries.
-				restoringSubspan, err = rewriteSpan(kr, restoringSubspan.Clone(), entry.ElidedPrefix)
+				restoringSubspan, err = rewriteSpan(&kr, restoringSubspan.Clone(), entry.ElidedPrefix)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Data race condition detected by Bazel Extended Tests, caused by workers writing to cached results in KeyRewriter without a lock

Passing `KeyWriter` by value should not break any existing behaviors as the mutation is only done for caching purposes via `prefixRewriter.rewriteKey` and the use of `KeyRewriter.lastKeyTenant`.

Release note: none

Epic: none