### PR TITLE
release-24.1: roachprod: remove abrupt exit when distributing certs

### DIFF
--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/install",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/cli/exit",
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -29,7 +29,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
@@ -1653,8 +1652,7 @@ tar cvf %[5]s %[2]s
 			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-certs"))
 		},
 	); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		exit.WithCode(exit.UnspecifiedError())
+		return err
 	}
 
 	tarfile, cleanup, err := c.getFileFromFirstNode(ctx, l, certsTarName)


### PR DESCRIPTION
Backport 1/1 commits from #121698 on behalf of @renatolabs.

/cc @cockroachdb/release

----

This somehow remained undetected in the codebase for a long time. It has recently caused a nightly run to exit early[^1].

[^1]:https://teamcity.cockroachdb.com/viewLog.html?buildId=14660501&buildTypeId=Cockroach_Nightlies_RoachtestNightlyGceBazel

Epic: none

Release note: None

----

Release justification: test only changes.