### PR TITLE
sql: add accounting for entries in Txn Fingerprint ID cache

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1059,6 +1059,7 @@ func (s *Server) newConnExecutor(
 		MaxHist:  memMetrics.TxnMaxBytesHist,
 		Settings: s.cfg.Settings,
 	})
+	txnFingerprintIDCacheAcc := sessionMon.MakeBoundAccount()
 
 	nodeIDOrZero, _ := s.cfg.NodeInfo.NodeID.OptionalNodeID()
 	ex := &connExecutor{
@@ -1100,7 +1101,8 @@ func (s *Server) newConnExecutor(
 		indexUsageStats:           s.indexUsageStats,
 		txnIDCacheWriter:          s.txnIDCache,
 		totalActiveTimeStopWatch:  timeutil.NewStopWatch(),
-		txnFingerprintIDCache:     NewTxnFingerprintIDCache(s.cfg.Settings),
+		txnFingerprintIDCache:     NewTxnFingerprintIDCache(ctx, s.cfg.Settings, &txnFingerprintIDCacheAcc),
+		txnFingerprintIDAcc:       &txnFingerprintIDCacheAcc,
 	}
 
 	ex.state.txnAbortCount = ex.metrics.EngineMetrics.TxnAbortCount
@@ -1329,6 +1331,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	ex.mu.IdleInSessionTimeout.Stop()
 	ex.mu.IdleInTransactionSessionTimeout.Stop()
 
+	ex.txnFingerprintIDAcc.Close(ctx)
 	if closeType != panicClose {
 		ex.state.mon.Stop(ctx)
 		ex.sessionPreparedMon.Stop(ctx)
@@ -1744,6 +1747,7 @@ type connExecutor struct {
 	// txnFingerprintIDCache is used to track the most recent
 	// txnFingerprintIDs executed in this session.
 	txnFingerprintIDCache *TxnFingerprintIDCache
+	txnFingerprintIDAcc   *mon.BoundAccount
 
 	// totalActiveTimeStopWatch tracks the total active time of the session.
 	// This is defined as the time spent executing transactions and statements.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3213,7 +3213,13 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 		ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionEndExecTransaction, timeutil.Now())
 		transactionFingerprintID :=
 			appstatspb.TransactionFingerprintID(ex.extraTxnState.transactionStatementsHash.Sum())
-		ex.txnFingerprintIDCache.Add(transactionFingerprintID)
+
+		err := ex.txnFingerprintIDCache.Add(ctx, transactionFingerprintID)
+		if err != nil {
+			if log.V(1) {
+				log.Warningf(ctx, "failed to enqueue transactionFingerprintID = %d: %s", transactionFingerprintID, err)
+			}
+		}
 
 		ex.statsCollector.EndTransaction(
 			ctx,
@@ -3229,7 +3235,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 			)
 		}
 
-		err := ex.recordTransactionFinish(ctx, transactionFingerprintID, ev, implicit, txnStart, txnErr)
+		err = ex.recordTransactionFinish(ctx, transactionFingerprintID, ev, implicit, txnStart, txnErr)
 		if err != nil {
 			if log.V(1) {
 				log.Warningf(ctx, "failed to record transaction stats: %s", err)

--- a/pkg/sql/testdata/txn_fingerprint_id_cache
+++ b/pkg/sql/testdata/txn_fingerprint_id_cache
@@ -25,6 +25,30 @@ show
 ----
 [8 7 6 5]
 
+# Each cache entry takes up 56 bytes.
+accounting
+----
+224 bytes
+
+# Attempt to add ids that are already present in the cache. Neither the cache
+# nor the accounting should change.
+
+enqueue id=05
+----
+size: 4
+
+enqueue id=07
+----
+size: 4
+
+show
+----
+[8 7 6 5]
+
+accounting
+----
+224 bytes
+
 enqueue id=09
 ----
 size: 5
@@ -36,6 +60,10 @@ size: 6
 show
 ----
 [10 9 8 7 6 5]
+
+accounting
+----
+336 bytes
 
 # Decrease the TxnFingerprintIDCacheCapacity cluster setting to below current size.
 override capacity=3
@@ -51,6 +79,10 @@ size: 3
 show
 ----
 [11 10 9]
+
+accounting
+----
+168 bytes
 
 # Check that retrieving IDs also properly truncates the cache when the capacity has
 # been changed.
@@ -75,3 +107,7 @@ TxnFingerprintIDCacheCapacity: 2
 show
 ----
 [13 12]
+
+accounting
+----
+112 bytes

--- a/pkg/sql/txn_fingerprint_id_cache.go
+++ b/pkg/sql/txn_fingerprint_id_cache.go
@@ -83,6 +83,10 @@ func (b *TxnFingerprintIDCache) Add(
 ) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if _, ok := b.mu.cache.StealthyGet(id); ok {
+		// The value is already in the cache - do nothing.
+		return nil
+	}
 	if err := b.mu.acc.Grow(ctx, cacheEntrySize+txnFingerprintIDSize); err != nil {
 		return err
 	}

--- a/pkg/sql/txn_fingerprint_id_cache.go
+++ b/pkg/sql/txn_fingerprint_id_cache.go
@@ -11,10 +11,14 @@
 package sql
 
 import (
+	"context"
+	"unsafe"
+
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -36,13 +40,22 @@ type TxnFingerprintIDCache struct {
 
 	mu struct {
 		syncutil.RWMutex
+		acc   *mon.BoundAccount
 		cache *cache.UnorderedCache
 	}
 }
 
+const (
+	cacheEntrySize       = int64(unsafe.Sizeof(cache.Entry{}))
+	txnFingerprintIDSize = int64(unsafe.Sizeof(appstatspb.TransactionFingerprintID(0)))
+)
+
 // NewTxnFingerprintIDCache returns a new TxnFingerprintIDCache.
-func NewTxnFingerprintIDCache(st *cluster.Settings) *TxnFingerprintIDCache {
+func NewTxnFingerprintIDCache(
+	ctx context.Context, st *cluster.Settings, acc *mon.BoundAccount,
+) *TxnFingerprintIDCache {
 	b := &TxnFingerprintIDCache{st: st}
+	b.mu.acc = acc
 	b.mu.cache = cache.NewUnorderedCache(cache.Config{
 		Policy: cache.CacheFIFO,
 		ShouldEvict: func(size int, _, _ interface{}) bool {
@@ -53,18 +66,28 @@ func NewTxnFingerprintIDCache(st *cluster.Settings) *TxnFingerprintIDCache {
 			capacity := TxnFingerprintIDCacheCapacity.Get(&st.SV)
 			return int64(size) > capacity
 		},
+		OnEvictedEntry: func(entry *cache.Entry) {
+			// We must be holding the mutex already because this callback is
+			// executed during Cache.Add which we surround with the lock.
+			b.mu.AssertHeld()
+			b.mu.acc.Shrink(ctx, cacheEntrySize+txnFingerprintIDSize)
+		},
 	})
 	return b
 }
 
 // Add adds a TxnFingerprintID to the cache, truncating the cache to the cache's
 // capacity if necessary.
-func (b *TxnFingerprintIDCache) Add(id appstatspb.TransactionFingerprintID) {
+func (b *TxnFingerprintIDCache) Add(
+	ctx context.Context, id appstatspb.TransactionFingerprintID,
+) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// TODO(yuzefovich): we should perform memory accounting for this. Note that
-	// it can be quite tricky to get right - see #121844.
+	if err := b.mu.acc.Grow(ctx, cacheEntrySize+txnFingerprintIDSize); err != nil {
+		return err
+	}
 	b.mu.cache.Add(id, nil /* value */)
+	return nil
 }
 
 // GetAllTxnFingerprintIDs returns a slice of all TxnFingerprintIDs in the cache.

--- a/pkg/sql/txn_fingerprint_id_cache_test.go
+++ b/pkg/sql/txn_fingerprint_id_cache_test.go
@@ -45,7 +45,7 @@ func TestTxnFingerprintIDCacheDataDriven(t *testing.T) {
 				d.ScanArgs(t, "capacity", &capacity)
 
 				st := cluster.MakeTestingClusterSettings()
-				txnFingerprintIDCache = NewTxnFingerprintIDCache(st)
+				txnFingerprintIDCache = NewTxnFingerprintIDCache(ctx, st, nil /* acc */)
 
 				TxnFingerprintIDCacheCapacity.Override(ctx, &st.SV, int64(capacity))
 
@@ -66,7 +66,9 @@ func TestTxnFingerprintIDCacheDataDriven(t *testing.T) {
 				require.NoError(t, err)
 				txnFingerprintID := appstatspb.TransactionFingerprintID(id)
 
-				txnFingerprintIDCache.Add(txnFingerprintID)
+				err = txnFingerprintIDCache.Add(ctx, txnFingerprintID)
+				require.NoError(t, err)
+
 				return fmt.Sprintf("size: %d", txnFingerprintIDCache.size())
 
 			case "show":

--- a/pkg/sql/txn_fingerprint_id_cache_test.go
+++ b/pkg/sql/txn_fingerprint_id_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -34,18 +35,21 @@ import (
 
 func TestTxnFingerprintIDCacheDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	memMonitor := execinfra.NewTestMemMonitor(ctx, st)
+	memAccount := memMonitor.MakeBoundAccount()
 	var txnFingerprintIDCache *TxnFingerprintIDCache
 
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "txn_fingerprint_id_cache"), func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
-			ctx := context.Background()
 			switch d.Cmd {
 			case "init":
 				var capacity int
 				d.ScanArgs(t, "capacity", &capacity)
 
-				st := cluster.MakeTestingClusterSettings()
-				txnFingerprintIDCache = NewTxnFingerprintIDCache(ctx, st, nil /* acc */)
+				txnFingerprintIDCache = NewTxnFingerprintIDCache(ctx, st, &memAccount)
 
 				TxnFingerprintIDCacheCapacity.Override(ctx, &st.SV, int64(capacity))
 
@@ -74,10 +78,12 @@ func TestTxnFingerprintIDCacheDataDriven(t *testing.T) {
 			case "show":
 				return printTxnFingerprintIDCache(txnFingerprintIDCache)
 
-			default:
-			}
-			return ""
+			case "accounting":
+				return fmt.Sprintf("%d bytes", memAccount.Used())
 
+			default:
+				return ""
+			}
 		})
 	})
 }


### PR DESCRIPTION
This commit fixes a bug that could previously result in the memory accounting leak that was exposed by https://github.com/cockroachdb/cockroach/commit/88ebd70d7ca24d8cebe1acdcb711d4f0e840c619. Namely, the problem is that we previously unconditionally grew the memory account in `Add` even though if the ID is already present in the cache, it wouldn't be inserted again. As a result, we'd only shrink the account once but might have grown it any number of times for a particular ID. Now we check whether the ID is present in the cache and only grow the account if not.

Epic: None

Release note: None