### PR TITLE
roachtest: orm tests install correct binary based on architecture

### DIFF
--- a/pkg/cmd/roachtest/tests/go_helpers.go
+++ b/pkg/cmd/roachtest/tests/go_helpers.go
@@ -12,10 +12,12 @@ package tests
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 )
 
 const goPath = `/mnt/data1/go`
@@ -42,15 +44,22 @@ func installGolang(
 		t.Fatal(err)
 	}
 
+	binary := "go1.21.3.linux-amd64.tar.gz"
+	sha := "1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"
+	if c.Architecture() == vm.ArchARM64 {
+		binary = "go1.21.3.linux-arm64.tar.gz"
+		sha = "fc90fa48ae97ba6368eecb914343590bbb61b388089510d0c56c2dde52987ef3"
+	}
+
 	if err := repeatRunE(
-		ctx, t, c, node, "download go", `curl -fsSL https://dl.google.com/go/go1.21.3.linux-amd64.tar.gz > /tmp/go.tgz`,
+		ctx, t, c, node, "download go", fmt.Sprintf(`curl -fsSL https://dl.google.com/go/%s > /tmp/go.tgz`, binary),
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := repeatRunE(
-		ctx, t, c, node, "verify tarball", `sha256sum -c - <<EOF
-1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8 /tmp/go.tgz
-EOF`,
+		ctx, t, c, node, "verify tarball", fmt.Sprintf(`sha256sum -c - <<EOF
+%s /tmp/go.tgz
+EOF`, sha),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/stretchr/testify/require"
 )
 
@@ -158,9 +160,10 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "knex",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
+		Name:  "knex",
+		Owner: registry.OwnerSQLFoundations,
+		// Requires a pre-built node-oracledb binary for linux arm64.
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -18,9 +18,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 )
 
@@ -173,9 +175,10 @@ echo '%s' | git apply --ignore-whitespace -`, fmt.Sprintf(npgsqlPatch, result.St
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "npgsql",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
+		Name:  "npgsql",
+		Owner: registry.OwnerSQLFoundations,
+		// .NET only supports AMD64 arch for 7.0.
+		Cluster:          r.MakeClusterSpec(1, spec.Arch(vm.ArchAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.Driver),


### PR DESCRIPTION
Recently arm64 was enabled for roachtests. Certain ORM tests download binaries which now need to selectively choose the arm or amd version depending on the cluster arch.

Fixes: none
Epic: none
Release note: none