### PR TITLE
kvclient/rangefeed: allow starting from a frontier

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -142,7 +142,6 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 		log.Infof(ctx, "starting event stream with initial scan at %s", initialTimestamp)
 		opts = append(opts,
 			rangefeed.WithInitialScan(s.onInitialScanDone),
-			rangefeed.WithScanRetryBehavior(rangefeed.ScanRetryRemaining),
 			rangefeed.WithRowTimestampInInitialScan(true),
 			rangefeed.WithInitialScanParallelismFn(func() int {
 				return int(s.spec.Config.InitialScanParallelism)

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/retry",
+        "//pkg/util/span",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -67,9 +67,6 @@ type scanConfig struct {
 	// callback to invoke when initial scan of a span completed.
 	onSpanDone OnScanCompleted
 
-	// configures retry behavior
-	retryBehavior ScanRetryBehavior
-
 	// overSystemTable indicates whether this rangefeed is over a system table
 	// (used internally for CRDB's own functioning) and therefore should be
 	// treated with a more appropriate admission pri (NormalPri instead of
@@ -304,23 +301,6 @@ type OnScanCompleted func(ctx context.Context, sp roachpb.Span) error
 func WithOnScanCompleted(fn OnScanCompleted) Option {
 	return optionFunc(func(c *config) {
 		c.onSpanDone = fn
-	})
-}
-
-// ScanRetryBehavior specifies how rangefeed should handle errors during initial scan.
-type ScanRetryBehavior int
-
-const (
-	// ScanRetryAll will retry all spans if any error occurred during initial scan.
-	ScanRetryAll ScanRetryBehavior = iota
-	// ScanRetryRemaining will retry remaining spans, including the one that failed.
-	ScanRetryRemaining
-)
-
-// WithScanRetryBehavior configures range feed to retry initial scan as per specified behavior.
-func WithScanRetryBehavior(b ScanRetryBehavior) Option {
-	return optionFunc(func(c *config) {
-		c.retryBehavior = b
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -64,8 +64,8 @@ type scanConfig struct {
 	// mon is the memory monitor to while scanning.
 	mon *mon.BytesMonitor
 
-	// callback to invoke when initial scan of a span completed.
-	onSpanDone OnScanCompleted
+	// OnSpanDone is invoked when initial scan of some span is completed.
+	OnSpanDone OnScanCompleted
 
 	// overSystemTable indicates whether this rangefeed is over a system table
 	// (used internally for CRDB's own functioning) and therefore should be
@@ -300,7 +300,7 @@ type OnScanCompleted func(ctx context.Context, sp roachpb.Span) error
 // have been completed when performing an initial scan.
 func WithOnScanCompleted(fn OnScanCompleted) Option {
 	return optionFunc(func(c *config) {
-		c.onSpanDone = fn
+		c.OnSpanDone = fn
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -101,7 +101,7 @@ func (dbc *dbAdapter) Scan(
 	// If we don't have parallelism configured, just scan each span in turn.
 	if cfg.scanParallelism == nil {
 		for _, sp := range spans {
-			if err := dbc.scanSpan(ctx, sp, asOf, rowFn, rowsFn, cfg.targetScanBytes, cfg.onSpanDone, cfg.overSystemTable, acc); err != nil {
+			if err := dbc.scanSpan(ctx, sp, asOf, rowFn, rowsFn, cfg.targetScanBytes, cfg.OnSpanDone, cfg.overSystemTable, acc); err != nil {
 				return err
 			}
 		}
@@ -137,7 +137,7 @@ func (dbc *dbAdapter) Scan(
 	g := ctxgroup.WithContext(ctx)
 	err := dbc.divideAndSendScanRequests(
 		ctx, &g, spans, asOf, rowFn, rowsFn,
-		parallelismFn, cfg.targetScanBytes, cfg.onSpanDone, cfg.overSystemTable, acc)
+		parallelismFn, cfg.targetScanBytes, cfg.OnSpanDone, cfg.overSystemTable, acc)
 	if err != nil {
 		cancel()
 	}

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -238,7 +238,6 @@ func TestDBClientScan(t *testing.T) {
 		feed, err := f.RangeFeed(ctx, "foo-feed", []roachpb.Span{fooSpan}, db.Clock().Now(),
 			func(ctx context.Context, value *kvpb.RangeFeedValue) {},
 
-			rangefeed.WithScanRetryBehavior(rangefeed.ScanRetryRemaining),
 			rangefeed.WithInitialScanParallelismFn(func() int { return parallelism }),
 
 			rangefeed.WithInitialScan(func(ctx context.Context) {

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -280,7 +280,7 @@ func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier) {
 	restartLogEvery := log.Every(10 * time.Second)
 
 	if f.withInitialScan {
-		if done := f.runInitialScan(ctx, &restartLogEvery, &r); done {
+		if failed := f.runInitialScan(ctx, &restartLogEvery, &r); failed {
 			return
 		}
 	}

--- a/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
@@ -372,7 +372,7 @@ func TestBackoffOnRangefeedFailure(t *testing.T) {
 
 	f := rangefeed.NewFactoryWithDB(stopper, db, nil /* knobs */)
 	r, err := f.RangeFeed(ctx, "foo",
-		[]roachpb.Span{{Key: keys.MinKey, EndKey: keys.MaxKey}},
+		[]roachpb.Span{{Key: keys.TableDataMin, EndKey: keys.TableDataMax}},
 		hlc.Timestamp{},
 		func(ctx context.Context, value *kvpb.RangeFeedValue) {},
 		rangefeed.WithInitialScan(func(ctx context.Context) {}),

--- a/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -340,6 +341,79 @@ func TestRangeFeedMock(t *testing.T) {
 		require.NoError(t, err)
 		<-done
 		r.Close()
+	})
+
+	// Test that the initial scan of [a, z) makes progress and completes even when
+	// the rangefeed is being fully restarted after errors during its initial scan
+	// such as might happen if a job running a rangefeed is replans or restarts,
+	// so long as that job passes progress previously made and persisted to the
+	// restarted rangefeed via a frontier. In this test the persistance of the
+	// frontier is simply that it is outside the loop used to run each rangefeed
+	// but in a job a frontier visitor would likely be copying state out of tthe
+	// rangefeed's frontier while it is running and persisting it somewhere to be
+	// used to construct a new but non-empty frontier to pass to resumptions.
+	t.Run("initial scan resumed from frontier makes progress", func(t *testing.T) {
+		stopper := stop.NewStopper()
+		ctx := context.Background()
+		defer stopper.Stop(ctx)
+
+		s := func(s, e string) roachpb.Span {
+			return roachpb.Span{Key: roachpb.Key(s), EndKey: roachpb.Key(e)}
+		}
+
+		// Valid result spans represent partial successes while invalid spans here
+		// result in synthetic scan errors.
+		scanResults := []roachpb.Span{
+			s("a", "c"), s("c", "f"), s("f", "g"), s("g", "z"),
+		}
+		resultCh := make(chan roachpb.Span, len(scanResults))
+		for _, sp := range scanResults {
+			resultCh <- sp
+		}
+
+		// Mock a rangefeed whose scan results will be partial successes or errors
+		// from the above channel, and for which successfully "scanned" spans will
+		// call the usual rangefeed initial scan span complete callback.
+		f := rangefeed.NewFactoryWithDB(stopper, &mockClient{
+			scan: func(ctx context.Context, requested []roachpb.Span, _ hlc.Timestamp,
+				rowFn func(_ roachpb.KeyValue), rowsFn func(_ []kv.KeyValue), cfg rangefeed.ScanConfig) error {
+				res := <-resultCh
+				if err := cfg.OnSpanDone(ctx, res); err != nil {
+					return err
+				}
+				require.Equal(t, res.Key, requested[0].Key, "rangefeed should have tried to scan remaining span")
+				return errors.New("err")
+			},
+		}, nil)
+
+		frontier, err := span.MakeFrontier(s("a", "z"))
+		require.NoError(t, err)
+		defer frontier.Release()
+
+		var runs int
+		done := false
+		// Run our rangefeed up to 5 times, or until it reports completing its
+		// initial scan, simulating a job performing an initial scan restarting.
+		for ; !done && runs < 5; runs++ {
+			// Sanity check that our frontier isn't empty (i.e. wasn't Released).
+			require.Greater(t, frontier.Len(), 0, frontier.String())
+			// Create a rangefeed that will abort on scan error, to give our test a
+			// chance to stop it and create a new one, similar to how a real one might
+			// get recreated if a job is resumed or replanned after something like a
+			// node restart or liveness failure.
+			r := f.New("test", hlc.Timestamp{WallTime: 1},
+				func(_ context.Context, _ *kvpb.RangeFeedValue) {},
+				rangefeed.WithInitialScan(func(_ context.Context) { done = true }),
+				rangefeed.WithOnInitialScanError(func(_ context.Context, _ error) (shouldFail bool) {
+					return true
+				}),
+			)
+			err := r.StartFromFrontier(ctx, frontier)
+			require.NoError(t, err)
+			r.Close()
+		}
+		require.True(t, done)
+		require.Equal(t, 5, runs)
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/scanner.go
+++ b/pkg/kv/kvclient/rangefeed/scanner.go
@@ -90,14 +90,6 @@ func (f *RangeFeed) runInitialScan(
 }
 
 func (f *RangeFeed) getSpansToScan(ctx context.Context) (func() []roachpb.Span, func()) {
-	retryAll := func() []roachpb.Span {
-		return f.spans
-	}
-
-	noCleanup := func() {}
-	if f.retryBehavior == ScanRetryAll {
-		return retryAll, noCleanup
-	}
 
 	// We want to retry remaining spans.
 	// Maintain a frontier in order to keep track of which spans still need to be scanned.
@@ -109,7 +101,7 @@ func (f *RangeFeed) getSpansToScan(ctx context.Context) (func() []roachpb.Span, 
 		// so, log it and fall back to retrying all spans.
 		log.Errorf(ctx, "failed to build frontier for the initial scan; "+
 			"falling back to retry all behavior: err=%v", err)
-		return retryAll, noCleanup
+		return func() []roachpb.Span { return f.spans }, func() {}
 	}
 	frontier = span.MakeConcurrentFrontier(frontier)
 

--- a/pkg/kv/kvclient/rangefeed/scanner.go
+++ b/pkg/kv/kvclient/rangefeed/scanner.go
@@ -72,8 +72,8 @@ func (f *RangeFeed) runInitialScan(
 	// Adjust the span completion callback to advance the frontier in addition to
 	// calling the user's callback, if any. We don't need to undo after we're done
 	// since it is never called again once we're done.
-	userSpanDoneCallback := f.onSpanDone
-	f.onSpanDone = func(ctx context.Context, sp roachpb.Span) error {
+	userSpanDoneCallback := f.scanConfig.OnSpanDone
+	f.scanConfig.OnSpanDone = func(ctx context.Context, sp roachpb.Span) error {
 		if userSpanDoneCallback != nil {
 			if err := userSpanDoneCallback(ctx, sp); err != nil {
 				return err

--- a/pkg/kv/kvclient/rangefeed/scanner.go
+++ b/pkg/kv/kvclient/rangefeed/scanner.go
@@ -22,14 +22,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 )
 
-// runInitialScan will attempt to perform an initial data scan.
+// runInitialScan will attempt to perform an initial data scan of all spans in
+// the passed frontier that are below f.initialTimestamp.
+//
 // It will retry in the face of errors and will only return upon
 // success, context cancellation, or an error handling function which indicates
 // that an error is unrecoverable. The return value will be true if the context
 // was canceled or if the OnInitialScanError function indicated that the
 // RangeFeed should stop.
 func (f *RangeFeed) runInitialScan(
-	ctx context.Context, n *log.EveryN, r *retry.Retry,
+	ctx context.Context, n *log.EveryN, r *retry.Retry, frontier span.Frontier,
 ) (canceled bool) {
 	onValue := func(kv roachpb.KeyValue) {
 		v := kvpb.RangeFeedValue{
@@ -63,8 +65,31 @@ func (f *RangeFeed) runInitialScan(
 		}
 	}
 
-	getSpansToScan, cleanup := f.getSpansToScan(ctx)
-	defer cleanup()
+	// Ensure the frontier is compatible with scan parallelism, which could be
+	// enabled mid-call since it is controlled via callback.
+	frontier = span.MakeConcurrentFrontier(frontier)
+
+	// Adjust the span completion callback to advance the frontier in addition to
+	// calling the user's callback, if any. We don't need to undo after we're done
+	// since it is never called again once we're done.
+	userSpanDoneCallback := f.onSpanDone
+	f.onSpanDone = func(ctx context.Context, sp roachpb.Span) error {
+		if userSpanDoneCallback != nil {
+			if err := userSpanDoneCallback(ctx, sp); err != nil {
+				return err
+			}
+		}
+		advanced, err := frontier.Forward(sp, f.initialTimestamp)
+		if err != nil {
+			return err
+		}
+		if f.frontierVisitor != nil {
+			f.frontierVisitor(ctx, advanced, frontier)
+		}
+		return nil
+	}
+
+	toScan := make(roachpb.Spans, 0, frontier.Len())
 
 	// We will exit this for loop only when we return false for failed/cancelled
 	// from inside the loop, or when we break due to the callback or the retry
@@ -72,7 +97,13 @@ func (f *RangeFeed) runInitialScan(
 	r.Reset()
 	for r.Next() {
 		// Figure out what spans are left to scan.
-		toScan := getSpansToScan()
+		toScan = toScan[:0]
+		frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+			if ts.IsEmpty() || ts.Less(f.initialTimestamp) {
+				toScan = append(toScan, sp)
+			}
+			return span.ContinueMatch
+		})
 
 		// Scan the spans.
 		if len(toScan) > 0 {
@@ -99,54 +130,4 @@ func (f *RangeFeed) runInitialScan(
 
 	// We left the for loop without returning false, so we were cancelled.
 	return true
-}
-
-func (f *RangeFeed) getSpansToScan(ctx context.Context) (func() []roachpb.Span, func()) {
-
-	// We want to retry remaining spans.
-	// Maintain a frontier in order to keep track of which spans still need to be scanned.
-	frontier, err := span.MakeFrontier(f.spans...)
-	if err != nil {
-		// Frontier construction shouldn't really fail. The spans have already
-		// been validated by frontier constructed when starting rangefeed.
-		// We don't really have a good mechanism to return an initialization error from here,
-		// so, log it and fall back to retrying all spans.
-		log.Errorf(ctx, "failed to build frontier for the initial scan; "+
-			"falling back to retry all behavior: err=%v", err)
-		return func() []roachpb.Span { return f.spans }, func() {}
-	}
-	frontier = span.MakeConcurrentFrontier(frontier)
-
-	userSpanDoneCallback := f.onSpanDone
-	f.onSpanDone = func(ctx context.Context, sp roachpb.Span) error {
-		if userSpanDoneCallback != nil {
-			if err := userSpanDoneCallback(ctx, sp); err != nil {
-				return err
-			}
-		}
-		advanced, err := frontier.Forward(sp, f.initialTimestamp)
-		if f.frontierVisitor != nil {
-			f.frontierVisitor(ctx, advanced, frontier)
-		}
-
-		return err
-	}
-
-	isRetry := false
-	var retrySpans []roachpb.Span
-	return func() []roachpb.Span {
-		if !isRetry {
-			isRetry = true
-			return f.spans
-		}
-
-		retrySpans = retrySpans[:0]
-		frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
-			if ts.IsEmpty() {
-				retrySpans = append(retrySpans, sp)
-			}
-			return span.ContinueMatch
-		})
-		return retrySpans
-	}, frontier.Release
 }


### PR DESCRIPTION
This extends the rangefeed client to allow starting a from an existing
frontier, rather than just a list of spans. This is particularly useful
when an initial scan is required and may have previously been partially
completed, as it allows resuming the partial scan from the previous
frontier instead of re-scanning all spans.

Release note: none.
Epic: none.
