### PR TITLE
backupccl: improve mismatch mr restore error msg

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -79,6 +79,7 @@ const (
 	restoreOptSkipMissingSequenceOwners = "skip_missing_sequence_owners"
 	restoreOptSkipMissingViews          = "skip_missing_views"
 	restoreOptSkipLocalitiesCheck       = "skip_localities_check"
+	restoreOptRemoveRegions             = "remove_regions"
 	restoreOptDebugPauseOn              = "debug_pause_on"
 	restoreOptAsTenant                  = "virtual_cluster_name"
 	restoreOptForceTenantID             = "virtual_cluster"
@@ -1615,10 +1616,10 @@ func checkClusterRegions(
 		sort.Strings(missingRegions)
 		mismatchErr := errors.Newf("detected a mismatch in regions between the restore cluster and the backup cluster, "+
 			"missing regions detected: %s.", strings.Join(missingRegions, ", "))
-		hintsMsg := fmt.Sprintf("there are two ways you can resolve this issue: "+
+		hintsMsg := fmt.Sprintf("there are several ways you can resolve this issue: "+
 			"1) update the cluster to which you're restoring to ensure that the regions present on the nodes' "+
 			"--locality flags match those present in the backup image, or "+
-			"2) restore with the %q option", restoreOptSkipLocalitiesCheck)
+			"2) restore with the %q or %q options", restoreOptSkipLocalitiesCheck, restoreOptRemoveRegions)
 		return errors.WithHint(mismatchErr, hintsMsg)
 	}
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -60,13 +60,13 @@ exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/';
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
-HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
+HINT: there are several ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" or "remove_regions" options
 
 exec-sql
 RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
-HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
+HINT: there are several ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" or "remove_regions" options
 
 exec-sql
 RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' WITH skip_localities_check;

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
@@ -60,13 +60,13 @@ exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' with schema_only;
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
-HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
+HINT: there are several ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" or "remove_regions" option
 
 exec-sql
 RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only;
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
-HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
+HINT: there are sever ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" or "remove_regions" option
 
 # Create a database with no regions to check default primary regions.
 exec-sql


### PR DESCRIPTION
Epic: none:

Release note(sql change): specify that "remove_regions" option as a workaround to running a restore into a cluster that cannot satisfy backup mr requirements.