### PR TITLE
ui: index recommendations properly handle quoted table names

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.spec.ts
@@ -69,6 +69,25 @@ describe("Create index name", () => {
       expected:
         "CREATE INDEX IF NOT EXISTS t_expr_storing_rec_idx ON t ((i + l)), (j + k), a) STORING (k)",
     },
+    {
+      name: "handles table names containing quotes, doesn't include quotes in idx name",
+      query:
+        'CREATE INDEX ON defaultdb.public."offers"."startdate" (n) STORING (b);',
+      expected:
+        'CREATE INDEX IF NOT EXISTS startdate_n_storing_rec_idx ON defaultdb.public."offers"."startdate" (n) STORING (b);',
+    },
+    {
+      name: "handles table and column names containing quotes & whitespace, doesn't include quotes in idx name",
+      query: 'CREATE INDEX ON "my table" ("my col");',
+      expected:
+        'CREATE INDEX IF NOT EXISTS my_table_my_col_rec_idx ON "my table" ("my col");',
+    },
+    {
+      name: "handles quotes within quotes, doesn't include quotes in idx name",
+      query: 'CREATE INDEX ON "my""table" ("with""quote");',
+      expected:
+        'CREATE INDEX IF NOT EXISTS mytable_withquote_rec_idx ON "my""table" ("with""quote");',
+    },
   ];
 
   for (let i = 0; i < testCases.length; i++) {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -264,7 +264,9 @@ export function createIdxName(statement: string): string {
   // The table name is fully qualified at this point, but we don't need the full name,
   // so just use the last value (also an index name can't have ".")
   const idxNameArr = idxName.split(".");
-  idxName = idxNameArr[idxNameArr.length - 1].replace(/\s/g, "_") + suffix;
+  idxName =
+    idxNameArr[idxNameArr.length - 1].replace(/"/g, "").replace(/\s/g, "_") +
+    suffix;
 
   return statement.replace(
     "CREATE INDEX ON ",


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/119579

Epic: none

The UI code used to modify the index recommendations provided by the
server was not properly accounting for table and column names containing
quotation marks. This was causing invalid CREATE INDEX statements to
be generated, which would fail on request.

This patch fixes this by updating the query modification code to strip
quotation marks from the table name prior to using it to generate an
index name.

Release note (bug fix): Index recommendations in the DB Console will now
function properly for indexes on tables/columns whose names contain
quotation marks and/or whitespace.
For example: `CREATE INDEX ON "my table" ("my col");`