### PR TITLE
roachprod: don't overwrite local cluster cache if ListCloud failed

### DIFF
--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -181,12 +181,20 @@ func LoadClusters() error {
 // This function assumes the caller took a lock on a file to ensure that
 // multiple processes don't run through this code at the same time. However, it
 // is allowed for LoadClusters to run in another process at the same time.
-func syncClustersCache(l *logger.Logger, cloud *cloud.Cloud) error {
+//
+// overwriteMissingClusters indicates if clusters should be removed from the cache
+// if not present in cloud This is used when we have a potentially incomplete list
+// of all clusters due to a transient provider error.
+func syncClustersCache(l *logger.Logger, cloud *cloud.Cloud, overwriteMissingClusters bool) error {
 	// Write all cluster files.
 	for _, c := range cloud.Clusters {
 		if err := saveCluster(l, c); err != nil {
 			return err
 		}
+	}
+
+	if !overwriteMissingClusters {
+		return nil
 	}
 
 	// Remove any other files.


### PR DESCRIPTION
In #110042 we changed ListCloud to log an warning if a provider.List failed. However, swallowing the error has the unintended side effect of Sync overwriting the local cluster cache with no clusters being found for that provider.

This can cause concurrent tests to suddenly fail as they can no longer find the cluster in the cache. This change keeps the warning in ListCloud, but now also returns the error and leaves it up to the caller to decide what to do.

Most usages retain the same behavior of swallowing the error, except for Sync. Sync now checks if ListCloud returns an error, and only adds clusters to the local cache if there was one.

Release note: none
Epic: none
Fixes: none