### PR TITLE
multiregionccl: don't run TestMultiRegionDataDriven under stress

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -122,6 +122,7 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	// (legitimate) timing issues on a deadlock build.
 	skip.UnderRace(t, "flaky test")
 	skip.UnderDeadlock(t, "flaky test")
+
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		ds := datadrivenTestState{}


### PR DESCRIPTION
TestMultiRegionDataDriven has race condititions that ocassionally cause it to fail under stress. Either we need to fix them or not run this test under stress.

Note this PR is a no-op just to force CI to run this test under stress.

Informs: #121239
Epic: none

Release note: None