### PR TITLE
keys: define sys tenant span as its sql tables

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -30,7 +30,7 @@ func MakeTenantPrefix(tenID roachpb.TenantID) roachpb.Key {
 // MakeTenantSpan creates the start/end key pair associated with the specified tenant.
 func MakeTenantSpan(tenID roachpb.TenantID) roachpb.Span {
 	if tenID == roachpb.SystemTenantID {
-		return roachpb.Span{Key: MinKey, EndKey: MaxKey}
+		return roachpb.Span{Key: TableDataMin, EndKey: TableDataMax}
 	}
 	tenIDint := tenID.ToUint64()
 	return roachpb.Span{
@@ -164,6 +164,9 @@ type sqlDecoder struct {
 
 // MakeSQLCodec creates a new  SQLCodec suitable for manipulating SQL keys.
 func MakeSQLCodec(tenID roachpb.TenantID) SQLCodec {
+	if tenID.IsSystem() {
+		return SystemSQLCodec
+	}
 	sp := MakeTenantSpan(tenID)
 	sp.Key = sp.Key[:len(sp.Key):len(sp.Key)]             // bound capacity, avoid aliasing
 	sp.EndKey = sp.EndKey[:len(sp.EndKey):len(sp.EndKey)] // bound capacity, avoid aliasing
@@ -174,7 +177,17 @@ func MakeSQLCodec(tenID roachpb.TenantID) SQLCodec {
 }
 
 // SystemSQLCodec is a SQL key codec for the system tenant.
-var SystemSQLCodec = MakeSQLCodec(roachpb.SystemTenantID)
+//
+// NB: We don't use MakeSQLCodec here since the system tenant is special and its
+// prefix is empty, rather than the start of its span, so the Codec for it wants
+// the empty key, rather than start key, as its buf. Ideally we would set the
+// endKey to TableDataMax instead of MaxKey here, but TableDataMax is currently
+// defined in terms of this codec. We would want to fix this if/when we make the
+// tenant with ID one non-system, but we'll get rid of/rename this then as well.
+var SystemSQLCodec = SQLCodec{
+	sqlEncoder: sqlEncoder{&MinKey, &MaxKey},
+	sqlDecoder: sqlDecoder{&MinKey},
+}
 
 // ForSystemTenant returns whether the encoder is bound to the system tenant.
 func (e sqlEncoder) ForSystemTenant() bool {


### PR DESCRIPTION
This excludes the non-table data in the cluster, which belongs to the cluster, but not to tenant 1. Auth decisions for this data should be made based on being system or not, rather than its span, so this shouldn't really affect the behavior of anything today.

Release note: none.
Epic: none.