### PR TITLE
concurrency: use heavy pool for tests

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":concurrency"],
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 16,
     deps = [
         "//pkg/clusterversion",


### PR DESCRIPTION
This test is only timing out on EngFlow. In my repros, I've confirmed that it's always been susceptible to overload. Switch to using a heavy pool.

Informs https://github.com/cockroachdb/cockroach/issues/122089

Release note: None