### PR TITLE
kv: fix rare deadlock between requests in the lock table 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -2297,19 +2297,56 @@ func (kl *keyLocks) isLocked() bool {
 // clearLockHeldBy removes the lock, if held, by the transaction referenced by
 // the supplied ID. It is a no-op if the lock isn't held by the transaction.
 //
+// A boolean indicating whether the lock was held by the transaction or not is
+// also returned.
+//
+// TODO(arul): this method may leave the requests' notion of isPromoting in an
+// incorrect state. As such, it shouldn't be called directly -- replace all
+// usages with releaseLock, and pull this into a closure there instead.
+//
 // REQUIRES: kl.mu to be locked.
-func (kl *keyLocks) clearLockHeldBy(ID uuid.UUID) {
+func (kl *keyLocks) clearLockHeldBy(ID uuid.UUID) bool {
 	e, held := kl.heldBy[ID]
 	if !held {
-		return // nothing to do
+		return false // nothing to do
 	}
 	kl.holders.Remove(e)
 	delete(kl.heldBy, ID)
+	return true
 }
 
 func (kl *keyLocks) clearAllLockHolders() {
 	kl.holders.Init()
 	kl.heldBy = nil
+}
+
+// releaseLock releases the lock, if held, by the supplied transaction.
+//
+// REQUIRES: kl.mu to be locked.
+func (kl *keyLocks) releaseLock(txn *enginepb.TxnMeta) {
+	cleared := kl.clearLockHeldBy(txn.ID)
+	if cleared {
+		// There may be requests in the wait queue that belong to the supplied
+		// transaction. They were considered promoters while the lock was held, but
+		// that's no longer the case. As such, their queueOrder.isPromoting flag is
+		// incorrect, and so is their spot in the lock's wait queue. We can fix this
+		// in two different ways:
+		// 1. Recompute queueOrder.isPromoting for waiting requests that belong to
+		// the transaction that just released its lock and then reorder the wait
+		// queue (if needed).
+		// 2. Release any locking requests that belong to the transaction that just
+		// released its lock. They'll re-scan, re-determine whether they're
+		// promoting or not, and be inserted in the correct spot.
+		//
+		// We choose option 2.
+		//
+		// TODO(arul): Option 1, where we push this complexity into
+		// recomputeWaitQueues, is better. We should switch to that, and in doing
+		// so, get rid of all calls to releaseLockingRequestsFromTxn and replace
+		// them with recomputeWaitQueues. Notably, this includes the call to that
+		// method in the lock acquisition path as well.
+		kl.releaseLockingRequestsFromTxn(txn)
+	}
 }
 
 // lockAcquiredOrDiscovered is called when the supplied lock is successfully
@@ -3156,33 +3193,12 @@ func (kl *keyLocks) tryUpdateLockLocked(
 		return false, false
 	}
 	if up.Status.IsFinalized() {
-		kl.clearLockHeldBy(up.Txn.ID)
+		kl.releaseLock(&up.Txn)
 		if !kl.isLocked() {
 			// The lock transitioned from held to unheld as a result of this lock
 			// update.
 			gc = kl.releaseWaitersOnKeyUnlocked()
 		} else {
-			// In some rare cases (such as replays), there may be requests belonging
-			// to the transaction that just released its lock in the lock's wait
-			// queue. These must be requests that are promoting their lock to
-			// something stronger, as otherwise they wouldn't be in the wait queue
-			// to begin with. However, now that the lock has been released, the
-			// queueOrder.isPromoting determination changes as well. We could handle
-			// this two different ways:
-			// 1. Recompute queueOrder.isPromoting for waiting requests that belong to
-			// the transaction that just released the lock and reorder the wait queue
-			// (if needed).
-			// 2. Release any locking requests that belong to the transaction that
-			// just released its lock. They'll re-scan, re-determine whether they're
-			// promoting or not, and get inserted in the correct spot. We choose the
-			// latter option.
-			//
-			// TODO(arul): The former option, where we push this complexity into
-			// recomputeWaitQueues, is better. We should switch to that, and in doing
-			// so, get rid of all calls to releaseLockingRequestsFromTxn and replace
-			// them with recomputeWaitQueues. Notably, this includes the call to that
-			// method in the lock acquisition path as well.
-			kl.releaseLockingRequestsFromTxn(&up.Txn)
 			// If we're in this branch, it must be the case that there were multiple
 			// shared locks held on this key.
 			//
@@ -3285,7 +3301,7 @@ func (kl *keyLocks) tryUpdateLockLocked(
 	}
 
 	if !isLocked {
-		kl.clearLockHeldBy(txn.ID)
+		kl.releaseLock(txn)
 		if !kl.isLocked() {
 			gc = kl.releaseWaitersOnKeyUnlocked()
 		} else {
@@ -3293,7 +3309,6 @@ func (kl *keyLocks) tryUpdateLockLocked(
 			// above for an explanation. Releasing a lock due to ignored sequence
 			// numbers is no different than releasing a lock because the holder's
 			// transaction has been finalized.
-			kl.releaseLockingRequestsFromTxn(&up.Txn)
 			if kl.holders.Len() == 1 {
 				kl.recomputeWaitQueues(st)
 			} else {
@@ -3604,6 +3619,7 @@ func (kl *keyLocks) tryFreeLockOnReplicatedAcquire(
 		return false /* freed */, false /* mustGC */
 	}
 
+	// TODO(arul): this should call releaseLock as well.
 	kl.clearLockHeldBy(acq.Txn.ID)
 	if kl.isLocked() {
 		return true /* freed */, false /* mustGC */

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
@@ -1184,3 +1184,235 @@ num=1
    queued locking requests:
     active: false req: 47 promoting: true, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 46, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
+
+# ------------------------------------------------------------------------------
+# Regression test for https://github.com/cockroachdb/cockroach/issues/121428.
+# Tests a scenario where there's a mismatch between the lock holder information
+# and requests' notion of their promotion status. This can lead to a deadlock
+# between requests.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req48 txn=txn1 ts=10 spans=exclusive@b
+----
+
+scan r=req48
+----
+start-waiting: false
+
+acquire r=req48 k=b durability=u strength=exclusive
+----
+num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req49 txn=txn1 ts=10 spans=intent@a+intent@b
+----
+
+scan r=req49
+----
+start-waiting: false
+
+new-request r=req50 txn=txn2 ts=10 spans=exclusive@a
+----
+
+# For this scenario to be realistic, req49 above must have waited at a different
+# key and dropped its latches. We don't show that as it's not critical to the
+# setup -- we'll simply re-scan with req49 further down the line.
+scan r=req50
+----
+start-waiting: false
+
+acquire r=req50 k=a durability=u strength=exclusive
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 49 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+
+new-request r=req51 txn=txn2 ts=10 spans=intent@a+intent@b
+----
+
+scan r=req51
+----
+start-waiting: true
+
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 51 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 49 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+scan r=req49
+----
+start-waiting: true
+
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 51 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 49 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# Both transactions get aborted and release their locks.
+release txn=txn2 span=a
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 51 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 49 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+release txn=txn1 span=b
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 51 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+   queued locking requests:
+    active: false req: 49 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# Deadlock.
+
+# ------------------------------------------------------------------------------
+# Very similar to the test above, however, instead of releasing the locks by
+# aborting the transaction, we'll instead roll back sequence numbers.
+# ------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+new-request r=req52 txn=txn1 ts=10 spans=exclusive@b
+----
+
+scan r=req52
+----
+start-waiting: false
+
+acquire r=req52 k=b durability=u strength=exclusive
+----
+num=1
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req53 txn=txn1 ts=10 spans=intent@a+intent@b
+----
+
+scan r=req53
+----
+start-waiting: false
+
+new-request r=req54 txn=txn2 ts=10 spans=exclusive@a
+----
+
+# For this scenario to be realistic, req53 above must have waited at a different
+# key and dropped its latches. We don't show that as it's not critical to the
+# setup -- we'll simply re-scan with req53 further down the line.
+scan r=req54
+----
+start-waiting: false
+
+acquire r=req54 k=a durability=u strength=exclusive
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 53 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+
+new-request r=req55 txn=txn2 ts=10 spans=intent@a+intent@b
+----
+
+scan r=req55
+----
+start-waiting: true
+
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 55 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 53 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+scan r=req53
+----
+start-waiting: true
+
+print
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 55 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 53 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# Both transactions release their locks by rolling back their sequence numbers.
+update txn=txn2 ts=10 epoch=1 span=a ignored-seqs=0
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 55 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: false req: 53 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+update txn=txn1 ts=10 epoch=1 span=b ignored-seqs=0
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 55 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+ lock: "b"
+   queued locking requests:
+    active: false req: 53 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# Deadlock.

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
@@ -1280,8 +1280,7 @@ release txn=txn2 span=a
 num=2
  lock: "a"
    queued locking requests:
-    active: false req: 51 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
@@ -1293,14 +1292,34 @@ release txn=txn1 span=b
 num=2
  lock: "a"
    queued locking requests:
-    active: false req: 51 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued locking requests:
-    active: false req: 49 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
-# Deadlock.
+# No Deadlock -- req49 and req51 can scan again without any issue.
+
+scan r=req49
+----
+start-waiting: false
+
+scan r=req51
+----
+start-waiting: true
+
+# Once they do, we see that the wait queues are ordered by sequence number, and
+# that req49 can proceed to evaluation.
+print
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+ lock: "b"
+   queued locking requests:
+    active: false req: 49, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 51, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
 # ------------------------------------------------------------------------------
 # Very similar to the test above, however, instead of releasing the locks by
@@ -1395,8 +1414,7 @@ update txn=txn2 ts=10 epoch=1 span=a ignored-seqs=0
 num=2
  lock: "a"
    queued locking requests:
-    active: false req: 55 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
@@ -1408,11 +1426,31 @@ update txn=txn1 ts=10 epoch=1 span=b ignored-seqs=0
 num=2
  lock: "a"
    queued locking requests:
-    active: false req: 55 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-    active: true req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
  lock: "b"
    queued locking requests:
-    active: false req: 53 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-    active: true req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+    active: false req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
-# Deadlock.
+# No Deadlock -- req53 and req55 can scan again without any issue.
+
+scan r=req53
+----
+start-waiting: false
+
+scan r=req55
+----
+start-waiting: true
+
+# Once they do, we see that the wait queues are ordered by sequence number, and
+# that req53 can proceed to evaluation.
+print
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: true req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+ lock: "b"
+   queued locking requests:
+    active: false req: 53, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+    active: false req: 55, strength: Intent, txn: 00000000-0000-0000-0000-000000000002


### PR DESCRIPTION
The lock table uses sequence number ordering in lock wait queues to
ensure there is never a deadlock between requests. However, a request's
promoting status takes precedence over its sequence number in the
queue's order. This is generally okay, and desired, as a promoting
request implies a lock is held, and the lock table handles deadlock
detection/resolution just fine as long as there is at least one lock
in the deadlock cycle.

This patch fixes a bug where the isPromoting flag wasn't re-computed in
certain cases when locks were released. This could leave the waitQueue
incorrectly ordered, causing a deadlock between requests, which we
weren't equipped to detect/resolve.

Fixes https://github.com/cockroachdb/cockroach/issues/121426
Fixes https://github.com/cockroachdb/cockroach/issues/121428

Release note: None