### PR TITLE
kv: auto-step read sequence on savepoint rollback

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator_test.go
@@ -206,7 +206,7 @@ func TestSequenceNumberAllocationWithStep(t *testing.T) {
 	currentStepSeqNum := s.writeSeq
 
 	ba := &kvpb.BatchRequest{}
-	ba.Requests = nil
+	ba.Header = kvpb.Header{Txn: &txn}
 	ba.Add(&kvpb.ConditionalPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
 	ba.Add(&kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
 	ba.Add(&kvpb.InitPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})


### PR DESCRIPTION
Fixes #121752.
Fixes #121748.

This commit fixes the `txnSeqNumAllocator` to conditionally (based on the stepping mode) auto-step the transaction's read sequence number to the write sequence number on savepoint rollbacks.

The commit also adds in an assertion into the `txnSeqNumAllocator` that the current read sequence is never part of a batch's ignored sequence number list. This helps us detect the cases that were leading to assertion errors in #121752 much faster.

Release note: None