### PR TITLE
sql: add method to clamp min value for metamorphic constants

### DIFF
--- a/pkg/sql/rowinfra/BUILD.bazel
+++ b/pkg/sql/rowinfra/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/rowinfra",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/testutils/skip",
         "//pkg/util",
         "//pkg/util/metric",
     ],

--- a/pkg/sql/rowinfra/base.go
+++ b/pkg/sql/rowinfra/base.go
@@ -12,7 +12,10 @@
 // that must also be accessible from other packages.
 package rowinfra
 
-import "github.com/cockroachdb/cockroach/pkg/util"
+import (
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
 
 // RowLimit represents a response limit expressed in terms of number of result
 // rows. RowLimits get ultimately converted to KeyLimits and are translated into
@@ -42,11 +45,14 @@ const ProductionKVBatchSize KeyLimit = 100000
 
 // defaultBatchBytesLimit is the maximum number of bytes a scan request can
 // return.
-var defaultBatchBytesLimit = BytesLimit(util.ConstantWithMetamorphicTestRange(
-	"default-batch-bytes-limit",
-	defaultBatchBytesLimitProductionValue, /* defaultValue */
-	1,                                     /* min */
-	64<<10,                                /* max, 64KiB */
+var defaultBatchBytesLimit = BytesLimit(skip.ClampMetamorphicConstantUnderStress(
+	util.ConstantWithMetamorphicTestRange(
+		"default-batch-bytes-limit",
+		defaultBatchBytesLimitProductionValue, /* defaultValue */
+		1,                                     /* min */
+		64<<10,                                /* max, 64KiB */
+	),
+	1<<10, /* min, 1KiB */
 ))
 
 const defaultBatchBytesLimitProductionValue = 10 << 20 /* 10MiB */

--- a/pkg/testutils/skip/BUILD.bazel
+++ b/pkg/testutils/skip/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "skip",
     srcs = [
+        "constants.go",
         "skip.go",
         "stress.go",
     ],

--- a/pkg/testutils/skip/constants.go
+++ b/pkg/testutils/skip/constants.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package skip
+
+// ClampMetamorphicConstantUnderStress ensures that the given integer constant
+// with metamorphic testing range is at least the given minimum value, when the
+// process is running under stress.
+func ClampMetamorphicConstantUnderStress(val, min int) int {
+	if Stress() && val < min {
+		return min
+	}
+	return val
+}


### PR DESCRIPTION
This commit adds `skip.ClampMetamorphicConstantUnderStress` as a way to ensure that a metamorphic constant is at least some minimum value when tested under stress. This is useful for cases where the default metamorphic testing range causes enough slowdowns under stress to cause timeouts. This commit also uses the new function to clamp the `default-batch-bytes-limit` setting to be at least `10KiB`.

Fixes #122127

Release note: None