### PR TITLE
teamcity: fix DN validation acceptance test for arm64 CI pipeline

### DIFF
--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
@@ -33,6 +33,7 @@ $BAZCI --artifacts_dir=$PWD/artifacts -- \
   "--test_tmpdir=$ARTIFACTSDIR" \
   --test_arg=-l="$ARTIFACTSDIR" \
   --test_arg=-b=$PWD/artifacts/cockroach \
+  --test_env=COCKROACH_DEV_LICENSE  \
   --test_env=TZ=America/New_York \
   --profile=$PWD/artifacts/profile.gz \
   --test_timeout=1800 || status=$?


### PR DESCRIPTION
Release note: None
Epic: None
fixes: https://github.com/cockroachdb/cockroach/issues/122036 
fixes: https://github.com/cockroachdb/cockroach/issues/122031 
Currently TC builds are failing for arm64 acceptance due to cockroach license not being available for one of the
tests(TestDockerCLI_test_distinguished_name_validation) for both main and 24.1 branches.
Release justification: Non-production code changes