### PR TITLE
sem/tree: clarify an error message

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -44,7 +44,7 @@ SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 NOTICE: follower reads disabled because you are running a non-CCL distribution
 NOTICE: follower reads disabled because you are running a non-CCL distribution
 
-statement error pq: unknown signature: follower_read_timestamp\(string\) \(desired <timestamptz>\)
+statement error pq: unknown signature: follower_read_timestamp\(string\) \(returning <timestamptz>\)
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp('boom')
 
 statement error pq: AS OF SYSTEM TIME: only constant expressions, with_min_timestamp, with_max_staleness, or follower_read_timestamp are allowed

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -109,7 +109,7 @@ statement ok
 CREATE FUNCTION foo(i INT) RETURNS VOID LANGUAGE SQL AS ''
 
 # This is similar to the test above, but with a non-matching function signature.
-statement error pgcode 42883 unknown signature: public.foo\(\) \(desired <int>\)
+statement error pgcode 42883 unknown signature: public.foo\(\) \(returning <int>\)
 CALL p(foo())
 
 statement error pgcode 42723 function "p" already exists with same argument types

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -122,7 +122,7 @@ SELECT 1 = ANY(ARRAY['foo'] || 'bar'::string)
 # Note that this relatively poor error message is caused by the fact that
 # strings are constant castable to string arrays. Postgres also makes this
 # same minor mistake in error generation.
-query error unsupported binary operator: <string\[\]> || <string> (desired <int\[\]>)
+query error unsupported binary operator: <string\[\]> || <string> (returning <int\[\]>)
 SELECT 1 = ANY(ARRAY['foo'] || 'bar')
 
 # ANY/SOME with subqueries.

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -922,7 +922,7 @@ SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy);
 # The outer ROW(ROW(a, b)) is already a tuple, so shouldn't be wrapped in
 # another tuple before comparison. But the comparison should fail due to
 # mismatched types.
-query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(desired <tuple\{int, int\}>\)
+query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(returning <tuple\{int, int\}>\)
 SELECT * FROM ab WHERE ROW(ROW(a, b)) IN (SELECT x+1 FROM xy);
 
 # The outer ROW(ROW(a, b)) is already a tuple, so shouldn't be wrapped in
@@ -959,7 +959,7 @@ true
 # The outer ((2, 2), (3, 3)) is already a tuple, so shouldn't be wrapped in
 # another tuple before comparison. But the comparison should fail due to
 # mismatched types.
-query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(desired \<tuple\{int\, int\}>\)
+query error pgcode 22023 unsupported binary operator: <int> \+ <int> \(returning \<tuple\{int\, int\}>\)
 SELECT (SELECT (2, 2), (3, 3)) IN (SELECT x+1, y+1 FROM xy)
 
 # Outer scalar is a tuple with 2 elements. Subquery has only 1 column.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -263,7 +263,7 @@ func TestPGPrepareFail(t *testing.T) {
 		"SELECT CASE WHEN TRUE THEN $1 ELSE $2 END": "pq: could not determine data type of placeholder $2",
 		"SELECT $1 > 0 AND NOT $1":                  "pq: placeholder $1 already has type int, cannot assign bool",
 		"CREATE TABLE $1 (id INT)":                  "pq: at or near \"1\": syntax error",
-		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <anyelement> (desired <string>)",
+		"UPDATE d.t SET s = i + $1":                 "pq: unsupported binary operator: <int> + <anyelement> (returning <string>)",
 		"SELECT $0 > 0":                             "pq: lexical error: placeholder index must be between 1 and 65536",
 		"SELECT $2 > 0":                             "pq: could not determine data type of placeholder $1",
 		"SELECT 3 + CASE (4) WHEN 4 THEN $1 END":    "pq: could not determine data type of placeholder $1",

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1647,7 +1647,7 @@ func getFuncSig(expr *FuncExpr, typedInputExprs []TypedExpr, desiredType *types.
 	}
 	var desStr string
 	if desiredType.Family() != types.AnyFamily {
-		desStr = fmt.Sprintf(" (desired <%s>)", desiredType)
+		desStr = fmt.Sprintf(" (returning <%s>)", desiredType)
 	}
 	return fmt.Sprintf("%s(%s)%s", &expr.Func, strings.Join(typeNames, ", "), desStr)
 }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -414,7 +414,7 @@ func (expr *BinaryExpr) TypeCheck(
 	if len(s.overloadIdxs) != 1 {
 		var desStr string
 		if desired.Family() != types.AnyFamily {
-			desStr = fmt.Sprintf(" (desired <%s>)", desired)
+			desStr = fmt.Sprintf(" (returning <%s>)", desired)
 		}
 		sig := fmt.Sprintf("<%s> %s <%s>%s", leftReturn, expr.Operator, rightReturn, desStr)
 		if len(s.overloadIdxs) == 0 {
@@ -1765,7 +1765,7 @@ func (expr *UnaryExpr) TypeCheck(
 	if numOps != 1 {
 		var desStr string
 		if desired.Family() != types.AnyFamily {
-			desStr = fmt.Sprintf(" (desired <%s>)", desired)
+			desStr = fmt.Sprintf(" (returning <%s>)", desired)
 		}
 		sig := fmt.Sprintf("%s <%s>%s", expr.Operator, exprReturn, desStr)
 		if numOps == 0 {


### PR DESCRIPTION
This commit changes a couple of error messages to use `returning` instead of `desired` to clarify what the following type is about. I find such wording less confusing.

Fixes: #120612.

Release note: None