### PR TITLE
changefeedccl: fix memory leak in deprecatedGcpPubsubClient

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -2248,7 +2248,8 @@ func (p *deprecatedFakePubsubClient) init() error {
 	return nil
 }
 
-func (p *deprecatedFakePubsubClient) closeTopics() {
+func (p *deprecatedFakePubsubClient) close() error {
+	return nil
 }
 
 // sendMessage sends a message to the topic


### PR DESCRIPTION
Previously, `deprecatedGcpPubsubClient` did not close `pubsub.Client` properly
which could lead to memory leaks. This patch fixes the problem by invoking
`pubsub.Client.Close()` during `deprecatedGcpPubsubClient.Close()`.

Epic: none
Release note: Fixed a slow memory leak in deprecated pubsub changefeeds which
can accumulate when restarting/cancelling many deprecated pubsub changefeeds.
The bug had been there since the deprecated pubsub was introduced in 22.1
(beta).