### PR TITLE
kv: shallow copy {,Reverse}ScanResponse.{BatchResponses,ColBatches} when pipelining

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1358,12 +1358,16 @@ func (crr *RevertRangeResponse) ShallowCopy() Response {
 // ShallowCopy implements the Response interface.
 func (sr *ScanResponse) ShallowCopy() Response {
 	shallowCopy := *sr
+	shallowCopy.BatchResponses = append([][]byte(nil), sr.BatchResponses...)
+	shallowCopy.ColBatches.ColBatches = append([]coldata.Batch(nil), sr.ColBatches.ColBatches...)
 	return &shallowCopy
 }
 
 // ShallowCopy implements the Response interface.
 func (rsr *ReverseScanResponse) ShallowCopy() Response {
 	shallowCopy := *rsr
+	shallowCopy.BatchResponses = append([][]byte(nil), rsr.BatchResponses...)
+	shallowCopy.ColBatches.ColBatches = append([]coldata.Batch(nil), rsr.ColBatches.ColBatches...)
 	return &shallowCopy
 }
 


### PR DESCRIPTION
Fixes #121759.

This commit updates ScanResponse and ReverseScanResponse's ShallowCopy implementations to perform a shallow copy of the BatchResponses and ColBatches slices. These are both slices of data array slices which can be mutated by `popBatch`, even though the underlying data slices are immutable.

Release note: None