### PR TITLE
sqlstats: delete sqlstats.StatsCollector interface

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -872,6 +872,7 @@ go_test(
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
+        "//pkg/sql/sqlstats/sslocal",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/stats",
         "//pkg/sql/stmtdiagnostics",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1649,7 +1649,7 @@ type connExecutor struct {
 
 	// statsCollector is used to collect statistics about SQL statements and
 	// transactions.
-	statsCollector sqlstats.StatsCollector
+	statsCollector *sslocal.StatsCollector
 
 	// cpuStatsCollector is used to estimate RU consumption due to CPU usage for
 	// tenants.

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -143,7 +144,7 @@ func (p *planner) maybeLogStatement(
 	telemetryLoggingMetrics *telemetryLoggingMetrics,
 	stmtFingerprintID appstatspb.StmtFingerprintID,
 	queryStats *topLevelQueryStats,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	shouldLogToTelemetry bool,
 ) {
 	p.maybeAuditRoleBasedAuditEvent(ctx, execType)
@@ -164,7 +165,7 @@ func (p *planner) maybeLogStatementInternal(
 	telemetryMetrics *telemetryLoggingMetrics,
 	stmtFingerprintID appstatspb.StmtFingerprintID,
 	topLevelQueryStats *topLevelQueryStats,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	shouldLogToTelemetry bool,
 ) {
 	// Note: if you find the code below crashing because p.execCfg == nil,

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -407,7 +408,7 @@ func (ih *instrumentationHelper) finalizeSetup(ctx context.Context, cfg *Executo
 func (ih *instrumentationHelper) Setup(
 	ctx context.Context,
 	cfg *ExecutorConfig,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	p *planner,
 	stmtDiagnosticsRecorder *stmtdiagnostics.Registry,
 	fingerprint string,
@@ -561,7 +562,7 @@ func (ih *instrumentationHelper) setupWithPlanGist(
 
 func (ih *instrumentationHelper) Finish(
 	cfg *ExecutorConfig,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	txnStats *execstats.QueryLevelStats,
 	collectExecStats bool,
 	p *planner,

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql/execstats",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats/insights",
         "//pkg/util/stop",
         "//pkg/util/uuid",

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -137,39 +136,6 @@ type TransactionVisitor func(context.Context, *appstatspb.CollectedTransactionSt
 // IterateAggregatedTransactionStats(). If an error is encountered when calling
 // the visitor, the iteration is aborted.
 type AggregatedTransactionVisitor func(appName string, statistics *appstatspb.TxnStats) error
-
-// StatsCollector is an interface that collects statistics for transactions and
-// statements for the entire lifetime of a session.
-type StatsCollector interface {
-	Writer
-
-	// PhaseTimes returns the sessionphase.Times that this StatsCollector is
-	// currently tracking.
-	PhaseTimes() *sessionphase.Times
-
-	// PreviousPhaseTimes returns the sessionphase.Times that this StatsCollector
-	// was previously tracking before being Reset.
-	PreviousPhaseTimes() *sessionphase.Times
-
-	// Reset resets the StatsCollector with a new ApplicationStats and a new copy
-	// of the sessionphase.Times.
-	Reset(ApplicationStats, *sessionphase.Times)
-
-	// StartTransaction sets up the StatsCollector for a new transaction.
-	StartTransaction()
-
-	// EndTransaction informs the StatsCollector that the current txn has
-	// finished execution. (Either COMMITTED or ABORTED). This means the txn's
-	// fingerprint ID is now available. StatsCollector will now go back to update
-	// the transaction fingerprint ID field of all the statement statistics for that
-	// txn.
-	EndTransaction(ctx context.Context, transactionFingerprintID appstatspb.TransactionFingerprintID)
-
-	// UpgradeImplicitTxn informs the StatsCollector that the current txn has been
-	// upgraded to an explicit transaction, thus all previously recorded statements
-	// should be updated accordingly.
-	UpgradeImplicitTxn(ctx context.Context) error
-}
 
 // Storage provides clients with interface to perform read and write operations
 // to sql statistics.

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -117,7 +117,7 @@ func TestTelemetryLogging(t *testing.T) {
 		queryLevelStats         execstats.QueryLevelStats
 		enableTracing           bool
 		enableInjectTxErrors    bool
-		expectedStatsCollector  sqlstats.StatsCollector
+		expectedStatsCollector  *sslocal.StatsCollector
 	}{
 		{
 			// Test case with statement that is not of type DML.


### PR DESCRIPTION
There is one implementation of this interface. Let us simply use the concrete type.

Epic: none

Release note: None