### PR TITLE
kv: subject query intents to circuit breaker grace period

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2727,7 +2727,7 @@ func (ds *DistSender) sendToReplicas(
 
 		tBegin := timeutil.Now() // for slow log message
 		sendCtx, cbToken, cbErr := ds.circuitBreakers.ForReplica(desc, &curReplica).
-			Track(ctx, ba, tBegin.UnixNano())
+			Track(ctx, ba, withCommit, tBegin.UnixNano())
 		if cbErr != nil {
 			// Circuit breaker is tripped. err will be handled below.
 			err = cbErr

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -228,7 +228,7 @@ func benchmarkCircuitBreakersTrack(
 	// If this shouldn't be the only request, add another concurrent request to
 	// the tracking.
 	if !alone {
-		_, _, err := cbs.ForReplica(rangeDesc, replDesc).Track(ctx, ba, 1)
+		_, _, err := cbs.ForReplica(rangeDesc, replDesc).Track(ctx, ba, false /* withCommit */, 1)
 		require.NoError(b, err)
 	}
 
@@ -272,7 +272,7 @@ func benchmarkCircuitBreakersTrack(
 			// Adjust b.N for concurrency.
 			for i := 0; i < b.N/conc; i++ {
 				cb := cbs.ForReplica(rangeDesc, replDesc)
-				_, cbToken, err := cb.Track(sendCtx, ba, nowNanos)
+				_, cbToken, err := cb.Track(sendCtx, ba, false /* withCommit */, nowNanos)
 				if err != nil {
 					assert.NoError(b, err)
 					return


### PR DESCRIPTION
Fixes #121997.

This commit subjects the "pre-commit query intent" sub-batch of a parallel commit to the same circuit breaker grace period as writes (introduced in 9eed3b1f). This prevents them from being eagerly cancelled on tripped DistSender circuit breakers, leading to ambiguous errors.

Release note: None