### PR TITLE
multiregionccl: update subtest naming for TestMrSystemDatabase

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -11,6 +11,7 @@ package multiregionccl
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,7 +103,7 @@ func TestMrSystemDatabase(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		t.Run("Sqlliveness", func(t *testing.T) {
+		t.Run(fmt.Sprintf("Sqlliveness %s", testCase.name), func(t *testing.T) {
 			row := testCase.database.QueryRow(t, `SELECT crdb_region, session_id, expiration FROM system.sqlliveness LIMIT 1`)
 			var sessionID string
 			var crdbRegion string
@@ -111,7 +112,7 @@ func TestMrSystemDatabase(t *testing.T) {
 			require.Equal(t, "us-east1", crdbRegion)
 		})
 
-		t.Run("Sqlinstances", func(t *testing.T) {
+		t.Run(fmt.Sprintf("Sqlinstances %s", testCase.name), func(t *testing.T) {
 			t.Run("InUse", func(t *testing.T) {
 				query := `
                 SELECT id, addr, session_id, locality, crdb_region
@@ -143,7 +144,7 @@ func TestMrSystemDatabase(t *testing.T) {
 				require.NoError(t, rows.Close())
 			})
 
-			t.Run("Preallocated", func(t *testing.T) {
+			t.Run(fmt.Sprintf("Preallocated %s", testCase.name), func(t *testing.T) {
 				query := `
                 SELECT id, addr, session_id, locality, crdb_region
                 FROM system.sql_instances
@@ -207,7 +208,7 @@ func TestMrSystemDatabase(t *testing.T) {
 				})
 			})
 
-			t.Run("Reclaim", func(t *testing.T) {
+			t.Run(fmt.Sprintf("Reclaim %s", testCase.name), func(t *testing.T) {
 				id := uuid.MakeV4()
 				s1, err := slstorage.MakeSessionID(make([]byte, 100), id)
 				require.NoError(t, err)
@@ -233,7 +234,7 @@ func TestMrSystemDatabase(t *testing.T) {
 			})
 		})
 
-		t.Run("GlobalTables", func(t *testing.T) {
+		t.Run(fmt.Sprintf("GlobalTables %s", testCase.name), func(t *testing.T) {
 			query := `
 		    SELECT target
 			FROM [SHOW ALL ZONE CONFIGURATIONS]
@@ -341,7 +342,7 @@ func TestMrSystemDatabase(t *testing.T) {
 			})
 		})
 
-		t.Run("QueryByEnum", func(t *testing.T) {
+		t.Run(fmt.Sprintf("QueryByEnum %s", testCase.name), func(t *testing.T) {
 			// This is a regression test for a bug triggered by setting up the system
 			// database. If the operation to configure the does not clear table
 			// statistics, this query will fail in the optimizer, because the stats will


### PR DESCRIPTION
Enhance test so we know if the subtests are system database or tenant database

Epic: none

Release note: None