### PR TITLE
admission: increase sleep in testGranter.grant for test determinism

### DIFF
--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -97,7 +97,7 @@ func (tg *testGranter) grant(grantChainID grantChainID) {
 		// was admitted. Sleep to let it get scheduled. We could do something more
 		// sophisticated like monitoring goroutine states like in
 		// concurrency_manager_test.go.
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 	}
 	tg.buf.printf("granted%s: returned %d", tg.name, rv)
 }


### PR DESCRIPTION
The sleep is increased from 50ms to 150ms. This increases the duration for running admission package tests from 17s to 20s, which is acceptable.

Informs #121450

Epic: none

Release note: None