### PR TITLE
clusterversion: rename obsolete gates

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -275,7 +275,7 @@ func backup(
 	// Create a channel that is large enough that it does not block.
 	perNodeProgressCh := make(chan map[execinfrapb.ComponentID]float32, numTotalSpans)
 	storePerNodeProgressLoop := func(ctx context.Context) error {
-		if !execCtx.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+		if !execCtx.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 			return nil
 		}
 		for {

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1886,7 +1886,7 @@ func TestBackupRestoreResume(t *testing.T) {
 				},
 			},
 			// Required because restore checkpointing is version gated.
-			clusterversion.V23_1.Version(),
+			clusterversion.TODODelete_V23_1.Version(),
 		)
 		// If the restore properly took the (incorrect) low-water mark into account,
 		// the first half of the table will be missing.

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -298,7 +298,7 @@ func restore(
 		return emptyRowCount, err
 	}
 
-	on231 := clusterversion.V23_1.Version().LessEq(job.Payload().CreationClusterVersion)
+	on231 := clusterversion.TODODelete_V23_1.Version().LessEq(job.Payload().CreationClusterVersion)
 	restoreCheckpoint := job.Progress().Details.(*jobspb.Progress_Restore).Restore.Checkpoint
 	requiredSpans := dataToRestore.getSpans()
 	progressTracker, err := makeProgressTracker(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -683,11 +683,11 @@ func createChangefeedJobRecord(
 	details.Opts = opts.AsMap()
 
 	if locFilter := details.Opts[changefeedbase.OptExecutionLocality]; locFilter != "" {
-		if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+		if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 			return nil, pgerror.Newf(
 				pgcode.FeatureNotSupported,
 				"cannot create new changefeed with %s until upgrade to version %s is complete",
-				changefeedbase.OptExecutionLocality, clusterversion.V23_1.String(),
+				changefeedbase.OptExecutionLocality, clusterversion.TODODelete_V23_1.String(),
 			)
 		}
 		if err := utilccl.CheckEnterpriseEnabled(

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -969,7 +969,7 @@ func (s StatementOptions) GetLaggingRangesConfig(
 	// This version gate prevents the scenario where the changefeed is created
 	// with options on a 23.2 node and resumed on a node with an old version
 	// which does not have those options.
-	laggingRangesVersionIsActive := settings.Version.IsActive(ctx, clusterversion.V23_2_ChangefeedLaggingRangesOpts)
+	laggingRangesVersionIsActive := settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_2_ChangefeedLaggingRangesOpts)
 	threshold = DefaultLaggingRangesThreshold
 	pollingInterval = DefaultLaggingRangesPollingInterval
 	_, ok := s.m[OptLaggingRangesThreshold]

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -68,11 +68,11 @@ func TestLaggingRangesVersionGate(t *testing.T) {
 	// The version does not matter if the default config is used.
 	t.Run("default config", func(t *testing.T) {
 		opts := MakeDefaultOptions()
-		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.V23_2_ChangefeedLaggingRangesOpts.Version(), clusterversion.V23_1.Version(), true)
+		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TODODelete_V23_2_ChangefeedLaggingRangesOpts.Version(), clusterversion.TODODelete_V23_1.Version(), true)
 		_, _, err := opts.GetLaggingRangesConfig(ctx, settings)
 		require.NoError(t, err)
 
-		settings = cluster.MakeTestingClusterSettingsWithVersions((clusterversion.V23_2_ChangefeedLaggingRangesOpts - 1).Version(), clusterversion.V23_1.Version(), true)
+		settings = cluster.MakeTestingClusterSettingsWithVersions((clusterversion.TODODelete_V23_2_ChangefeedLaggingRangesOpts - 1).Version(), clusterversion.TODODelete_V23_1.Version(), true)
 		_, _, err = opts.GetLaggingRangesConfig(ctx, settings)
 		require.NoError(t, err)
 	})
@@ -83,11 +83,11 @@ func TestLaggingRangesVersionGate(t *testing.T) {
 		opts.m[OptLaggingRangesThreshold] = "25ms"
 		opts.m[OptLaggingRangesPollingInterval] = "250ms"
 
-		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.V23_2_ChangefeedLaggingRangesOpts.Version(), clusterversion.V23_1.Version(), true)
+		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TODODelete_V23_2_ChangefeedLaggingRangesOpts.Version(), clusterversion.TODODelete_V23_1.Version(), true)
 		_, _, err := opts.GetLaggingRangesConfig(ctx, settings)
 		require.NoError(t, err)
 
-		settings = cluster.MakeTestingClusterSettingsWithVersions((clusterversion.V23_2_ChangefeedLaggingRangesOpts - 1).Version(), clusterversion.V23_1.Version(), true)
+		settings = cluster.MakeTestingClusterSettingsWithVersions((clusterversion.TODODelete_V23_2_ChangefeedLaggingRangesOpts - 1).Version(), clusterversion.TODODelete_V23_1.Version(), true)
 		_, _, err = opts.GetLaggingRangesConfig(ctx, settings)
 		require.Error(t, err, "cluster version must be 23.2 or greater")
 	})

--- a/pkg/cli/debug_recover_loss_of_quorum.go
+++ b/pkg/cli/debug_recover_loss_of_quorum.go
@@ -575,7 +575,7 @@ Discarded live replicas: %d
 	v := clusterversion.ClusterVersion{
 		Version: plan.Version,
 	}
-	if v.IsActive(clusterversion.V23_1) {
+	if v.IsActive(clusterversion.TODODelete_V23_1) {
 		// No args means we collected connection info from cluster and need to
 		// preserve flags for subsequent invocation.
 		remoteArgs := getCLIClusterFlags(len(args) == 0, cmd, func(flag string) bool {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -177,25 +177,25 @@ const (
 
 	VBootstrapMax
 
-	// V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
-	V23_1
+	// TODODelete_V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
+	TODODelete_V23_1
 
-	// V23_2_UseSizedPebblePointTombstones enables the use of Pebble's new
+	// TODODelete_V23_2_UseSizedPebblePointTombstones enables the use of Pebble's new
 	// DeleteSized operations.
-	V23_2_UseSizedPebblePointTombstones
+	TODODelete_V23_2_UseSizedPebblePointTombstones
 
-	// V23_2_StmtDiagForPlanGist enables statement diagnostic feature to collect
+	// TODODelete_V23_2_StmtDiagForPlanGist enables statement diagnostic feature to collect
 	// the bundle for particular plan gist.
-	V23_2_StmtDiagForPlanGist
+	TODODelete_V23_2_StmtDiagForPlanGist
 
-	// V23_2_RemoveLockTableWaiterTouchPush simplifies the push logic in
+	// TODODelete_V23_2_RemoveLockTableWaiterTouchPush simplifies the push logic in
 	// lock_table_waiter by passing the wait policy of the pusher as part of the
 	// push request and leaving the push outcome to the server-side logic.
-	V23_2_RemoveLockTableWaiterTouchPush
+	TODODelete_V23_2_RemoveLockTableWaiterTouchPush
 
-	// V23_2_ChangefeedLaggingRangesOpts is used to version gate the changefeed
+	// TODODelete_V23_2_ChangefeedLaggingRangesOpts is used to version gate the changefeed
 	// options lagging_ranges_threshold and lagging_ranges_polling_interval.
-	V23_2_ChangefeedLaggingRangesOpts
+	TODODelete_V23_2_ChangefeedLaggingRangesOpts
 
 	// ***************************************************************************
 	//            WHERE TO ADD VERSION GATES DURING 23.2 STABILITY?
@@ -295,13 +295,13 @@ var versionTable = [numKeys]roachpb.Version{
 	VBootstrapTenant: {Major: 0, Minor: 0, Internal: 4},
 	VBootstrapMax:    {Major: 0, Minor: 0, Internal: 424242},
 
-	V23_1: {Major: 23, Minor: 1, Internal: 0},
+	TODODelete_V23_1: {Major: 23, Minor: 1, Internal: 0},
 
 	// v23.2 versions. Internal versions must be even.
-	V23_2_UseSizedPebblePointTombstones:  {Major: 23, Minor: 1, Internal: 14},
-	V23_2_StmtDiagForPlanGist:            {Major: 23, Minor: 1, Internal: 18},
-	V23_2_RemoveLockTableWaiterTouchPush: {Major: 23, Minor: 1, Internal: 22},
-	V23_2_ChangefeedLaggingRangesOpts:    {Major: 23, Minor: 1, Internal: 24},
+	TODODelete_V23_2_UseSizedPebblePointTombstones:  {Major: 23, Minor: 1, Internal: 14},
+	TODODelete_V23_2_StmtDiagForPlanGist:            {Major: 23, Minor: 1, Internal: 18},
+	TODODelete_V23_2_RemoveLockTableWaiterTouchPush: {Major: 23, Minor: 1, Internal: 22},
+	TODODelete_V23_2_ChangefeedLaggingRangesOpts:    {Major: 23, Minor: 1, Internal: 24},
 
 	V23_2: {Major: 23, Minor: 2, Internal: 0},
 

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -79,7 +79,7 @@ func (r *Registry) maybeDumpTrace(resumerCtx context.Context, resumer Resumer, j
 		return
 	}
 
-	if !r.settings.Version.IsActive(dumpCtx, clusterversion.V23_1) {
+	if !r.settings.Version.IsActive(dumpCtx, clusterversion.TODODelete_V23_1) {
 		return
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -1177,7 +1177,7 @@ func TestTxnErrorWaitPolicyWithOldVersionPushTouch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	cv := (clusterversion.V23_2_RemoveLockTableWaiterTouchPush - 1).Version()
+	cv := (clusterversion.TODODelete_V23_2_RemoveLockTableWaiterTouchPush - 1).Version()
 	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		InitialReplicaVersionOverride: &cv,
 	})

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1433,7 +1433,7 @@ func mergeTrigger(
 	if merge.RightRangeIDLocalMVCCStats != (enginepb.MVCCStats{}) {
 		ms.Subtract(merge.RightRangeIDLocalMVCCStats)
 	} else {
-		_ = clusterversion.V23_1 // remove this branch when 23.1 support is removed
+		_ = clusterversion.TODODelete_V23_1 // remove this branch when 23.1 support is removed
 		ridPrefix := keys.MakeRangeIDReplicatedPrefix(merge.RightDesc.RangeID)
 		sysMS, err := storage.ComputeStats(
 			ctx, batch, ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -347,7 +347,7 @@ func PushTxn(
 		// know to check the timestamp cache again on commit to learn about any
 		// successful timestamp pushes.
 		// TODO(nvanbenschoten): remove this logic in v23.2.
-		if ok && !cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1) {
+		if ok && !cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 			txnRecord := reply.PusheeTxn.AsRecord()
 			if err := storage.MVCCPutProto(ctx, readWriter, key, hlc.Timestamp{}, &txnRecord,
 				storage.MVCCWriteOptions{Stats: cArgs.Stats, Category: fs.BatchEvalReadCategory}); err != nil {

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -103,7 +103,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "concurrency_manager"), func(t *testing.T, path string) {
 		c := newCluster()
 		if strings.HasSuffix(path, "_v23_1") {
-			v := clusterversion.V23_1.Version()
+			v := clusterversion.TODODelete_V23_1.Version()
 			st := clustersettings.MakeTestingClusterSettingsWithVersions(v, v, true)
 			c = newClusterWithSettings(st)
 		}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -452,7 +452,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 	// to abort the lock holder entirely so the write request can revoke and
 	// replace the lock with its own lock.
 	if req.WaitPolicy == lock.WaitPolicy_Error &&
-		!w.st.Version.IsActive(ctx, clusterversion.V23_2_RemoveLockTableWaiterTouchPush) {
+		!w.st.Version.IsActive(ctx, clusterversion.TODODelete_V23_2_RemoveLockTableWaiterTouchPush) {
 		// This wait policy signifies that the request wants to raise an error
 		// upon encountering a conflicting lock. We still need to push the lock
 		// holder to ensure that it is active and that this isn't an abandoned

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -186,7 +186,7 @@ func visitStoreReplicas(
 		}
 
 		var localIsLeaseholder bool
-		if targetVersion.IsActive(clusterversion.V23_1) {
+		if targetVersion.IsActive(clusterversion.TODODelete_V23_1) {
 			localIsLeaseholder = rstate.Lease != nil && rstate.Lease.Replica.StoreID == storeID
 		}
 

--- a/pkg/kv/kvserver/loqrecovery/marshalling.go
+++ b/pkg/kv/kvserver/loqrecovery/marshalling.go
@@ -30,7 +30,7 @@ func MarshalReplicaInfo(replicaInfo loqrecoverypb.ClusterReplicaInfo) ([]byte, e
 	v := clusterversion.ClusterVersion{
 		Version: replicaInfo.Version,
 	}
-	if v.IsActive(clusterversion.V23_1) {
+	if v.IsActive(clusterversion.TODODelete_V23_1) {
 		out, err := jsonpb.Marshal(&replicaInfo)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to marshal replica info")
@@ -90,7 +90,7 @@ func MarshalPlan(plan loqrecoverypb.ReplicaUpdatePlan) ([]byte, error) {
 	v := clusterversion.ClusterVersion{
 		Version: plan.Version,
 	}
-	if v.IsActive(clusterversion.V23_1) {
+	if v.IsActive(clusterversion.TODODelete_V23_1) {
 		out, err := jsonpb.Marshal(&plan)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to marshal recovery plan")

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -195,7 +195,7 @@ func PlanReplicas(
 	v := clusterversion.ClusterVersion{
 		Version: clusterInfo.Version,
 	}
-	if v.IsActive(clusterversion.V23_1) {
+	if v.IsActive(clusterversion.TODODelete_V23_1) {
 		return loqrecoverypb.ReplicaUpdatePlan{
 			Updates:                 updates,
 			PlanID:                  planID,

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -141,7 +141,7 @@ func (s Server) ServeClusterReplicas(
 	// We can't assume that caller is up-to-date with cluster version and process
 	// regardless of version known by current node as recommended for RPC
 	// requests because caller is a CLI which that only knows its binary version.
-	if !s.settings.Version.IsActive(ctx, clusterversion.V23_1) {
+	if !s.settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		return errors.Newf("loss of quorum recovery service requires cluster upgraded to 23.1")
 	}
 
@@ -265,7 +265,7 @@ func (s Server) StagePlan(
 	// We can't assume that caller is up-to-date with cluster version and process
 	// regardless of version known by current node as recommended for RPC
 	// requests because caller is a CLI which that only knows its binary version.
-	if !s.settings.Version.IsActive(ctx, clusterversion.V23_1) {
+	if !s.settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		return nil, errors.Newf("loss of quorum recovery service requires cluster upgraded to 23.1")
 	}
 
@@ -472,7 +472,7 @@ func (s Server) Verify(
 	ctx context.Context, req *serverpb.RecoveryVerifyRequest, nl *liveness.NodeLiveness, db *kv.DB,
 ) (*serverpb.RecoveryVerifyResponse, error) {
 	// Block requests that require fan-out to other nodes until upgrade is finalized.
-	if !s.settings.Version.IsActive(ctx, clusterversion.V23_1) {
+	if !s.settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		return nil, errors.Newf("loss of quorum recovery service requires cluster upgraded to 23.1")
 	}
 

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -743,7 +743,7 @@ func (mgcq *mvccGCQueue) process(
 	maxLocksKeyBytesPerCleanupBatch := gc.MaxLockKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	txnCleanupThreshold := gc.TxnCleanupThreshold.Get(&repl.store.ClusterSettings().SV)
 	var clearRangeMinKeys int64 = 0
-	if repl.store.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1) {
+	if repl.store.ClusterSettings().Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		clearRangeMinKeys = gc.ClearRangeMinKeys.Get(&repl.store.ClusterSettings().SV)
 	}
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2682,7 +2682,7 @@ func (r *Replica) getSenderReplicas(
 
 	// Unless all nodes are on V23.1, don't delegate. This prevents sending to a
 	// node that doesn't understand the request.
-	if !r.store.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1) {
+	if !r.store.ClusterSettings().Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		return []roachpb.ReplicaDescriptor{coordinator}, nil
 	}
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -322,7 +322,7 @@ func (r *Replica) maybeAddRangeInfoToResponse(
 		}
 	} else if ba.IsSingleRequestLeaseRequest() {
 		// TODO(erikgrinaker): Remove this branch when 23.1 support is dropped.
-		_ = clusterversion.V23_1
+		_ = clusterversion.TODODelete_V23_1
 		return
 	}
 

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -442,7 +442,7 @@ func verifySpanStatsRequest(
 ) error {
 
 	// If the cluster's active version is less than 23.1 return a mixed version error.
-	if !version.IsActive(ctx, clusterversion.V23_1) {
+	if !version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		return errors.New(MixedVersionErr)
 	}
 

--- a/pkg/server/statement_diagnostics_requests.go
+++ b/pkg/server/statement_diagnostics_requests.go
@@ -145,7 +145,7 @@ func (s *statusServer) StatementDiagnosticsRequests(
 	var err error
 
 	var extraColumns string
-	if s.st.Version.IsActive(ctx, clusterversion.V23_2_StmtDiagForPlanGist) {
+	if s.st.Version.IsActive(ctx, clusterversion.TODODelete_V23_2_StmtDiagForPlanGist) {
 		extraColumns = `,
 			plan_gist,
 			anti_plan_gist`

--- a/pkg/sql/catalog/bootstrap/initial_values.go
+++ b/pkg/sql/catalog/bootstrap/initial_values.go
@@ -75,7 +75,7 @@ var initialValuesFactoryByKey = map[clusterversion.Key]initialValuesFactoryFn{
 		nonSystem:     v23_2_tenant_keys,
 		nonSystemHash: v23_2_tenant_sha256,
 	}.build,
-	clusterversion.V23_1: hardCodedInitialValues{
+	clusterversion.TODODelete_V23_1: hardCodedInitialValues{
 		system:        v23_1_system_keys,
 		systemHash:    v23_1_system_sha256,
 		nonSystem:     v23_1_tenant_keys,

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -119,7 +119,7 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 		}
 
 	case types.TSQueryFamily, types.TSVectorFamily:
-		if !version.IsActive(ctx, clusterversion.V23_1) {
+		if !version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 			return pgerror.Newf(pgcode.FeatureNotSupported,
 				"TSVector/TSQuery not supported until version 23.1")
 		}

--- a/pkg/sql/catalog/funcdesc/helpers.go
+++ b/pkg/sql/catalog/funcdesc/helpers.go
@@ -17,9 +17,9 @@ import (
 )
 
 var schemaExprContextAllowingUDF = map[tree.SchemaExprContext]clusterversion.Key{
-	tree.CheckConstraintExpr:           clusterversion.V23_1,
-	tree.ColumnDefaultExprInNewTable:   clusterversion.V23_1,
-	tree.ColumnDefaultExprInSetDefault: clusterversion.V23_1,
+	tree.CheckConstraintExpr:           clusterversion.TODODelete_V23_1,
+	tree.ColumnDefaultExprInNewTable:   clusterversion.TODODelete_V23_1,
+	tree.ColumnDefaultExprInSetDefault: clusterversion.TODODelete_V23_1,
 }
 
 // MaybeFailOnUDFUsage returns an error if the given expression or any

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -315,10 +315,10 @@ func (p *planner) createUserDefinedType(params runParams, n *createTypeNode) err
 			params, id, n.n.EnumLabels, n.dbDesc, n.typeName, EnumTypeUserDefined,
 		)
 	case tree.Composite:
-		if !p.execCfg.Settings.Version.IsActive(params.ctx, clusterversion.V23_1) {
+		if !p.execCfg.Settings.Version.IsActive(params.ctx, clusterversion.TODODelete_V23_1) {
 			return pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to create composite types",
-				clusterversion.V23_1)
+				clusterversion.TODODelete_V23_1)
 		}
 		return params.p.createCompositeWithID(
 			params, id, n.n.CompositeTypeList, n.dbDesc, n.typeName,

--- a/pkg/sql/fingerprint_span.go
+++ b/pkg/sql/fingerprint_span.go
@@ -51,9 +51,9 @@ func (p *planner) FingerprintSpan(
 	defer sp.Finish()
 
 	evalCtx := p.EvalContext()
-	if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+	if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 		return 0, errors.Errorf("cannot fingeprint span until the cluster version is at least %s",
-			clusterversion.V23_1.String())
+			clusterversion.TODODelete_V23_1.String())
 	}
 
 	fingerprint, ssts, err := p.fingerprintSpanFanout(ctx, span, startTime, allRevisions, stripped)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -125,7 +125,7 @@ func alterPrimaryKey(b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t alterPri
 	// This behavior is added in V23.1 and gated.
 	oldShardColToDrop := getprimaryIndexShardColumn(b, tbl.TableID, inflatedChain.oldSpec.primary.IndexID)
 	if checkIfColumnCanBeDropped(b, oldShardColToDrop) {
-		if b.EvalCtx().Settings.Version.IsActive(b, clusterversion.V23_1) {
+		if b.EvalCtx().Settings.Version.IsActive(b, clusterversion.TODODelete_V23_1) {
 			elts := b.QueryByID(oldShardColToDrop.TableID).Filter(hasColumnIDAttrFilter(oldShardColToDrop.ColumnID))
 			dropColumn(b, tn, tbl, t.n, oldShardColToDrop, elts, tree.DropRestrict)
 		}
@@ -732,7 +732,7 @@ func recreateAllSecondaryIndexes(
 			}
 		}
 		in, temp := makeSwapIndexSpec(b, out, sourcePrimaryIndex.IndexID, inColumns, false /* inUseTempIDs */)
-		if b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+		if b.ClusterSettings().Version.IsActive(b, clusterversion.TODODelete_V23_1) {
 			in.secondary.RecreateSourceIndexID = out.indexID()
 		}
 		out.apply(b.Drop)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -276,7 +276,7 @@ func dropColumn(
 		case *scpb.UniqueWithoutIndexConstraint:
 			// Until the appropriate version gate is hit, we still do not allow
 			// dropping unique without index constraints.
-			if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+			if !b.ClusterSettings().Version.IsActive(b, clusterversion.TODODelete_V23_1) {
 				panic(scerrors.NotImplementedErrorf(nil, "dropping without"+
 					"index constraints is not allowed."))
 			}
@@ -290,7 +290,7 @@ func dropColumn(
 		case *scpb.UniqueWithoutIndexConstraintUnvalidated:
 			// Until the appropriate version gate is hit, we still do not allow
 			// dropping unique without index constraints.
-			if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+			if !b.ClusterSettings().Version.IsActive(b, clusterversion.TODODelete_V23_1) {
 				panic(scerrors.NotImplementedErrorf(nil, "dropping without"+
 					"index constraints is not allowed."))
 			}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
@@ -246,7 +246,7 @@ func maybeDropDependentFKConstraints(
 	shouldDropFK := func(fkReferencedColIDs []catid.ColumnID) bool {
 		// Until the appropriate version gate is hit, we still do not allow
 		// dropping foreign keys in any the context of secondary indexes.
-		if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+		if !b.ClusterSettings().Version.IsActive(b, clusterversion.TODODelete_V23_1) {
 			panic(scerrors.NotImplementedErrorf(nil, "dropping FK constraints"+
 				" as a result of `DROP INDEX CASCADE` is not supported yet."))
 		}

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -121,7 +121,7 @@ func (w *walkCtx) walkRoot() {
 	case catalog.TableDescriptor:
 		w.walkRelation(d)
 	case catalog.FunctionDescriptor:
-		if !w.clusterVersion.IsActive(clusterversion.V23_1) {
+		if !w.clusterVersion.IsActive(clusterversion.TODODelete_V23_1) {
 			panic(
 				scerrors.NotImplementedErrorf(
 					nil, // n
@@ -693,7 +693,7 @@ func (w *walkCtx) walkUniqueWithoutIndexConstraint(
 				c.GetName(), tbl.GetName(), tbl.GetID()))
 		}
 	}
-	if c.IsConstraintUnvalidated() && w.clusterVersion.IsActive(clusterversion.V23_1) {
+	if c.IsConstraintUnvalidated() && w.clusterVersion.IsActive(clusterversion.TODODelete_V23_1) {
 		uwi := &scpb.UniqueWithoutIndexConstraintUnvalidated{
 			TableID:      tbl.GetID(),
 			ConstraintID: c.GetConstraintID(),
@@ -730,7 +730,7 @@ func (w *walkCtx) walkCheckConstraint(tbl catalog.TableDescriptor, c catalog.Che
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "check constraint %q in table %q (%d)",
 			c.GetName(), tbl.GetName(), tbl.GetID()))
 	}
-	if c.IsConstraintUnvalidated() && w.clusterVersion.IsActive(clusterversion.V23_1) {
+	if c.IsConstraintUnvalidated() && w.clusterVersion.IsActive(clusterversion.TODODelete_V23_1) {
 		w.ev(scpb.Status_PUBLIC, &scpb.CheckConstraintUnvalidated{
 			TableID:      tbl.GetID(),
 			ConstraintID: c.GetConstraintID(),
@@ -763,7 +763,7 @@ func (w *walkCtx) walkCheckConstraint(tbl catalog.TableDescriptor, c catalog.Che
 func (w *walkCtx) walkForeignKeyConstraint(
 	tbl catalog.TableDescriptor, c catalog.ForeignKeyConstraint,
 ) {
-	if c.IsConstraintUnvalidated() && w.clusterVersion.IsActive(clusterversion.V23_1) {
+	if c.IsConstraintUnvalidated() && w.clusterVersion.IsActive(clusterversion.TODODelete_V23_1) {
 		w.ev(scpb.Status_PUBLIC, &scpb.ForeignKeyConstraintUnvalidated{
 			TableID:                 tbl.GetID(),
 			ConstraintID:            c.GetConstraintID(),

--- a/pkg/sql/schemachanger/scdecomp/helpers.go
+++ b/pkg/sql/schemachanger/scdecomp/helpers.go
@@ -142,6 +142,6 @@ func NewElementCreationMetadata(
 	clusterVersion clusterversion.ClusterVersion,
 ) *scpb.ElementCreationMetadata {
 	return &scpb.ElementCreationMetadata{
-		In_23_1OrLater: clusterVersion.IsActive(clusterversion.V23_1),
+		In_23_1OrLater: clusterVersion.IsActive(clusterversion.TODODelete_V23_1),
 	}
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_family.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_family.go
@@ -42,7 +42,7 @@ func init() {
 					// when the element reaches absent the column family has actually
 					// been removed. This would have been done via the last column
 					// type element referencing it.
-					if md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.AssertColumnFamilyIsRemoved{
 							TableID:  this.TableID,
 							FamilyID: this.FamilyID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database.go
@@ -50,7 +50,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.Database, md *opGenContext) *scop.CreateGCJobForDatabase {
-					if !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForDatabase{
 							DatabaseID:          this.DatabaseID,
 							StatementForDropJob: statementForDropJob(this, md),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_primary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_primary_index.go
@@ -147,7 +147,7 @@ func init() {
 			equiv(scpb.Status_BACKFILL_ONLY),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.PrimaryIndex, md *opGenContext) *scop.CreateGCJobForIndex {
-					if !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForIndex{
 							TableID:             this.TableID,
 							IndexID:             this.IndexID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_secondary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_secondary_index.go
@@ -190,7 +190,7 @@ func init() {
 			equiv(scpb.Status_BACKFILL_ONLY),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.SecondaryIndex, md *opGenContext) *scop.CreateGCJobForIndex {
-					if !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForIndex{
 							TableID:             this.TableID,
 							IndexID:             this.IndexID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
@@ -57,7 +57,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.Sequence, md *opGenContext) *scop.CreateGCJobForTable {
-					if !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForTable{
 							TableID:             this.SequenceID,
 							DatabaseID:          databaseIDFromDroppedNamespaceTarget(md, this.SequenceID),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
@@ -47,7 +47,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.Table, md *opGenContext) *scop.CreateGCJobForTable {
-					if !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForTable{
 							TableID:             this.TableID,
 							DatabaseID:          databaseIDFromDroppedNamespaceTarget(md, this.TableID),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_temporary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_temporary_index.go
@@ -77,7 +77,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.TemporaryIndex, md *opGenContext) *scop.CreateGCJobForIndex {
-					if !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForIndex{
 							TableID:             this.TableID,
 							IndexID:             this.IndexID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
@@ -63,7 +63,7 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.View, md *opGenContext) *scop.CreateGCJobForTable {
-					if this.IsMaterialized && !md.ActiveVersion.IsActive(clusterversion.V23_1) {
+					if this.IsMaterialized && !md.ActiveVersion.IsActive(clusterversion.TODODelete_V23_1) {
 						return &scop.CreateGCJobForTable{
 							TableID:             this.ViewID,
 							DatabaseID:          databaseIDFromDroppedNamespaceTarget(md, this.ViewID),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_23_1/helpers.go
@@ -25,7 +25,7 @@ const (
 )
 
 // rulesVersionKey version of elements used by this rule set.
-var rulesVersionKey = clusterversion.V23_1
+var rulesVersionKey = clusterversion.TODODelete_V23_1
 
 // descriptorIsNotBeingDropped creates a clause which leads to the outer clause
 // failing to unify if the passed element is part of a descriptor and

--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -161,7 +161,7 @@ type rulesForRelease struct {
 var rulesForReleases = []rulesForRelease{
 	{activeVersion: clusterversion.V24_1, rulesRegistry: current.GetRegistry()},
 	{activeVersion: clusterversion.V23_2, rulesRegistry: release_23_2.GetRegistry()},
-	{activeVersion: clusterversion.V23_1, rulesRegistry: release_23_1.GetRegistry()},
+	{activeVersion: clusterversion.TODODelete_V23_1, rulesRegistry: release_23_1.GetRegistry()},
 }
 
 // minVersionForRules the oldest version supported by the rules.

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -893,10 +893,10 @@ func performCastWithoutPrecisionTruncation(
 			return tree.ParseDJSON(string(j))
 		}
 	case types.TSQueryFamily:
-		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to use TSVector",
-				clusterversion.V23_1.Version())
+				clusterversion.TODODelete_V23_1.Version())
 		}
 		switch v := d.(type) {
 		case *tree.DString:
@@ -907,10 +907,10 @@ func performCastWithoutPrecisionTruncation(
 			return &tree.DTSQuery{TSQuery: q}, nil
 		}
 	case types.TSVectorFamily:
-		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to use TSVector",
-				clusterversion.V23_1.Version())
+				clusterversion.TODODelete_V23_1.Version())
 		}
 		switch v := d.(type) {
 		case *tree.DString:

--- a/pkg/sql/sqlliveness/slstorage/slstorage_internal_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_internal_test.go
@@ -52,7 +52,7 @@ func TestGetEncoder(t *testing.T) {
 	tests := []testCase{
 		{
 			name:      "v23_1",
-			version:   clusterversion.V23_1,
+			version:   clusterversion.TODODelete_V23_1,
 			readCodec: isRbr,
 			dualCodec: isNil,
 		},

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -289,7 +289,7 @@ func (r *Registry) insertRequestInternal(
 	minExecutionLatency time.Duration,
 	expiresAfter time.Duration,
 ) (RequestID, error) {
-	if planGist != "" && !r.st.Version.IsActive(ctx, clusterversion.V23_2_StmtDiagForPlanGist) {
+	if planGist != "" && !r.st.Version.IsActive(ctx, clusterversion.TODODelete_V23_2_StmtDiagForPlanGist) {
 		return 0, errors.Newf("plan gists only supported after 23.2 version migrations have completed")
 	}
 	if samplingProbability != 0 {
@@ -654,7 +654,7 @@ func (r *Registry) InsertStatementDiagnostics(
 // updates r.mu.requests accordingly.
 func (r *Registry) pollRequests(ctx context.Context) error {
 	var rows []tree.Datums
-	isPlanGistSupported := r.st.Version.IsActive(ctx, clusterversion.V23_2_StmtDiagForPlanGist)
+	isPlanGistSupported := r.st.Version.IsActive(ctx, clusterversion.TODODelete_V23_2_StmtDiagForPlanGist)
 
 	// Loop until we run the query without straddling an epoch increment.
 	for {

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -148,7 +148,7 @@ func storageParamPreChecks(
 
 	for _, key := range keys {
 		if key == `schema_locked` {
-			if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+			if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.TODODelete_V23_1) {
 				return pgerror.Newf(pgcode.FeatureNotSupported, "cannot set/reset "+
 					"storage parameter %q until the cluster version is at least 23.1", key)
 			}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1684,7 +1684,7 @@ func (p *Pebble) ClearEngineKey(key EngineKey, opts ClearOptions) error {
 		return emptyKeyError()
 	}
 	if !opts.ValueSizeKnown || !p.cfg.settings.Version.ActiveVersionOrEmpty(context.TODO()).
-		IsActive(clusterversion.V23_2_UseSizedPebblePointTombstones) {
+		IsActive(clusterversion.TODODelete_V23_2_UseSizedPebblePointTombstones) {
 		return p.db.Delete(key.Encode(), pebble.Sync)
 	}
 	return p.db.DeleteSized(key.Encode(), opts.ValueSize, pebble.Sync)
@@ -1695,7 +1695,7 @@ func (p *Pebble) clear(key MVCCKey, opts ClearOptions) error {
 		return emptyKeyError()
 	}
 	if !opts.ValueSizeKnown || !p.cfg.settings.Version.ActiveVersionOrEmpty(context.TODO()).
-		IsActive(clusterversion.V23_2_UseSizedPebblePointTombstones) {
+		IsActive(clusterversion.TODODelete_V23_2_UseSizedPebblePointTombstones) {
 		return p.db.Delete(EncodeMVCCKey(key), pebble.Sync)
 	}
 	// Use DeleteSized to propagate the value size.

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -60,7 +60,7 @@ func newWriteBatch(
 		// write the store identifer key; this is written before any cluster
 		// version has been initialized.
 		mayWriteSizedDeletes: settings.Version.ActiveVersionOrEmpty(context.TODO()).
-			IsActive(clusterversion.V23_2_UseSizedPebblePointTombstones),
+			IsActive(clusterversion.TODODelete_V23_2_UseSizedPebblePointTombstones),
 	}
 	return wb
 }
@@ -496,7 +496,7 @@ func newPebbleBatch(
 			// write the store identifer key; this is written before any cluster
 			// version has been initialized.
 			mayWriteSizedDeletes: settings.Version.ActiveVersionOrEmpty(context.TODO()).
-				IsActive(clusterversion.V23_2_UseSizedPebblePointTombstones),
+				IsActive(clusterversion.TODODelete_V23_2_UseSizedPebblePointTombstones),
 		},
 		prefixIter: pebbleIterator{
 			lowerBoundBuf: pb.prefixIter.lowerBoundBuf,

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1226,7 +1226,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	tsQueryNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.V23_1.Version())
+		clusterversion.TODODelete_V23_1.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1264,7 +1264,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	forwardIndexesOnArraysNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.V23_1.Version())
+		clusterversion.TODODelete_V23_1.Version())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Prepend `TODODelete_` to the remaining pre-23.2 gates.

Epic: REL-696
Release note: None