### PR TITLE
release-23.1: sql: grant to all tables did not skip privileges on sequences

### DIFF
--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -254,14 +254,15 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 		descPrivsChanged := false
 
 		if len(n.desiredprivs) > 0 {
-			var sequencePrivilegesNoOp privilege.List
+			privsToIgnore := privilege.List{}
+			unsupportedPrivsForType := make(map[privilege.ObjectType]struct{})
 			for _, priv := range n.desiredprivs {
 				// Only allow granting/revoking privileges that the requesting
 				// user themselves have on the descriptor.
 				if err := p.CheckPrivilege(ctx, descriptor, priv); err != nil {
 					return err
 				}
-
+				// Track privileges that do not apply to sequences.
 				if objType == privilege.Sequence {
 					switch priv {
 					case privilege.ALL,
@@ -270,7 +271,7 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 						privilege.SELECT,
 						privilege.DROP:
 					default:
-						sequencePrivilegesNoOp = append(sequencePrivilegesNoOp, priv)
+						privsToIgnore = append(privsToIgnore, priv)
 					}
 				}
 			}
@@ -281,8 +282,52 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 			}
 
 			privileges := descriptor.GetPrivileges()
+			// Ensure we are only setting privilleges valid for this object type.
+			// i.e. We only expect this for sequences.
+			validPrivs, err := privilege.GetValidPrivilegesForObject(objType)
+			if err != nil {
+				return err
+			}
+			targetPrivs := n.desiredprivs.ToBitField() & validPrivs.ToBitField()
+			// If there are privs that are ignored for sequences, lets exclude
+			// those here.
+			privsToIgnoreBits := privsToIgnore.ToBitField()
+			targetPrivs = targetPrivs & (^privsToIgnoreBits)
+			// If any privileges have been dropped or ignored, then lets log
+			// a message for this type.
+			if targetPrivs != n.desiredprivs.ToBitField() {
+				missingPrivs, err := privilege.ListFromBitField(
+					n.desiredprivs.ToBitField()&(^targetPrivs), privilege.Any)
+				if err != nil {
+					return err
+				}
+				if _, ok := unsupportedPrivsForType[objType]; !ok {
+					params.p.BufferClientNotice(
+						ctx,
+						pgnotice.Newf(
+							"some privileges have no effect on %ss: %s",
+							objType,
+							missingPrivs.SortedNames(),
+						),
+					)
+					unsupportedPrivsForType[objType] = struct{}{}
+				}
+				// For the purpose of revoke restore ignored fields back,
+				// so we can at least remove them from the object.
+				if !n.isGrant {
+					targetPrivs = targetPrivs | privsToIgnoreBits
+				}
+				// If nothing will be applied move to the next descriptor.
+				if targetPrivs == 0 {
+					continue
+				}
+			}
+			privsToSet, err := privilege.ListFromBitField(targetPrivs, objType)
+			if err != nil {
+				return err
+			}
 			for _, grantee := range n.grantees {
-				changed, err := n.changePrivilege(privileges, n.desiredprivs, grantee)
+				changed, err := n.changePrivilege(privileges, privsToSet, grantee)
 				if err != nil {
 					return err
 				}
@@ -298,17 +343,6 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 					)
 				}
 			}
-
-			if len(sequencePrivilegesNoOp) > 0 {
-				params.p.BufferClientNotice(
-					ctx,
-					pgnotice.Newf(
-						"some privileges have no effect on sequences: %s",
-						sequencePrivilegesNoOp.SortedNames(),
-					),
-				)
-			}
-
 			// Ensure superusers have exactly the allowed privilege set.
 			// Postgres does not actually enforce this, instead of checking that
 			// superusers have all the privileges, Postgres allows superusers to

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
@@ -32,11 +32,22 @@ SET ROLE root
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s TO testuser
 
-query TTTTTB colnames
+# This should be a no-op, since backup privellege is not
+# supported on sequences.
+query T noticetrace
+GRANT BACKUP ON ALL TABLES IN SCHEMA S TO testuser
+----
+NOTICE: some privileges have no effect on sequences: [BACKUP]
+
+statement error pgcode 0LP01 invalid privilege type BACKUP for sequence
+GRANT BACKUP ON ALL SEQUENCES IN SCHEMA S TO testuser
+
+query TTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
 test           s            q              testuser  SELECT          false
+test           s            t              testuser  BACKUP          false
 
 statement ok
 GRANT USAGE ON ALL SEQUENCES IN SCHEMA s TO testuser
@@ -47,6 +58,7 @@ SHOW GRANTS FOR testuser
 database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
 test           s            q              testuser  SELECT          false
 test           s            q              testuser  USAGE           false
+test           s            t              testuser  BACKUP          false
 
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s, s2 TO testuser, testuser2
@@ -58,6 +70,7 @@ database_name  schema_name  relation_name  grantee    privilege_type  is_grantab
 test           s            q              testuser   SELECT          false
 test           s            q              testuser   USAGE           false
 test           s            q              testuser2  SELECT          false
+test           s            t              testuser   BACKUP          false
 test           s2           q              testuser   SELECT          false
 test           s2           q              testuser2  SELECT          false
 
@@ -70,6 +83,7 @@ SHOW GRANTS FOR testuser, testuser2
 database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
 test           s            q              testuser   ALL             false
 test           s            q              testuser2  ALL             false
+test           s            t              testuser   BACKUP          false
 test           s2           q              testuser   ALL             false
 test           s2           q              testuser2  ALL             false
 
@@ -102,6 +116,7 @@ SHOW GRANTS FOR testuser, testuser2
 database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
 test           s            q              testuser   ALL             false
 test           s            q              testuser2  ALL             false
+test           s            t              testuser   BACKUP          false
 test           s2           q              testuser   ALL             false
 test           s2           q              testuser2  ALL             false
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -381,7 +381,7 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 									descs,
 									DescriptorWithObjectType{
 										descriptor: mut,
-										objectType: privilege.Table,
+										objectType: mut.GetObjectType(),
 									})
 							}
 						}


### PR DESCRIPTION
1. Backport 1/1 commits from #120685.

/cc @cockroachdb/release

---

Previously, grant privilege to all tables attempted to apply privileges meant only for tables on to sequences. This could lead to validation error preventing certain combinations like "GRANT BACKUP ON ALL TABLES..." from working correctly. To address this, this patch adds support for correctly propogating the object type and skipping over unsupported privileges. When an unsupported privilege is encountered on an object other then a sequence a warning is now logged.

Fixes: #117861

Release note (bug fix): GRANT <...> ON ALL TABLES could fail if sequences existed and they did not support a privilege (for example BACKUP).

Release justification: low risk fix for an issue that can cause grant on all tables to be unusable if a database has sequences.
