### PR TITLE
release-23.1: util/mon: add cluster setting for disabling monitor tree tracking

### DIFF
--- a/pkg/util/mon/BUILD.bazel
+++ b/pkg/util/mon/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/mon",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -17,6 +17,7 @@ import (
 	"math/bits"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -264,10 +265,19 @@ type BytesMonitor struct {
 	settings *cluster.Settings
 }
 
-// enableMonitorTreeTracking indicates whether tracking of all children of a
-// BytesMonitor (which is what powers TraverseTree) is enabled.
-var enableMonitorTreeTracking = envutil.EnvOrDefaultBool(
+// enableMonitorTreeTrackingEnvVar indicates whether tracking of all children of
+// a BytesMonitor (which is what powers TraverseTree) is enabled.
+var enableMonitorTreeTrackingEnvVar = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_MONITOR_TREE", true)
+
+// enableMonitorTreeTrackingSetting indicates whether tracking of all children
+// of a BytesMonitor (which is what powers TraverseTree) is enabled.
+var enableMonitorTreeTrackingSetting = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"diagnostics.memory_monitor_tree.enabled",
+	"enable tracking of memory monitor tree",
+	true,
+)
 
 // MonitorState describes the current state of a single monitor.
 type MonitorState struct {
@@ -499,7 +509,9 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 
 	var effectiveLimit int64
 	if pool != nil {
-		if enableMonitorTreeTracking {
+		// mm.settings can be nil in tests in which case we use the default
+		// value of enableMonitorTreeTrackingSetting cluster setting (true).
+		if enableMonitorTreeTrackingEnvVar && (mm.settings == nil || enableMonitorTreeTrackingSetting.Get(&mm.settings.SV)) {
 			// If we have a "parent" monitor, then register mm as its child by
 			// making it the head of the doubly-linked list.
 			pool.mu.Lock()


### PR DESCRIPTION
Backport 1/1 commits from #121722.

/cc @cockroachdb/release

---

We already have an env var for this, but it requires a node restart to apply. Having a cluster setting will allow us to disable the monitor tree tracking without the node restart, but it might also help us prove that it's Go GC deficiency to blame for the suspected memory leak: namely, if we find a cluster that has the leak and disable the tree tracking via the cluster setting, if it's Go GC deficiency, the leak would be cleaned up; if it's CRDB memory leak, then the leak will remain but will stop growing.

Epic: None

Release note: None

Release justification: low-risk improvement.