### PR TITLE
release: do not version bump on baking/staging branches

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -410,6 +410,11 @@ func generateRepoList(
 	log.Printf("will bump version in the following branches: %s", strings.Join(maybeVersionBumpBranches, ", "))
 
 	for _, branch := range maybeVersionBumpBranches {
+		// skip extraordinary and baking branches
+		if strings.HasPrefix(branch, "staging-") || strings.HasSuffix(branch, "-rc") {
+			log.Printf("not bumping version on staging/backing branch %s", branch)
+			continue
+		}
 		ok, err := fileExistsInGit(branch, versionFile)
 		if err != nil {
 			return []prRepo{}, fmt.Errorf("checking version file: %w", err)


### PR DESCRIPTION
Previously, release automation created version bump PRs against the staging and baking branches. We don't need these PRs, because the branches are supposed to be merged to the main release branch, where the actual version bump happens.

This PR skips branches with names starting with "staging-" or ending with "-rc".

Epic: none
Release note: None