### PR TITLE
server: adding API side redaction support for debug zip

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -98,6 +98,7 @@ Note: this does *not* check readiness. Use the Health RPC for that purpose.
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.DetailsRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.DetailsRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 
@@ -229,6 +230,10 @@ The nodes are SQL instances in case of multi-tenant
 clusters.
 
 
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| redact | [bool](#cockroach.server.serverpb.NodesListRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
+
 
 
 
@@ -297,6 +302,10 @@ Support status: [alpha](#support-status)
 NodesRequest requests a copy of the node information as known to gossip
 and the KV layer.
 
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| redact | [bool](#cockroach.server.serverpb.NodesRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 
@@ -463,6 +472,7 @@ Support status: [alpha](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.NodeRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 
@@ -598,6 +608,10 @@ Support status: [reserved](#support-status)
 NodesRequest requests a copy of the node information as known to gossip
 and the KV layer.
 
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| redact | [bool](#cockroach.server.serverpb.NodesRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 
@@ -870,6 +884,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.NodeRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.NodeRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 
@@ -1417,6 +1432,7 @@ Support status: [reserved](#support-status)
 | range_ids | [int64](#cockroach.server.serverpb.RangesRequest-int64) | repeated |  | [reserved](#support-status) |
 | limit | [int32](#cockroach.server.serverpb.RangesRequest-int32) |  | The pagination limit to use, if set. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
 | offset | [int32](#cockroach.server.serverpb.RangesRequest-int32) |  | The pagination offset to use, if set. NB: Pagination is based on ascending RangeID. | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.RangesRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 
@@ -1907,6 +1923,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.GossipRequest-string) |  | node_id is a string so that "local" can be used to specify that no forwarding is necessary. | [reserved](#support-status) |
+| redact | [bool](#cockroach.server.serverpb.GossipRequest-bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/nodes-request.md
+++ b/docs/generated/http/nodes-request.md
@@ -9,4 +9,8 @@ and the KV layer.
 Support status: [alpha](#support-status)
 
 
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| redact | [bool](#bool) |  | redact, if true, requests redaction of sensitive data away from the API response. | [reserved](#support-status) |
+
 

--- a/pkg/cli/testdata/zip/testzip_redacted
+++ b/pkg/cli/testdata/zip/testzip_redacted
@@ -1,0 +1,137 @@
+zip
+----
+debug zip --concurrency=1 --cpu-profile-duration=1s --redact /dev/null
+[cluster] discovering virtual clusters... done
+[cluster] creating output file /dev/null... done
+[cluster] establishing RPC connection to ...
+[cluster] using SQL address: ...
+[cluster] requesting data for debug/events... received response... writing JSON output: debug/events.json... done
+[cluster] requesting data for debug/rangelog... received response... writing JSON output: debug/rangelog.json... done
+[cluster] requesting data for debug/settings... received response... writing JSON output: debug/settings.json... done
+[cluster] requesting data for debug/reports/problemranges... received response... writing JSON output: debug/reports/problemranges.json... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_node_stream_checkpoints... writing output: debug/crdb_internal.cluster_replication_node_stream_checkpoints.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_node_stream_spans... writing output: debug/crdb_internal.cluster_replication_node_stream_spans.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_node_streams... writing output: debug/crdb_internal.cluster_replication_node_streams.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_spans... writing output: debug/crdb_internal.cluster_replication_spans.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_function_statements... writing output: debug/crdb_internal.create_function_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_procedure_statements... writing output: debug/crdb_internal.create_procedure_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_schema_statements... writing output: debug/crdb_internal.create_schema_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_statements... writing output: debug/crdb_internal.create_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_type_statements... writing output: debug/crdb_internal.create_type_statements.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_contention_events... writing output: debug/crdb_internal.cluster_contention_events.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_database_privileges... writing output: debug/crdb_internal.cluster_database_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_distsql_flows... writing output: debug/crdb_internal.cluster_distsql_flows.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_execution_insights... writing output: debug/crdb_internal.cluster_execution_insights.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_locks... writing output: debug/crdb_internal.cluster_locks.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_queries... writing output: debug/crdb_internal.cluster_queries.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_sessions... writing output: debug/crdb_internal.cluster_sessions.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_settings... writing output: debug/crdb_internal.cluster_settings.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_transactions... writing output: debug/crdb_internal.cluster_transactions.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_txn_execution_insights... writing output: debug/crdb_internal.cluster_txn_execution_insights.txt... done
+[cluster] retrieving SQL data for crdb_internal.default_privileges... writing output: debug/crdb_internal.default_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.index_usage_statistics... writing output: debug/crdb_internal.index_usage_statistics.txt... done
+[cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/crdb_internal.invalid_objects.txt... done
+[cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/crdb_internal.jobs.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/crdb_internal.kv_node_liveness.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/crdb_internal.kv_node_status.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_protected_ts_records... writing output: debug/crdb_internal.kv_protected_ts_records.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/crdb_internal.kv_store_status.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/crdb_internal.kv_system_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/crdb_internal.partitions.txt... done
+[cluster] retrieving SQL data for crdb_internal.probe_ranges_1s_read_limit_100... writing output: debug/crdb_internal.probe_ranges_1s_read_limit_100.txt... done
+[cluster] retrieving SQL data for crdb_internal.regions... writing output: debug/crdb_internal.regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.schema_changes... writing output: debug/crdb_internal.schema_changes.txt... done
+[cluster] retrieving SQL data for crdb_internal.super_regions... writing output: debug/crdb_internal.super_regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.system_jobs... writing output: debug/crdb_internal.system_jobs.txt... done
+[cluster] retrieving SQL data for crdb_internal.table_indexes... writing output: debug/crdb_internal.table_indexes.txt... done
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events... writing output: debug/crdb_internal.transaction_contention_events.txt... done
+[cluster] retrieving SQL data for crdb_internal.zones... writing output: debug/crdb_internal.zones.txt... done
+[cluster] retrieving SQL data for system.database_role_settings... writing output: debug/system.database_role_settings.txt... done
+[cluster] retrieving SQL data for system.descriptor... writing output: debug/system.descriptor.txt... done
+[cluster] retrieving SQL data for system.eventlog... writing output: debug/system.eventlog.txt... done
+[cluster] retrieving SQL data for system.external_connections... writing output: debug/system.external_connections.txt... done
+[cluster] retrieving SQL data for system.job_info... writing output: debug/system.job_info.txt... done
+[cluster] retrieving SQL data for system.jobs... writing output: debug/system.jobs.txt... done
+[cluster] retrieving SQL data for system.lease... writing output: debug/system.lease.txt... done
+[cluster] retrieving SQL data for system.locations... writing output: debug/system.locations.txt... done
+[cluster] retrieving SQL data for system.migrations... writing output: debug/system.migrations.txt... done
+[cluster] retrieving SQL data for system.namespace... writing output: debug/system.namespace.txt... done
+[cluster] retrieving SQL data for system.privileges... writing output: debug/system.privileges.txt... done
+[cluster] retrieving SQL data for system.protected_ts_meta... writing output: debug/system.protected_ts_meta.txt... done
+[cluster] retrieving SQL data for system.protected_ts_records... writing output: debug/system.protected_ts_records.txt... done
+[cluster] retrieving SQL data for system.rangelog... writing output: debug/system.rangelog.txt... done
+[cluster] retrieving SQL data for system.replication_constraint_stats... writing output: debug/system.replication_constraint_stats.txt... done
+[cluster] retrieving SQL data for system.replication_critical_localities... writing output: debug/system.replication_critical_localities.txt... done
+[cluster] retrieving SQL data for system.replication_stats... writing output: debug/system.replication_stats.txt... done
+[cluster] retrieving SQL data for system.reports_meta... writing output: debug/system.reports_meta.txt... done
+[cluster] retrieving SQL data for system.role_id_seq... writing output: debug/system.role_id_seq.txt... done
+[cluster] retrieving SQL data for system.role_members... writing output: debug/system.role_members.txt... done
+[cluster] retrieving SQL data for system.role_options... writing output: debug/system.role_options.txt... done
+[cluster] retrieving SQL data for system.scheduled_jobs... writing output: debug/system.scheduled_jobs.txt... done
+[cluster] retrieving SQL data for system.settings... writing output: debug/system.settings.txt... done
+[cluster] retrieving SQL data for system.span_configurations... writing output: debug/system.span_configurations.txt... done
+[cluster] retrieving SQL data for system.sql_instances... writing output: debug/system.sql_instances.txt... done
+[cluster] retrieving SQL data for system.sql_stats_cardinality... writing output: debug/system.sql_stats_cardinality.txt... done
+[cluster] retrieving SQL data for system.sqlliveness... writing output: debug/system.sqlliveness.txt... done
+[cluster] retrieving SQL data for system.statement_diagnostics... writing output: debug/system.statement_diagnostics.txt... done
+[cluster] retrieving SQL data for system.statement_diagnostics_requests... writing output: debug/system.statement_diagnostics_requests.txt... done
+[cluster] retrieving SQL data for system.statement_statistics_limit_5000... writing output: debug/system.statement_statistics_limit_5000.txt... done
+[cluster] retrieving SQL data for system.table_statistics... writing output: debug/system.table_statistics.txt... done
+[cluster] retrieving SQL data for system.task_payloads... writing output: debug/system.task_payloads.txt... done
+[cluster] retrieving SQL data for system.tenant_settings... writing output: debug/system.tenant_settings.txt... done
+[cluster] retrieving SQL data for system.tenant_tasks... writing output: debug/system.tenant_tasks.txt... done
+[cluster] retrieving SQL data for system.tenant_usage... writing output: debug/system.tenant_usage.txt... done
+[cluster] retrieving SQL data for system.tenants... writing output: debug/system.tenants.txt... done
+[cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
+[cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
+[cluster] requesting tenant ranges... received response...
+[cluster] requesting tenant ranges: last request failed: rpc error: ...
+[cluster] requesting tenant ranges: creating error output: debug/tenant_ranges.err.txt... done
+[cluster] collecting the inflight traces for jobs... received response... done
+[cluster] requesting CPU profiles
+[cluster] profiles generated
+[cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
+[node 1] node status... writing JSON output: debug/nodes/1/status.json... done
+[node 1] using SQL connection URL: postgresql://...
+[node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/nodes/1/crdb_internal.active_range_feeds.txt... done
+[node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/nodes/1/crdb_internal.feature_usage.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/nodes/1/crdb_internal.gossip_alerts.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/nodes/1/crdb_internal.gossip_liveness.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/nodes/1/crdb_internal.gossip_nodes.txt... done
+[node 1] retrieving SQL data for crdb_internal.kv_session_based_leases... writing output: debug/nodes/1/crdb_internal.kv_session_based_leases.txt... done
+[node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/nodes/1/crdb_internal.leases.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/nodes/1/crdb_internal.node_build_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_contention_events... writing output: debug/nodes/1/crdb_internal.node_contention_events.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_distsql_flows... writing output: debug/nodes/1/crdb_internal.node_distsql_flows.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_execution_insights... writing output: debug/nodes/1/crdb_internal.node_execution_insights.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing output: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_memory_monitors... writing output: debug/nodes/1/crdb_internal.node_memory_monitors.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_metrics... writing output: debug/nodes/1/crdb_internal.node_metrics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_queries... writing output: debug/nodes/1/crdb_internal.node_queries.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_runtime_info... writing output: debug/nodes/1/crdb_internal.node_runtime_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_sessions... writing output: debug/nodes/1/crdb_internal.node_sessions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_statement_statistics... writing output: debug/nodes/1/crdb_internal.node_statement_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache... writing output: debug/nodes/1/crdb_internal.node_tenant_capabilities_cache.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transaction_statistics... writing output: debug/nodes/1/crdb_internal.node_transaction_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transactions... writing output: debug/nodes/1/crdb_internal.node_transactions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_execution_insights... writing output: debug/nodes/1/crdb_internal.node_txn_execution_insights.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_stats... writing output: debug/nodes/1/crdb_internal.node_txn_stats.txt... done
+[node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
+[node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
+[node 1] requesting data for debug/nodes/1/enginestats... received response... writing JSON output: debug/nodes/1/enginestats.json... done
+[node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done
+[node 1] requesting stacks with labels... received response... writing binary output: debug/nodes/1/stacks_with_labels.txt... done
+[node 1] requesting heap profile... received response... writing binary output: debug/nodes/1/heap.pprof... done
+[node 1] requesting heap profile list... received response... done
+[node ?] ? heap profiles found
+[node 1] requesting goroutine dump list... received response... done
+[node ?] ? goroutine dumps found
+[node 1] requesting cpu profile list... received response... done
+[node ?] ? cpu profiles found
+[node 1] requesting log files list... received response... done
+[node ?] ? log files found
+[node 1] requesting ranges... received response... done
+[node 1] writing ranges... writing JSON output: debug/nodes/1/ranges.json... done
+[cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
+[cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
+[cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -78,12 +78,17 @@ func makeClusterWideZipRequests(
 // occur once for the entire cluster.
 func (zc *debugZipContext) collectClusterData(
 	ctx context.Context,
-) (nodesList *serverpb.NodesListResponse, livenessByNodeID nodeLivenesses, err error) {
+) (
+	nodesList *serverpb.NodesListResponse,
+	nodesListRedacted *serverpb.NodesListResponse,
+	livenessByNodeID nodeLivenesses,
+	err error,
+) {
 	clusterWideZipRequests := makeClusterWideZipRequests(zc.admin, zc.status, zc.prefix)
 
 	for _, r := range clusterWideZipRequests {
 		if err := zc.runZipRequest(ctx, zc.clusterPrinter, r); err != nil {
-			return &serverpb.NodesListResponse{}, nil, err
+			return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, err
 		}
 	}
 
@@ -100,29 +105,37 @@ func (zc *debugZipContext) collectClusterData(
 		return nil
 	}
 	if err := queryAndDumpTables(zipInternalTablesPerCluster); err != nil {
-		return &serverpb.NodesListResponse{}, nil, err
+		return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, err
 	}
 	if err := queryAndDumpTables(zipSystemTables); err != nil {
-		return &serverpb.NodesListResponse{}, nil, err
+		return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, err
 	}
 
 	{
 		s := zc.clusterPrinter.start("requesting nodes")
+
 		var nodesStatus *serverpb.NodesResponse
-		err := zc.runZipFn(ctx, s, func(ctx context.Context) error {
+		err = zc.runZipFn(ctx, s, func(ctx context.Context) error {
 			nodesList, err = zc.status.NodesList(ctx, &serverpb.NodesListRequest{})
-			nodesStatus, err = zc.status.Nodes(ctx, &serverpb.NodesRequest{})
+			if err != nil {
+				return err
+			}
+			nodesStatus, err = zc.status.Nodes(ctx, &serverpb.NodesRequest{Redact: zipCtx.redact})
+			if err != nil {
+				return err
+			}
+			nodesListRedacted, err = zc.status.NodesList(ctx, &serverpb.NodesListRequest{Redact: zipCtx.redact})
 			return err
 		})
 
 		if code := status.Code(errors.Cause(err)); code == codes.Unimplemented {
-			// running on non system tenant, use data from NodesList()
-			if cErr := zc.z.createJSONOrError(s, debugBase+"/nodes.json", nodesList, err); cErr != nil {
-				return &serverpb.NodesListResponse{}, nil, cErr
+			// running on non system tenant, use data from redacted NodesList()
+			if cErr := zc.z.createJSONOrError(s, debugBase+"/nodes.json", nodesListRedacted, err); cErr != nil {
+				return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, cErr
 			}
 		} else {
 			if cErr := zc.z.createJSONOrError(s, debugBase+"/nodes.json", nodesStatus, err); cErr != nil {
-				return &serverpb.NodesListResponse{}, nil, cErr
+				return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, cErr
 			}
 		}
 
@@ -130,9 +143,9 @@ func (zc *debugZipContext) collectClusterData(
 			// In case the NodesList() RPC failed), we still want to inspect the
 			// per-node endpoints on the head node.
 			s = zc.clusterPrinter.start("retrieving the node status")
-			firstNodeDetails, err := zc.status.Details(ctx, &serverpb.DetailsRequest{NodeId: "local"})
+			firstNodeDetails, err := zc.status.Details(ctx, &serverpb.DetailsRequest{NodeId: "local", Redact: zipCtx.redact})
 			if err != nil {
-				return &serverpb.NodesListResponse{}, nil, err
+				return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, err
 			}
 			s.done()
 			nodesList = &serverpb.NodesListResponse{
@@ -152,7 +165,7 @@ func (zc *debugZipContext) collectClusterData(
 			return err
 		})
 		if cErr := zc.z.createJSONOrError(s, zc.prefix+livenessName+".json", nodes, err); cErr != nil {
-			return &serverpb.NodesListResponse{}, nil, cErr
+			return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, cErr
 		}
 		livenessByNodeID = map[roachpb.NodeID]livenesspb.NodeLivenessStatus{}
 		if lresponse != nil {
@@ -169,7 +182,7 @@ func (zc *debugZipContext) collectClusterData(
 			return err
 		}); requestErr != nil {
 			if err := zc.z.createError(s, zc.prefix+tenantRangesName, requestErr); err != nil {
-				return &serverpb.NodesListResponse{}, nil, s.fail(err)
+				return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, s.fail(err)
 			}
 		} else {
 			s.done()
@@ -183,7 +196,7 @@ func (zc *debugZipContext) collectClusterData(
 				name := fmt.Sprintf("%s/%s/%s", zc.prefix, tenantRangesName, locality)
 				s := zc.clusterPrinter.start("writing tenant ranges for locality %s", locality)
 				if err := zc.z.createJSON(s, name+".json", rangeList.Ranges); err != nil {
-					return &serverpb.NodesListResponse{}, nil, s.fail(err)
+					return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, s.fail(err)
 				}
 				sLocality.done()
 			}
@@ -197,12 +210,12 @@ func (zc *debugZipContext) collectClusterData(
 			return zc.dumpTraceableJobTraces(ctx)
 		}); requestErr != nil {
 			if err := zc.z.createError(s, zc.prefix+"/jobs", requestErr); err != nil {
-				return &serverpb.NodesListResponse{}, nil, s.fail(err)
+				return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, s.fail(err)
 			}
 		} else {
 			s.done()
 		}
 	}
 
-	return nodesList, livenessByNodeID, nil
+	return nodesList, nodesListRedacted, livenessByNodeID, nil
 }

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -176,6 +176,37 @@ func TestZip(t *testing.T) {
 	})
 }
 
+// This tests the operation of redacted zip over secure clusters.
+func TestZipRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderRace(t, "test too slow under race")
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	c := NewCLITest(TestCLIParams{
+		StoreSpecs: []base.StoreSpec{{
+			Path: dir,
+		}},
+	})
+	defer c.Cleanup()
+
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --redact " + os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Strip any non-deterministic messages.
+	out = eraseNonDeterministicZipOutput(out)
+
+	// We use datadriven simply to read the golden output file; we don't actually
+	// run any commands. Using datadriven allows TESTFLAGS=-rewrite.
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "zip", "testzip_redacted"), func(t *testing.T, td *datadriven.TestData) string {
+		return out
+	})
+}
+
 // This tests the operation of zip using --include-goroutine-stacks.
 func TestZipIncludeGoroutineStacks(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -455,6 +455,7 @@ go_test(
         "span_stats_test.go",
         "statements_test.go",
         "status_ext_test.go",
+        "status_test.go",
         "tcp_keepalive_manager_test.go",
         "tenant_delayed_id_set_test.go",
         "tenant_range_lookup_test.go",

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -92,6 +92,9 @@ message DetailsRequest {
   // forwarding is necessary.
   string node_id = 1;
   reserved 2;
+  // redact, if true, requests redaction of sensitive data away
+  // from the API response.
+  bool redact = 3;
 }
 
 // SystemInfo contains information about the host system.
@@ -118,7 +121,11 @@ message DetailsResponse {
 // NodesRequest requests a copy of the node information as known to gossip
 // and the KV layer.
 // API: PUBLIC ALPHA
-message NodesRequest {}
+message NodesRequest {
+  // redact, if true, requests redaction of sensitive data away
+  // from the API response.
+  bool redact = 1;
+}
 
 // NodesResponse describe the nodes in the cluster.
 // API: PUBLIC ALPHA
@@ -315,7 +322,11 @@ message RegionsResponse {
 // clusters.
 // The nodes are SQL instances in case of multi-tenant
 // clusters.
-message NodesListRequest {}
+message NodesListRequest {
+  // redact, if true, requests redaction of sensitive data away
+  // from the API response.
+  bool redact = 1;
+}
 
 message NodeDetails {
   // node_id is a unique identifier for the node. This corresponds
@@ -347,6 +358,9 @@ message NodeRequest {
   // node_id is a string so that "local" can be used to specify that no
   // forwarding is necessary.
   string node_id = 1;
+  // redact, if true, requests redaction of sensitive data away
+  // from the API response.
+  bool redact = 2;
 }
 
 // RaftState gives internal details about a Raft group's state.
@@ -539,6 +553,9 @@ message RangesRequest {
   // The pagination offset to use, if set.
   // NB: Pagination is based on ascending RangeID.
   int32 offset = 4;
+  // redact, if true, requests redaction of sensitive data away
+  // from the API response.
+  bool redact = 5;
 }
 
 message RangesResponse {
@@ -577,6 +594,9 @@ message GossipRequest {
   // node_id is a string so that "local" can be used to specify that no
   // forwarding is necessary.
   string node_id = 1;
+  // redact, if true, requests redaction of sensitive data away
+  // from the API response.
+  bool redact = 2;
 }
 
 message EngineStatsInfo {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1,0 +1,398 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetailsRedacted checks if the `DetailsResponse` contains redacted fields
+// when the `Redact` flag is set in the `DetailsRequest`
+func TestDetailsRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Details(ctx, &serverpb.DetailsRequest{
+		NodeId: "local",
+		Redact: true,
+	})
+	require.NoError(t, err)
+
+	jsonResponse, _ := json.Marshal(res)
+	hostname, _ := os.Hostname()
+
+	require.Equal(t, redactedMarker, res.Address.AddressField)
+	require.Equal(t, redactedMarker, res.SQLAddress.AddressField)
+	require.NotContains(t, string(jsonResponse), hostname)
+}
+
+// TestDetailsUnredacted checks if the `DetailsResponse` contains un-redacted fields
+// when the `Redact` flag is not set in the `DetailsRequest`
+func TestDetailsUnredacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Details(ctx, &serverpb.DetailsRequest{
+		NodeId: "local",
+	})
+	require.NoError(t, err)
+
+	require.NotEqual(t, redactedMarker, res.Address.AddressField)
+	require.NotEqual(t, redactedMarker, res.SQLAddress.AddressField)
+}
+
+// TestNodesListRedacted checks if the `NodesListResponse` contains redacted fields
+// when the `Redact` flag is set in the `NodesListRequest`
+func TestNodesListRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.NodesList(ctx, &serverpb.NodesListRequest{
+		Redact: true,
+	})
+	require.NoError(t, err)
+
+	jsonResponse, _ := json.Marshal(res)
+	hostname, _ := os.Hostname()
+
+	require.NotContains(t, string(jsonResponse), hostname)
+
+	for i := range res.Nodes {
+		require.Equal(t, redactedMarker, res.Nodes[i].Address.AddressField)
+		require.Equal(t, redactedMarker, res.Nodes[i].SQLAddress.AddressField)
+	}
+}
+
+// TestNodesListUnredacted checks if the `NodesListResponse` contains un-redacted fields
+// when the `Redact` flag is not set in the `NodesListRequest`
+func TestNodesListUnredacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.NodesList(ctx, &serverpb.NodesListRequest{})
+	require.NoError(t, err)
+
+	for i := range res.Nodes {
+		require.NotEqual(t, redactedMarker, res.Nodes[i].Address.AddressField)
+		require.NotEqual(t, redactedMarker, res.Nodes[i].SQLAddress.AddressField)
+	}
+}
+
+// TestNodesRedacted checks if the `NodesResponse` contains redacted fields
+// when the `Redact` flag is set in the `NodesRequest`
+func TestNodesRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Nodes(ctx, &serverpb.NodesRequest{Redact: true})
+	require.NoError(t, err)
+
+	jsonResponse, _ := json.Marshal(res)
+	hostname, _ := os.Hostname()
+
+	require.NotContains(t, string(jsonResponse), hostname)
+
+	for i := range res.Nodes {
+		require.Equal(t, redactedMarker, res.Nodes[i].Desc.Address.AddressField)
+		require.Equal(t, redactedMarker, res.Nodes[i].Desc.SQLAddress.AddressField)
+		require.Equal(t, redactedMarker, res.Nodes[i].Desc.HTTPAddress.AddressField)
+
+		for j := range res.Nodes[i].Desc.Locality.Tiers {
+			require.Equal(t, redactedMarker, res.Nodes[0].Desc.Locality.Tiers[j].Value)
+		}
+
+		for j := range res.Nodes[i].StoreStatuses {
+			require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.Address.AddressField)
+			require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.SQLAddress.AddressField)
+			require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.HTTPAddress.AddressField)
+
+			for k := range res.Nodes[i].StoreStatuses[j].Desc.Node.Locality.Tiers {
+				require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.Locality.Tiers[k].Value)
+			}
+		}
+	}
+}
+
+// TestNodesUnredacted checks if the `NodesResponse` contains un-redacted fields
+// when the `Redact` flag is not set in the `NodesRequest`
+func TestNodesUnredacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Nodes(ctx, &serverpb.NodesRequest{})
+	require.NoError(t, err)
+
+	for i := range res.Nodes {
+		require.NotEqual(t, redactedMarker, res.Nodes[i].Desc.Address.AddressField)
+		require.NotEqual(t, redactedMarker, res.Nodes[i].Desc.SQLAddress.AddressField)
+		require.NotEqual(t, redactedMarker, res.Nodes[i].Desc.HTTPAddress.AddressField)
+
+		for j := range res.Nodes[i].Desc.Locality.Tiers {
+			require.NotEqual(t, redactedMarker, res.Nodes[0].Desc.Locality.Tiers[j].Value)
+		}
+
+		for j := range res.Nodes[i].StoreStatuses {
+			require.NotEqual(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.Address.AddressField)
+			require.NotEqual(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.SQLAddress.AddressField)
+			require.NotEqual(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.HTTPAddress.AddressField)
+
+			for k := range res.Nodes[i].StoreStatuses[j].Desc.Node.Locality.Tiers {
+				require.NotEqual(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.Locality.Tiers[k].Value)
+			}
+		}
+	}
+}
+
+func TestRedactNodesResponse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	resp := serverpb.NodesResponse{
+		Nodes: []statuspb.NodeStatus{
+			{
+				Desc: roachpb.NodeDescriptor{
+					Address: util.UnresolvedAddr{
+						AddressField: "127.0.0.1:5328",
+					},
+					SQLAddress: util.UnresolvedAddr{
+						AddressField: "127.0.0.1:5328",
+					},
+					HTTPAddress: util.UnresolvedAddr{
+						AddressField: "127.0.0.1:5328",
+					},
+					Locality: roachpb.Locality{},
+				},
+				StoreStatuses: []statuspb.StoreStatus{
+					{
+						Desc: roachpb.StoreDescriptor{
+							Node: roachpb.NodeDescriptor{
+								Address: util.UnresolvedAddr{
+									AddressField: "127.0.0.1:5328",
+								},
+								SQLAddress: util.UnresolvedAddr{
+									AddressField: "127.0.0.1:5328",
+								},
+								HTTPAddress: util.UnresolvedAddr{
+									AddressField: "http://127.0.0.1/abcd",
+								},
+								Locality: roachpb.Locality{
+									Tiers: []roachpb.Tier{
+										{
+											Key:   "dns",
+											Value: "127.0.0.1:5328",
+										},
+										{
+											Key:   "abc",
+											Value: "127.0.0.1:5328",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := server.StatusServer().(*systemStatusServer)
+	res := s.redactNodesResponse(&resp)
+
+	for i := range res.Nodes {
+		require.Equal(t, redactedMarker, res.Nodes[i].Desc.Address.AddressField)
+		require.Equal(t, redactedMarker, res.Nodes[i].Desc.SQLAddress.AddressField)
+		require.Equal(t, redactedMarker, res.Nodes[i].Desc.HTTPAddress.AddressField)
+
+		for j := range res.Nodes[i].Desc.Locality.Tiers {
+			require.Equal(t, redactedMarker, res.Nodes[0].Desc.Locality.Tiers[j].Value)
+		}
+
+		for j := range res.Nodes[i].StoreStatuses {
+			require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.Address.AddressField)
+			require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.SQLAddress.AddressField)
+			require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.HTTPAddress.AddressField)
+
+			for k := range res.Nodes[i].StoreStatuses[j].Desc.Node.Locality.Tiers {
+				require.Equal(t, redactedMarker, res.Nodes[i].StoreStatuses[j].Desc.Node.Locality.Tiers[k].Value)
+			}
+		}
+	}
+}
+
+// TestNodeStatusRedacted checks if the `NodeResponse` contains redacted fields
+// when the `Redact` flag is set in the `NodeRequest`
+func TestNodeStatusRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Node(ctx, &serverpb.NodeRequest{Redact: true})
+	require.NoError(t, err)
+
+	jsonResponse, _ := json.Marshal(res)
+	hostname, _ := os.Hostname()
+
+	require.NotContains(t, string(jsonResponse), hostname)
+	require.Equal(t, redactedMarker, res.Desc.Address.AddressField)
+	require.Equal(t, redactedMarker, res.Desc.SQLAddress.AddressField)
+}
+
+// TestNodeStatusUnredacted checks if the `NodeResponse` contains un-redacted fields
+// when the `Redact` flag is not set in the `NodeRequest`
+func TestNodeStatusUnredacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Node(ctx, &serverpb.NodeRequest{})
+	require.NoError(t, err)
+
+	require.NotEqual(t, redactedMarker, res.Desc.Address.AddressField)
+	require.NotEqual(t, redactedMarker, res.Desc.SQLAddress.AddressField)
+}
+
+// TestRangesRedacted checks if the `RangesResponse` contains redacted fields
+// when the `Redact` flag is set in the `RangesRequest`
+func TestRangesRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Ranges(ctx, &serverpb.RangesRequest{Redact: true})
+	require.NoError(t, err)
+
+	jsonResponse, _ := json.Marshal(res)
+	hostname, _ := os.Hostname()
+
+	require.NotContains(t, string(jsonResponse), hostname)
+
+	for i := range res.Ranges {
+		for j := range res.Ranges[i].Locality.Tiers {
+			if res.Ranges[i].Locality.Tiers[j].Key == "dns" {
+				require.Equal(t, redactedMarker, res.Ranges[i].Locality.Tiers[j].Value)
+			}
+		}
+	}
+}
+
+// TestRangesUnredacted checks if the `RangesResponse` contains un-redacted fields
+// when the `Redact` flag is not set in the `RangesRequest`
+func TestRangesUnredacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Ranges(ctx, &serverpb.RangesRequest{})
+	require.NoError(t, err)
+
+	for i := range res.Ranges {
+		for j := range res.Ranges[i].Locality.Tiers {
+			if res.Ranges[i].Locality.Tiers[j].Key == "dns" {
+				require.NotEqual(t, redactedMarker, res.Ranges[i].Locality.Tiers[j].Value)
+			}
+		}
+	}
+}
+
+// TestGossipRedacted checks if the `GossipResponse` contains redacted fields
+// when the `Redact` flag is set in the `GossipRequest`
+func TestGossipRedacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Gossip(ctx, &serverpb.GossipRequest{
+		Redact: true,
+	})
+	require.NoError(t, err)
+
+	jsonResponse, _ := json.Marshal(res)
+	hostname, _ := os.Hostname()
+
+	require.NotContains(t, string(jsonResponse), hostname)
+
+	for i := range res.Server.ConnStatus {
+		require.Equal(t, redactedMarker, res.Server.ConnStatus[i].Address)
+	}
+}
+
+// TestGossipUnredacted checks if the `GossipResponse` contains un-redacted fields
+// when the `Redact` flag is not set in the `GossipRequest`
+func TestGossipUnredacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	server := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	s := server.StatusServer().(*systemStatusServer)
+	res, err := s.Gossip(ctx, &serverpb.GossipRequest{})
+	require.NoError(t, err)
+
+	for i := range res.Server.ConnStatus {
+		require.NotEqual(t, redactedMarker, res.Server.ConnStatus[i].Address)
+	}
+}


### PR DESCRIPTION
Debug zip has many files like nodes.json, gossip.json, status.json, details.json, ranges.json etc which contain un-redacted hostname / ip addresses. Some self hosted customers are very particular about security and they have objections sharing such critical data out of their network. This PR addresses this problem. If redaction flag is set to true in the debug zip command, these changes make sure that host name / ip addresses coming from internal APIs get redacted and show up as "<r>" in the dumped json files.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-19369
Release note: None