### PR TITLE
backup: separate tenant spans in include_all_secondary_tenants

### DIFF
--- a/pkg/ccl/backupccl/restoration_data.go
+++ b/pkg/ccl/backupccl/restoration_data.go
@@ -120,7 +120,7 @@ func (b *restorationDataBase) getSystemTables() []catalog.TableDescriptor {
 // addTenant implements restorationData.
 func (b *restorationDataBase) addTenant(fromTenantID, toTenantID roachpb.TenantID) {
 	prefix := keys.MakeTenantPrefix(fromTenantID)
-	b.spans = append(b.spans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
+	b.spans = append(b.spans, backupTenantSpan(prefix))
 	b.tenantRekeys = append(b.tenantRekeys, execinfrapb.TenantRekey{
 		OldID: fromTenantID,
 		NewID: toTenantID,

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -611,14 +611,14 @@ func TestShowBackupTenants(t *testing.T) {
 		{"10", "TENANT", "NULL"},
 	}, res)
 
-	res = systemDB.QueryStr(t, `SELECT start_pretty, end_pretty FROM [SHOW BACKUP RANGES FROM LATEST IN 'nodelocal://1/t10']`)
+	res = systemDB.QueryStr(t, `SELECT start_pretty FROM [SHOW BACKUP FILES FROM LATEST IN 'nodelocal://1/t10'] ORDER BY start_key LIMIT 1`)
 	require.Equal(t, [][]string{
-		{"/Tenant/10", "/Tenant/11"},
+		{"/Tenant/10"},
 	}, res)
 
-	res = systemDB.QueryStr(t, `SELECT start_pretty, end_pretty FROM [SHOW BACKUP FILES FROM LATEST IN 'nodelocal://1/t10']`)
+	res = systemDB.QueryStr(t, `SELECT end_pretty FROM [SHOW BACKUP FILES FROM LATEST IN 'nodelocal://1/t10'] ORDER BY end_key DESC LIMIT 1`)
 	require.Equal(t, [][]string{
-		{"/Tenant/10", "/Tenant/11"},
+		{"/Tenant/10/Max"},
 	}, res)
 
 	res = systemDB.QueryStr(t, `SELECT database_id, parent_schema_id, object_id FROM [SHOW BACKUP FROM LATEST IN 'nodelocal://1/t10' WITH debug_ids]`)

--- a/pkg/sql/logictest/testdata/logic_test/cross_version_tenant_backup
+++ b/pkg/sql/logictest/testdata/logic_test/cross_version_tenant_backup
@@ -1,0 +1,30 @@
+# LogicTest: cockroach-go-testserver-23.2
+
+# Ensure that a backup of a tenant can restore into an new version.  
+# 
+# NB: Ideally this test would be run on clusterVersion.PreviousVersion to
+# clusterVersion.Latest, so the test would not be tied to a specific base
+# version.
+
+# Create tenant using old binary.
+statement ok
+CREATE VIRTUAL CLUSTER foo
+
+statement ok
+BACKUP TENANT 2 INTO 'userfile:///1/example'
+
+upgrade 0
+
+upgrade 1
+
+upgrade 2
+
+statement ok
+RESTORE TENANT 2 FROM LATEST IN 'userfile:///1/example' with tenant_name = 'baz'
+
+query TI nodeidx=0
+SELECT name, id FROM [SHOW TENANTS] ORDER BY id
+----
+system 1
+foo 2
+baz 3

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 6,
+    shard_count = 7,
     tags = [
         "cpu:2",
     ],

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_cross_version_tenant_backup(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cross_version_tenant_backup")
+}
+
 func TestLogic_mixed_version_bootstrap_tenant(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -338,6 +338,11 @@ func TestSchemaChangeComparator_cross_join(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cross_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_cross_version_tenant_backup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cross_version_tenant_backup"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_cursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cursor"


### PR DESCRIPTION
Previously they would be merged by distsender which would then cause a single
export response to include multiple tenants, in violation of the sink's
expectations about a single prefix per response.

This patch also enables to remove tenant span adjusting during online restore.

Release note: none.
Epic: none.