### PR TITLE
backupccl: skip online restore variant of TestBackupRestoreRandomDataRountrips

### DIFF
--- a/pkg/ccl/backupccl/backuprand/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backuprand/backup_rand_test.go
@@ -166,7 +166,9 @@ database_name = 'rand' AND schema_name = 'public'`)
 	withOnlineRestore := func() string {
 		onlineRestoreExtension := ""
 		if rng.Intn(2) != 0 {
-			onlineRestoreExtension = " , experimental deferred copy"
+			// TODO(msbutler): once this test is deflaked, add back the online restore
+			// variant of this test.
+			onlineRestoreExtension = ""
 		}
 		return onlineRestoreExtension
 	}


### PR DESCRIPTION
Epic: none

Release note: none