### PR TITLE
roachtest: add allowLocal to backup specs

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -137,10 +137,8 @@ type backupDriver struct {
 }
 
 func (bd *backupDriver) prepareCluster(ctx context.Context) {
-
-	if bd.c.Cloud() != bd.sp.scheduledBackupSpecs.cloud {
-		// For now, only run the test on the cloud provider that also stores the backup.
-		bd.t.Skip(fmt.Sprintf("test configured to run on %s", bd.sp.scheduledBackupSpecs.cloud))
+	if err := bd.sp.scheduledBackupSpecs.CloudIsCompatible(bd.c.Cloud()); err != nil {
+		bd.t.Skip(err.Error())
 	}
 	version := clusterupgrade.CurrentVersion()
 	if bd.sp.scheduledBackupSpecs.version != fixtureFromMasterVersion {
@@ -387,7 +385,7 @@ func registerBackupFixtures(r registry.Registry) {
 			Cluster:           bf.hardware.makeClusterSpecs(r, bf.scheduledBackupSpecs.cloud),
 			Timeout:           bf.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
-			CompatibleClouds:  registry.Clouds(bf.scheduledBackupSpecs.cloud),
+			CompatibleClouds:  bf.scheduledBackupSpecs.CompatibleClouds(),
 			Suites:            bf.suites,
 			Skip:              bf.skip,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -120,7 +120,7 @@ func registerOnlineRestore(r registry.Registry) {
 						// These tests measure performance. To ensure consistent perf,
 						// disable metamorphic encryption.
 						EncryptionSupport: registry.EncryptionAlwaysDisabled,
-						CompatibleClouds:  registry.Clouds(sp.backup.cloud),
+						CompatibleClouds:  sp.backup.CompatibleClouds(),
 						Suites:            sp.suites,
 						Skip:              sp.skip,
 						// Takes 10 minutes on OR tests for some reason.


### PR DESCRIPTION
This adds the ability to register a test to run locally.

While most of our roachtests are too large to run locally, it is often useful to have a smaller version of a test that can run locally to make it faster to debug.

This commit doesn't set allowLocal on any of the existing tests yet.

Epic: none
Release note: None