### PR TITLE
roachprod: fix tcpdump symlink condition

### DIFF
--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -70,10 +70,7 @@ sh -c 'echo "MaxStartups 64:30:128" >> /etc/ssh/sshd_config'
 sed -i'' 's/LogLevel.*$/LogLevel DEBUG3/' /etc/ssh/sshd_config
 # N.B. RSA SHA1 is no longer supported in the latest versions of OpenSSH. Existing tooling, e.g.,
 # jepsen still relies on it for authentication.
-# FIPS is still on Ubuntu 20.04 however, so don't enable if using FIPS.
-{{ if not .EnableFIPS }}
 sudo sh -c 'echo "PubkeyAcceptedAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config'
-{{ end }}
 service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent
@@ -92,10 +89,7 @@ EOF
 # N.B. Ubuntu 22.04 changed the location of tcpdump to /usr/bin. Since existing tooling, e.g.,
 # jepsen uses /usr/sbin, we create a symlink.
 # See https://ubuntu.pkgs.org/22.04/ubuntu-main-amd64/tcpdump_4.99.1-3build2_amd64.deb.html
-# FIPS is still on Ubuntu 20.04 however, so don't enable if using FIPS.
-{{ if .EnableFIPS }}
 sudo ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
-{{ end }}
 
 # Enable core dumps
 cat <<EOF > /etc/security/limits.d/core_unlimited.conf

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -174,8 +174,8 @@ sudo sh -c 'echo "root - nofile 1048576\n* - nofile 1048576" > /etc/security/lim
 # N.B. Ubuntu 22.04 changed the location of tcpdump to /usr/bin. Since existing tooling, e.g.,
 # jepsen uses /usr/sbin, we create a symlink.
 # See https://ubuntu.pkgs.org/22.04/ubuntu-main-amd64/tcpdump_4.99.1-3build2_amd64.deb.html
-# FIPS is still on Ubuntu 20.04 however, so don't enable if using FIPS.
-{{ if .EnableFIPS }}
+# FIPS is still on Ubuntu 20.04 however, so don't create if using FIPS.
+{{ if not .EnableFIPS }}
 sudo ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 {{ end }}
 


### PR DESCRIPTION
We want to make a symlink if not using FIPS. There was a missing not in the script.

Release note: none
Fixes: none
Epic: none


------------

This "fixes" the recent string of Jepsen SSH flake errors seen in https://github.com/cockroachdb/cockroach/issues/90695, but I won't close it as we still expect actual SSH flake errors to show up.