### PR TITLE
stats: set the type resolver when dealing with virtual comp cols

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -378,6 +378,7 @@ func createStatsDefaultColumns(
 	cannotDistribute := make([]bool, len(desc.PublicColumns()))
 	if virtColEnabled {
 		semaCtx := tree.MakeSemaContext()
+		semaCtx.TypeResolver = evalCtx.Planner
 		exprs, _, err := schemaexpr.MakeComputedExprs(
 			ctx,
 			desc.PublicColumns(),

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -454,6 +454,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if len(virtComputedCols) != 0 {
 		// Resolve names and types.
 		semaCtx := tree.MakeSemaContext()
+		semaCtx.TypeResolver = planCtx.planner
 		virtComputedExprs, _, err := schemaexpr.MakeComputedExprs(
 			ctx,
 			virtComputedCols,

--- a/pkg/sql/logictest/testdata/logic_test/stats
+++ b/pkg/sql/logictest/testdata/logic_test/stats
@@ -39,3 +39,14 @@ SELECT CASE
   END
 ----
 true
+
+# Regression for not setting the TypeResolver on the SemaContext when dealing
+# with stats on virtual computed columns (#122312).
+statement ok
+CREATE TYPE greeting AS ENUM ('hello', 'hi', 'yo');
+
+statement ok
+CREATE TABLE t122312 (s STRING, g greeting AS (s::greeting) STORED);
+
+statement ok
+ANALYZE t122312;


### PR DESCRIPTION
We forgot to set the type resolver on the sema context that we create when dealing with virtual computed columns, and as a result stats collection on tables with such columns now might fail altogether. In a separate change I'll audit all callers of `MakeSemaContext` to prevent such a mistake in the future.

Fixes: #122312.

Release note (bug fix): CockroachDB could fail to collect table statistics on tables that have virtual computed columns of user-defined type if `sql.stats.virtual_computed_columns.enabled` cluster setting is enabled. The setting is introduced in 23.2.4 version and is disabled by default, so only this particular version is affected with non-default setting.