### PR TITLE
WIP fix: sequence cache and last value stays within minvalue and maxvalue

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_sequence
@@ -395,3 +395,29 @@ SHOW CREATE SEQUENCE seq_alter_no_min_max_des
 ----
 table_name                create_statement
 seq_alter_no_min_max_des  CREATE SEQUENCE public.seq_alter_no_min_max_des MINVALUE -9223372036854775808 MAXVALUE -1 INCREMENT -1 START -5
+
+statement ok
+CREATE SEQUENCE seq_cache_limit MINVALUE -10 MAXVALUE 10 INCREMENT 3 CACHE 100 START 0;
+
+query III
+select nextval('seq_cache_limit'),nextval('seq_cache_limit'),nextval('seq_cache_limit');
+----
+0  3  6
+
+query I
+SELECT last_value FROM seq_cache_limit;
+----
+9
+
+statement ok
+ALTER SEQUENCE seq_cache_limit INCREMENT -3;
+
+query III
+select nextval('seq_cache_limit'),nextval('seq_cache_limit'),nextval('seq_cache_limit');
+----
+6  3  0
+
+query I
+SELECT last_value FROM seq_cache_limit;
+----
+-9

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1608,7 +1608,7 @@ SELECT nextval('cached_upper_bound_test');
 query I
 SELECT last_value FROM cached_upper_bound_test;
 ----
-10
+4
 
 # nextval() should return errors while still incrementing the underlying sequence
 # by 10 each time (cache size of 5 * increment of 2). Despite the underlying sequence changing,
@@ -1633,7 +1633,7 @@ SELECT currval('cached_upper_bound_test');
 query I
 SELECT last_value FROM cached_upper_bound_test;
 ----
-30
+4
 
 # Performing a schema change on the sequence to increase the bounds should reset the underlying
 # sequence to its original MAXVALUE.
@@ -1692,7 +1692,7 @@ SELECT nextval('cached_lower_bound_test');
 query I
 SELECT last_value FROM cached_lower_bound_test;
 ----
--10
+-4
 
 statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "cached_lower_bound_test" \(-4\)
 SELECT nextval('cached_lower_bound_test');
@@ -1703,7 +1703,7 @@ SELECT nextval('cached_lower_bound_test');
 query I
 SELECT last_value FROM cached_lower_bound_test;
 ----
--30
+-4
 
 statement ok
 ALTER SEQUENCE cached_lower_bound_test MINVALUE -100;
@@ -1750,7 +1750,7 @@ SELECT nextval('cached_lower_bound_test_2');
 query I
 SELECT last_value FROM cached_lower_bound_test_2;
 ----
--6
+-2
 
 statement error pgcode 2200H pq: nextval\(\): reached minimum value of sequence "cached_lower_bound_test_2" \(-2\)
 SELECT nextval('cached_lower_bound_test_2');
@@ -1761,7 +1761,7 @@ SELECT nextval('cached_lower_bound_test_2');
 query I
 SELECT last_value FROM cached_lower_bound_test_2;
 ----
--26
+-2
 
 statement ok
 ALTER SEQUENCE cached_lower_bound_test_2 MINVALUE -100;


### PR DESCRIPTION
This commit addresss an issue when increasing the sequence value. If the next value increase beyond the minvalue or maxvalue, the cache size is decreased to keep the sequence value within the range. To ensure that we do not go beyond the sequence limit, the sequence value is fetched first, calculations are done and then cput is used to write the new sequence value. Since it is possible for this process to be executed concurrently, the writing of the value is in a retry loop which will not fail if the error return is from cput. This process can be considered to be similair to a transaction as it ensures consistency.

Release note (bug fix): Sequence fetchValues ensures that the the next value does not go beyond sequence limits.