### PR TITLE
roachtest: add mixed version test for sql stats apis

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/httpclient.go
+++ b/pkg/cmd/roachtest/roachtestutil/httpclient.go
@@ -99,12 +99,12 @@ func (r *RoachtestHTTPClient) Get(ctx context.Context, url string) (*http.Respon
 }
 
 func (r *RoachtestHTTPClient) GetJSON(
-	ctx context.Context, path string, response protoutil.Message,
+	ctx context.Context, path string, response protoutil.Message, opts ...httputil.JSONOption,
 ) error {
 	if err := r.addCookie(ctx, path); err != nil {
 		return err
 	}
-	return httputil.GetJSON(*r.client.Client, path, response)
+	return httputil.GetJSONWithOptions(*r.client.Client, path, response, opts...)
 }
 
 func (r *RoachtestHTTPClient) PostProtobuf(

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -113,6 +113,7 @@ go_library(
         "mixed_version_job_compatibility_in_declarative_schema_changer.go",
         "mixed_version_multi_region.go",
         "mixed_version_schemachange.go",
+        "mixed_version_sql_stats.go",
         "multi_region_system_database.go",
         "multiregion_leasing.go",
         "multitenant.go",

--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -1,0 +1,240 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	crdbInternalStmtStatsCombined = "crdb_internal.statement_statistics"
+	crdbInternalTxnStatsCombined  = "crdb_internal.transaction_statistics"
+)
+
+func registerSqlStatsMixedVersion(r registry.Registry) {
+	// sql-tats/mixed-version tests that requesting sql stats from admin-ui works across
+	// mixed version clusters.
+	r.Add(registry.TestSpec{
+		Name:             "sql-stats/mixed-version",
+		Owner:            registry.OwnerObservability,
+		Cluster:          r.MakeClusterSpec(5),
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.Suites(registry.Nightly),
+		Run:              runSQLStatsMixedVersion,
+		Timeout:          15 * time.Minute,
+	})
+}
+
+// runSQLStatsMixedVersion tests that accessing sql stats works across mixed version clusters.
+func runSQLStatsMixedVersion(ctx context.Context, t test.Test, c cluster.Cluster) {
+	roachNodes := c.Range(1, c.Spec().NodeCount-1)
+	workloadNode := c.Node(c.Spec().NodeCount)
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, roachNodes)
+	flushInterval := 2 * time.Minute
+
+	initWorkload := roachtestutil.NewCommand("./cockroach workload init tpcc").
+		Arg("{pgurl%s}", roachNodes)
+	runWorkload := roachtestutil.NewCommand("./cockroach workload run tpcc").
+		Arg("{pgurl%s}", roachNodes).
+		Option("tolerate-errors")
+
+	setClusterSettings := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
+		// SQL Stats are flushed every 10m by default, set it to 3m to speed up the test.
+		l.Printf("setting sql.stats.flush.interval to %s", flushInterval.String())
+		return h.Exec(r, `SET CLUSTER SETTING sql.stats.flush.interval = $1`, flushInterval.String())
+	}
+
+	mvt.OnStartup("set cluster settings", setClusterSettings)
+	stopTpcc := mvt.Workload("tpcc", workloadNode, initWorkload, runWorkload)
+	defer stopTpcc()
+
+	requestTypes := map[string]serverpb.CombinedStatementsStatsRequest_StatsType{
+		"stmts stats": serverpb.CombinedStatementsStatsRequest_StmtStatsOnly,
+		"txn stats":   serverpb.CombinedStatementsStatsRequest_TxnStatsOnly,
+	}
+
+	for name, reqType := range requestTypes {
+		mvt.InMixedVersion("request "+name, func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+			return runGetRequests(ctx, c, l, roachNodes, reqType)
+		})
+	}
+	mvt.Run()
+}
+
+func runGetRequests(
+	ctx context.Context,
+	c cluster.Cluster,
+	l *logger.Logger,
+	roachNodes option.NodeListOption,
+	statsType serverpb.CombinedStatementsStatsRequest_StatsType,
+) error {
+	// We'll validate that hitting the in-memory tables and either one of the
+	// persisted (full or cached activity) does not return error on any node.
+	// Ideally we'd have prior data in the persisted tables already so that we
+	// can easily query data from the previous aggregation interval. For now
+	// we'll just have to rely on waiting for the flush to occur.
+	expectedTableCount := 2
+
+	// Track the source tables used to service each request.
+	foundTableSources := make(map[string]interface{})
+
+	addToTableSources := func(res *serverpb.StatementsResponse) {
+		if statsType == serverpb.CombinedStatementsStatsRequest_StmtStatsOnly {
+			if res.StmtsSourceTable != "" {
+				foundTableSources[res.StmtsSourceTable] = struct{}{}
+			}
+			return
+		}
+		if res.TxnsSourceTable != "" {
+			foundTableSources[res.TxnsSourceTable] = struct{}{}
+		}
+	}
+
+	s := createSQLStatsRequestHelper(c, l)
+	// First, we'll attempt to get stats from the in-memory tables.
+	// We can ensure we request from in-memory tables by requesting stats from
+	// a time range for which no data is available, as the in-memory table
+	// is only used when no data is available from system tables.
+	if err := s.requestSQLStatsFromEmptyInterval(ctx, roachNodes, statsType, addToTableSources); err != nil {
+		return errors.Wrap(err, "failed to request stats for empty interval")
+	}
+	inMemTable := crdbInternalStmtStatsCombined
+	if statsType == serverpb.CombinedStatementsStatsRequest_TxnStatsOnly {
+		inMemTable = crdbInternalTxnStatsCombined
+	}
+	if foundTableSources[inMemTable] == nil {
+		return errors.Newf("expected to find in-memory tables in response, found %v", maps.Keys(foundTableSources))
+	}
+
+	// Now we'll wait for the flush to occur and request stats from the persisted tables.
+	r := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: 10 * time.Second,
+		MaxBackoff:     30 * time.Second,
+		MaxRetries:     6, // 6 * 30s = 3m, which is well past the flush interval.
+	})
+	foundFlushedStats := false
+	for r.Next() {
+		// Requesting data from the last two hours should return data from the persisted tables eventually.
+		if err := s.requestSQLStatsFromLastTwoHours(ctx, roachNodes, statsType, addToTableSources); err != nil {
+			return errors.Wrap(err, "failed to request stats for last two hours")
+		}
+		if len(foundTableSources) >= expectedTableCount {
+			foundFlushedStats = true
+			break
+		}
+		l.Printf("waiting for flushed stats...")
+	}
+	if !foundFlushedStats {
+		return errors.Newf("failed to find flushed stats, found: %v", maps.Keys(foundTableSources))
+	}
+
+	return nil
+}
+
+func getCombinedStatementStatsURL(
+	adminUIAddr string,
+	statsType serverpb.CombinedStatementsStatsRequest_StatsType,
+	requestedRange timeRange,
+) string {
+	searchParams := fmt.Sprintf("?fetch_mode.stats_type=%d&start=%d&end=%d&limit=10",
+		statsType, requestedRange[0].Unix(), requestedRange[1].Unix())
+	return `http://` + adminUIAddr + `/_status/combinedstmts` + searchParams
+}
+
+// timeRange is a pair of time.Time values.
+type timeRange [2]time.Time
+
+type sqlStatsRequestHelper struct {
+	cluster cluster.Cluster
+	client  *roachtestutil.RoachtestHTTPClient
+	logger  *logger.Logger
+}
+
+func createSQLStatsRequestHelper(
+	cluster cluster.Cluster, logger *logger.Logger,
+) *sqlStatsRequestHelper {
+	client := roachtestutil.DefaultHTTPClient(cluster, logger)
+	return &sqlStatsRequestHelper{
+		cluster: cluster,
+		logger:  logger,
+		client:  client,
+	}
+}
+
+// Requests stmt stats data from all nodes in `gatewayNodes` from
+// the statusServer via `_status/combinedstmts`.
+func (s *sqlStatsRequestHelper) requestSQLStats(
+	ctx context.Context,
+	gatewayNodes option.NodeListOption,
+	statsType serverpb.CombinedStatementsStatsRequest_StatsType,
+	requestedRange timeRange,
+	respHandler func(*serverpb.StatementsResponse),
+) error {
+	adminUIAddrs, err := s.cluster.ExternalAdminUIAddr(ctx, s.logger, gatewayNodes)
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range adminUIAddrs {
+		url := getCombinedStatementStatsURL(addr, statsType, requestedRange)
+		statsResponse := &serverpb.StatementsResponse{}
+		if err := s.client.GetJSON(ctx, url, statsResponse, httputil.IgnoreUnknownFields()); err != nil {
+			s.logger.Printf("error requesting stats from url: %s", url)
+			return err
+		}
+		respHandler(statsResponse)
+	}
+
+	return nil
+}
+
+// Requests stmt stats data from the last two hours.
+func (s *sqlStatsRequestHelper) requestSQLStatsFromLastTwoHours(
+	ctx context.Context,
+	gatewayNodes option.NodeListOption,
+	statsType serverpb.CombinedStatementsStatsRequest_StatsType,
+	respHandler func(*serverpb.StatementsResponse),
+) error {
+	start := timeutil.Now().Add(-2 * time.Hour)
+	end := timeutil.Now()
+	return s.requestSQLStats(ctx, gatewayNodes, statsType, timeRange{start, end}, respHandler)
+}
+
+// Requests stmt stats data  by using a time range for which no data
+// is available. The source table returned in the response should be
+// the in-memory table.
+func (s *sqlStatsRequestHelper) requestSQLStatsFromEmptyInterval(
+	ctx context.Context,
+	gatewayNodes option.NodeListOption,
+	statsType serverpb.CombinedStatementsStatsRequest_StatsType,
+	respHandler func(*serverpb.StatementsResponse),
+) error {
+	end := timeutil.Unix(100, 0)
+	start := timeutil.Unix(0, 0)
+	return s.requestSQLStats(ctx, gatewayNodes, statsType, timeRange{start, end}, respHandler)
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -156,4 +156,5 @@ func RegisterTests(r registry.Registry) {
 	registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r)
 	registerMultiRegionMixedVersion(r)
 	registerMultiRegionSystemDatabase(r)
+	registerSqlStatsMixedVersion(r)
 }


### PR DESCRIPTION
The SQL activity pages on db-console fetch data from statusServer procedures that build and execute different queries. We've had issues in the past where the page broke in a mixed version state due to missing version gates. This commit adds a mixed version roachtest that makes requests to the statusServer to fetch sql stats to ensure the sql stats apis are functional in mixed versions.

Epic: CRDB-37098