### PR TITLE
backupccl: update mixed version tests

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -82,8 +82,8 @@ var localityCfgs = map[string]roachpb.Locality{
 }
 
 var clusterVersionKeys = map[string]clusterversion.Key{
-	"23_2_Start": clusterversion.V23_2Start,
-	"23_2":       clusterversion.V23_2,
+	"latest":           clusterversion.Latest,
+	"previous-release": clusterversion.PreviousRelease,
 }
 
 type sqlDBKey struct {
@@ -177,7 +177,6 @@ func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 		if !ok {
 			t.Fatalf("clusterVersion %s does not exist in data driven global map", cfg.beforeVersion)
 		}
-		beforeKey--
 		params.ServerArgs.Knobs.Server = &server.TestingKnobs{
 			BinaryVersionOverride:          beforeKey.Version(),
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
@@ -562,11 +561,11 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 			if d.HasArg("splits") {
 				d.ScanArgs(t, "splits", &splits)
 			}
-			if d.HasArg("beforeVersion") {
-				d.ScanArgs(t, "beforeVersion", &beforeVersion)
+			if d.HasArg("before-version") {
+				d.ScanArgs(t, "before-version", &beforeVersion)
 				if !d.HasArg("disable-tenant") {
 					// TODO(msbutler): figure out why test tenants don't mix with version testing
-					t.Fatal("tests that use beforeVersion must use disable-tenant")
+					t.Fatal("tests that use before-version must use disable-tenant")
 				}
 			}
 			if d.HasArg("testingKnobCfg") {

--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
@@ -507,9 +507,9 @@ SELECT f()
 ----
 pq: unknown function: f()
 
-# Test that backing up and restoring a cluster with a function on 23.2 does not
-# grant EXECUTE privileges on the public role for functions where that privilege
-# has been revoked.
+# Test that backing up and restoring a cluster with a function does not grant
+# EXECUTE privileges on the public role for functions where that privilege has
+# been revoked.
 new-cluster name=s4
 ----
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-mixed-version
@@ -1,4 +1,4 @@
-new-cluster name=s1 beforeVersion=23_2_Start disable-tenant
+new-cluster name=s1 before-version=previous-release disable-tenant
 ----
 
 exec-sql
@@ -15,7 +15,7 @@ BACKUP INTO 'nodelocal://1/full_cluster_backup/';
 # This is a cluster where the cluster version is behind the binary version. Such
 # a condition only occurs when the user has upgraded the node to a new major
 # version but has not yet finalized the upgrade.
-new-cluster name=s2 beforeVersion=23_2_Start share-io-dir=s1 disable-tenant
+new-cluster name=s2 before-version=previous-release share-io-dir=s1 disable-tenant
 ----
 
 exec-sql expect-error-regex=(pq: cluster restore not supported during major version upgrade: restore started at cluster version .* but binary version is.*)

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-regionless-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-regionless-mixed-version
@@ -1,4 +1,4 @@
-new-cluster name=s1 beforeVersion=23_2_Start disable-tenant localities=us-east-1,us-west-1,eu-central-1
+new-cluster name=s1 before-version=previous-release disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 
 exec-sql
@@ -28,17 +28,17 @@ exec-sql
 BACKUP INTO 'nodelocal://1/cluster_backup/';
 ----
 
-new-cluster name=s2 beforeVersion=23_2_Start share-io-dir=s1 disable-tenant
+new-cluster name=s2 before-version=previous-release share-io-dir=s1 disable-tenant
 ----
 
-# restore fails when cluster is in mixed version state while upgrading to 23.2
-exec-sql expect-error-regex=(cluster version must be >= *)
+# restore fails when cluster is in mixed version state while upgrading
+exec-sql expect-error-regex=(cluster restore not supported during major version upgrade)
 RESTORE FROM LATEST IN 'nodelocal://1/cluster_backup/' WITH remove_regions;
 ----
 regex matches error
 
 # upgrade cluster
-upgrade-cluster version=23_2
+upgrade-cluster version=latest
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -401,9 +401,9 @@ SELECT f()
 ----
 pq: unknown function: f()
 
-# Test that backing up and restoring a cluster with a function on 23.2 does not
-# grant EXECUTE privileges on the public role for functions where that privilege
-# has been revoked.
+# Test that backing up and restoring a cluster with a function does not grant
+# EXECUTE privileges on the public role for functions where that privilege has
+# been revoked.
 new-cluster name=s4
 ----
 


### PR DESCRIPTION
The mixed version backupccl tests break if we bump the min supported version to 23.2. This commit updates them to use the previous release and the latest version.

Epic: REL-696
Release note: None