### PR TITLE
roachtest/multiregion_leasing: fix flaky benchmark test

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -293,7 +293,6 @@ go_library(
         "@com_github_ibm_sarama//:sarama",
         "@com_github_jackc_pgtype//:pgtype",
         "@com_github_jackc_pgx_v4//:pgx",
-        "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
         "@com_github_montanaflynn_stats//:stats",


### PR DESCRIPTION
Previously, the leasing benchmark was flaky because of latency issues between the roachtest machine and the server could vary. This test would intentionally create a large number of tables and select from each one on each node, with the purpose of showing a regression when expiry based table leasing was used. This unfortunately could also be impacted between the latency observed and the benchmark could flake even with multiple samples. To address this, this patch will execute the select statements at the server side without waiting on the client, and time at the server. Additionally the query used is modified to only lease out the descriptor and not fetch *any* data so that its pure leasing benchmark.

Fixes: #122344

Release note: None