### PR TITLE
release-24.1: roachtest: work around T2A limitations

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -2991,6 +2992,18 @@ func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSp
 		arch = vm.ArchFIPS
 	} else {
 		arch = vm.ArchAMD64
+	}
+	if roachtestflags.Cloud == spec.GCE && arch == vm.ArchARM64 {
+		// N.B. T2A support is rather limited, both in terms of supported regions and no local SSDs. Thus, we must
+		// fall back to AMD64 in those cases. See #122035.
+		if !gce.IsSupportedT2AZone(strings.Split(testSpec.Cluster.GCE.Zones, ",")) {
+			l.PrintfCtx(ctx, "%q specified one or more GCE regions unsupported by T2A, falling back to AMD64; see #122035", testSpec.Name)
+			return vm.ArchAMD64
+		}
+		if roachtestflags.PreferLocalSSD && testSpec.Cluster.VolumeSize == 0 && testSpec.Cluster.SSDs > 1 {
+			l.PrintfCtx(ctx, "%q specified multiple _local_ SSDs unsupported by T2A, falling back to AMD64; see #122035", testSpec.Name)
+			return vm.ArchAMD64
+		}
 	}
 	l.PrintfCtx(ctx, "Using randomly chosen arch=%q, %s", arch, testSpec.Name)
 

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1104,17 +1103,8 @@ func computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, err
 			zones = []string{"us-central1-a"}
 		}
 
-		// Extracted from https://cloud.google.com/compute/docs/regions-zones#available
-		supportedT2AZones := []string{
-			"asia-southeast1-b", "asia-southeast1-c",
-			"europe-west4-a", "europe-west4-b", "europe-west4-c",
-			"us-central1-a", "us-central1-b", "us-central1-f",
-		}
-
-		for _, zone := range providerOpts.Zones {
-			if slices.Index(supportedT2AZones, zone) == -1 {
-				return nil, errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(supportedT2AZones, ","))
-			}
+		if !IsSupportedT2AZone(providerOpts.Zones) {
+			return nil, errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(SupportedT2AZones, ","))
 		}
 	}
 	return zones, nil

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -388,4 +389,21 @@ func GetUserAuthorizedKeys(l *logger.Logger) (authorizedKeys []byte, err error) 
 		pubKeyBuf.WriteRune('\n')
 	}
 	return pubKeyBuf.Bytes(), nil
+}
+
+// Extracted from https://cloud.google.com/compute/docs/regions-zones#available
+var SupportedT2AZones = []string{
+	"asia-southeast1-b", "asia-southeast1-c",
+	"europe-west4-a", "europe-west4-b", "europe-west4-c",
+	"us-central1-a", "us-central1-b", "us-central1-f",
+}
+
+// Used mainly in support of https://github.com/cockroachdb/cockroach/issues/122035.
+func IsSupportedT2AZone(zones []string) bool {
+	for _, zone := range zones {
+		if slices.Index(SupportedT2AZones, zone) == -1 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Backport 1/1 commits from #122047.

/cc @cockroachdb/release

---

After enabling metamorphic arm64 CI runs in GCE [1], new cluster creation errors were observed, owing
to the fact that T2A instances do not support US regions other than us-central1. Another limitation is no support for local SSDs, which may result in test failures when multiple local SSD stores are configured.

This PR adds a workaround by falling back to AMD64 in the above cases.

Epic: none
Release note: None
Fixes: #122035
Release justification: test-only change

[1] https://github.com/cockroachdb/cockroach/pull/117661
