### PR TITLE
sql: run tenant logic tests with manual replication mode

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant
@@ -179,20 +179,30 @@ user_name  query                                         phase
 testuser   DELETE FROM t WHERE (k >= 'b') AND (k < 'x')  executing
 
 # looking at each transaction separately, validate the expected results in the lock table
-query TTTTTTTBB colnames,retry
+query TTTTTTTBB colnames,rowsort,retry
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn3'
 ----
-database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"a"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"z"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
-query TTTTTTTBB colnames
+query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn4'
 ----
-database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     false    true
 
 query I
 SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
 ----
-0
+10
 
 statement ok
 ROLLBACK

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1489,16 +1489,6 @@ func (t *logicTest) newCluster(
 	setSQLTestingKnobs(&params.ServerArgs.Knobs)
 
 	cfg := t.cfg
-	if cfg.UseSecondaryTenant == logictestbase.Always {
-		// In the tenant case we need to enable replication in order to split and
-		// relocate ranges correctly.
-		//
-		// TODO(#76378): This condition is faulty. In the case where the
-		// profile is configured with "Random", we want to set the
-		// replication mode as well when a test tenant is effectively
-		// created. This currently is not happening.
-		params.ReplicationMode = base.ReplicationAuto
-	}
 	if cfg.BootstrapVersion != clusterversion.Key(0) {
 		if params.ServerArgs.Knobs.Server == nil {
 			params.ServerArgs.Knobs.Server = &server.TestingKnobs{}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -1,20 +1,29 @@
 # LogicTest: 3node-tenant-multiregion
 
+user host-cluster-root
+
+statement ok
+ALTER TENANT [10] GRANT CAPABILITY can_admin_relocate_range=true
+
+user root
+
 # Create a table on the secondary tenant.
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, FAMILY (k, v));
 INSERT INTO t SELECT i, i FROM generate_series(1, 6) AS g(i)
 
+# Upreplicate the table's range.
+statement ok
+ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1, 2, 3], 0)
+
 # Split the ranges in the table.
 statement ok
 ALTER TABLE t SPLIT AT SELECT generate_series(1, 6)
 
-# Relocate ranges in the admin tenant so that
+# Relocate ranges so that
 # - [1-2) and [2-3) are on node 2
 # - [3-4) and [4-5) are on node 3
 # - [5-6) and [6-7) are on node 1.
-user host-cluster-root
-
 statement ok
 ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%1';
 ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%2';
@@ -22,8 +31,6 @@ ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WH
 ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%4';
 ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%5';
 ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%6';
-
-user root
 
 # Populate the range cache.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -1,20 +1,29 @@
 # LogicTest: 3node-tenant-multiregion
 skip under duress 118627
 
+user host-cluster-root
+
+statement ok
+ALTER TENANT [10] GRANT CAPABILITY can_admin_relocate_range=true
+
+user root
+
 # Create a table on the secondary tenant.
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, FAMILY (k, v))
+
+# Upreplicate the table's range.
+statement ok
+ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1, 2, 3], 0)
 
 # Split the ranges in the table.
 statement ok
 ALTER TABLE t SPLIT AT SELECT generate_series(1, 6)
 
-# Relocate ranges in the admin tenant so that
+# Relocate ranges so that
 # - [1-2) and [2-3) are on node 2
 # - [3-4) and [4-5) are on node 3
 # - [5-6) and [6-7) are on node 1.
-user host-cluster-root
-
 statement ok
 ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%1';
 ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%2';
@@ -23,7 +32,7 @@ ALTER RANGE RELOCATE LEASE TO 3 FOR SELECT range_id FROM crdb_internal.ranges WH
 ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%5';
 ALTER RANGE RELOCATE LEASE TO 1 FOR SELECT range_id FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%6';
 
-# Check range lease holders in the admin tenant.
+# Check range lease holders.
 query TI rowsort,retry
 SELECT start_pretty, lease_holder FROM crdb_internal.ranges WHERE start_pretty LIKE '%Tenant%Table%/1/%'
 ----
@@ -33,8 +42,6 @@ SELECT start_pretty, lease_holder FROM crdb_internal.ranges WHERE start_pretty L
 /Tenant/10/Table/106/1/4  3
 /Tenant/10/Table/106/1/5  1
 /Tenant/10/Table/106/1/6  1
-
-user root
 
 # Populate the range cache.
 statement ok


### PR DESCRIPTION
Fixes #121401.

This commit removes the use of automatic replication mode for secondary tenant SQL logic tests, so that the configuration more closely matches that for single tenant SQL logic tests. In doing so, it eliminates some of the recent flakiness which has come from 3d87bec3, where ranges now split and rebalance much more often for secondary tenants.

To accomplish this, the commit updates the `distsql_tenant_locality` tests to manually upreplicate.

The commit also needed to fix up `cluster_locks_tenant`, which was broken by #99735. Now that we're running with manual replication mode, we can't rely on a range split or lease transfer to clear unreplicated locks, which was undermining the point of the test anyway.

Release note: None