### PR TITLE
release-23.2: roachprod: better identification of transient failures

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -103,7 +103,6 @@ go_test(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/azure",
-        "//pkg/roachprod/vm/gce",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -487,17 +487,19 @@ func (t *testImpl) failureMsg() string {
 	return b.String()
 }
 
-// failuresContainError returns true if any of the errors in any of
-// the given failures matches the reference error.
-func failuresContainsError(failures []failure, refError error) bool {
+// failuresMatchingError checks whether the first error in trees of
+// any of the errors in the failures passed match the `refError`
+// target. If it does, `refError` is set to that target error value
+// and returns true. Otherwise, it returns false.
+func failuresMatchingError(failures []failure, refError any) bool {
 	for _, f := range failures {
 		for _, err := range f.errors {
-			if errors.Is(err, refError) {
+			if errors.As(err, refError) {
 				return true
 			}
 		}
 
-		if errors.Is(f.squashedErr, refError) {
+		if errors.As(f.squashedErr, refError) {
 			return true
 		}
 	}

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,6 +42,129 @@ func TestTeamCityEscape(t *testing.T) {
 	require.Equal(t, "|0x00bf", TeamCityEscape("\u00bf"))
 	require.Equal(t, "|0x00bfaaa", TeamCityEscape("\u00bfaaa"))
 	require.Equal(t, "bb|0x00bfaaa", TeamCityEscape("bb\u00bfaaa"))
+}
+
+type targetError struct {
+	err error
+}
+
+func (te targetError) Error() string {
+	return "TARGET_ERROR"
+}
+
+func Test_failuresMatchingError(t *testing.T) {
+	createFailure := func(ref error, squashedErr error) failure {
+		return failure{errors: []error{ref}, squashedErr: squashedErr}
+	}
+	type args struct {
+		failures []failure
+		refError targetError
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "empty failures",
+			args: args{
+				failures: []failure{},
+				refError: targetError{errors.New("testerror")},
+			},
+			want: false,
+		},
+		{
+			name: "failures contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(targetError{errors.New("testerror")}, nil),
+				},
+				refError: targetError{errors.New("testerror")},
+			},
+			want: true,
+		},
+		{
+			name: "non first failure contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), nil),
+					createFailure(targetError{errors.New("expected-error")}, nil),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: true,
+		},
+		{
+			name: "first failure contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(targetError{errors.New("expected-error")}, nil),
+					createFailure(errors.New("unexpected-error"), nil),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: true,
+		},
+		{
+			name: "first failure's squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(nil, targetError{errors.New("expected-error")}),
+					createFailure(errors.New("unexpected-error"), nil),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: true,
+		},
+		{
+			name: "non first failure's squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), errors.New("unexpected-squashed-error")),
+					createFailure(nil, targetError{errors.New("expected-error")}),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: true,
+		},
+		{
+			name: "both errors and squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(targetError{errors.New("expected-error")}, targetError{errors.New("expected-error")}),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: true,
+		},
+		{
+			name: "single failure - none of errors or squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), errors.New("unexpected-error1")),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: false,
+		},
+		{
+			name: "multiple failures - none of errors or squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), errors.New("unexpected-error1")),
+					createFailure(errors.New("unexpected-error2"), errors.New("unexpected-error3")),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, failuresMatchingError(tt.args.failures, &tt.args.refError), "failureMatchingError(%v, %v)", tt.args.failures, tt.args.refError)
+		})
+	}
 }
 
 func Test_failureSpecifyOwnerAndAddFailureCombination(t *testing.T) {

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_10.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_10.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 )
 
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
@@ -181,9 +180,9 @@ func registerActiveRecord(r registry.Registry) {
 					`sudo RAILS_VERSION=%s RUBYOPT="-W0" TESTOPTS="-v" bundle exec rake test`, supportedRailsVersion),
 		)
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 )
 
 var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<point>\d+))?$`)
@@ -186,9 +185,9 @@ func registerDjango(r registry.Registry) {
 			t.Status("Running django test app ", testName)
 			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node, fmt.Sprintf(djangoRunTestCmd, testName))
 
-			// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+			// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 			// Proceed for any other (command) errors
-			if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+			if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 				t.Fatal(err)
 			}
 

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -115,9 +115,9 @@ func registerGopg(r registry.Registry) {
 				destPath, removeColorCodes, resultsFilePath),
 		)
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 
@@ -151,9 +151,9 @@ func registerGopg(r registry.Registry) {
 			c.Run(ctx, c.All(), "go clean -modcache")
 		}()
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,9 +146,9 @@ PGSSLCERT=$HOME/certs/client.%[1]s.crt PGSSLKEY=$HOME/certs/client.%[1]s.key PGS
 			),
 		)
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -23,7 +23,6 @@ import (
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/errors"
 )
 
 var npgsqlReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -140,9 +139,9 @@ echo '%s' | git apply --ignore-whitespace -`, fmt.Sprintf(npgsqlPatch, result.St
 		rawResults := "stdout:\n" + result.Stdout + "\n\nstderr:\n" + result.Stderr
 		t.L().Printf("Test results for npgsql: %s", rawResults)
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 
@@ -198,11 +197,11 @@ index ecfdd85f..17527129 100644
      public const string DefaultConnectionString =
 -        "Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0;SSL Mode=Disable";
 +        "Server=127.0.0.1;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Port=%s;Timeout=0;Command Timeout=0;SSL Mode=Prefer;Include Error Detail=true";
- 
+
      /// <summary>
      /// The connection string that will be used when opening the connection to the tests database.
 @@ -186,7 +186,6 @@ internal static async Task<string> CreateTempTable(NpgsqlConnection conn, string
- 
+
          await conn.ExecuteNonQueryAsync(@$"
  START TRANSACTION;
 -SELECT pg_advisory_xact_lock(0);

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 )
 
 var pgxReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
@@ -118,9 +117,9 @@ func registerPgx(r registry.Registry) {
 				"`go env GOPATH`/bin/go-junit-report", install.DefaultUser, install.DefaultPassword),
 		)
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 )
 
 var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:_(?P<minor>\d+)(?:_(?P<point>\d+)(?:_(?P<subpoint>\d+))?)?)?$`)
@@ -118,9 +117,9 @@ func registerPsycopg(r registry.Registry) {
 			make check PYTHON_VERSION=3`,
 			install.DefaultUser, install.DefaultPassword))
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -28,7 +28,6 @@ import (
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -161,9 +160,9 @@ func registerRubyPG(r registry.Registry) {
 			`cd /mnt/data1/ruby-pg/ && bundle exec rake compile test`,
 		)
 
-		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors
-		if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+		if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 )
 
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
@@ -150,9 +149,9 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 		test/test_suite_sqlalchemy.py
 	`, install.DefaultUser, install.DefaultPassword))
 
-	// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
+	// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.
 	// Proceed for any other (command) errors
-	if err != nil && (result.Err == nil || errors.Is(err, rperrors.ErrSSH255)) {
+	if err != nil && (result.Err == nil || rperrors.IsTransient(err)) {
 		t.Fatal(err)
 	}
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -112,7 +112,7 @@ var DefaultRetryOpt = &retry.Options{
 	MaxRetries: 2,
 }
 
-var DefaultShouldRetryFn = func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) }
+var DefaultShouldRetryFn = func(res *RunResultDetails) bool { return rperrors.IsTransient(res.Err) }
 
 // defaultSCPRetry won't retry if the error output contains any of the following
 // substrings, in which cases retries are unlikely to help.

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -128,7 +128,7 @@ var defaultSCPShouldRetryFn = func(res *RunResultDetails) bool {
 }
 
 // runWithMaybeRetry will run the specified function `f` at least once, or only
-// once if `runRetryOpts` is nil
+// once if `retryOpts` is nil
 //
 // Any RunResultDetails containing a non nil err from `f` is passed to `shouldRetryFn` which,
 // if it returns true, will result in `f` being retried using the `RetryOpts`
@@ -2741,7 +2741,7 @@ func scp(l *logger.Logger, src, dest string) (*RunResultDetails, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		err = errors.Wrapf(err, "~ %s\n%s", strings.Join(args, " "), out)
+		err = rperrors.NewSSHError(errors.Wrapf(err, "~ %s\n%s", strings.Join(args, " "), out))
 	}
 
 	res := newRunResultDetails(-1, err)

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -22,67 +22,6 @@ import (
 )
 
 var installCmds = map[string]string{
-	"cassandra": `
-echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | \
-	sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list;
-curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -;
-sudo apt-get update;
-sudo apt-get install -y cassandra;
-sudo service cassandra stop;
-`,
-
-	"charybdefs": `
-  thrift_dir="/opt/thrift"
-
-  if [ ! -f "/usr/bin/thrift" ]; then
-	sudo apt-get update;
-	sudo apt-get install -qy automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config python-setuptools libglib2.0-dev python2 python-six
-
-    sudo mkdir -p "${thrift_dir}"
-    sudo chmod 777 "${thrift_dir}"
-    cd "${thrift_dir}"
-    curl "https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz" | sudo tar xvz --strip-components 1
-    sudo ./configure --prefix=/usr
-    sudo make -j$(nproc)
-    sudo make install
-    (cd "${thrift_dir}/lib/py" && sudo python2 setup.py install)
-  fi
-
-  charybde_dir="/opt/charybdefs"
-  nemesis_path="${charybde_dir}/charybdefs-nemesis"
-
-  if [ ! -f "${nemesis_path}" ]; then
-    sudo apt-get install -qy build-essential cmake libfuse-dev fuse
-    sudo rm -rf "${charybde_dir}" "${nemesis_path}" /usr/local/bin/charybdefs{,-nemesis}
-    sudo mkdir -p "${charybde_dir}"
-    sudo chmod 777 "${charybde_dir}"
-    git clone --depth 1 --branch crl "https://github.com/cockroachdb/charybdefs.git" "${charybde_dir}"
-
-    cd "${charybde_dir}"
-    thrift -r --gen cpp server.thrift
-    cmake CMakeLists.txt
-    make -j$(nproc)
-
-    sudo modprobe fuse
-    sudo ln -s "${charybde_dir}/charybdefs" /usr/local/bin/charybdefs
-    cat > "${nemesis_path}" <<EOF
-#!/bin/bash
-cd /opt/charybdefs/cookbook
-./recipes "\$@"
-EOF
-    chmod +x "${nemesis_path}"
-	sudo ln -s "${nemesis_path}" /usr/local/bin/charybdefs-nemesis
-fi
-`,
-
-	"confluent": `
-sudo apt-get update;
-sudo apt-get install -y default-jdk-headless;
-curl https://packages.confluent.io/archive/5.0/confluent-oss-5.0.0-2.11.tar.gz | sudo tar -C /usr/local -xz;
-sudo ln -s /usr/local/confluent-5.0.0 /usr/local/confluent;
-`,
-
-	// Docker installation steps are lifted from https://docs.docker.com/engine/install/ubuntu/
 	"docker": `
 # Add Docker's official GPG key:
 sudo apt-get update;
@@ -133,18 +72,6 @@ sudo apt-get install -y \
 	"sysbench": `
 sudo apt-get update;
 sudo apt-get install -y sysbench;
-`,
-
-	"tools": `
-sudo apt-get update;
-sudo apt-get install -y \
-  fio \
-  iftop \
-  iotop \
-  sysstat \
-  linux-tools-common \
-  linux-tools-4.10.0-35-generic \
-  linux-cloud-tools-4.10.0-35-generic;
 `,
 
 	"zfs": `

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"sort"
 
+	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 )
 
@@ -194,5 +195,9 @@ func InstallTool(
 	}
 	// Ensure that we early exit if any of the shell statements fail.
 	cmd = "set -exuo pipefail;" + cmd
-	return c.Run(ctx, l, stdout, stderr, OnNodes(nodes), "installing "+softwareName, cmd)
+	if err := c.Run(ctx, l, stdout, stderr, OnNodes(nodes), "installing "+softwareName, cmd); err != nil {
+		return rperrors.TransientFailure(err, "install_flake")
+	}
+
+	return nil
 }

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -139,8 +139,8 @@ func (s *remoteSession) errWithDebug(err error) error {
 	err = rperrors.ClassifyCmdError(err)
 	// The verbose logs are noisy and not useful for most errors, so only
 	// retain them for potential flakes.
-	if errors.Is(err, rperrors.ErrSSH255) && s.logfile != "" {
-		err = errors.Wrap(err, "_potential_ SSH flake (`ssh -vvv` log retained under ssh/)")
+	if rperrors.IsSSHError(err) && s.logfile != "" {
+		err = errors.Wrapf(err, "_potential_ SSH flake (`ssh -vvv` log retained in %s)", s.logfile)
 		s.logfile = "" // prevent removal on close
 	}
 	return err

--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -11,11 +11,15 @@
 package install
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"regexp"
+	"strings"
 
+	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
@@ -302,9 +306,18 @@ func stageRemoteBinary(
 	cmdStr := fmt.Sprintf(
 		`curl -sfSL -o "%s" "%s" && chmod 755 %s`, target, binURL, target,
 	)
-	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err = c.Run(
+		ctx, l, &stdout, &stderr, OnNodes(c.Nodes), fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
 	)
+
+	combinedOut := strings.Join([]string{stdout.String(), stderr.String()}, "\n")
+	l.Printf("%s", combinedOut)
+
+	return processStageError(err, combinedOut)
 }
 
 // StageOptionalRemoteLibrary downloads a library from the cockroach edge with
@@ -357,6 +370,9 @@ func StageCockroachRelease(
 	}
 	l.Printf("Resolved release url for cockroach version %s: %s", version, binURL)
 
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
 	// This command incantation:
 	// - Creates a temporary directory on the remote machine
 	// - Downloads and unpacks the cockroach release into the temp directory
@@ -371,7 +387,35 @@ mkdir -p ${dir}/lib && \
 if [ -d ${tmpdir}/lib ]; then mv ${tmpdir}/lib/* ${dir}/lib; fi && \
 chmod 755 ${dir}/cockroach
 `, dir, binURL)
-	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), "staging cockroach release binary", cmdStr,
+
+	err = c.Run(
+		ctx, l, &stdout, &stderr, OnNodes(c.Nodes), "staging cockroach release binary", cmdStr,
+	)
+
+	combinedOut := strings.Join([]string{stdout.String(), stderr.String()}, "\n")
+	l.Printf("%s", combinedOut)
+
+	return processStageError(err, combinedOut)
+}
+
+func processStageError(err error, output string) error {
+	if err == nil {
+		return nil
+	}
+
+	// If we get a 404 (Not Found) error when trying to download a
+	// released binary, that indicates a programming error that should
+	// be corrected by the original caller. All other errors are deemed
+	// transient (blips in the blob storage provider).
+	notFoundRegexp := regexp.MustCompile(`\b404\b`)
+	if notFoundRegexp.MatchString(output) {
+		return err
+	}
+
+	// Mark other errors as transient, which will cause the staging
+	// command to be retried.
+	return errors.Wrapf(
+		rperrors.TransientFailure(err, "stage_failure"),
+		"output:\n%s\n", output,
 	)
 }

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachprod/config",
+        "//pkg/roachprod/errors",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",

--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -31,9 +32,11 @@ const (
 	dnsDomain                = "roachprod-managed.crdb.io"
 	dnsMaxResults            = 1000
 	dnsMaxConcurrentRequests = 4
-)
 
-var ErrDNSOperation = fmt.Errorf("error during Google Cloud DNS operation")
+	// dnsProblemLabel is the label used when we see transient DNS
+	// errors while making API calls to Cloud DNS.
+	dnsProblemLabel = "dns_problem"
+)
 
 var _ vm.DNSProvider = &dnsProvider{}
 
@@ -97,7 +100,7 @@ func (n *dnsProvider) CreateRecords(ctx context.Context, records ...vm.DNSRecord
 		cmd := exec.CommandContext(ctx, "gcloud", args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			return markDNSOperationError(errors.Wrapf(err, "output: %s", out))
+			return rperrors.TransientFailure(errors.Wrapf(err, "output: %s", out), dnsProblemLabel)
 		}
 		n.updateCache(name, maps.Values(combinedRecords))
 	}
@@ -129,7 +132,7 @@ func (n *dnsProvider) DeleteRecordsByName(ctx context.Context, names ...string) 
 			cmd := exec.CommandContext(ctx, "gcloud", args...)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				return markDNSOperationError(errors.Wrapf(err, "output: %s", out))
+				return rperrors.TransientFailure(errors.Wrapf(err, "output: %s", out), dnsProblemLabel)
 			}
 			n.clearCacheEntry(name)
 			return nil
@@ -213,7 +216,7 @@ func (n *dnsProvider) listSRVRecords(
 	cmd := exec.CommandContext(ctx, "gcloud", args...)
 	res, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, markDNSOperationError(errors.Wrapf(err, "output: %s", res))
+		return nil, rperrors.TransientFailure(errors.Wrapf(err, "output: %s", res), dnsProblemLabel)
 	}
 	var jsonList []struct {
 		Name       string   `json:"name"`
@@ -225,7 +228,7 @@ func (n *dnsProvider) listSRVRecords(
 
 	err = json.Unmarshal(res, &jsonList)
 	if err != nil {
-		return nil, markDNSOperationError(errors.Wrapf(err, "error unmarshalling output: %s", res))
+		return nil, rperrors.TransientFailure(errors.Wrapf(err, "error unmarshaling output: %s", res), dnsProblemLabel)
 	}
 
 	records := make([]vm.DNSRecord, 0)
@@ -267,10 +270,4 @@ func (n *dnsProvider) clearCacheEntry(name string) {
 // may or may not have a trailing dot.
 func (n *dnsProvider) normaliseName(name string) string {
 	return strings.TrimSuffix(name, ".")
-}
-
-// markDNSOperationError should be used to mark any external DNS API or Google
-// Cloud DNS CLI errors as DNS operation errors.
-func markDNSOperationError(err error) error {
-	return errors.Mark(err, ErrDNSOperation)
 }


### PR DESCRIPTION
Backport 6/6 commits from #121788

/cc @cockroachdb/release

----

This PR introduces a roachprod API to allow certain errors to be labeled as _transient_. When using `roachprod` in the command line, these errors are returned to the caller as usual (and include a `TRANSIENT_ERROR` string). More importantly, when `roachtest` sees a transient error from roachprod, the resulting test failure is marked as a test-flake and routed to Test Eng.

The following commits then use this API to resolve a few related issues:

**roachprod: mark internal scp failures as transient**\
This uses the transient failures mechanism recently introduced to mark
failures from internal `scp` commands (when setting up a cluster or
starting the cockroach process) as transient.

Fixes: #121126

**roachprod: mark failures to stage binaries as transient**
This commit uses the recently introduced transient failure mechanism
in roachprod to automatically detect when staging a cockroach (or
workload) binary on a node fails in order to mark that as a transient
failure.

Note that 404 errors (i.e., binary not found on the GCS bucket)
is *not* marked as a transient failure as that often corresponds to a
programming error where an invalid version was requested.

Fixes: #88044

**roachprod: mark failures to find an open port transient**
These failures should not happen in regular clusters, and if they do,
they shouldn't fail tests as it indicates a problem in the test
infrastructure itself.

Fixes: #120339

**roachtest: mark failures in cluster.Install as transient**
This function only runs a fixed set of installation commands. If they
fail, we create an issue assigned to Test Eng and label the issue as
an infra flake.

Informs: #103316

The final commit in this PR also removes some outdated `install` targets; it's a bit unrelated with the rest of the PR, but I decided to clean that up while I was changing that file.

----

Release justification: test only changes.