### PR TITLE
kv: fix lock promotion state mismatch in tryFreeLockOnReplicatedAcquire

### DIFF
--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
@@ -48,12 +48,11 @@ num=1
     active: false req: 2 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
 
 # Replicated lock acquisition will cause us to forget the unreplicated lock.
+# Additionally, the inactive waiter will be removed from the lock's wait queue
+# as its "promoting" state is no longer in line with the lock's held state.
 acquire r=req2 k=a durability=r strength=intent
 ----
-num=1
- lock: "a"
-   queued locking requests:
-    active: false req: 2 promoting: true, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
+num=0
 
 dequeue r=req2
 ----


### PR DESCRIPTION
Previously, when a lock was free-ed on replicated re-acquisition, we woudln't release any locking requests from the lock holder's transaction. Now, if the re-acquisition corresponded to a lock promotion, we would leave the lock's wait queue in mismatched state -- the request that acquired the replicated lock would think it's promoting, but we just released the lock.

This mismatched state was short lived (and thus benign), as the lock acquisition was quickly followed by a call to `Dequeue` that would do the right thing. However, this would have prevented us from making verification claims around lock promoters (see #120909), so it's worth addressing.

Informs #120909

Release note: None