### PR TITLE
sql: improve error message for key collision from addsstable

### DIFF
--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -89,6 +89,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/stats",
         "//pkg/sql/types",
+        "//pkg/storage",
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/cancelchecker",


### PR DESCRIPTION
Previously, when a backfill encounters a key collision error, it logs a message with the sst key. However, this message is not very helpful to users. To address this, we are enhancing the error message by converting it into a SQL value which will improve the UX and debuggability.

Steps to reproduce:
`SET CLUSTER SETTING kv.bulk_io_write.small_write_size = '1';`
`CREATE TABLE location (city INT PRIMARY KEY, town INT);`
`INSERT INTO location (city) SELECT * FROM generate_series(1, 3000);`
`SET sql_safe_updates = false;`
`UPDATE location SET town = city % 1000;`
`ALTER TABLE location SPLIT AT (SELECT * FROM generate_series(1000, 3000, 1000));`
`SHOW RANGES FROM TABLE movr.location;`
`ALTER RANGE <id> RELOCATE LEASE TO <node>;` (do this in a round-robin fashion i.e. node 1->2->3->1...)
`CREATE TABLE tmp (town primary key) AS (SELECT town from location);`
(Currently, to get it to reproduce, I have also needed to alter line 366 of pkg/storage/sst.go to `if allowShadow {`)

Fixes: #117504
Epic: CRDB-35221

Release note (sql change): Improved error message for key collision from addstable by converting the key into a SQL value.

