### PR TITLE
release-24.1: sql/stats: improve query to ensure all tables

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -621,37 +621,38 @@ func (r *Refresher) Start(
 
 const (
 	getAllTablesTemplateSQL = `
-SELECT
-	tbl.table_id
-FROM
-	crdb_internal.tables AS tbl
-	INNER JOIN system.descriptor AS d ON d.id = tbl.table_id
-		AS OF SYSTEM TIME '-%s'
+WITH descs AS (
+  SELECT
+    d.id AS id,
+    crdb_internal.pb_to_json('desc', d.descriptor, false) AS descriptor_json,
+    (n."parentID" = 1) AS is_system_table
+  FROM system.descriptor AS d
+  INNER JOIN system.namespace AS n ON d.id = n.id
+	WHERE n."parentSchemaID" != 0
+)
+SELECT descs.id
+FROM descs
+AS OF SYSTEM TIME '-%s'
 WHERE
-	tbl.database_name IS NOT NULL
-	AND tbl.table_id NOT IN (%d, %d, %d)  -- excluded system tables
-	AND tbl.drop_time IS NULL
-	AND (
-			crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', d.descriptor, false)->'table'->>'viewQuery'
-		) IS NULL
+	id NOT IN (%d, %d, %d)  -- excluded system tables
+  AND descriptor_json ? 'table'
+	AND NOT descriptor_json->'table' ? 'viewQuery'
+	AND NOT descriptor_json->'table' ? 'dropTime'
 	%s
 	%s`
 
 	explicitlyEnabledTablesPredicate = `AND
-	(crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
-		d.descriptor, false)->'table'->'autoStatsSettings' ->> 'enabled' = 'true'
-	)`
+	(descriptor_json->'table'->'autoStatsSettings' ->> 'enabled' = 'true')`
 
 	autoStatsEnabledOrNotSpecifiedPredicate = `AND
-	(crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
-		d.descriptor, false)->'table'->'autoStatsSettings'->'enabled' IS NULL
-	 OR crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor',
-		d.descriptor, false)->'table'->'autoStatsSettings' ->> 'enabled' = 'true'
+	(
+    descriptor_json->'table'->'autoStatsSettings'->'enabled' IS NULL
+	  OR descriptor_json->'table'->'autoStatsSettings' ->> 'enabled' = 'true'
 	)`
 
 	autoStatsOnSystemTablesEnabledPredicate = `AND TRUE`
 
-	autoStatsOnSystemTablesDisabledPredicate = `AND tbl.database_name != 'system'`
+	autoStatsOnSystemTablesDisabledPredicate = `AND NOT is_system_table`
 )
 
 func (r *Refresher) getApplicableTables(

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -270,6 +270,46 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 	}
 }
 
+// BenchmarkEnsureAllTables was added since this operation appeared as a major
+// source of memory usage in https://github.com/cockroachlabs/support/issues/2870.
+func BenchmarkEnsureAllTables(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	for _, numTables := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("numTables=%d", numTables), func(b *testing.B) {
+			srv, sqlDB, _ := serverutils.StartServer(b, base.TestServerArgs{})
+			defer srv.Stopper().Stop(ctx)
+			s := srv.ApplicationLayer()
+			codec, st := s.Codec(), s.ClusterSettings()
+			AutomaticStatisticsClusterMode.Override(ctx, &st.SV, true)
+			AutomaticStatisticsOnSystemTables.Override(ctx, &st.SV, true)
+
+			sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+			sqlRun.Exec(b, `CREATE DATABASE t;`)
+
+			for i := 0; i < numTables; i++ {
+				sqlRun.Exec(b, fmt.Sprintf(`CREATE TABLE t.a%d (k INT PRIMARY KEY);`, i))
+			}
+
+			executor := s.InternalExecutor().(isql.Executor)
+			cache := NewTableStatisticsCache(
+				10, /* cacheSize */
+				s.ClusterSettings(),
+				s.InternalDB().(descs.DB),
+			)
+			require.NoError(b, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
+			r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r.ensureAllTables(ctx, &st.SV, time.Microsecond)
+			}
+		})
+	}
+}
+
 func checkAllTablesCount(ctx context.Context, systemTables bool, expected int, r *Refresher) error {
 	const collectionDelay = time.Microsecond
 	systemTablesPredicate := autoStatsOnSystemTablesEnabledPredicate


### PR DESCRIPTION
Backport 2/3 commits from #121739.

/cc @cockroachdb/release

Release justification: high value performance improvement

---

This avoids joining to crdb_internal.tables. This helps because
crdb_internal.tables is a virtual table, so populating it when the
cluster has a huge number of tables can be expensive since it
materializes all descriptors in memory.

```
goos: darwin
goarch: arm64
                                  │ bench-old.txt │            bench-new.txt            │
                                  │    sec/op     │   sec/op     vs base                │
EnsureAllTables/numTables=10-10       39.41m ± 7%   18.52m ± 1%  -53.01% (p=0.000 n=10)
EnsureAllTables/numTables=100-10      63.66m ± 0%   30.51m ± 5%  -52.07% (p=0.000 n=10)
EnsureAllTables/numTables=1000-10     304.6m ± 1%   148.4m ± 1%  -51.30% (p=0.000 n=10)
geomean                               91.42m        43.76m       -52.13%

                                  │ bench-old.txt │            bench-new.txt             │
                                  │     B/op      │     B/op      vs base                │
EnsureAllTables/numTables=10-10      18.19Mi ± 0%   10.25Mi ± 0%  -43.64% (p=0.000 n=10)
EnsureAllTables/numTables=100-10     29.43Mi ± 1%   16.97Mi ± 0%  -42.32% (p=0.000 n=10)
EnsureAllTables/numTables=1000-10   136.75Mi ± 0%   79.65Mi ± 0%  -41.76% (p=0.000 n=10)
geomean                              41.83Mi        24.02Mi       -42.58%

                                  │ bench-old.txt │            bench-new.txt            │
                                  │   allocs/op   │  allocs/op   vs base                │
EnsureAllTables/numTables=10-10       361.8k ± 0%   175.7k ± 0%  -51.43% (p=0.000 n=10)
EnsureAllTables/numTables=100-10      600.0k ± 0%   288.3k ± 0%  -51.95% (p=0.000 n=10)
EnsureAllTables/numTables=1000-10     2.889M ± 0%   1.390M ± 0%  -51.88% (p=0.000 n=10)
geomean                               856.0k        413.0k       -51.75%
```

informs https://github.com/cockroachlabs/support/issues/2870
Epic: CRDB-37483
Release note: None
