### PR TITLE
release-24.1: import: add ability to disable validation checks

### DIFF
--- a/pkg/ccl/importerccl/ccl_test.go
+++ b/pkg/ccl/importerccl/ccl_test.go
@@ -153,6 +153,7 @@ DROP VIEW IF EXISTS v`,
 			table     string
 			sql       string
 			create    string
+			setting   string
 			args      []interface{}
 			errString string
 			data      string
@@ -193,6 +194,17 @@ DROP VIEW IF EXISTS v`,
 				args:      []interface{}{srv.URL},
 				data:      "1,us-east1\n",
 				errString: `failed to validate unique constraint`,
+			},
+			{
+				name:  "import-into-multi-region-regional-by-row-dupes-no-validate",
+				db:    "multi_region",
+				table: "mr_regional_by_row",
+				create: "CREATE TABLE mr_regional_by_row (i INT8 PRIMARY KEY) LOCALITY REGIONAL BY ROW;" +
+					"INSERT INTO mr_regional_by_row (i, crdb_region) VALUES (1, 'us-east2')",
+				setting: "SET CLUSTER SETTING bulkio.import.constraint_validation.enabled=false",
+				sql:     "IMPORT INTO mr_regional_by_row (i, crdb_region) CSV DATA ($1)",
+				args:    []interface{}{srv.URL},
+				data:    "1,us-east1\n",
 			},
 			{
 				name:   "import-into-multi-region-regional-by-row-to-multi-region-database-concurrent-table-add",
@@ -265,6 +277,10 @@ CREATE TABLE mr_regional_by_row (i INT8 PRIMARY KEY, s typ, b bytea) LOCALITY RE
 				}
 				tdb.Exec(t, fmt.Sprintf(`SET DATABASE = %q`, test.db))
 				tdb.Exec(t, fmt.Sprintf("DROP TABLE IF EXISTS %q CASCADE", test.table))
+
+				if test.setting != "" {
+					tdb.Exec(t, test.setting)
+				}
 
 				if test.data != "" {
 					data = test.data

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -105,6 +105,15 @@ var processorsPerNode = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
+var performConstraintValidation = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"bulkio.import.constraint_validation.enabled",
+	"should import perform constraint validation after data load. "+
+		"NOTE: this setting should not be used on production clusters, as it could result in "+
+		"incorrect query results if the imported data set violates constraints (i.e. contains duplicates).",
+	true,
+)
+
 type preparedSchemaMetadata struct {
 	schemaPreparedDetails jobspb.ImportDetails
 	schemaRewrites        jobspb.DescRewriteMap
@@ -331,8 +340,10 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		return err
 	}
 
-	if err := r.checkVirtualConstraints(ctx, p.ExecCfg(), r.job, p.User()); err != nil {
-		return err
+	if performConstraintValidation.Get(&p.ExecCfg().Settings.SV) {
+		if err := r.checkVirtualConstraints(ctx, p.ExecCfg(), r.job, p.User()); err != nil {
+			return err
+		}
 	}
 
 	// If the table being imported into referenced UDTs, ensure that a concurrent


### PR DESCRIPTION
Backport 1/1 commits from #121320.

/cc @cockroachdb/release

---

Adds an internal-only cluster setting to disable constraint validation after import. This flag should only be used for testing purposes as it could leave duplicates in the presence of a unique constraint, thereby producing incorrect query results.

Release note: None
Release justification: Cluster setting protected change to facilitate DRT testing

Epic: none
Fixes: #121281
