### PR TITLE
loqrecovery: fix port reuse in TestReplicaCollection

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -52,6 +52,12 @@ func TestReplicaCollection(t *testing.T) {
 
 	ctx := context.Background()
 
+	// This test stops cluster servers. Use "reusable" listeners, otherwise the
+	// ports can be reused by other test clusters, and we may accidentally connect
+	// to a wrong node.
+	// TODO(pav-kv): force all tests calling StopServer to use sticky listeners.
+	listenerReg := listenerutil.NewListenerRegistry()
+	defer listenerReg.Close()
 	tc := testcluster.NewTestCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			StoreSpecs: []base.StoreSpec{{InMemory: true}},
@@ -62,6 +68,7 @@ func TestReplicaCollection(t *testing.T) {
 				},
 			},
 		},
+		ReusableListenerReg: listenerReg,
 	})
 	tc.Start(t)
 	defer tc.Stopper().Stop(ctx)


### PR DESCRIPTION
Fixes #114643, #117863

Epic: none
Release note: none