### PR TITLE
release-23.2: roachprod: account for cost of boot partition

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -666,7 +666,7 @@ func (p *Provider) ListVolumes(l *logger.Logger, v *vm.VM) ([]vm.Volume, error) 
 		})
 	}
 
-	// TODO(irfansharif): Update v.PersistentVolumes? It's awkward to have
+	// TODO(irfansharif): Update v.NonBootAttachedVolumes? It's awkward to have
 	// that field at all.
 	return volumes, nil
 }

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -194,6 +194,7 @@ func (jsonVM *jsonVM) toVM(
 
 	var volumes []vm.Volume
 	var localDisks []vm.Volume
+	var bootVolume vm.Volume
 
 	parseDiskSize := func(size string) int {
 		if val, err := strconv.Atoi(size); err == nil {
@@ -213,23 +214,25 @@ func (jsonVM *jsonVM) toVM(
 			})
 			continue
 		}
-		if !jsonVMDisk.Boot {
-			// Find a persistent volume (detailedDisk) matching the attached non-boot disk.
-			for _, detailedDisk := range disks {
-				if detailedDisk.SelfLink == jsonVMDisk.Source {
-					vol := vm.Volume{
-						// NB: See TODO in toDescribeVolumeCommandResponse. We
-						// should be able to "just" use detailedDisk.Name here,
-						// but we're abusing that field elsewhere, and
-						// incorrectly. Using SelfLink is correct.
-						ProviderResourceID: lastComponent(detailedDisk.SelfLink),
-						ProviderVolumeType: detailedDisk.Type,
-						Zone:               lastComponent(detailedDisk.Zone),
-						Name:               detailedDisk.Name,
-						Labels:             detailedDisk.Labels,
-						Size:               parseDiskSize(detailedDisk.SizeGB),
-					}
+		// Find a persistent volume (detailedDisk) matching the attached non-boot disk.
+		for _, detailedDisk := range disks {
+			if detailedDisk.SelfLink == jsonVMDisk.Source {
+				vol := vm.Volume{
+					// NB: See TODO in toDescribeVolumeCommandResponse. We
+					// should be able to "just" use detailedDisk.Name here,
+					// but we're abusing that field elsewhere, and
+					// incorrectly. Using SelfLink is correct.
+					ProviderResourceID: lastComponent(detailedDisk.SelfLink),
+					ProviderVolumeType: detailedDisk.Type,
+					Zone:               lastComponent(detailedDisk.Zone),
+					Name:               detailedDisk.Name,
+					Labels:             detailedDisk.Labels,
+					Size:               parseDiskSize(detailedDisk.SizeGB),
+				}
+				if !jsonVMDisk.Boot {
 					volumes = append(volumes, vol)
+				} else {
+					bootVolume = vol
 				}
 			}
 		}
@@ -257,6 +260,7 @@ func (jsonVM *jsonVM) toVM(
 		Zone:                   zone,
 		Project:                project,
 		NonBootAttachedVolumes: volumes,
+		BootVolume:             bootVolume,
 		LocalDisks:             localDisks,
 	}
 }
@@ -662,7 +666,7 @@ func (p *Provider) ListVolumes(l *logger.Logger, v *vm.VM) ([]vm.Volume, error) 
 		})
 	}
 
-	// TODO(irfansharif): Update v.NonBootAttachedVolumes? It's awkward to have
+	// TODO(irfansharif): Update v.PersistentVolumes? It's awkward to have
 	// that field at all.
 	return volumes, nil
 }
@@ -1887,9 +1891,8 @@ func toDescribeVolumeCommandResponse(
 // using a basic estimation method.
 //  1. Compute and attached disks are estimated at the list prices, ignoring
 //     all discounts, but including any automatically applied credits.
-//  2. Boot disk costs are completely ignored.
-//  3. Network egress costs are completely ignored.
-//  4. Blob storage costs are completely ignored.
+//  2. Network egress costs are completely ignored.
+//  3. Blob storage costs are completely ignored.
 func populateCostPerHour(l *logger.Logger, vms vm.List) error {
 	// Construct cost estimation service
 	ctx := context.Background()
@@ -1975,7 +1978,8 @@ func populateCostPerHour(l *logger.Logger, vms vm.List) error {
 					},
 				}
 			}
-			for _, v := range vm.NonBootAttachedVolumes {
+			volumes := append(vm.NonBootAttachedVolumes, vm.BootVolume)
+			for _, v := range volumes {
 				workload.ComputeVmWorkload.PersistentDisks = append(workload.ComputeVmWorkload.PersistentDisks, &cloudbilling.PersistentDisk{
 					DiskSize: &cloudbilling.Usage{
 						UsageRateTimeline: &cloudbilling.UsageRateTimeline{

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -140,6 +140,9 @@ type VM struct {
 	// NonBootAttachedVolumes are the non-bootable, _persistent_ volumes attached to the VM.
 	NonBootAttachedVolumes []Volume `json:"non_bootable_volumes"`
 
+	// BootVolume is the bootable, _persistent_ volume attached to the VM.
+	BootVolume Volume `json:"bootable_volume"`
+
 	// LocalDisks are the ephemeral SSD disks attached to the VM.
 	LocalDisks []Volume `json:"local_disks"`
 


### PR DESCRIPTION
Backport 3/3 commits from #121938.

/cc @cockroachdb/release

---

Previously, when creating a GCE cluster on roachprod we were ignoring the cost of the boot disk.
This change ensures that we also account for the cost of the boot disk.

Epic: none
Fixes: #120728
Release note: None

---

Release justification: This backport ensures that we take the cost of the boot disk into account when creating a GCE cluster on roachprod
