### PR TITLE
application_api: run on `heavy` pool under `race`

### DIFF
--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -33,7 +33,7 @@ go_test(
         "zcfg_test.go",
     ],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "default"},
     }),
     shard_count = 8,


### PR DESCRIPTION
This test is flaky under `race`.

Epic: CRDB-8308
Release note: None