### PR TITLE
scplan: run on `large` pool under `race`

### DIFF
--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -43,6 +43,10 @@ go_test(
         "plan_test.go",
     ],
     data = glob(["testdata/**"]),
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         ":scplan",
         "//pkg/base",


### PR DESCRIPTION
This has OOM'ed in remote execution under `race`.
Epic: CRDB-8308
Release note: None