### PR TITLE
roachtest: wait 5m before asserting on QPS in kv/restart/nodes=12

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -1012,9 +1012,12 @@ func registerKVRestartImpact(r registry.Registry) {
 
 			// Begin the monitoring goroutine to track QPS every 5 seconds.
 			m.Go(func(ctx context.Context) error {
-				// Wait until 10s after the workload began to begin asserting on QPS.
-				if dur := timeutil.Since(workloadStartTime); dur < 10*time.Second {
-					time.Sleep(10*time.Second - dur)
+				// Wait until 5 minutes after the workload began to begin asserting on
+				// QPS.
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(5 * time.Minute):
 				}
 
 				t.Status(fmt.Sprintf("verify QPS is at least %d during the test, expecting %d", int(passingQPS), int(expectedQPS)))


### PR DESCRIPTION
`kv/restart/nodes=12` would previously wait 10 seconds before beginning to assert on workload QPS. It was possible that the workload throughput hadn't reached the steady state during this time, causing the test to fail in an unrelated (setup) phase.

Increase the grace period to 5 minutes.

Fixes: #121884
Release note: None