### PR TITLE
*: remove some pre-23.2 gates

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -180,40 +180,13 @@ const (
 	// V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
 	V23_1
 
-	// V23_2Start demarcates the start of cluster versions stepped through during
-	// the process of upgrading from previous supported releases to 23.2.
-	V23_2Start
-
-	// V23_2_EnableRangeCoalescingForSystemTenant enables range coalescing for
-	// the system tenant.
-	V23_2_EnableRangeCoalescingForSystemTenant
-
-	// V23_2_UseACRaftEntryEntryEncodings gates the use of raft entry encodings
-	// that (optionally) embed below-raft admission data.
-	V23_2_UseACRaftEntryEntryEncodings
-
-	// V23_2_PebbleFormatDeleteSizedAndObsolete upgrades Pebble's format major
-	// version to FormatDeleteSizedAndObsolete, allowing use of a new sstable
-	// format version Pebblev4. This version has two improvements:
-	//   a) It allows the use of DELSIZED point tombstones.
-	//   b) It encodes the obsolence of keys in a key-kind bit.
-	V23_2_PebbleFormatDeleteSizedAndObsolete
-
 	// V23_2_UseSizedPebblePointTombstones enables the use of Pebble's new
 	// DeleteSized operations.
 	V23_2_UseSizedPebblePointTombstones
 
-	// V23_2_PebbleFormatVirtualSSTables upgrades Pebble's format major version to
-	// FormatVirtualSSTables, allowing use of virtual sstables in Pebble.
-	V23_2_PebbleFormatVirtualSSTables
-
 	// V23_2_StmtDiagForPlanGist enables statement diagnostic feature to collect
 	// the bundle for particular plan gist.
 	V23_2_StmtDiagForPlanGist
-
-	// V23_2_RegionaLivenessTable guarantees the regional liveness table exists
-	// and its ready for use.
-	V23_2_RegionaLivenessTable
 
 	// V23_2_RemoveLockTableWaiterTouchPush simplifies the push logic in
 	// lock_table_waiter by passing the wait policy of the pusher as part of the
@@ -223,24 +196,6 @@ const (
 	// V23_2_ChangefeedLaggingRangesOpts is used to version gate the changefeed
 	// options lagging_ranges_threshold and lagging_ranges_polling_interval.
 	V23_2_ChangefeedLaggingRangesOpts
-
-	// V23_2_GrantExecuteToPublic is no longer used. See #114203.
-	V23_2_GrantExecuteToPublic
-
-	// V23_2_EnablePebbleFormatVirtualSSTables enables the Pebble
-	// FormatMajorVersion for virtual sstables. Note that the ratcheting for the
-	// format major version in Pebble should have happened with
-	// V23_2_PebbleFormatVirtualSSTables above.
-	V23_2_EnablePebbleFormatVirtualSSTables
-
-	// V23_2_MVCCStatisticsTable adds the system.mvcc_statistics
-	// table and update job. The table is used to serve fast reads of historical
-	// mvcc data from observability surfaces.
-	V23_2_MVCCStatisticsTable
-
-	// V23_2_AddSystemExecInsightsTable is the version at which Cockroach creates
-	// {statement|transaction}_execution_insights system tables.
-	V23_2_AddSystemExecInsightsTable
 
 	// ***************************************************************************
 	//            WHERE TO ADD VERSION GATES DURING 23.2 STABILITY?
@@ -339,20 +294,10 @@ var versionTable = [numKeys]roachpb.Version{
 	V23_1: {Major: 23, Minor: 1, Internal: 0},
 
 	// v23.2 versions. Internal versions must be even.
-	V23_2Start: {Major: 23, Minor: 1, Internal: 2},
-	V23_2_EnableRangeCoalescingForSystemTenant: {Major: 23, Minor: 1, Internal: 8},
-	V23_2_UseACRaftEntryEntryEncodings:         {Major: 23, Minor: 1, Internal: 10},
-	V23_2_PebbleFormatDeleteSizedAndObsolete:   {Major: 23, Minor: 1, Internal: 12},
-	V23_2_UseSizedPebblePointTombstones:        {Major: 23, Minor: 1, Internal: 14},
-	V23_2_PebbleFormatVirtualSSTables:          {Major: 23, Minor: 1, Internal: 16},
-	V23_2_StmtDiagForPlanGist:                  {Major: 23, Minor: 1, Internal: 18},
-	V23_2_RegionaLivenessTable:                 {Major: 23, Minor: 1, Internal: 20},
-	V23_2_RemoveLockTableWaiterTouchPush:       {Major: 23, Minor: 1, Internal: 22},
-	V23_2_ChangefeedLaggingRangesOpts:          {Major: 23, Minor: 1, Internal: 24},
-	V23_2_GrantExecuteToPublic:                 {Major: 23, Minor: 1, Internal: 26},
-	V23_2_EnablePebbleFormatVirtualSSTables:    {Major: 23, Minor: 1, Internal: 28},
-	V23_2_MVCCStatisticsTable:                  {Major: 23, Minor: 1, Internal: 30},
-	V23_2_AddSystemExecInsightsTable:           {Major: 23, Minor: 1, Internal: 32},
+	V23_2_UseSizedPebblePointTombstones:  {Major: 23, Minor: 1, Internal: 14},
+	V23_2_StmtDiagForPlanGist:            {Major: 23, Minor: 1, Internal: 18},
+	V23_2_RemoveLockTableWaiterTouchPush: {Major: 23, Minor: 1, Internal: 22},
+	V23_2_ChangefeedLaggingRangesOpts:    {Major: 23, Minor: 1, Internal: 24},
 
 	V23_2: {Major: 23, Minor: 2, Internal: 0},
 

--- a/pkg/kv/kvserver/kvadmission/BUILD.bazel
+++ b/pkg/kv/kvserver/kvadmission/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
@@ -333,8 +332,7 @@ func (n *controllerImpl) AdmitKVWork(
 	// number of tokens available.
 	if ba.IsWrite() && !ba.IsSingleHeartbeatTxnRequest() {
 		var admitted bool
-		attemptFlowControl := kvflowcontrol.Enabled.Get(&n.settings.SV) &&
-			n.settings.Version.IsActive(ctx, clusterversion.V23_2_UseACRaftEntryEntryEncodings)
+		attemptFlowControl := kvflowcontrol.Enabled.Get(&n.settings.SV)
 		if attemptFlowControl && !bypassAdmission {
 			kvflowHandle, found := n.kvflowHandles.Lookup(ba.RangeID)
 			if !found {

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
@@ -495,8 +494,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
 	keyRanges := rditer.MakeReplicatedKeySpans(header.State.Desc)
 
-	doExcise := header.SharedReplicate || header.ExternalReplicate || (storage.UseExciseForSnapshots.Get(&s.ClusterSettings().SV) &&
-		s.cfg.Settings.Version.IsActive(ctx, clusterversion.V23_2_EnablePebbleFormatVirtualSSTables))
+	doExcise := header.SharedReplicate || header.ExternalReplicate || storage.UseExciseForSnapshots.Get(&s.ClusterSettings().SV)
 	if header.SharedReplicate && !s.cfg.SharedStorageEnabled {
 		return noSnap, sendSnapshotError(ctx, s, stream, errors.New("cannot accept shared sstables"))
 	}

--- a/pkg/spanconfig/spanconfigstore/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigstore/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",

--- a/pkg/spanconfig/spanconfigstore/span_store.go
+++ b/pkg/spanconfig/spanconfigstore/span_store.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -159,8 +158,7 @@ func (s *spanConfigStore) computeSplitKey(
 			// ranges.
 			systemTableUpperBound := keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID + 1)
 			if roachpb.Key(rem).Compare(systemTableUpperBound) < 0 ||
-				!(StorageCoalesceAdjacentSetting.Get(&s.settings.SV) &&
-					s.settings.Version.IsActive(ctx, clusterversion.V23_2_EnableRangeCoalescingForSystemTenant)) {
+				!StorageCoalesceAdjacentSetting.Get(&s.settings.SV) {
 				return roachpb.RKey(match.span.Key), nil
 			}
 		} else {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -15,7 +15,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -425,12 +424,6 @@ func (oc *optCatalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error
 
 // CheckExecutionPrivilege is part of the cat.Catalog interface.
 func (oc *optCatalog) CheckExecutionPrivilege(ctx context.Context, oid oid.Oid) error {
-	// If the required cluster version is not active, revert to pre-23.2
-	// behavior without any privilege checks.
-	activeVersion := oc.planner.ExecCfg().Settings.Version.ActiveVersion(ctx)
-	if !activeVersion.IsActive(clusterversion.V23_2_GrantExecuteToPublic) {
-		return nil
-	}
 	desc, err := oc.planner.FunctionDesc(ctx, oid)
 	if err != nil {
 		return errors.WithAssertionFailure(err)

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/scheduledjobs",

--- a/pkg/sql/sqlstats/persistedsqlstats/controller.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -87,10 +86,6 @@ func (s *Controller) ResetActivityTables(ctx context.Context) error {
 // ResetInsightsTables implements the tree.SQLStatsController interface. This
 // method reset the {statement|transaction}_execution_insights tables.
 func (s *Controller) ResetInsightsTables(ctx context.Context) error {
-	if !s.st.Version.IsActive(ctx, clusterversion.V23_2_AddSystemExecInsightsTable) {
-		return nil
-	}
-
 	if err := s.resetSysTableStats(ctx, "system.statement_execution_insights"); err != nil {
 		return err
 	}

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/errors"
@@ -73,14 +72,9 @@ func (*noopFinishAbort) Abort() {}
 func MakeIngestionWriterOptions(ctx context.Context, cs *cluster.Settings) sstable.WriterOptions {
 	// By default, take a conservative approach and assume we don't have newer
 	// table features available. Upgrade to an appropriate version only if the
-	// cluster supports it.
-	format := sstable.TableFormatPebblev2
-	if ValueBlocksEnabled.Get(&cs.SV) {
-		format = sstable.TableFormatPebblev3
-	}
-	if cs.Version.IsActive(ctx, clusterversion.V23_2_EnablePebbleFormatVirtualSSTables) {
-		format = sstable.TableFormatPebblev4
-	}
+	// cluster supports it. Currently, all supported versions understand
+	// TableFormatPebblev4.
+	format := sstable.TableFormatPebblev4
 	opts := DefaultPebbleOptions().MakeWriterOptions(0, format)
 	opts.Compression = getCompressionAlgorithm(ctx, cs)
 	opts.MergerName = "nullptr"


### PR DESCRIPTION
These were the gates that were trivial to remove.

Release note: None
Epic: REL-696