### PR TITLE
release-23.2: roachprod: don't overwrite local cluster cache if ListCloud failed

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -246,12 +246,12 @@ func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 			return errors.Wrapf(err, "provider %s", provider.Name())
 		})
 	}
-
-	if err := g.Wait(); err != nil {
+	providerErr := g.Wait()
+	if providerErr != nil {
 		// We continue despite the error as we don't want to fail for all providers if only one
-		// has an issue. The function that calls ListCloud may not even use the erring provider.
-		// If it does, it will fail later when it doesn't find the specified cluster.
-		l.Printf("WARNING: Error listing VMs, continuing but list may be incomplete. %s \n", err.Error())
+		// has an issue. The function that calls ListCloud may not even use the erring provider,
+		// so log a warning and let the caller decide how to handle the error.
+		l.Printf("WARNING: Error listing VMs, continuing but list may be incomplete. %s \n", providerErr.Error())
 	}
 
 	for _, vms := range providerVMs {
@@ -298,15 +298,15 @@ func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 	}
 
 	// Sort VMs for each cluster. We want to make sure we always have the same order.
-	// Also assert that no cluster can be empty.
+	// Also check and warn if we find an empty cluster.
 	for _, c := range cloud.Clusters {
 		if len(c.VMs) == 0 {
-			return nil, errors.Errorf("found no VMs in cluster %s", c.Name)
+			l.Printf("WARNING: found no VMs in cluster %s\n", c.Name)
 		}
 		sort.Sort(c.VMs)
 	}
 
-	return cloud, nil
+	return cloud, providerErr
 }
 
 // CreateCluster TODO(peter): document

--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -181,12 +181,20 @@ func LoadClusters() error {
 // This function assumes the caller took a lock on a file to ensure that
 // multiple processes don't run through this code at the same time. However, it
 // is allowed for LoadClusters to run in another process at the same time.
-func syncClustersCache(l *logger.Logger, cloud *cloud.Cloud) error {
+//
+// overwriteMissingClusters indicates if clusters should be removed from the cache
+// if not present in cloud This is used when we have a potentially incomplete list
+// of all clusters due to a transient provider error.
+func syncClustersCache(l *logger.Logger, cloud *cloud.Cloud, overwriteMissingClusters bool) error {
 	// Write all cluster files.
 	for _, c := range cloud.Clusters {
 		if err := saveCluster(l, c); err != nil {
 			return err
 		}
+	}
+
+	if !overwriteMissingClusters {
+		return nil
 	}
 
 	// Remove any other files.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -241,10 +241,13 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 	defer unlock()
 
 	cld, err := cloud.ListCloud(l, options)
-	if err != nil {
-		return nil, err
-	}
-	if err := syncClustersCache(l, cld); err != nil {
+	// ListCloud may fail for a provider, but we still want to continue as
+	// the cluster the caller is trying to add and use may have been found.
+	// Instead, we tell syncClustersCache not to remove any clusters as we
+	// can't tell if a cluster was deleted or not found due to the error.
+	// The next successful ListCloud call will clean it up.
+	overwriteMissingClusters := err == nil
+	if err := syncClustersCache(l, cld, overwriteMissingClusters); err != nil {
 		return nil, err
 	}
 
@@ -547,13 +550,9 @@ func Reset(l *logger.Logger, clusterName string) error {
 		return nil
 	}
 
-	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	c, err := getCluster(l, clusterName)
 	if err != nil {
 		return err
-	}
-	c, ok := cld.Clusters[clusterName]
-	if !ok {
-		return errors.New("cluster not found")
 	}
 
 	return vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
@@ -637,14 +636,9 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	c, err := getCluster(l, clusterName)
 	if err != nil {
 		return err
-	}
-
-	c, ok := cld.Clusters[clusterName]
-	if !ok {
-		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
 
 	if err := cloud.ExtendCluster(l, c, lifetime); err != nil {
@@ -652,14 +646,9 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 	}
 
 	// Reload the clusters and print details.
-	cld, err = cloud.ListCloud(l, vm.ListOptions{})
+	c, err = getCluster(l, clusterName)
 	if err != nil {
 		return err
-	}
-
-	c, ok = cld.Clusters[clusterName]
-	if !ok {
-		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
 
 	return c.PrintDetails(l)
@@ -1290,10 +1279,10 @@ func Destroy(
 		if err != nil {
 			return err
 		}
-		cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
-		if err != nil {
-			return err
-		}
+		// ListCloud may fail due to a transient provider error, but we may have still
+		// found the cluster(s) we care about. Destroy the cluster(s) we know about
+		// and let the caller retry.
+		cld, _ = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 		clusters := cld.Clusters.FilterByName(destroyPattern)
 		clusterNames = clusters.Names()
 
@@ -1319,11 +1308,10 @@ func Destroy(
 				return destroyLocalCluster(ctx, l, name)
 			}
 			if cld == nil {
-				var err error
-				cld, err = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
-				if err != nil {
-					return err
-				}
+				// ListCloud may fail due to a transient provider error, but we may have still
+				// found the cluster(s) we care about. Destroy the cluster(s) we know about
+				// and let the caller retry.
+				cld, _ = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 			}
 			return destroyCluster(cld, l, name)
 		}); err != nil {
@@ -1372,14 +1360,11 @@ func (e *ClusterAlreadyExistsError) Error() string {
 }
 
 func cleanupFailedCreate(l *logger.Logger, clusterName string) error {
-	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
+	c, err := getCluster(l, clusterName)
 	if err != nil {
-		return err
-	}
-	c, ok := cld.Clusters[clusterName]
-	if !ok {
 		// If the cluster doesn't exist, we didn't manage to create any VMs
 		// before failing. Not an error.
+		//nolint:returnerrcheck
 		return nil
 	}
 	return cloud.DestroyCluster(l, c)
@@ -1447,10 +1432,11 @@ func Create(
 	}
 
 	if !isLocal {
-		cld, err := cloud.ListCloud(l, vm.ListOptions{})
-		if err != nil {
-			return err
-		}
+		// ListCloud may fail due to a transient provider error, but
+		// we may not even be creating a cluster with that provider.
+		// If the cluster does exist, and we didn't find it, it will
+		// fail on the provider's end.
+		cld, _ := cloud.ListCloud(l, vm.ListOptions{})
 		if _, ok := cld.Clusters[clusterName]; ok {
 			return &ClusterAlreadyExistsError{name: clusterName}
 		}
@@ -1522,18 +1508,15 @@ func GC(l *logger.Logger, dryrun bool) error {
 		return cloud.GCAWSKeyPairs(l, dryrun)
 	})
 
-	// The operations below depend on ListCloud so only call it if ListCloud runs
-	// without errors.
-	cld, listErr := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
-	errorsChan <- listErr
-	if listErr == nil {
-		addOpFn(func() error {
-			return cloud.GCClusters(l, cld, dryrun)
-		})
-		addOpFn(func() error {
-			return cloud.GCDNS(l, cld, dryrun)
-		})
-	}
+	// ListCloud may fail for a provider, but we can still attempt GC on
+	// the clusters we do have.
+	cld, _ := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
+	addOpFn(func() error {
+		return cloud.GCClusters(l, cld, dryrun)
+	})
+	addOpFn(func() error {
+		return cloud.GCDNS(l, cld, dryrun)
+	})
 
 	// Wait for all operations to finish and combine all errors.
 	go func() {
@@ -2347,4 +2330,20 @@ func createAttachMountVolumes(
 		l.Printf("Successfully mounted volume to %s", cVM.ProviderID)
 	}
 	return nil
+}
+
+func getCluster(l *logger.Logger, clusterName string) (*cloud.Cluster, error) {
+	// ListCloud may fail due to a transient provider error, but
+	// we may have still found the cluster we care about. It will
+	// fail below if it can't find the cluster.
+	cld, err := cloud.ListCloud(l, vm.ListOptions{})
+	c, ok := cld.Clusters[clusterName]
+	if !ok {
+		if err != nil {
+			return &cloud.Cluster{}, errors.Wrapf(err, "cluster %s not found", clusterName)
+		}
+		return &cloud.Cluster{}, fmt.Errorf("cluster %s does not exist", clusterName)
+	}
+
+	return c, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #122158.

/cc @cockroachdb/release

---

In #110042 we changed ListCloud to log an warning if a provider.List failed. However, swallowing the error has the unintended side effect of Sync overwriting the local cluster cache with no clusters being found for that provider.

This can cause concurrent tests to suddenly fail as they can no longer find the cluster in the cache. This change keeps the warning in ListCloud, but now also returns the error and leaves it up to the caller to decide what to do.

Most usages retain the same behavior of swallowing the error, except for Sync. Sync now checks if ListCloud returns an error, and only adds clusters to the local cache if there was one.

Release note: none
Epic: none
Fixes: none

Release Justification: test only change