### PR TITLE
release-23.2: backupccl: add backup.restore_span.max_file_count cluster setting

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -97,6 +97,7 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 												nil,
 												introducedSpanFrontier,
 												0,
+												defaultMaxFileCount,
 												false)
 											require.NoError(b, err)
 

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -469,6 +469,7 @@ func runGenerativeSplitAndScatter(
 			spec.HighWater,
 			introducedSpanFrontier,
 			spec.TargetSize,
+			spec.MaxFileCount,
 			spec.UseFrontierCheckpointing)
 		if err != nil {
 			return errors.Wrap(err, "failed to make span covering filter")

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -327,6 +327,7 @@ func restore(
 			job.Progress().Details.(*jobspb.Progress_Restore).Restore.HighWater,
 			introducedSpanFrontier,
 			targetRestoreSpanSize.Get(&execCtx.ExecCfg().Settings.SV),
+			maxFileCount.Get(&execCtx.ExecCfg().Settings.SV),
 			progressTracker.useFrontier)
 	}(); err != nil {
 		return roachpb.RowCount{}, err

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -184,6 +184,7 @@ func distRestore(
 			HighWater:                md.spanFilter.highWaterMark,
 			UserProto:                execCtx.User().EncodeProto(),
 			TargetSize:               md.spanFilter.targetSize,
+			MaxFileCount:             int64(md.spanFilter.maxFileCount),
 			ChunkSize:                int64(chunkSize),
 			NumEntries:               int64(md.numImportSpans),
 			NumNodes:                 int64(numNodes),

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -57,6 +57,16 @@ var targetRestoreSpanSize = settings.RegisterByteSizeSetting(
 	384<<20,
 )
 
+var maxFileCount = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"backup.restore_span.max_file_count",
+	"the maximum number of backup files an extending restore span may contain",
+	defaultMaxFileCount,
+	settings.PositiveInt,
+)
+
+const defaultMaxFileCount = 200
+
 // backupManifestFileIterator exposes methods that can be used to iterate over
 // the `BackupManifest_Files` field of a manifest.
 type backupManifestFileIterator interface {
@@ -132,6 +142,7 @@ type spanCoveringFilter struct {
 	introducedSpanFrontier   *spanUtils.Frontier
 	useFrontierCheckpointing bool
 	targetSize               int64
+	maxFileCount             int
 }
 
 func makeSpanCoveringFilter(
@@ -140,15 +151,24 @@ func makeSpanCoveringFilter(
 	highWater roachpb.Key,
 	introducedSpanFrontier *spanUtils.Frontier,
 	targetSize int64,
+	maxFileCount int64,
 	useFrontierCheckpointing bool,
 ) (spanCoveringFilter, error) {
 	f, err := loadCheckpointFrontier(requiredSpans, checkpointedSpans)
 	if err != nil {
 		return spanCoveringFilter{}, err
 	}
+	if maxFileCount == 0 {
+		// A 0 valued maxFileCount may get passed in a mixed version cluster:
+		// specifically, when the job coordinator is on an older version and the
+		// generative split and scatter processor is on a newer version. In this
+		// case, ensure the maxFileCount is set to default.
+		maxFileCount = defaultMaxFileCount
+	}
 	sh := spanCoveringFilter{
 		introducedSpanFrontier:   introducedSpanFrontier,
 		targetSize:               targetSize,
+		maxFileCount:             int(maxFileCount),
 		highWaterMark:            highWater,
 		useFrontierCheckpointing: useFrontierCheckpointing,
 		checkpointFrontier:       f,
@@ -417,12 +437,12 @@ func generateAndSendImportSpans(
 					lastCovSpanCount = newCovFilesCount
 				} else {
 					// We have room to add to the last span if doing so would remain below
-					// both the target byte size and 200 total files. We limit the number
+					// both the target byte size and maxFileCount total files. We limit the number
 					// of files since we default to running multiple concurrent workers so
 					// we want to bound sum total open files across all of them to <= 1k.
 					// We bound the span byte size to improve work distribution and make
 					// the progress more granular.
-					fits := lastCovSpanSize+newCovFilesSize <= filter.targetSize && lastCovSpanCount+newCovFilesCount <= 200
+					fits := lastCovSpanSize+newCovFilesSize <= filter.targetSize && lastCovSpanCount+newCovFilesCount <= filter.maxFileCount
 
 					if (newCovFilesCount == 0 || fits) && !firstInSpan {
 						// If there are no new files that cover this span or if we can add the

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -292,6 +292,7 @@ func makeImportSpans(
 		highWaterMark,
 		introducedSpanFrontier,
 		targetSize,
+		defaultMaxFileCount,
 		highWaterMark == nil)
 	if err != nil {
 		return nil, err
@@ -685,6 +686,7 @@ func TestCheckpointFilter(t *testing.T) {
 			nil,
 			nil,
 			0,
+			defaultMaxFileCount,
 			true)
 		require.NoError(t, err)
 		require.Equal(t, tc.expectedToDoSpans, f.filterCompleted(requiredSpan))

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -368,11 +368,9 @@ func registerRestore(r registry.Registry) {
 			// The weekly 32TB, 400 incremental layer Restore test on AWS.
 			//
 			// NB: Prior to 23.1, restore would OOM on backups that had many
-			// incremental layers and many import spans. This test disables span
-			// target size so restore can process the maximum number of import
-			// spans. Together with having a 400 incremental chain, this
-			// regression tests against the OOMs that we've seen in previous
-			// versions.
+			// incremental layers and many import spans. Together with having a 400
+			// incremental chain, this regression tests against the OOMs that we've
+			// seen in previous versions.
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 15, cpus: 16, volumeSize: 5000,
 				ebsThroughput: 250 /* MB/s */}),
 			backup: makeRestoringBackupSpecs(backupSpecs{
@@ -383,7 +381,7 @@ func registerRestore(r registry.Registry) {
 			timeout: 30 * time.Hour,
 			suites:  registry.Suites(registry.Weekly),
 			setUpStmts: []string{
-				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
+				`SET CLUSTER SETTING backup.restore_span.max_file_count = 800`,
 			},
 			restoreUptoIncremental: 400,
 		},

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -444,7 +444,8 @@ message GenerativeSplitAndScatterSpec {
   optional int64 job_id = 18 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID"];
   optional bool use_frontier_checkpointing = 20 [(gogoproto.nullable) = false];
   repeated jobs.jobspb.RestoreProgress.FrontierEntry checkpointed_spans = 21 [(gogoproto.nullable) = false];
-
+  // MaxFileCount is the max number of files in an extending restore span entry.
+  optional int64 max_file_count = 22 [(gogoproto.nullable) = false];
   reserved 19;
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #120845.

/cc @cockroachdb/release

---

As of #119840, restore limits the number of files to an extending restore span entry to 200. When this file cap is less than the number of inc layers, restore slows signficantly, as the restore span entries become much smaller. This patch introduces a cluster setting which allows the user to raise this file cap.

Informs: #120186

Release note: none

Release justification: introduces a workaround for the significat perf regression introduced by #119840 for restores from an incremental backup of more than 200 layers.
