### PR TITLE
kvserver: enable stricter lease acquisition check

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1392,6 +1392,15 @@ func (rp *replicaProposer) leaderStatus(
 	leaderKnown := leader != raft.None
 	var leaderEligibleForLease bool
 	rangeDesc := r.descRLocked()
+	// In the special case of RF=1, even if we don't know the leader, assume it is or soon will be the only Replica.
+	if len(rangeDesc.InternalReplicas) == 1 {
+		return rangeLeaderInfo{
+			iAmTheLeader:           true,
+			leader:                 rangeDesc.InternalReplicas[0].ReplicaID,
+			leaderEligibleForLease: true,
+		}
+	}
+
 	if leaderKnown {
 		// Figure out if the leader is eligible for getting a lease.
 		leaderRep, ok := rangeDesc.GetReplicaDescriptorByID(roachpb.ReplicaID(leader))

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -147,13 +147,12 @@ var LeaseCheckPreferencesOnAcquisitionEnabled = settings.RegisterBoolSetting(
 // RejectLeaseOnLeaderUnknown controls whether a replica that does not know the
 // current raft leader rejects a lease request.
 //
-// TODO(pav-kv): flip the default to true, and remove this setting when this
-// becomes the only behaviour.
+// TODO(pav-kv): Remove this setting when this becomes the only behaviour.
 var RejectLeaseOnLeaderUnknown = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lease.reject_on_leader_unknown.enabled",
 	"reject lease requests on a replica that does not know the raft leader",
-	false,
+	true,
 )
 
 var leaseStatusLogLimiter = func() *log.EveryN {


### PR DESCRIPTION
Previously we added a flag RejectLeaseOnLeaderUnknown to reject lease attempts if the leader was unknown. There were a number of failing unit tests that needed to be fixed to fully enable this. This PR addresses all the unit test failures and enables the setting by default.

Epic: none

Release note: None