### PR TITLE
cli: add --shutdown flag to `node drain`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1352,7 +1352,12 @@ status, without actually decommissioning the node.`,
 	NodeDrainSelf = FlagInfo{
 		Name: "self",
 		Description: `Use the node ID of the node connected to via --host
-as target of the drain or quit command.`,
+as target of the drain command.`,
+	}
+
+	NodeDrainShutdown = FlagInfo{
+		Name:        "shutdown",
+		Description: `Shutdown the target node after it is drained.`,
 	}
 
 	SQLFmtLen = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -578,6 +578,8 @@ var drainCtx struct {
 	// nodeDrainSelf indicates that the command should target
 	// the node we're connected to (this is the default behavior).
 	nodeDrainSelf bool
+	// shutdown is true if the node should be shutdown after draining.
+	shutdown bool
 }
 
 // setDrainContextDefaults set the default values in drainCtx.  This
@@ -586,6 +588,7 @@ var drainCtx struct {
 func setDrainContextDefaults() {
 	drainCtx.drainWait = 10 * time.Minute
 	drainCtx.nodeDrainSelf = false
+	drainCtx.shutdown = false
 }
 
 // nodeCtx captures the command-line parameters of the `node` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -737,6 +737,7 @@ func init() {
 		f := drainNodeCmd.Flags()
 		cliflagcfg.DurationFlag(f, &drainCtx.drainWait, cliflags.DrainWait)
 		cliflagcfg.BoolFlag(f, &drainCtx.nodeDrainSelf, cliflags.NodeDrainSelf)
+		cliflagcfg.BoolFlag(f, &drainCtx.shutdown, cliflags.NodeDrainShutdown)
 	}
 
 	// Commands that establish a SQL connection.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/120520

Release note (cli change): The `cockroach node drain` command now has an optional --shutdown flag. When set, the node will shutdown after draining successfully completes.