### PR TITLE
workload: add query trace output option to tpcc workload

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,6 +93,8 @@ type tpcc struct {
 
 	replicateStaticColumns bool
 
+	queryTraceFile string
+
 	randomCIDsCache struct {
 		syncutil.Mutex
 		values [][]int
@@ -137,6 +141,51 @@ func (w *waitSetter) String() string {
 	}
 }
 
+var _ pgx.QueryTracer = fileLoggerQueryTracer{}
+
+type fileLoggerQueryTracer struct {
+	file *os.File
+}
+
+func newFileLoggerQueryTracer(filePath string) (*fileLoggerQueryTracer, error) {
+	tracer := &fileLoggerQueryTracer{}
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+	tracer.file = file
+	return tracer, nil
+}
+
+func (t *fileLoggerQueryTracer) Close() error {
+	return errors.CombineErrors(
+		errors.Wrap(t.file.Sync(), "failed to sync query trace file"),
+		errors.Wrap(t.file.Close(), "failed to close query trace file"),
+	)
+}
+
+func (t fileLoggerQueryTracer) Write(p []byte) (n int, err error) {
+	return t.file.Write(p)
+}
+
+func (t fileLoggerQueryTracer) TraceQueryStart(
+	ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData,
+) context.Context {
+	whitespacePattern := regexp.MustCompile(`\s+`)
+	fmt.Fprintf(t, "Query: %s\n", whitespacePattern.ReplaceAllString(strings.TrimSpace(data.SQL), " "))
+	return ctx
+}
+
+func (t fileLoggerQueryTracer) TraceQueryEnd(
+	ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData,
+) {
+	if data.Err == nil {
+		fmt.Fprintf(t, "CommandTag: %s\n", data.CommandTag.String())
+	} else {
+		fmt.Fprintf(t, "Error: %s\n", data.Err)
+	}
+}
+
 func init() {
 	workload.Register(tpccMeta)
 }
@@ -177,6 +226,7 @@ var tpccMeta = workload.Meta{
 			`survival-goal`:            {RuntimeOnly: true},
 			`replicate-static-columns`: {RuntimeOnly: true},
 			`deprecated-fk-indexes`:    {RuntimeOnly: true},
+			`query-trace-file`:         {RuntimeOnly: true},
 		}
 
 		g.flags.IntVar(&g.warehouses, `warehouses`, 1, `Number of warehouses for loading`)
@@ -213,6 +263,7 @@ var tpccMeta = workload.Meta{
 		g.flags.BoolVar(&g.separateColumnFamilies, `families`, false, `Use separate column families for dynamic and static columns`)
 		g.flags.BoolVar(&g.replicateStaticColumns, `replicate-static-columns`, false, "Create duplicate indexes for all static columns in district, items and warehouse tables, such that each zone or rack has them locally.")
 		g.flags.BoolVar(&g.localWarehouses, `local-warehouses`, false, `Force transactions to use a local warehouse in all cases (in violation of the TPC-C specification)`)
+		g.flags.StringVar(&g.queryTraceFile, `query-trace-file`, ``, `File to write the query traces to. Defaults to no output`)
 		RandomSeed.AddFlag(&g.flags)
 		g.connFlags = workload.NewConnFlags(&g.flags)
 
@@ -338,6 +389,10 @@ func (w *tpcc) Hooks() workload.Hooks {
 			if w.waitFraction > 0 && w.workers != w.activeWarehouses*NumWorkersPerWarehouse {
 				return errors.Errorf(`--wait > 0 and --warehouses=%d requires --workers=%d`,
 					w.activeWarehouses, w.warehouses*NumWorkersPerWarehouse)
+			}
+
+			if w.queryTraceFile != `` && w.workers != 1 {
+				return errors.Errorf(`--query-trace-file must be used with exactly one worker`)
 			}
 
 			w.auditor = newAuditor(w.activeWarehouses)
@@ -753,6 +808,17 @@ func (w *tpcc) Ops(
 	cfg.MaxConnsPerPool = w.connFlags.Concurrency
 	fmt.Printf("Initializing %d connections...\n", w.numConns)
 
+	// Set up the query tracer.
+	var tracer *fileLoggerQueryTracer
+	if w.queryTraceFile != `` {
+		var err error
+		tracer, err = newFileLoggerQueryTracer(w.queryTraceFile)
+		if err != nil {
+			return workload.QueryLoad{}, err
+		}
+		cfg.QueryTracer = tracer
+	}
+
 	dbs := make([]*workload.MultiConnPool, len(urls))
 	var g errgroup.Group
 	for i := range urls {
@@ -882,6 +948,11 @@ func (w *tpcc) Ops(
 	ql.Close = func(context context.Context) error {
 		for _, conn := range conns {
 			if err := conn.Close(ctx); err != nil {
+				log.Warningf(ctx, "%v", err)
+			}
+		}
+		if tracer != nil {
+			if err := tracer.Close(); err != nil {
 				log.Warningf(ctx, "%v", err)
 			}
 		}


### PR DESCRIPTION
Adds a `--query-trace-file` option to `tpcc` workload to allow for tracing of any SQL queries run in the workload. This will be used to facilitate the evaluation of queries in certain roachtests

Epic: none

Release note: none

## Sample Output

```
> cockroach workload run tpcc --init --warehouses=1 --workers=1 --wait=false --query-trace-file=log.txt
```

```
[...]
Query: new-order-1
CommandTag: UPDATE 1
Query: new-order-2
CommandTag: SELECT 1
Query: new-order-3
CommandTag: SELECT 1
Query: SELECT i_price, i_name, i_data FROM item WHERE i_id IN (8527, 16276, 17268, 41331, 47721, 57484, 77076, 86499, 94612, 98160) ORDER BY i_id
CommandTag: SELECT 10
Query: SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_01 FROM stock WHERE (s_i_id, s_w_id) IN ((8527, 0), (16276, 0), (17268, 0), (41331, 0), (47721, 0), (57484, 0), (77076, 0), (86499, 0), (94612, 0), (98160, 0)) ORDER BY s_i_id FOR UPDATE
CommandTag: SELECT 10
Query: new-order-4
CommandTag: INSERT 0 1
Query: new-order-5
CommandTag: INSERT 0 1
Query: UPDATE stock SET s_quantity = CASE (s_i_id, s_w_id) WHEN (8527, 0) THEN 94 WHEN (16276, 0) THEN 37 WHEN (17268, 0) THEN 53 WHEN (41331, 0) THEN 30 WHEN (47721, 0) THEN 19 WHEN (57484, 0) THEN 44 WHEN (77076, 0) THEN 79 WHEN (86499, 0) THEN 90 WHEN (94612, 0) THEN 90 WHEN (98160, 0) THEN 10 ELSE crdb_internal.force_error('', 'unknown case') END, s_ytd = CASE (s_i_id, s_w_id) WHEN (8527, 0) THEN 2 WHEN (16276, 0) THEN 4 WHEN (17268, 0) THEN 6 WHEN (41331, 0) THEN 2 WHEN (47721, 0) THEN 10 WHEN (57484, 0) THEN 4 WHEN (77076, 0) THEN 1 WHEN (86499, 0) THEN 3 WHEN (94612, 0) THEN 10 WHEN (98160, 0) THEN 1 END, s_order_cnt = CASE (s_i_id, s_w_id) WHEN (8527, 0) THEN 1 WHEN (16276, 0) THEN 1 WHEN (17268, 0) THEN 1 WHEN (41331, 0) THEN 1 WHEN (47721, 0) THEN 1 WHEN (57484, 0) THEN 1 WHEN (77076, 0) THEN 1 WHEN (86499, 0) THEN 1 WHEN (94612, 0) THEN 1 WHEN (98160, 0) THEN 1 END, s_remote_cnt = CASE (s_i_id, s_w_id) WHEN (8527, 0) THEN 0 WHEN (16276, 0) THEN 0 WHEN (17268, 0) THEN 0 WHEN (41331, 0) THEN 0 WHEN (47721, 0) THEN 0 WHEN (57484, 0) THEN 0 WHEN (77076, 0) THEN 0 WHEN (86499, 0) THEN 0 WHEN (94612, 0) THEN 0 WHEN (98160, 0) THEN 0 END WHERE (s_i_id, s_w_id) IN ((8527, 0), (16276, 0), (17268, 0), (41331, 0), (47721, 0), (57484, 0), (77076, 0), (86499, 0), (94612, 0), (98160, 0))
CommandTag: UPDATE 10
Query: INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info) VALUES (3001,1,0,2,8527,0,2,171.940000,'URuRZTKr6BFStKKq2dDxwUIr'), (3001,1,0,1,16276,0,4,77.600000,'X3vQolpn3F33F7SM7oWvGRPP'), (3001,1,0,4,17268,0,6,203.940000,'AB46F6SPCURuRZTKr6BFStKK'), (3001,1,0,7,41331,0,2,181.360000,'JX3vQolpn3F33F7SM7oWvGRP'), (3001,1,0,8,47721,0,10,265.800000,'PxqqVY8sNAB46F6SPCURuRZT'), (3001,1,0,10,57484,0,4,22.160000,'F6SPCURuRZTKr6BFStKKq2dD'), (3001,1,0,3,77076,0,1,42.910000,'LZp6m0JTJX3vQolpn3F33F7S'), (3001,1,0,5,86499,0,3,166.980000,'7SM7oWvGRPPxqqVY8sNAB46F'), (3001,1,0,9,94612,0,10,642.000000,'pn3F33F7SM7oWvGRPPxqqVY8'), (3001,1,0,6,98160,0,1,87.710000,'SPCURuRZTKr6BFStKKq2dDxw')
CommandTag: INSERT 0 10
Query: RELEASE SAVEPOINT cockroach_restart
CommandTag: COMMIT
Query: commit
CommandTag: COMMIT
[...]
```

> Note: This does not output the actual results of the queries, but rather the command tag information provided by `pgx.QueryTracer`