### PR TITLE
build: reduce build triggering for crdb-api-client workflow

### DIFF
--- a/.github/workflows/crdb-api-client-npm-publish.yml
+++ b/.github/workflows/crdb-api-client-npm-publish.yml
@@ -11,12 +11,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'pkg/ui/workspaces/crdb-api-client'
+      - 'pkg/**/*.proto'
 
 jobs:
   publish_crdb_api_client:
     if: github.repository == 'cockroachdb/cockroach'
     environment: ${{ github.ref_name == 'master' && 'master' || null }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     steps:
     - uses: actions/checkout@v4
@@ -70,14 +75,33 @@ jobs:
         else
           echo "same_version=false" >> $GITHUB_OUTPUT
         fi
+        # Check if PR to increment package version already exists. 
+        prs=$(gh pr list \
+          --repo "${{ github.repository }}" \
+          --head 'crdb-api-client-increment-version' \
+          --base 'master' \
+          --author 'cockroach-teamcity' \
+          --json title \
+          --jq 'length')
+        if ((prs > 0)); then
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_pr=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Increment version
-      if: steps.check-changes.outputs.modified == 'true' && steps.check-changes.outputs.same_version == 'true'
+      if: |
+        steps.check-changes.outputs.modified == 'true' && \
+          steps.check-changes.outputs.same_version == 'true' && \
+          steps.check-changes.outputs.has_pr == 'false'
       working-directory: pkg/ui/workspaces/crdb-api-client
       run: npm version patch
 
     - name: Create PR to increment package version
-      if: steps.check-changes.outputs.modified == 'true' && steps.check-changes.outputs.same_version == 'true'
+      if: |
+        steps.check-changes.outputs.modified == 'true' && \
+          steps.check-changes.outputs.same_version == 'true' && \
+          steps.check-changes.outputs.has_pr == 'false'
       uses: peter-evans/create-pull-request@v5
       with:
         base: master


### PR DESCRIPTION
This change is aimed to reduce the number of times `crdb-api-client` workflow is triggered and also avoids pushing updated PR if version of package is incremented.

1. Paths added to run workflow if *.proto files are modified or files within `crdb-api-client` directory. It should greatly reduce the time this workflow executes. Developers always have an option to trigger this workflow manually in case some specific change was done which doesn't forces workflow to execute (which should be a rare case).

2. I noticed, that having an open PR to increment version takes some time to run CI checks and at this time running workflow once again would cause to **force** update existing PR (because of different commit SHA) and it causes re-trigger checks and resets approval. It might be annoying so it is checked if PR is already opened and don't open it again.

Related to PR https://github.com/cockroachdb/cockroach/pull/121923

Release note: None