### PR TITLE
opt: remove unused parameter of `ScanPrivate.IsFullIndexScan`

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -737,7 +737,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (_ execPlan, outputCols colOrdM
 		// NO_FULL_SCAN hint (isUnfiltered is false for partial indexes), but if the
 		// user has explicitly forced the partial index *and* used NO_FULL_SCAN, we
 		// disallow the full index scan.
-		if isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan(md)) {
+		if isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan()) {
 			return execPlan{}, colOrdMap{}, fmt.Errorf("could not produce a query plan conforming to the NO_FULL_SCAN hint")
 		}
 	}

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -844,7 +844,7 @@ func (s *ScanPrivate) IsUnfiltered(md *opt.Metadata) bool {
 
 // IsFullIndexScan returns true if the ScanPrivate will produce all rows in the
 // index.
-func (s *ScanPrivate) IsFullIndexScan(md *opt.Metadata) bool {
+func (s *ScanPrivate) IsFullIndexScan() bool {
 	return (s.Constraint == nil || s.Constraint.IsUnconstrained()) &&
 		s.InvertedConstraint == nil &&
 		s.HardLimit == 0

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -768,7 +768,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 		// NO_FULL_SCAN hint (isUnfiltered is false for partial indexes), but if the
 		// user has explicitly forced the partial index *and* used NO_FULL_SCAN, we
 		// disallow the full index scan.
-		if isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan(c.mem.Metadata())) {
+		if isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan()) {
 			return hugeCost
 		}
 	}


### PR DESCRIPTION
Epic: None

Release note: None