### PR TITLE
release-24.1: sql: add version gate for UDF invoking UDFs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
@@ -248,6 +248,7 @@ CREATE PROCEDURE p_nested(curs REFCURSOR) AS $$
   END;
 $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
 statement ok
 DROP FUNCTION f;
 CREATE FUNCTION f(n INT) RETURNS INT AS $$
@@ -283,6 +284,7 @@ $$ LANGUAGE PLpgSQL;
 statement ok
 CLOSE ALL;
 
+skipif config local-mixed-23.2
 query I
 SELECT f(0);
 ----
@@ -291,6 +293,7 @@ SELECT f(0);
 statement ok
 CLOSE ALL;
 
+skipif config local-mixed-23.2
 query I
 SELECT f(1);
 ----
@@ -299,6 +302,7 @@ SELECT f(1);
 statement ok
 CLOSE ALL;
 
+skipif config local-mixed-23.2
 query I
 SELECT f(2);
 ----
@@ -307,6 +311,7 @@ SELECT f(2);
 statement ok
 CLOSE ALL;
 
+skipif config local-mixed-23.2
 query I
 SELECT f(3);
 ----
@@ -461,7 +466,7 @@ CALL p(1);
 ----
 NOTICE: 1
 
-statement error pgcode 34000 pq: cursor \"<unnamed portal 19>\" does not exist
+statement error pgcode 34000 pq: cursor \"<unnamed portal .*>\" does not exist
 CALL p(2);
 
 query T noticetrace

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
@@ -733,38 +733,56 @@ DROP PROCEDURE f;
 statement ok
 CREATE FUNCTION f1(a INT, b INT = 2) RETURNS INT AS $$ BEGIN RETURN a + b; END; $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 CREATE PROCEDURE p2(OUT o INT, a INT, b INT = f1(1)) AS $$ BEGIN SELECT a + b INTO o; END; $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query I
 CALL p2(NULL, 1);
 ----
 4
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query I
 CALL p2(NULL, 1, 1);
 ----
 2
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 CREATE OR REPLACE FUNCTION f1(a INT, b INT = 2) RETURNS INT AS $$ BEGIN RETURN a * b; END; $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query I
 CALL p2(NULL, 1);
 ----
 3
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query I
 CALL p2(NULL, 1, 1);
 ----
 2
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement error pgcode 2BP01 cannot drop function "f1" because other objects \(\[test.public.p2\]\) still depend on it
 DROP FUNCTION f1;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 DROP PROCEDURE p2;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 DROP FUNCTION f1;
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_params
@@ -905,9 +905,13 @@ DROP FUNCTION f;
 statement ok
 CREATE FUNCTION f1(a INT, b INT = 2) RETURNS INT AS $$ BEGIN RETURN a + b; END; $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 CREATE FUNCTION f2(a INT, b INT = f1(1)) RETURNS INT AS $$ BEGIN RETURN a + b; END; $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query III
 SELECT f1(1), f2(1), f2(1, 1);
 ----
@@ -916,14 +920,20 @@ SELECT f1(1), f2(1), f2(1, 1);
 statement ok
 CREATE OR REPLACE FUNCTION f1 (a INT, b INT = 2) RETURNS INT AS $$ BEGIN RETURN a * b; END; $$ LANGUAGE PLpgSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query III
 SELECT f1(1), f2(1), f2(1, 1);
 ----
 2  3  2
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement error pgcode 2BP01 cannot drop function "f1" because other objects \(\[test.public.f2\]\) still depend on it
 DROP FUNCTION f1;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 DROP FUNCTION f2;
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -231,6 +231,8 @@ $$ LANGUAGE PLpgSQL;
 statement ok
 DROP FUNCTION f_rewrite();
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 CREATE FUNCTION f_rewrite() RETURNS weekday AS
 $$
@@ -277,11 +279,15 @@ $$
   END
 $$ LANGUAGE PLPGSQL;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query T
 SELECT get_body_str('f_rewrite');
 ----
 "DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nSELECT public.f_nested(1:::INT8, b'\\x80':::@100107);\nCALL public.p_nested(1, b'\\x80':::@100107, day);\nDECLARE\nyesterday @100107 := b'\\x80':::@100107;\nBEGIN\nRAISE NOTICE 'val3: %, val4: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nIF yesterday IS NOT NULL THEN\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEND;\n"
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query TT
 SHOW CREATE FUNCTION f_rewrite;
 ----
@@ -343,11 +349,15 @@ ALTER TYPE weekday RENAME VALUE 'wednesday' TO 'humpday';
 statement ok
 ALTER TYPE weekday RENAME TO workday;
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query T
 SELECT get_body_str('f_rewrite');
 ----
 "DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nSELECT public.f_nested(1:::INT8, b'\\x80':::@100107);\nCALL public.p_nested(1, b'\\x80':::@100107, day);\nDECLARE\nyesterday @100107 := b'\\x80':::@100107;\nBEGIN\nRAISE NOTICE 'val3: %, val4: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nIF yesterday IS NOT NULL THEN\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEND;\n"
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 query TT
 SHOW CREATE FUNCTION f_rewrite;
 ----
@@ -410,6 +420,8 @@ ALTER TYPE workday RENAME TO weekday;
 statement ok
 ALTER TYPE weekday RENAME VALUE 'humpday' TO 'wednesday';
 
+skipif config local-mixed-23.2
+skipif config local-mixed-23.1
 statement ok
 DROP FUNCTION f_rewrite();
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -257,24 +257,38 @@ subtest functions_calling_functions
 statement ok
 CREATE FUNCTION f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok
 CREATE FUNCTION f_called_by_b2() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 + f_called_by_b() $$;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok;
 CREATE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT (f_called_by_b2()) /f_called_by_b2() FROM f_called_by_b() $$;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2, test.public.f_b\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b2\" because other objects \(\[test.public.f_b\]\) still depend on it
 DROP FUNCTION f_called_by_b2;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok
 CREATE OR REPLACE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2\]\) still depend on it
 DROP FUNCTION f_called_by_b;
 
@@ -284,6 +298,8 @@ CREATE SCHEMA altSchema;
 CREATE FUNCTION altSchema.f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE TABLE t1_with_b_2_ref(j int default altSchema.f_called_by_b() CHECK (altSchema.f_called_by_b() > 0));
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions \(\[test.public.f_called_by_b2\]\) still depend on it
 ALTER FUNCTION f_called_by_b SET SCHEMA altSchema;
 
@@ -295,6 +311,8 @@ onlyif config local-legacy-schema-changer
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other object \(\[test.public.t1_with_b_2_ref\]\) still depend on it
 DROP SCHEMA altSchema CASCADE;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok
 SELECT * FROM  f_called_by_b2();
 
@@ -313,5 +331,7 @@ statement ok
 DROP FUNCTION f_called_by_b2;
 DROP TABLE t1_with_b_2_ref;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok
 DROP FUNCTION f_b;

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -640,35 +640,43 @@ DROP PROCEDURE f;
 statement ok
 CREATE FUNCTION f1(a INT, b INT = 2) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b; $$;
 
+skipif config local-mixed-23.2
 statement ok
 CREATE PROCEDURE p2(OUT INT, a INT, b INT = f1(1)) LANGUAGE SQL AS $$ SELECT a + b; $$;
 
+skipif config local-mixed-23.2
 query I
 CALL p2(NULL, 1);
 ----
 4
 
+skipif config local-mixed-23.2
 query I
 CALL p2(NULL, 1, 1);
 ----
 2
 
+skipif config local-mixed-23.2
 statement ok
 CREATE OR REPLACE FUNCTION f1(a INT, b INT = 2) RETURNS INT LANGUAGE SQL AS $$ SELECT a * b; $$;
 
+skipif config local-mixed-23.2
 query I
 CALL p2(NULL, 1);
 ----
 3
 
+skipif config local-mixed-23.2
 query I
 CALL p2(NULL, 1, 1);
 ----
 2
 
+skipif config local-mixed-23.2
 statement error pgcode 2BP01 cannot drop function "f1" because other objects \(\[test.public.p2\]\) still depend on it
 DROP FUNCTION f1;
 
+skipif config local-mixed-23.2
 statement ok
 DROP PROCEDURE p2;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -1,4 +1,4 @@
-# LogicTest: !local-mixed-23.1
+# LogicTest: !local-mixed-23.1 !local-mixed-23.2
 
 statement ok
 CREATE FUNCTION lower_hello() RETURNS STRING LANGUAGE SQL AS $$ SELECT lower('hello') $$;

--- a/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
+++ b/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
@@ -97,9 +97,13 @@ CREATE FUNCTION f_in_udf() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 let $fn_oid
 SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'f_in_udf'
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok
 CREATE FUNCTION f_using_udf() RETURNS INT LANGUAGE SQL AS $$ SELECT [FUNCTION $fn_oid]() $$;
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 query I
 SELECT f_using_udf()
 ----

--- a/pkg/sql/logictest/testdata/logic_test/udf_params
+++ b/pkg/sql/logictest/testdata/logic_test/udf_params
@@ -765,9 +765,11 @@ DROP FUNCTION f;
 statement ok
 CREATE FUNCTION f1(a INT, b INT = 2) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b; $$;
 
+skipif config local-mixed-23.2
 statement ok
 CREATE FUNCTION f2(a INT, b INT = f1(1)) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b; $$;
 
+skipif config local-mixed-23.2
 query III
 SELECT f1(1), f2(1), f2(1, 1);
 ----
@@ -776,14 +778,17 @@ SELECT f1(1), f2(1), f2(1, 1);
 statement ok
 CREATE OR REPLACE FUNCTION f1 (a INT, b INT = 2) RETURNS INT LANGUAGE SQL AS $$ SELECT a * b; $$;
 
+skipif config local-mixed-23.2
 query III
 SELECT f1(1), f2(1), f2(1, 1);
 ----
 2  3  2
 
+skipif config local-mixed-23.2
 statement error pgcode 2BP01 cannot drop function "f1" because other objects \(\[test.public.f2\]\) still depend on it
 DROP FUNCTION f1;
 
+skipif config local-mixed-23.2
 statement ok
 DROP FUNCTION f2;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_rewrite
@@ -190,6 +190,7 @@ CREATE FUNCTION nested_func() RETURNS INT AS $$
   SELECT 1;
 $$ LANGUAGE SQL
 
+skipif config local-mixed-23.2
 statement ok
 CREATE PROCEDURE p_rewrite() AS $$
   SELECT nested_func();
@@ -197,6 +198,7 @@ CREATE PROCEDURE p_rewrite() AS $$
 $$ LANGUAGE SQL
 
 # TODO(fqazi): Renaming function calls will break today until #120351 is completed.
+skipif config local-mixed-23.2
 query T
 SELECT get_body_str('p_rewrite');
 ----

--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -134,7 +134,17 @@ CREATE FUNCTION rec(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT CASE i WHEN 0 THE
 statement ok
 CREATE FUNCTION other_udf() RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
 statement ok
+CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT other_udf()'
+
+onlyif config config local-mixed-23.2
+statement error pgcode 0A000 user defined functions cannot reference other user defined functions
+CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT other_udf()'
+
+onlyif config config local-mixed-23.1
+statement error pgcode 0A000 user defined functions cannot reference other user defined functions
 CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT other_udf()'
 
 subtest end

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -2185,13 +2185,6 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
-func TestLogic_udf_calling_udf(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "udf_calling_udf")
-}
-
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -13,6 +13,7 @@ package scbuildstmt
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcinfo"
@@ -237,6 +238,10 @@ func validateFunctionToFunctionReferences(
 	b BuildCtx, refProvider ReferenceProvider, parentDBID descpb.ID,
 ) {
 	err := refProvider.ForEachFunctionReference(func(id descpb.ID) error {
+		if !b.ClusterSettings().Version.IsActive(b, clusterversion.V24_1) {
+			return pgerror.Newf(pgcode.FeatureNotSupported,
+				"user defined functions cannot reference other user defined functions")
+		}
 		funcElts := b.QueryByID(id)
 		funcName := funcElts.FilterFunctionName().MustGetOneElement()
 		schemaParent := funcElts.FilterSchemaChild().MustGetOneElement()


### PR DESCRIPTION
Backport 1/1 commits from #121990.

/cc @cockroachdb/release

---

Previously, user-defined functions (UDFs) could invoke other UDFs even with mixed version states. This was problematic, as nodes running 23.2 might not be able to correctly invoke these functions or could break UDF references. This patch adds a version gate to prevent this behavior and updates tests to skip the functionality as needed.

Fixes: #121821
Release note: None
Release justification: without a version gate its possible for users to create UDFs which are not going to be usable in a mixed version state, this is a fairly low risk change
