### PR TITLE
workflows: don't re-run GitHub Actions CI on `edited` event

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -1,7 +1,7 @@
 name: GitHub Actions Essential CI
 on:
   pull_request:
-    types: [ opened, reopened, synchronize, edited ]
+    types: [ opened, reopened, synchronize ]
     branches:
       - 'master'
       - 'release-*'


### PR DESCRIPTION
This event is only triggered if the PR body or title is updated or if the base branch is updated. A base branch is typically not updated and we don't rebase anyway, so that would not affect the result of the CI job anyway. So it seems this event can be skipped and we can save on CI re-runs.

Epic: CRDB-8308
Release note: None