### PR TITLE
roachtest: add an Operation for network failures

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2365,7 +2365,10 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 	defer l.Close()
 
 	cmd := strings.Join(args, " ")
-	c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
+	// TODO(bilal): Remove the need to check for nil.
+	if c.t != nil {
+		c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
+	}
 	l.Printf("> %s", cmd)
 	if err := roachprod.Run(
 		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),

--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "add_column.go",
         "add_index.go",
+        "network_partition.go",
         "register.go",
         "utils.go",
     ],

--- a/pkg/cmd/roachtest/operations/network_partition.go
+++ b/pkg/cmd/roachtest/operations/network_partition.go
@@ -1,0 +1,112 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+)
+
+type cleanupNetworkPartition struct {
+	nodeID int
+}
+
+// Cleanup removes the network partition created by the operation.
+func (np *cleanupNetworkPartition) Cleanup(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) {
+	o.Status(fmt.Sprintf("remove the partition on node n%d", np.nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(np.nodeID)), `sudo iptables -F`)
+}
+
+// createNetworkPartition creates a network partition between two random nodes.
+func createNetworkPartialPartition(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	nodeCount := c.Spec().NodeCount
+	if nodeCount <= 1 {
+		o.Fatal("not enough nodes to create a partition")
+	}
+	nodeID := rand.Intn(nodeCount) + 1
+
+	// Create a partial partition between two random nodes.
+	var otherNodeID int
+	// Choose a different nodeID to partition from.
+	for {
+		otherNodeID = rand.Intn(nodeCount) + 1
+		if otherNodeID != nodeID {
+			break
+		}
+	}
+
+	// Get the internal IPs of the remote node.
+	ips, err := c.InternalIP(ctx, o.L(), c.Node(otherNodeID))
+	if err != nil {
+		o.Fatal(err)
+	}
+	otherNodeIP := ips[0]
+	o.Status(fmt.Sprintf("creating a partition between nodes n%d and n%d", nodeID, otherNodeID))
+	// Block all input and output traffic between the two nodes.
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp -s %s -j DROP`, otherNodeIP))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp -d %s -j DROP`, otherNodeIP))
+
+	return &cleanupNetworkPartition{nodeID: nodeID}
+}
+
+// createNetworkFullPartition creates a network partition between a random node
+// and all other nodes.
+func createNetworkFullPartition(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	nodeCount := c.Spec().NodeCount
+	if nodeCount <= 1 {
+		o.Fatal("not enough nodes to create a partition")
+	}
+	nodeID := rand.Intn(nodeCount) + 1
+
+	// Drop bi-directional traffic between the node and all other nodes on the
+	// pgport.
+	o.Status(fmt.Sprintf("partition node n%d from the cluster", nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --sport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A INPUT  -p tcp --dport {pgport:%d} -j DROP`, nodeID))
+	c.Run(ctx, option.WithNodes(c.Node(nodeID)), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport {pgport:%d} -j DROP`, nodeID))
+
+	return &cleanupNetworkPartition{nodeID: nodeID}
+}
+
+// registerNetworkPartition registers both the full and partial network
+// partition operations.
+func registerNetworkPartition(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "network-partition/full",
+		Owner:            registry.OwnerKV,
+		Timeout:          1 * time.Minute,
+		CompatibleClouds: registry.AllClouds,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
+		Run:              createNetworkFullPartition,
+	})
+	r.AddOperation(registry.OperationSpec{
+		Name:             "network-partition/partial",
+		Owner:            registry.OwnerKV,
+		Timeout:          1 * time.Minute,
+		CompatibleClouds: registry.AllClouds,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
+		Run:              createNetworkPartialPartition,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -16,4 +16,5 @@ import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 func RegisterOperations(r registry.Registry) {
 	registerAddColumn(r)
 	registerAddIndex(r)
+	registerNetworkPartition(r)
 }

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -530,13 +530,14 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 
 	op.Status(fmt.Sprintf("operation ran successfully; waiting %s before cleanup", roachtestflags.WaitBeforeCleanup))
 	select {
+	// Don't exit if the context is done due to a Ctrl-C, instead still run the
+	// cleanup code.
 	case <-ctx.Done():
-		return ctx.Err()
 	case <-time.After(roachtestflags.WaitBeforeCleanup):
 	}
 	op.Status("running cleanup")
 	func() {
-		ctx, cancel := context.WithTimeout(ctx, opSpec.Timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), opSpec.Timeout)
 		defer cancel()
 
 		cleanup.Cleanup(ctx, op, c)


### PR DESCRIPTION
We want to be able to test network partitions, but full and partial as
part of our DRT cluster. This commit adds a failure mode for network
partitions. Half the time it does a partial partition and the other half
it does a full partition.

Fixes: https://github.com/cockroachdb/cockroach/issues/121940

Epic: none

Release note: None