### PR TITLE
release-24.1: opt: allow OptSplitScanLimit to be set to zero

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -189,6 +189,7 @@ type Memo struct {
 	mergeJoinsEnabled                          bool
 	plpgsqlUseStrictInto                       bool
 	useVirtualComputedColumnStats              bool
+	splitScanLimit                             int32
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -264,6 +265,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		mergeJoinsEnabled:                          evalCtx.SessionData().OptimizerMergeJoinsEnabled,
 		plpgsqlUseStrictInto:                       evalCtx.SessionData().PLpgSQLUseStrictInto,
 		useVirtualComputedColumnStats:              evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats,
+		splitScanLimit:                             evalCtx.SessionData().OptSplitScanLimit,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -417,6 +419,7 @@ func (m *Memo) IsStale(
 		m.mergeJoinsEnabled != evalCtx.SessionData().OptimizerMergeJoinsEnabled ||
 		m.plpgsqlUseStrictInto != evalCtx.SessionData().PLpgSQLUseStrictInto ||
 		m.useVirtualComputedColumnStats != evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats ||
+		m.splitScanLimit != evalCtx.SessionData().OptSplitScanLimit ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -442,6 +442,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = false
 	notStale()
 
+	// Stale opt_split_scan_limit.
+	evalCtx.SessionData().OptSplitScanLimit = 100
+	stale()
+	evalCtx.SessionData().OptSplitScanLimit = 0
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -271,14 +271,6 @@ func (c *CustomFuncs) splitScanIntoUnionScansOrSelects(
 	// If OptSplitScanLimit is below maxScanCount, we will decrease maxScanCount
 	// to that value because a hard limit should never be lower than a soft limit.
 	hardMaxScanCount := int(c.e.evalCtx.SessionData().OptSplitScanLimit)
-	// Hack: If OptSplitScanLimit is set to 0, it may be because it is
-	// uninitialized for an internal SQL execution. Set it to the old maximum of
-	// 16 to ensure there are no regressions.
-	if hardMaxScanCount == 0 {
-		// TODO(msirek): Remove this code once the following PR ships:
-		//   https://github.com/cockroachdb/cockroach/pull/73267
-		hardMaxScanCount = 16
-	}
 	if hardMaxScanCount < maxScanCount {
 		maxScanCount = hardMaxScanCount
 	}


### PR DESCRIPTION
Backport 1/1 commits from #122388.

/cc @cockroachdb/release

---

Now that the internal executor gets defaults for session variables, we can remove this hack added to make OptSplitScanLimit = 0 become 16.

Also add OptSplitScanLimit to the memo staleness checks.

Epic: None

Release note: None

Co-authored-by: Drew Kimball <drewk@cockroachlabs.com>

---

Release justification: fix for a session variable that will allow us to work around an expensive optimizer rule.