### PR TITLE
sql/stats: avoid internal executor in ensureAllTables

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -621,37 +621,38 @@ func (r *Refresher) Start(
 
 const (
 	getAllTablesTemplateSQL = `
-SELECT
-	tbl.table_id
-FROM
-	crdb_internal.tables AS tbl
-	INNER JOIN system.descriptor AS d ON d.id = tbl.table_id
-		AS OF SYSTEM TIME '-%s'
+WITH descs AS (
+  SELECT
+    d.id AS id,
+    crdb_internal.pb_to_json('desc', d.descriptor, false) AS descriptor_json,
+    (n."parentID" = 1) AS is_system_table
+  FROM system.descriptor AS d
+  INNER JOIN system.namespace AS n ON d.id = n.id
+	WHERE n."parentSchemaID" != 0
+)
+SELECT descs.id
+FROM descs
+AS OF SYSTEM TIME '-%s'
 WHERE
-	tbl.database_name IS NOT NULL
-	AND tbl.table_id NOT IN (%d, %d, %d)  -- excluded system tables
-	AND tbl.drop_time IS NULL
-	AND (
-			crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', d.descriptor, false)->'table'->>'viewQuery'
-		) IS NULL
+	id NOT IN (%d, %d, %d)  -- excluded system tables
+  AND descriptor_json ? 'table'
+	AND NOT descriptor_json->'table' ? 'viewQuery'
+	AND NOT descriptor_json->'table' ? 'dropTime'
 	%s
 	%s`
 
 	explicitlyEnabledTablesPredicate = `AND
-	(crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
-		d.descriptor, false)->'table'->'autoStatsSettings' ->> 'enabled' = 'true'
-	)`
+	(descriptor_json->'table'->'autoStatsSettings' ->> 'enabled' = 'true')`
 
 	autoStatsEnabledOrNotSpecifiedPredicate = `AND
-	(crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
-		d.descriptor, false)->'table'->'autoStatsSettings'->'enabled' IS NULL
-	 OR crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
-		d.descriptor, false)->'table'->'autoStatsSettings' ->> 'enabled' = 'true'
+	(
+    descriptor_json->'table'->'autoStatsSettings'->'enabled' IS NULL
+	  OR descriptor_json->'table'->'autoStatsSettings' ->> 'enabled' = 'true'
 	)`
 
 	autoStatsOnSystemTablesEnabledPredicate = `AND TRUE`
 
-	autoStatsOnSystemTablesDisabledPredicate = `AND tbl.database_name != 'system'`
+	autoStatsOnSystemTablesDisabledPredicate = `AND NOT is_system_table`
 )
 
 func (r *Refresher) getApplicableTables(

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -274,6 +274,46 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 	}
 }
 
+// BenchmarkEnsureAllTables was added since this operation appeared as a major
+// source of memory usage in https://github.com/cockroachlabs/support/issues/2870.
+func BenchmarkEnsureAllTables(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	for _, numTables := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("numTables=%d", numTables), func(b *testing.B) {
+			srv, sqlDB, _ := serverutils.StartServer(b, base.TestServerArgs{})
+			defer srv.Stopper().Stop(ctx)
+			s := srv.ApplicationLayer()
+			codec, st := s.Codec(), s.ClusterSettings()
+			AutomaticStatisticsClusterMode.Override(ctx, &st.SV, true)
+			AutomaticStatisticsOnSystemTables.Override(ctx, &st.SV, true)
+
+			sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+			sqlRun.Exec(b, `CREATE DATABASE t;`)
+
+			for i := 0; i < numTables; i++ {
+				sqlRun.Exec(b, fmt.Sprintf(`CREATE TABLE t.a%d (k INT PRIMARY KEY);`, i))
+			}
+
+			executor := s.InternalExecutor().(isql.Executor)
+			cache := NewTableStatisticsCache(
+				10, /* cacheSize */
+				s.ClusterSettings(),
+				s.InternalDB().(descs.DB),
+			)
+			require.NoError(b, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
+			r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r.ensureAllTables(ctx, &st.SV, time.Microsecond)
+			}
+		})
+	}
+}
+
 func checkAllTablesCount(ctx context.Context, systemTables bool, expected int, r *Refresher) error {
 	const collectionDelay = time.Microsecond
 	systemTablesPredicate := autoStatsOnSystemTablesEnabledPredicate

--- a/pkg/sql/stats/delete_stats.go
+++ b/pkg/sql/stats/delete_stats.go
@@ -127,8 +127,8 @@ func DeleteOldStatsForOtherColumns(
 
 // deleteStatsForDroppedTables deletes all statistics for at most 'limit' number
 // of dropped tables.
-func deleteStatsForDroppedTables(ctx context.Context, ex isql.Executor, limit int64) error {
-	_, err := ex.Exec(
+func deleteStatsForDroppedTables(ctx context.Context, db isql.DB, limit int64) error {
+	_, err := db.Executor().Exec(
 		ctx, "delete-statistics-for-dropped-tables", nil, /* txn */
 		fmt.Sprintf(`DELETE FROM system.table_statistics
                             WHERE "tableID" NOT IN (SELECT table_id FROM crdb_internal.tables)


### PR DESCRIPTION
This PR contains two commits that improve the EnsureAllTables query with
two separate strategies. The first one is only included for reference in case
we feel it would be more maintainable to keep using the internal executor, or if
it's safer to backport that one and not the 2nd improvement.

---

This improves the performance of ensureAllTables by removing the usage
of the internal executor entirely. By using the Collections API, we
avoid many allocations and improve memory usage.

```
goos: darwin
goarch: arm64
                                  │ bench-orig.txt │        bench-collections.txt        │
                                  │     sec/op     │   sec/op     vs base                │
EnsureAllTables/numTables=10-10       32.678m ± 1%   4.660m ± 1%  -85.74% (p=0.000 n=10)
EnsureAllTables/numTables=100-10      53.151m ± 1%   5.767m ± 0%  -89.15% (p=0.000 n=10)
EnsureAllTables/numTables=1000-10     255.20m ± 1%   16.69m ± 0%  -93.46% (p=0.000 n=10)
geomean                                76.25m        7.655m       -89.96%

                                  │ bench-orig.txt │        bench-collections.txt         │
                                  │      B/op      │     B/op      vs base                │
EnsureAllTables/numTables=10-10      18.073Mi ± 0%   3.821Mi ± 0%  -78.86% (p=0.000 n=10)
EnsureAllTables/numTables=100-10     29.299Mi ± 0%   5.008Mi ± 0%  -82.91% (p=0.000 n=10)
EnsureAllTables/numTables=1000-10    136.67Mi ± 0%   17.44Mi ± 0%  -87.24% (p=0.000 n=10)
geomean                               41.67Mi        6.936Mi       -83.35%

                                  │ bench-orig.txt │        bench-collections.txt        │
                                  │   allocs/op    │  allocs/op   vs base                │
EnsureAllTables/numTables=10-10       359.85k ± 0%   23.78k ± 0%  -93.39% (p=0.000 n=10)
EnsureAllTables/numTables=100-10      597.67k ± 0%   33.90k ± 0%  -94.33% (p=0.000 n=10)
EnsureAllTables/numTables=1000-10     2888.8k ± 0%   136.2k ± 0%  -95.29% (p=0.000 n=10)
geomean                                853.3k        47.88k       -94.39%
```

informs https://github.com/cockroachlabs/support/issues/2870
Epic: CRDB-37483
Release note: None