### PR TITLE
builtins: add manual raw key split and scatter

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5964,6 +5964,33 @@ SELECT
 			Info:       "This function returns the span that contains the keys for the given index.",
 			Volatility: volatility.Leakproof,
 		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "tenant_id", Typ: types.Int},
+				{Name: "table_id", Typ: types.Int},
+				{Name: "index_id", Typ: types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.BytesArray),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				tenID := uint64(tree.MustBeDInt(args[0]))
+				tabID := uint32(tree.MustBeDInt(args[1]))
+				indexID := uint32(tree.MustBeDInt(args[2]))
+				tenant, err := roachpb.MakeTenantID(tenID)
+				if err != nil {
+					return nil, err
+				}
+
+				start := roachpb.Key(rowenc.MakeIndexKeyPrefix(keys.MakeSQLCodec(tenant),
+					catid.DescID(tabID),
+					catid.IndexID(indexID)))
+				return spanToDatum(roachpb.Span{
+					Key:    start,
+					EndKey: start.PrefixEnd(),
+				})
+			},
+			Info:       "This function returns the span that contains the keys for the given index.",
+			Volatility: volatility.Leakproof,
+		},
 	),
 	// Return a pretty key for a given raw key, skipping the specified number of
 	// fields.

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2578,6 +2578,9 @@ var builtinOidsArray = []string{
 	2610: `crdb_internal.request_statement_bundle(stmtFingerprint: string, planGist: string, samplingProbability: float, minExecutionLatency: interval, expiresAfter: interval, redacted: bool) -> bool`,
 	2611: `crdb_internal.request_statement_bundle(stmtFingerprint: string, planGist: string, antiPlanGist: bool, samplingProbability: float, minExecutionLatency: interval, expiresAfter: interval, redacted: bool) -> bool`,
 	2612: `crdb_internal.index_span(tenant_id: int, table_id: int, index_id: int) -> bytes[]`,
+	2613: `crdb_internal.split_at(key: bytes, ttl: interval) -> void`,
+	2614: `crdb_internal.scatter(key: bytes) -> void`,
+	2615: `crdb_internal.scatter(key: bytes, end_key: bytes) -> void`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2577,6 +2577,7 @@ var builtinOidsArray = []string{
 	2609: `crdb_internal.request_statement_bundle(stmtFingerprint: string, samplingProbability: float, minExecutionLatency: interval, expiresAfter: interval, redacted: bool) -> bool`,
 	2610: `crdb_internal.request_statement_bundle(stmtFingerprint: string, planGist: string, samplingProbability: float, minExecutionLatency: interval, expiresAfter: interval, redacted: bool) -> bool`,
 	2611: `crdb_internal.request_statement_bundle(stmtFingerprint: string, planGist: string, antiPlanGist: bool, samplingProbability: float, minExecutionLatency: interval, expiresAfter: interval, redacted: bool) -> bool`,
+	2612: `crdb_internal.index_span(tenant_id: int, table_id: int, index_id: int) -> bytes[]`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
The SQL syntax versions are more friendly/what we want a user to use, but having these available for internal debugging and manual use by CRL engineers can be handy, particularly when operating on tenants where the SQL versions are not active.

Release note: none.
Epic: none.