### PR TITLE
sem/tree: avoid an allocation when converting DInt to Oid

### DIFF
--- a/pkg/sql/opt/partition/BUILD.bazel
+++ b/pkg/sql/opt/partition/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/intsets",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_lib_pq//oid",
     ],
 )
 

--- a/pkg/sql/opt/partition/testutils.go
+++ b/pkg/sql/opt/partition/testutils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 // ParseDatumPath parses a span key string like "/1/2/3".
@@ -57,7 +58,9 @@ func ParseDatumPath(evalCtx *eval.Context, str string, typs []types.Family) []tr
 			var dInt *tree.DInt
 			dInt, err = tree.ParseDInt(valStr)
 			if err == nil {
-				val, err = tree.IntToOid(*dInt)
+				var o oid.Oid
+				o, err = tree.IntToOid(*dInt)
+				val = tree.NewDOid(o)
 			}
 		case types.UuidFamily:
 			val, err = tree.ParseDUuidFromString(valStr)

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -1004,11 +1004,10 @@ func performIntToOidCast(
 	// OIDs are always unsigned 32-bit integers. Some languages, like Java,
 	// store OIDs as signed 32-bit integers, so we implement the cast
 	// by converting to a uint32 first. This matches Postgres behavior.
-	dOid, err := tree.IntToOid(v)
+	o, err := tree.IntToOid(v)
 	if err != nil {
 		return nil, err
 	}
-	o := dOid.Oid
 	switch t.Oid() {
 	case oid.T_oid:
 		return tree.NewDOidWithType(o, t), nil

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -412,8 +412,8 @@ func (expr *NumVal) ResolveAsType(
 		if err != nil {
 			return nil, err
 		}
-		dInt := MustBeDInt(d)
-		return IntToOid(dInt)
+		o, err := IntToOid(MustBeDInt(d))
+		return NewDOid(o), err
 	default:
 		return nil, errors.AssertionFailedf("could not resolve %T %v into a %s", expr, expr, typ.SQLStringForError())
 	}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -765,7 +765,7 @@ func (d *DInt) CompareError(ctx CompareContext, other Datum) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		thisInt = DInt(o.Oid)
+		thisInt = DInt(o)
 		v = DInt(t.Oid)
 	default:
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -5545,15 +5545,15 @@ type DOid struct {
 	name string
 }
 
-// IntToOid is a helper that turns a DInt into a *DOid and checks that the value
-// is in range.
-func IntToOid(i DInt) (*DOid, error) {
+// IntToOid is a helper that turns a DInt into an oid.Oid and checks that the
+// value is in range.
+func IntToOid(i DInt) (oid.Oid, error) {
 	if intIsOutOfOIDRange(i) {
-		return nil, pgerror.Newf(
+		return 0, pgerror.Newf(
 			pgcode.NumericValueOutOfRange, "OID out of range: %d", i,
 		)
 	}
-	return NewDOid(oid.Oid(i)), nil
+	return oid.Oid(i), nil
 }
 
 func intIsOutOfOIDRange(i DInt) bool {
@@ -5653,11 +5653,11 @@ func (d *DOid) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// OIDs are always unsigned 32-bit integers. Some languages, like Java,
 		// compare OIDs to signed 32-bit integers, so we implement the comparison
 		// by converting to a uint32 first. This matches Postgres behavior.
-		o, err := IntToOid(*t)
+		var err error
+		v, err = IntToOid(*t)
 		if err != nil {
 			return 0, err
 		}
-		v = o.Oid
 	default:
 		return 0, makeUnsupportedComparisonMessage(d, other)
 	}

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/lib/pq/oid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -179,4 +180,20 @@ func (fcc *testTimestampCompareContext) GetLocation() *time.Location {
 
 func (fcc *testTimestampCompareContext) UnwrapDatum(d Datum) Datum {
 	return d
+}
+
+func BenchmarkDatumCompare(b *testing.B) {
+	compareCtx := &testTimestampCompareContext{}
+	for _, tc := range []struct {
+		name     string
+		d, other Datum
+	}{
+		{name: "DIntToDOid", d: DZero, other: NewDOid(oid.Oid(0))},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = tc.d.CompareError(compareCtx, tc.other)
+			}
+		})
+	}
 }

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -141,7 +141,8 @@ func ParseDOidAsInt(s string) (*DOid, error) {
 	if err != nil {
 		return nil, MakeParseError(s, types.Oid, err)
 	}
-	return IntToOid(DInt(i))
+	o, err := IntToOid(DInt(i))
+	return NewDOid(o), err
 }
 
 // FormatBitArrayToType formats bit arrays such that they fill the total width


### PR DESCRIPTION
This commit adjusts `IntToOid` helper to return `oid.Oid` instead of `*DOid` since some callers don't need the full datum. I observed one such caller to drive the most number of allocations on a cluster with 100k tables (62% of all allocations).
```
name                        old time/op    new time/op    delta
DatumCompare/DIntToDOid-10    24.8ns ± 1%     3.8ns ± 1%   -84.59%  (p=0.000 n=9+10)

name                        old alloc/op   new alloc/op   delta
DatumCompare/DIntToDOid-10     32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
DatumCompare/DIntToDOid-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

Epic: None

Release note: None