### PR TITLE
roachprod: remove abrupt exit when distributing certs

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1653,8 +1653,7 @@ tar cvf %[5]s %[2]s
 			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-certs"))
 		},
 	); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		exit.WithCode(exit.UnspecifiedError())
+		return err
 	}
 
 	tarfile, cleanup, err := c.getFileFromFirstNode(ctx, l, certsTarName)


### PR DESCRIPTION
This somehow remained undetected in the codebase for a long time. It has recently caused a nightly run to exit early[^1].

[^1]:https://teamcity.cockroachdb.com/viewLog.html?buildId=14660501&buildTypeId=Cockroach_Nightlies_RoachtestNightlyGceBazel

Epic: none

Release note: None