### PR TITLE
roachtest: enable vmodule logging in tpcc-nowait/isolation-level=mixed/nodes=3/w=1

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -613,7 +613,7 @@ func registerTPCC(r registry.Registry) {
 				// Increase the vmodule level around transaction pushes so that if we do
 				// see a transaction retry error, we can debug it. This may affect perf,
 				// so we should not use this as a performance test.
-				ExtraStartArgs: []string{"--vmodule=cmd_push_txn=2,queue=2"},
+				ExtraStartArgs: []string{"--vmodule=cmd_push_txn=2,queue=2,transaction=2"},
 			})
 		},
 	})
@@ -633,6 +633,10 @@ func registerTPCC(r registry.Registry) {
 				ExtraRunArgs:    "--wait=false",
 				SetupType:       usingImport,
 				ExpensiveChecks: true,
+				// Increase the vmodule level around transaction pushes so that if we do
+				// see a transaction retry error, we can debug it. This may affect perf,
+				// so we should not use this as a performance test.
+				ExtraStartArgs: []string{"--vmodule=cmd_push_txn=2,queue=2,transaction=2"},
 				WorkloadInstances: func() (ret []workloadInstance) {
 					isoLevels := []string{"read_uncommitted", "read_committed", "repeatable_read", "snapshot", "serializable"}
 					for i, isoLevel := range isoLevels {


### PR DESCRIPTION
Informs #119511.

This commit enables vmodule logging for transaction pushes and other transaction lifecycle events in the `tpcc-nowait/isolation-level=mixed/nodes=3/w=1` roachtest. This should help us debug #119511.

Release note: None