### PR TITLE
cli: disable mutlitenant in demo

### DIFF
--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -46,7 +46,7 @@ end_test
 start_test "Check that demo insecure, env var, says hello properly"
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --no-line-editor --no-example-database --log-dir=logs
+spawn $argv demo --no-line-editor --no-example-database --log-dir=logs --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 end_test
@@ -105,7 +105,7 @@ start_test "Check that demo secure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --no-line-editor --no-example-database --log-dir=logs
+spawn $argv demo --no-line-editor --no-example-database --log-dir=logs --multitenant=true
 eexpect "Welcome"
 
 eexpect "(webui)"
@@ -268,7 +268,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --no-line-editor --no-example-database --nodes 3 --sql-port 23000 --log-dir=logs
+spawn $argv demo --no-line-editor --no-example-database --nodes 3 --sql-port 23000 --log-dir=logs --multitenant=true
 eexpect "Welcome"
 eexpect "defaultdb>"
 


### PR DESCRIPTION
This is a forward port of #122362.

The test changes here ensures that the expected test output
doesn't change when the default for mt in demo changes.

Fixes #122053
Release note: none