### PR TITLE
sql: fix nightly schema changer corpus script

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
@@ -75,7 +75,7 @@ if [ $exit_status = 0 ]; then
 fi
 
 # Generate a corpus for all mixed version variants
-for config in local-mixed-23.1; do
+for config in local-mixed-23.2; do
   $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
       //pkg/sql/logictest/tests/$config/... \
       --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed \


### PR DESCRIPTION
Previously, the nightly script for generating corpuses for declarative schema changer mixed version tests was using the 23.1 mixed version logic tests. Since these have been removed the nightly started failing because we are not generating a mixed version corpus any more. To address this, this patch will update the nightly script to generate the corpus against the newer 23.2 logic tests.

Fixes: #122082

Release note: None