### PR TITLE
sql,multiregionccl: rename multiregion system DB cluster setting

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -544,7 +544,7 @@ ALTER DATABASE system PRIMARY REGION "ap-southeast-2"
 # are in the system tenant. Hence the lack of error code checking and the
 # regex matching both possible outcomes.
 skipif config multiregion-9node-3region-3azs-tenant
-statement error user testuser may not modify the system database|Modifying the regions of system database is not supported. Set up your system database as multi-region using the cluster setting `sql.multiregion.preview_multiregion_system_database.enabled` https://www.cockroachlabs.com/docs/stable/cluster-settings
+statement error (user testuser may not modify the system database|modifying the regions of system database is not supported)
 ALTER DATABASE system PRIMARY REGION "ap-southeast-2"
 
 user root

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -87,7 +87,7 @@ func TestMrSystemDatabase(t *testing.T) {
 
 	sDB := sqlutils.MakeSQLRunner(systemSQL)
 
-	sDB.Exec(t, `SET CLUSTER SETTING sql.multiregion.preview_multiregion_system_database.enabled = true`)
+	sDB.Exec(t, `SET CLUSTER SETTING sql.multiregion.system_database_multiregion.enabled = true`)
 	sDB.Exec(t, `ALTER DATABASE system SET PRIMARY REGION "us-east1"`)
 	sDB.Exec(t, `ALTER DATABASE system ADD REGION "us-east2"`)
 	sDB.Exec(t, `ALTER DATABASE system ADD REGION "us-east3"`)

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -49,7 +49,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 
 			require.NoError(t, WaitFor3XReplication(ctx, t, t.L(), conn))
 
-			_, err := conn.ExecContext(ctx, "SET CLUSTER SETTING sql.multiregion.preview_multiregion_system_database.enabled = true")
+			_, err := conn.ExecContext(ctx, "SET CLUSTER SETTING sql.multiregion.system_database_multiregion.enabled = true")
 			require.NoError(t, err)
 
 			_, err = conn.ExecContext(ctx,

--- a/pkg/sql/sqlclustersettings/clustersettings.go
+++ b/pkg/sql/sqlclustersettings/clustersettings.go
@@ -83,7 +83,7 @@ var SecondaryTenantsAllZoneConfigsEnabled = settings.RegisterBoolSetting(
 // to be set up to be multi-region.
 var MultiRegionSystemDatabaseEnabled = settings.RegisterBoolSetting(
 	settings.SystemVisible,
-	"sql.multiregion.preview_multiregion_system_database.enabled",
+	"sql.multiregion.system_database_multiregion.enabled",
 	"enable option to set up system database as multi-region",
 	false,
 )


### PR DESCRIPTION
Avoid using the word "preview" in the name. That shouldn't be needed, since the cluster setting is hidden, so users would only know about it if we tell them to enable it. Keeping "preview" in the name isn't a huge problem, but it's just slightly annoying if we decide that we want to keep the setting around even after the feature leaves the "preview" status, since it requires updating docs and any customer code that was using the old name.

Also, this removes the mention of the setting in error messages. An error should not refer to an undocumented setting, since a user would have no way of learning more about it.

informs: https://github.com/cockroachdb/cockroach/issues/63365
Epic: CRDB-33032
Release note: None