### PR TITLE
keys: remove DecodeTenantPrefixE

### DIFF
--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -704,7 +704,7 @@ func TestEnsureSafeSplitKey(t *testing.T) {
 	}
 }
 
-func testDecodeTenantPrefixShared(t *testing.T) {
+func TestDecodeTenantPrefix(t *testing.T) {
 	tIDs := []roachpb.TenantID{
 		roachpb.SystemTenantID,
 		roachpb.MustMakeTenantID(2),
@@ -737,16 +737,8 @@ func testDecodeTenantPrefixShared(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-}
 
-func TestDecodeTenantPrefix(t *testing.T) {
-	testDecodeTenantPrefixShared(t)
-}
-
-func TestDecodeTenantPrefixE(t *testing.T) {
-	testDecodeTenantPrefixShared(t)
-
-	_, _, err := DecodeTenantPrefixE([]byte("\xfe\x88\x28\xa0\x9b"))
+	_, _, err := DecodeTenantPrefix([]byte("\xfe\x88\x28\xa0\x9b"))
 	require.Error(t, err, roachpb.ErrInvalidTenantID)
 }
 

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -59,28 +59,6 @@ func DecodeTenantPrefix(key roachpb.Key) ([]byte, roachpb.TenantID, error) {
 	return rem, id, nil
 }
 
-// DecodeTenantPrefixE determines the tenant ID from the key prefix, returning
-// the remainder of the key (with the prefix removed) and the decoded tenant ID.
-// Unlike DecodeTenantPrefix, it returns an error rather than panicking if the
-// tenant ID is invalid.
-func DecodeTenantPrefixE(key roachpb.Key) ([]byte, roachpb.TenantID, error) {
-	if len(key) == 0 { // key.Equal(roachpb.RKeyMin)
-		return nil, roachpb.SystemTenantID, nil
-	}
-	if key[0] != tenantPrefixByte {
-		return key, roachpb.SystemTenantID, nil
-	}
-	rem, tenID, err := encoding.DecodeUvarintAscending(key[1:])
-	if err != nil {
-		return nil, roachpb.TenantID{}, err
-	}
-	id, err := roachpb.MakeTenantID(tenID)
-	if err != nil {
-		return rem, roachpb.TenantID{}, err
-	}
-	return rem, id, nil
-}
-
 // StripTenantPrefix removes the tenant prefix from the provided key. This
 // function should be used instead of sqlDecoder.StripTenantPrefix, if the user
 // cannot instantiate a codec that operates on a single tenant.

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -426,7 +426,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		if !storage.IsValidSplitKey(foundSplitKey) {
 			return reply, errors.Errorf("cannot split range at key %s", splitKey)
 		}
-		if _, _, err := keys.DecodeTenantPrefixE(splitKey.AsRawKey()); err != nil {
+		if _, _, err := keys.DecodeTenantPrefix(splitKey.AsRawKey()); err != nil {
 			return reply, errors.Wrapf(err, "checking for valid tenantID")
 		}
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5754,7 +5754,7 @@ SELECT
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				key := tree.MustBeDBytes(args[0])
-				remainder, _, err := keys.DecodeTenantPrefixE([]byte(key))
+				remainder, _, err := keys.DecodeTenantPrefix([]byte(key))
 				if errors.Is(err, roachpb.ErrInvalidTenantID) {
 					return tree.NewDBytes(key), nil
 				} else if err != nil {


### PR DESCRIPTION
This function was added to avoid changing the behaviour of DecodeTenantPrefix. Then, we subsequently changed
DecodeTenantPrefix to behave like DecodeTenantPrefixE. So now, we can remove this one.

Epic: none
Release note: None