### PR TITLE
release-24.1: backupccl: include relevant information in online restore return statement

### DIFF
--- a/pkg/ccl/backupccl/backuptestutils/testutils.go
+++ b/pkg/ccl/backupccl/backuptestutils/testutils.go
@@ -206,7 +206,7 @@ func setTestClusterDefaults(params *base.TestClusterArgs, dataDir string, useDat
 }
 
 // VerifyBackupRestoreStatementResult conducts a Backup or Restore and verifies
-// it was properly written to the jobs table
+// it was properly written to the jobs table. Note, does not verify online restores
 func VerifyBackupRestoreStatementResult(
 	t *testing.T, sqlDB *sqlutils.SQLRunner, query string, args ...interface{},
 ) error {
@@ -217,7 +217,7 @@ func VerifyBackupRestoreStatementResult(
 	if err != nil {
 		return err
 	}
-	if e, a := columns, []string{
+	if a, e := columns, []string{
 		"job_id", "status", "fraction_completed", "rows", "index_entries", "bytes",
 	}; !reflect.DeepEqual(e, a) {
 		return errors.Errorf("unexpected columns:\n%s", strings.Join(pretty.Diff(e, a), "\n"))

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -94,7 +94,7 @@ func sendAddRemoteSSTs(
 
 	restoreWorkers := int(onlineRestoreLinkWorkers.Get(&execCtx.ExecCfg().Settings.SV))
 	for i := 0; i < restoreWorkers; i++ {
-		grp.GoCtx(sendAddRemoteSSTWorker(execCtx, restoreSpanEntriesCh, requestFinishedCh, kr, fromSystemTenant, &approxRows, &approxDataSize))
+		grp.GoCtx(sendAddRemoteSSTWorker(execCtx, restoreSpanEntriesCh, requestFinishedCh, *kr, fromSystemTenant, &approxRows, &approxDataSize))
 	}
 
 	if err := grp.Wait(); err != nil {
@@ -145,7 +145,7 @@ func sendAddRemoteSSTWorker(
 	execCtx sql.JobExecContext,
 	restoreSpanEntriesCh <-chan execinfrapb.RestoreSpanEntry,
 	requestFinishedCh chan<- struct{},
-	kr *KeyRewriter,
+	kr KeyRewriter,
 	fromSystemTenant bool,
 	approxRows *int64,
 	approxDataSize *int64,
@@ -222,7 +222,7 @@ func sendAddRemoteSSTWorker(
 				}
 				// Clone the key because rewriteSpan could modify the keys in place, but
 				// we reuse backup files across restore span entries.
-				restoringSubspan, err = rewriteSpan(kr, restoringSubspan.Clone(), entry.ElidedPrefix)
+				restoringSubspan, err = rewriteSpan(&kr, restoringSubspan.Clone(), entry.ElidedPrefix)
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -11,6 +11,8 @@ package backupccl
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -27,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,12 +42,13 @@ func TestOnlineRestoreBasic(t *testing.T) {
 	ctx := context.Background()
 
 	const numAccounts = 1000
-	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, base.TestClusterArgs{
+	params := base.TestClusterArgs{
 		// Online restore is not supported in a secondary tenant yet.
 		ServerArgs: base.TestServerArgs{
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		},
-	})
+	}
+	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
 	defer cleanupFn()
 	externalStorage := "nodelocal://1/backup"
 
@@ -53,11 +57,6 @@ func TestOnlineRestoreBasic(t *testing.T) {
 
 	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
 
-	params := base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-		},
-	}
 	rtc, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, params)
 	defer cleanupFnRestored()
 	var preRestoreTs float64
@@ -80,6 +79,75 @@ func TestOnlineRestoreBasic(t *testing.T) {
 	jobutils.WaitForJobToSucceed(t, rSQLDB, downloadJobID)
 
 	rSQLDB.CheckQueryResults(t, createStmt, createStmtRes)
+}
+
+func TestOnlineRestoreStatementResult(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+
+	const numAccounts = 1
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
+		t,
+		singleNode,
+		numAccounts,
+		InitManualReplication,
+		base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			},
+		},
+	)
+	defer cleanupFn()
+
+	sqlDB.ExecMultiple(
+		t,
+		"USE data",
+		"CREATE TABLE foo (x INT PRIMARY KEY, y INT)",
+		"INSERT INTO foo VALUES (1, 2)",
+	)
+	sqlDB.Exec(t, "BACKUP DATABASE data INTO $1", localFoo)
+
+	rows := sqlDB.Query(
+		t,
+		"RESTORE DATABASE data FROM LATEST IN $1 WITH OPTIONS (new_db_name='data2', experimental deferred copy)",
+		localFoo,
+	)
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a, e := columns, []string{
+		"job_id", "tables", "approx_rows", "approx_bytes", "background_download_job_id",
+	}; !reflect.DeepEqual(e, a) {
+		t.Fatalf("unexpected columns:\n%s", strings.Join(pretty.Diff(e, a), "\n"))
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("zero rows in result")
+	}
+
+	var id, expectedID, tables, approxRows, approxBytes, downloadJobID int64
+	require.NoError(t, rows.Scan(
+		&id, &tables, &approxRows, &approxBytes, &downloadJobID,
+	))
+	sqlDB.QueryRow(t,
+		`SELECT job_id FROM crdb_internal.jobs WHERE job_id = $1`, id,
+	).Scan(
+		&expectedID,
+	)
+
+	require.Equal(t, expectedID, id, "result does not match system.jobs")
+	require.Equal(t, id+1, downloadJobID, "download job id should be one greater than restore job id")
+	require.Equal(t, int64(2), tables, "expected 2 tables to be in result")
+	require.Greater(t, approxRows, int64(0), "no rows estimated in result")
+	require.Greater(t, approxBytes, int64(0), "no bytes estimated in result")
+
+	if rows.Next() {
+		t.Fatal("more than one row in result")
+	}
 }
 
 // TestOnlineRestoreWaitForDownload checks that the download job succeeeds even

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1195,6 +1195,8 @@ func restoreTypeCheck(
 	}
 	if restoreStmt.Options.Detached {
 		header = jobs.DetachedJobExecutionResultHeader
+	} else if restoreStmt.Options.ExperimentalOnline {
+		header = jobs.OnlineRestoreJobExecutionResultHeader
 	} else {
 		header = jobs.BulkJobExecutionResultHeader
 	}
@@ -1291,7 +1293,7 @@ func restorePlanHook(
 			return nil, nil, nil, false, err
 		}
 	} else {
-		// Deprecation notice for non-colelction `RESTORE FROM` syntax. Remove this
+		// Deprecation notice for non-collection `RESTORE FROM` syntax. Remove this
 		// once the syntax is deleted in 22.2.
 		p.BufferClientNotice(ctx,
 			pgnotice.Newf("The `RESTORE FROM <backup>` syntax will be removed in a future release, please"+
@@ -1441,10 +1443,15 @@ func restorePlanHook(
 		)
 	}
 
+	var header colinfo.ResultColumns
 	if restoreStmt.Options.Detached {
-		return fn, jobs.DetachedJobExecutionResultHeader, nil, false, nil
+		header = jobs.DetachedJobExecutionResultHeader
+	} else if restoreStmt.Options.ExperimentalOnline {
+		header = jobs.OnlineRestoreJobExecutionResultHeader
+	} else {
+		header = jobs.BulkJobExecutionResultHeader
 	}
-	return fn, jobs.BulkJobExecutionResultHeader, nil, false, nil
+	return fn, header, nil, false, nil
 }
 
 // checkRestoreDestinationPrivileges iterates over the External Storage URIs and

--- a/pkg/cloud/nodelocal/test_nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/test_nodelocal_storage.go
@@ -26,7 +26,7 @@ import (
 // nodelocal with one reads and writes directly from the given
 // directory.
 //
-// The returned func restores the prooduction implemenation.
+// The returned func restores the prooduction implementation.
 func ReplaceNodeLocalForTesting(root string) func() {
 	makeFn := func(ctx context.Context, conf cloud.EarlyBootExternalStorageContext, es cloudpb.ExternalStorage) (cloud.ExternalStorage, error) {
 		return TestingMakeNodelocalStorage(root, conf.Settings, es), nil

--- a/pkg/jobs/resultcols.go
+++ b/pkg/jobs/resultcols.go
@@ -26,6 +26,16 @@ var BulkJobExecutionResultHeader = colinfo.ResultColumns{
 	{Name: "bytes", Typ: types.Int},
 }
 
+// OnlineRestoreJobExecutionResultHeader is the header for an online restore
+// job, which provides a header different from the usual bulk job execution
+var OnlineRestoreJobExecutionResultHeader = colinfo.ResultColumns{
+	{Name: "job_id", Typ: types.Int},
+	{Name: "tables", Typ: types.Int},
+	{Name: "approx_rows", Typ: types.Int},
+	{Name: "approx_bytes", Typ: types.Int},
+	{Name: "background_download_job_id", Typ: types.Int},
+}
+
 // DetachedJobExecutionResultHeader is a the header for various job commands when
 // job executes in detached mode (i.e. the caller doesn't wait for job completion).
 var DetachedJobExecutionResultHeader = colinfo.ResultColumns{


### PR DESCRIPTION
Backport 1/1 commits from #121388.

/cc @cockroachdb/release

---

Fixes #120053

Online restore return statement now returns the following:
- Job ID
- Number of tables
- Approximate number of rows
- Approximate number of bytes
- Download job ID

Release note: None

—

Data race condition detected by Bazel Extended Tests, caused by workers
writing to cached results in KeyRewriter without a lock

Release note: none

Release justification: Bug fix for online restore output