### PR TITLE
sql: increase some test timeouts

### DIFF
--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -94,7 +94,7 @@ go_library(
 
 go_test(
     name = "row_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "expr_walker_test.go",
         "fetcher_mvcc_test.go",

--- a/pkg/sql/sqlliveness/slstorage/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slstorage/BUILD.bazel
@@ -44,7 +44,7 @@ go_library(
 
 go_test(
     name = "slstorage_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "key_encoder_test.go",
         "main_test.go",


### PR DESCRIPTION
This commit increases the timeout from "small" to "medium" for the `sql/row` and `sql/sqlliveness/slstorage` packages. It seems like the tests in these packages are just expensive enough to occasionally flake with the smallest timeout setting.

Fixes #121960
Fixes #121958

Release note: None