### PR TITLE
intentresolver: serialize race in intent resolution test

### DIFF
--- a/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
@@ -14,6 +14,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -392,7 +393,7 @@ func TestIntentResolutionUnavailableRange(t *testing.T) {
 	const intentResolutionSendBatchTimeout = 1 * time.Second
 	serverArgs := make(map[int]base.TestServerArgs)
 	waitForIntentResolutionForT2 := make(chan struct{})
-	var t2RangeID roachpb.RangeID
+	var t2RangeID atomic.Int32
 	storeTestingKnobs := []kvserver.StoreTestingKnobs{
 		{
 			IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
@@ -407,7 +408,7 @@ func TestIntentResolutionUnavailableRange(t *testing.T) {
 				for _, req := range ba.Requests {
 					switch req.GetInner().(type) {
 					case *kvpb.ResolveIntentRequest:
-						if ba.RangeID == t2RangeID {
+						if ba.RangeID == roachpb.RangeID(t2RangeID.Load()) {
 							close(waitForIntentResolutionForT2)
 							// Block until the request is cancelled.
 							<-ctx.Done()
@@ -477,8 +478,10 @@ func TestIntentResolutionUnavailableRange(t *testing.T) {
 
 	{
 		// Get the range ID for t2.
-		err := db.QueryRow("select range_id from [show ranges from table t2] limit 1").Scan(&t2RangeID)
+		var tmpT2RangeID int32
+		err := db.QueryRow("select range_id from [show ranges from table t2] limit 1").Scan(&tmpT2RangeID)
 		require.NoError(t, err)
+		t2RangeID.Store(tmpT2RangeID)
 	}
 
 	{


### PR DESCRIPTION
`TestIntentResolutionUnavailableRange` had a race condition on a test only variable. Serialize access to the var to remove the race.

Fixes: #122360
Release note: None