### PR TITLE
roachtest: add disk-stall operation

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -638,6 +638,7 @@ type clusterImpl struct {
 	cloud string
 	spec  spec.ClusterSpec
 	t     test.Test
+	f     roachtestutil.Fataler
 	// r is the registry tracking this cluster. Destroying the cluster will
 	// unregister it.
 	r *clusterRegistry
@@ -1051,6 +1052,7 @@ func attachToExistingCluster(
 // TODO(andrei): Get rid of c.t, c.l and of this method.
 func (c *clusterImpl) setTest(t test.Test) {
 	c.t = t
+	c.f = t
 	c.l = t.L()
 }
 
@@ -1128,8 +1130,8 @@ func (c *clusterImpl) validate(
 
 func (c *clusterImpl) lister() option.NodeLister {
 	fatalf := func(string, ...interface{}) {}
-	if c.t != nil { // accommodates poorly set up tests
-		fatalf = c.t.Fatalf
+	if c.f != nil { // accommodates poorly set up tests
+		fatalf = c.f.Fatalf
 	}
 	return option.NodeLister{NodeCount: c.spec.NodeCount, Fatalf: fatalf}
 }
@@ -1818,7 +1820,7 @@ func (c *clusterImpl) ApplySnapshots(ctx context.Context, snapshots []vm.VolumeS
 // Put is DEPRECATED. Use PutE instead.
 func (c *clusterImpl) Put(ctx context.Context, src, dest string, nodes ...option.Option) {
 	if err := c.PutE(ctx, c.l, src, dest, nodes...); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2131,7 +2133,7 @@ func (c *clusterImpl) StartServiceForVirtualCluster(
 	settings install.ClusterSettings,
 ) {
 	if err := c.StartServiceForVirtualClusterE(ctx, l, startOpts, settings); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2158,7 +2160,7 @@ func (c *clusterImpl) StopServiceForVirtualCluster(
 	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts,
 ) {
 	if err := c.StopServiceForVirtualClusterE(ctx, l, stopOpts); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2231,7 +2233,7 @@ func (c *clusterImpl) Start(
 	opts ...option.Option,
 ) {
 	if err := c.StartE(ctx, l, startOpts, settings, opts...); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2273,7 +2275,7 @@ func (c *clusterImpl) StopE(
 }
 
 // Stop is like StopE, except instead of returning an error, it does
-// c.t.Fatal(). c.t needs to be set.
+// c.f.Fatal(). c.t needs to be set.
 func (c *clusterImpl) Stop(
 	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
 ) {
@@ -2282,7 +2284,7 @@ func (c *clusterImpl) Stop(
 		return
 	}
 	if err := c.StopE(ctx, l, stopOpts, opts...); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2300,7 +2302,7 @@ func (c *clusterImpl) SignalE(
 }
 
 // Signal is like SignalE, except instead of returning an error, it does
-// c.t.Fatal(). c.t needs to be set.
+// c.f.Fatal(). c.t needs to be set.
 func (c *clusterImpl) Signal(
 	ctx context.Context, l *logger.Logger, sig int, nodes ...option.Option,
 ) {
@@ -2309,7 +2311,7 @@ func (c *clusterImpl) Signal(
 		return
 	}
 	if err := c.SignalE(ctx, l, sig, nodes...); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2331,13 +2333,13 @@ func (c *clusterImpl) WipeE(
 }
 
 // Wipe is like WipeE, except instead of returning an error, it does
-// c.t.Fatal(). c.t needs to be set.
+// c.f.Fatal(). c.t needs to be set.
 func (c *clusterImpl) Wipe(ctx context.Context, nodes ...option.Option) {
 	if ctx.Err() != nil {
 		return
 	}
 	if err := c.WipeE(ctx, c.l, nodes...); err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2345,7 +2347,7 @@ func (c *clusterImpl) Wipe(ctx context.Context, nodes ...option.Option) {
 func (c *clusterImpl) Run(ctx context.Context, options install.RunOptions, args ...string) {
 	err := c.RunE(ctx, options, args...)
 	if err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 }
 
@@ -2365,10 +2367,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 	defer l.Close()
 
 	cmd := strings.Join(args, " ")
-	// TODO(bilal): Remove the need to check for nil.
-	if c.t != nil {
-		c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
-	}
+	c.f.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
 	l.Printf("> %s", cmd)
 	if err := roachprod.Run(
 		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),
@@ -2735,7 +2734,7 @@ func (c *clusterImpl) Conn(
 ) *gosql.DB {
 	db, err := c.ConnE(ctx, l, node, opts...)
 	if err != nil {
-		c.t.Fatal(err)
+		c.f.Fatal(err)
 	}
 	return db
 }

--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "add_column.go",
         "add_index.go",
+        "disk_stall.go",
         "network_partition.go",
         "register.go",
         "utils.go",
@@ -17,6 +18,7 @@ go_library(
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",
+        "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/util/randutil",
     ],
 )

--- a/pkg/cmd/roachtest/operations/disk_stall.go
+++ b/pkg/cmd/roachtest/operations/disk_stall.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+type cleanupDiskStall struct {
+	nodes   option.NodeListOption
+	staller roachtestutil.DiskStaller
+}
+
+func (cl *cleanupDiskStall) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	cl.staller.Unstall(ctx, cl.nodes)
+	o.Status("unstalled nodes; waiting 10 seconds before restarting")
+	time.Sleep(10 * time.Second)
+	// We might need to restart the node if it isn't live.
+	db, err := c.ConnE(ctx, o.L(), cl.nodes[0])
+	if err != nil {
+		c.Run(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
+		return
+	}
+	defer db.Close()
+	_, err = db.Query("SELECT 1")
+	if err != nil {
+		c.Run(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
+	}
+}
+
+func runDiskStall(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	rng, _ := randutil.NewPseudoRand()
+
+	nodes := c.All()
+	nid := nodes[rng.Intn(len(nodes))]
+	o.Status("stalling disk on node %d", nid)
+	ds := roachtestutil.MakeCgroupDiskStaller(o, c, false, false)
+
+	ds.Stall(ctx, c.Node(nid))
+
+	return &cleanupDiskStall{
+		nodes:   c.Node(nid),
+		staller: ds,
+	}
+}
+
+func registerDiskStall(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "disk-stall/cgroup",
+		Owner:            registry.OwnerStorage,
+		Timeout:          10 * time.Minute,
+		CompatibleClouds: registry.OnlyGCE,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
+		Run:              runDiskStall,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -17,4 +17,5 @@ func RegisterOperations(r registry.Registry) {
 	registerAddColumn(r)
 	registerAddIndex(r)
 	registerNetworkPartition(r)
+	registerDiskStall(r)
 }

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -32,6 +32,11 @@ var (
 		Usage: `Cloud provider to use ("local", "gce", "aws", or "azure"); by
 		        default, only tests compatible with the given cloud are run`,
 	})
+	_ = registerRunOpsFlag(&Cloud, FlagInfo{
+		Name: "cloud",
+		Usage: `Cloud provider that the cluster is running on. Used by operations
+		        to tailor behaviour to that cloud.`,
+	})
 
 	Suite string
 	_     = registerListFlag(&Suite, FlagInfo{

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "roachtestutil",
     srcs = [
         "commandbuilder.go",
+        "disk_stall.go",
         "disk_usage.go",
         "health_checker.go",
         "httpclient.go",
@@ -16,6 +17,7 @@ go_library(
     deps = [
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/kv/kvpb",
         "//pkg/roachprod/config",

--- a/pkg/cmd/roachtest/roachtestutil/disk_stall.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_stall.go
@@ -1,0 +1,175 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachtestutil
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+type DiskStaller interface {
+	Setup(ctx context.Context)
+	Cleanup(ctx context.Context)
+	Stall(ctx context.Context, nodes option.NodeListOption)
+	Unstall(ctx context.Context, nodes option.NodeListOption)
+	DataDir() string
+	LogDir() string
+}
+
+type Fataler interface {
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	L() *logger.Logger
+}
+
+type cgroupDiskStaller struct {
+	f           Fataler
+	c           cluster.Cluster
+	readOrWrite []bandwidthReadWrite
+	logsToo     bool
+}
+
+var _ DiskStaller = (*cgroupDiskStaller)(nil)
+
+func MakeCgroupDiskStaller(f Fataler, c cluster.Cluster, readsToo bool, logsToo bool) DiskStaller {
+	bwRW := []bandwidthReadWrite{writeBandwidth}
+	if readsToo {
+		bwRW = append(bwRW, readBandwidth)
+	}
+	return &cgroupDiskStaller{f: f, c: c, readOrWrite: bwRW, logsToo: logsToo}
+}
+
+func (s *cgroupDiskStaller) DataDir() string { return "{store-dir}" }
+func (s *cgroupDiskStaller) LogDir() string {
+	return "logs"
+}
+func (s *cgroupDiskStaller) Setup(ctx context.Context) {
+	if s.logsToo {
+		s.c.Run(ctx, option.WithNodes(s.c.All()), "mkdir -p {store-dir}/logs")
+		s.c.Run(ctx, option.WithNodes(s.c.All()), "rm -f logs && ln -s {store-dir}/logs logs || true")
+	}
+}
+func (s *cgroupDiskStaller) Cleanup(ctx context.Context) {}
+
+func (s *cgroupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
+	// Shuffle the order of read and write stall initiation.
+	rand.Shuffle(len(s.readOrWrite), func(i, j int) {
+		s.readOrWrite[i], s.readOrWrite[j] = s.readOrWrite[j], s.readOrWrite[i]
+	})
+	for _, rw := range s.readOrWrite {
+		// NB: I don't understand why, but attempting to set a
+		// bytesPerSecond={0,1} results in Invalid argument from the io.max
+		// cgroupv2 API.
+		if err := s.setThroughput(ctx, nodes, rw, throughput{limited: true, bytesPerSecond: 4}); err != nil {
+			s.f.Fatal(err)
+		}
+	}
+}
+
+func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
+	for _, rw := range s.readOrWrite {
+		err := s.setThroughput(ctx, nodes, rw, throughput{limited: false})
+		if err != nil {
+			s.f.L().PrintfCtx(ctx, "error unstalling the disk; stumbling on: %v", err)
+		}
+		// NB: We log the error and continue on because unstalling may not
+		// succeed if the process has successfully exited.
+	}
+}
+
+func (s *cgroupDiskStaller) device() (major, minor int) {
+	// TODO(jackson): Programmatically determine the device major,minor numbers.
+	// eg,:
+	//    deviceName := getDevice(s.t, s.c)
+	//    `cat /proc/partitions` and find `deviceName`
+	switch s.c.Cloud() {
+	case spec.GCE:
+		// ls -l /dev/sdb
+		// brw-rw---- 1 root disk 8, 16 Mar 27 22:08 /dev/sdb
+		return 8, 16
+	default:
+		s.f.Fatalf("unsupported cloud %q", s.c.Cloud())
+		return 0, 0
+	}
+}
+
+type throughput struct {
+	limited        bool
+	bytesPerSecond int
+}
+
+type bandwidthReadWrite int8
+
+const (
+	readBandwidth bandwidthReadWrite = iota
+	writeBandwidth
+)
+
+func (rw bandwidthReadWrite) cgroupV2BandwidthProp() string {
+	switch rw {
+	case readBandwidth:
+		return "rbps"
+	case writeBandwidth:
+		return "wbps"
+	default:
+		panic("unreachable")
+	}
+}
+
+func (s *cgroupDiskStaller) setThroughput(
+	ctx context.Context, nodes option.NodeListOption, rw bandwidthReadWrite, bw throughput,
+) error {
+	maj, min := s.device()
+	cockroachIOController := filepath.Join("/sys/fs/cgroup/system.slice", SystemInterfaceSystemdUnitName()+".service", "io.max")
+
+	bytesPerSecondStr := "max"
+	if bw.limited {
+		bytesPerSecondStr = fmt.Sprintf("%d", bw.bytesPerSecond)
+	}
+	return s.c.RunE(ctx, option.WithNodes(nodes), "sudo", "/bin/bash", "-c", fmt.Sprintf(
+		`'echo %d:%d %s=%s > %s'`,
+		maj,
+		min,
+		rw.cgroupV2BandwidthProp(),
+		bytesPerSecondStr,
+		cockroachIOController,
+	))
+}
+
+func GetDiskDevice(f Fataler, c cluster.Cluster) string {
+	s := c.Spec()
+	switch c.Cloud() {
+	case spec.GCE:
+		switch s.LocalSSD {
+		case spec.LocalSSDDisable:
+			return "/dev/sdb"
+		case spec.LocalSSDPreferOn, spec.LocalSSDDefault:
+			// TODO(jackson): These spec values don't guarantee that we are actually
+			// using local SSDs, just that we might've.
+			return "/dev/nvme0n1"
+		default:
+			f.Fatalf("unsupported LocalSSD enum %v", s.LocalSSD)
+			return ""
+		}
+	case spec.AWS:
+		return "/dev/nvme1n1"
+	default:
+		f.Fatalf("unsupported cloud %q", c.Cloud())
+		return ""
+	}
+}

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -194,13 +193,13 @@ func registerDiskStalledDetection(r registry.Registry) {
 	stallers := map[string]func(test.Test, cluster.Cluster) diskStaller{
 		"dmsetup": func(t test.Test, c cluster.Cluster) diskStaller { return &dmsetupDiskStaller{t: t, c: c} },
 		"cgroup/read-write/logs-too=false": func(t test.Test, c cluster.Cluster) diskStaller {
-			return &cgroupDiskStaller{t: t, c: c, readOrWrite: []bandwidthReadWrite{writeBandwidth, readBandwidth}}
+			return roachtestutil.MakeCgroupDiskStaller(t, c, true, false)
 		},
 		"cgroup/read-write/logs-too=true": func(t test.Test, c cluster.Cluster) diskStaller {
-			return &cgroupDiskStaller{t: t, c: c, readOrWrite: []bandwidthReadWrite{writeBandwidth, readBandwidth}, logsToo: true}
+			return roachtestutil.MakeCgroupDiskStaller(t, c, true, true)
 		},
 		"cgroup/write-only/logs-too=true": func(t test.Test, c cluster.Cluster) diskStaller {
-			return &cgroupDiskStaller{t: t, c: c, readOrWrite: []bandwidthReadWrite{writeBandwidth}, logsToo: true}
+			return roachtestutil.MakeCgroupDiskStaller(t, c, false, true)
 		},
 	}
 
@@ -437,14 +436,7 @@ func getProcessMonotonicTimestamp(
 	return time.Duration(u) * time.Microsecond, true
 }
 
-type diskStaller interface {
-	Setup(ctx context.Context)
-	Cleanup(ctx context.Context)
-	Stall(ctx context.Context, nodes option.NodeListOption)
-	Unstall(ctx context.Context, nodes option.NodeListOption)
-	DataDir() string
-	LogDir() string
-}
+type diskStaller = roachtestutil.DiskStaller
 
 type dmsetupDiskStaller struct {
 	t test.Test
@@ -456,7 +448,7 @@ type dmsetupDiskStaller struct {
 
 var _ diskStaller = (*dmsetupDiskStaller)(nil)
 
-func (s *dmsetupDiskStaller) device() string { return getDevice(s.t, s.c) }
+func (s *dmsetupDiskStaller) device() string { return roachtestutil.GetDiskDevice(s.t, s.c) }
 
 func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 	dev := s.device()
@@ -501,130 +493,3 @@ func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListO
 
 func (s *dmsetupDiskStaller) DataDir() string { return "{store-dir}" }
 func (s *dmsetupDiskStaller) LogDir() string  { return "logs" }
-
-type cgroupDiskStaller struct {
-	t           test.Test
-	c           cluster.Cluster
-	readOrWrite []bandwidthReadWrite
-	logsToo     bool
-}
-
-var _ diskStaller = (*cgroupDiskStaller)(nil)
-
-func (s *cgroupDiskStaller) DataDir() string { return "{store-dir}" }
-func (s *cgroupDiskStaller) LogDir() string {
-	return "logs"
-}
-func (s *cgroupDiskStaller) Setup(ctx context.Context) {
-	if s.logsToo {
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "mkdir -p {store-dir}/logs")
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "rm -f logs && ln -s {store-dir}/logs logs || true")
-	}
-}
-func (s *cgroupDiskStaller) Cleanup(ctx context.Context) {}
-
-func (s *cgroupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
-	// Shuffle the order of read and write stall initiation.
-	rand.Shuffle(len(s.readOrWrite), func(i, j int) {
-		s.readOrWrite[i], s.readOrWrite[j] = s.readOrWrite[j], s.readOrWrite[i]
-	})
-	for _, rw := range s.readOrWrite {
-		// NB: I don't understand why, but attempting to set a
-		// bytesPerSecond={0,1} results in Invalid argument from the io.max
-		// cgroupv2 API.
-		if err := s.setThroughput(ctx, nodes, rw, throughput{limited: true, bytesPerSecond: 4}); err != nil {
-			s.t.Fatal(err)
-		}
-	}
-}
-
-func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
-	for _, rw := range s.readOrWrite {
-		err := s.setThroughput(ctx, nodes, rw, throughput{limited: false})
-		s.t.L().PrintfCtx(ctx, "error unstalling the disk; stumbling on: %v", err)
-		// NB: We log the error and continue on because unstalling may not
-		// succeed if the process has successfully exited.
-	}
-}
-
-func (s *cgroupDiskStaller) device() (major, minor int) {
-	// TODO(jackson): Programmatically determine the device major,minor numbers.
-	// eg,:
-	//    deviceName := getDevice(s.t, s.c)
-	//    `cat /proc/partitions` and find `deviceName`
-	switch s.c.Cloud() {
-	case spec.GCE:
-		// ls -l /dev/sdb
-		// brw-rw---- 1 root disk 8, 16 Mar 27 22:08 /dev/sdb
-		return 8, 16
-	default:
-		s.t.Fatalf("unsupported cloud %q", s.c.Cloud())
-		return 0, 0
-	}
-}
-
-type throughput struct {
-	limited        bool
-	bytesPerSecond int
-}
-
-type bandwidthReadWrite int8
-
-const (
-	readBandwidth bandwidthReadWrite = iota
-	writeBandwidth
-)
-
-func (rw bandwidthReadWrite) cgroupV2BandwidthProp() string {
-	switch rw {
-	case readBandwidth:
-		return "rbps"
-	case writeBandwidth:
-		return "wbps"
-	default:
-		panic("unreachable")
-	}
-}
-
-func (s *cgroupDiskStaller) setThroughput(
-	ctx context.Context, nodes option.NodeListOption, rw bandwidthReadWrite, bw throughput,
-) error {
-	maj, min := s.device()
-	cockroachIOController := filepath.Join("/sys/fs/cgroup/system.slice", roachtestutil.SystemInterfaceSystemdUnitName()+".service", "io.max")
-
-	bytesPerSecondStr := "max"
-	if bw.limited {
-		bytesPerSecondStr = fmt.Sprintf("%d", bw.bytesPerSecond)
-	}
-	return s.c.RunE(ctx, option.WithNodes(nodes), "sudo", "/bin/bash", "-c", fmt.Sprintf(
-		`'echo %d:%d %s=%s > %s'`,
-		maj,
-		min,
-		rw.cgroupV2BandwidthProp(),
-		bytesPerSecondStr,
-		cockroachIOController,
-	))
-}
-
-func getDevice(t test.Test, c cluster.Cluster) string {
-	s := c.Spec()
-	switch c.Cloud() {
-	case spec.GCE:
-		switch s.LocalSSD {
-		case spec.LocalSSDDisable:
-			return "/dev/sdb"
-		case spec.LocalSSDPreferOn, spec.LocalSSDDefault:
-			// TODO(jackson): These spec values don't guarantee that we are actually
-			// using local SSDs, just that we might've.
-			return "/dev/nvme0n1"
-		default:
-			t.Fatalf("unsupported LocalSSD enum %v", s.LocalSSD)
-			return ""
-		}
-	case spec.AWS:
-		return "/dev/nvme1n1"
-	default:
-		t.Fatalf("unsupported cloud %q", c.Cloud())
-		return ""
-	}
-}


### PR DESCRIPTION
This change adapts the disk-stall roachtest by moving some of its code into roachtestutil, so it can be called from a new disk-stall operation. This change also updates the roachprod Cluster impl to not strictly require a test.Test to be passed in, for Fatal() calls.

Fixes #121942.

Epic: none

Release note: None