### PR TITLE
release-24.1: cli: fix merge skew

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlexec"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlshell"
 	"github.com/cockroachdb/cockroach/pkg/cli/democluster"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/pull/121989 and  https://github.com/cockroachdb/cockroach/pull/121290

Release note: none.
Epic: none.

Release justification: Merge skew fix.