### PR TITLE
workload: patch tpcc nondeterministic behavior with using set seed

### DIFF
--- a/pkg/workload/tpcc/BUILD.bazel
+++ b/pkg/workload/tpcc/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "random.go",
         "result.go",
         "stock_level.go",
+        "timeutil.go",
         "tpcc.go",
         "worker.go",
     ],

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
@@ -128,10 +127,10 @@ func createNewOrder(
 	return n, nil
 }
 
-func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
+func (n *newOrder) run(
+	ctx context.Context, wID int, tpccTime *tpccTime, rng *rand.Rand,
+) (interface{}, error) {
 	n.config.auditor.newOrderTransactions.Add(1)
-
-	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 
 	d := newOrderData{
 		wID:    wID,
@@ -208,7 +207,7 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 		return d.items[i].olIID < d.items[j].olIID
 	})
 
-	d.oEntryD = timeutil.Now()
+	d.oEntryD = tpccTime.Now()
 
 	err := n.config.executeTx(
 		ctx, n.mcp.Get(),

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgtype"
@@ -114,10 +113,10 @@ func createOrderStatus(
 	return o, nil
 }
 
-func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
+func (o *orderStatus) run(
+	ctx context.Context, wID int, tpccTime *tpccTime, rng *rand.Rand,
+) (interface{}, error) {
 	o.config.auditor.orderStatusTransactions.Add(1)
-
-	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 
 	d := orderStatusData{
 		dID: rng.Intn(10) + 1,

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
@@ -147,16 +146,16 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 	return p, nil
 }
 
-func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
+func (p *payment) run(
+	ctx context.Context, wID int, tpccTime *tpccTime, rng *rand.Rand,
+) (interface{}, error) {
 	p.config.auditor.paymentTransactions.Add(1)
-
-	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
 
 	d := paymentData{
 		dID: rng.Intn(10) + 1,
 		// hAmount is randomly selected within [1.00..5000.00]
 		hAmount: float64(randInt(rng, 100, 500000)) / float64(100.0),
-		hDate:   timeutil.Now(),
+		hDate:   tpccTime.Now(),
 	}
 
 	// 2.5.1.2: 85% chance of paying through home warehouse, otherwise

--- a/pkg/workload/tpcc/stock_level.go
+++ b/pkg/workload/tpcc/stock_level.go
@@ -13,7 +13,6 @@ package tpcc
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
@@ -86,9 +85,9 @@ func createStockLevel(
 	return s, nil
 }
 
-func (s *stockLevel) run(ctx context.Context, wID int) (interface{}, error) {
-	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
-
+func (s *stockLevel) run(
+	ctx context.Context, wID int, tpccTime *tpccTime, rng *rand.Rand,
+) (interface{}, error) {
 	// 2.8.1.2: The threshold of minimum quantity in stock is selected at random
 	// within [10..20].
 	d := stockLevelData{

--- a/pkg/workload/tpcc/timeutil.go
+++ b/pkg/workload/tpcc/timeutil.go
@@ -1,0 +1,50 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpcc
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"golang.org/x/exp/rand"
+)
+
+type tpccTime struct {
+	syncutil.Mutex
+	fakeTime time.Time
+	stepMax  time.Duration
+	rng      *rand.Rand
+}
+
+func (t *tpccTime) Now() time.Time {
+	if t.fakeTime.IsZero() {
+		return timeutil.Now()
+	}
+
+	t.Lock()
+	defer t.Unlock()
+	t.fakeTime = t.fakeTime.Add(
+		time.Duration(t.rng.Float64()*t.stepMax.Seconds()) * time.Second,
+	)
+	return t.fakeTime
+}
+
+func newTpccTime(fakeStartTime time.Time, stepMax time.Duration, seed uint64) *tpccTime {
+	rng := rand.New(new(rand.LockedSource))
+	rng.Seed(seed)
+
+	return &tpccTime{
+		fakeTime: fakeStartTime,
+		stepMax:  stepMax,
+		rng:      rng,
+	}
+}


### PR DESCRIPTION
The tpcc workload would have non-deterministic behavior when using a set
seed as parts of the workload would seed the random generators using
unix time instead of the provided seed. Additionally, queries were time
based, so the time the workload would run would affect query output. To
fix this, added the option to provide a fake time that would
artificially increase.

Epic: none

Release note: none