### PR TITLE
roachtest: check if dependencies are met before running operations

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1174,6 +1174,7 @@ GO_TARGETS = [
     "//pkg/cmd/roachtest/roachtestutil/clusterupgrade:clusterupgrade",
     "//pkg/cmd/roachtest/roachtestutil/mixedversion:mixedversion",
     "//pkg/cmd/roachtest/roachtestutil/mixedversion:mixedversion_test",
+    "//pkg/cmd/roachtest/roachtestutil/operations:operations",
     "//pkg/cmd/roachtest/roachtestutil:roachtestutil",
     "//pkg/cmd/roachtest/roachtestutil:roachtestutil_test",
     "//pkg/cmd/roachtest/spec:spec",

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",
         "//pkg/cmd/roachtest/roachtestutil",
+        "//pkg/cmd/roachtest/roachtestutil/operations",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/cmd/roachtest/tests",

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -29,7 +29,7 @@ const (
 	OperationRequiresNodes OperationDependency = iota
 	OperationRequiresPopulatedDatabase
 	OperationRequiresZeroUnavailableRanges
-	OperationRequiresZeroLaggingRanges
+	OperationRequiresZeroUnderreplicatedRanges
 )
 
 // OperationCleanup specifies an operation that
@@ -60,8 +60,6 @@ type OperationSpec struct {
 	// operation to work. This will be used in filtering eligible operations to
 	// run. Multiple dependencies could be specified, and any schedulers will take
 	// care of ensuring those dependencies are met before running Run().
-	//
-	// TODO(bilal): Unused.
 	Dependencies []OperationDependency
 
 	// CanRunConcurrently specifies whether this operation is safe to run

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -123,6 +123,14 @@ var (
             by the operation. Note that this time does not count towards the timeout.`,
 	})
 
+	SkipDependencyCheck bool = false
+	_                        = registerRunOpsFlag(&SkipDependencyCheck, FlagInfo{
+		Name: "skip-dependency-check",
+		Usage: `Skips the pre-operation dependency check and runs the operation regardless of
+		whether its dependencies are met or not. Note that running operations with this flag could
+		lead to cluster unavailability or operation failures.`,
+	})
+
 	CockroachEAPath string
 	_               = registerRunFlag(&CockroachEAPath, FlagInfo{
 		Name: "cockroach-ea",

--- a/pkg/cmd/roachtest/roachtestutil/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/operations/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "operations",
+    srcs = ["dependency.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/operations",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cmd/roachtest/cluster",
+        "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/registry",
+        "//pkg/cmd/roachtest/roachtestflags",
+        "//pkg/roachprod/logger",
+    ],
+)

--- a/pkg/cmd/roachtest/roachtestutil/operations/dependency.go
+++ b/pkg/cmd/roachtest/roachtestutil/operations/dependency.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+// CheckDependencies returns true if an operation with the provided spec
+// can be run on the specified cluster.
+func CheckDependencies(
+	ctx context.Context, c cluster.Cluster, l *logger.Logger, spec *registry.OperationSpec,
+) (ok bool, err error) {
+	for _, dep := range spec.Dependencies {
+		switch dep {
+		case registry.OperationRequiresNodes:
+			if len(c.Nodes()) == 0 {
+				return false, nil
+			}
+		case registry.OperationRequiresPopulatedDatabase:
+			conn := c.Conn(ctx, l, 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+			defer conn.Close()
+
+			dbsCount, err := conn.QueryContext(ctx, "SELECT count(database_name) FROM [SHOW DATABASES] WHERE database_name NOT IN ('postgres', 'system')")
+			if err != nil {
+				return false, err
+			}
+			dbsCount.Next()
+			var count int
+			if err := dbsCount.Scan(&count); err != nil {
+				return false, err
+			}
+			if count == 0 {
+				return false, nil
+			}
+		case registry.OperationRequiresZeroUnavailableRanges:
+			conn := c.Conn(ctx, l, 1, option.VirtualClusterName("system"))
+			defer conn.Close()
+
+			rangesCur, err := conn.QueryContext(ctx, "SELECT sum(unavailable_ranges) FROM system.replication_stats")
+			if err != nil {
+				return false, err
+			}
+			rangesCur.Next()
+			var count int
+			if err := rangesCur.Scan(&count); err != nil {
+				return false, err
+			}
+			if count != 0 {
+				return false, nil
+			}
+		case registry.OperationRequiresZeroUnderreplicatedRanges:
+			conn := c.Conn(ctx, l, 1, option.VirtualClusterName("system"))
+			defer conn.Close()
+
+			rangesCur, err := conn.QueryContext(ctx, "SELECT sum(under_replicated_ranges) FROM system.replication_stats")
+			if err != nil {
+				return false, err
+			}
+			rangesCur.Next()
+			var count int
+			if err := rangesCur.Scan(&count); err != nil {
+				return false, err
+			}
+			if count != 0 {
+				return false, nil
+			}
+		default:
+			panic(fmt.Sprintf("unknown operation dependency %d", dep))
+		}
+	}
+	return true, nil
+}

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/operations"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -441,14 +442,19 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 	//lint:ignore SA1019 deprecated
 	rand.Seed(roachtestflags.GlobalSeed)
 	r := makeTestRegistry()
-
-	register(&r)
-	ctx := context.Background()
 	// NB: root logger with no path always tees to Stdout.
 	l, err := logger.RootLogger("", logger.NoTee)
 	if err != nil {
 		return err
 	}
+	// Install goroutine leak checker and run it at the end of the entire operation
+	// run. This is good hygiene for operations, as operations can one day be
+	// called from roachtests as well.
+	defer leaktest.AfterTest(l)()
+
+	register(&r)
+	ctx := context.Background()
+
 	// TODO(bilal): This is excessive for just getting the number of nodes in the
 	// cluster. We should expose a roachprod.Nodes method or so.
 	nodes, err := roachprod.PgURL(ctx, l, clusterName, roachtestflags.CertsDir, roachprod.PGURLOptions{})
@@ -486,10 +492,6 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 	defer cancel()
 	// Cancel this context if we get an interrupt.
 	CtrlC(ctx, l, cancel, nil /* registry */)
-	// Install goroutine leak checker and run it at the end of the entire operation
-	// run. This is good hygiene for operations, as operations can one day be
-	// called from roachtests as well.
-	defer leaktest.AfterTest(l)()
 
 	op := &operationImpl{
 		spec:      opSpec,
@@ -497,6 +499,18 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 		l:         l,
 	}
 	op.mu.cancel = cancel
+	op.Status(fmt.Sprintf("checking if operation %s dependencies are met", opSpec.Name))
+
+	if roachtestflags.SkipDependencyCheck {
+		op.Status("skipping dependency check")
+	} else if ok, err := operations.CheckDependencies(ctx, c, l, opSpec); !ok || err != nil {
+		if err != nil {
+			op.Fatalf("error checking dependencies: %s", err)
+		}
+		op.Status("operation dependencies not met. Use --skip-dependency-check to skip this check.")
+		return nil
+	}
+
 	var cleanup registry.OperationCleanup
 	func() {
 		ctx, cancel := context.WithTimeout(ctx, opSpec.Timeout)


### PR DESCRIPTION
Previously, OperationSpec would include a list of dependencies but these were unenforced; we wouldn't see if the cluster met these before scheduling an operation on that cluster. This change does some validation to confirm if an operation is eligible to be run before running it.

Epic: none

Release note: None