### PR TITLE
sql: grant admin option repeatedly on role should not trigger schema change

### DIFF
--- a/pkg/sql/grant_role.go
+++ b/pkg/sql/grant_role.go
@@ -184,7 +184,7 @@ VALUES ($1, $2, $3, (SELECT user_id FROM system.users WHERE username = $1), (SEL
 ON CONFLICT ("role", "member")`
 	if n.adminOption {
 		// admin option: true, set "isAdmin" even if the membership exists.
-		memberStmt += ` DO UPDATE SET "isAdmin" = true`
+		memberStmt += ` DO UPDATE SET "isAdmin" = true WHERE role_members."isAdmin" IS NOT true`
 	} else {
 		// admin option: false, do not clear it from existing memberships.
 		memberStmt += ` DO NOTHING`

--- a/pkg/sql/logictest/testdata/logic_test/grant_role
+++ b/pkg/sql/logictest/testdata/logic_test/grant_role
@@ -24,6 +24,28 @@ SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)-
 ----
 true
 
+# Test that granting a role with admin option to a user that is already a member of the role and has admin option on the role does not perform a schema change.
+subtest no_op_grant_role_admin_option
+
+# Grant admin option to user 'roach' on role 'developer' for the first time.
+statement ok
+GRANT developer TO roach WITH ADMIN OPTION
+
+# Remember the current table version for 'system.role_members'
+let $role_members_version
+SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->>'version' FROM system.descriptor WHERE id = 'system.public.role_members'::REGCLASS
+
+# Repeatedly grant admin option to user 'roach' on role 'developer'
+repeat 10
+statement ok
+GRANT developer TO roach WITH ADMIN OPTION
+
+# Assert that it is indeed a no-op by checking the 'role_members' table version is the same as before
+query B
+SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->>'version' = $role_members_version::STRING FROM system.descriptor WHERE id = 'system.public.role_members'::REGCLASS
+----
+true
+
 # GRANT or REVOKE on the public role should result in "not exists"
 subtest grant_revoke_public
 


### PR DESCRIPTION
Previously, when `GRANT {role} TO {user} WITH ADMIN OPTION` was run for a role-user mapping that already existed with the `ADMIN OPTION` enabled, a `SCHEMA CHANGE` job would get created. This was unnecessary as there was no effective change in `system.role_members`.

To address this, this patch adds a simple WHERE clause to the conflict-handling `ON UPDATE SET` statement that gets executed when a `GRANT` is being run for a user with the ADMIN option. The `WHERE` clause checks if the user already has `"isAdmin" = true` for the role being granted before running `UPDATE`.

Fixes: #119657

Release note: None