### PR TITLE
stop: avoid logging race in Stopper.Quiesce

### DIFF
--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/util/log/logcrash",
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
Fixes #119844.

This commit avoids a race where the log message "quiescing..." is logged after the call to `Stopper.Quiesce` has already returned and the tracing span in the provided context has already been finished. It does so by moving the logging calls from inside AfterFunc closures to inside the quiesce loop.

I have not been able to reproduce the issue in #119844 with the current logic, but can reproduce the panic with the following diff, which makes the hypothesized race condition much more likely:
```go
diff --git a/pkg/util/stop/stopper.go b/pkg/util/stop/stopper.go
index f375e5a0dca..60f21062edc 100644
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -573,7 +573,8 @@ func (s *Stopper) IsStopped() <-chan struct{} {
 // Quiesce moves the stopper to state quiescing and waits until all
 // tasks complete. This is used from Stop() and unittests.
 func (s *Stopper) Quiesce(ctx context.Context) {
-       defer time.AfterFunc(5*time.Second, func() {
+       defer time.AfterFunc(1*time.Millisecond, func() {
+               time.Sleep(1 * time.Second)
                log.Infof(ctx, "quiescing...")
        }).Stop()
        defer time.AfterFunc(2*time.Minute, func() {
```

I'm still not sure why ptstorage.TestStorage is so good at hitting this race. Maybe it occasionally takes a long time to quiesce, triggering the AfterFunc timer. The `skip.UnderStressRace` also implies that it puts a lot of stress on the CI runner.

Release note: None