### PR TITLE
build: fix setup for ARM64 acceptance tests

### DIFF
--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
@@ -1,5 +1,46 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
-source build/teamcity/cockroach/ci/tests/acceptance.sh
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+source "$dir/teamcity-support.sh"
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+if [[ "$(uname -m)" =~ (arm64|aarch64)$ ]]; then
+  export CROSSLINUX_CONFIG="crosslinuxarm"
+else
+  export CROSSLINUX_CONFIG="crosslinux"
+fi
+
+tc_start_block "Build cockroach"
+build_script='bazel build --config $1 --config ci //pkg/cmd/cockroach-short && cp $(bazel info bazel-bin --config $1 --config ci)/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short /artifacts/cockroach && chmod a+w /artifacts/cockroach'
+run_bazel /usr/bin/bash -c "$build_script" -- "$CROSSLINUX_CONFIG"
+tc_end_block "Build cockroach"
+
+export ARTIFACTSDIR=$PWD/artifacts/acceptance
+mkdir -p "$ARTIFACTSDIR"
+
+tc_start_block "Run acceptance tests"
+status=0
+
+bazel build //pkg/cmd/bazci --config=ci
+BAZCI=$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci
+
+$BAZCI --artifacts_dir=$PWD/artifacts -- \
+  test //pkg/acceptance:acceptance_test \
+  --config=$CROSSLINUX_CONFIG --config=ci \
+  "--sandbox_writable_path=$ARTIFACTSDIR" \
+  "--test_tmpdir=$ARTIFACTSDIR" \
+  --test_arg=-l="$ARTIFACTSDIR" \
+  --test_arg=-b=$PWD/artifacts/cockroach \
+  --test_env=TZ=America/New_York \
+  --profile=$PWD/artifacts/profile.gz \
+  --test_timeout=1800 || status=$?
+
+# Some unit tests test automatic ballast creation. These ballasts can be
+# larger than the maximum artifact size. Remove any artifacts with the
+# EMERGENCY_BALLAST filename.
+find "$ARTIFACTSDIR" -name "EMERGENCY_BALLAST" -delete
+
+tc_end_block "Run acceptance tests"
+exit $status


### PR DESCRIPTION
Previously, ARM64 acceptance tests were indirectly referring to build/teamcity/cockroach/ci/tests/acceptance.sh

However, as part of moving to to GitHub actions, we want to want to prevent acceptance tests running on CI in TeamCity.

This PR copies the [previous content of build/teamcity/cockroach/ci/tests/acceptance.sh](https://raw.githubusercontent.com/cockroachdb/cockroach/f18eb75611c546feb60b40830c51cdea40e451eb/build/teamcity/cockroach/ci/tests/acceptance.sh) directly into build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh.


Fixes Merged ARM64 Tests for master/release-24.1:
https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_PostMerge_MergedArm64Tests?mode=builds

Release Justification: non-production / release-infra-only change
Release note: None
Epic: None