### PR TITLE
release-24.1: roachprod: create load balancer (gcloud)

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -365,7 +365,7 @@ func initFlags() {
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -369,7 +369,7 @@ func initFlags() {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}
-	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, jaegerStartCmd} {
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, loadBalanceCmd, jaegerStartCmd} {
 		cmd.Flags().StringVar(&virtualClusterName,
 			"cluster", "", "specific virtual cluster to connect to")
 		cmd.Flags().IntVar(&sqlInstance,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -468,6 +468,30 @@ destroyed:
 	}),
 }
 
+var loadBalanceCmd = &cobra.Command{
+	Use:   "load-balance <cluster> [virtual-cluster-name]",
+	Short: "create a load balancer for a cluster",
+	Long: `Create a load balancer for a specific service (port), system by default, for the given cluster.
+
+The load balancer is created using the cloud provider's load balancer service.
+Currently only Google Cloud is supported, and the cluster must have been created
+with the --gce-managed flag. On Google Cloud a load balancer consists of various
+components that include backend services, health checks and forwarding rules.
+These resources will automatically be destroyed when the cluster is destroyed.
+`,
+
+	Args: cobra.RangeArgs(1, 2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		serviceName := install.SystemInterfaceName
+		if len(args) == 2 {
+			serviceName = args[1]
+		}
+		return roachprod.CreateLoadBalancer(context.Background(), config.Logger,
+			args[0], secure, serviceName, sqlInstance,
+		)
+	}),
+}
+
 const tagHelp = `
 The --tag flag can be used to to associate a tag with the process. This tag can
 then be used to restrict the processes which are operated on by the status and
@@ -552,7 +576,7 @@ SIGHUP), unless you also configure --max-wait.
 }
 
 var startInstanceCmd = &cobra.Command{
-	Use:   "start-sql <name> --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes]",
+	Use:   "start-sql <name> --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes>]",
 	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
 	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
@@ -1526,6 +1550,7 @@ func main() {
 		resetCmd,
 		destroyCmd,
 		extendCmd,
+		loadBalanceCmd,
 		listCmd,
 		syncCmd,
 		gcCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -469,7 +469,7 @@ destroyed:
 }
 
 var loadBalanceCmd = &cobra.Command{
-	Use:   "load-balance <cluster> [virtual-cluster-name]",
+	Use:   "load-balance <cluster>",
 	Short: "create a load balancer for a cluster",
 	Long: `Create a load balancer for a specific service (port), system by default, for the given cluster.
 
@@ -480,14 +480,10 @@ components that include backend services, health checks and forwarding rules.
 These resources will automatically be destroyed when the cluster is destroyed.
 `,
 
-	Args: cobra.RangeArgs(1, 2),
+	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		serviceName := install.SystemInterfaceName
-		if len(args) == 2 {
-			serviceName = args[1]
-		}
 		return roachprod.CreateLoadBalancer(context.Background(), config.Logger,
-			args[0], secure, serviceName, sqlInstance,
+			args[0], secure, virtualClusterName, sqlInstance,
 		)
 	}),
 }

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -32,5 +32,6 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@org_golang_x_sys//unix",
     ],
 )

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1620,7 +1620,7 @@ func (c *SyncedCluster) DistributeCerts(ctx context.Context, l *logger.Logger) e
 		return nil
 	}
 
-	nodeNames, err := c.createNodeCertArguments()
+	nodeNames, err := c.createNodeCertArguments(l)
 	if err != nil {
 		return err
 	}
@@ -1666,6 +1666,46 @@ tar cvf %[5]s %[2]s
 	return c.distributeLocalCertsTar(ctx, l, tarfile, nodes, 0)
 }
 
+// RedistributeNodeCert will generate a new node cert to capture any new hosts
+// and distribute the updated certificate to all the nodes.
+func (c *SyncedCluster) RedistributeNodeCert(ctx context.Context, l *logger.Logger) error {
+	nodeNames, err := c.createNodeCertArguments(l)
+	if err != nil {
+		return err
+	}
+
+	// Generate only the node certificate on the first node.
+	display := fmt.Sprintf("%s: initializing node cert", c.Name)
+	if err := c.Parallel(ctx, l, WithNodes(c.Nodes[0:1]).WithDisplay(display),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			var cmd string
+			if c.IsLocal() {
+				cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
+			}
+			cmd += fmt.Sprintf(`
+rm -fr %[2]s/node*
+mkdir -p %[2]s
+%[1]s cert create-node %[4]s --certs-dir=%[2]s --ca-key=%[2]s/ca.key
+tar cvf %[5]s %[2]s
+`, cockroachNodeBinary(c, 1), CockroachNodeCertsDir, DefaultUser, strings.Join(nodeNames, " "), certsTarName)
+
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("redist-node-cert"))
+		},
+	); err != nil {
+		return err
+	}
+
+	tarfile, cleanup, err := c.getFileFromFirstNode(ctx, l, certsTarName)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	// Skip the first node which is where we generated the certs.
+	nodes := allNodes(len(c.VMs))[1:]
+	return c.distributeLocalCertsTar(ctx, l, tarfile, nodes, 0)
+}
+
 // DistributeTenantCerts will generate and distribute certificates to all of the
 // nodes, using the host cluster to generate tenant certificates.
 func (c *SyncedCluster) DistributeTenantCerts(
@@ -1679,7 +1719,7 @@ func (c *SyncedCluster) DistributeTenantCerts(
 		return errors.New("host cluster missing certificate bundle")
 	}
 
-	nodeNames, err := c.createNodeCertArguments()
+	nodeNames, err := c.createNodeCertArguments(l)
 	if err != nil {
 		return err
 	}
@@ -1819,7 +1859,9 @@ func (c *SyncedCluster) fileExistsOnFirstNode(
 
 // createNodeCertArguments returns a list of strings appropriate for use as
 // SubjectAlternativeName arguments to the ./cockroach cert create-node command.
-func (c *SyncedCluster) createNodeCertArguments() ([]string, error) {
+// It gathers all the internal and external IP addresses and hostnames for every
+// node in the cluster, and finally any load balancer IPs.
+func (c *SyncedCluster) createNodeCertArguments(l *logger.Logger) ([]string, error) {
 	nodeNames := []string{"localhost"}
 	if c.IsLocal() {
 		// For local clusters, we only need to add one of the VM IP addresses.
@@ -1841,7 +1883,14 @@ func (c *SyncedCluster) createNodeCertArguments() ([]string, error) {
 			nodeNames = append(nodeNames, "ip-"+strings.ReplaceAll(ip, ".", "-"))
 		}
 	}
-
+	// Add any load balancers IPs to the list of names.
+	lbAddresses, err := c.ListLoadBalancers(l)
+	if err != nil {
+		return nil, err
+	}
+	for _, lb := range lbAddresses {
+		nodeNames = append(nodeNames, lb.IP)
+	}
 	return nodeNames, nil
 }
 

--- a/pkg/roachprod/install/services.go
+++ b/pkg/roachprod/install/services.go
@@ -246,6 +246,23 @@ func (c *SyncedCluster) DiscoverService(
 	return services[0], err
 }
 
+// ListLoadBalancers returns a list of load balancers from all providers, for
+// the cluster.
+func (c *SyncedCluster) ListLoadBalancers(l *logger.Logger) ([]vm.ServiceAddress, error) {
+	lock := syncutil.Mutex{}
+	allAddresses := make([]vm.ServiceAddress, 0)
+	err := vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
+		addresses, listErr := provider.ListLoadBalancers(l, vms)
+		if listErr != nil {
+			return listErr
+		}
+		defer lock.Lock()
+		allAddresses = append(allAddresses, addresses...)
+		return nil
+	})
+	return allAddresses, err
+}
+
 // MapServices discovers all service types for a given virtual cluster
 // and instance and maps it by node and service type.
 func (c *SyncedCluster) MapServices(

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"golang.org/x/sys/unix"
 )
 
 // verifyClusterName ensures that the given name conforms to
@@ -2430,32 +2431,17 @@ func CreateLoadBalancer(
 	}
 
 	// Find the SQL ports for the service on all nodes.
-	services, err := c.DiscoverServices(
-		ctx, virtualClusterName, install.ServiceTypeSQL,
-		install.ServiceNodePredicate(c.TargetNodes()...), install.ServiceInstancePredicate(sqlInstance),
-	)
+	serviceDesc, err := c.DiscoverService(ctx, c.TargetNodes()[0], virtualClusterName, install.ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return err
-	}
-	if len(services) == 0 {
-		return errors.Errorf("%s SQL service not found on cluster %s, start a service first.", virtualClusterName, clusterName)
-	}
-
-	// Confirm that the service has the same port on all nodes.
-	port := services[0].Port
-	for _, service := range services[1:] {
-		if port != service.Port {
-			return errors.Errorf("service %s must share the same port on all nodes, different ports found %d and %d",
-				virtualClusterName, port, service.Port)
-		}
 	}
 
 	// Create a load balancer for the service's port.
 	err = vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
-		createErr := provider.CreateLoadBalancer(l, vms, port)
+		createErr := provider.CreateLoadBalancer(l, vms, serviceDesc.Port)
 		if createErr != nil {
 			l.Errorf("Cleaning up partially-created load balancer (prev err: %s)", createErr)
-			cleanupErr := provider.DeleteLoadBalancer(l, vms, port)
+			cleanupErr := provider.DeleteLoadBalancer(l, vms, serviceDesc.Port)
 			if cleanupErr != nil {
 				l.Errorf("Error while cleaning up partially-created load balancer: %s", cleanupErr)
 			} else {
@@ -2467,6 +2453,20 @@ func CreateLoadBalancer(
 	})
 	if err != nil {
 		return err
+	}
+
+	// For secure clusters, the load balancer IP needs to be added to the
+	// cluster's certificate.
+	if secure {
+		err = c.RedistributeNodeCert(ctx, l)
+		if err != nil {
+			return err
+		}
+		// Send a SIGHUP to the nodes to reload the certificates.
+		err = c.Signal(ctx, l, int(unix.SIGHUP))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2430,18 +2430,41 @@ func CreateLoadBalancer(
 		return err
 	}
 
+	// If virtualClusterName is not provided, use the system interface name.
+	if virtualClusterName == "" {
+		virtualClusterName = install.SystemInterfaceName
+	}
+
 	// Find the SQL ports for the service on all nodes.
-	serviceDesc, err := c.DiscoverService(ctx, c.TargetNodes()[0], virtualClusterName, install.ServiceTypeSQL, sqlInstance)
+	services, err := c.DiscoverServices(
+		ctx, virtualClusterName, install.ServiceTypeSQL,
+		install.ServiceNodePredicate(c.TargetNodes()...), install.ServiceInstancePredicate(sqlInstance),
+	)
 	if err != nil {
 		return err
 	}
 
+	port := config.DefaultSQLPort
+	if len(services) == 0 {
+		l.Errorf("WARNING: %s SQL service not found on cluster %s, using default SQL port %d",
+			virtualClusterName, clusterName, port)
+	} else {
+		port = services[0].Port
+		// Confirm that the service has the same port on all nodes.
+		for _, service := range services[1:] {
+			if port != service.Port {
+				return errors.Errorf("service %s must share the same port on all nodes, different ports found %d and %d",
+					virtualClusterName, port, service.Port)
+			}
+		}
+	}
+
 	// Create a load balancer for the service's port.
 	err = vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
-		createErr := provider.CreateLoadBalancer(l, vms, serviceDesc.Port)
+		createErr := provider.CreateLoadBalancer(l, vms, port)
 		if createErr != nil {
 			l.Errorf("Cleaning up partially-created load balancer (prev err: %s)", createErr)
-			cleanupErr := provider.DeleteLoadBalancer(l, vms, serviceDesc.Port)
+			cleanupErr := provider.DeleteLoadBalancer(l, vms, port)
 			if cleanupErr != nil {
 				l.Errorf("Error while cleaning up partially-created load balancer: %s", cleanupErr)
 			} else {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2451,9 +2451,24 @@ func CreateLoadBalancer(
 	}
 
 	// Create a load balancer for the service's port.
-	return vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
-		return provider.CreateLoadBalancer(l, vms, port)
+	err = vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
+		createErr := provider.CreateLoadBalancer(l, vms, port)
+		if createErr != nil {
+			l.Errorf("Cleaning up partially-created load balancer (prev err: %s)", createErr)
+			cleanupErr := provider.DeleteLoadBalancer(l, vms, port)
+			if cleanupErr != nil {
+				l.Errorf("Error while cleaning up partially-created load balancer: %s", cleanupErr)
+			} else {
+				l.Printf("Cleaned up partially-created load balancer")
+			}
+			return errors.CombineErrors(createErr, cleanupErr)
+		}
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func getCluster(l *logger.Logger, clusterName string) (*cloud.Cluster, error) {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2411,6 +2411,51 @@ func createAttachMountVolumes(
 	return nil
 }
 
+// CreateLoadBalancer creates a load balancer for the SQL service on the given
+// cluster. Currently only supports GCE.
+func CreateLoadBalancer(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	secure bool,
+	virtualClusterName string,
+	sqlInstance int,
+) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName, install.SecureOption(secure))
+	if err != nil {
+		return err
+	}
+
+	// Find the SQL ports for the service on all nodes.
+	services, err := c.DiscoverServices(
+		ctx, virtualClusterName, install.ServiceTypeSQL,
+		install.ServiceNodePredicate(c.TargetNodes()...), install.ServiceInstancePredicate(sqlInstance),
+	)
+	if err != nil {
+		return err
+	}
+	if len(services) == 0 {
+		return errors.Errorf("%s SQL service not found on cluster %s, start a service first.", virtualClusterName, clusterName)
+	}
+
+	// Confirm that the service has the same port on all nodes.
+	port := services[0].Port
+	for _, service := range services[1:] {
+		if port != service.Port {
+			return errors.Errorf("service %s must share the same port on all nodes, different ports found %d and %d",
+				virtualClusterName, port, service.Port)
+		}
+	}
+
+	// Create a load balancer for the service's port.
+	return vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
+		return provider.CreateLoadBalancer(l, vms, port)
+	})
+}
+
 func getCluster(l *logger.Logger, clusterName string) (*cloud.Cluster, error) {
 	// ListCloud may fail due to a transient provider error, but
 	// we may have still found the cluster we care about. It will

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1614,3 +1614,7 @@ func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.Volum
 func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
+
+func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1618,3 +1618,8 @@ func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
+
+func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	// This Provider has no concept of load balancers yet, return an empty list.
+	return nil, nil
+}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1610,3 +1610,7 @@ func (p *Provider) ListVolumeSnapshots(
 func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.VolumeSnapshot) error {
 	panic("unimplemented")
 }
+
+func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -143,6 +143,10 @@ func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -151,6 +151,11 @@ func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	// This Provider has no concept of load balancers yet, return an empty list.
+	return nil, nil
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -147,6 +147,10 @@ func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -74,6 +74,10 @@ func (p *provider) AttachVolume(*logger.Logger, vm.Volume, *vm.VM) (string, erro
 	return "", errors.Newf("%s", p.unimplemented)
 }
 
+func (p *provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // CleanSSH implements vm.Provider and is a no-op.
 func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -78,6 +78,10 @@ func (p *provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // CleanSSH implements vm.Provider and is a no-op.
 func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -82,6 +82,10 @@ func (p *provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	return nil, nil
+}
+
 // CleanSSH implements vm.Provider and is a no-op.
 func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1544,6 +1544,223 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	return propagateDiskLabels(l, project, labelsJoined, zoneToHostNames, len(vms[0].LocalDisks) != 0)
 }
 
+type jsonBackendService struct {
+	Name     string `json:"name"`
+	Backends []struct {
+		Group string `json:"group"`
+	} `json:"backends"`
+	HealthChecks []string `json:"healthChecks"`
+	SelfLink     string   `json:"selfLink"`
+}
+
+func listBackendServices(project string) ([]jsonBackendService, error) {
+	args := []string{"compute", "backend-services", "list", "--project", project, "--format", "json"}
+	var backends []jsonBackendService
+	if err := runJSONCommand(args, &backends); err != nil {
+		return nil, err
+	}
+	return backends, nil
+}
+
+type jsonForwardingRule struct {
+	Name     string `json:"name"`
+	SelfLink string `json:"selfLink"`
+	Target   string `json:"target"`
+}
+
+func listForwardingRules(project string) ([]jsonForwardingRule, error) {
+	args := []string{"compute", "forwarding-rules", "list", "--project", project, "--format", "json"}
+	var rules []jsonForwardingRule
+	if err := runJSONCommand(args, &rules); err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
+type jsonTargetTCPProxy struct {
+	Name     string `json:"name"`
+	SelfLink string `json:"selfLink"`
+	Service  string `json:"service"`
+}
+
+func listTargetTCPProxies(project string) ([]jsonTargetTCPProxy, error) {
+	args := []string{"compute", "target-tcp-proxies", "list", "--project", project, "--format", "json"}
+	var proxies []jsonTargetTCPProxy
+	if err := runJSONCommand(args, &proxies); err != nil {
+		return nil, err
+	}
+	return proxies, nil
+}
+
+type jsonHealthCheck struct {
+	Name     string `json:"name"`
+	SelfLink string `json:"selfLink"`
+}
+
+func listHealthChecks(project string) ([]jsonHealthCheck, error) {
+	args := []string{"compute", "health-checks", "list", "--project", project, "--format", "json"}
+	var checks []jsonHealthCheck
+	if err := runJSONCommand(args, &checks); err != nil {
+		return nil, err
+	}
+	return checks, nil
+}
+
+// deleteLoadBalancerResources deletes all load balancer resources associated
+// with a given cluster and project. This function does not return an error if
+// the resources do not exist. Multiple load balancers can be associated with a
+// single cluster, so we need to delete all of them. Health checks associated
+// with the cluster are also deleted.
+func deleteLoadBalancerResources(project, clusterName string) error {
+	// List all the components of the load balancer resources tied to the cluster.
+	services, err := listBackendServices(project)
+	if err != nil {
+		return err
+	}
+	filteredServices := make([]jsonBackendService, 0)
+	// Find all backend services tied to the managed instance group.
+	for _, service := range services {
+		for _, backend := range service.Backends {
+			if strings.HasSuffix(backend.Group, fmt.Sprintf("instanceGroups/%s", instanceGroupName(clusterName))) {
+				filteredServices = append(filteredServices, service)
+				break
+			}
+		}
+	}
+	proxies, err := listTargetTCPProxies(project)
+	if err != nil {
+		return err
+	}
+	filteredProxies := make([]jsonTargetTCPProxy, 0)
+	for _, proxy := range proxies {
+		for _, service := range filteredServices {
+			if proxy.Service == service.SelfLink {
+				filteredProxies = append(filteredProxies, proxy)
+				break
+			}
+		}
+	}
+	rules, err := listForwardingRules(project)
+	if err != nil {
+		return err
+	}
+	filteredForwardingRules := make([]jsonForwardingRule, 0)
+	for _, rule := range rules {
+		for _, proxy := range filteredProxies {
+			if rule.Target == proxy.SelfLink {
+				filteredForwardingRules = append(filteredForwardingRules, rule)
+			}
+		}
+	}
+	healthChecks, err := listHealthChecks(project)
+	if err != nil {
+		return err
+	}
+	filteredHealthChecks := make([]jsonHealthCheck, 0)
+	for _, healthCheck := range healthChecks {
+		cluster, resourceType, _, ok := loadBalancerNameParts(healthCheck.Name)
+		if !ok {
+			continue
+		}
+		if cluster == clusterName && resourceType == "health-check" {
+			filteredHealthChecks = append(filteredHealthChecks, healthCheck)
+		}
+	}
+
+	// Delete all the components of the load balancer.
+	var g errgroup.Group
+	for _, rule := range filteredForwardingRules {
+		args := []string{"compute", "forwarding-rules", "delete",
+			rule.Name,
+			"--global",
+			"--quiet",
+			"--project", project,
+		}
+		g.Go(func() error {
+			cmd := exec.Command("gcloud", args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+			}
+			return nil
+		})
+	}
+	if err = g.Wait(); err != nil {
+		return err
+	}
+	g = errgroup.Group{}
+	for _, proxy := range filteredProxies {
+		args := []string{"compute", "target-tcp-proxies", "delete",
+			proxy.Name,
+			"--quiet",
+			"--project", project,
+		}
+		g.Go(func() error {
+			cmd := exec.Command("gcloud", args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+			}
+			return nil
+		})
+	}
+	if err = g.Wait(); err != nil {
+		return err
+	}
+	g = errgroup.Group{}
+	for _, service := range filteredServices {
+		args := []string{"compute", "backend-services", "delete",
+			service.Name,
+			"--global",
+			"--quiet",
+			"--project", project,
+		}
+		g.Go(func() error {
+			cmd := exec.Command("gcloud", args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+			}
+			return nil
+		})
+	}
+	if err = g.Wait(); err != nil {
+		return err
+	}
+	g = errgroup.Group{}
+	for _, healthCheck := range filteredHealthChecks {
+		args := []string{"compute", "health-checks", "delete",
+			healthCheck.Name,
+			"--quiet",
+			"--project", project,
+		}
+		g.Go(func() error {
+			cmd := exec.Command("gcloud", args...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// loadBalancerNameParts returns the cluster name, resource type, and port of a
+// load balancer resource name. The resource type is the type of resource, e.g.
+// "health-check", "load-balancer", "proxy".
+func loadBalancerNameParts(name string) (cluster string, resourceType string, port int, ok bool) {
+	regex := regexp.MustCompile(`^([a-z0-9\-]+)-(\d+)-([a-z0-9\-]+)-roachprod$`)
+	match := regex.FindStringSubmatch(name)
+	if match != nil {
+		cluster = match[1]
+		port, _ = strconv.Atoi(match[2])
+		resourceType = match[3]
+		return cluster, resourceType, port, true
+	}
+	return "", "", 0, false
+}
+
 // loadBalancerResourceName returns the name of a load balancer resource. The
 // port is used instead of a service name in order to be able to identify
 // different parts of the name, since we have limited delimiter options.
@@ -1858,6 +2075,14 @@ func (p *Provider) deleteManaged(l *logger.Logger, vms vm.List) error {
 
 	var g errgroup.Group
 	for cluster, project := range clusterProjectMap {
+		cluster, project := cluster, project // capture loop variables
+		// Delete any load balancer resources associated with the cluster. Trying to
+		// delete the instance group before the load balancer resources will result
+		// in an error.
+		err := deleteLoadBalancerResources(project, cluster)
+		if err != nil {
+			return err
+		}
 		// Multiple instance groups can exist for a single cluster, one for each zone.
 		projectGroups, err := listManagedInstanceGroups(project, instanceGroupName(cluster))
 		if err != nil {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1912,6 +1912,37 @@ func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) e
 	return g.Wait()
 }
 
+// ListLoadBalancers returns the list of load balancers associated with the
+// given VMs. The VMs have to be part of a managed instance group. The load
+// balancers are returned as a list of service addresses.
+func (p *Provider) ListLoadBalancers(_ *logger.Logger, vms vm.List) ([]vm.ServiceAddress, error) {
+	// Only managed instance groups support load balancers.
+	if !isManaged(vms) {
+		return nil, nil
+	}
+	project := vms[0].Project
+	clusterName, err := vms[0].ClusterName()
+	if err != nil {
+		return nil, err
+	}
+	rules, err := listForwardingRules(project)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses := make([]vm.ServiceAddress, 0)
+	for _, rule := range rules {
+		cluster, resourceType, port, ok := loadBalancerNameParts(rule.Name)
+		if !ok {
+			continue
+		}
+		if cluster == clusterName && resourceType == "forwarding-rule" {
+			addresses = append(addresses, vm.ServiceAddress{IP: rule.IPAddress, Port: port})
+		}
+	}
+	return addresses, nil
+}
+
 // Given a machine type, return the allowed number (> 0) of local SSDs, sorted in ascending order.
 // N.B. Only n1, n2, n2d and c2 instances are supported since we don't typically use other instance types.
 // Consult https://cloud.google.com/compute/docs/disks/#local_ssd_machine_type_restrictions for other types of instances.
@@ -2101,11 +2132,10 @@ func (p *Provider) deleteManaged(l *logger.Logger, vms vm.List) error {
 
 	var g errgroup.Group
 	for cluster, project := range clusterProjectMap {
-		cluster, project := cluster, project // capture loop variables
 		// Delete any load balancer resources associated with the cluster. Trying to
 		// delete the instance group before the load balancer resources will result
 		// in an error.
-		err := deleteLoadBalancerResources(project, cluster)
+		err := deleteLoadBalancerResources(project, cluster, "" /* portFilter */)
 		if err != nil {
 			return err
 		}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1563,9 +1563,10 @@ func listBackendServices(project string) ([]jsonBackendService, error) {
 }
 
 type jsonForwardingRule struct {
-	Name     string `json:"name"`
-	SelfLink string `json:"selfLink"`
-	Target   string `json:"target"`
+	Name      string `json:"name"`
+	IPAddress string `json:"IPAddress"`
+	SelfLink  string `json:"selfLink"`
+	Target    string `json:"target"`
 }
 
 func listForwardingRules(project string) ([]jsonForwardingRule, error) {
@@ -1607,11 +1608,24 @@ func listHealthChecks(project string) ([]jsonHealthCheck, error) {
 }
 
 // deleteLoadBalancerResources deletes all load balancer resources associated
-// with a given cluster and project. This function does not return an error if
-// the resources do not exist. Multiple load balancers can be associated with a
-// single cluster, so we need to delete all of them. Health checks associated
-// with the cluster are also deleted.
-func deleteLoadBalancerResources(project, clusterName string) error {
+// with a given cluster and project. If a portFilter is specified only the load
+// balancer resources associated with the specified port will be deleted. This
+// function does not return an error if the resources do not exist. Multiple
+// load balancers can be associated with a single cluster, so we need to delete
+// all of them. Health checks associated with the cluster are also deleted.
+func deleteLoadBalancerResources(project, clusterName, portFilter string) error {
+	// Convenience function to determine if a load balancer resource should be
+	// excluded from deletion.
+	shouldExclude := func(name string, expectedResourceType string) bool {
+		cluster, resourceType, port, ok := loadBalancerNameParts(name)
+		if !ok || cluster != clusterName || resourceType != expectedResourceType {
+			return true
+		}
+		if portFilter != "" && strconv.Itoa(port) != portFilter {
+			return true
+		}
+		return false
+	}
 	// List all the components of the load balancer resources tied to the cluster.
 	services, err := listBackendServices(project)
 	if err != nil {
@@ -1620,6 +1634,9 @@ func deleteLoadBalancerResources(project, clusterName string) error {
 	filteredServices := make([]jsonBackendService, 0)
 	// Find all backend services tied to the managed instance group.
 	for _, service := range services {
+		if shouldExclude(service.Name, "load-balancer") {
+			continue
+		}
 		for _, backend := range service.Backends {
 			if strings.HasSuffix(backend.Group, fmt.Sprintf("instanceGroups/%s", instanceGroupName(clusterName))) {
 				filteredServices = append(filteredServices, service)
@@ -1633,6 +1650,9 @@ func deleteLoadBalancerResources(project, clusterName string) error {
 	}
 	filteredProxies := make([]jsonTargetTCPProxy, 0)
 	for _, proxy := range proxies {
+		if shouldExclude(proxy.Name, "proxy") {
+			continue
+		}
 		for _, service := range filteredServices {
 			if proxy.Service == service.SelfLink {
 				filteredProxies = append(filteredProxies, proxy)
@@ -1658,13 +1678,10 @@ func deleteLoadBalancerResources(project, clusterName string) error {
 	}
 	filteredHealthChecks := make([]jsonHealthCheck, 0)
 	for _, healthCheck := range healthChecks {
-		cluster, resourceType, _, ok := loadBalancerNameParts(healthCheck.Name)
-		if !ok {
+		if shouldExclude(healthCheck.Name, "health-check") {
 			continue
 		}
-		if cluster == clusterName && resourceType == "health-check" {
-			filteredHealthChecks = append(filteredHealthChecks, healthCheck)
-		}
+		filteredHealthChecks = append(filteredHealthChecks, healthCheck)
 	}
 
 	// Delete all the components of the load balancer.
@@ -1744,6 +1761,15 @@ func deleteLoadBalancerResources(project, clusterName string) error {
 		})
 	}
 	return g.Wait()
+}
+
+// DeleteLoadBalancer implements the vm.Provider interface.
+func (p *Provider) DeleteLoadBalancer(_ *logger.Logger, vms vm.List, port int) error {
+	clusterName, err := vms[0].ClusterName()
+	if err != nil {
+		return err
+	}
+	return deleteLoadBalancerResources(vms[0].Project, clusterName, strconv.Itoa(port))
 }
 
 // loadBalancerNameParts returns the cluster name, resource type, and port of a

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1544,6 +1544,131 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	return propagateDiskLabels(l, project, labelsJoined, zoneToHostNames, len(vms[0].LocalDisks) != 0)
 }
 
+// loadBalancerResourceName returns the name of a load balancer resource. The
+// port is used instead of a service name in order to be able to identify
+// different parts of the name, since we have limited delimiter options.
+func loadBalancerResourceName(clusterName string, port int, resourceType string) string {
+	return fmt.Sprintf("%s-%d-%s-roachprod", clusterName, port, resourceType)
+}
+
+// CreateLoadBalancer creates a load balancer for the given cluster, derived
+// from the VM list, and port. The cluster has to be part of a managed instance
+// group. Additionally, a health check is created for the given port. A proxy is
+// used to support global load balancing. The different parts of the load
+// balancer are created sequentially, as they depend on each other.
+func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) error {
+	if err := checkSDKVersion("450.0.0" /* minVersion */, "required by load balancers"); err != nil {
+		return err
+	}
+	if !isManaged(vms) {
+		return errors.New("load balancer creation is only supported for managed instance groups")
+	}
+	project := vms[0].Project
+	clusterName, err := vms[0].ClusterName()
+	if err != nil {
+		return err
+	}
+	groups, err := listManagedInstanceGroups(project, instanceGroupName(clusterName))
+	if err != nil {
+		return err
+	}
+	if len(groups) == 0 {
+		return errors.Errorf("no managed instance groups found for cluster %s", clusterName)
+	}
+
+	healthCheckName := loadBalancerResourceName(clusterName, port, "health-check")
+	args := []string{"compute", "health-checks", "create", "tcp",
+		healthCheckName,
+		"--project", project,
+		"--port", strconv.Itoa(port),
+	}
+	cmd := exec.Command("gcloud", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	loadBalancerName := loadBalancerResourceName(clusterName, port, "load-balancer")
+	args = []string{"compute", "backend-services", "create", loadBalancerName,
+		"--project", project,
+		"--load-balancing-scheme", "EXTERNAL_MANAGED",
+		"--global-health-checks",
+		"--global",
+		"--protocol", "TCP",
+		"--health-checks", healthCheckName,
+		"--timeout", "5m",
+		"--port-name", "cockroach",
+	}
+	cmd = exec.Command("gcloud", args...)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	// Add the instance group to the backend service. This has to be done
+	// sequentially, and for each zone, because gcloud does not allow adding
+	// multiple instance groups in parallel.
+	for _, group := range groups {
+		args = []string{"compute", "backend-services", "add-backend", loadBalancerName,
+			"--project", project,
+			"--global",
+			"--instance-group", group.Name,
+			"--instance-group-zone", group.Zone,
+			"--balancing-mode", "UTILIZATION",
+			"--max-utilization", "0.8",
+		}
+		cmd = exec.Command("gcloud", args...)
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+		}
+	}
+
+	proxyName := loadBalancerResourceName(clusterName, port, "proxy")
+	args = []string{"compute", "target-tcp-proxies", "create", proxyName,
+		"--project", project,
+		"--backend-service", loadBalancerName,
+		"--proxy-header", "NONE",
+	}
+	cmd = exec.Command("gcloud", args...)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	args = []string{"compute", "forwarding-rules", "create",
+		loadBalancerResourceName(clusterName, port, "forwarding-rule"),
+		"--project", project,
+		"--global",
+		"--target-tcp-proxy", proxyName,
+		"--ports", strconv.Itoa(port),
+	}
+	cmd = exec.Command("gcloud", args...)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	// Named ports can be set in parallel for all instance groups.
+	var g errgroup.Group
+	for _, group := range groups {
+		groupArgs := []string{"compute", "instance-groups", "set-named-ports", group.Name,
+			"--project", project,
+			"--zone", group.Zone,
+			"--named-ports", "cockroach:" + strconv.Itoa(port),
+		}
+		g.Go(func() error {
+			cmd := exec.Command("gcloud", groupArgs...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", groupArgs, output)
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
 // Given a machine type, return the allowed number (> 0) of local SSDs, sorted in ascending order.
 // N.B. Only n1, n2, n2d and c2 instances are supported since we don't typically use other instance types.
 // Consult https://cloud.google.com/compute/docs/disks/#local_ssd_machine_type_restrictions for other types of instances.

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -196,6 +196,10 @@ func (p *Provider) RemoveLabels(l *logger.Logger, vms vm.List, labels []string) 
 	return nil
 }
 
+func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // Create just creates fake host-info entries in the local filesystem
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -200,6 +200,10 @@ func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // Create just creates fake host-info entries in the local filesystem
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -204,6 +204,10 @@ func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	return nil, nil
+}
+
 // Create just creates fake host-info entries in the local filesystem
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -489,6 +489,10 @@ type Provider interface {
 	// GetPreemptedSpotVMs returns a list of Spot VMs that were preempted since the time specified.
 	// Returns nil, nil when SupportsSpotVMs() is false.
 	GetPreemptedSpotVMs(l *logger.Logger, vms List, since time.Time) ([]PreemptedVM, error)
+
+	// CreateLoadBalancer creates a load balancer, for a specific port, that
+	// delegates to the given cluster.
+	CreateLoadBalancer(l *logger.Logger, vms List, port int) error
 }
 
 // DeleteCluster is an optional capability for a Provider which can

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -493,6 +493,9 @@ type Provider interface {
 	// CreateLoadBalancer creates a load balancer, for a specific port, that
 	// delegates to the given cluster.
 	CreateLoadBalancer(l *logger.Logger, vms List, port int) error
+
+	// DeleteLoadBalancer deletes a load balancers created for a specific port.
+	DeleteLoadBalancer(l *logger.Logger, vms List, port int) error
 }
 
 // DeleteCluster is an optional capability for a Provider which can

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -429,6 +429,12 @@ type PreemptedVM struct {
 	PreemptedAt time.Time
 }
 
+// ServiceAddress stores the IP and port of a service.
+type ServiceAddress struct {
+	IP   string
+	Port int
+}
+
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
 	CreateProviderOpts() ProviderOpts
@@ -496,6 +502,10 @@ type Provider interface {
 
 	// DeleteLoadBalancer deletes a load balancers created for a specific port.
 	DeleteLoadBalancer(l *logger.Logger, vms List, port int) error
+
+	// ListLoadBalancers returns a list of load balancer IPs and ports that are currently
+	// routing to services for the given VMs.
+	ListLoadBalancers(l *logger.Logger, vms List) ([]ServiceAddress, error)
 }
 
 // DeleteCluster is an optional capability for a Provider which can


### PR DESCRIPTION
Previously we did not support load balancers and workloads usually connected to
a single node with fallback support to other nodes. This change adds the ability
to create a load balancer for a managed cluster (only support GCE currently).

A load balancer can be created for each service (virtual cluster). Load
balancers are discerned by the port they serve. A simple health check is also
added to monitor the connectivity on these ports. Currently, the load balancers
will be set to use utilisation as a metric for load balancing. But if required
we can switch this to something else.

Load balancers consist of various components in Google Cloud that work together
to achieve load balancing. The main parts require an instance group that becomes
part of a backend service. Forwarding rules are then set up to configure the
correct ports and policies.

See: #119009
Epic: CRDB-33832

Release Note: None

Backport 7/7 commits from #119382.

/cc @cockroachdb/release

Release justification: Test only change.

