### PR TITLE
release-23.2: codeowners: update all obs links to use obs-prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,11 +63,11 @@
 /pkg/sql/importer/           @cockroachdb/sql-queries-prs
 /pkg/ccl/importerccl/        @cockroachdb/sql-queries-prs
 
-/pkg/sql/appstatspb          @cockroachdb/cluster-observability
-/pkg/sql/execstats/          @cockroachdb/cluster-observability
-/pkg/sql/scheduledlogging/   @cockroachdb/cluster-observability
-/pkg/sql/sqlstats/           @cockroachdb/cluster-observability
-/pkg/ccl/testccl/sqlstatsccl/ @cockroachdb/cluster-observability
+/pkg/sql/appstatspb          @cockroachdb/obs-prs
+/pkg/sql/execstats/          @cockroachdb/obs-prs
+/pkg/sql/scheduledlogging/   @cockroachdb/obs-prs
+/pkg/sql/sqlstats/           @cockroachdb/obs-prs
+/pkg/ccl/testccl/sqlstatsccl/ @cockroachdb/obs-prs
 
 /pkg/sql/sem/tree/           @cockroachdb/sql-syntax-prs
 /pkg/sql/parser/             @cockroachdb/sql-syntax-prs
@@ -127,8 +127,8 @@
 /pkg/cli/convert_url*        @cockroachdb/sql-foundations   @cockroachdb/cli-prs
 /pkg/cli/debug*.go           @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/debug_job_trace*.go @cockroachdb/jobs-prs       @cockroachdb/disaster-recovery
-/pkg/cli/debug_logconfig.go  @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
-/pkg/cli/debug_merg_logs*.go @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
+/pkg/cli/debug_logconfig.go  @cockroachdb/obs-prs    @cockroachdb/cli-prs
+/pkg/cli/debug_merg_logs*.go @cockroachdb/obs-prs    @cockroachdb/cli-prs
 /pkg/cli/declarative_*       @cockroachdb/sql-foundations
 /pkg/cli/decode*.go          @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/demo*.go            @cockroachdb/sql-foundations   @cockroachdb/server-prs @cockroachdb/cli-prs
@@ -136,9 +136,9 @@
 /pkg/cli/doctor*.go          @cockroachdb/sql-foundations     @cockroachdb/cli-prs
 /pkg/cli/flags*.go           @cockroachdb/cli-prs
 /pkg/cli/import*.go          @cockroachdb/sql-foundations   @cockroachdb/cli-prs
-/pkg/cli/inflight_trace_dump/ @cockroachdb/cluster-observability @cockroachdb/cli-prs
+/pkg/cli/inflight_trace_dump/ @cockroachdb/obs-prs @cockroachdb/cli-prs
 /pkg/cli/init.go             @cockroachdb/kv-prs         @cockroachdb/cli-prs
-/pkg/cli/log*.go             @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
+/pkg/cli/log*.go             @cockroachdb/obs-prs    @cockroachdb/cli-prs
 /pkg/cli/mt_cert*            @cockroachdb/prodsec
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
@@ -147,14 +147,14 @@
 /pkg/cli/rpc*.go             @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/sql*.go             @cockroachdb/sql-foundations   @cockroachdb/cli-prs
 /pkg/cli/start*.go           @cockroachdb/server-prs     @cockroachdb/cli-prs
-/pkg/cli/statement*.go       @cockroachdb/cluster-observability @cockroachdb/cli-prs
+/pkg/cli/statement*.go       @cockroachdb/obs-prs @cockroachdb/cli-prs
 /pkg/cli/syncbench/          @cockroachdb/storage @cockroachdb/kv-prs
 /pkg/cli/swappable_fs*       @cockroachdb/storage
 /pkg/cli/testutils.go        @cockroachdb/test-eng
-/pkg/cli/tsdump.go           @cockroachdb/obs-inf-prs
+/pkg/cli/tsdump.go           @cockroachdb/obs-prs
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
 /pkg/cli/workload*           @cockroachdb/sql-foundations
-/pkg/cli/zip*.go             @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
+/pkg/cli/zip*.go             @cockroachdb/obs-prs    @cockroachdb/cli-prs
 
 # Beware to not assign the entire server package directory to a single
 # team, at least until we heavily refactor the package to extract
@@ -163,71 +163,71 @@
 #
 #!/pkg/server/                           @cockroachdb/unowned
 /pkg/server/addjoin*.go                  @cockroachdb/prodsec @cockroachdb/server-prs
-/pkg/server/admin*.go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/api_v2*.go                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/api_v2_auth*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/server/admin*.go                    @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/api_v2*.go                   @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/api_v2_auth*.go              @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/authentication*.go           @cockroachdb/prodsec     @cockroachdb/server-prs
 /pkg/server/auto_tls_init*go             @cockroachdb/prodsec     @cockroachdb/server-prs
 /pkg/server/autoconfig/                  @cockroachdb/jobs-prs
 /pkg/server/clock_monotonicity.go        @cockroachdb/kv-prs
-/pkg/server/combined_statement_stats*.go @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/critical_nodes*.go           @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/debug/                       @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/combined_statement_stats*.go @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/critical_nodes*.go           @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/debug/                       @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/decommission*.go             @cockroachdb/kv-prs      @cockroachdb/server-prs
 /pkg/server/drain*.go                    @cockroachdb/kv-prs      @cockroachdb/server-prs
-/pkg/server/dumpstore/                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/dumpstore/                   @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/external_storage*.go         @cockroachdb/sql-queries-prs @cockroachdb/server-prs
-/pkg/server/fanout*.go                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/diagnostics/                 @cockroachdb/obs-inf-prs
-/pkg/server/dumpstore/                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/goroutinedumper/             @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/heapprofiler/                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/import_ts*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs  @cockroachdb/kv-prs
-/pkg/server/index_usage*.go              @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
+/pkg/server/fanout*.go                   @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/diagnostics/                 @cockroachdb/obs-prs
+/pkg/server/dumpstore/                   @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/goroutinedumper/             @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/heapprofiler/                @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/import_ts*.go                @cockroachdb/obs-prs @cockroachdb/server-prs  @cockroachdb/kv-prs
+/pkg/server/index_usage*.go              @cockroachdb/obs-prs @cockroachdb/obs-prs
 /pkg/server/init*.go                     @cockroachdb/kv-prs      @cockroachdb/server-prs
 /pkg/server/init_handshake*.go           @cockroachdb/prodsec     @cockroachdb/server-prs
 /pkg/server/intent_*.go                  @cockroachdb/kv-prs      @cockroachdb/server-prs
-/pkg/server/key_vis*                     @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/load_endpoint*               @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/key_vis*                     @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/load_endpoint*               @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/loss_of_quorum*.go           @cockroachdb/kv-prs
 /pkg/server/migration*                   @cockroachdb/sql-foundations
 /pkg/server/multi_store*                 @cockroachdb/kv-prs      @cockroachdb/storage
 /pkg/server/node*                        @cockroachdb/kv-prs      @cockroachdb/server-prs
-/pkg/server/node_http*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/node_http*.go                @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/node_tenant*go               @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/pgurl/                       @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/server/pagination*                  @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/problem_ranges*.go           @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/profiler/                    @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
-/pkg/server/purge_auth_*                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/pagination*                  @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/problem_ranges*.go           @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/profiler/                    @cockroachdb/obs-prs @cockroachdb/kv-prs
+/pkg/server/purge_auth_*                 @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/server_controller_*.go       @cockroachdb/server-prs
-/pkg/server/server_controller_http.go    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/server_controller_http.go    @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/server_controller_sql.go     @cockroachdb/sql-foundations @cockroachdb/server-prs
-/pkg/server/server_http*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/server_import_ts*.go         @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
-/pkg/server/server_obs*                  @cockroachdb/obs-inf-prs
-/pkg/server/server_systemlog*            @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/serverpb/                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/serverpb/authentication*     @cockroachdb/obs-inf-prs @cockroachdb/prodsec @cockroachdb/server-prs
-/pkg/server/serverpb/index_reco*         @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/serverrules/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/server_http*.go              @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/server_import_ts*.go         @cockroachdb/obs-prs @cockroachdb/kv-prs
+/pkg/server/server_obs*                  @cockroachdb/obs-prs
+/pkg/server/server_systemlog*            @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/serverpb/                    @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/serverpb/authentication*     @cockroachdb/obs-prs @cockroachdb/prodsec @cockroachdb/server-prs
+/pkg/server/serverpb/index_reco*         @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/serverrules/                 @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/settings_cache*.go           @cockroachdb/server-prs
 /pkg/server/settingswatcher/             @cockroachdb/server-prs
-/pkg/server/span_stats*.go               @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/sql_stats*.go                @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/statement*.go                @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/status*go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/status*go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/status/                      @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/span_stats*.go               @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/sql_stats*.go                @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/statement*.go                @cockroachdb/obs-prs @cockroachdb/obs-prs
+/pkg/server/status*go                    @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/status*go                    @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/status/                      @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/sticky_vfs*                  @cockroachdb/storage
-/pkg/server/structlogging/               @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
+/pkg/server/structlogging/               @cockroachdb/obs-prs @cockroachdb/obs-prs
 /pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs
-/pkg/server/telemetry/                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/tenant*.go                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/telemetry/                   @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/tenant*.go                   @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/tenantsettingswatcher/       @cockroachdb/server-prs
 /pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
-/pkg/server/tracedumper/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/user*.go                     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/server/tracedumper/                 @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/user*.go                     @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/version_cluster*.go          @cockroachdb/dev-inf
 
 /pkg/configprofiles/                     @cockroachdb/server-prs
@@ -340,13 +340,13 @@
 /pkg/ccl/storageccl/engineccl   @cockroachdb/storage
 /pkg/storage/                   @cockroachdb/storage
 
-/pkg/ui/                     @cockroachdb/admin-ui-prs
-/pkg/ui/embedded.go          @cockroachdb/admin-ui-prs
-/pkg/ui/src/js/protos.d.ts   @cockroachdb/admin-ui-prs
-/pkg/ui/src/js/protos.js     @cockroachdb/admin-ui-prs
+/pkg/ui/                     @cockroachdb/obs-prs
+/pkg/ui/embedded.go          @cockroachdb/obs-prs
+/pkg/ui/src/js/protos.d.ts   @cockroachdb/obs-prs
+/pkg/ui/src/js/protos.js     @cockroachdb/obs-prs
 
-/docs/generated/http/        @cockroachdb/http-api-prs @cockroachdb/server-prs
-/pkg/cmd/docgen/http.go      @cockroachdb/http-api-prs @cockroachdb/server-prs
+/docs/generated/http/        @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/cmd/docgen/http.go      @cockroachdb/obs-prs @cockroachdb/server-prs
 
 /pkg/ccl/sqlproxyccl/        @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
 
@@ -377,22 +377,22 @@
 /pkg/ccl/multitenantccl/     @cockroachdb/server-prs
 /pkg/ccl/multitenant/tenantcostclient/ @cockroachdb/sqlproxy-prs
 /pkg/ccl/multitenant/tenantcostserver/ @cockroachdb/sqlproxy-prs
-/pkg/ccl/oidcccl/            @cockroachdb/obs-inf-prs
+/pkg/ccl/oidcccl/            @cockroachdb/obs-prs
 /pkg/ccl/partitionccl/       @cockroachdb/sql-foundations
 /pkg/ccl/pgcryptoccl/        @cockroachdb/sql-foundations
 /pkg/ccl/plpgsqlccl/         @cockroachdb/sql-queries-prs
 
 #!/pkg/ccl/serverccl/        @cockroachdb/unowned
-/pkg/ccl/serverccl/diagnosticsccl/ @cockroachdb/obs-inf-prs
+/pkg/ccl/serverccl/diagnosticsccl/ @cockroachdb/obs-prs
 /pkg/ccl/serverccl/server_sql* @cockroachdb/server-prs
 /pkg/ccl/serverccl/server_controller* @cockroachdb/server-prs
 /pkg/ccl/serverccl/tenant_*  @cockroachdb/server-prs
-/pkg/ccl/serverccl/statusccl/ @cockroachdb/cluster-observability
-/pkg/ccl/serverccl/admin_*   @cockroachdb/cluster-observability
-/pkg/ccl/serverccl/api_*     @cockroachdb/cluster-observability
-/pkg/ccl/serverccl/chart_*   @cockroachdb/obs-inf-prs
+/pkg/ccl/serverccl/statusccl/ @cockroachdb/obs-prs
+/pkg/ccl/serverccl/admin_*   @cockroachdb/obs-prs
+/pkg/ccl/serverccl/api_*     @cockroachdb/obs-prs
+/pkg/ccl/serverccl/chart_*   @cockroachdb/obs-prs
 
-/pkg/ccl/telemetryccl/       @cockroachdb/obs-inf-prs
+/pkg/ccl/telemetryccl/       @cockroachdb/obs-prs
 
 /pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity @cockroachdb/prodsec
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries-prs
@@ -468,7 +468,7 @@
 #!/pkg/cmd/urlcheck/           @cockroachdb/docs-infra-prs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
 /pkg/cmd/workload/           @cockroachdb/test-eng #! @cockroachdb/sql-foundations-noreview
-#!/pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
+#!/pkg/cmd/wraprules/          @cockroachdb/obs-prs-noreview
 #!/pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries-prs
 /pkg/compose/                @cockroachdb/sql-foundations
@@ -492,14 +492,14 @@
 # Don't ping KV on updates to reserved descriptor IDs and such.
 #!/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
 /pkg/upgrade/                @cockroachdb/release-eng
-/pkg/keyvisualizer/          @cockroachdb/cluster-observability
+/pkg/keyvisualizer/          @cockroachdb/obs-prs
 /pkg/multitenant/            @cockroachdb/server-prs
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/.gitattributes  @cockroachdb/dev-inf
 #!/pkg/roachpb/BUILD.bazel     @cockroachdb/kv-prs-noreview
 /pkg/roachpb/data*           @cockroachdb/kv-prs
 /pkg/roachpb/leaseinfo*      @cockroachdb/kv-prs
-/pkg/roachpb/index*          @cockroachdb/cluster-observability
+/pkg/roachpb/index*          @cockroachdb/obs-prs
 /pkg/roachpb/internal*       @cockroachdb/kv-prs
 /pkg/roachpb/io-formats*     @cockroachdb/disaster-recovery
 #!/pkg/roachpb/main_test.go    @cockroachdb/kv-prs-noreview
@@ -539,20 +539,20 @@
 /pkg/testutils/sqlutils/     @cockroachdb/sql-queries-prs
 /pkg/testutils/jobutils/     @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/ts/                     @cockroachdb/kv-prs
-/pkg/ts/catalog/             @cockroachdb/obs-inf-prs
+/pkg/ts/catalog/             @cockroachdb/obs-prs
 #!/pkg/util/                 @cockroachdb/unowned
-/pkg/util/log/               @cockroachdb/obs-inf-prs
-/pkg/util/addr/              @cockroachdb/obs-inf-prs
-/pkg/util/metric/            @cockroachdb/obs-inf-prs
+/pkg/util/log/               @cockroachdb/obs-prs
+/pkg/util/addr/              @cockroachdb/obs-prs
+/pkg/util/metric/            @cockroachdb/obs-prs
 /pkg/util/stop/              @cockroachdb/kv-prs
 /pkg/util/grunning/          @cockroachdb/admission-control
 /pkg/util/admission/         @cockroachdb/admission-control
 /pkg/util/schedulerlatency/  @cockroachdb/admission-control
-/pkg/util/tracing            @cockroachdb/obs-inf-prs
+/pkg/util/tracing            @cockroachdb/obs-prs
 /pkg/workload/               @cockroachdb/test-eng #! @cockroachdb/sql-foundations-noreview
-/pkg/obs/                    @cockroachdb/obs-inf-prs
-/pkg/obsservice/             @cockroachdb/obs-inf-prs
-/pkg/ccl/auditloggingccl     @cockroachdb/cluster-observability
+/pkg/obs/                    @cockroachdb/obs-prs
+/pkg/obsservice/             @cockroachdb/obs-prs
+/pkg/ccl/auditloggingccl     @cockroachdb/obs-prs
 
 # Own all bazel files to dev-inf, but don't request reviews for them
 # as they are mostly - but not only - generated code that changes with

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -38,9 +38,6 @@ cockroachdb/sql-queries:
   # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
   silence_mentions: true
-cockroachdb/cluster-observability:
-  triage_column_id: 12618343
-  label: T-cluster-observability
 cockroachdb/kv:
   aliases:
     cockroachdb/kv-triage: roachtest
@@ -89,16 +86,6 @@ cockroachdb/server:
     cockroachdb/cli-prs: other
     cockroachdb/server-prs: other
   triage_column_id: 2521812
-cockroachdb/admin-ui:
-  aliases:
-    cockroachdb/admin-ui-prs: other
-  triage_column_id: 6598672
-  label: T-observability-inf
-cockroachdb/obs-inf-prs:
-  aliases:
-    cockroachdb/http-api-prs: other
-  triage_column_id: 14196277
-  label: T-observability-inf
 cockroachdb/jobs:
   aliases:
     cockroachdb/jobs-prs: other
@@ -117,3 +104,6 @@ cockroachdb/migrations:
 cockroachdb/release-eng:
   label: T-release
   triage_column_id: 9149730
+cockroachdb/obs-prs:
+  # The observability team uses Jira for managing issues. So there is no triage column ID.
+  label: T-observability

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -29,7 +29,7 @@ const (
 	OwnerKV               Owner = `kv`
 	OwnerReplication      Owner = `replication`
 	OwnerAdmissionControl Owner = `admission-control`
-	OwnerObsInf           Owner = `obs-inf-prs`
+	OwnerObservability    Owner = `obs-prs`
 	OwnerServer           Owner = `server` // not currently staffed
 	OwnerSQLFoundations   Owner = `sql-foundations`
 	OwnerMigrations       Owner = `migrations`
@@ -37,7 +37,6 @@ const (
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`
 	OwnerDevInf           Owner = `dev-inf`
-	OwnerClusterObs       Owner = `cluster-observability`
 )
 
 // IsValid returns true if the owner is valid, i.e. it has a corresponding team

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -48,7 +48,7 @@ func registerAcceptance(r registry.Registry) {
 			{name: "cluster-init", fn: runClusterInit},
 			{name: "rapid-restart", fn: runRapidRestart},
 		},
-		registry.OwnerObsInf: {
+		registry.OwnerObservability: {
 			{name: "status-server", fn: runStatusServer},
 		},
 		registry.OwnerDevInf: {

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -213,7 +213,7 @@ func registerKV(r registry.Registry) {
 		{nodes: 3, cpus: 8, readPercent: 0, sharedProcessMT: true},
 		{nodes: 3, cpus: 8, readPercent: 95},
 		{nodes: 3, cpus: 8, readPercent: 95, sharedProcessMT: true},
-		{nodes: 3, cpus: 8, readPercent: 95, tracing: true, owner: registry.OwnerObsInf},
+		{nodes: 3, cpus: 8, readPercent: 95, tracing: true, owner: registry.OwnerObservability},
 		{nodes: 3, cpus: 8, readPercent: 0, splits: -1 /* no splits */},
 		{nodes: 3, cpus: 8, readPercent: 95, splits: -1 /* no splits */},
 		{nodes: 3, cpus: 32, readPercent: 0},

--- a/pkg/cmd/roachtest/tests/network_logging.go
+++ b/pkg/cmd/roachtest/tests/network_logging.go
@@ -111,7 +111,7 @@ func registerNetworkLogging(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "network_logging",
-		Owner:            registry.OwnerObsInf,
+		Owner:            registry.OwnerObservability,
 		Cluster:          r.MakeClusterSpec(numNodesNetworkLogging),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
Release note: None

Epic: None

----
Release justification: test-only change

Same changes as https://github.com/cockroachdb/cockroach/pull/121693