### PR TITLE
roachprod: exclude `.roachprod-initialized` from wipe

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -563,7 +563,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 			}
 		} else {
 			rmCmds := []string{
-				`sudo find /mnt/data* -maxdepth 1 -type f -exec rm -f {} \;`,
+				`sudo find /mnt/data* -maxdepth 1 -type f -not -name .roachprod-initialized -exec rm -f {} \;`,
 				`sudo rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data}`,
 				`sudo rm -fr logs* data*`,
 			}


### PR DESCRIPTION
Previously, `Wipe` would delete the `roachprod` marker file `.roachprod-initialized` from '/mnt/data1', that is created by the start-up script.  This file is required by the `Wait` operation, which is required for `SetupSSH` and others to function correctly. Hence, after running Wipe on a cluster it becomes problematic to do some operations.

This change excludes the file from deletion.

Epic: None
Release Note: None