### PR TITLE
kvserver: add testing for txn recovery involving pipelined repl locks

### DIFF
--- a/pkg/kv/kvserver/txnrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/txnrecovery/BUILD.bazel
@@ -29,7 +29,9 @@ go_test(
     deps = [
         "//pkg/kv",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/roachpb",
+        "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",


### PR DESCRIPTION
This patch extends TestResolveIndeterminateCommit and TestResolveIndeterminateCommitTxnChanges to run a version for each of the lock strengths.

While here, we also extend TestResolveIndeterminateCommit to make assertions about IgnoredSequenceNums and Txn.Sequence used when constructing QueryIntentRequests during recovery.

Closes https://github.com/cockroachdb/cockroach/issues/121945

Release note: None