### PR TITLE
fixtures: create roachtest for generating tpcc fixtures

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -109,7 +109,8 @@ type backupFixtureSpecs struct {
 	initWorkloadViaRestore *restoreSpecs
 
 	timeout time.Duration
-	suites  registry.SuiteSet
+	// A no-op, used only to set larger timeouts due roachtests limiting timeouts based on the suite
+	suites registry.SuiteSet
 
 	testName string
 
@@ -374,6 +375,22 @@ func registerBackupFixtures(r registry.Registry) {
 			// Use weekly to allow an over 24 hour timeout.
 			suites:  registry.Suites(registry.Weekly),
 			timeout: 48 * time.Hour,
+			skip:    "only for fixture generation",
+		},
+		{
+			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{
+				backupSpecs: backupSpecs{
+					workload:           tpccRestore{opts: tpccRestoreOptions{warehouses: 500}},
+					nonRevisionHistory: true,
+				},
+			}),
+			initWorkloadViaRestore: &restoreSpecs{
+				backup:                 backupSpecs{version: "v23.1.1", numBackupsInChain: 48},
+				restoreUptoIncremental: 48,
+			},
+			timeout: 1 * time.Hour,
+			suites:  registry.Suites(registry.Nightly),
 			skip:    "only for fixture generation",
 		},
 	} {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -813,6 +813,54 @@ func (tpce tpceRestore) DatabaseName() string {
 	return "tpce"
 }
 
+type tpccRestoreOptions struct {
+	warehouses     int
+	workers        int
+	waitFraction   float64
+	queryTraceFile string
+}
+
+type tpccRestore struct {
+	opts tpccRestoreOptions
+}
+
+func (tpcc tpccRestore) init(
+	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
+) {
+	crdbNodes := sp.getCRDBNodes()
+	cmd := roachtestutil.NewCommand(`./cockroach workload init tpcc`).
+		MaybeFlag(tpcc.opts.warehouses > 0, "warehouses", tpcc.opts.warehouses).
+		MaybeFlag(tpcc.opts.workers > 0, "workers", tpcc.opts.workers).
+		MaybeFlag(tpcc.opts.waitFraction != 1, "wait", tpcc.opts.waitFraction).
+		Arg(fmt.Sprintf("{pgurl:%d-%d}", crdbNodes[0], crdbNodes[len(crdbNodes)-1]))
+	c.Run(ctx, option.WithNodes([]int{sp.getWorkloadNode()}), cmd.String())
+}
+
+func (tpcc tpccRestore) run(
+	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
+) error {
+	crdbNodes := sp.getCRDBNodes()
+	cmd := roachtestutil.NewCommand(`./cockroach workload run tpcc`).
+		MaybeFlag(tpcc.opts.warehouses > 0, "warehouses", tpcc.opts.warehouses).
+		MaybeFlag(tpcc.opts.workers > 0, "workers", tpcc.opts.workers).
+		MaybeFlag(tpcc.opts.waitFraction != 1, "wait", tpcc.opts.waitFraction).
+		MaybeFlag(tpcc.opts.queryTraceFile != "", "query-trace-file", tpcc.opts.queryTraceFile).
+		Arg(fmt.Sprintf("{pgurl:%d-%d}", crdbNodes[0], crdbNodes[len(crdbNodes)-1]))
+	return c.RunE(ctx, option.WithNodes([]int{sp.getWorkloadNode()}), cmd.String())
+}
+
+func (tpcc tpccRestore) fixtureDir() string {
+	return fmt.Sprintf("tpc-c/warehouses=%d", tpcc.opts.warehouses)
+}
+
+func (tpcc tpccRestore) String() string {
+	return fmt.Sprintf("tpc-c/%d", tpcc.opts.warehouses)
+}
+
+func (tpcc tpccRestore) DatabaseName() string {
+	return "tpcc"
+}
+
 // restoreSpecs define input parameters to a restore roachtest set during
 // registration. They should not be modified within test_spec.run(), as they are shared
 // across driver runs.


### PR DESCRIPTION
Create a roachtest for generating tpcc fixtures with variable warehouse sizes

Epic: none
Release note: none