### PR TITLE
storage: consult intent history in VerifyLock

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_query_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_intent.go
@@ -150,7 +150,7 @@ func QueryIntent(
 			log.VEventf(ctx, 2, "found no intent")
 		}
 	} else {
-		found, err := storage.VerifyLock(
+		found, err := storage.MVCCVerifyLock(
 			ctx, reader, &args.Txn, args.Strength, args.Key, args.IgnoredSeqNums,
 		)
 		if err != nil {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6108,12 +6108,12 @@ func validateLockAcquisitionStrength(str lock.Strength) error {
 	return nil
 }
 
-// VerifyLock returns true if the supplied transaction holds a lock that offers
-// equal to or greater protection[1] than the supplied lock strength.
+// MVCCVerifyLock returns true if the supplied transaction holds a lock that
+// offers equal to or greater protection[1] than the supplied lock strength.
 //
 // [1] Locks that were acquired at sequence numbers that have since been ignored
 // aren't considered, as they may be rolled back in the future.
-func VerifyLock(
+func MVCCVerifyLock(
 	ctx context.Context,
 	reader Reader,
 	txn *enginepb.TxnMeta,
@@ -6173,8 +6173,8 @@ func VerifyLock(
 			// providing the required protection.
 			//
 			// This is not just an optimization. It is necessary for the correctness
-			// of VerifyLock because MVCCAcquireLock will skip lock acquisition if it
-			// finds a non-rolled back intent in the intent history.
+			// of MVCCVerifyLock because MVCCAcquireLock will skip lock acquisition if
+			// it finds a non-rolled back intent in the intent history.
 			inHistoryNotRolledBack := false
 			for _, e := range foundLock.IntentHistory {
 				if !enginepb.TxnSeqIsIgnored(e.Sequence, ignoredSeqNums) {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1190,7 +1190,7 @@ func cmdVerifyLock(e *evalCtx) error {
 		txn := e.getTxn(optional)
 		key := e.getKey()
 		str := e.getStrength()
-		found, err := storage.VerifyLock(e.ctx, r, &txn.TxnMeta, str, key, txn.IgnoredSeqNums)
+		found, err := storage.MVCCVerifyLock(e.ctx, r, &txn.TxnMeta, str, key, txn.IgnoredSeqNums)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/testdata/mvcc_histories/verify_locks
+++ b/pkg/storage/testdata/mvcc_histories/verify_locks
@@ -256,3 +256,60 @@ found: true
 found: false
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+
+# Test that the intent history is consulted when verifying locks.
+run ok
+with t=A
+  txn_step seq=20
+  put k=k8 v=v8
+  txn_step seq=25
+  put k=k8 v=v8_second
+  txn_step seq=30
+  put k=k8 v=v8_third
+----
+put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20 Replicated Intent [{5 15}]}
+put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=25 Replicated Intent [{5 15}]}
+put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30 Replicated Intent [{5 15}]}
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+data: "k1"/5.000000000,0 -> /BYTES/v1
+data: "k2"/5.000000000,0 -> /BYTES/v2
+data: "k3"/5.000000000,0 -> /BYTES/v3
+meta: "k4"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=10.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k4"/10.000000000,0 -> /BYTES/v_new
+data: "k4"/5.000000000,0 -> /BYTES/v4
+data: "k5"/5.000000000,0 -> /BYTES/v5
+data: "k6"/5.000000000,0 -> /BYTES/v6
+data: "k7"/5.000000000,0 -> /BYTES/v7
+meta: "k8"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} ts=10.000000000,0 del=false klen=12 vlen=13 ih={{20 /BYTES/v8}{25 /BYTES/v8_second}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k8"/10.000000000,0 -> /BYTES/v8_third
+
+run ok
+with t=A
+  verify_lock k=k8 str=shared
+  verify_lock k=k8 str=exclusive
+  txn_ignore_seqs seqs=(30-30)
+  verify_lock k=k8 str=shared
+  verify_lock k=k8 str=exclusive
+  txn_ignore_seqs seqs=(25-25,30-30)
+  verify_lock k=k8 str=shared
+  verify_lock k=k8 str=exclusive
+  txn_ignore_seqs seqs=(20-20,30-30)
+  verify_lock k=k8 str=shared
+  verify_lock k=k8 str=exclusive
+  txn_ignore_seqs seqs=(20-20,25-25,30-30)
+  verify_lock k=k8 str=shared
+  verify_lock k=k8 str=exclusive
+----
+found: true
+found: true
+found: true
+found: true
+found: true
+found: true
+found: true
+found: true
+found: false
+found: false
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=3


### PR DESCRIPTION
Fixes #121920.

This commit updates the new VerifyLock function to consult an intent's intent history when determining whether the supplied transaction holds a lock that offers equal to or greater protection than the supplied lock strength.

This is not just an optimization. It is necessary for the correctness of VerifyLock because MVCCAcquireLock will skip lock acquisition if it finds a non-rolled back intent in the intent history.

Release note: None