### PR TITLE
testutils/serverutils: reduce test noise about mt interfaces

### DIFF
--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -143,13 +143,11 @@ go_test(
     ],
     embed = [":serverutils"],
     deps = [
-        "//pkg/base",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/util/leaktest",
-        "//pkg/util/log",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/serverutils/conditional_wrap_test.go
+++ b/pkg/testutils/serverutils/conditional_wrap_test.go
@@ -11,20 +11,15 @@
 package serverutils_test
 
 import (
-	"bytes"
-	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,59 +59,3 @@ func otherFn() string {
 }
 
 var externalC = func() string { return serverutils.GetExternalCaller() }()
-
-func TestInterfaceNotices(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	runCalls := func(s serverutils.TestServerInterface) {
-		_ = s.AppStopper()
-		_ = s.NodeID()
-		_ = s.StartedDefaultTestTenant()
-	}
-
-	testCases := []struct {
-		name     string
-		opts     base.DefaultTestTenantOptions
-		scenario func(t *testing.T, exec func(func(serverutils.TestServerInterface)) string)
-	}{
-		{
-			name: "default",
-			opts: (base.DefaultTestTenantOptions{}),
-			scenario: func(t *testing.T, exec func(func(serverutils.TestServerInterface)) string) {
-				result := exec(runCalls)
-				require.Contains(t, result, "NOTICE: .AppStopper() called via implicit interface ApplicationLayerInterface")
-				require.Contains(t, result, "NOTICE: .NodeID() called via implicit interface StorageLayerInterface")
-				require.Contains(t, result, "NOTICE: .StartedDefaultTestTenant() called via implicit interface TenantControlInterface")
-			},
-		},
-		{
-			name: "systemonly",
-			opts: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-			scenario: func(t *testing.T, exec func(func(serverutils.TestServerInterface)) string) {
-				result := exec(runCalls)
-				require.NotContains(t, result, ".AppStopper()")
-				require.NotContains(t, result, ".NodeID()")
-				require.Contains(t, result, "NOTICE: .StartedDefaultTestTenant() called via implicit interface TenantControlInterface")
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			defer log.Scope(t).Close(t)
-
-			s := serverutils.StartServerOnly(t, base.TestServerArgs{DefaultTestTenant: tc.opts})
-			defer s.Stopper().Stop(context.Background())
-
-			var buf bytes.Buffer
-			serverutils.TestingSetWrapperLogger(s, func(format string, args ...interface{}) { fmt.Fprintf(&buf, format, args...) })
-
-			exec := func(fn func(serverutils.TestServerInterface)) string {
-				buf.Reset()
-				fn(s)
-				return buf.String()
-			}
-			tc.scenario(t, exec)
-		})
-	}
-}


### PR DESCRIPTION
Release note: none.
Epic: none.