### PR TITLE
WIP on reusing the same mvcc iterator across Gets

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -56,6 +56,8 @@ func Get(
 		TargetBytes:           cArgs.Header.TargetBytes,
 		AllowEmpty:            cArgs.Header.AllowEmpty,
 		ReadCategory:          fs.BatchEvalReadCategory,
+		GetIter:               cArgs.GetIter,
+		KeepIter:              cArgs.KeepIter,
 	})
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -217,4 +218,6 @@ type CommandArgs struct {
 	Uncertainty           uncertainty.Interval
 	DontInterleaveIntents bool
 	OmitInRangefeeds      bool
+	GetIter               func() storage.MVCCIterator
+	KeepIter              func(storage.MVCCIterator)
 }


### PR DESCRIPTION
```
name                                       old time/op    new time/op    delta
IndexJoin/Cockroach-24                       5.28ms ± 2%    5.04ms ± 1%  -4.52%  (p=0.000 n=10+9)
IndexJoin/SharedProcessTenantCockroach-24    5.57ms ± 5%    5.17ms ± 2%  -7.19%  (p=0.000 n=10+9)
IndexJoin/MultinodeCockroach-24              6.66ms ± 4%    6.38ms ± 4%  -4.16%  (p=0.015 n=10+10)

name                                       old alloc/op   new alloc/op   delta
IndexJoin/Cockroach-24                       1.38MB ± 0%    1.38MB ± 1%  -0.29%  (p=0.017 n=9+10)
IndexJoin/SharedProcessTenantCockroach-24    1.51MB ± 0%    1.50MB ± 0%  -0.36%  (p=0.005 n=10+10)
IndexJoin/MultinodeCockroach-24              1.84MB ± 2%    1.83MB ± 1%    ~     (p=0.780 n=10+9)

name                                       old allocs/op  new allocs/op  delta
IndexJoin/Cockroach-24                        8.87k ± 0%     8.87k ± 0%    ~     (p=0.920 n=9+10)
IndexJoin/SharedProcessTenantCockroach-24     10.1k ± 0%     10.1k ± 0%  -0.09%  (p=0.019 n=7+10)
IndexJoin/MultinodeCockroach-24               12.6k ± 0%     12.6k ± 0%    ~     (p=0.563 n=10+9)
```

Epic: None

Release note: None