### PR TITLE
roachtest: read from cache when checking for preemption

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -208,7 +208,7 @@ var cachedHostsCmd = &cobra.Command{
 	Short: "list all clusters (and optionally their host numbers) from local cache",
 	Args:  cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		roachprod.CachedClusters(config.Logger, func(clusterName string, numVMs int) {
+		roachprod.CachedClusters(func(clusterName string, numVMs int) {
 			if strings.HasPrefix(clusterName, "teamcity") {
 				return
 			}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1243,7 +1243,7 @@ func (r *testRunner) runTest(
 func getPreemptedVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) string {
 	preemptedVMs, err := c.GetPreemptedVMs(ctx, l)
 	if err != nil {
-		l.Printf("failed to check preempted VMs: %s", err)
+		l.Printf("failed to check preempted VMs:\n%+v", err)
 		return ""
 	}
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -217,14 +217,19 @@ func Version(l *logger.Logger) string {
 
 // CachedClusters iterates over all roachprod clusters from the local cache, in
 // alphabetical order.
-func CachedClusters(l *logger.Logger, fn func(clusterName string, numVMs int)) {
+func CachedClusters(fn func(clusterName string, numVMs int)) {
 	for _, name := range sortedClusters() {
-		c, ok := readSyncedClusters(name)
+		c, ok := CachedCluster(name)
 		if !ok {
 			return
 		}
 		fn(c.Name, len(c.VMs))
 	}
+}
+
+// CachedCluster returns the cached information about a given cluster.
+func CachedCluster(name string) (*cloud.Cluster, bool) {
+	return readSyncedClusters(name)
 }
 
 // Sync grabs an exclusive lock on the roachprod state and then proceeds to


### PR DESCRIPTION
Previously, the check for VM preemptions after test failure would perform a `Sync` operation, making API calls to GCE in order to find clusters. However, that shouldn't be necessary -- roachtest itself created the cluster, so the cluster data should exist in the cache.

This commit also adds more debug information when the cluster cannot be found (a list of existing clusters). While this shouldn't happen in practice in regular runs, we have seen it fail in the past.

Fixes: #121488

Release note: None