### PR TITLE
sqlliveness: extend expiration on insertion retries

### DIFF
--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -31,6 +31,8 @@ go_test(
     deps = [
         ":slinstance",
         "//pkg/clusterversion",
+        "//pkg/kv/kvpb",
+        "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/enum",
         "//pkg/sql/sqlliveness",
@@ -41,6 +43,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -27,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -50,7 +53,41 @@ func TestSQLInstance(t *testing.T) {
 
 	fakeStorage := slstorage.NewFakeStorage()
 	sqlInstance := slinstance.NewSQLInstance(ambientCtx, stopper, clock, fakeStorage, settings, nil, nil)
+	// Ensure that the first iteration always fails with an artificial error, this
+	// should lead to a retry. Which confirms that the retry logic works correctly.
+	var failureMu struct {
+		syncutil.Mutex
+		numRetries       int
+		initialTimestamp hlc.Timestamp
+		nextTimestamp    hlc.Timestamp
+	}
+	fakeStorage.SetInjectedFailure(func(sid sqlliveness.SessionID, expiration hlc.Timestamp) error {
+		failureMu.Lock()
+		defer failureMu.Unlock()
+		failureMu.numRetries++
+		if failureMu.numRetries == 1 {
+			failureMu.initialTimestamp = expiration
+			return kvpb.NewReplicaUnavailableError(errors.Newf("fake injected error"), &roachpb.RangeDescriptor{}, roachpb.ReplicaDescriptor{})
+		}
+		failureMu.nextTimestamp = expiration
+		return nil
+	})
 	sqlInstance.Start(ctx, nil)
+	// We expect two attempts to insert, since we inject a replica unavailable
+	// error on the first attempt.
+	testutils.SucceedsSoon(t, func() error {
+		failureMu.Lock()
+		defer failureMu.Unlock()
+		if failureMu.numRetries < 2 {
+			return errors.AssertionFailedf("unexpected number of retries on session insertion, "+
+				"expected at least 2, got %d", failureMu.numRetries)
+		}
+		if !failureMu.nextTimestamp.After(failureMu.initialTimestamp) {
+			return errors.AssertionFailedf("timestamp should move forward on each retry, "+
+				"got %s. Previous timestamp was: %s", failureMu.nextTimestamp, failureMu.initialTimestamp)
+		}
+		return nil
+	})
 
 	// Add one more instance to introduce concurrent access to storage.
 	dummy := slinstance.NewSQLInstance(ambientCtx, stopper, clock, fakeStorage, settings, nil, nil)


### PR DESCRIPTION
When the sqlliveness session was created we insert into the sqlliveness table, if an availability issue occurs, we will retry with the same timestamp as the first retry. For longer availability issues this was problematic, because we could end up inserting an expired session leading later initialization code during start up to fail (i.e. the session expiration can be used as a transaction deadline for certain operations). To address this, this patch allows the session creation logic to extend timestamps until a successful retry occurs when creating the session initially.

Fixes: #121891

Release note: None