### PR TITLE
roachpb: add experimental flag for sys tenant 2

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -335,9 +335,12 @@ var (
 	// minimum, prefix them all with "System".
 
 	// TableDataMin is the start of the range of table data keys.
-	TableDataMin = SystemSQLCodec.TablePrefix(0)
+	TableDataMin           = SystemSQLCodec.TablePrefix(0)
+	PrefixlessTableDataMin = PrefixlessCodec.TablePrefix(0).PrefixEnd()
+
 	// TableDataMax is the end of the range of table data keys.
-	TableDataMax = SystemSQLCodec.TablePrefix(math.MaxUint32).PrefixEnd()
+	TableDataMax           = SystemSQLCodec.TablePrefix(math.MaxUint32).PrefixEnd()
+	PrefixlessTableDataMax = PrefixlessCodec.TablePrefix(math.MaxUint32).PrefixEnd()
 	// ScratchRangeMin is a key used in tests to write arbitrary data without
 	// overlapping with meta, system or tenant ranges.
 	ScratchRangeMin = TableDataMax

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -856,7 +856,7 @@ func init() {
 		{Name: "/NamespaceTable", start: NamespaceTableMin, end: NamespaceTableMax, Entries: []DictEntry{
 			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: parseUnsupported},
 		}},
-		{Name: "/Table", start: TableDataMin, end: TableDataMax, Entries: []DictEntry{
+		{Name: "/Table", start: PrefixlessTableDataMin, end: PrefixlessTableDataMax, Entries: []DictEntry{
 			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: tableKeyParse, sfFunc: formatTableKey},
 		}},
 		{Name: "/Tenant", start: TenantTableDataMin, end: TenantTableDataMax, Entries: []DictEntry{

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -176,6 +176,10 @@ func MakeSQLCodec(tenID roachpb.TenantID) SQLCodec {
 // SystemSQLCodec is a SQL key codec for the system tenant.
 var SystemSQLCodec = MakeSQLCodec(roachpb.SystemTenantID)
 
+// PrefixlessCodec is a SQL key codec for the prefix-free tenant (typically the
+// system tenant).
+var PrefixlessCodec = MakeSQLCodec(roachpb.SystemTenantID)
+
 // ForSystemTenant returns whether the encoder is bound to the system tenant.
 func (e sqlEncoder) ForSystemTenant() bool {
 	return len(e.TenantPrefix()) == 0

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/interval",

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -17,19 +17,25 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base/serverident"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
-// SystemTenantID is the ID associated with the system's internal tenant in a
-// multi-tenant cluster and the only tenant in a single-tenant cluster.
-//
-// The system tenant differs from all other tenants in four important ways:
-// 1. the system tenant's keyspace is not prefixed with a tenant specifier.
-// 2. the system tenant is created by default during cluster initialization.
-// 3. the system tenant is always present and can never be destroyed.
-// 4. the system tenant has the ability to create and destroy other tenants.
-var SystemTenantID = MustMakeTenantID(1)
+// SystemTenantID is the ID of a tenant must exist and must use shared service,
+// to be available to node-internal processes. Additionally it is given special
+// treatment in any authorization decisions, bypassing typical restrictions that
+// tenants act only on their own key spans.
+var SystemTenantID = func() TenantID {
+	if envutil.EnvOrDefaultBool("COCKROACH_EXPERIMENTAL_UA", false) {
+		return MustMakeTenantID(2)
+	}
+	return TenantOne
+}()
+
+// TenantOne is a special tenant ID, associated the numeric ID 1, which for
+// legacy compatibility reasons stores its tables without a tenant prefix.
+var TenantOne = MustMakeTenantID(1)
 
 // MinTenantID is the minimum ID of a (non-system) tenant in a multi-tenant
 // cluster.


### PR DESCRIPTION
Release note: none.
Epic: none.