### PR TITLE
backupccl: fix a test that relies on deterministic IDs

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/import-epoch
+++ b/pkg/ccl/backupccl/testdata/backup-restore/import-epoch
@@ -17,12 +17,16 @@ CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
 INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
 ----
 
+let $foo_id
+SELECT id FROM system.namespace WHERE name = 'foo';
+----
+
 exec-sql
 CREATE VIEW import_epoch (epoch, type)
 AS WITH tbls AS (
    	SELECT id, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor) AS orig FROM system.descriptor
    )
-   SELECT orig->'table'->'importEpoch', orig->'table'->'importType' FROM tbls WHERE id = '109';
+   SELECT orig->'table'->'importEpoch', orig->'table'->'importType' FROM tbls WHERE id = '$foo_id';
 ----
 
 exec-sql
@@ -37,7 +41,7 @@ IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 query-sql
 SELECT name, id FROM system.namespace WHERE name = 'foo';
 ----
-foo 109
+foo $foo_id
 
 query-sql
 SELECT * FROM import_epoch


### PR DESCRIPTION
The ID of a table is not deterministic across test runs, so instead the ID is captured as a variable.

Epic: None
Release note: None