### PR TITLE
release-23.2: roachtest: ignore 2 flaky ruby-pg tests and 1 flaky pgjdbc test

### DIFF
--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -916,6 +916,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",
+	"org.postgresql.test.jdbc2.DatabaseMetaDataCacheTest.testGetTypeInfoUsesCache":                                                                  "https://github.com/cockroachdb/cockroach/issues/119332#issuecomment-1950242848",
 	"org.postgresql.test.jdbc2.StatementTest.testShortQueryTimeout":                                                                                 "flaky",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyNotVisibilityTableInsideFunction":                                         "https://github.com/pgjdbc/pgjdbc/pull/2806",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyVisibilityFunction":                                                       "https://github.com/pgjdbc/pgjdbc/pull/2806",

--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -200,8 +200,12 @@ var rubyPGBlocklist = blocklist{
 }
 
 var rubyPGIgnorelist = blocklist{
-	`PG::Connection OS thread support Connection.new shouldn't block a second thread`:                             "flaky",
-	`running with sync_* methods PG::Connection consume_input should raise ConnectionBad for a closed connection`: "flaky",
-	`running with sync_* methods PG::Connection OS thread support Connection.new shouldn't block a second thread`: "flaky",
-	`running with sync_* methods PG::Connection handles server close while asynchronous connect`:                  "flaky",
+	`PG::Connection consume_input should raise ConnectionBad for a closed connection`:                                                                                              "flaky",
+	`PG::Connection handles server close while asynchronous connect`:                                                                                                               "flaky",
+	`PG::Connection OS thread support Connection.new shouldn't block a second thread`:                                                                                              "flaky",
+	`PG::Connection multinationalization support respect and convert character encoding of input strings should convert error string to #put_copy_end`:                             "unknown",
+	`running with sync_* methods PG::Connection consume_input should raise ConnectionBad for a closed connection`:                                                                  "flaky",
+	`running with sync_* methods PG::Connection OS thread support Connection.new shouldn't block a second thread`:                                                                  "flaky",
+	`running with sync_* methods PG::Connection handles server close while asynchronous connect`:                                                                                   "flaky",
+	`running with sync_* methods PG::Connection multinationalization support respect and convert character encoding of input strings should convert error string to #put_copy_end`: "flaky",
 }


### PR DESCRIPTION
Backport 2/2 commits from #121842.

/cc @cockroachdb/release

Release justification: test only change

---

fixes https://github.com/cockroachdb/cockroach/issues/120762
fixes https://github.com/cockroachdb/cockroach/issues/120976
Release note: None
