### PR TITLE
release-23.1: colexec: fix evaluation of the IN expression with INT2 and INT4 types

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/select_in_gen.go
@@ -25,6 +25,7 @@ func genSelectIn(inputFileContents string, wr io.Writer) error {
 		"_CANONICAL_TYPE_FAMILY", "{{.CanonicalTypeFamilyStr}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_GOTYPESLICE", "{{.GoTypeSliceName}}",
+		"_GOTYPE_UPCAST_INT", `{{if or (eq .VecMethod "Int16") (eq .VecMethod "Int32")}}int64{{else}}{{.GoType}}{{end}}`,
 		"_GOTYPE", "{{.GoType}}",
 		"_TYPE", "{{.VecMethod}}",
 		"TemplateType", "{{.VecMethod}}",

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -1039,7 +1039,7 @@ func (pi *projectInOpDecimal) Next() coldata.Batch {
 
 type selectInOpInt16 struct {
 	colexecop.OneInputHelper
-	filterRow []int16
+	filterRow []int64
 	colIdx    int
 	hasNulls  bool
 	negate    bool
@@ -1050,7 +1050,7 @@ var _ colexecop.Operator = &selectInOpInt16{}
 type projectInOpInt16 struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
-	filterRow []int16
+	filterRow []int64
 	colIdx    int
 	outputIdx int
 	hasNulls  bool
@@ -1061,19 +1061,20 @@ var _ colexecop.Operator = &projectInOpInt16{}
 
 func fillDatumRowInt16(
 	evalCtx *eval.Context, t *types.T, datumTuple *tree.DTuple,
-) ([]int16, bool) {
+) ([]int64, bool) {
 	// Sort the contents of the tuple, if they are not already sorted.
 	datumTuple.Normalize(evalCtx)
 
-	conv := colconv.GetDatumToPhysicalFn(t)
-	var result []int16
+	// Ensure that we always upcast all integer types.
+	conv := colconv.GetDatumToPhysicalFn(types.Int)
+	var result []int64
 	hasNulls := false
 	for _, d := range datumTuple.D {
 		if d == tree.DNull {
 			hasNulls = true
 		} else {
 			convRaw := conv(d)
-			converted := convRaw.(int16)
+			converted := convRaw.(int64)
 			result = append(result, converted)
 		}
 	}
@@ -1081,7 +1082,7 @@ func fillDatumRowInt16(
 }
 
 func cmpInInt16(
-	targetElem int16, targetCol coldata.Int16s, filterRow []int16, hasNulls bool,
+	targetElem int16, targetCol coldata.Int16s, filterRow []int64, hasNulls bool,
 ) comparisonResult {
 	// Filter row input was already sorted in fillDatumRowInt16, so we can
 	// perform a binary search.
@@ -1276,7 +1277,7 @@ func (pi *projectInOpInt16) Next() coldata.Batch {
 
 type selectInOpInt32 struct {
 	colexecop.OneInputHelper
-	filterRow []int32
+	filterRow []int64
 	colIdx    int
 	hasNulls  bool
 	negate    bool
@@ -1287,7 +1288,7 @@ var _ colexecop.Operator = &selectInOpInt32{}
 type projectInOpInt32 struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
-	filterRow []int32
+	filterRow []int64
 	colIdx    int
 	outputIdx int
 	hasNulls  bool
@@ -1298,19 +1299,20 @@ var _ colexecop.Operator = &projectInOpInt32{}
 
 func fillDatumRowInt32(
 	evalCtx *eval.Context, t *types.T, datumTuple *tree.DTuple,
-) ([]int32, bool) {
+) ([]int64, bool) {
 	// Sort the contents of the tuple, if they are not already sorted.
 	datumTuple.Normalize(evalCtx)
 
-	conv := colconv.GetDatumToPhysicalFn(t)
-	var result []int32
+	// Ensure that we always upcast all integer types.
+	conv := colconv.GetDatumToPhysicalFn(types.Int)
+	var result []int64
 	hasNulls := false
 	for _, d := range datumTuple.D {
 		if d == tree.DNull {
 			hasNulls = true
 		} else {
 			convRaw := conv(d)
-			converted := convRaw.(int32)
+			converted := convRaw.(int64)
 			result = append(result, converted)
 		}
 	}
@@ -1318,7 +1320,7 @@ func fillDatumRowInt32(
 }
 
 func cmpInInt32(
-	targetElem int32, targetCol coldata.Int32s, filterRow []int32, hasNulls bool,
+	targetElem int32, targetCol coldata.Int32s, filterRow []int64, hasNulls bool,
 ) comparisonResult {
 	// Filter row input was already sorted in fillDatumRowInt32, so we can
 	// perform a binary search.

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -862,3 +862,14 @@ SELECT -488 OF FROM t;
 ----
 of
 -488
+
+# Regression test for incorrect evaluation of the IN filter due to integer
+# overflow when working with INT4 type (#102864).
+statement ok
+CREATE TABLE t102864 (c INT4);
+INSERT INTO t102864 (c) VALUES (0);
+
+query I
+SELECT c FROM t102864 WHERE c IN (0, 862827606027206657::INT8);
+----
+0


### PR DESCRIPTION
Backport 1/1 commits from #121904.

/cc @cockroachdb/release

---

This commit fixes a possible incorrect result of evaluation of the IN expression where the left side is INT2 or INT4 type and the right side has integers outside of the range of the left side's type. We do so by upcasting the "filter" row to INT8. Note that we already do the appropriate upcast in the comparison function, so the incorrect results could only be produced due to the "filter row" no longer being sorted in case a value overflows.

Fixes: #102864.

Release note (bug fix): CockroachDB could previously incorrectly evaluate IN expressions that had INT2 or INT4 type on the left side and values outside of the range of the left side on the right side. The bug has been present since at least 21.1 and is now fixed.

Release justification: bug fix.