### PR TITLE
build: skip posting issue if branch no longer exists

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -11,6 +11,14 @@ else
     TAGS="bazel,gss,$TAGS"
 fi
 
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$TC_BUILD_BRANCH" != "$GIT_BRANCH" ]; then
+    echo "Skipping test $TARGET, as the expected branch is $TC_BUILD_BRANCH, but actual branch is $GIT_BRANCH"
+    exit 0
+else
+    echo "Confirmed that git branch is $GIT_BRANCH matches build branch $TC_BUILD_BRANCH"
+fi
+
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 ARTIFACTS_DIR=/artifacts


### PR DESCRIPTION
(Will favor this simpler solution over https://github.com/cockroachdb/cockroach/pull/122254)

Once we publish a maintenance release, we delete its corresponding staging branch (one of `staging-` or `release-MM.d.p-rc`). However, we run 1000s of nightly tests against all release- branches. And these TC jobs will post GH issues with incorrect branch details, if we delete these staging branches before the TC job completes.

This PR fails skips test if expected branch does not match actual git branch.

### Test Plan

- [x] create/clone a [test TC Project](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_StressTriggerCeliaTestBazel?branch=release-23.2.4-rc&mode=builds)
- [x] manually edit (hard-coded logic) in the [build step](https://teamcity.cockroachdb.com/admin/editRunType.html?id=buildType:Cockroach_Nightlies_StressTriggerCeliaTestBazel&runnerId=RUNNER_32&cameFromUrl=%2Fadmin%2FeditBuildRunners.html%3Fid%3DbuildType%253ACockroach_Nightlies_StressTriggerCeliaTestBazel%26init%3D1&cameFromTitle=) for verify the following test cases:
  - [x] test case 1: TC_BUILD_BRANCH == GIT_BRANCH ([works as expected](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_StressTriggerCeliaTestBazel/14883257?buildTab=log&focusLine=184&logView=flowAware&expandAll=true))
  - [x] test case 2: manually override `TC_BUILD_BRANCH` to some bogus value
    - [x] verify that script exits as expected ([works as expected](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_StressTriggerCeliaTestBazel/14883256?buildTab=log&focusLine=187&logView=flowAware&expandAll=true))

----
Fixes: DEVINF-1084
Epic: None.
Release note: None.
Release justification: non-production, test-infra only change.