### PR TITLE
docker: pass `COCKROACH_ARGS` without quoting

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -298,7 +298,7 @@ _main() {
 set_env_var "COCKROACH_ARGS"
 
 if [[ -n "$COCKROACH_ARGS" ]]; then
-  _main "$COCKROACH_ARGS"
+  _main $COCKROACH_ARGS
 else
   _main "$@"
 fi


### PR DESCRIPTION
Previously, the `COCKROACH_ARGS` variable was passed quoted, what converted it into a single string. If the variable is set to something more than one word, the whole string is passed as a single argument.

This PR removes the surrounding quotes to let field splitting convert the string into multiple arguments.

Fixes: #122441
Release note: None