### PR TITLE
roachprod: fix unused `serviceMode` parameter

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -248,8 +248,11 @@ func (c *SyncedCluster) maybeRegisterServices(
 	switch startOpts.Target {
 	case StartDefault:
 		startOpts.VirtualClusterName = SystemInterfaceName
+		// The system interface on the storage cluster is always regarded as an
+		// external service. Only non-system virtual clusters, running on the
+		// storage cluster, are regarded as shared services.
 		servicesToRegister, err = c.servicesWithOpenPortSelection(
-			ctx, l, startOpts, ServiceModeShared, serviceMap, portFunc,
+			ctx, l, startOpts, ServiceModeExternal, serviceMap, portFunc,
 		)
 	case StartSharedProcessForVirtualCluster:
 		// Specifying a sql instance for shared process virtual clusters
@@ -304,7 +307,7 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 			services = append(services, ServiceDesc{
 				VirtualClusterName: startOpts.VirtualClusterName,
 				ServiceType:        ServiceTypeSQL,
-				ServiceMode:        ServiceModeExternal,
+				ServiceMode:        serviceMode,
 				Node:               node,
 				Port:               startOpts.SQLPort,
 				Instance:           startOpts.SQLInstance,
@@ -314,7 +317,7 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 			services = append(services, ServiceDesc{
 				VirtualClusterName: startOpts.VirtualClusterName,
 				ServiceType:        ServiceTypeUI,
-				ServiceMode:        ServiceModeExternal,
+				ServiceMode:        serviceMode,
 				Node:               node,
 				Port:               startOpts.AdminUIPort,
 				Instance:           startOpts.SQLInstance,


### PR DESCRIPTION
Previously, `servicesWithOpenPortSelection` did not use the `serviceMode` parameter that was passed, and it assumed `ServiceModeExternal` in the function itself.

This was updated to use the `serviceMode` parameter instead, but caused issues during start-up, because the mode being passed in for the storage cluster was shared instead of external.

The mode has been updated to `ServiceModeExternal` now for storage clusters (`StartDefault` with System Interface). A comment has also been added to avoid confusion in the future regarding if the storage cluster is shared or external (it's external).

In conclusion, only shared process tenants (non-system) are regarded shared. Any other registered services are regarded as external.

Epic: None
Release Note: None