### PR TITLE
streamingccl: skip TestTenantStreamingFailback on 23.2

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -102,7 +102,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	skip.UnderStressRace(t, "test takes ~5 minutes under stressrace")
+	skip.WithIssue(t, 121221, "failback unsuppported on 23.2")
 
 	serverA, aDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,


### PR DESCRIPTION
Fixes #121221

Release note: none