### PR TITLE
roachprod: split start-up script logic for disks

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -563,7 +563,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 			}
 		} else {
 			rmCmds := []string{
-				`sudo find /mnt/data* -maxdepth 1 -type f -not -name .roachprod-initialized -exec rm -f {} \;`,
+				fmt.Sprintf(`sudo find /mnt/data* -maxdepth 1 -type f -not -name %s -exec rm -f {} \;`, vm.InitializedFile),
 				`sudo rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data}`,
 				`sudo rm -fr logs* data*`,
 			}
@@ -1365,7 +1365,7 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 		func(ctx context.Context, node Node) (*RunResultDetails, error) {
 			res := &RunResultDetails{Node: node}
 			var err error
-			cmd := "test -e /mnt/data1/.roachprod-initialized"
+			cmd := fmt.Sprintf("test -e %s", vm.DisksInitializedFile)
 			opts := defaultCmdOpts("wait-init")
 			for j := 0; j < 600; j++ {
 				res, err = c.runCmdOnSingleNode(ctx, l, node, cmd, opts)

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -37,7 +37,7 @@ const awsStartupScriptTemplate = `#!/usr/bin/env bash
 
 set -x
 
-if [ -e /mnt/data1/.roachprod-initialized ]; then
+if [ -e {{ .DisksInitializedFile }} ]; then
   echo "Already initialized, exiting."
   exit 0
 fi
@@ -205,7 +205,7 @@ sudo hostnamectl set-hostname {{.VMName}}
 sudo ua enable fips --assume-yes
 {{ end }}
 
-sudo touch /mnt/data1/.roachprod-initialized
+sudo touch {{ .DisksInitializedFile }}
 `
 
 // writeStartupScript writes the startup script to a temp file.
@@ -218,17 +218,19 @@ func writeStartupScript(
 	name string, extraMountOpts string, useMultiple bool, enableFips bool,
 ) (string, error) {
 	type tmplParams struct {
-		VMName           string
-		ExtraMountOpts   string
-		UseMultipleDisks bool
-		EnableFIPS       bool
+		VMName               string
+		ExtraMountOpts       string
+		UseMultipleDisks     bool
+		EnableFIPS           bool
+		DisksInitializedFile string
 	}
 
 	args := tmplParams{
-		VMName:           name,
-		ExtraMountOpts:   extraMountOpts,
-		UseMultipleDisks: useMultiple,
-		EnableFIPS:       enableFips,
+		VMName:               name,
+		ExtraMountOpts:       extraMountOpts,
+		UseMultipleDisks:     useMultiple,
+		EnableFIPS:           enableFips,
+		DisksInitializedFile: vm.DisksInitializedFile,
 	}
 
 	tmpfile, err := os.CreateTemp("", "aws-startup-script")

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -664,7 +664,10 @@ func (p *Provider) createVM(
 	opts vm.CreateOpts,
 	providerOpts ProviderOpts,
 ) (machine compute.VirtualMachine, err error) {
-	startupArgs := azureStartupArgs{RemoteUser: remoteUser}
+	startupArgs := azureStartupArgs{
+		RemoteUser:           remoteUser,
+		DisksInitializedFile: vm.DisksInitializedFile,
+	}
 	if !opts.SSDOpts.UseLocalSSD {
 		// We define lun42 explicitly in the data disk request below.
 		lun := 42

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -22,8 +22,9 @@ import (
 // created from /mnt/data<disknum> to the mount point.
 // azureStartupArgs specifies template arguments for the setup template.
 type azureStartupArgs struct {
-	RemoteUser      string // The uname for /data* directories.
-	AttachedDiskLun *int   // Use attached disk, with specified LUN; Use local ssd if nil.
+	RemoteUser           string // The uname for /data* directories.
+	AttachedDiskLun      *int   // Use attached disk, with specified LUN; Use local ssd if nil.
+	DisksInitializedFile string // File to touch when disks are initialized.
 }
 
 const azureStartupTemplate = `#!/bin/bash
@@ -107,7 +108,7 @@ sed -i'~' 's/enabled=1/enabled=0/' /etc/default/apport
 sed -i'~' '/.*kernel\\.core_pattern.*/c\\' /etc/sysctl.conf
 echo "kernel.core_pattern=$CORE_PATTERN" >> /etc/sysctl.conf
 sysctl --system  # reload sysctl settings
-touch /mnt/data1/.roachprod-initialized
+touch {{ .DisksInitializedFile }}
 `
 
 // evalStartupTemplate evaluates startup template defined above and returns

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -47,6 +47,19 @@ const (
 	ArchAMD64   = CPUArch("amd64")
 	ArchFIPS    = CPUArch("fips")
 	ArchUnknown = CPUArch("unknown")
+
+	// InitializedFile is the base name of the initialization paths defined below.
+	InitializedFile = ".roachprod-initialized"
+	// OSInitializedFile is a marker file that is created on a VM to indicate
+	// that it has been initialized at least once by the VM start-up script. This
+	// is used to avoid re-initializing a VM that has been stopped and restarted.
+	OSInitializedFile = "/" + InitializedFile
+	// DisksInitializedFile is a marker file that is created on a VM to indicate
+	// that the disks have been initialized by the VM start-up script. This is
+	// separate from OSInitializedFile, because the disks may be ephemeral and
+	// need to be re-initialized on every start. The presence of this file
+	// automatically implies the presence of OSInitializedFile.
+	DisksInitializedFile = "/mnt/data1/" + InitializedFile
 )
 
 type CPUArch string


### PR DESCRIPTION
Previously, the start-up script for GCE VMs would determine if it should run by looking at `/mnt/data1/.roachprod-initialized`. This logic fails if the disks are ephemeral. The VM also completely fails to boot due to an `fstab` entry that does not have the `nofail` option. Because, a new disk is attached, but it's not formatted.

This change adds the `nofail` option, but also divides the start-up script into parts to handle the scenario where the OS might have been previously initialed, but the disks are not initialised. To fix this we now track OS initialization via `/.roachprod-initialized` and disk initialization via `/mnt/data1/.roachprod-initialized`. We also prevent the `fstab` entries from being written again, as these are part of the OS initialization.

Fixes: #122094

Epic: None
Release Note: None