### PR TITLE
kvserver: fix CT regressions in reproposal tests

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -131,9 +131,10 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 			log.Infof(context.Background(), "inserting illegal lease index for %s (seen %d times)", roachpb.Key(key), seen[key])
 			// LAI 1 is always going to fail because the LAI is initialized when the lease
 			// comes into existence. (It's important that we pick one here that reliably
-			// fails because otherwise we may accidentally regress the closed timestamp[^1].
+			// fails because otherwise we may accidentally regress the closed timestamp[^1][^2].
 			//
 			// [^1]: https://github.com/cockroachdb/cockroach/issues/70894#issuecomment-1433244880
+			// [^2]: https://github.com/cockroachdb/cockroach/issues/70894#issuecomment-1881165404
 			return 1
 		}
 	}


### PR DESCRIPTION
A few tests, such as `TestKVNemesisMultiNode`, use `leaseIndexFilter` to inject "out-of-order LAI" proposals, and cause/test reproposals as a result. Typically, the tests inject LAI=1 in hope that this proposal will come out of raft after proposals with LAIs >= 1.

In a rare case though (probably involving the raft leader being on a different node than the leaseholder/proposer), this proposal with the injected LAI=1 races with a "real" proposal at LAI=1, and the former wins. This can cause a closed timestamp regression.

This commit initializes the proposal buffer with the initial LAI value of >= 1, so that all the "real" proposals are issued at LAI > 1, and the race described above resolves in favor of the "real" proposal.

Fixes #118017
Epic: none
Release note: none