### PR TITLE
kvserver: Small optimizations for MaybeGossipNodeLivenessRaftMuLocked

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -47,6 +47,7 @@ the system with minimal total hops. The algorithm is as follows:
 package gossip
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -891,6 +892,33 @@ func (g *Gossip) AddInfoProto(key string, msg protoutil.Message, ttl time.Durati
 	return g.AddInfo(key, bytes, ttl)
 }
 
+// AddInfoIfNotRedundant adds or updates an info object if it isn't already
+// present in the local infoStore with exactly the same value and with this
+// node as the source. Motivated by the node liveness range's desire to only
+// gossip changed entries.
+//
+// Assumes the values have a TTL of 0 (always adding the gossip anew if the
+// stored value wasn't added with a TTL of 0), because if a value had a non-0
+// TTL then we'd have to make some sort of value judgment about whether it's
+// worth re-gossiping yet given how old the existing matching info was.
+func (g *Gossip) AddInfoIfNotRedundant(key string, val []byte) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	info := g.mu.is.getInfo(key)
+
+	if info != nil {
+		infoBytes, err := info.Value.GetBytes()
+		if err == nil && bytes.Equal(infoBytes, val) && g.infoOriginatedHere(info) && info.TTLStamp == math.MaxInt64 {
+			// Nothing has changed, so no need to re-gossip.
+			return nil
+		}
+	}
+
+	// Something is different, so we do need to add the provided key/value.
+	return g.addInfoLocked(key, val, 0 /* ttl */)
+}
+
 // AddClusterID is a convenience method for gossipping the cluster ID. There's
 // no TTL - the record lives forever.
 func (g *Gossip) AddClusterID(val uuid.UUID) error {
@@ -983,6 +1011,12 @@ func (g *Gossip) InfoOriginatedHere(key string) bool {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	info := g.mu.is.getInfo(key)
+	return g.infoOriginatedHere(info)
+}
+
+// infoOriginatedHere is a simple reusable helper for InfoOriginatedHere that
+// doesn't involve taking the mutex.
+func (g *Gossip) infoOriginatedHere(info *Info) bool {
 	return info != nil && info.NodeID == g.NodeID.Get()
 }
 

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -110,13 +110,15 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 		return errors.Errorf("unexpected intents on node liveness span %s: %+v", span, result.Local.EncounteredIntents)
 	}
 	kvs := br.Responses[0].GetInner().(*kvpb.ScanResponse).Rows
+
 	log.VEventf(ctx, 2, "gossiping %d node liveness record(s) from span %s", len(kvs), span)
-	for _, kv := range kvs {
+	if len(kvs) == 1 {
 		// Parse the value to both confirm it's well-formatted and to extract the
 		// node ID from it. We could instead derive the node ID from the key and
 		// skip unmarshaling the value at all, which would be (marginally) faster,
 		// but that would be a greater change from how this code has historically
 		// worked and it's not likely to be a huge difference.
+		kv := kvs[0]
 		var kvLiveness livenesspb.Liveness
 		if err := kv.Value.GetProto(&kvLiveness); err != nil {
 			return errors.Wrapf(err, "failed to unmarshal liveness value %s", kv.Key)
@@ -129,7 +131,28 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 		if err := r.store.Gossip().AddInfoIfNotRedundant(key, valBytes); err != nil {
 			return errors.Wrapf(err, "failed to gossip node liveness for %s", kv.Key)
 		}
+	} else {
+		// Same code as above, but for more than one liveness record. Allocate a
+		// slice that can be passed to a bulk gossip operation rather than taking
+		// and releasing the gossip mutex separately for each.
+		gossipInfos := make([]gossip.InfoToAdd, 0, len(kvs))
+		for _, kv := range kvs {
+			var kvLiveness livenesspb.Liveness
+			if err := kv.Value.GetProto(&kvLiveness); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal liveness value %s", kv.Key)
+			}
+			key := gossip.MakeNodeLivenessKey(kvLiveness.NodeID)
+			valBytes, err := kv.Value.GetBytes()
+			if err != nil {
+				return errors.Wrapf(err, "failed to GetBytes to gossip node liveness for %s", kv.Key)
+			}
+			gossipInfos = append(gossipInfos, gossip.InfoToAdd{Key: key, Val: valBytes})
+		}
+		if err := r.store.Gossip().BulkAddInfoIfNotRedundant(gossipInfos); err != nil {
+			return errors.Wrapf(err, "failed to gossip node liveness for %d keys", len(kvs))
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Full description in the two commit messages, but these are basically attempts to reduce the cost both in terms of CPU cycles and gossip mutex contention when gossiping node liveness from the leaseholder, by both:

1. Doing less protobuf serialization+deserialization
2. Taking the gossip mutex many fewer times

It's debatable whether it's a good idea for the gossip mutex to be taken at all while the node liveness leaseholder `Replica`'s mutex is also held since it seems like a priority inversion, but I didn't really want to boil the whole ocean here at once, and this gets much of the benefit already.

I did a lame microbenchmark (377e8565a1ea61d15610f520bc4ed167accf5aaa) of the old code, the code after the first commit, and the code after the second commit and got:

```
BenchmarkOldCode
BenchmarkOldCode-10                        1526    683569 ns/op
BenchmarkIntermediateCode
BenchmarkIntermediateCode-10               2661    380633 ns/op
BenchmarkNewCode
BenchmarkNewCode-10                        3194    377339 ns/op
```

If I tweaked the code to always have to add the new value to gossip rather than treating it as a no-op, I got:

```
BenchmarkOldCode
BenchmarkOldCode-10                         643   1791176 ns/op
BenchmarkIntermediateCode
BenchmarkIntermediateCode-10                868   1321190 ns/op
BenchmarkNewCode
BenchmarkNewCode-10                         904   1278004 ns/op
```

So it's not exactly world-changing in terms of CPU usage, but (1) it is an improvement, and (2) I'm at least as concerned about possible gossip mutex contention here as I am about cpu usage, and this takes the gossip mutex drastically fewer times than before -- once vs three times when updating a single liveness entry, and once vs (approximately) the number of decommissioned+dead+live nodes times 2 in the bulk case.

Epic: None
(although it marginally helps with #97966)