### PR TITLE
plpgsql: avoid internal error when parsing variable type

### DIFF
--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -489,10 +489,6 @@ func (l *lexer) Unimplemented(feature string) {
 	}
 }
 
-func (l *lexer) GetTypeFromValidSQLSyntax(sqlStr string) (tree.ResolvableTypeReference, error) {
-	return parser.GetTypeFromValidSQLSyntax(sqlStr)
-}
-
 func (l *lexer) ParseExpr(sqlStr string) (plpgsqltree.Expr, error) {
 	// Use ParseExprs instead of ParseExpr in order to correctly handle the case
 	// when multiple expressions are incorrectly passed.

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -202,16 +202,11 @@ DECLARE
 BEGIN
 END
 ----
-at or near "four": at or near ".": syntax error
+at or near "four": syntax error: unable to parse type of variable declaration
 DETAIL: source SQL:
-SET ROW (1::one.two.three.four)
-                         ^
---
-source SQL:
 DECLARE
   var1 one.two.three.four;
                      ^
-HINT: try \h SET SESSION
 
 error
 DECLARE
@@ -219,39 +214,58 @@ DECLARE
 BEGIN
 END
 ----
-at or near "four": at or near ".": syntax error
+at or near "four": syntax error: unable to parse type of variable declaration
 DETAIL: source SQL:
-SET ROW (1::one.two.three.four )
-                         ^
---
-source SQL:
 DECLARE
   var1 one.two.three.four := 0;
                      ^
-HINT: try \h SET SESSION
 
 error
-<<foo>>
+DECLARE
+  var1 1;
 BEGIN
-  SELECT 1;
-END bar
+END
 ----
-at or near "bar": syntax error: end label "bar" differs from block's label "foo"
+at or near "1": syntax error: unable to parse type of variable declaration
 DETAIL: source SQL:
-<<foo>>
-BEGIN
-  SELECT 1;
-END bar
-    ^
+DECLARE
+  var1 1;
+       ^
 
 error
+DECLARE
+  var1 'foo';
 BEGIN
-  SELECT 1;
-END foo
+END
 ----
-at or near "foo": syntax error: end label "foo" specified for unlabeled block
+at or near "foo": syntax error: unable to parse type of variable declaration
 DETAIL: source SQL:
+DECLARE
+  var1 'foo';
+       ^
+
+error
+DECLARE
+  var1 xy%ROWTYPE;
 BEGIN
-  SELECT 1;
-END foo
-    ^
+END
+----
+at or near "rowtype": syntax error: unable to parse type of variable declaration
+DETAIL: source SQL:
+DECLARE
+  var1 xy%ROWTYPE;
+          ^
+
+error
+DECLARE
+  var1 INT;
+  var2 var1%TYPE;
+BEGIN
+END
+----
+at or near "type": syntax error: unable to parse type of variable declaration
+DETAIL: source SQL:
+DECLARE
+  var1 INT;
+  var2 var1%TYPE;
+            ^

--- a/pkg/sql/plpgsql/parser/testdata/stmt_block
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_block
@@ -289,3 +289,29 @@ BEGIN
   END
   RAISE NOTICE '%', x;
   ^
+
+error
+<<foo>>
+BEGIN
+  SELECT 1;
+END bar
+----
+at or near "bar": syntax error: end label "bar" differs from block's label "foo"
+DETAIL: source SQL:
+<<foo>>
+BEGIN
+  SELECT 1;
+END bar
+    ^
+
+error
+BEGIN
+  SELECT 1;
+END foo
+----
+at or near "foo": syntax error: end label "foo" specified for unlabeled block
+DETAIL: source SQL:
+BEGIN
+  SELECT 1;
+END foo
+    ^


### PR DESCRIPTION
Previously, when parsing the type of a declared PL/pgSQL variable, the parser could return an internal error when attempting to parse an expression like `xy@ROWTYPE`. This syntax, isn't currently supported in CRDB, but shouldn't result in an internal error, either. Now, the parser has inlined some logic from `GetTypeFromCastOrCollate` and will now return an expected syntax error instead.

Informs #114676

Release note (bug fix): Fixed a bug that could result in an internal error when attempting to create a PL/pgSQL routine using the (currently unsupported) `%ROWTYPE` syntax for a variable declaration.