### PR TITLE
opt: make access to Instance constraints safer

### DIFF
--- a/pkg/sql/opt/idxconstraint/BUILD.bazel
+++ b/pkg/sql/opt/idxconstraint/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         ":idxconstraint",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
+        "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/exec/execbuilder",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1157,26 +1157,34 @@ func (ic *Instance) Init(
 	ic.initialized = true
 }
 
-// Constraint returns the constraint created by Init. Panics if Init wasn't
-// called, or if a consolidated constraint was not built because
+// Constraint shallow-copies the constraint created by Init into c. Panics if
+// Init wasn't called, or if a consolidated constraint was not built because
 // consolidate=false was passed as an argument to Init.
-func (ic *Instance) Constraint() *constraint.Constraint {
+//
+// This method is designed specifically to avoid returning a reference to
+// Instance.consolidatedConstraint. If it did so, the entire Instance could not
+// be GC'd while the reference lived.
+func (ic *Instance) Constraint(c *constraint.Constraint) {
 	if !ic.initialized {
 		panic(errors.AssertionFailedf("Init was not called"))
 	}
 	if !ic.consolidated {
 		panic(errors.AssertionFailedf("Init was called with consolidate=false"))
 	}
-	return &ic.consolidatedConstraint
+	*c = ic.consolidatedConstraint
 }
 
-// UnconsolidatedConstraint returns the constraint created by Init before it was
-// consolidated. Panics if Init wasn't called.
-func (ic *Instance) UnconsolidatedConstraint() *constraint.Constraint {
+// UnconsolidatedConstraint shallow-copies the unconsolidated constraint created
+// by Init into c. Panics if Init wasn't called.
+//
+// This method is designed specifically to avoid returning a reference to
+// Instance.constraint. If it did so, the entire Instance could not be GC'd
+// while the reference lived.
+func (ic *Instance) UnconsolidatedConstraint(c *constraint.Constraint) {
 	if !ic.initialized {
 		panic(errors.AssertionFailedf("Init was not called"))
 	}
-	return &ic.constraint
+	*c = ic.constraint
 }
 
 // RemainingFilters calculates a simplified FiltersExpr that needs to be applied

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/idxconstraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -138,7 +139,8 @@ func TestIndexConstraints(t *testing.T) {
 					true /* consolidate */, &evalCtx, &f, partition.PrefixSorter{},
 					func() {}, /* checkCancellation */
 				)
-				result := ic.Constraint()
+				var result constraint.Constraint
+				ic.Constraint(&result)
 				var buf bytes.Buffer
 				for i := 0; i < result.Spans.Count(); i++ {
 					fmt.Fprintf(&buf, "%s\n", result.Spans.Get(i))
@@ -257,7 +259,8 @@ func BenchmarkIndexConstraints(b *testing.B) {
 					&evalCtx, &f, partition.PrefixSorter{},
 					func() {}, /* checkCancellation */
 				)
-				_ = ic.Constraint()
+				var result constraint.Constraint
+				ic.Constraint(&result)
 				_ = ic.RemainingFilters()
 			}
 		})


### PR DESCRIPTION
This commit refactors the `Instance.Constraint` and
`Instance.UnconsolidatedConstraint` methods to make their usage safer.
Rather than returning references to fields of `Instance`, it
shallow-copies the constraints into an existing constraint reference.
This prevents returning a reference to a constraint that can prevent the
entire `Instance` from being GC'd while the reference is live.

Epic: None

Release note: None
