### PR TITLE
concurrency: correctly handle replay attempts from SKIP LOCKED requests

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -115,10 +115,6 @@ func exceptSharedLockPromotionError(err error) bool { // true if lock promotion 
 	return errors.Is(err, &concurrency.LockPromotionError{})
 }
 
-func exceptSkipLockedReplayError(err error) bool { // true if skip locked replay error
-	return errors.Is(err, &concurrency.SkipLockedReplayError{})
-}
-
 func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 	switch o := op.GetValue().(type) {
 	case *GetOperation,

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -797,7 +797,7 @@ func (v *validator) processOp(op Operation) {
 		// effect of perhaps registering a failure with the validator.
 		v.failIfError(
 			op, t.Result,
-			exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError, exceptSkipLockedReplayError,
+			exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError,
 		)
 
 		ops := t.Ops
@@ -1379,7 +1379,6 @@ func (v *validator) checkError(
 		exceptAmbiguous, exceptOmitted, exceptRetry,
 		exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
 		exceptSharedLockPromotionError,
-		exceptSkipLockedReplayError,
 	}
 	sl = append(sl, extraExceptions...)
 	return v.failIfError(op, r, sl...)

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -750,22 +750,11 @@ func (g *lockTableGuardImpl) IsKeyLockedByConflictingTxn(
 			break
 		}
 		if qqg.guard.txnMeta() != nil && g.isSameTxn(qqg.guard.txnMeta()) {
-			// A SKIP LOCKED request should not find another waiting request from its
-			// own transaction, at least not in the way that SQL uses KV. The only way
-			// we can end up finding another request in the lock's wait queue from our
-			// own transaction is if we're a replay.  We could handle this case by
-			// treating it as a non-conflict, but doing so expands the testing surface
-			// area -- we would want to include tests for:
-			// 1. Just our own request in the wait queue, treated as a non-conflict.
-			// 2. A request from a different transaction in the wait queue, with a
-			// lower sequence number, that conflicts.
-			// 3. A request from a different transaction in the wait queue, with a
-			// higher sequence number, that conflicts.
-			// 4. A request from a different transaction in the wait queue, with a
-			// lower sequence number, that does not conflict.
-			// For now, we simply return an error, and mark it for the benefit of
-			// KVNemesis.
-			return false, nil, MarkSkipLockedReplayError(errors.Errorf("SKIP LOCKED request should not find another waiting request from the same transaction"))
+			// Normally, in the way SQL uses KV, a SKIP LOCKED request should never
+			// find another request from its own transaction in a lock's wait queue.
+			// However, this is possible in case there is a replay involved. We handle
+			// this by treating the request as non-conflicting.
+			continue
 		}
 		if lock.Conflicts(qqg.mode, makeLockMode(str, g.txnMeta(), g.ts), &g.lt.settings.SV) {
 			return true, nil, nil // the conflict isn't with a lock holder, nil is returned
@@ -4692,22 +4681,4 @@ func MarkLockPromotionError(cause error) error {
 		return nil
 	}
 	return errors.Mark(cause, &LockPromotionError{})
-}
-
-// SkipLockedReplayError is used to mark errors resulting from replayed SKIP
-// LOCKED requests that discover other requests from their own transactions in
-// a lock's wait queue. We mark such errors for the benefit of KVNemesis.
-type SkipLockedReplayError struct{}
-
-func (e *SkipLockedReplayError) Error() string {
-	return "skip locked replay error"
-}
-
-// MarkSkipLockedReplayError wraps the given error, if non-nil, as a skip locked
-// replay error.
-func MarkSkipLockedReplayError(cause error) error {
-	if cause == nil {
-		return nil
-	}
-	return errors.Mark(cause, &SkipLockedReplayError{})
 }

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -7,6 +7,9 @@ new-txn txn=txn1 ts=10,1 epoch=0
 new-txn txn=txn2 ts=9,1 epoch=0
 ----
 
+new-txn txn=txn3 ts=10,1 epoch=0
+----
+
 # keyspace:
 #  a: unlocked
 #  b: locked by txn1
@@ -473,7 +476,7 @@ false
 
 is-key-locked-by-conflicting-txn r=req10 k=f strength=exclusive
 ----
-SKIP LOCKED request should not find another waiting request from the same transaction
+locked: false
 
 # ------------------------------------------------------------------------------
 # Ensure SKIP LOCKED works correctly when a transaction holds one of multiple
@@ -522,3 +525,196 @@ start-waiting: false
 is-key-locked-by-conflicting-txn r=req13 k=a strength=exclusive
 ----
 locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+# ------------------------------------------------------------------------------
+# Ensure SKIP LOCKED requests that find other requests belonging to their
+# transaction in a lock's wait queues are handled correctly. They should be
+# treated as non-conflicting.
+# ---------------------------------------------------------------------------------
+
+clear
+----
+num=0
+
+# 1. Simple test where there's only one request in the wait queue, and it
+# belongs to our own transaction.
+
+new-request r=req14 txn=txn1 ts=10,1 spans=exclusive@a
+----
+
+scan r=req14
+----
+start-waiting: false
+
+acquire r=req14 k=a strength=exclusive durability=u
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req15 txn=txn2 ts=10,1 spans=exclusive@a
+----
+
+scan r=req15
+----
+start-waiting: true
+
+release txn=txn1 span=a
+----
+num=1
+ lock: "a"
+   queued locking requests:
+    active: false req: 15, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+
+new-request r=req16 txn=txn2 ts=10,1 spans=exclusive@a skip-locked
+----
+
+scan r=req16
+----
+start-waiting: false
+
+is-key-locked-by-conflicting-txn r=req16 k=a strength=exclusive
+----
+locked: false
+
+clear
+----
+num=0
+
+# 2. Throw in a request from a different transaction in the wait-queue (2
+# variants -- one with strength shared and another with strength exclusive).
+# We'll test skip locked requests with both higher and lower sequence numbers.
+# Again, 2 variants each, one with strength shared and another with strength
+# exclusive.
+
+new-request r=req17 txn=txn1 ts=10,1 spans=exclusive@a,b
+----
+
+scan r=req17
+----
+start-waiting: false
+
+acquire r=req17 k=a strength=exclusive durability=u
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+acquire r=req17 k=b strength=exclusive durability=u
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+new-request r=req18 txn=txn2 ts=9,1 spans=exclusive@a
+----
+
+scan r=req18
+----
+start-waiting: true
+
+new-request r=req19 txn=txn2 ts=9,1 spans=exclusive@b
+----
+
+scan r=req19
+----
+start-waiting: true
+
+# Before adding requests from txn3 in the wait-queue, create 2 SKIP LOCKED
+# requests for txn2 (with lock strength shared and exclusive). This way, they'll
+# have a lower sequence number than the requests from txn3.
+
+new-request r=req20 txn=txn2 ts=9,1 spans=exclusive@a,b skip-locked
+----
+
+scan r=req20
+----
+start-waiting: false
+
+new-request r=req21 txn=txn2 ts=9,1 spans=shared@a,b skip-locked
+----
+
+scan r=req21
+----
+start-waiting: false
+
+# Now, add requests from txn3 to the wait queue.
+new-request r=req22 txn=txn3 ts=10,1 spans=exclusive@a
+----
+
+scan r=req22
+----
+start-waiting: true
+
+new-request r=req23 txn=txn3 ts=10,1 spans=shared@b
+----
+
+scan r=req23
+----
+start-waiting: true
+
+# Setup complete.
+release txn=txn1 span=a,c
+----
+num=2
+ lock: "a"
+   queued locking requests:
+    active: false req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 22, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
+ lock: "b"
+   queued locking requests:
+    active: false req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
+    active: true req: 23, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
+
+# Lastly, create 2 more SKIP LOCKED requests for txn2, one each for strength
+# shared and exclusive. They'll have a higher sequence number than requests
+# that belong to txn3.
+
+new-request r=req24 txn=txn2 ts=9,1 spans=exclusive@a,b skip-locked
+----
+
+scan r=req24
+----
+start-waiting: false
+
+new-request r=req25 txn=txn2 ts=9,1 spans=shared@a,b skip-locked
+----
+
+scan r=req25
+----
+start-waiting: false
+
+# Now, for the actual tests.
+is-key-locked-by-conflicting-txn r=req20 k=a strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req20 k=b strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req21 k=a strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req21 k=b strength=shared
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req24 k=a strength=exclusive
+----
+locked: true, holder: <nil>
+
+is-key-locked-by-conflicting-txn r=req24 k=b strength=exclusive
+----
+locked: true, holder: <nil>
+
+is-key-locked-by-conflicting-txn r=req25 k=a strength=shared
+----
+locked: true, holder: <nil>
+
+is-key-locked-by-conflicting-txn r=req25 k=b strength=shared
+----
+locked: false


### PR DESCRIPTION
Previously, whenever a SKIP LOCKED request encountered another request from its own transaction in a lock's wait queue, it would return an error. However, we've wanted to handle such cases by treating the found request as non-conflicting -- see discussion on the attached issue. This patch does exactly that. In doing so, we're also able to clean up some error special casing in KVNemesis.

Closes https://github.com/cockroachdb/cockroach/issues/111527

Release note: None