### PR TITLE
roachtest: make lease benchmark test more stable

### DIFF
--- a/pkg/cmd/roachtest/tests/multiregion_leasing.go
+++ b/pkg/cmd/roachtest/tests/multiregion_leasing.go
@@ -37,7 +37,7 @@ func runSchemaChangeMultiRegionBenchmarkLeasing(
 ) {
 	var durations [2][]time.Duration
 	defaultOpts := install.MakeClusterSettings()
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), defaultOpts)
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), defaultOpts)
 	// Create 600 tables inside the database, which is above our default lease
 	// refresh limit of 500. This will only be done when session based leasing
 	// is enabled.
@@ -92,7 +92,7 @@ func runSchemaChangeMultiRegionBenchmarkLeasing(
 		}
 	}
 
-	for numTestIters := 0; numTestIters < 3; numTestIters++ {
+	for numTestIters := 0; numTestIters < 5; numTestIters++ {
 		for modeIdx, sessionBasedLeasingEnabled := range []bool{true, false} {
 			func() {
 				// When session based leasing is disabled, force expiry based leasing.
@@ -121,7 +121,7 @@ func runSchemaChangeMultiRegionBenchmarkLeasing(
 					}
 				}
 				c.Stop(ctx, t.L(), option.DefaultStopOpts())
-				c.Start(ctx, t.L(), option.DefaultStartOpts(), defaultOpts)
+				c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), defaultOpts)
 
 				// Next spawn a thread on each node to select from all the tables created
 				// above. We are going to do two passes, with multiple threads. After 30
@@ -231,8 +231,8 @@ func registerSchemaChangeMultiRegionBenchmarkLeasing(r registry.Registry) {
 		),
 		CompatibleClouds: registry.AllExceptLocal,
 		Suites:           registry.Suites(registry.Nightly),
-		Leases:           registry.MetamorphicLeases,
-		Timeout:          time.Hour,
+		Leases:           registry.DefaultLeases,
+		Timeout:          2 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSchemaChangeMultiRegionBenchmarkLeasing(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -270,20 +270,19 @@ WHERE
 		killNodes <- struct{}{}
 		<-nodesKilled
 		for {
-			t.Status("Running schema change with lease held...")
+			t.Status("running schema change with lease held...")
 			_, err = db.Exec("ALTER TABLE foo ADD COLUMN newcol int")
 			// Confirm that we hit the expected error or no error.
 			if err != nil &&
 				!strings.Contains(err.Error(), "count-lease timed out reading from a region") {
 				// Unrelated error, so lets kill off the test.
-				return errors.CombineErrors(errors.AssertionFailedf("no time out detected because of dead region."),
-					err)
+				return errors.NewAssertionErrorWithWrappedErrf(err, "no time out detected because of dead region")
 			} else if err != nil {
-				t.Status("Waiting for schema change completion, hit expected error: ", err)
+				t.Status("waiting for schema change completion, found expected error: ", err)
 				continue
 			} else {
 				// Schema change compleded successfully.
-				t.Status("Schema change was successful")
+				t.Status("schema change was successful")
 				return err
 			}
 		}
@@ -295,7 +294,7 @@ WHERE
 	c.Run(ctx, install.WithNodes(c.Range(otherRegionNode, len(c.All())).InstallNodes()), "killall -9 cockroach")
 	nodesKilled <- struct{}{}
 
-	require.NoErrorf(t, grp.Wait(), "Waited for go routines, expected no error.")
+	require.NoErrorf(t, grp.Wait(), "waited for go routines, expected no error.")
 	t.Status("stopping the server ahead of checking for the tenant server")
 
 	// Restart the KV storage servers first.


### PR DESCRIPTION
This is an attempt to deflake the benchmark by counting more samples, disabling metamorphic leases, and removing backup schedules.

It also has minor logging changes for another test.

fixes https://github.com/cockroachdb/cockroach/issues/122141
Release note: None