### PR TITLE
upgrade: change RestoreAction aliases to constructors

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -479,7 +479,8 @@ func TestTenantUpgradeFailure(t *testing.T) {
 								) error {
 									t.Logf("v1 migration running")
 									return nil
-								}, "test"), true
+								}, upgrade.RestoreActionNotRequired("test"),
+							), true
 						case v2:
 							return upgrade.NewTenantUpgrade("testing next",
 								v2,
@@ -502,7 +503,8 @@ func TestTenantUpgradeFailure(t *testing.T) {
 										}
 									}
 									return nil
-								}, "test"), true
+								}, upgrade.RestoreActionNotRequired("test"),
+							), true
 						default:
 							return nil, false
 						}

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -429,11 +429,11 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 				return upgrade.NewTenantUpgrade("testing",
 					v1,
 					upgrade.NoPrecondition,
-					func(
-						ctx context.Context, version clusterversion.ClusterVersion, deps upgrade.TenantDeps,
-					) error {
+					func(ctx context.Context, version clusterversion.ClusterVersion, deps upgrade.TenantDeps) error {
 						return nil
-					}, "test"), true
+					},
+					upgrade.RestoreActionNotRequired("test"),
+				), true
 			},
 		},
 	}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -56,19 +56,25 @@ type JobDeps interface {
 // If an upgrade migration only affects state that is not restored, such as the
 // system tables that contain instance information and liveness, it can use a
 // RestoreActionNotRequired string explaining this fact, e.g.
-// `RestoreActionNotRequired("liveness table is not restored").
-type RestoreBehavior string
+// RestoreActionNotRequired("liveness table is not restored").
+type RestoreBehavior struct {
+	msg string
+}
 
 // RestoreActionNotRequired is used to signal an upgrade migration only affects
 // persisted state that is not written by restore. The string should mention
 // why no action is required.
-type RestoreActionNotRequired = RestoreBehavior
+func RestoreActionNotRequired(msg string) RestoreBehavior {
+	return RestoreBehavior{msg: msg}
+}
 
 // RestoreActionImplemented is used to signal an upgrade migration affects state
 // that is written by restore and has implemented the requisite logic in restore
 // to perform the equivalent upgrade on restored data as it is restored. The
 // string should mention what is done during restore and where it is done.
-type RestoreActionImplemented = RestoreBehavior
+func RestoreActionImplemented(msg string) RestoreBehavior {
+	return RestoreBehavior{msg: msg}
+}
 
 type upgrade struct {
 	description string
@@ -99,5 +105,5 @@ func (m *upgrade) Name() string {
 }
 
 func (m *upgrade) RestoreBehavior() string {
-	return string(m.restore)
+	return m.restore.msg
 }


### PR DESCRIPTION
String literals can be assigned to a string type like `RestoreBehavior` without casts; uses of `RestoreActionNotRequired` are grayed out by GoLand as unnecessary.

This commit changes `RestoreBehavior` to a struct and `RestoreActionNotRequired / RestoreActionImplemented` to constructor functions.

Epic: none
Release note: None