### PR TITLE
roachtest: use durable locking in tpcc-nowait/isolation-level=mixed

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -641,8 +641,20 @@ func registerTPCC(r registry.Registry) {
 					isoLevels := []string{"read_uncommitted", "read_committed", "repeatable_read", "snapshot", "serializable"}
 					for i, isoLevel := range isoLevels {
 						args := "--isolation-level=" + isoLevel
-						if i <= 1 { // read_uncommitted and read_committed
+						switch isoLevel {
+						case "read_uncommitted", "read_committed":
+							// Disable retries for read uncommitted and read committed. These
+							// isolation levels are weak enough that we don't expect 40001
+							// "serialization_failure" errors which would necessitate a
+							// transaction retry loop. If we do see a 40001 error when running
+							// at one of these isolation levels, fail the test.
 							args += " --txn-retries=false"
+						case "serializable":
+							// Enable durable locking for serializable transactions. This
+							// ensures that we do not run into issues with best-effort locks
+							// acquired by SELECT FOR UPDATE being lost and creating lock
+							// order inversions which lead to transaction deadlocks.
+							args += " --conn-vars=enable_durable_locking_for_serializable=true"
 						}
 						ret = append(ret, workloadInstance{
 							nodes:          c.Range(1, c.Spec().NodeCount-1),


### PR DESCRIPTION
Fixes #119511.

This commit updates the `tpcc-nowait/isolation-level=mixed/nodes=3/w=1` roachtest to use durable locking for serializable transactions. This ensures that we do not run into issues with best-effort locks acquired by SELECT FOR UPDATE being lost and creating lock order inversions which lead to transaction deadlocks.

Release note: None