### PR TITLE
ssmemstorage: fix a race

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -319,7 +319,7 @@ func (s *Container) RecordTransaction(
 	// fingerprints for this app. We also abort the operation and return an error.
 	if created {
 		estimatedMemAllocBytes :=
-			stats.sizeUnsafe() + key.Size() + 8 /* hash of transaction key */
+			stats.sizeUnsafeLocked() + key.Size() + 8 /* hash of transaction key */
 		if err := func() error {
 			s.mu.Lock()
 			defer s.mu.Unlock()


### PR DESCRIPTION
This commit audits all usages of `txnStats` objects to ensure that proper locking when accessing `mu.data` is performed. This fixes a race in one spot.

Fixes: #121888.

Release note: None