### PR TITLE
opt: remove unnecessary copying of constraints

### DIFF
--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -446,11 +446,7 @@ func constrainPrefixColumns(
 		return nil, nil, false
 	}
 
-	// Make a copy of constraint so that the idxconstraint.Instance is not
-	// referenced.
-	copy := *constraint
-	remainingFilters = ic.RemainingFilters()
-	return &copy, remainingFilters, true
+	return constraint, ic.RemainingFilters(), true
 }
 
 type invertedFilterPlanner interface {

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -958,12 +958,7 @@ func (c *CustomFuncs) tryConstrainIndex(
 		return nil, nil, false
 	}
 
-	// Return 0 if no remaining filter.
-	remaining := ic.RemainingFilters()
-
-	// Make copy of constraint so that idxconstraint instance is not referenced.
-	copy := *constraint
-	return &copy, remaining, true
+	return constraint, ic.RemainingFilters(), true
 }
 
 // canMaybeConstrainNonInvertedIndex returns true if we should try to constrain


### PR DESCRIPTION
This commit removes unnecessary shallow-copies of
`constraint.Constraint`. The comments explaining these copies do not
seem to make sense. They seem to suggest that the copied constraint
holds some reference to an `idxconstraint.Instance`. I could not find
any such reference, even transitively. I'm guessing the comments have
become stale. As far as I can tell, the copies are not necessary.

Release note: None
