### PR TITLE
changefeedccl: reset statusCodesIndex in mock webhook sink

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
+++ b/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
@@ -114,6 +114,7 @@ func (s *MockWebhookSink) SetStatusCodes(statusCodes []int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.statusCodes = statusCodes
+	s.mu.statusCodesIndex = 0
 }
 
 // Close closes the mock Webhook sink.


### PR DESCRIPTION
The mock webhook sink has a way for testers to provide a ring buffer of status codes for it to respond to messages with. As messages arrive, the sink increments an index that loops around the ring buffer. However, if the user sets the status codes to another size, the index was unchanged, so it was possible for the index to be out of bounds. This PR resets the index to 0 whenever the status codes are set.

Epic: none

Fixes: #122359

Release note: none