### PR TITLE
tree: add resolver argument to MakeSemaContext

### DIFF
--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -56,9 +56,7 @@ var testTypeResolver = tree.MakeTestingMapTypeResolver(testTypes)
 const primary = descpb.FamilyID(0)
 
 func makeTestSemaCtx() tree.SemaContext {
-	testSemaCtx := tree.MakeSemaContext()
-	testSemaCtx.TypeResolver = testTypeResolver
-	return testSemaCtx
+	return tree.MakeSemaContext(testTypeResolver)
 }
 
 func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {

--- a/pkg/ccl/changefeedccl/cdceval/functions_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions_test.go
@@ -53,7 +53,7 @@ func TestEvaluatesCDCFunctionOverloads(t *testing.T) {
 	ctx := context.Background()
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	defer configSemaForCDC(&semaCtx, hlc.Timestamp{})()
 
 	t.Run("time", func(t *testing.T) {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1750,7 +1750,7 @@ func makeKafkaFeedFactory(srvOrCluster interface{}, rootDB *gosql.DB) cdctest.Te
 
 func exprAsString(expr tree.Expr) (string, error) {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	te, err := expr.TypeCheck(context.Background(), &semaCtx, types.String)
 	if err != nil {
 		return "", err

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -350,7 +350,7 @@ func (pt partitioningTest) parse() (parsed parsedPartitioningTest, _ error) {
 
 	{
 		ctx := context.Background()
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		stmt, err := parser.ParseOne(parsed.createStmt)
 		if err != nil {
 			return parsed, errors.Wrapf(err, `parsing %s`, parsed.createStmt)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -791,8 +791,7 @@ func (sc *SchemaChanger) validateConstraints(
 				// Use the DistSQLTypeResolver because we need to resolve types by ID.
 				collection := evalCtx.Descs
 				resolver := descs.NewDistSQLTypeResolver(collection, txn.KV())
-				semaCtx := tree.MakeSemaContext()
-				semaCtx.TypeResolver = &resolver
+				semaCtx := tree.MakeSemaContext(&resolver)
 				semaCtx.NameResolver = NewSkippingCacheSchemaResolver(
 					txn.Descriptors(),
 					sessiondata.NewStack(NewInternalSessionData(ctx, sc.settings, "validate constraint")),
@@ -1553,9 +1552,7 @@ func ValidateConstraint(
 	) error {
 		// Use a schema resolver because we need to resolve types by ID and table by name.
 		resolver := NewSkippingCacheSchemaResolver(txn.Descriptors(), sessiondata.NewStack(sessionData), txn.KV(), nil /* authAccessor */)
-		semaCtx := tree.MakeSemaContext()
-		semaCtx.TypeResolver = resolver
-		semaCtx.NameResolver = resolver
+		semaCtx := tree.MakeSemaContext(resolver)
 		semaCtx.FunctionResolver = descs.NewDistSQLFunctionResolver(txn.Descriptors(), txn.KV())
 		defer func() { txn.Descriptors().ReleaseAll(ctx) }()
 

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -234,8 +234,7 @@ func (cb *ColumnBackfiller) InitForDistributedUse(
 			return err
 		}
 		// Set up a SemaContext to type check the default and computed expressions.
-		semaCtx := tree.MakeSemaContext()
-		semaCtx.TypeResolver = &resolver
+		semaCtx := tree.MakeSemaContext(&resolver)
 		semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(evalCtx.Settings.Version)
 		var err error
 		defaultExprs, err = schemaexpr.MakeDefaultExprs(
@@ -669,8 +668,7 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 			return err
 		}
 		// Set up a SemaContext to type check the default and computed expressions.
-		semaCtx := tree.MakeSemaContext()
-		semaCtx.TypeResolver = &resolver
+		semaCtx := tree.MakeSemaContext(&resolver)
 		semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(evalCtx.Settings.Version)
 		// Convert any partial index predicate strings into expressions.
 		predicates, colExprs, referencedColumns, err = constructExprs(

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -159,7 +159,7 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context, output execinfra.RowRec
 		output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
 	}
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	if err := ibm.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, ibm.flowCtx.NewEvalCtx()); err != nil {
 		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestIndexForDisplay(t *testing.T) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	database := tree.Name("foo")
 	table := tree.Name("bar")

--- a/pkg/sql/catalog/schemaexpr/check_constraint_test.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCheckConstraintBuilder_Build(t *testing.T) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	// Trick to get the init() for the builtins package to run.
 	_ = builtins.AllBuiltinNames()
@@ -147,7 +147,7 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 
 func TestCheckConstraintBuilder_DefaultName(t *testing.T) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	database := tree.Name("foo")
 	table := tree.Name("bar")

--- a/pkg/sql/catalog/schemaexpr/expr_test.go
+++ b/pkg/sql/catalog/schemaexpr/expr_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestValidateExpr(t *testing.T) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	// Trick to get the init() for the builtins package to run.
 	_ = builtins.AllBuiltinNames()

--- a/pkg/sql/catalog/schemaexpr/partial_index_test.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestIndexPredicateValidator_Validate(t *testing.T) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	// Trick to get the init() for the builtins package to run.
 	_ = builtins.AllBuiltinNames()

--- a/pkg/sql/catalog/seqexpr/sequence_test.go
+++ b/pkg/sql/catalog/seqexpr/sequence_test.go
@@ -43,7 +43,7 @@ func TestGetSequenceFromFunc(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -93,7 +93,7 @@ func TestGetUsedSequences(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -144,7 +144,7 @@ func TestReplaceSequenceNamesWithIDs(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -223,7 +223,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	}
 	inputCols := []int{0, 1, 2}
 	p := &colexectestutils.MockTypeContext{Typs: typs}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.IVarContainer = p
 	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 	if err != nil {

--- a/pkg/sql/colexec/colexectestutils/proj_utils.go
+++ b/pkg/sql/colexec/colexectestutils/proj_utils.go
@@ -64,7 +64,7 @@ func CreateTestProjectingOperator(
 		return nil, err
 	}
 	p := &MockTypeContext{Typs: inputTypes}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.IVarContainer = p
 	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 	if err != nil {

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -740,7 +740,7 @@ func stringToDatum(val string, typ *types.T, evalCtx *eval.Context) tree.Datum {
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	typedExpr, err := tree.TypeCheck(context.Background(), expr, &semaCtx, typ)
 	if err != nil {
 		colexecerror.InternalError(err)

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -63,7 +63,7 @@ func TestWindowFunctions(t *testing.T) {
 		},
 		DiskMonitor: testDiskMonitor,
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
 	var monitorRegistry colexecargs.MonitorRegistry
@@ -1102,7 +1102,7 @@ func BenchmarkWindowFunctions(b *testing.B) {
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	const (
 		memLimit        = 64 << 20

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -136,7 +136,7 @@ func TestDefaultAggregateFunc(t *testing.T) {
 	aggMemAcc := evalCtx.TestingMon.MakeBoundAccount()
 	defer aggMemAcc.Close(context.Background())
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	for _, agg := range aggTypes {
 		for _, tc := range testCases {
 			t.Run(fmt.Sprintf("%s/%s", agg.name, tc.name), func(t *testing.T) {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1196,8 +1196,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			}
 			numOldMonitors := len(s.monitorRegistry.GetMonitors())
 			if args.ExprHelper.SemaCtx == nil {
-				semaCtx := tree.MakeSemaContext()
-				semaCtx.TypeResolver = &s.typeResolver
+				semaCtx := tree.MakeSemaContext(&s.typeResolver)
 				args.ExprHelper.SemaCtx = &semaCtx
 			}
 			var result *colexecargs.NewColOperatorResult

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -377,8 +377,7 @@ func createStatsDefaultColumns(
 	// local-only virtual computed column expression is needed.
 	cannotDistribute := make([]bool, len(desc.PublicColumns()))
 	if virtColEnabled {
-		semaCtx := tree.MakeSemaContext()
-		semaCtx.TypeResolver = evalCtx.Planner
+		semaCtx := tree.MakeSemaContext(evalCtx.Planner)
 		exprs, _, err := schemaexpr.MakeComputedExprs(
 			ctx,
 			desc.PublicColumns(),

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -671,7 +671,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 		// metadata, so we can use a nil rowContainerHelper.
 		resultWriter := NewRowResultWriter(nil /* rowContainer */)
 		if err := dsp.planAndRunCreateStats(
-			ctx, evalCtx, planCtx, txn.KV(), r.job, resultWriter,
+			ctx, evalCtx, planCtx, p.SemaCtx(), txn.KV(), r.job, resultWriter,
 		); err != nil {
 			// Check if this was a context canceled error and restart if it was.
 			if grpcutil.IsContextCanceled(err) {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3700,8 +3700,9 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 			if err != nil {
 				return nil, err
 			}
-			plan, err = dsp.createPlanForCreateStats(ctx, planCtx, 0, /* jobID */
-				record.Details.(jobspb.CreateStatsDetails))
+			plan, err = dsp.createPlanForCreateStats(
+				ctx, planCtx, planCtx.planner.SemaCtx(), 0 /* jobID */, record.Details.(jobspb.CreateStatsDetails),
+			)
 		}
 
 	case *distinctNode:

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -168,8 +168,7 @@ func (flowCtx *FlowCtx) NewTypeResolver(txn *kv.Txn) descs.DistSQLTypeResolver {
 // input transaction.
 func (flowCtx *FlowCtx) NewSemaContext(txn *kv.Txn) *tree.SemaContext {
 	resolver := flowCtx.NewTypeResolver(txn)
-	semaCtx := tree.MakeSemaContext()
-	semaCtx.TypeResolver = &resolver
+	semaCtx := tree.MakeSemaContext(&resolver)
 	return &semaCtx
 }
 

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -786,8 +786,7 @@ func (pb *ProcessorBase) InitWithEvalCtx(
 	if err := resolver.HydrateTypeSlice(ctx, coreOutputTypes); err != nil {
 		return err
 	}
-	pb.SemaCtx = tree.MakeSemaContext()
-	pb.SemaCtx.TypeResolver = &resolver
+	pb.SemaCtx = tree.MakeSemaContext(&resolver)
 
 	return pb.OutputHelper.Init(ctx, post, coreOutputTypes, &pb.SemaCtx, pb.EvalCtx)
 }

--- a/pkg/sql/execinfrapb/expr_test.go
+++ b/pkg/sql/execinfrapb/expr_test.go
@@ -29,7 +29,7 @@ func TestDeserializeExpr(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	expr, err := DeserializeExpr(
 		context.Background(),
 		e,
@@ -88,7 +88,7 @@ func TestDeserializeExpressionConstantEval(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	expr, err := DeserializeExpr(
 		context.Background(),
 		e,

--- a/pkg/sql/exprutil/evaluator_test.go
+++ b/pkg/sql/exprutil/evaluator_test.go
@@ -28,7 +28,7 @@ func TestEvalAsString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	sc := tree.MakeSemaContext()
+	sc := tree.MakeSemaContext(nil /* resolver */)
 	s := cluster.MakeTestingClusterSettings()
 	exprEval := exprutil.MakeEvaluator(
 		"test", &sc, eval.NewTestingEvalContext(s),

--- a/pkg/sql/function_resolver_test.go
+++ b/pkg/sql/function_resolver_test.go
@@ -411,9 +411,7 @@ CREATE FUNCTION sc1.lower(a STRING) RETURNS STRING VOLATILE LANGUAGE SQL AS $$ S
 		// Set "defaultdb" as current database.
 		ec.SessionData().Database = "defaultdb"
 
-		funcResolver := planner.(tree.FunctionReferenceResolver)
-		semaCtx := tree.MakeSemaContext()
-		semaCtx.FunctionResolver = funcResolver
+		semaCtx := tree.MakeSemaContext(planner)
 
 		for _, tc := range testCases {
 			t.Run(tc.testName, func(t *testing.T) {

--- a/pkg/sql/importer/bench_test.go
+++ b/pkg/sql/importer/bench_test.go
@@ -53,7 +53,7 @@ func toTableDescriptor(
 	t workload.Table, tableID descpb.ID, ts time.Time,
 ) (catalog.TableDescriptor, error) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	stmt, err := parser.ParseOne(fmt.Sprintf(`CREATE TABLE "%s" %s`, t.Name, t.Schema))
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 				Codec:            keys.SystemSQLCodec,
 				Settings:         cluster.MakeTestingClusterSettings(),
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			return wc.Worker(ctx, evalCtx, &semaCtx)
 		})
 		for kvBatch := range kvCh {

--- a/pkg/sql/importer/csv_internal_test.go
+++ b/pkg/sql/importer/csv_internal_test.go
@@ -74,7 +74,7 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 	tableID := parentID + 2
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	for _, tc := range tests {
 		t.Run(tc.stmt, func(t *testing.T) {

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -144,7 +144,7 @@ func newCSVWriterProcessor(
 		spec:        spec,
 		input:       input,
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -67,7 +67,7 @@ func newParquetWriterProcessor(
 		spec:        spec,
 		input:       input,
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -125,7 +125,7 @@ func TestConverterFlushesBatches(t *testing.T) {
 				}
 
 				kvCh := make(chan row.KVBatch, batchSize)
-				semaCtx := tree.MakeSemaContext()
+				semaCtx := tree.MakeSemaContext(nil /* resolver */)
 				conv, err := makeInputConverter(ctx, &semaCtx, converterSpec, &evalCtx, kvCh,
 					nil /* seqChunkProvider */, db)
 				if err != nil {

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -4062,7 +4062,7 @@ func BenchmarkCSVConvertRecord(b *testing.B) {
 
 	create := stmt.AST.(*tree.CreateTable)
 	st := cluster.MakeTestingClusterSettings()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 
 	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), NoFKs, 1)
@@ -5013,7 +5013,7 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 	}
 	create := stmt.AST.(*tree.CreateTable)
 	st := cluster.MakeTestingClusterSettings()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 
 	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaIDForBackup, descpb.ID(100), NoFKs, 1)
@@ -5115,7 +5115,7 @@ func BenchmarkPgCopyConvertRecord(b *testing.B) {
 		b.Fatal(err)
 	}
 	create := stmt.AST.(*tree.CreateTable)
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
 

--- a/pkg/sql/importer/read_import_avro_test.go
+++ b/pkg/sql/importer/read_import_avro_test.go
@@ -254,7 +254,7 @@ func (th *testHelper) newRecordStream(
 		opts.SchemaJSON = th.schemaJSON
 		th.genRecordsData(t, format, numRecords, opts.RecordSeparator, records)
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	avro, err := newAvroInputReader(&semaCtx, nil, th.schemaTable, opts, 0, 1, &th.evalCtx, db)
 	require.NoError(t, err)
@@ -590,7 +590,7 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 
 	create := stmt.AST.(*tree.CreateTable)
 	st := cluster.MakeTestingClusterSettings()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 
 	tableDesc, err := MakeTestingSimpleTableDescriptor(ctx, &semaCtx, st, create, descpb.ID(100), keys.PublicSchemaID, descpb.ID(100), NoFKs, 1)

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -71,8 +71,7 @@ func runImport(
 
 	evalCtx := flowCtx.NewEvalCtx()
 	evalCtx.Regions = makeImportRegionOperator(spec.DatabasePrimaryRegion)
-	semaCtx := tree.MakeSemaContext()
-	semaCtx.TypeResolver = importResolver
+	semaCtx := tree.MakeSemaContext(importResolver)
 	conv, err := makeInputConverter(ctx, &semaCtx, spec, evalCtx, kvCh, seqChunkProvider, flowCtx.Cfg.DB.KV())
 	if err != nil {
 		return nil, err

--- a/pkg/sql/importer/read_import_base_test.go
+++ b/pkg/sql/importer/read_import_base_test.go
@@ -135,7 +135,7 @@ func TestParallelImportProducerHandlesConsumerErrors(t *testing.T) {
 	}()
 
 	// Prepare import context, which flushes to kvCh frequently.
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	importCtx := &parallelImportContext{
 		semaCtx:    &semaCtx,
 		numWorkers: 1,
@@ -176,7 +176,7 @@ func TestParallelImportProducerHandlesCancellation(t *testing.T) {
 	}()
 
 	// Prepare import context, which flushes to kvCh frequently.
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	importCtx := &parallelImportContext{
 		numWorkers: 1,
 		batchSize:  2,

--- a/pkg/sql/importer/read_import_mysql.go
+++ b/pkg/sql/importer/read_import_mysql.go
@@ -526,11 +526,13 @@ func mysqlTableToCockroach(
 		stmt.Defs = append(stmt.Defs, c)
 	}
 
-	semaCtx := tree.MakeSemaContext()
-	semaCtxPtr := &semaCtx
+	var semaCtxPtr *tree.SemaContext
 	// p is nil in some tests.
 	if p != nil && p.SemaCtx() != nil {
 		semaCtxPtr = p.SemaCtx()
+	} else {
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
+		semaCtxPtr = &semaCtx
 	}
 
 	// Bundle imports do not support user defined types, and so we nil out the

--- a/pkg/sql/importer/read_import_mysql_test.go
+++ b/pkg/sql/importer/read_import_mysql_test.go
@@ -62,7 +62,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 	opts := roachpb.MysqldumpOptions{}
 
 	kvCh := make(chan row.KVBatch, 50)
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	// When creating a new dump reader, we need to pass in the walltime that will be used as
 	// a parameter used for generating unique rowid, random, and gen_random_uuid as default
 	// expressions. Here, the parameter doesn't matter so we pass in 0.
@@ -302,7 +302,7 @@ func compareTables(t *testing.T, expected, got *descpb.TableDescriptor) {
 	sd := &sessiondata.SessionData{}
 	for i := range expected.Indexes {
 		ctx := context.Background()
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		tableName := &descpb.AnonymousTable
 		expectedDesc := tabledesc.NewBuilder(expected).BuildImmutableTable()
 		gotDesc := tabledesc.NewBuilder(got).BuildImmutableTable()

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -783,7 +783,7 @@ func readPostgresStmt(
 				switch expr := selExpr.Expr.(type) {
 				case *tree.FuncExpr:
 					// Look for function calls that mutate schema (this is actually a thing).
-					semaCtx := tree.MakeSemaContext()
+					semaCtx := tree.MakeSemaContext(nil /* resolver */)
 					semaCtx.Properties.Require("pg_dump function arguments", tree.RejectSubqueries)
 					if _, err := expr.TypeCheck(ctx, &semaCtx, nil /* desired */); err != nil {
 						// If the expression does not type check, it may be a case of using
@@ -1065,7 +1065,7 @@ func (m *pgDumpReader) readFile(
 	var inserts, count int64
 	rowLimit := m.opts.RowLimit
 	ps := newPostgreStream(ctx, input, int(m.opts.MaxRowSize), m.unsupportedStmtLogger)
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	for _, conv := range m.tables {
 		conv.KvBatch.Source = inputIdx
 		conv.FractionFn = input.ReadFraction

--- a/pkg/sql/importer/testutils_test.go
+++ b/pkg/sql/importer/testutils_test.go
@@ -84,7 +84,7 @@ func descForTable(
 	} else {
 		stmt = parsed[0].AST.(*tree.CreateTable)
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	table, err := MakeTestingSimpleTableDescriptor(context.Background(), &semaCtx, settings, stmt, parent, parentSchemaID, id, fks, nanos)
 	if err != nil {
 		t.Fatalf("could not interpret %q: %v", create, err)

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -716,7 +716,7 @@ type harness struct {
 func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 	h := &harness{
 		ctx:     context.Background(),
-		semaCtx: tree.MakeSemaContext(),
+		semaCtx: tree.MakeSemaContext(nil /* resolver */),
 		evalCtx: eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
 

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -62,7 +62,7 @@ func TestIndexConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	datadriven.Walk(t, tu.TestDataPath(t), func(t *testing.T, path string) {
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
@@ -229,7 +229,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 		testCases = append(testCases, tc)
 	}
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	for _, tc := range testCases {

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestTryJoinGeoIndex(t *testing.T) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 
@@ -315,7 +315,7 @@ func TestTryJoinGeoIndex(t *testing.T) {
 }
 
 func TestTryFilterGeoIndex(t *testing.T) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestTryJoinJsonOrArrayIndex(t *testing.T) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 
@@ -219,7 +219,7 @@ func TestTryJoinJsonOrArrayIndex(t *testing.T) {
 }
 
 func TestTryFilterJsonOrArrayIndex(t *testing.T) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 

--- a/pkg/sql/opt/invertedidx/trigram_test.go
+++ b/pkg/sql/opt/invertedidx/trigram_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestTryFilterTrigram(t *testing.T) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 

--- a/pkg/sql/opt/invertedidx/tsearch_test.go
+++ b/pkg/sql/opt/invertedidx/tsearch_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestTryFilterTSVector(t *testing.T) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -57,7 +57,7 @@ func TestLookupConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	datadriven.Walk(t, tu.TestDataPath(t), func(t *testing.T, path string) {
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 		evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
 

--- a/pkg/sql/opt/memo/expr_test.go
+++ b/pkg/sql/opt/memo/expr_test.go
@@ -62,7 +62,7 @@ func TestExprIsNeverNull(t *testing.T) {
 			switch d.Cmd {
 			case "scalar-is-not-nullable":
 				ctx := context.Background()
-				semaCtx := tree.MakeSemaContext()
+				semaCtx := tree.MakeSemaContext(nil /* resolver */)
 				evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 				var o xform.Optimizer

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -67,7 +67,7 @@ func TestStatsQuality(t *testing.T) {
 
 func TestCompositeSensitive(t *testing.T) {
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "composite_sensitive"), func(t *testing.T, d *datadriven.TestData) string {
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 		var f norm.Factory

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -76,7 +76,7 @@ func TestBuilder(t *testing.T) {
 				tester.Flags.ExprFormat &= ^(memo.ExprFmtHideScalars | memo.ExprFmtHideTypes)
 
 				ctx := context.Background()
-				semaCtx := tree.MakeSemaContext()
+				semaCtx := tree.MakeSemaContext(nil /* resolver */)
 				evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 				evalCtx.SessionData().OptimizerUseForecasts = true
 				evalCtx.SessionData().OptimizerUseHistograms = true

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1593,7 +1593,7 @@ func (s *scope) replaceCount(
 			}
 			// We call TypeCheck to fill in FuncExpr internals. This is a fixed
 			// expression; we should not hit an error here.
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			if _, err := e.TypeCheck(s.builder.ctx, &semaCtx, types.Any); err != nil {
 				panic(err)
 			}

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -53,7 +53,7 @@ func TestImplicator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	datadriven.Walk(t, tu.TestDataPath(t, "implicator"), func(t *testing.T, path string) {
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
@@ -263,7 +263,7 @@ func BenchmarkImplicator(b *testing.B) {
 		testCases = append(testCases, tc)
 	}
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	for _, tc := range testCases {

--- a/pkg/sql/opt/testutils/build.go
+++ b/pkg/sql/opt/testutils/build.go
@@ -35,8 +35,7 @@ func BuildQuery(
 	}
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
-	semaCtx.FunctionResolver = catalog
+	semaCtx := tree.MakeSemaContext(catalog)
 	semaCtx.SearchPath = &evalCtx.SessionData().SearchPath
 	semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
 	semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -277,7 +277,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 		catalog: catalog,
 		sql:     sql,
 		ctx:     ctx,
-		semaCtx: tree.MakeSemaContext(),
+		semaCtx: tree.MakeSemaContext(catalog),
 		evalCtx: eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
 	ot.f = &norm.Factory{}
@@ -287,7 +287,6 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.Flags.ctx = ot.ctx
 	ot.Flags.evalCtx = ot.evalCtx
 	ot.semaCtx.SearchPath = tree.EmptySearchPath
-	ot.semaCtx.FunctionResolver = ot.catalog
 	// To allow opttester tests to use now(), we hardcode a preset transaction
 	// time. May 10, 2017 is a historic day: the release date of CockroachDB 1.0.
 	ot.evalCtx.TxnTimestamp = time.Date(2017, 05, 10, 13, 0, 0, 0, time.UTC)

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -57,7 +57,7 @@ func (tc *Catalog) AlterTable(stmt *tree.AlterTable) {
 // injectTableStats sets the table statistics as specified by a JSON object.
 func injectTableStats(tt *Table, statsExpr tree.Expr, tc *Catalog) {
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	typedExpr, err := tree.TypeCheckAndRequire(ctx, statsExpr, &semaCtx, types.Jsonb, "INJECT STATISTICS")
 	if err != nil {

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -963,7 +963,7 @@ func (tt *Table) addIndexWithVersion(
 	}
 	if partitionBy != nil {
 		ctx := context.Background()
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 		if len(partitionBy.List) > 0 {

--- a/pkg/sql/opt/testutils/testcat/table_expr.go
+++ b/pkg/sql/opt/testutils/testcat/table_expr.go
@@ -56,7 +56,7 @@ func typeCheckTableExpr(e tree.Expr, cols []cat.Column) *types.T {
 		panic(err)
 	}
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	typedExpr, err := resolved.TypeCheck(ctx, &semaCtx, types.Any)
 	if err != nil {
 		panic(err)

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -58,7 +58,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 	f.Close()
 
 	ctx := context.Background()
-	sema := tree.MakeSemaContext()
+	sema := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(nil)
 
 	for _, tc := range tests {

--- a/pkg/sql/physicalplan/aggregator_funcs.go
+++ b/pkg/sql/physicalplan/aggregator_funcs.go
@@ -140,7 +140,7 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 					Type: types.Float,
 				}
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx.IVarContainer = h.Container()
 			return expr.TypeCheck(context.TODO(), &semaCtx, types.Any)
 		},

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -413,11 +413,8 @@ func newInternalPlanner(
 	p.stmt = Statement{}
 	p.cancelChecker.Reset(ctx)
 
-	p.semaCtx = tree.MakeSemaContext()
+	p.semaCtx = tree.MakeSemaContext(p)
 	p.semaCtx.SearchPath = &sd.SearchPath
-	p.semaCtx.TypeResolver = p
-	p.semaCtx.FunctionResolver = p
-	p.semaCtx.NameResolver = p
 	p.semaCtx.DateStyle = sd.GetDateStyle()
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 	p.semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(execCfg.Settings.Version)
@@ -906,12 +903,9 @@ func (p *planner) resetPlanner(
 
 	p.cancelChecker.Reset(ctx)
 
-	p.semaCtx = tree.MakeSemaContext()
+	p.semaCtx = tree.MakeSemaContext(p)
 	p.semaCtx.SearchPath = &sd.SearchPath
 	p.semaCtx.Annotations = nil
-	p.semaCtx.TypeResolver = p
-	p.semaCtx.FunctionResolver = p
-	p.semaCtx.NameResolver = p
 	p.semaCtx.DateStyle = sd.GetDateStyle()
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 	p.semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(p.execCfg.Settings.Version)

--- a/pkg/sql/row/expr_walker.go
+++ b/pkg/sql/row/expr_walker.go
@@ -803,7 +803,7 @@ func (v *importDefaultExprVisitor) VisitPost(expr tree.Expr) (newExpr tree.Expr)
 func sanitizeExprsForImport(
 	ctx context.Context, evalCtx *eval.Context, expr tree.Expr, targetType *types.T,
 ) (tree.TypedExpr, overrideVolatility, error) {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	// If we have immutable expressions, then we can just return it right away.
 	typedExpr, err := schemaexpr.SanitizeVarFreeExpr(

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -1182,7 +1182,7 @@ func makeTrigramBinOp(
 	expr, err := parser.ParseExpr(fmt.Sprintf("'%s' %s '%s'", indexedValue, opstr, value))
 	require.NoError(t, err)
 
-	semaContext := tree.MakeSemaContext()
+	semaContext := tree.MakeSemaContext(nil /* resolver */)
 	typedExpr, err = tree.TypeCheck(context.Background(), expr, &semaContext, types.Bool)
 	require.NoError(t, err)
 	return typedExpr

--- a/pkg/sql/rowenc/roundtrip_format.go
+++ b/pkg/sql/rowenc/roundtrip_format.go
@@ -29,7 +29,7 @@ func ParseDatumStringAs(
 	// only parses the internal postgres string representation of arrays.
 	case types.ArrayFamily, types.CollatedStringFamily:
 		if semaCtx == nil {
-			sema := tree.MakeSemaContext()
+			sema := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx = &sema
 		}
 		return parseAsTyp(ctx, evalCtx, semaCtx, t, s)

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -100,7 +100,7 @@ func (sp *bulkRowWriter) work(ctx context.Context) error {
 	kvCh := make(chan row.KVBatch, 10)
 	var g ctxgroup.Group
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	conv, err := row.NewDatumRowConverter(
 		ctx, &semaCtx, sp.tableDesc, nil /* targetColNames */, sp.EvalCtx, kvCh, nil,
 		/* seqChunkProvider */ sp.flowCtx.GetRowMetrics(), sp.flowCtx.Cfg.DB.KV(),

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -114,7 +114,7 @@ func (*columnBackfiller) Resume(output execinfra.RowReceiver) {
 }
 
 func (cb *columnBackfiller) doRun(ctx context.Context) *execinfrapb.ProducerMetadata {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	if err := cb.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, cb.flowCtx.NewEvalCtx()); err != nil {
 		return &execinfrapb.ProducerMetadata{Err: err}
 	}

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -349,7 +349,7 @@ func (ib *indexBackfiller) Run(ctx context.Context, output execinfra.RowReceiver
 
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	if err := ib.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, ib.flowCtx.NewEvalCtx()); err != nil {
 		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -190,7 +190,7 @@ func TestPostProcess(t *testing.T) {
 			outBuf := &distsqlutils.RowBuffer{}
 
 			var out execinfra.ProcOutputHelper
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			if err := out.Init(context.Background(), &tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx); err != nil {

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -209,7 +209,7 @@ func ClassifyConversion(
 	}
 
 	// See if there's existing cast logic.  If so, return general.
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 
 	// Use a placeholder just to sub in the original type.

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -31,12 +31,9 @@ func (b buildCtx) SemaCtx() *tree.SemaContext {
 }
 
 func newSemaCtx(d Dependencies) *tree.SemaContext {
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(d.CatalogReader())
 	semaCtx.Annotations = nil
 	semaCtx.SearchPath = &d.SessionData().SearchPath
-	semaCtx.TypeResolver = d.CatalogReader()
-	semaCtx.FunctionResolver = d.CatalogReader()
-	semaCtx.NameResolver = d.CatalogReader()
 	semaCtx.DateStyle = d.SessionData().GetDateStyle()
 	semaCtx.IntervalStyle = d.SessionData().GetIntervalStyle()
 	semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(d.ClusterSettings().Version)

--- a/pkg/sql/schemachanger/sctest/comparator.go
+++ b/pkg/sql/schemachanger/sctest/comparator.go
@@ -326,7 +326,7 @@ WHERE id = '%v'::REGCLASS;`, name.String()))
 		sameShardBuckets := func(
 			currShardBuckets int32, newPKShardingDef *tree.ShardedIndexDef, newPKStorageParams tree.StorageParams,
 		) bool {
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			evalCtx := eval.Context{
 				Settings: cluster.MakeTestingClusterSettings(),
 			}

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7974,7 +7974,7 @@ func applyGeoindexConfigStorageParams(
 	if err != nil {
 		return geopb.Config{}, errors.Newf("invalid storage parameters specified: %s", params)
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	if err := storageparam.Set(
 		ctx,
 		&semaCtx,

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -84,7 +84,7 @@ func TestEval(t *testing.T) {
 	t.Run("no-opt", func(t *testing.T) {
 		walkExpr(t, func(e tree.Expr) (tree.TypedExpr, error) {
 			// expr.TypeCheck to avoid constant folding.
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedExpr, err := e.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				return nil, err
@@ -98,7 +98,7 @@ func optBuildScalar(evalCtx *eval.Context, e tree.Expr) (tree.TypedExpr, error) 
 	var o xform.Optimizer
 	ctx := context.Background()
 	o.Init(ctx, evalCtx, nil /* catalog */)
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	b := optbuilder.NewScalar(ctx, &semaCtx, evalCtx, o.Factory())
 	scalar, err := b.Build(e)
 	if err != nil {
@@ -202,7 +202,7 @@ func TestTimeConversion(t *testing.T) {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
 		}
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		typedExpr, err := expr.TypeCheck(context.Background(), &semaCtx, types.Timestamp)
 		if err != nil {
 			t.Errorf("%s: %v", exprStr, err)
@@ -363,7 +363,7 @@ func TestEvalError(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 		if err == nil {
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())

--- a/pkg/sql/sem/eval/eval_test/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test/eval_test.go
@@ -99,7 +99,7 @@ func TestEval(t *testing.T) {
 				t.Fatal(err)
 			}
 			// expr.TypeCheck to avoid constant folding.
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				// An error here should have been found above by QueryRow.
@@ -161,7 +161,7 @@ func TestEval(t *testing.T) {
 				// method returns an error, so skip it for execution.
 				return strings.TrimSpace(d.Expected)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				// Skip this test as it's testing an expected error which would be

--- a/pkg/sql/sem/normalize/constant_eval_test.go
+++ b/pkg/sql/sem/normalize/constant_eval_test.go
@@ -36,7 +36,7 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	typedExpr, err := expr.TypeCheck(context.Background(), &semaCtx, types.Any)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sem/normalize/normalize_test.go
+++ b/pkg/sql/sem/normalize/normalize_test.go
@@ -222,7 +222,7 @@ func TestNormalizeExpr(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
 			expr, err := parser.ParseExpr(d.expr)

--- a/pkg/sql/sem/tree/collatedstring_test.go
+++ b/pkg/sql/sem/tree/collatedstring_test.go
@@ -43,7 +43,7 @@ func TestCastToCollatedString(t *testing.T) {
 				Type:       cas.typ,
 				SyntaxMode: tree.CastShort,
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typedexpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -117,7 +117,7 @@ func TestNumericConstantVerifyAndResolveAvailableTypes(t *testing.T) {
 		// Make sure it can be resolved as each of those types.
 		for _, availType := range avail {
 			ctx := context.Background()
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			if res, err := c.ResolveAsType(ctx, &semaCtx, availType); err != nil {
 				t.Errorf("%d: expected resolving %v as available type %s would succeed, found %v",
 					i, c.ExactString(), availType, err)
@@ -219,7 +219,7 @@ func TestStringConstantVerifyAvailableTypes(t *testing.T) {
 				continue
 			}
 
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			if _, err := test.c.ResolveAsType(context.Background(), &semaCtx, availType); err != nil {
 				if !strings.Contains(err.Error(), "could not parse") &&
 					!strings.Contains(err.Error(), "invalid input syntax") {
@@ -684,7 +684,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 					continue
 				}
 
-				semaCtx := tree.MakeSemaContext()
+				semaCtx := tree.MakeSemaContext(nil /* resolver */)
 				typedExpr, err := test.c.ResolveAsType(context.Background(), &semaCtx, availType)
 				var res tree.Datum
 				if err == nil {

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -46,7 +46,7 @@ func prepareExpr(t *testing.T, datumExpr string) tree.Datum {
 	// Type checking ensures constant folding is performed and type
 	// annotations have come into effect.
 	ctx := context.Background()
-	sema := tree.MakeSemaContext()
+	sema := tree.MakeSemaContext(nil /* resolver */)
 	typedExpr, err := tree.TypeCheck(ctx, expr, &sema, types.Any)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -242,7 +242,7 @@ func TestFormatExpr(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			semaContext := tree.MakeSemaContext()
+			semaContext := tree.MakeSemaContext(nil /* resolver */)
 			typeChecked, err := tree.TypeCheck(ctx, expr, &semaContext, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -428,7 +428,7 @@ func TestFormatExpr2(t *testing.T) {
 	ctx := context.Background()
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.expr), func(t *testing.T) {
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typeChecked, err := tree.TypeCheck(ctx, test.expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -489,7 +489,7 @@ func TestFormatPgwireText(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -58,7 +58,7 @@ func TestIndexedVars(t *testing.T) {
 
 	// Verify the expression evaluates correctly.
 	ctx := context.Background()
-	semaContext := tree.MakeSemaContext()
+	semaContext := tree.MakeSemaContext(nil /* resolver */)
 	semaContext.IVarContainer = c
 	typedExpr, err := expr.TypeCheck(ctx, &semaContext, types.Any)
 	if err != nil {

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1213,8 +1213,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
 			constExpr := s.exprs[i].(Constant)
 			filter := makeFilter(i, func(params TypeList, ordinal int) bool {
-				semaCtx := MakeSemaContext()
-				_, err := constExpr.ResolveAsType(ctx, &semaCtx, params.GetAt(ordinal))
+				_, err := constExpr.ResolveAsType(ctx, semaCtx, params.GetAt(ordinal))
 				return err == nil
 			})
 			s.overloadIdxs = filterParams(s.overloadIdxs, s.overloads, s.params, filter)

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -282,7 +282,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	ctx := context.Background()
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
-			semaCtx := MakeSemaContext()
+			semaCtx := MakeSemaContext(nil /* resolver */)
 			semaCtx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */)
 			desired := types.Any
 			if d.desired != nil {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -258,13 +258,23 @@ func (s *ScalarAncestors) clear() {
 	*s = 0
 }
 
-// MakeSemaContext initializes a simple SemaContext suitable
-// for "lightweight" type checking such as the one performed for default
-// expressions.
+// MakeSemaContext initializes a simple SemaContext suitable for "lightweight"
+// type checking such as the one performed for default expressions.
+//
 // Note: if queries with placeholders are going to be used,
 // SemaContext.Placeholders.Init must be called separately.
-func MakeSemaContext() SemaContext {
-	return SemaContext{}
+//
+// resolver is optional and can implement any number of TypeReferenceResolver,
+// FunctionReferenceResolver, and QualifiedNameResolver interfaces.
+func MakeSemaContext(resolver interface{}) SemaContext {
+	typeResolver, _ := resolver.(TypeReferenceResolver)
+	functionResolver, _ := resolver.(FunctionReferenceResolver)
+	nameResolver, _ := resolver.(QualifiedNameResolver)
+	return SemaContext{
+		TypeResolver:     typeResolver,
+		FunctionResolver: functionResolver,
+		NameResolver:     nameResolver,
+	}
 }
 
 // isUnresolvedPlaceholder provides a nil-safe method to determine whether expr is an

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1158,7 +1158,9 @@ func (expr *FuncExpr) TypeCheck(
 	searchPath := EmptySearchPath
 	var resolver FunctionReferenceResolver
 	if semaCtx != nil {
-		searchPath = semaCtx.SearchPath
+		if semaCtx.SearchPath != nil {
+			searchPath = semaCtx.SearchPath
+		}
 		resolver = semaCtx.FunctionResolver
 	}
 

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -36,7 +36,7 @@ func BenchmarkTypeCheck(b *testing.B) {
 	if err != nil {
 		b.Fatalf("%s: %v", expr, err)
 	}
-	ctx := tree.MakeSemaContext()
+	ctx := tree.MakeSemaContext(nil /* resolver */)
 	ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 	for i := 0; i < b.N; i++ {
 		_, err := tree.TypeCheck(context.Background(), expr, &ctx, types.Int)
@@ -65,7 +65,7 @@ func TestTypeCheckNormalize(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatal(err)
@@ -185,7 +185,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	}
 	ctx := context.Background()
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
-		semaCtx := tree.MakeSemaContext()
+		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		semaCtx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes))
 		desired := types.Any
 		if test.desired != nil {
@@ -340,7 +340,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	ctx := context.Background()
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes)
 			desired := types.Any
 			if d.desired != nil {
@@ -380,7 +380,7 @@ func TestTypeCheckSameTypedExprsImplicitCastOneWay(t *testing.T) {
 	ctx := context.Background()
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes)
 			desired := types.Any
 			if d.desired != nil {
@@ -416,7 +416,7 @@ func TestProcessPlaceholderAnnotations(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	intType := types.Int
 	boolType := types.Bool
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	testData := []struct {
 		initArgs  tree.PlaceholderTypes
@@ -596,7 +596,7 @@ func TestProcessPlaceholderAnnotationsError(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	intType := types.Int
 	floatType := types.Float
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	testData := []struct {
 		initArgs  tree.PlaceholderTypes

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -233,9 +233,8 @@ func TestTypeCheck(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
-			semaCtx := tree.MakeSemaContext()
+			semaCtx := tree.MakeSemaContext(mapResolver)
 			semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
-			semaCtx.TypeResolver = mapResolver
 			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
 				t.Fatalf("%s: unexpected error %s", d.expr, err)
@@ -356,8 +355,7 @@ func TestTypeCheckError(t *testing.T) {
 		t.Run(d.expr, func(t *testing.T) {
 			// Test with a nil and non-nil semaCtx.
 			t.Run("semaCtx not nil", func(t *testing.T) {
-				semaCtx := tree.MakeSemaContext()
-				semaCtx.TypeResolver = mapResolver
+				semaCtx := tree.MakeSemaContext(mapResolver)
 				expr, err := parser.ParseExpr(d.expr)
 				if err != nil {
 					t.Fatalf("%s: %v", d.expr, err)
@@ -410,7 +408,7 @@ func TestTypeCheckVolatility(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
 
 	typeCheck := func(sql string) error {
@@ -454,7 +452,7 @@ func TestTypeCheckCollatedString(t *testing.T) {
 	ctx := context.Background()
 
 	// Typecheck without any restrictions.
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.Properties.Require("", 0 /* flags */)
 
 	// Hint a normal string type for $1.
@@ -478,7 +476,7 @@ func TestTypeCheckCollatedStringNestedCaseComparison(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 
 	// The collated string constant must be on the LHS for this test, so that
 	// the type-checker chooses the collated string overload first.
@@ -506,7 +504,7 @@ func TestTypeCheckCaseExprWithPlaceholders(t *testing.T) {
 
 	// Typecheck without any restrictions.
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.Properties.Require("", 0 /* flags */)
 
 	// Hint all int4 types.
@@ -528,7 +526,7 @@ func TestTypeCheckCaseExprWithConstantsAndUnresolvedPlaceholders(t *testing.T) {
 
 	// Typecheck without any restrictions.
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.Properties.Require("", 0 /* flags */)
 
 	// Hint all int4 types, but leave one of the THEN branches unhinted.
@@ -559,7 +557,7 @@ func TestTypeCheckArrayWithNullAndPlaceholder(t *testing.T) {
 
 	// Typecheck without any restrictions.
 	ctx := context.Background()
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.Properties.Require("", 0 /* flags */)
 
 	placeholderTypes := []*types.T{types.Int}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -763,7 +763,7 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		}
 		serializedGen := tree.Serialize(generated)
 
-		sema := tree.MakeSemaContext()
+		sema := tree.MakeSemaContext(nil /* resolver */)
 		// We don't care about errors below because they are often
 		// caused by sqlsmith generating bogus queries. We're just
 		// looking for datums that don't match.

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -50,7 +50,7 @@ func CreateTestTableDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	evalCtx := eval.MakeTestingEvalContext(st)
 	sessionData := &sessiondata.SessionData{
 		LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -187,7 +187,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 
 	// Virtual tables never use SERIAL so we need not process SERIAL
 	// types here.
-	semaCtx := tree.MakeSemaContext()
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	mutDesc, err := NewTableDesc(
 		ctx,
 		nil, /* txn */


### PR DESCRIPTION
This commit introduces a resolver argument to `MakeSemaContext` (which can be left nil) that will be tried against three "resolver" interfaces stored in the sema context. This should make it less likely in the future that we'd run into a bug similar to the one fixed in 108990dbb102cdc148085b50ef70be5b3c567b2c.

Release note: None

Epic: None