### PR TITLE
sidetransport: annotate incoming stream ctx with remote node id

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/receiver.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/receiver.go
@@ -165,6 +165,7 @@ func (s *Receiver) onRecvErr(ctx context.Context, nodeID roachpb.NodeID, err err
 // timestamp information. It maintains the latest closed timestamps communicated
 // by the sender node.
 type incomingStream struct {
+	log.AmbientContext
 	// The server that created this stream.
 	server       *Receiver
 	stores       Stores
@@ -324,6 +325,8 @@ func (r *incomingStream) Run(
 				if !msg.Snapshot {
 					log.Fatal(ctx, "expected the first message to be a snapshot")
 				}
+				r.AddLogTag("remote", r.nodeID)
+				ctx = r.AnnotateCtx(ctx)
 			}
 
 			r.processUpdate(ctx, msg)


### PR DESCRIPTION
It is useful to know which remote node published a closed timestamp update when looking at causal log lines, such as closed timestamp regressions.

Annotate the incoming closed timestamp stream context with the ID of the publishing node. The log context now presents as `[nX,remote=Y]`, where X is the local node ID, and Y is the remote node ID.

Informs: #121480
Informs: #122016
Release note: None