### PR TITLE
sql: remove an allocation in checkScanParallelizationIfLocal

### DIFF
--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -1785,7 +1785,8 @@ func TestCheckScanParallelizationIfLocal(t *testing.T) {
 			prohibitParallelization: true,
 		},
 	} {
-		prohibitParallelization, hasScanNodeToParallize := checkScanParallelizationIfLocal(context.Background(), &tc.plan)
+		var c localScanParallelizationChecker
+		prohibitParallelization, hasScanNodeToParallize := checkScanParallelizationIfLocal(context.Background(), &tc.plan, &c)
 		require.Equal(t, tc.prohibitParallelization, prohibitParallelization)
 		require.Equal(t, tc.hasScanNodeToParallelize, hasScanNodeToParallize)
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -290,6 +290,9 @@ type planner struct {
 	// This field is embedded into the planner to avoid an allocation in
 	// checkExprForDistSQL.
 	distSQLVisitor distSQLExprCheckVisitor
+	// This field is embedded into the planner to avoid an allocation in
+	// checkScanParallelizationIfLocal.
+	parallelizationChecker localScanParallelizationChecker
 }
 
 // hasFlowForPausablePortal returns true if the planner is for re-executing a


### PR DESCRIPTION
This commit reuses a visitor stored on the planner to avoid an allocation for local flows in `checkScanParallelizationIfLocal`. On one very busy cluster I observed this allocation to be 0.1% of all allocations.

Epic: None

Release note: None