### PR TITLE
release-24.1: roachprod: flag to enable cron on GCE

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -312,6 +312,8 @@ type ProviderOpts struct {
 	// Use an instance template and a managed instance group to create VMs. This
 	// enables cluster resizing, load balancing, and health monitoring.
 	Managed bool
+	// Enable the cron service. It is disabled by default.
+	EnableCron bool
 
 	// GCE allows two availability policies in case of a maintenance event (see --maintenance-policy via gcloud),
 	// 'TERMINATE' or 'MIGRATE'. The default is 'MIGRATE' which we denote by 'TerminateOnMigration == false'.
@@ -951,6 +953,8 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"use 'TERMINATE' maintenance policy (for GCE live migrations)")
 	flags.BoolVar(&o.Managed, ProviderName+"-managed", false,
 		"use a managed instance group (enables resizing, load balancing, and health monitoring)")
+	flags.BoolVar(&o.EnableCron, ProviderName+"-enable-cron",
+		false, "Enables the cron service (it is disabled by default)")
 }
 
 // ConfigureClusterFlags implements vm.ProviderFlags.
@@ -1222,7 +1226,11 @@ func (p *Provider) computeInstanceArgs(
 	}
 
 	// Create GCE startup script file.
-	filename, err := writeStartupScript(extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
+	filename, err := writeStartupScript(
+		extraMountOpts, opts.SSDOpts.FileSystem,
+		providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS),
+		providerOpts.EnableCron,
+	)
 	if err != nil {
 		return nil, cleanUpFn, errors.Wrapf(err, "could not write GCE startup script to temp file")
 	}

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -189,8 +189,10 @@ sudo apt-get install -qy chrony
 systemctl stop unattended-upgrades
 apt-get purge -y unattended-upgrades
 
+{{ if not .EnableCron }}
 systemctl stop cron
 systemctl mask cron
+{{ end }}
 
 # Override the chrony config. In particular,
 # log aggressively when clock is adjusted (0.01s)
@@ -265,7 +267,7 @@ sudo touch /mnt/data1/.roachprod-initialized
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool,
+	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool, enableCron bool,
 ) (string, error) {
 	type tmplParams struct {
 		ExtraMountOpts   string
@@ -274,6 +276,7 @@ func writeStartupScript(
 		EnableFIPS       bool
 		SharedUser       string
 		PublicKey        string
+		EnableCron       bool
 	}
 
 	publicKey, err := config.SSHPublicKey()
@@ -288,6 +291,7 @@ func writeStartupScript(
 		EnableFIPS:       enableFIPS,
 		SharedUser:       config.SharedUser,
 		PublicKey:        publicKey,
+		EnableCron:       enableCron,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")


### PR DESCRIPTION
Backport 1/1 commits from #122099.

/cc @cockroachdb/release

---

Previously, the cron service was masked and disabled on GCE via the start-up script.

This change allows a flag to be passed to prevent the script from masking and disabling cron.

Fixes: #122098

Epic: None
Release Note: None
Release justification: Test only change.
