### PR TITLE
backupccl: remove unnecessary call to `skip.WithIssue()`

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9171,8 +9171,6 @@ func TestRestorePauseOnError(t *testing.T) {
 
 	defer jobs.TestingSetProgressThresholds()()
 
-	skip.WithIssue(t, 121336)
-
 	baseDir := "testdata"
 	args := base.TestServerArgs{
 		ExternalIODir: baseDir,


### PR DESCRIPTION
There are two here from two PR's that skipped the same test at around the same time (#121484 and #121494)

Epic: none
Release note: None