### PR TITLE
backupccl: allocate work on index level

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -57,13 +57,13 @@ func distBackupPlanSpecs(
 	var introducedSpanPartitions []sql.SpanPartition
 	var err error
 	if len(spans) > 0 {
-		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, spans)
+		spanPartitions, err = dsp.PartitionSpansWithoutMerging(ctx, planCtx, spans)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if len(introducedSpans) > 0 {
-		introducedSpanPartitions, err = dsp.PartitionSpans(ctx, planCtx, introducedSpans)
+		introducedSpanPartitions, err = dsp.PartitionSpansWithoutMerging(ctx, planCtx, introducedSpans)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -94,7 +94,7 @@ var WriteMetadataSST = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.bulkio.write_metadata_sst.enabled",
 	"write experimental new format BACKUP metadata file",
-	util.ConstantWithMetamorphicTestBool("write-metadata-sst", false),
+	false,
 )
 
 // WriteMetadataWithExternalSSTsEnabled controls if we write a `BACKUP_METADATA`

--- a/pkg/ccl/backupccl/backuprand/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backuprand/backup_rand_test.go
@@ -166,9 +166,7 @@ database_name = 'rand' AND schema_name = 'public'`)
 	withOnlineRestore := func() string {
 		onlineRestoreExtension := ""
 		if rng.Intn(2) != 0 {
-			// TODO(msbutler): once this test is deflaked, add back the online restore
-			// variant of this test.
-			onlineRestoreExtension = ""
+			onlineRestoreExtension = ", experimental deferred copy"
 		}
 		return onlineRestoreExtension
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1321,7 +1321,16 @@ func (dsp *DistSQLPlanner) checkInstanceHealthAndVersionSystem(
 func (dsp *DistSQLPlanner) PartitionSpans(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) ([]SpanPartition, error) {
-	partitions, _, err := dsp.partitionSpansEx(ctx, planCtx, spans)
+	partitions, _, err := dsp.partitionSpansEx(ctx, planCtx, spans, false /* disallowMergeToExistingParition */)
+	return partitions, err
+}
+
+// ParitionSpansWithoutMerging is the same as PartitionSpans but does not merge
+// an input span into any existing partitioned span.
+func (dsp *DistSQLPlanner) PartitionSpansWithoutMerging(
+	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
+) ([]SpanPartition, error) {
+	partitions, _, err := dsp.partitionSpansEx(ctx, planCtx, spans, true /* disallowMergeToExistingParition */)
 	return partitions, err
 }
 
@@ -1329,7 +1338,10 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 // boolean indicating whether the misplanned ranges metadata should not be
 // generated.
 func (dsp *DistSQLPlanner) partitionSpansEx(
-	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
+	ctx context.Context,
+	planCtx *PlanningCtx,
+	spans roachpb.Spans,
+	disallowMergeToExistingParition bool,
 ) (_ []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	if len(spans) == 0 {
 		return nil, false, errors.AssertionFailedf("no spans")
@@ -1343,9 +1355,9 @@ func (dsp *DistSQLPlanner) partitionSpansEx(
 			true /* ignoreMisplannedRanges */, nil
 	}
 	if dsp.useGossipPlanning(ctx, planCtx) {
-		return dsp.deprecatedPartitionSpansSystem(ctx, planCtx, spans)
+		return dsp.deprecatedPartitionSpansSystem(ctx, planCtx, spans, disallowMergeToExistingParition)
 	}
-	return dsp.partitionSpans(ctx, planCtx, spans)
+	return dsp.partitionSpans(ctx, planCtx, spans, disallowMergeToExistingParition)
 }
 
 // partitionSpan takes a single span and splits it up according to the owning
@@ -1370,6 +1382,7 @@ func (dsp *DistSQLPlanner) partitionSpan(
 	nodeMap map[base.SQLInstanceID]int,
 	getSQLInstanceIDForKVNodeID func(roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason),
 	ignoreMisplannedRanges *bool,
+	disallowMergeToExistingParition bool,
 ) (_ []SpanPartition, lastPartitionIdx int, _ error) {
 	it := planCtx.spanIter
 	// rSpan is the span we are currently partitioning.
@@ -1447,7 +1460,7 @@ func (dsp *DistSQLPlanner) partitionSpan(
 				partitionedSpan.String(), sqlInstanceID, reason.String())
 		}
 
-		if lastSQLInstanceID == sqlInstanceID {
+		if lastSQLInstanceID == sqlInstanceID && !disallowMergeToExistingParition {
 			// Two consecutive ranges on the same node, merge the spans.
 			partition.Spans[len(partition.Spans)-1].EndKey = endKey.AsRawKey()
 		} else {
@@ -1469,7 +1482,10 @@ func (dsp *DistSQLPlanner) partitionSpan(
 // deprecatedPartitionSpansSystem finds node owners for ranges touching the given spans
 // for a system tenant.
 func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
-	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
+	ctx context.Context,
+	planCtx *PlanningCtx,
+	spans roachpb.Spans,
+	disallowMergeToExistingParition bool,
 ) (partitions []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	nodeMap := make(map[base.SQLInstanceID]int)
 	resolver := func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
@@ -1478,7 +1494,7 @@ func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 	for _, span := range spans {
 		var err error
 		partitions, _, err = dsp.partitionSpan(
-			ctx, planCtx, span, partitions, nodeMap, resolver, &ignoreMisplannedRanges,
+			ctx, planCtx, span, partitions, nodeMap, resolver, &ignoreMisplannedRanges, disallowMergeToExistingParition,
 		)
 		if err != nil {
 			return nil, false, err
@@ -1494,7 +1510,10 @@ func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 // available SQL instances if the locality info is available on at least some of
 // the instances, and it falls back to naive round-robin assignment if not.
 func (dsp *DistSQLPlanner) partitionSpans(
-	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
+	ctx context.Context,
+	planCtx *PlanningCtx,
+	spans roachpb.Spans,
+	disallowMergeToExistingParition bool,
 ) (partitions []SpanPartition, ignoreMisplannedRanges bool, _ error) {
 	resolver, err := dsp.makeInstanceResolver(ctx, planCtx)
 	if err != nil {
@@ -1519,7 +1538,7 @@ func (dsp *DistSQLPlanner) partitionSpans(
 			lastKey = safeKey
 		}
 		partitions, lastPartitionIdx, err = dsp.partitionSpan(
-			ctx, planCtx, span, partitions, nodeMap, resolver, &ignoreMisplannedRanges,
+			ctx, planCtx, span, partitions, nodeMap, resolver, &ignoreMisplannedRanges, disallowMergeToExistingParition,
 		)
 		if err != nil {
 			return nil, false, err
@@ -2108,7 +2127,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		// still read too eagerly in the soft limit case. To prevent this we'll
 		// need a new mechanism on the execution side to modulate table reads.
 		// TODO(yuzefovich): add that mechanism.
-		spanPartitions, ignoreMisplannedRanges, err = dsp.partitionSpansEx(ctx, planCtx, info.spans)
+		spanPartitions, ignoreMisplannedRanges, err = dsp.partitionSpansEx(ctx, planCtx, info.spans, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -672,6 +672,8 @@ func TestPartitionSpans(t *testing.T) {
 
 		locFilter string
 
+		withoutMerging bool
+
 		// expected result: a map of node to list of spans.
 		partitions      map[int][][2]string
 		partitionStates []string
@@ -964,6 +966,34 @@ func TestPartitionSpans(t *testing.T) {
 				totalPartitionSpans: 2,
 			},
 		},
+		// A single span touching multiple ranges but on the same node results
+		// in a multiple partitioned span iff ParitionSpansWithoutMerging is used.
+		{
+			withoutMerging: true,
+			ranges:         []testSpanResolverRange{{"A", 1}, {"A1", 1}, {"B", 2}},
+			gatewayNode:    1,
+
+			spans: [][2]string{{"A", "B"}},
+
+			partitions: map[int][][2]string{
+				1: {{"A", "A1"}, {"A1", "B"}},
+			},
+
+			partitionStates: []string{
+				"partition span: A{-1}, instance ID: 1, reason: gossip-target-healthy",
+				"partition span: {A1-B}, instance ID: 1, reason: gossip-target-healthy",
+			},
+
+			partitionState: spanPartitionState{
+				partitionSpans: map[base.SQLInstanceID]int{
+					1: 2,
+				},
+				partitionSpanDecisions: [SpanPartitionReason_LOCALITY_FILTERED_RANDOM_GATEWAY_OVERLOADED + 1]int{
+					SpanPartitionReason_GOSSIP_TARGET_HEALTHY: 2,
+				},
+				totalPartitionSpans: 2,
+			},
+		},
 		// Test some locality-filtered planning too.
 		//
 		// Since this test is run on a system tenant but there is a locality filter,
@@ -1205,11 +1235,17 @@ func TestPartitionSpans(t *testing.T) {
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
 			}
-
-			partitions, err := dsp.PartitionSpans(ctx, planCtx, spans)
+			var partitions []SpanPartition
+			var err error
+			if tc.withoutMerging {
+				partitions, err = dsp.PartitionSpansWithoutMerging(ctx, planCtx, spans)
+			} else {
+				partitions, err = dsp.PartitionSpans(ctx, planCtx, spans)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			countRanges := func(parts []SpanPartition) (count int) {
 				for _, sp := range parts {
 					ri := tsp.NewSpanResolverIterator(nil, nil)


### PR DESCRIPTION
Previously, backup planning would pass a list of merged index spans for
PartitionSpans to assign to nodes. With this patch, a list of unmerged
index spans are now passed to PartitionSpans.

Previously, online restore could create a virtual sst that pointed to empty key
space which would then cause pebble to panic during the download phase. This
was possible because of the following:

1.  backup could previously create a backup file that spanned a table key
space, but which contained an empty index.
2. restore allocates work using unmerged table index spans
3. online restore creates virtual sst spans by intersecting each backup file
with each restore span entry. The virtual sst for this empty index would then
point to empty key space.

This patch prevents this empty index span from being written to a backup file,
thus preventing this online restore vulnerability.

Informs https://github.com/cockroachdb/cockroach/issues/122176

Release note: none