### PR TITLE
sqlsmith: add DisableNondeterministicLimits option

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -325,7 +325,8 @@ func runOneRoundQueryComparison(
 
 		// Initialize a smither that generates only deterministic SELECT statements.
 		smither, err := sqlsmith.NewSmither(conn, rnd,
-			sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns(), sqlsmith.DisableLimits(),
+			sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns(),
+			sqlsmith.DisableNondeterministicLimits(),
 			sqlsmith.UnlikelyConstantPredicate(), sqlsmith.FavorCommonData(),
 			sqlsmith.UnlikelyRandomNulls(), sqlsmith.DisableCrossJoins(),
 			sqlsmith.DisableIndexHints(), sqlsmith.DisableWith(), sqlsmith.DisableDecimals(),

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -63,6 +63,7 @@ var (
 		"DisableLimits":                           sqlsmith.DisableLimits(),
 		"DisableMutations":                        sqlsmith.DisableMutations(),
 		"DisableNondeterministicFns":              sqlsmith.DisableNondeterministicFns(),
+		"DisableNondeterministicLimits":           sqlsmith.DisableNondeterministicLimits(),
 		"DisableWindowFuncs":                      sqlsmith.DisableWindowFuncs(),
 		"DisableWith":                             sqlsmith.DisableWith(),
 		"EnableAlters":                            sqlsmith.EnableAlters(),

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -834,11 +834,21 @@ func (s *Smither) makeSelect(desiredTypes []*types.T, refs colRefs) (*tree.Selec
 		return nil, nil, ok
 	}
 
+	var orderBy tree.OrderBy
+	limit := makeLimit(s)
+	if limit != nil && s.disableNondeterministicLimits {
+		// The ORDER BY clause must be fully specified with all select list columns
+		// in order to make a LIMIT clause deterministic.
+		orderBy = s.makeOrderByWithAllCols(orderByRefs.extend(selectRefs...))
+	} else {
+		orderBy = s.makeOrderBy(orderByRefs)
+	}
+
 	stmt := tree.Select{
 		Select:  clause,
 		With:    withStmt,
-		OrderBy: s.makeOrderBy(orderByRefs),
-		Limit:   makeLimit(s),
+		OrderBy: orderBy,
+		Limit:   limit,
 	}
 
 	return &stmt, selectRefs, true
@@ -1179,12 +1189,22 @@ func (s *Smither) makeDelete(refs colRefs) (*tree.Delete, []*tableRef, bool) {
 		cols = append(cols, c...)
 	}
 
+	var orderBy tree.OrderBy
+	limit := makeLimit(s)
+	if limit != nil && s.disableNondeterministicLimits {
+		// The ORDER BY clause must be fully specified with all columns in order to
+		// make a LIMIT clause deterministic.
+		orderBy = s.makeOrderByWithAllCols(cols)
+	} else {
+		orderBy = s.makeOrderBy(cols)
+	}
+
 	del := &tree.Delete{
 		Table:     table,
 		Where:     s.makeWhere(cols, hasJoinTable),
-		OrderBy:   s.makeOrderBy(cols),
+		OrderBy:   orderBy,
 		Using:     using,
-		Limit:     makeLimit(s),
+		Limit:     limit,
 		Returning: &tree.NoReturningClause{},
 	}
 	if del.Limit == nil {
@@ -1245,12 +1265,22 @@ func (s *Smither) makeUpdate(refs colRefs) (*tree.Update, []*tableRef, bool) {
 		cols = append(cols, c...)
 	}
 
+	var orderBy tree.OrderBy
+	limit := makeLimit(s)
+	if limit != nil && s.disableNondeterministicLimits {
+		// The ORDER BY clause must be fully specified with all columns in order to
+		// make a LIMIT clause deterministic.
+		orderBy = s.makeOrderByWithAllCols(cols)
+	} else {
+		orderBy = s.makeOrderBy(cols)
+	}
+
 	update := &tree.Update{
 		Table:     table,
 		From:      from,
 		Where:     s.makeWhere(cols, hasJoinTable),
-		OrderBy:   s.makeOrderBy(cols),
-		Limit:     makeLimit(s),
+		OrderBy:   orderBy,
+		Limit:     limit,
 		Returning: &tree.NoReturningClause{},
 	}
 	colByName := make(map[tree.Name]*tree.ColumnTableDef)
@@ -1616,6 +1646,28 @@ func (s *Smither) makeOrderBy(refs colRefs) tree.OrderBy {
 			NullsOrder: s.randNullsOrder(),
 		})
 	}
+	return ob
+}
+
+func (s *Smither) makeOrderByWithAllCols(refs colRefs) tree.OrderBy {
+	if len(refs) == 0 {
+		return nil
+	}
+	var ob tree.OrderBy
+	for _, ref := range refs {
+		// PostGIS cannot order box2d types.
+		if s.postgres && ref.typ.Family() == types.Box2DFamily {
+			continue
+		}
+		ob = append(ob, &tree.Order{
+			Expr:       ref.item,
+			Direction:  s.randDirection(),
+			NullsOrder: s.randNullsOrder(),
+		})
+	}
+	s.rnd.Shuffle(len(ob), func(i, j int) {
+		ob[i], ob[j] = ob[j], ob[i]
+	})
 	return ob
 }
 

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -88,33 +88,34 @@ type Smither struct {
 	plpgsqlStmtSampler                 *plpgsqlStmtSampler
 	plpgsqlStmtWeights                 []plpgsqlStatementWeight
 
-	disableWith                bool
-	disableNondeterministicFns bool
-	disableLimits              bool
-	disableWindowFuncs         bool
-	disableAggregateFuncs      bool
-	disableMutations           bool
-	simpleDatums               bool
-	simpleNames                bool
-	avoidConsts                bool
-	outputSort                 bool
-	postgres                   bool
-	ignoreFNs                  []*regexp.Regexp
-	complexity                 float64
-	scalarComplexity           float64
-	unlikelyConstantPredicate  bool
-	favorCommonData            bool
-	unlikelyRandomNulls        bool
-	stringConstPrefix          string
-	disableJoins               bool
-	disableCrossJoins          bool
-	disableIndexHints          bool
-	lowProbWhereWithJoinTables bool
-	disableInsertSelect        bool
-	disableDivision            bool
-	disableDecimals            bool
-	disableOIDs                bool
-	disableUDFs                bool
+	disableWith                   bool
+	disableNondeterministicFns    bool
+	disableLimits                 bool
+	disableNondeterministicLimits bool
+	disableWindowFuncs            bool
+	disableAggregateFuncs         bool
+	disableMutations              bool
+	simpleDatums                  bool
+	simpleNames                   bool
+	avoidConsts                   bool
+	outputSort                    bool
+	postgres                      bool
+	ignoreFNs                     []*regexp.Regexp
+	complexity                    float64
+	scalarComplexity              float64
+	unlikelyConstantPredicate     bool
+	favorCommonData               bool
+	unlikelyRandomNulls           bool
+	stringConstPrefix             string
+	disableJoins                  bool
+	disableCrossJoins             bool
+	disableIndexHints             bool
+	lowProbWhereWithJoinTables    bool
+	disableInsertSelect           bool
+	disableDivision               bool
+	disableDecimals               bool
+	disableOIDs                   bool
+	disableUDFs                   bool
 
 	bulkSrv     *httptest.Server
 	bulkFiles   map[string][]byte
@@ -443,6 +444,12 @@ var DisableLimits = simpleOption("disable LIMIT", func(s *Smither) {
 	s.disableLimits = true
 })
 
+// DisableNondeterministicLimits causes the Smither to disable non-deterministic
+// LIMIT clauses.
+var DisableNondeterministicLimits = simpleOption("disable non-deterministic LIMIT", func(s *Smither) {
+	s.disableNondeterministicLimits = true
+})
+
 // AvoidConsts causes the Smither to prefer column references over generating
 // constants.
 var AvoidConsts = simpleOption("avoid consts", func(s *Smither) {
@@ -557,7 +564,7 @@ var CompareMode = multiOption(
 	DisableNondeterministicFns(),
 	DisableCRDBFns(),
 	IgnoreFNs("^version"),
-	DisableLimits(),
+	DisableNondeterministicLimits(),
 	OutputSort(),
 )
 


### PR DESCRIPTION
This commit adds a `DisableNondeterministicLimits` option to sqlsmith, which ensures that if a `LIMIT` is generated for a statement, the statement also includes a fully-specified `ORDER BY` clause. This ensures that the output of the statement will be deterministic. Deterministic output is needed for several roachtests including `costfuzz` and `unoptimized-query-oracle`, and this option allows them to test statements with `LIMIT` clauses.

Fixes #90572

Release note: None