### PR TITLE
workload: add --conn-vars flag to all workloads

### DIFF
--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -181,7 +181,8 @@ func TestTenantBackupNemesis(t *testing.T) {
 			return err
 		}
 		defer cleanupGoDB()
-		reg := histogram.NewRegistry(20*time.Second, "bank")
+		pgURL.Path = bankData.Meta().Name
+		reg := histogram.NewRegistry(20*time.Second, bankData.Meta().Name)
 		ops, err := bankData.(workload.Opser).Ops(ctx, []string{pgURL.String()}, reg)
 		if err != nil {
 			return err

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -100,6 +100,7 @@ func TestWorkload(t *testing.T) {
 
 	pgURL, cleanup := sqlutils.PGUrl(t, tc.Server(0).AdvSQLAddr(), t.Name(), url.User("testuser"))
 	defer cleanup()
+	pgURL.Path = wl.Meta().Name
 
 	const concurrency = 2
 	require.NoError(t, wl.Flags().Parse([]string{

--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -111,6 +111,9 @@ func (m *roachmart) Meta() workload.Meta { return roachmartMeta }
 // Flags implements the Flagser interface.
 func (m *roachmart) Flags() workload.Flags { return m.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (m *roachmart) ConnFlags() *workload.ConnFlags { return m.connFlags }
+
 // Hooks implements the Hookser interface.
 func (m *roachmart) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -206,10 +206,6 @@ func (m *roachmart) Tables() []workload.Table {
 func (m *roachmart) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -206,7 +206,7 @@ func (m *roachmart) Tables() []workload.Table {
 func (m *roachmart) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -218,7 +218,7 @@ func (m *roachmart) Ops(
 	db.SetMaxOpenConns(m.connFlags.Concurrency + 1)
 	db.SetMaxIdleConns(m.connFlags.Concurrency + 1)
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 
 	const query = `SELECT * FROM orders WHERE user_zone = $1 AND user_email = $2`
 	for i := 0; i < m.connFlags.Concurrency; i++ {

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1716,7 +1716,7 @@ func (c *transientCluster) SetupWorkload(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				sqlURLs = append(sqlURLs, sqlURL.ToPQ().String())
+				sqlURLs = append(sqlURLs, sqlURL.WithDatabase(gen.Meta().Name).ToPQ().String())
 			}
 			if err := c.runWorkload(ctx, c.demoCtx.WorkloadGenerator, sqlURLs); err != nil {
 				return errors.Wrapf(err, "starting background workload")

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -107,6 +107,9 @@ func (*bank) Meta() workload.Meta { return bankMeta }
 // Flags implements the Flagser interface.
 func (b *bank) Flags() workload.Flags { return b.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (b *bank) ConnFlags() *workload.ConnFlags { return b.connFlags }
+
 // Hooks implements the Hookser interface.
 func (b *bank) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -182,7 +182,7 @@ func (b *bank) Tables() []workload.Table {
 func (b *bank) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -205,7 +205,6 @@ func (b *bank) Ops(
 	}
 
 	ql := workload.QueryLoad{
-		SQLDatabase: sqlDatabase,
 		Close: func(_ context.Context) error {
 			return db.Close()
 		},

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -182,10 +182,6 @@ func (b *bank) Tables() []workload.Table {
 func (b *bank) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -183,10 +183,6 @@ func (w *bulkingest) Tables() []workload.Table {
 func (w *bulkingest) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -183,7 +183,7 @@ func (w *bulkingest) Tables() []workload.Table {
 func (w *bulkingest) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -204,7 +204,7 @@ func (w *bulkingest) Ops(
 		return workload.QueryLoad{}, err
 	}
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		rng := rand.New(rand.NewSource(RandomSeed.Seed()))
 		hists := reg.GetHandle()

--- a/pkg/workload/bulkingest/bulkingest.go
+++ b/pkg/workload/bulkingest/bulkingest.go
@@ -118,6 +118,9 @@ func (*bulkingest) Meta() workload.Meta { return bulkingestMeta }
 // Flags implements the Flagser interface.
 func (w *bulkingest) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *bulkingest) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *bulkingest) Hooks() workload.Hooks {
 	return workload.Hooks{}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -194,11 +194,9 @@ func CmdHelper(
 			}
 		}
 
-		// HACK: Steal the dbOverride out of flags. This should go away
-		// once more of run.go moves inside workload.
 		var dbOverride string
-		if dbFlag := cmd.Flag(`db`); dbFlag != nil {
-			dbOverride = dbFlag.Value.String()
+		if cf, ok := gen.(workload.ConnFlagser); ok {
+			dbOverride = cf.ConnFlags().DBOverride
 		}
 
 		urls := args

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -194,9 +194,9 @@ func CmdHelper(
 			}
 		}
 
-		var dbOverride string
+		var connFlags *workload.ConnFlags
 		if cf, ok := gen.(workload.ConnFlagser); ok {
-			dbOverride = cf.ConnFlags().DBOverride
+			connFlags = cf.ConnFlags()
 		}
 
 		urls := args
@@ -217,8 +217,11 @@ func CmdHelper(
 
 			urls = []string{crdbDefaultURL}
 		}
-		dbName, err := workload.SanitizeUrls(gen, dbOverride, urls)
+		dbName, err := workload.SanitizeUrls(gen, connFlags, urls)
 		if err != nil {
+			return err
+		}
+		if err := workload.SetUrlConnVars(gen, connFlags, urls); err != nil {
 			return err
 		}
 		return fn(gen, urls, dbName)

--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -14,16 +14,21 @@ import (
 	"fmt"
 	"net/url"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 )
 
 // ConnFlags is helper of common flags that are relevant to QueryLoads.
 type ConnFlags struct {
 	*pflag.FlagSet
-	DBOverride  string
+	DBOverride string
+	IsoLevel   string
+	ConnVars   []string
+
 	Concurrency int
 	Method      string // Method for issuing queries; see SQLRunner.
 
@@ -42,8 +47,11 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 	c.FlagSet = pflag.NewFlagSet(`conn`, pflag.ContinueOnError)
 	c.StringVar(&c.DBOverride, `db`, ``,
 		`Override for the SQL database to use. If empty, defaults to the generator name`)
-	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.GOMAXPROCS(0),
-		`Number of concurrent workers`)
+	c.StringVar(&c.IsoLevel, `isolation-level`, ``,
+		`Isolation level to run workload transactions under [serializable, snapshot, read_committed]. `+
+			`If unset, the workload will run with the default isolation level of the database.`)
+	c.StringSliceVar(&c.ConnVars, `conn-vars`, []string{}, `Session variables to configure on database connections`)
+	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.GOMAXPROCS(0), `Number of concurrent workers`)
 	c.StringVar(&c.Method, `method`, `cache_statement`, `SQL issue method (cache_statement, cache_describe, describe_exec, exec, simple_protocol)`)
 	c.DurationVar(&c.DNSRefreshInterval, `dns-refresh`, defaultDNSCacheRefresh, `Interval used to refresh cached DNS entries (<0 disables)`)
 	c.DurationVar(&c.ConnHealthCheckPeriod, `conn-healthcheck-period`, 30*time.Second, `Interval that health checks are run on connections`)
@@ -59,8 +67,10 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 	for _, k := range []string{
 		`concurrency`,
 		`conn-healthcheck-period`,
+		`conn-vars`,
 		`db`,
 		`dns-refresh`,
+		`isolation-level`,
 		`max-conn-idle-time`,
 		`max-conn-lifetime-jitter`,
 		`max-conn-lifetime`,
@@ -81,10 +91,10 @@ func NewConnFlags(genFlags *Flags) *ConnFlags {
 // SanitizeUrls verifies that the give SQL connection strings have the correct
 // SQL database set, rewriting them in place if necessary. This database name is
 // returned.
-func SanitizeUrls(gen Generator, dbOverride string, urls []string) (string, error) {
+func SanitizeUrls(gen Generator, connFlags *ConnFlags, urls []string) (string, error) {
 	dbName := gen.Meta().Name
-	if dbOverride != `` {
-		dbName = dbOverride
+	if connFlags != nil && connFlags.DBOverride != `` {
+		dbName = connFlags.DBOverride
 	}
 	for i := range urls {
 		parsed, err := url.Parse(urls[i])
@@ -97,10 +107,6 @@ func SanitizeUrls(gen Generator, dbOverride string, urls []string) (string, erro
 		}
 		parsed.Path = dbName
 
-		q := parsed.Query()
-		q.Set("application_name", gen.Meta().Name)
-		parsed.RawQuery = q.Encode()
-
 		switch parsed.Scheme {
 		case "postgres", "postgresql":
 			urls[i] = parsed.String()
@@ -111,30 +117,45 @@ func SanitizeUrls(gen Generator, dbOverride string, urls []string) (string, erro
 	return dbName, nil
 }
 
-// SetDefaultIsolationLevel configures the provided URLs with the specified
-// default transaction isolation level, if any.
-func SetDefaultIsolationLevel(urls []string, isoLevel string) error {
-	if isoLevel == "" {
-		return nil
+// SetUrlConnVars augments the provided URLs with additional query parameters
+// which are used by the SQL server during connection establishment to configure
+// default session variables.
+func SetUrlConnVars(gen Generator, connFlags *ConnFlags, urls []string) error {
+	vars := make(map[string]string)
+	vars["application_name"] = gen.Meta().Name
+	if connFlags != nil {
+		if connFlags.IsoLevel != "" {
+			// As a convenience, replace underscores with spaces. This allows users of
+			// the workload tool to pass --isolation-level=read_committed instead of
+			// needing to pass --isolation-level="read committed".
+			isoLevel := strings.ReplaceAll(connFlags.IsoLevel, "_", " ")
+			// NOTE: validation of the isolation level value is done by the server during
+			// connection establishment.
+			vars["default_transaction_isolation"] = isoLevel
+		}
+		for _, v := range connFlags.ConnVars {
+			parts := strings.Split(v, "=")
+			if len(parts) != 2 {
+				return errors.Errorf(`expected "key=value" format for --conn-vars, got %q`, v)
+			}
+			vars[parts[0]] = parts[1]
+		}
 	}
-	// As a convenience, replace underscores with spaces. This allows users of the
-	// workload tool to pass --isolation-level=read_committed instead of needing
-	// to pass --isolation-level="read committed".
-	isoLevel = strings.ReplaceAll(isoLevel, "_", " ")
-	// NOTE: validation of the isolation level value is done by the server during
-	// connection establishment.
-	return setUrlParam(urls, "default_transaction_isolation", isoLevel)
-}
+	varKeys := make([]string, 0, len(vars))
+	for k := range vars {
+		varKeys = append(varKeys, k)
+	}
+	sort.Strings(varKeys)
 
-// setUrlParam sets the given parameter to the given value in the provided URLs.
-func setUrlParam(urls []string, param, value string) error {
 	for i := range urls {
 		parsed, err := url.Parse(urls[i])
 		if err != nil {
 			return err
 		}
 		q := parsed.Query()
-		q.Set(param, value)
+		for _, k := range varKeys {
+			q.Set(k, vars[k])
+		}
 		parsed.RawQuery = q.Encode()
 		urls[i] = parsed.String()
 	}

--- a/pkg/workload/connectionlatency/connectionlatency.go
+++ b/pkg/workload/connectionlatency/connectionlatency.go
@@ -53,6 +53,9 @@ func (connectionLatency) Meta() workload.Meta { return connectionLatencyMeta }
 // Flags implements the Flagser interface.
 func (c *connectionLatency) Flags() workload.Flags { return c.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (c *connectionLatency) ConnFlags() *workload.ConnFlags { return c.connFlags }
+
 // Tables implements the Generator interface.
 func (connectionLatency) Tables() []workload.Table {
 	return nil

--- a/pkg/workload/connectionlatency/connectionlatency.go
+++ b/pkg/workload/connectionlatency/connectionlatency.go
@@ -66,11 +66,6 @@ func (c *connectionLatency) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
 	ql := workload.QueryLoad{}
-	_, err := workload.SanitizeUrls(c, c.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
-
 	for _, url := range urls {
 		op := &connectionOp{
 			url:   url,

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -162,7 +162,7 @@ func (w *indexes) Tables() []workload.Table {
 func (w *indexes) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -188,7 +188,7 @@ func (w *indexes) Ops(
 		return workload.QueryLoad{}, errors.Errorf("unknown workload: %q", w.workload)
 	}
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := &indexesOp{
 			config: w,

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -89,6 +89,9 @@ func (*indexes) Meta() workload.Meta { return indexesMeta }
 // Flags implements the Flagser interface.
 func (w *indexes) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *indexes) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *indexes) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/indexes/indexes.go
+++ b/pkg/workload/indexes/indexes.go
@@ -162,10 +162,6 @@ func (w *indexes) Tables() []workload.Table {
 func (w *indexes) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	cfg := workload.NewMultiConnPoolCfgFromFlags(w.connFlags)
 	cfg.MaxTotalConnections = w.connFlags.Concurrency + 1
 	mcp, err := workload.NewMultiConnPool(ctx, cfg, urls...)

--- a/pkg/workload/insights/insights.go
+++ b/pkg/workload/insights/insights.go
@@ -214,10 +214,6 @@ func (b *insights) Tables() []workload.Table {
 func (b *insights) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/insights/insights.go
+++ b/pkg/workload/insights/insights.go
@@ -126,6 +126,9 @@ func (*insights) Meta() workload.Meta { return insightsMeta }
 // Flags implements the Flagser interface.
 func (b *insights) Flags() workload.Flags { return b.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (b *insights) ConnFlags() *workload.ConnFlags { return b.connFlags }
+
 // Hooks implements the Hookser interface.
 func (b *insights) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/insights/insights.go
+++ b/pkg/workload/insights/insights.go
@@ -214,7 +214,7 @@ func (b *insights) Tables() []workload.Table {
 func (b *insights) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(b, b.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -226,7 +226,7 @@ func (b *insights) Ops(
 	db.SetMaxOpenConns(b.connFlags.Concurrency + 1)
 	db.SetMaxIdleConns(b.connFlags.Concurrency + 1)
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	rng := rand.New(rand.NewSource(RandomSeed.Seed()))
 
 	// Most of the insight queries are slow by design. This prevents them from

--- a/pkg/workload/jsonload/json.go
+++ b/pkg/workload/jsonload/json.go
@@ -137,10 +137,6 @@ func (w *jsonLoad) Tables() []workload.Table {
 func (w *jsonLoad) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/jsonload/json.go
+++ b/pkg/workload/jsonload/json.go
@@ -93,6 +93,9 @@ func (*jsonLoad) Meta() workload.Meta { return jsonLoadMeta }
 // Flags implements the Flagser interface.
 func (w *jsonLoad) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *jsonLoad) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *jsonLoad) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/jsonload/json.go
+++ b/pkg/workload/jsonload/json.go
@@ -137,7 +137,7 @@ func (w *jsonLoad) Tables() []workload.Table {
 func (w *jsonLoad) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -191,7 +191,7 @@ func (w *jsonLoad) Ops(
 		return workload.QueryLoad{}, err
 	}
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := jsonOp{
 			config:    w,

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -196,6 +196,9 @@ func (*kv) Meta() workload.Meta { return kvMeta }
 // Flags implements the Flagser interface.
 func (w *kv) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *kv) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *kv) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -449,10 +449,6 @@ func (w *kv) Tables() []workload.Table {
 func (w *kv) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	cfg := workload.NewMultiConnPoolCfgFromFlags(w.connFlags)
 	cfg.MaxTotalConnections = w.connFlags.Concurrency + 1
 	mcp, err := workload.NewMultiConnPool(ctx, cfg, urls...)

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -449,7 +449,7 @@ func (w *kv) Tables() []workload.Table {
 func (w *kv) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -537,7 +537,7 @@ func (w *kv) Ops(
 	delStmtStr := buf.String()
 
 	gen, _, kt, _ := w.createKeyGenerator()
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	var numEmptyResults atomic.Int64
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := &kvOp{

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -182,10 +182,6 @@ func (w *ledger) Tables() []workload.Table {
 func (w *ledger) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -182,7 +182,7 @@ func (w *ledger) Tables() []workload.Table {
 func (w *ledger) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -195,7 +195,7 @@ func (w *ledger) Ops(
 	db.SetMaxIdleConns(w.connFlags.Concurrency + 1)
 
 	w.reg = reg
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	now := timeutil.Now().UnixNano()
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		worker := &worker{

--- a/pkg/workload/ledger/ledger.go
+++ b/pkg/workload/ledger/ledger.go
@@ -82,6 +82,9 @@ func (*ledger) Meta() workload.Meta { return ledgerMeta }
 // Flags implements the Flagser interface.
 func (w *ledger) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *ledger) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *ledger) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/movr/movr.go
+++ b/pkg/workload/movr/movr.go
@@ -248,6 +248,9 @@ func (*movr) Meta() workload.Meta { return movrMeta }
 // Flags implements the Flagser interface.
 func (g *movr) Flags() workload.Flags { return g.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (g *movr) ConnFlags() *workload.ConnFlags { return g.connFlags }
+
 // Hooks implements the Hookser interface.
 func (g *movr) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/movr/workload.go
+++ b/pkg/workload/movr/workload.go
@@ -303,10 +303,6 @@ func (m *movr) Ops(
 	m.fakerOnce.Do(func() {
 		m.faker = faker.NewFaker()
 	})
-	_, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	ql := workload.QueryLoad{}
 	db, err := workload.NewRoundRobinDB(urls)
 	if err != nil {

--- a/pkg/workload/movr/workload.go
+++ b/pkg/workload/movr/workload.go
@@ -303,11 +303,11 @@ func (m *movr) Ops(
 	m.fakerOnce.Do(func() {
 		m.faker = faker.NewFaker()
 	})
-	sqlDatabase, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(m, m.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	db, err := workload.NewRoundRobinDB(urls)
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -119,10 +119,6 @@ func (*queryBench) Tables() []workload.Table {
 func (g *queryBench) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -119,7 +119,7 @@ func (*queryBench) Tables() []workload.Table {
 func (g *queryBench) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -143,7 +143,7 @@ func (g *queryBench) Ops(
 		maxNumStmts = g.numRunsPerQuery * len(stmts)
 	}
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < g.connFlags.Concurrency; i++ {
 		op := queryBenchWorker{
 			hists:       reg.GetHandle(),

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -83,6 +83,9 @@ func (*queryBench) Meta() workload.Meta { return queryBenchMeta }
 // Flags implements the Flagser interface.
 func (g *queryBench) Flags() workload.Flags { return g.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (g *queryBench) ConnFlags() *workload.ConnFlags { return g.connFlags }
+
 // Hooks implements the Hookser interface.
 func (g *queryBench) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/querylog/querylog.go
+++ b/pkg/workload/querylog/querylog.go
@@ -176,7 +176,7 @@ func (w *querylog) Hooks() workload.Hooks {
 func (w *querylog) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -214,7 +214,7 @@ func (w *querylog) Ops(
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	if w.querybenchPath != `` {
 		conn, err := pgx.ConnectConfig(ctx, connCfg)
 		if err != nil {

--- a/pkg/workload/querylog/querylog.go
+++ b/pkg/workload/querylog/querylog.go
@@ -176,10 +176,6 @@ func (w *querylog) Hooks() workload.Hooks {
 func (w *querylog) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/querylog/querylog.go
+++ b/pkg/workload/querylog/querylog.go
@@ -134,6 +134,9 @@ func (*querylog) Meta() workload.Meta { return querylogMeta }
 // Flags implements the Flagser interface.
 func (w *querylog) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *querylog) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Tables implements the Generator interface.
 func (*querylog) Tables() []workload.Table {
 	// Assume the necessary tables are already present.

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -75,10 +75,6 @@ func (w *queue) Tables() []workload.Table {
 func (w *queue) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -75,7 +75,7 @@ func (w *queue) Tables() []workload.Table {
 func (w *queue) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -110,7 +110,7 @@ func (w *queue) Ops(
 
 	seqFunc := makeSequenceFunc()
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := queueOp{
 			workerID:   i + 1,

--- a/pkg/workload/queue/queue.go
+++ b/pkg/workload/queue/queue.go
@@ -59,6 +59,9 @@ func (*queue) Meta() workload.Meta { return queueMeta }
 // Flags implements the Flagser interface.
 func (w *queue) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *queue) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Tables implements the Generator interface.
 func (w *queue) Tables() []workload.Table {
 	table := workload.Table{

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -87,6 +87,9 @@ func (w *random) Meta() workload.Meta {
 // Flags implements the Flagser interface.
 func (w *random) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *random) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *random) Hooks() workload.Hooks {
 	return workload.Hooks{}

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -150,10 +150,6 @@ func typeForOid(db *gosql.DB, typeOid oid.Oid, tableName, columnName string) (*t
 func (w *random) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (ql workload.QueryLoad, retErr error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -150,7 +150,7 @@ func typeForOid(db *gosql.DB, typeOid oid.Oid, tableName, columnName string) (*t
 func (w *random) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (ql workload.QueryLoad, retErr error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -289,7 +289,7 @@ AND    i.indisprimary`, relid)
 		}
 	}
 
-	fmt.Fprintf(&buf, `%s INTO %s.%s (`, dmlMethod, tree.NameString(sqlDatabase), tree.NameString(tableName))
+	fmt.Fprintf(&buf, `%s INTO %s (`, dmlMethod, tree.NameString(tableName))
 	for i, c := range nonComputedCols {
 		if i > 0 {
 			buf.WriteString(",")
@@ -320,7 +320,7 @@ AND    i.indisprimary`, relid)
 		return workload.QueryLoad{}, err
 	}
 
-	ql = workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql = workload.QueryLoad{}
 
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := randOp{

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -209,7 +209,7 @@ func (s *schemaChange) Ops(
 	ctx, span := tracer.Start(ctx, "schemaChange.Ops")
 	defer func() { EndSpan(span, err) }()
 
-	sqlDatabase, err := workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
+	_, err = workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -254,7 +254,6 @@ func (s *schemaChange) Ops(
 	}
 
 	ql := workload.QueryLoad{
-		SQLDatabase: sqlDatabase,
 		Close: func(_ context.Context) error {
 			// Create a new context for shutting down the tracer provider. The
 			// provided context may be cancelled depending on why the workload is

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -209,10 +209,6 @@ func (s *schemaChange) Ops(
 	ctx, span := tracer.Start(ctx, "schemaChange.Ops")
 	defer func() { EndSpan(span, err) }()
 
-	_, err = workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	cfg := workload.NewMultiConnPoolCfgFromFlags(s.connFlags)
 	// We will need double the concurrency, since we need watch
 	// dog connections. There is a danger of the pool emptying on

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -170,19 +170,16 @@ func setupSchemaChangePromCounter(reg prometheus.Registerer) schemaChangeCounter
 }
 
 // Meta implements the workload.Generator interface.
-func (s *schemaChange) Meta() workload.Meta {
-	return schemaChangeMeta
-}
+func (s *schemaChange) Meta() workload.Meta { return schemaChangeMeta }
 
 // Flags implements the workload.Flagser interface.
-func (s *schemaChange) Flags() workload.Flags {
-	return s.flags
-}
+func (s *schemaChange) Flags() workload.Flags { return s.flags }
+
+// ConnFlags implements the ConnFlagser interface.
+func (s *schemaChange) ConnFlags() *workload.ConnFlags { return s.connFlags }
 
 // Tables implements the workload.Generator interface.
-func (s *schemaChange) Tables() []workload.Table {
-	return nil
-}
+func (s *schemaChange) Tables() []workload.Table { return nil }
 
 // Ops implements the workload.Opser interface.
 func (s *schemaChange) Ops(

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -82,7 +82,6 @@ type schemaChangeCounter struct {
 type schemaChange struct {
 	flags                           workload.Flags
 	connFlags                       *workload.ConnFlags
-	dbOverride                      string
 	maxOpsPerWorker                 int
 	errorRate                       int
 	enumPct                         int
@@ -112,8 +111,6 @@ var schemaChangeMeta = workload.Meta{
 	New: func() workload.Generator {
 		s := &schemaChange{}
 		s.flags.FlagSet = pflag.NewFlagSet(`schemachange`, pflag.ContinueOnError)
-		s.flags.StringVar(&s.dbOverride, `db`, ``,
-			`Override for the SQL database to use. If empty, defaults to the generator name`)
 		s.flags.IntVar(&s.maxOpsPerWorker, `max-ops-per-worker`, defaultMaxOpsPerWorker,
 			`Number of operations to execute in a single transaction`)
 		s.flags.IntVar(&s.errorRate, `error-rate`, defaultErrorRate,
@@ -215,7 +212,7 @@ func (s *schemaChange) Ops(
 	ctx, span := tracer.Start(ctx, "schemaChange.Ops")
 	defer func() { EndSpan(span, err) }()
 
-	sqlDatabase, err := workload.SanitizeUrls(s, s.dbOverride, urls)
+	sqlDatabase, err := workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -71,6 +71,10 @@ func (*sqlSmith) Meta() workload.Meta { return sqlSmithMeta }
 // Flags implements the Flagser interface.
 func (g *sqlSmith) Flags() workload.Flags { return g.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (g *sqlSmith) ConnFlags() *workload.ConnFlags { return g.connFlags }
+
+// Hooks implements the Hookser interface.
 func (g *sqlSmith) Hooks() workload.Hooks {
 	return workload.Hooks{}
 }

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -134,10 +134,6 @@ func (g *sqlSmith) Ops(
 	if err := g.validateErrorSetting(); err != nil {
 		return workload.QueryLoad{}, err
 	}
-	_, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -134,7 +134,7 @@ func (g *sqlSmith) Ops(
 	if err := g.validateErrorSetting(); err != nil {
 		return workload.QueryLoad{}, err
 	}
-	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -146,7 +146,7 @@ func (g *sqlSmith) Ops(
 	db.SetMaxOpenConns(g.connFlags.Concurrency + 1)
 	db.SetMaxIdleConns(g.connFlags.Concurrency + 1)
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < g.connFlags.Concurrency; i++ {
 		rng := rand.New(rand.NewSource(RandomSeed.Seed() + int64(i)))
 		smither, err := sqlsmith.NewSmither(db, rng)

--- a/pkg/workload/sqlstats/sqlstats.go
+++ b/pkg/workload/sqlstats/sqlstats.go
@@ -135,10 +135,6 @@ func genPermutations() *gen {
 func (s *sqlStats) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/sqlstats/sqlstats.go
+++ b/pkg/workload/sqlstats/sqlstats.go
@@ -73,13 +73,14 @@ var sqlStatsMeta = workload.Meta{
 	},
 }
 
-func (s *sqlStats) Meta() workload.Meta {
-	return sqlStatsMeta
-}
+// Meta implements the Generator interface.
+func (s *sqlStats) Meta() workload.Meta { return sqlStatsMeta }
 
-func (s *sqlStats) Flags() workload.Flags {
-	return s.flags
-}
+// Flags implements the Flagser interface.
+func (s *sqlStats) Flags() workload.Flags { return s.flags }
+
+// ConnFlags implements the ConnFlagser interface.
+func (s *sqlStats) ConnFlags() *workload.ConnFlags { return s.connFlags }
 
 func (s *sqlStats) Tables() []workload.Table {
 	return []workload.Table{{

--- a/pkg/workload/sqlstats/sqlstats.go
+++ b/pkg/workload/sqlstats/sqlstats.go
@@ -135,7 +135,7 @@ func genPermutations() *gen {
 func (s *sqlStats) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(s, s.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -150,7 +150,6 @@ func (s *sqlStats) Ops(
 	gen := genPermutations()
 
 	ql := workload.QueryLoad{
-		SQLDatabase: sqlDatabase,
 		Close: func(_ context.Context) error {
 			return db.Close()
 		},

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -746,7 +746,7 @@ func (w *tpcc) Ops(
 		w.txCounters = setupTPCCMetrics(reg.Registerer())
 	}
 
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -830,7 +830,7 @@ func (w *tpcc) Ops(
 		}
 	}
 	fmt.Printf("Initializing %d workers and preparing statements...\n", w.workers)
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	ql.WorkerFns = make([]func(context.Context) error, 0, w.workers)
 	var group errgroup.Group
 

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -746,10 +746,6 @@ func (w *tpcc) Ops(
 		w.txCounters = setupTPCCMetrics(reg.Registerer())
 	}
 
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	if err := workload.SetDefaultIsolationLevel(urls, w.isoLevel); err != nil {
 		return workload.QueryLoad{}, err
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -60,7 +60,6 @@ type tpcc struct {
 	// deprecatedFKIndexes adds in foreign key indexes that are no longer needed
 	// due to origin index restrictions being lifted.
 	deprecatedFkIndexes bool
-	dbOverride          string
 
 	txInfos []txInfo
 	// deck contains indexes into the txInfos slice.
@@ -191,8 +190,6 @@ var tpccMeta = workload.Meta{
 			`Weights for the transaction mix. The default matches the TPCC spec.`)
 		g.waitFraction = 1.0
 		g.flags.Var(&waitSetter{&g.waitFraction}, `wait`, `Wait mode (include think/keying sleeps): 1/true for tpcc-standard wait, 0/false for no waits, other factors also allowed`)
-		g.flags.StringVar(&g.dbOverride, `db`, ``,
-			`Override for the SQL database to use. If empty, defaults to the generator name`)
 		g.flags.IntVar(&g.workers, `workers`, 0, fmt.Sprintf(
 			`Number of concurrent workers. Defaults to --warehouses * %d`, NumWorkersPerWarehouse,
 		))
@@ -746,7 +743,7 @@ func (w *tpcc) Ops(
 		w.txCounters = setupTPCCMetrics(reg.Registerer())
 	}
 
-	sqlDatabase, err := workload.SanitizeUrls(w, w.dbOverride, urls)
+	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -257,6 +257,9 @@ func (*tpcc) Meta() workload.Meta { return tpccMeta }
 // Flags implements the Flagser interface.
 func (w *tpcc) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *tpcc) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *tpcc) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -102,7 +102,7 @@ func (*tpccChecks) Meta() workload.Meta {
 func (w *tpccChecks) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, errors.Wrapf(err, "could not sanitize urls %v", urls)
 	}
@@ -117,7 +117,7 @@ func (w *tpccChecks) Ops(
 		dbs[i].SetMaxOpenConns(3 * w.concurrency)
 		dbs[i].SetMaxIdleConns(3 * w.concurrency)
 	}
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	ql.WorkerFns = make([]func(context.Context) error, w.concurrency)
 	checks, err := filterChecks(tpcc.AllChecks(), w.checks)
 	if err != nil {

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -102,12 +102,9 @@ func (*tpccChecks) Meta() workload.Meta {
 func (w *tpccChecks) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, errors.Wrapf(err, "could not sanitize urls %v", urls)
-	}
 	dbs := make([]*gosql.DB, len(urls))
 	for i, url := range urls {
+		var err error
 		dbs[i], err = gosql.Open(`cockroach`, url)
 		if err != nil {
 			return workload.QueryLoad{}, errors.Wrapf(err, "failed to dial %s", url)

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -35,9 +35,7 @@ foreground TPC-C workload`,
 		g := &tpccChecks{}
 		g.flags.FlagSet = pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)
 		g.flags.Meta = map[string]workload.FlagMeta{
-			`db`:          {RuntimeOnly: true},
-			`concurrency`: {RuntimeOnly: true},
-			`as-of`:       {RuntimeOnly: true},
+			`as-of`: {RuntimeOnly: true},
 		}
 		g.flags.IntVar(&g.concurrency, `concurrency`, 1,
 			`Number of concurrent workers. Defaults to 1.`,
@@ -100,7 +98,7 @@ func (*tpccChecks) Meta() workload.Meta {
 func (w *tpccChecks) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.flags.Lookup("db").Value.String(), urls)
+	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, errors.Wrapf(err, "could not sanitize urls %v", urls)
 	}

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -68,9 +68,13 @@ foreground TPC-C workload`,
 	},
 }
 
+// Flags implements the Flagser interface.
 func (w *tpccChecks) Flags() workload.Flags {
 	return w.flags
 }
+
+// ConnFlags implements the ConnFlagser interface.
+func (w *tpccChecks) ConnFlags() *workload.ConnFlags { return w.connFlags }
 
 func init() {
 	workload.Register(tpccChecksMeta)

--- a/pkg/workload/tpcds/tpcds.go
+++ b/pkg/workload/tpcds/tpcds.go
@@ -264,7 +264,7 @@ func (w *tpcds) Tables() []workload.Table {
 func (w *tpcds) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -276,7 +276,7 @@ func (w *tpcds) Ops(
 	db.SetMaxOpenConns(w.connFlags.Concurrency + 1)
 	db.SetMaxIdleConns(w.connFlags.Concurrency + 1)
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		worker := &worker{
 			config: w,

--- a/pkg/workload/tpcds/tpcds.go
+++ b/pkg/workload/tpcds/tpcds.go
@@ -79,6 +79,9 @@ func (*tpcds) Meta() workload.Meta { return tpcdsMeta }
 // Flags implements the Flagser interface.
 func (w *tpcds) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *tpcds) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *tpcds) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/tpcds/tpcds.go
+++ b/pkg/workload/tpcds/tpcds.go
@@ -264,10 +264,6 @@ func (w *tpcds) Tables() []workload.Table {
 func (w *tpcds) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -298,7 +298,7 @@ func (w *tpch) Tables() []workload.Table {
 func (w *tpch) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -310,7 +310,7 @@ func (w *tpch) Ops(
 	db.SetMaxOpenConns(w.connFlags.Concurrency + 1)
 	db.SetMaxIdleConns(w.connFlags.Concurrency + 1)
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		worker := &worker{
 			config:  w,

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -298,10 +298,6 @@ func (w *tpch) Tables() []workload.Table {
 func (w *tpch) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -124,6 +124,9 @@ func (*tpch) Meta() workload.Meta { return tpchMeta }
 // Flags implements the Flagser interface.
 func (w *tpch) Flags() workload.Flags { return w.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (w *tpch) ConnFlags() *workload.ConnFlags { return w.connFlags }
+
 // Hooks implements the Hookser interface.
 func (w *tpch) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/ttlbench/ttlbench.go
+++ b/pkg/workload/ttlbench/ttlbench.go
@@ -412,6 +412,8 @@ func (t *ttlBench) Tables() []workload.Table {
 	}
 }
 
-func (t *ttlBench) Flags() workload.Flags {
-	return t.flags
-}
+// Flags implements the Flagser interface.
+func (t *ttlBench) Flags() workload.Flags { return t.flags }
+
+// ConnFlags implements the ConnFlagser interface.
+func (t *ttlBench) ConnFlags() *workload.ConnFlags { return t.connFlags }

--- a/pkg/workload/ttllogger/ttllogger.go
+++ b/pkg/workload/ttllogger/ttllogger.go
@@ -86,7 +86,7 @@ var logChars = []rune("abdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ !.")
 func (l *ttlLogger) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(l, l.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(l, l.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -118,7 +118,7 @@ func (l *ttlLogger) Ops(
 		return workload.QueryLoad{}, errors.Newf("concurrency must be divisible by 2")
 	}
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 	for len(ql.WorkerFns) < l.connFlags.Concurrency {
 		rng := rand.New(rand.NewSource(l.seed + int64(len(ql.WorkerFns))))
 		hists := reg.GetHandle()

--- a/pkg/workload/ttllogger/ttllogger.go
+++ b/pkg/workload/ttllogger/ttllogger.go
@@ -86,10 +86,6 @@ var logChars = []rune("abdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ !.")
 func (l *ttlLogger) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(l, l.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return workload.QueryLoad{}, err

--- a/pkg/workload/ttllogger/ttllogger.go
+++ b/pkg/workload/ttllogger/ttllogger.go
@@ -182,6 +182,8 @@ func (l ttlLogger) Tables() []workload.Table {
 	}
 }
 
-func (l ttlLogger) Flags() workload.Flags {
-	return l.flags
-}
+// Flags implements the Flagser interface.
+func (l ttlLogger) Flags() workload.Flags { return l.flags }
+
+// ConnFlags implements the ConnFlagser interface.
+func (l ttlLogger) ConnFlags() *workload.ConnFlags { return l.connFlags }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -388,8 +388,6 @@ func (l requiresCCLBinaryDataLoader) InitialDataLoad(
 // QueryLoad represents some SQL query workload performable on a database
 // initialized with the requisite tables.
 type QueryLoad struct {
-	SQLDatabase string
-
 	// WorkerFns is one function per worker. It is to be called once per unit of
 	// work to be done.
 	WorkerFns []func(context.Context) error

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -83,6 +83,12 @@ type Flagser interface {
 	Flags() Flags
 }
 
+// ConnFlagser returns the connection flags this Generator is configured with.
+type ConnFlagser interface {
+	Generator
+	ConnFlags() *ConnFlags
+}
+
 // Opser returns the work functions for this generator. The tables are required
 // to have been created and initialized before running these.
 type Opser interface {

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -381,10 +381,6 @@ func (g *ycsb) Tables() []workload.Table {
 func (g *ycsb) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	_, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	if err := workload.SetDefaultIsolationLevel(urls, g.isoLevel); err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -442,6 +438,7 @@ func (g *ycsb) Ops(
 	rowCounter := NewAcknowledgedCounter((uint64)(g.recordCount))
 
 	var requestGen randGenerator
+	var err error
 	requestGenRng := rand.New(rand.NewSource(RandomSeed.Seed()))
 	switch strings.ToLower(g.requestDistribution) {
 	case "zipfian":

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -164,6 +164,9 @@ func (*ycsb) Meta() workload.Meta { return ycsbMeta }
 // Flags implements the Flagser interface.
 func (g *ycsb) Flags() workload.Flags { return g.flags }
 
+// ConnFlags implements the ConnFlagser interface.
+func (g *ycsb) ConnFlags() *workload.ConnFlags { return g.connFlags }
+
 // Hooks implements the Hookser interface.
 func (g *ycsb) Hooks() workload.Hooks {
 	return workload.Hooks{

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -381,7 +381,7 @@ func (g *ycsb) Tables() []workload.Table {
 func (g *ycsb) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	sqlDatabase, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
+	_, err := workload.SanitizeUrls(g, g.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
@@ -478,7 +478,7 @@ func (g *ycsb) Ops(
 		return workload.QueryLoad{}, err
 	}
 
-	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	ql := workload.QueryLoad{}
 
 	const (
 		readStmt                     stmtKey = "read"


### PR DESCRIPTION
Informs #119511.

This commit adds a new `--conn-vars` flag to all workloads. This flag defines the initial session variables to configure on database connections.

While here, we also lift the `--isolation-level` flag from `tpcc` and `ycsb` to all workloads.

While here, we also clean up `workload` to avoid inconsistencies and redundancy around the use of `SanitizeUrls`.

Epic: None
Release note: None