### PR TITLE
opt: fix histograms in inverted trigram stats tests

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/inverted-trigram
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-trigram
@@ -7,18 +7,18 @@ CREATE TABLE a (a TEXT)
 ----
 
 exec-ddl
-CREATE INDEX ON a(a)
+CREATE INDEX fwd ON a(a)
 ----
 
 exec-ddl
-CREATE INVERTED INDEX ON a(a gin_trgm_ops)
+CREATE INVERTED INDEX inv ON a(a gin_trgm_ops)
 ----
 
 # First, check both plans without stats.
 opt
 SELECT * FROM a WHERE a = 'foo'
 ----
-scan a@a_a_idx
+scan a@fwd
  ├── columns: a:1(string!null)
  ├── constraint: /1/2: [/'foo' - /'foo']
  ├── stats: [rows=10, distinct(1)=1, null(1)=0]
@@ -33,7 +33,7 @@ select
  ├── index-join a
  │    ├── columns: a:1(string)
  │    ├── stats: [rows=111.1111]
- │    └── scan a@a_a_idx1
+ │    └── scan a@inv
  │         ├── columns: rowid:2(int!null)
  │         ├── inverted constraint: /5/2
  │         │    └── spans: ["\x12foo\x00\x01", "\x12foo\x00\x01"]
@@ -72,21 +72,21 @@ ALTER TABLE a INJECT STATISTICS '[
 
 # Check the plan for a forward scan.
 opt
-SELECT * FROM a WHERE a = 'foo'
+SELECT * FROM a WHERE a = 'blah'
 ----
-scan a@a_a_idx
+scan a@fwd
  ├── columns: a:1(string!null)
- ├── constraint: /1/2: [/'foo' - /'foo']
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0]
- │   histogram(1)=  0    0
- │                <--- 'foo'
+ ├── constraint: /1/2: [/'blah' - /'blah']
+ ├── stats: [rows=10, distinct(1)=1, null(1)=0]
+ │   histogram(1)=  0    10
+ │                <--- 'blah'
  └── fd: ()-->(1)
 
 # Make sure that this query doesn't have a problem, even though the inverted
 # scan could see "forward histogram" data.
 
 opt
-SELECT * FROM a WHERE a LIKE '%foo%'
+SELECT * FROM a WHERE a LIKE '%blah%'
 ----
 select
  ├── columns: a:1(string!null)
@@ -94,14 +94,31 @@ select
  ├── index-join a
  │    ├── columns: a:1(string)
  │    ├── stats: [rows=111.1111]
- │    └── scan a@a_a_idx1
+ │    └── inverted-filter
  │         ├── columns: rowid:2(int!null)
- │         ├── inverted constraint: /5/2
- │         │    └── spans: ["\x12foo\x00\x01", "\x12foo\x00\x01"]
- │         ├── stats: [rows=111.1111, distinct(5)=100, null(5)=0]
- │         └── key: (2)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: empty
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: true
+ │         │         │    └── union spans: ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │         ├── stats: [rows=111.1111]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │              │         └── ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │              ├── stats: [rows=111.1111, distinct(2)=111.111, null(2)=0, distinct(5)=100, null(5)=0]
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
  └── filters
-      └── a:1 LIKE '%foo%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── a:1 LIKE '%blah%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # Now, inject inverted statistics with forward statistics also.
 exec-ddl
@@ -116,27 +133,63 @@ ALTER TABLE a INJECT STATISTICS '[
     "histo_buckets": [
       {
         "distinct_range": 0,
-        "num_eq": 9,
+        "num_eq": 10,
         "num_range": 0,
-        "upper_bound": "\\x122020310001"
+        "upper_bound": "\\x122020620001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 8,
+        "num_eq": 990,
         "num_range": 0,
-        "upper_bound": "\\x122020320001"
+        "upper_bound": "\\x1220207a0001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 6,
+        "num_eq": 10,
         "num_range": 0,
-        "upper_bound": "\\x122020330001"
+        "upper_bound": "\\x1220626c0001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 6,
+        "num_eq": 990,
         "num_range": 0,
-        "upper_bound": "\\x127973200001"
+        "upper_bound": "\\x12207a6f0001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x126168200001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x12626c610001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x126c61680001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x126f6f200001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x126f6f6f0001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x127a6f6f0001"
       }
     ]
   },
@@ -167,35 +220,91 @@ ALTER TABLE a INJECT STATISTICS '[
 
 # Test that we get a plan that uses the inverted index now that there are stats.
 opt
-SELECT * FROM a WHERE a LIKE '%foo%'
+SELECT * FROM a WHERE a LIKE '%blah%'
 ----
 select
  ├── columns: a:1(string!null)
  ├── stats: [rows=333.3333, distinct(1)=333.333, null(1)=0]
  ├── index-join a
  │    ├── columns: a:1(string)
- │    ├── stats: [rows=5.8e-09]
- │    └── scan a@a_a_idx1
+ │    ├── stats: [rows=20]
+ │    └── inverted-filter
  │         ├── columns: rowid:2(int!null)
- │         ├── inverted constraint: /5/2
- │         │    └── spans: ["\x12foo\x00\x01", "\x12foo\x00\x01"]
- │         ├── stats: [rows=5.8e-09, distinct(5)=5.8e-09, null(5)=0]
- │         │   histogram(5)=  0         0
- │         │                <--- '\x12666f6f0002'
- │         └── key: (2)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: empty
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: true
+ │         │         │    └── union spans: ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │         ├── stats: [rows=20]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │              │         └── ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │              ├── stats: [rows=20, distinct(2)=4, null(2)=0, distinct(5)=2, null(5)=0]
+ │              │   histogram(5)=  0         10         0         10         0         0
+ │              │                <--- '\x12626c610001' --- '\x126c61680001' --- '\x126c61680002'
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
  └── filters
-      └── a:1 LIKE '%foo%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── a:1 LIKE '%blah%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+
+# Test a less selective filter, forcing the inverted index scan.
+opt
+SELECT * FROM a@inv WHERE a LIKE '%zooo%'
+----
+select
+ ├── columns: a:1(string!null)
+ ├── stats: [rows=333.3333, distinct(1)=333.333, null(1)=0]
+ ├── index-join a
+ │    ├── columns: a:1(string)
+ │    ├── stats: [rows=1980]
+ │    └── inverted-filter
+ │         ├── columns: rowid:2(int!null)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: empty
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: true
+ │         │         │    └── union spans: ["\x12ooo\x00\x01", "\x12ooo\x00\x01"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x12zoo\x00\x01", "\x12zoo\x00\x01"]
+ │         ├── stats: [rows=1980]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["\x12ooo\x00\x01", "\x12ooo\x00\x01"]
+ │              │         └── ["\x12zoo\x00\x01", "\x12zoo\x00\x01"]
+ │              ├── flags: force-index=inv
+ │              ├── stats: [rows=1980, distinct(2)=396, null(2)=0, distinct(5)=2, null(5)=0]
+ │              │   histogram(5)=  0        990         0        990
+ │              │                <--- '\x126f6f6f0001' --- '\x127a6f6f0001'
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
+ └── filters
+      └── a:1 LIKE '%zooo%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # Now, check what happens with a forward scan now that we have an inverted histogram.
 opt
-SELECT * FROM a WHERE a = 'foobarbaz'
+SELECT * FROM a WHERE a = 'blah'
 ----
-scan a@a_a_idx
+scan a@fwd
  ├── columns: a:1(string!null)
- ├── constraint: /1/2: [/'foobarbaz' - /'foobarbaz']
- ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0]
- │   histogram(1)=  0       0
- │                <--- 'foobarbaz'
+ ├── constraint: /1/2: [/'blah' - /'blah']
+ ├── stats: [rows=10, distinct(1)=1, null(1)=0]
+ │   histogram(1)=  0    10
+ │                <--- 'blah'
  └── fd: ()-->(1)
 
 # Finally, check what happens when there are only inverted stats.
@@ -211,27 +320,63 @@ ALTER TABLE a INJECT STATISTICS '[
     "histo_buckets": [
       {
         "distinct_range": 0,
-        "num_eq": 9,
+        "num_eq": 990,
         "num_range": 0,
-        "upper_bound": "\\x122020310001"
+        "upper_bound": "\\x1220207a0001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 8,
+        "num_eq": 10,
         "num_range": 0,
-        "upper_bound": "\\x122020320001"
+        "upper_bound": "\\x122020620001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 6,
+        "num_eq": 10,
         "num_range": 0,
-        "upper_bound": "\\x122020330001"
+        "upper_bound": "\\x1220626c0001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 6,
+        "num_eq": 990,
         "num_range": 0,
-        "upper_bound": "\\x127973200001"
+        "upper_bound": "\\x12207a6f0001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x126168200001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x12626c610001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x126c61680001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x126f6f200001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x126f6f6f0001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x127a6f6f0001"
       }
     ]
   }
@@ -239,31 +384,87 @@ ALTER TABLE a INJECT STATISTICS '[
 ----
 
 opt
-SELECT * FROM a WHERE a LIKE '%foo%'
+SELECT * FROM a WHERE a LIKE '%blah%'
 ----
 select
  ├── columns: a:1(string!null)
  ├── stats: [rows=333.3333, distinct(1)=333.333, null(1)=0]
  ├── index-join a
  │    ├── columns: a:1(string)
- │    ├── stats: [rows=5.8e-09]
- │    └── scan a@a_a_idx1
+ │    ├── stats: [rows=20]
+ │    └── inverted-filter
  │         ├── columns: rowid:2(int!null)
- │         ├── inverted constraint: /5/2
- │         │    └── spans: ["\x12foo\x00\x01", "\x12foo\x00\x01"]
- │         ├── stats: [rows=5.8e-09, distinct(5)=5.8e-09, null(5)=0]
- │         │   histogram(5)=  0         0
- │         │                <--- '\x12666f6f0002'
- │         └── key: (2)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: empty
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: true
+ │         │         │    └── union spans: ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │         ├── stats: [rows=20]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │              │         └── ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │              ├── stats: [rows=20, distinct(2)=4, null(2)=0, distinct(5)=2, null(5)=0]
+ │              │   histogram(5)=  0         10         0         10         0         0
+ │              │                <--- '\x12626c610001' --- '\x126c61680001' --- '\x126c61680002'
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
  └── filters
-      └── a:1 LIKE '%foo%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+      └── a:1 LIKE '%blah%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
+
+# Test a less selective filter, forcing the inverted index scan.
+opt
+SELECT * FROM a@inv WHERE a LIKE '%zooo%'
+----
+select
+ ├── columns: a:1(string!null)
+ ├── stats: [rows=333.3333, distinct(1)=333.333, null(1)=0]
+ ├── index-join a
+ │    ├── columns: a:1(string)
+ │    ├── stats: [rows=1980]
+ │    └── inverted-filter
+ │         ├── columns: rowid:2(int!null)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    ├── union spans: empty
+ │         │    └── INTERSECTION
+ │         │         ├── span expression
+ │         │         │    ├── tight: false, unique: true
+ │         │         │    └── union spans: ["\x12ooo\x00\x01", "\x12ooo\x00\x01"]
+ │         │         └── span expression
+ │         │              ├── tight: false, unique: false
+ │         │              └── union spans: ["\x12zoo\x00\x01", "\x12zoo\x00\x01"]
+ │         ├── stats: [rows=1980]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["\x12ooo\x00\x01", "\x12ooo\x00\x01"]
+ │              │         └── ["\x12zoo\x00\x01", "\x12zoo\x00\x01"]
+ │              ├── flags: force-index=inv
+ │              ├── stats: [rows=1980, distinct(2)=396, null(2)=0, distinct(5)=2, null(5)=0]
+ │              │   histogram(5)=  0        990         0        990
+ │              │                <--- '\x126f6f6f0001' --- '\x127a6f6f0001'
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
+ └── filters
+      └── a:1 LIKE '%zooo%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 opt
-SELECT * FROM a WHERE a = 'foobarbaz'
+SELECT * FROM a WHERE a = 'blah'
 ----
-scan a@a_a_idx
+scan a@fwd
  ├── columns: a:1(string!null)
- ├── constraint: /1/2: [/'foobarbaz' - /'foobarbaz']
+ ├── constraint: /1/2: [/'blah' - /'blah']
  ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  └── fd: ()-->(1)
 
@@ -303,27 +504,63 @@ ALTER TABLE a INJECT STATISTICS '[
     "histo_buckets": [
       {
         "distinct_range": 0,
-        "num_eq": 9,
+        "num_eq": 990,
         "num_range": 0,
-        "upper_bound": "\\x122020310001"
+        "upper_bound": "\\x1220207a0001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 8,
+        "num_eq": 10,
         "num_range": 0,
-        "upper_bound": "\\x122020320001"
+        "upper_bound": "\\x122020620001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 6,
+        "num_eq": 10,
         "num_range": 0,
-        "upper_bound": "\\x122020330001"
+        "upper_bound": "\\x1220626c0001"
       },
       {
         "distinct_range": 0,
-        "num_eq": 6,
+        "num_eq": 990,
         "num_range": 0,
-        "upper_bound": "\\x127973200001"
+        "upper_bound": "\\x12207a6f0001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x126168200001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x12626c610001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 10,
+        "num_range": 0,
+        "upper_bound": "\\x126c61680001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x126f6f200001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x126f6f6f0001"
+      },
+      {
+        "distinct_range": 0,
+        "num_eq": 990,
+        "num_range": 0,
+        "upper_bound": "\\x127a6f6f0001"
       }
     ]
   },
@@ -342,10 +579,10 @@ ALTER TABLE a INJECT STATISTICS '[
 # exist with histograms.
 
 opt
-SELECT * FROM a WHERE a = 'foobarbaz'
+SELECT * FROM a WHERE a = 'blah'
 ----
-scan a@a_a_idx
+scan a@fwd
  ├── columns: a:1(string!null)
- ├── constraint: /1/2: [/'foobarbaz' - /'foobarbaz']
+ ├── constraint: /1/2: [/'blah' - /'blah']
  ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  └── fd: ()-->(1)


### PR DESCRIPTION
This commit fixes injected histograms for inverted key columns that
didn't match the stats for their corresponding non-inverted columns. It
also adjusts the tests so that the query filters match the values in the
histograms.

Epic: None

Release note: None
