### PR TITLE
cli: deflake TestLossOfQuorumRecovery

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -206,6 +206,9 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 	// recovery, we'll check that the range is still accessible for writes as
 	// normal.
 	sk := tcBefore.ScratchRange(t)
+	// The LOQ tooling does not work when a node fails during a split/merge
+	// operation. Make sure that splitting the scratch range fully completes.
+	require.NoError(t, tcBefore.WaitForSplitAndInitialization(sk))
 	require.NoError(t,
 		tcBefore.Server(0).DB().Put(ctx, testutils.MakeKey(sk, []byte{1}), "value"),
 		"failed to write value to scratch range")


### PR DESCRIPTION
LOQ tooling works poorly when nodes stop in the middle of a split/merge operation. Prevent test flakes by making sure the scratch range split completes on all replicas, before turning down the nodes and running the LOQ tool. Also, disable the split and merge queue.

Fixes #121547
Epic: none
Release note: none