### PR TITLE
ui: removed the p95 metric from tooltip of row ttl's graph

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -16,6 +16,7 @@ import * as protos from "src/js/protos";
 import { hoverOff, hoverOn, HoverState } from "src/redux/hover";
 import { findChildrenOfType } from "src/util/find";
 import {
+  canShowMetric,
   configureUPlotLineChart,
   formatMetricData,
   formattedSeries,
@@ -394,23 +395,24 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
     ) : null;
     // Extend tooltip to include metrics names
     if (showMetricsInTooltip) {
-      if (data?.results?.length === 1) {
+      const metrics = _.filter(data?.results, canShowMetric);
+      if (metrics.length === 1) {
         tt = (
           <>
             {tt}
             {addLines}
-            Metric: {data.results[0].query.name}
+            Metric: {metrics[0].query.name}
           </>
         );
-      } else if (data?.results?.length > 1) {
-        const metrics = unique(data.results.map(m => m.query.name));
+      } else if (metrics.length > 1) {
+        const metricNames = unique(metrics.map(m => m.query.name));
         tt = (
           <>
             {tt}
             {addLines}
             Metrics:
             <ul>
-              {metrics.map(m => (
+              {metricNames.map(m => (
                 <li key={m}>{m}</li>
               ))}
             </ul>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
@@ -20,7 +20,7 @@ import { GraphDashboardProps } from "./dashboardUtils";
 export default function (props: GraphDashboardProps) {
   const { nodeSources, tenantSource } = props;
 
-  const percentiles = ["p50", "p75", "p90", "p95", "p99"];
+  const percentiles = ["p50", "p75", "p90", "p99"];
 
   return [
     <LineGraph

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -20,6 +20,7 @@ import {
 import uPlot from "uplot";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
+type TSQueryResult = protos.cockroach.ts.tspb.TimeSeriesQueryResponse.IResult;
 
 // Global set of colors for graph series.
 const seriesPalette = [
@@ -49,6 +50,11 @@ export type formattedSeries = {
   color?: string;
 };
 
+// logic to decide when to show a metric based on the query's result
+export function canShowMetric(result: TSQueryResult) {
+  return !_.isEmpty(result.datapoints);
+}
+
 export function formatMetricData(
   metrics: React.ReactElement<MetricProps>[],
   data: TSResponse,
@@ -57,7 +63,7 @@ export function formatMetricData(
 
   _.each(metrics, (s, idx) => {
     const result = data.results[idx];
-    if (result && !_.isEmpty(result.datapoints)) {
+    if (result && canShowMetric(result)) {
       const scaledValues = result.datapoints.map(v => ({
         ...v,
         // if defined scale it, otherwise remain undefined


### PR DESCRIPTION
Removed the p95 metrics from the row ttl's graph, as we currently don't compute and store the p95 values for any of the recorded Histogram metrics.

Also updated the line graph to show the metric label in tooltip only when it's legends are displayed, i.e. when there is datapoint for that metric.

Release note (bug fix): removed p95 metrics from tooltip of row ttl's graph, as there are no p95 values computed for any of the metrics currently.

Fixes: https://github.com/cockroachdb/cockroach/issues/117867