### PR TITLE
server: fix tenant auto upgrade loop frequency override

### DIFF
--- a/pkg/server/tenant_auto_upgrade.go
+++ b/pkg/server/tenant_auto_upgrade.go
@@ -34,7 +34,9 @@ func (s *SQLServer) startTenantAutoUpgradeLoop(ctx context.Context) error {
 	return s.stopper.RunAsyncTask(ctx, "tenant-auto-upgrade-checker", func(ctx context.Context) {
 		loopFrequency := 30 * time.Second
 		if k := s.cfg.TestingKnobs.Server; k != nil {
-			loopFrequency = k.(*TestingKnobs).TenantAutoUpgradeLoopFrequency
+			if override := k.(*TestingKnobs).TenantAutoUpgradeLoopFrequency; override > 0 {
+				loopFrequency = override
+			}
 		}
 
 		for {


### PR DESCRIPTION
Previously, we were overriding the loop frequency whenever the test specified `Server` testing knobs. However, the testing knobs might not (and often don't) specify a custom frequency override (but instead set different parameters).

In this commit, we fix that by only overriding the frequency when a custom value is set.

Epic: none

Release note: None