### PR TITLE
release-23.2.4-rc: sql: fix leak in memory accounting around TxnFingerprintIDCache

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1058,7 +1058,6 @@ func (s *Server) newConnExecutor(
 		memMetrics.TxnMaxBytesHist,
 		-1 /* increment */, noteworthyMemoryUsageBytes, s.cfg.Settings,
 	)
-	txnFingerprintIDCacheAcc := sessionMon.MakeBoundAccount()
 
 	nodeIDOrZero, _ := s.cfg.NodeInfo.NodeID.OptionalNodeID()
 	ex := &connExecutor{
@@ -1100,8 +1099,7 @@ func (s *Server) newConnExecutor(
 		indexUsageStats:           s.indexUsageStats,
 		txnIDCacheWriter:          s.txnIDCache,
 		totalActiveTimeStopWatch:  timeutil.NewStopWatch(),
-		txnFingerprintIDCache:     NewTxnFingerprintIDCache(ctx, s.cfg.Settings, &txnFingerprintIDCacheAcc),
-		txnFingerprintIDAcc:       &txnFingerprintIDCacheAcc,
+		txnFingerprintIDCache:     NewTxnFingerprintIDCache(s.cfg.Settings),
 	}
 
 	ex.state.txnAbortCount = ex.metrics.EngineMetrics.TxnAbortCount
@@ -1318,7 +1316,6 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	ex.mu.IdleInSessionTimeout.Stop()
 	ex.mu.IdleInTransactionSessionTimeout.Stop()
 
-	ex.txnFingerprintIDAcc.Close(ctx)
 	if closeType != panicClose {
 		ex.state.mon.Stop(ctx)
 		ex.sessionPreparedMon.Stop(ctx)
@@ -1712,7 +1709,6 @@ type connExecutor struct {
 	// txnFingerprintIDCache is used to track the most recent
 	// txnFingerprintIDs executed in this session.
 	txnFingerprintIDCache *TxnFingerprintIDCache
-	txnFingerprintIDAcc   *mon.BoundAccount
 
 	// totalActiveTimeStopWatch tracks the total active time of the session.
 	// This is defined as the time spent executing transactions and statements.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3121,13 +3121,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 		ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionEndExecTransaction, timeutil.Now())
 		transactionFingerprintID :=
 			appstatspb.TransactionFingerprintID(ex.extraTxnState.transactionStatementsHash.Sum())
-
-		err := ex.txnFingerprintIDCache.Add(ctx, transactionFingerprintID)
-		if err != nil {
-			if log.V(1) {
-				log.Warningf(ctx, "failed to enqueue transactionFingerprintID = %d: %s", transactionFingerprintID, err)
-			}
-		}
+		ex.txnFingerprintIDCache.Add(transactionFingerprintID)
 
 		ex.statsCollector.EndTransaction(
 			ctx,
@@ -3143,7 +3137,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 			)
 		}
 
-		err = ex.recordTransactionFinish(ctx, transactionFingerprintID, ev, implicit, txnStart, txnErr)
+		err := ex.recordTransactionFinish(ctx, transactionFingerprintID, ev, implicit, txnStart, txnErr)
 		if err != nil {
 			if log.V(1) {
 				log.Warningf(ctx, "failed to record transaction stats: %s", err)

--- a/pkg/sql/txn_fingerprint_id_cache_test.go
+++ b/pkg/sql/txn_fingerprint_id_cache_test.go
@@ -45,7 +45,7 @@ func TestTxnFingerprintIDCacheDataDriven(t *testing.T) {
 				d.ScanArgs(t, "capacity", &capacity)
 
 				st := cluster.MakeTestingClusterSettings()
-				txnFingerprintIDCache = NewTxnFingerprintIDCache(ctx, st, nil /* acc */)
+				txnFingerprintIDCache = NewTxnFingerprintIDCache(st)
 
 				TxnFingerprintIDCacheCapacity.Override(ctx, &st.SV, int64(capacity))
 
@@ -66,9 +66,7 @@ func TestTxnFingerprintIDCacheDataDriven(t *testing.T) {
 				require.NoError(t, err)
 				txnFingerprintID := appstatspb.TransactionFingerprintID(id)
 
-				err = txnFingerprintIDCache.Add(ctx, txnFingerprintID)
-				require.NoError(t, err)
-
+				txnFingerprintIDCache.Add(txnFingerprintID)
 				return fmt.Sprintf("size: %d", txnFingerprintIDCache.size())
 
 			case "show":


### PR DESCRIPTION
Backport 1/1 commits from #121847.

/cc @cockroachdb/release

---

This commit is partial revert of 88ebd70d7ca24d8cebe1acdcb711d4f0e840c619. Until that change, we attempted to perform memory accounting for txn fingeprint IDs stored in the cache for each session, but we never initialized the bytes monitor, so it didn't actually count towards the root SQL memory budget. In that change, we derived an account from the "session" monitor to fix that.

However, this exposed another problem with how accounting was done: namely, on `Cache.Add` call we always grow the account and on `Cache.OnEvicted` we shrink the account. The problem is that if the txn fingerprint ID already exists in the cache, we still call `Cache.Add` (growing the account) but we will never shrink it because we didn't add a new entry. As a result, until the session is closed, we'll keep on accumulating the leak.

The fix in this commit is simple - just remove any attempt for memory accounting for this txn fingerprint ID cache. Effectively, this brings us back to the state of how we were before the change mentioned above (no accounting done) without the overhead of creating redundant BytesMonitor / BoundAccount objects (since they served no real purpose). Not having any accounting done for this cache seems acceptable given that the cache stores up to 100 txns (by default), and each txn results in about 56B of usage, so we'll have about 5KiB of unaccounted for (per session) memory usage. We have much larger omissions elsewhere, so for now I left a TODO to add memory accounting in the future.

Addresses: #121844.
Epic: None

Release note (bug fix): CockroachDB could previously "leak" reported memory usage (as accounted by the internal memory accounting system, the limit for which is configured via --max-sql-memory flag) on long-running sessions that issue many (hundreds of thousands or more) transactions. This, in turn, could result in "root: memory budget exceeded" errors for other queries. The bug is present in versions 23.1.17 and 23.2.3 and is now fixed.

Release justification: bug fix to a recent regression.