### PR TITLE
release-23.2: workload/schemachange: fix deadlock between watch dogs and workers

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -171,10 +171,17 @@ func (s *schemaChange) Ops(
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
+
 	seqNum, err := s.initSeqNum(ctx, pool)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
+
+	watchDogPool, err := workload.NewMultiConnPool(ctx, cfg, urls...)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+
 	stdoutLog := makeAtomicLog(os.Stdout)
 	rng, seed := randutil.NewTestRand()
 	stdoutLog.printLn(fmt.Sprintf("using random seed: %d", seed))
@@ -194,6 +201,7 @@ func (s *schemaChange) Ops(
 		SQLDatabase: sqlDatabase,
 		Close: func(ctx context.Context) error {
 			pool.Close()
+			watchDogPool.Close()
 			return s.closeJSONLogFile()
 		},
 	}
@@ -233,6 +241,7 @@ func (s *schemaChange) Ops(
 			dryRun:          s.dryRun,
 			maxOpsPerWorker: s.maxOpsPerWorker,
 			pool:            pool,
+			watchDogPool:    watchDogPool,
 			hists:           reg.GetHandle(),
 			opGen:           makeOperationGenerator(&opGeneratorParams),
 			logger: &logger{
@@ -300,6 +309,7 @@ type schemaChangeWorker struct {
 	dryRun              bool
 	maxOpsPerWorker     int
 	pool                *workload.MultiConnPool
+	watchDogPool        *workload.MultiConnPool
 	hists               *histogram.Histograms
 	opGen               *operationGenerator
 	isHoldingEntryLocks bool
@@ -424,7 +434,8 @@ func (w *schemaChangeWorker) runInTxn(
 }
 
 func (w *schemaChangeWorker) run(ctx context.Context) error {
-	conn, err := w.pool.Get().Acquire(ctx)
+	connPool := w.pool.Get()
+	conn, err := connPool.Acquire(ctx)
 	if err != nil {
 		return errors.Wrap(err, "cannot get a connection")
 	}
@@ -451,9 +462,20 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 			return errors.Wrap(err, "cannot to get active")
 		}
 		if !cannotEnableSchemaChanges {
-			_, err = w.pool.Get().Exec(ctx, `SET CLUSTER SETTING sql.schema.force_declarative_statements="+CREATE SCHEMA, +CREATE SEQUENCE"`)
+			// Transaction confirmed we are on a new enough version, so set the
+			// cluster setting.
+			err := tx.Rollback(ctx)
+			if err != nil {
+				return errors.Wrap(err, "could not rollback before cluster setting")
+			}
+			_, err = conn.Exec(ctx, `SET CLUSTER SETTING sql.schema.force_declarative_statements="+CREATE SCHEMA, +CREATE SEQUENCE"`)
 			if err != nil {
 				return errors.Wrap(err, "cannot to enable extra schema changes")
+			}
+			// Restart the txn after the update.
+			tx, err = conn.Begin(ctx)
+			if err != nil {
+				return errors.Wrap(err, "cannot get a connection and begin a txn")
 			}
 			w.workload.declarativeStatementsEnabled.Store(true)
 		}
@@ -463,7 +485,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 	defer w.releaseLocksIfHeld()
 
 	// Run between 1 and maxOpsPerWorker schema change operations.
-	watchDog := newSchemaChangeWatchDog(w.pool.Get(), w.logger)
+	watchDog := newSchemaChangeWatchDog(w.watchDogPool.Get(), w.logger)
 	if err := watchDog.Start(ctx, tx); err != nil {
 		return errors.Wrapf(err, "unable to start watch dog")
 	}


### PR DESCRIPTION
Backport 1/1 commits from #121552.

/cc @cockroachdb/release

---

Previously, the schema change workload would hang with the worker threads waiting for the watch dog connections to terminate. Unfortunately, this would happen because when running workloads with multiple URLs there would be an upper limit on total connections, which could mean that some connection pools could be depleted if both the workers and watch dogs were on them. Because the watch dogs monitor loops needs connection for a single iteration, and the worker needs the watch dog to terminate before closing its connection. This would lead to dead lock, since the watch dog would never break out of its monitor loop. To address this, this patch will create a connection pool for the watch dog connections.

Fixes: #121906

Release note: None

---

Release justification: test change
