### PR TITLE
release-23.2: roachtest: work around T2A limitations

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1017,15 +1017,10 @@ func computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, err
 	if providerOpts.useArmAMI() {
 		if len(providerOpts.Zones) == 0 {
 			zones = []string{"us-central1-a"}
-		} else {
-			supportedT2ARegions := []string{"us-central1", "asia-southeast1", "europe-west4"}
-			for _, zone := range providerOpts.Zones {
-				for _, region := range supportedT2ARegions {
-					if !strings.HasPrefix(zone, region) {
-						return nil, errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(supportedT2ARegions, ","))
-					}
-				}
-			}
+		}
+
+		if !IsSupportedT2AZone(providerOpts.Zones) {
+			return nil, errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(SupportedT2AZones, ","))
 		}
 	}
 	return zones, nil

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -396,4 +397,21 @@ func GetUserAuthorizedKeys(l *logger.Logger) (authorizedKeys []byte, err error) 
 		pubKeyBuf.WriteRune('\n')
 	}
 	return pubKeyBuf.Bytes(), nil
+}
+
+// Extracted from https://cloud.google.com/compute/docs/regions-zones#available
+var SupportedT2AZones = []string{
+	"asia-southeast1-b", "asia-southeast1-c",
+	"europe-west4-a", "europe-west4-b", "europe-west4-c",
+	"us-central1-a", "us-central1-b", "us-central1-f",
+}
+
+// Used mainly in support of https://github.com/cockroachdb/cockroach/issues/122035.
+func IsSupportedT2AZone(zones []string) bool {
+	for _, zone := range zones {
+		if slices.Index(SupportedT2AZones, zone) == -1 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Backport 1/1 commits from #122047.

/cc @cockroachdb/release

---

After enabling metamorphic arm64 CI runs in GCE [1], new cluster creation errors were observed, owing
to the fact that T2A instances do not support US regions other than us-central1. Another limitation is no support for local SSDs, which may result in test failures when multiple local SSD stores are configured.

This PR adds a workaround by falling back to AMD64 in the above cases.

Epic: none
Release note: None
Fixes: #122035
Release justification: test-only change

[1] https://github.com/cockroachdb/cockroach/pull/117661
