### PR TITLE
bazci: skip posting issue if branch no longer exists

### DIFF
--- a/pkg/cmd/bazci/BUILD.bazel
+++ b/pkg/cmd/bazci/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/build/bazel/bes",
         "//pkg/build/util",
         "//pkg/cmd/bazci/githubpost",
+        "//pkg/cmd/release:release_lib",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//types",

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -33,6 +33,7 @@ import (
 	bes "github.com/cockroachdb/cockroach/pkg/build/bazel/bes"
 	bazelutil "github.com/cockroachdb/cockroach/pkg/build/util"
 	"github.com/cockroachdb/cockroach/pkg/cmd/bazci/githubpost"
+	release "github.com/cockroachdb/cockroach/pkg/cmd/release"
 	"github.com/cockroachdb/errors"
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
@@ -53,6 +54,10 @@ const (
 	mungeTestXMLSubcmd      = "munge-test-xml"
 	beaverHubServerEndpoint = "https://beaver-hub-server-jjd2v2r2dq-uk.a.run.app/process"
 )
+
+// deletedStagingBranches keeps track of staging branches that have since been deleted, so that stress
+// tests can gracefully handle the deletion of a branch once a job has started.
+var deletedStagingBranches = map[string]bool{}
 
 type builtArtifact struct {
 	src, dst string
@@ -516,6 +521,26 @@ func doPost() bool {
 		fmt.Printf("branch %s does not appear to be a release branch; skipping reporting issues to GitHub\n", branch)
 		return false
 	}
+
+	// If this is a temporary staging branch, enforce that the branch
+	// still exists before posting.
+	if release.IsStagingBranch(branch) {
+		if deletedStagingBranches[branch] {
+			fmt.Printf("branch %s no longer exists; skip reporting issues to GitHub\n", branch)
+			return false
+		}
+		remoteBranches, err := release.ListRemoteBranches(branch)
+		if err != nil {
+			fmt.Printf("failed to list remote branches for %s: %v", branch, err)
+			return false
+		}
+		if len(remoteBranches) == 0 {
+			deletedStagingBranches[branch] = true
+			fmt.Printf("branch %s no longer exists; skip reporting issues to GitHub\n", branch)
+			return false
+		}
+	}
+
 	// GITHUB_API_TOKEN must be in the env or github-post will barf if it's
 	// ever asked to post, so enforce that on all runs.
 	// The way this env var is made available here is quite tricky. The build

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "update_versions.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//pkg/build",
         "//pkg/testutils/release",

--- a/pkg/cmd/release/git_test.go
+++ b/pkg/cmd/release/git_test.go
@@ -10,7 +10,11 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestBumpVersion(t *testing.T) {
 	tests := []struct {
@@ -124,6 +128,60 @@ func TestBumpVersion(t *testing.T) {
 			if got != tt.nextVersion {
 				t.Errorf("bumpVersion() got = %v, nextVersion %v", got, tt.nextVersion)
 			}
+		})
+	}
+}
+
+func TestIsStagingBranch(t *testing.T) {
+	tests := []struct {
+		description        string
+		maybeStagingBranch string
+		want               bool
+	}{
+		// happy path tests: should return true
+		{
+			description:        "should match `release-*-rc` staging branch",
+			maybeStagingBranch: "release-23.1.4-rc",
+			want:               true,
+		},
+		{
+			description:        "should match `release-*-rc` staging branch",
+			maybeStagingBranch: "release-23.0.44-rc",
+			want:               true,
+		},
+		{
+			description:        "should match `staging-*` staging branch",
+			maybeStagingBranch: "staging-v23.1.4",
+			want:               true,
+		},
+		{
+			description:        "should match `staging-*` staging branch",
+			maybeStagingBranch: "staging-v23.0.44",
+			want:               true,
+		},
+		// should return false for:
+		// - main release branches, e.g. release-23.1
+		// - doesn't begin with release or staging
+		// - has extra stuff before/after expected pattern
+		{
+			description:        "should not match main release branch",
+			maybeStagingBranch: "release-23.2",
+			want:               false,
+		},
+		{
+			description:        "should not match something with extra stuff before pattern",
+			maybeStagingBranch: "extra-release-23.2.1-rc",
+			want:               false,
+		},
+		{
+			description:        "should not match something with extra stuff after pattern",
+			maybeStagingBranch: "release-23.2.1-rc-extra",
+			want:               false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.maybeStagingBranch+": "+tt.description, func(t *testing.T) {
+			require.Equal(t, tt.want, IsStagingBranch(tt.maybeStagingBranch))
 		})
 	}
 }

--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -382,7 +382,7 @@ func generateRepoList(
 	// 1. Bump the version. Branches we need to bump the version on:
 	// stable releases: release-major.minor and all RC branches of the same release series.
 	// alpha, beta, rc: 1) master or 2) release-major.minor and all RC branches for the same release series
-	maybeVersionBumpBranches, err := listRemoteBranches(fmt.Sprintf("release-%d.%d.*", releasedVersion.Major(), releasedVersion.Minor()))
+	maybeVersionBumpBranches, err := ListRemoteBranches(fmt.Sprintf("release-%d.%d.*", releasedVersion.Major(), releasedVersion.Minor()))
 	if err != nil {
 		return []prRepo{}, fmt.Errorf("listing staging branches: %w", err)
 	}
@@ -392,7 +392,7 @@ func generateRepoList(
 		// For alpha/betas/rc releases, if we have not created the dot-zero branch
 		// (which is covered by the `release-major.minor.*` pattern), then use either the `release-major.minor` or the master branch for version bump.
 		// First, try to find the `release-major.minor` branch.
-		maybeReleaseBranches, err := listRemoteBranches(fmt.Sprintf("release-%d.%d", releasedVersion.Major(), releasedVersion.Minor()))
+		maybeReleaseBranches, err := ListRemoteBranches(fmt.Sprintf("release-%d.%d", releasedVersion.Major(), releasedVersion.Minor()))
 		if err != nil {
 			return []prRepo{}, fmt.Errorf("listing release branches: %w", err)
 		}
@@ -503,7 +503,7 @@ func generateRepoList(
 	}
 	var bakingBranches []string
 	for _, branch := range maybeBakingbranches {
-		maybeMergeBranches, err := listRemoteBranches(branch)
+		maybeMergeBranches, err := ListRemoteBranches(branch)
 		if err != nil {
 			return []prRepo{}, fmt.Errorf("listing merge branch %s: %w", branch, err)
 		}


### PR DESCRIPTION
Once we publish a maintenance release, we delete its corresponding staging branch (one of `staging-` or `release-MM.d.p-rc`). However, we run 1000s of nightly tests against all release- branches. And these TC jobs will post GH issues with incorrect branch details, if we delete these staging branches before the TC job completes.

This PR fails skips posting if staging branch no longer exists.

Epic: None.
Release note: None.
Release justification: non-production, test-infra only change.