### PR TITLE
sql: avoid an allocation in checkExprForDistSQL

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -342,7 +342,7 @@ func runPlanInsidePlan(
 
 	distributePlan := getPlanDistribution(
 		ctx, plannerCopy.Descriptors().HasUncommittedTypes(),
-		plannerCopy.SessionData().DistSQLMode, plan.main,
+		plannerCopy.SessionData().DistSQLMode, plan.main, &plannerCopy.distSQLVisitor,
 	)
 	distributeType := DistributionType(LocalDistribution)
 	if distributePlan.WillDistribute() {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1966,7 +1966,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 	distributePlan := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
-		distSQLMode, planner.curPlan.main,
+		distSQLMode, planner.curPlan.main, &planner.distSQLVisitor,
 	)
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan.WillDistribute())
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -390,8 +390,9 @@ func createStatsDefaultColumns(
 		if err != nil {
 			return nil, err
 		}
+		var distSQLVisitor distSQLExprCheckVisitor
 		for i, col := range desc.PublicColumns() {
-			cannotDistribute[i] = col.IsVirtual() && checkExprForDistSQL(exprs[i]) != nil
+			cannotDistribute[i] = col.IsVirtual() && checkExprForDistSQL(exprs[i], &distSQLVisitor) != nil
 		}
 	}
 

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -378,13 +378,13 @@ func hasOidType(t *types.T) bool {
 
 // checkExprForDistSQL verifies that an expression doesn't contain things that
 // are not yet supported by distSQL, like distSQL-blocklisted functions.
-func checkExprForDistSQL(expr tree.Expr) error {
+func checkExprForDistSQL(expr tree.Expr, distSQLVisitor *distSQLExprCheckVisitor) error {
 	if expr == nil {
 		return nil
 	}
-	v := distSQLExprCheckVisitor{}
-	tree.WalkExprConst(&v, expr)
-	return v.err
+	distSQLVisitor.err = nil
+	tree.WalkExprConst(distSQLVisitor, expr)
+	return distSQLVisitor.err
 }
 
 type distRecommendation int
@@ -509,7 +509,9 @@ func mustWrapValuesNode(planCtx *PlanningCtx, specifiedInQuery bool) bool {
 // The error doesn't indicate complete failure - it's instead the reason that
 // this plan couldn't be distributed.
 // TODO(radu): add tests for this.
-func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
+func checkSupportForPlanNode(
+	node planNode, distSQLVisitor *distSQLExprCheckVisitor,
+) (distRecommendation, error) {
 	switch n := node.(type) {
 	// Keep these cases alphabetized, please!
 	case *createStatsNode:
@@ -519,19 +521,19 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		return shouldDistribute, nil
 
 	case *distinctNode:
-		return checkSupportForPlanNode(n.plan)
+		return checkSupportForPlanNode(n.plan, distSQLVisitor)
 
 	case *exportNode:
-		return checkSupportForPlanNode(n.source)
+		return checkSupportForPlanNode(n.source, distSQLVisitor)
 
 	case *filterNode:
-		if err := checkExprForDistSQL(n.filter); err != nil {
+		if err := checkExprForDistSQL(n.filter, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		return checkSupportForPlanNode(n.source.plan)
+		return checkSupportForPlanNode(n.source.plan, distSQLVisitor)
 
 	case *groupNode:
-		rec, err := checkSupportForPlanNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -553,13 +555,13 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		}
 		// n.table doesn't have meaningful spans, but we need to check support (e.g.
 		// for any filtering expression).
-		if _, err := checkSupportForPlanNode(n.table); err != nil {
+		if _, err := checkSupportForPlanNode(n.table, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		return checkSupportForPlanNode(n.input)
+		return checkSupportForPlanNode(n.input, distSQLVisitor)
 
 	case *invertedFilterNode:
-		return checkSupportForInvertedFilterNode(n)
+		return checkSupportForInvertedFilterNode(n, distSQLVisitor)
 
 	case *invertedJoinNode:
 		if n.table.lockingStrength != descpb.ScanLockingStrength_FOR_NONE {
@@ -569,24 +571,24 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 			// TODO(nvanbenschoten): lift this restriction.
 			return cannotDistribute, cannotDistributeRowLevelLockingErr
 		}
-		if err := checkExprForDistSQL(n.onExpr); err != nil {
+		if err := checkExprForDistSQL(n.onExpr, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		rec, err := checkSupportForPlanNode(n.input)
+		rec, err := checkSupportForPlanNode(n.input, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
 		return rec.compose(shouldDistribute), nil
 
 	case *joinNode:
-		if err := checkExprForDistSQL(n.pred.onCond); err != nil {
+		if err := checkExprForDistSQL(n.pred.onCond, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		recLeft, err := checkSupportForPlanNode(n.left.plan)
+		recLeft, err := checkSupportForPlanNode(n.left.plan, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
-		recRight, err := checkSupportForPlanNode(n.right.plan)
+		recRight, err := checkSupportForPlanNode(n.right.plan, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -603,7 +605,7 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		// Note that we don't need to check whether we support distribution of
 		// n.countExpr or n.offsetExpr because those expressions are evaluated
 		// locally, during the physical planning.
-		return checkSupportForPlanNode(n.plan)
+		return checkSupportForPlanNode(n.plan, distSQLVisitor)
 
 	case *lookupJoinNode:
 		if n.remoteLookupExpr != nil || n.remoteOnlyLookups {
@@ -618,16 +620,16 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 			return cannotDistribute, cannotDistributeRowLevelLockingErr
 		}
 
-		if err := checkExprForDistSQL(n.lookupExpr); err != nil {
+		if err := checkExprForDistSQL(n.lookupExpr, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		if err := checkExprForDistSQL(n.remoteLookupExpr); err != nil {
+		if err := checkExprForDistSQL(n.remoteLookupExpr, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		if err := checkExprForDistSQL(n.onCond); err != nil {
+		if err := checkExprForDistSQL(n.onCond, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
-		rec, err := checkSupportForPlanNode(n.input)
+		rec, err := checkSupportForPlanNode(n.input, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -640,19 +642,19 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 
 	case *projectSetNode:
 		for i := range n.exprs {
-			if err := checkExprForDistSQL(n.exprs[i]); err != nil {
+			if err := checkExprForDistSQL(n.exprs[i], distSQLVisitor); err != nil {
 				return cannotDistribute, err
 			}
 		}
-		return checkSupportForPlanNode(n.source)
+		return checkSupportForPlanNode(n.source, distSQLVisitor)
 
 	case *renderNode:
 		for _, e := range n.render {
-			if err := checkExprForDistSQL(e); err != nil {
+			if err := checkExprForDistSQL(e, distSQLVisitor); err != nil {
 				return cannotDistribute, err
 			}
 		}
-		return checkSupportForPlanNode(n.source.plan)
+		return checkSupportForPlanNode(n.source.plan, distSQLVisitor)
 
 	case *scanNode:
 		if n.lockingStrength != descpb.ScanLockingStrength_FOR_NONE {
@@ -681,14 +683,14 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		}
 
 	case *sortNode:
-		rec, err := checkSupportForPlanNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
 		return rec.compose(shouldDistribute), nil
 
 	case *topKNode:
-		rec, err := checkSupportForPlanNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -699,11 +701,11 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		return canDistribute, nil
 
 	case *unionNode:
-		recLeft, err := checkSupportForPlanNode(n.left)
+		recLeft, err := checkSupportForPlanNode(n.left, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
-		recRight, err := checkSupportForPlanNode(n.right)
+		recRight, err := checkSupportForPlanNode(n.right, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -719,7 +721,7 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 
 		for _, tuple := range n.tuples {
 			for _, expr := range tuple {
-				if err := checkExprForDistSQL(expr); err != nil {
+				if err := checkExprForDistSQL(expr, distSQLVisitor); err != nil {
 					return cannotDistribute, err
 				}
 			}
@@ -727,7 +729,7 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		return canDistribute, nil
 
 	case *windowNode:
-		rec, err := checkSupportForPlanNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan, distSQLVisitor)
 		if err != nil {
 			return cannotDistribute, err
 		}
@@ -753,7 +755,7 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 				return cannotDistribute, cannotDistributeRowLevelLockingErr
 			}
 		}
-		if err := checkExprForDistSQL(n.onCond); err != nil {
+		if err := checkExprForDistSQL(n.onCond, distSQLVisitor); err != nil {
 			return cannotDistribute, err
 		}
 		return shouldDistribute, nil
@@ -765,8 +767,10 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 	}
 }
 
-func checkSupportForInvertedFilterNode(n *invertedFilterNode) (distRecommendation, error) {
-	rec, err := checkSupportForPlanNode(n.input)
+func checkSupportForInvertedFilterNode(
+	n *invertedFilterNode, distSQLVisitor *distSQLExprCheckVisitor,
+) (distRecommendation, error) {
+	rec, err := checkSupportForPlanNode(n.input, distSQLVisitor)
 	if err != nil {
 		return cannotDistribute, err
 	}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -473,6 +473,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 
 		ivh := tree.MakeIndexedVarHelper(nil /* container */, len(scan.cols))
 		var scanIdx, virtIdx int
+		var distSQLVisitor distSQLExprCheckVisitor
 		for i, col := range requestedCols {
 			if col.IsVirtual() {
 				if virtIdx >= len(virtComputedExprs) {
@@ -484,7 +485,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 				// Check that the virtual computed column expression can be distributed.
 				// TODO(michae2): Add the ability to run CREATE STATISTICS locally if a
 				// local-only virtual computed column expression is needed.
-				if err := checkExprForDistSQL(virtComputedExprs[virtIdx]); err != nil {
+				if err := checkExprForDistSQL(virtComputedExprs[virtIdx], &distSQLVisitor); err != nil {
 					return nil, err
 				}
 				exprs[i] = virtComputedExprs[virtIdx]

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1782,7 +1782,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 ) error {
 	distributeSubquery := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
-		planner.SessionData().DistSQLMode, subqueryPlan.plan,
+		planner.SessionData().DistSQLMode, subqueryPlan.plan, &planner.distSQLVisitor,
 	).WillDistribute()
 	distribute := DistributionType(LocalDistribution)
 	if distributeSubquery {
@@ -2278,7 +2278,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 ) error {
 	distributePostquery := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
-		planner.SessionData().DistSQLMode, postqueryPlan,
+		planner.SessionData().DistSQLMode, postqueryPlan, &planner.distSQLVisitor,
 	).WillDistribute()
 	distribute := DistributionType(LocalDistribution)
 	if distributePostquery {

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -44,6 +44,7 @@ type distSQLSpecExecFactory struct {
 	singleTenant         bool
 	planningMode         distSQLPlanningMode
 	gatewaySQLInstanceID base.SQLInstanceID
+	distSQLVisitor       distSQLExprCheckVisitor
 }
 
 var _ exec.Factory = &distSQLSpecExecFactory{}
@@ -314,7 +315,7 @@ func (e *distSQLSpecExecFactory) checkExprsAndMaybeMergeLastStage(
 		recommendation = cannotDistribute
 	}
 	for _, expr := range exprs {
-		if err := checkExprForDistSQL(expr); err != nil {
+		if err := checkExprForDistSQL(expr, &e.distSQLVisitor); err != nil {
 			recommendation = cannotDistribute
 			if physPlan != nil {
 				// The filter expression cannot be distributed, so we need to

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1878,6 +1878,7 @@ func getPlanDistribution(
 	txnHasUncommittedTypes bool,
 	distSQLMode sessiondatapb.DistSQLExecMode,
 	plan planMaybePhysical,
+	distSQLVisitor *distSQLExprCheckVisitor,
 ) physicalplan.PlanDistribution {
 	if plan.isPhysicalPlan() {
 		return plan.physPlan.Distribution
@@ -1899,7 +1900,7 @@ func getPlanDistribution(
 		return physicalplan.LocalPlan
 	}
 
-	rec, err := checkSupportForPlanNode(plan.planNode)
+	rec, err := checkSupportForPlanNode(plan.planNode, distSQLVisitor)
 	if err != nil {
 		// Don't use distSQL for this request.
 		log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -64,7 +64,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// created).
 		distribution := getPlanDistribution(
 			params.ctx, params.p.Descriptors().HasUncommittedTypes(),
-			params.extendedEvalCtx.SessionData().DistSQLMode, plan.main,
+			params.extendedEvalCtx.SessionData().DistSQLMode, plan.main, &params.p.distSQLVisitor,
 		)
 
 		outerSubqueries := params.p.curPlan.subqueryPlans

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -42,7 +42,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution := getPlanDistribution(
 		params.ctx, params.p.Descriptors().HasUncommittedTypes(),
-		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main,
+		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main, &params.p.distSQLVisitor,
 	)
 	outerSubqueries := params.p.curPlan.subqueryPlans
 	planCtx := newPlanningCtxForExplainPurposes(distSQLPlanner, params, n.plan.subqueryPlans, distribution)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -286,6 +286,10 @@ type planner struct {
 	trackDependency map[catid.DescID]bool
 
 	reducedAuditConfig *auditlogging.ReducedAuditConfig
+
+	// This field is embedded into the planner to avoid an allocation in
+	// checkExprForDistSQL.
+	distSQLVisitor distSQLExprCheckVisitor
 }
 
 // hasFlowForPausablePortal returns true if the planner is for re-executing a

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -460,7 +460,8 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 
 			isLocal := !getPlanDistribution(
 				ctx, localPlanner.Descriptors().HasUncommittedTypes(),
-				localPlanner.extendedEvalCtx.SessionData().DistSQLMode, localPlanner.curPlan.main,
+				localPlanner.extendedEvalCtx.SessionData().DistSQLMode,
+				localPlanner.curPlan.main, &localPlanner.distSQLVisitor,
 			).WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
 				Table: *table.TableDesc(),


### PR DESCRIPTION
This commit removes an allocation of `distSQLExprCheckVisitor` that previously happened on each `checkExprForDistSQL` call. We now reuse the same visitor that is stored on the `planner`. In some profiles I looked at recently this allocation accounted for over 1% of all allocations.

Fixes: #121302.

Release note: None