### PR TITLE
release-23.1: sql/delegate: added object_type and object_name to show grants

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -642,11 +642,11 @@ job paused at pausepoint
 # https://github.com/cockroachdb/cockroach/issues/106370 was a bug where
 # this would fail with `schema "public" is offline: restoring`.
 query-sql
-SELECT * FROM [SHOW GRANTS] WHERE relation_name = 'testtable_simple';
+SELECT * FROM [SHOW GRANTS] WHERE object_name = 'testtable_simple';
 ----
-testdb public testtable_simple admin ALL true
-testdb public testtable_simple root ALL true
-testdb public testtable_simple testuser ALL true
+testdb public testtable_simple table admin ALL true
+testdb public testtable_simple table root ALL true
+testdb public testtable_simple table testuser ALL true
 
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = ''
@@ -663,9 +663,9 @@ USE bar;
 ----
 
 query-sql
-SELECT * FROM [SHOW GRANTS] WHERE relation_name = 'testtable_simple';
+SELECT * FROM [SHOW GRANTS] WHERE object_name = 'testtable_simple';
 ----
-bar public testtable_simple admin ALL true
-bar public testtable_simple root ALL true
+bar public testtable_simple table admin ALL true
+bar public testtable_simple table root ALL true
 
 subtest end

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -38,6 +38,7 @@ func (d *delegator) delegateShowGrants(n *tree.ShowGrants) (tree.Statement, erro
 
 	const dbPrivQuery = `
 SELECT database_name,
+       'database' AS object_type,
        grantee,
        privilege_type,
 			 is_grantable::boolean
@@ -45,21 +46,32 @@ SELECT database_name,
 	const schemaPrivQuery = `
 SELECT table_catalog AS database_name,
        table_schema AS schema_name,
+       'schema' AS object_type,
        grantee,
        privilege_type,
        is_grantable::boolean
   FROM "".information_schema.schema_privileges`
 	const tablePrivQuery = `
-SELECT table_catalog AS database_name,
-       table_schema AS schema_name,
-       table_name,
-       grantee,
-       privilege_type,
-       is_grantable::boolean
-FROM "".information_schema.table_privileges`
+SELECT tp.table_catalog AS database_name,
+       tp.table_schema AS schema_name,
+       tp.table_name,
+       tp.grantee,
+       tp.privilege_type,
+       tp.is_grantable::boolean,
+       CASE
+           WHEN s.sequence_name IS NOT NULL THEN 'sequence'
+           ELSE 'table'
+       END AS object_type
+  FROM "".information_schema.table_privileges tp
+	LEFT JOIN "".information_schema.sequences s ON (
+  	tp.table_catalog = s.sequence_catalog AND
+  	tp.table_schema = s.sequence_schema AND
+  	tp.table_name = s.sequence_name
+	)`
 	const typePrivQuery = `
 SELECT type_catalog AS database_name,
        type_schema AS schema_name,
+       'type' AS object_type,
        type_name,
        grantee,
        privilege_type,
@@ -120,6 +132,7 @@ WITH fn_grants AS (
 SELECT database_name,
        schema_name,
        function_id,
+       'routine' AS object_type,
        concat(
 				 function_name,
          '(',
@@ -320,27 +333,27 @@ SELECT database_name,
 			fmt.Fprintf(&cond, `WHERE (database_name, schema_name, table_name) IN (%s)`, strings.Join(params, ","))
 		}
 	} else {
-		nameCols = "database_name, schema_name, relation_name,"
+		nameCols = "database_name, schema_name, object_name, object_type,"
 		// No target: only look at types, tables and schemas in the current database.
 		source.WriteString(
-			`SELECT database_name, schema_name, table_name AS relation_name, grantee, privilege_type, is_grantable FROM (`,
+			`SELECT database_name, schema_name, table_name AS object_name, object_type, grantee, privilege_type, is_grantable FROM (`,
 		)
 		source.WriteString(tablePrivQuery)
 		source.WriteByte(')')
 		source.WriteString(` UNION ALL ` +
-			`SELECT database_name, schema_name, NULL::STRING AS relation_name, grantee, privilege_type, is_grantable FROM (`)
+			`SELECT database_name, schema_name, NULL::STRING AS object_name, object_type, grantee, privilege_type, is_grantable FROM (`)
 		source.WriteString(schemaPrivQuery)
 		source.WriteByte(')')
 		source.WriteString(` UNION ALL ` +
-			`SELECT database_name, NULL::STRING AS schema_name, NULL::STRING AS relation_name, grantee, privilege_type, is_grantable FROM (`)
+			`SELECT database_name, NULL::STRING AS schema_name, NULL::STRING AS object_name, object_type, grantee, privilege_type, is_grantable FROM (`)
 		source.WriteString(dbPrivQuery)
 		source.WriteByte(')')
 		source.WriteString(` UNION ALL ` +
-			`SELECT database_name, schema_name, type_name AS relation_name, grantee, privilege_type, is_grantable FROM (`)
+			`SELECT database_name, schema_name, type_name AS object_name, object_type, grantee, privilege_type, is_grantable FROM (`)
 		source.WriteString(typePrivQuery)
 		source.WriteByte(')')
 		source.WriteString(` UNION ALL ` +
-			`SELECT database_name, schema_name, function_signature AS relation_name, grantee, privilege_type, is_grantable FROM (`)
+			`SELECT database_name, schema_name, function_signature AS object_name, object_type , grantee, privilege_type, is_grantable FROM (`)
 		source.WriteString(udfQuery)
 		source.WriteByte(')')
 		// If the current database is set, restrict the command to it.

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
@@ -9,10 +9,10 @@ CREATE SCHEMA s2;
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s TO testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
 statement ok
 CREATE SEQUENCE s.q;
@@ -42,50 +42,50 @@ NOTICE: some privileges have no effect on sequences: [BACKUP]
 statement error pgcode 0LP01 invalid privilege type BACKUP for sequence
 GRANT BACKUP ON ALL SEQUENCES IN SCHEMA S TO testuser
 
-query TTTTTB colnames,rowsort
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           s            q              testuser  SELECT          false
-test           s            t              testuser  BACKUP          false
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           s            q            sequence     testuser  SELECT          false
+test           s            t            table        testuser  BACKUP          false
 
 statement ok
 GRANT USAGE ON ALL SEQUENCES IN SCHEMA s TO testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           s            q              testuser  SELECT          false
-test           s            q              testuser  USAGE           false
-test           s            t              testuser  BACKUP          false
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           s            q            sequence     testuser  SELECT          false
+test           s            q            sequence     testuser  USAGE           false
+test           s            t            table        testuser  BACKUP          false
 
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s, s2 TO testuser, testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            q              testuser   SELECT          false
-test           s            q              testuser   USAGE           false
-test           s            q              testuser2  SELECT          false
-test           s            t              testuser   BACKUP          false
-test           s2           q              testuser   SELECT          false
-test           s2           q              testuser2  SELECT          false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            q            sequence     testuser   SELECT          false
+test           s            q            sequence     testuser   USAGE           false
+test           s            q            sequence     testuser2  SELECT          false
+test           s            t            table        testuser   BACKUP          false
+test           s2           q            sequence     testuser   SELECT          false
+test           s2           q            sequence     testuser2  SELECT          false
 
 statement ok
 GRANT ALL ON ALL SEQUENCES IN SCHEMA s, s2 TO testuser, testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            q              testuser   ALL             false
-test           s            q              testuser2  ALL             false
-test           s            t              testuser   BACKUP          false
-test           s2           q              testuser   ALL             false
-test           s2           q              testuser2  ALL             false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            q            sequence     testuser   ALL             false
+test           s            q            sequence     testuser2  ALL             false
+test           s            t            table        testuser   BACKUP          false
+test           s2           q            sequence     testuser   ALL             false
+test           s2           q            sequence     testuser2  ALL             false
 
 statement ok
 CREATE USER testuser3
@@ -94,12 +94,12 @@ CREATE USER testuser3
 statement ok
 GRANT ALL ON ALL TABLES IN SCHEMA s2 TO testuser3
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser3
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s2           q              testuser3  ALL             false
-test           s2           t              testuser3  ALL             false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s2           q            sequence     testuser3  ALL             false
+test           s2           t            table        testuser3  ALL             false
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON SEQUENCES TO testuser3;
@@ -110,23 +110,23 @@ CREATE SCHEMA s4;
 CREATE SEQUENCE s3.q;
 CREATE SEQUENCE s4.q;
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            q              testuser   ALL             false
-test           s            q              testuser2  ALL             false
-test           s            t              testuser   BACKUP          false
-test           s2           q              testuser   ALL             false
-test           s2           q              testuser2  ALL             false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            q            sequence     testuser   ALL             false
+test           s            q            sequence     testuser2  ALL             false
+test           s            t            table        testuser   BACKUP          false
+test           s2           q            sequence     testuser   ALL             false
+test           s2           q            sequence     testuser2  ALL             false
 
 
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser3
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s2           q              testuser3  ALL             false
-test           s2           t              testuser3  ALL             false
-test           s3           q              testuser3  USAGE           false
-test           s4           q              testuser3  USAGE           false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s2           q            sequence     testuser3  ALL             false
+test           s2           t            table        testuser3  ALL             false
+test           s3           q            sequence     testuser3  USAGE           false
+test           s4           q            sequence     testuser3  USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
@@ -9,10 +9,10 @@ CREATE SCHEMA s2;
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
 statement ok
 CREATE TABLE s.t();
@@ -21,83 +21,83 @@ CREATE TABLE s2.t();
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           s            t              testuser  SELECT          false
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           s            t            table        testuser  SELECT          false
 
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s, s2 TO testuser, testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            t              testuser   SELECT          false
-test           s            t              testuser2  SELECT          false
-test           s2           t              testuser   SELECT          false
-test           s2           t              testuser2  SELECT          false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            t            table        testuser   SELECT          false
+test           s            t            table        testuser2  SELECT          false
+test           s2           t            table        testuser   SELECT          false
+test           s2           t            table        testuser2  SELECT          false
 
 statement ok
 GRANT ALL ON ALL TABLES IN SCHEMA s, s2 TO testuser, testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            t              testuser   ALL             false
-test           s            t              testuser2  ALL             false
-test           s2           t              testuser   ALL             false
-test           s2           t              testuser2  ALL             false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            t            table        testuser   ALL             false
+test           s            t            table        testuser2  ALL             false
+test           s2           t            table        testuser   ALL             false
+test           s2           t            table        testuser2  ALL             false
 
 statement ok
 REVOKE SELECT ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            t              testuser   BACKUP          false
-test           s            t              testuser   CHANGEFEED      false
-test           s            t              testuser   CREATE          false
-test           s            t              testuser   DELETE          false
-test           s            t              testuser   DROP            false
-test           s            t              testuser   INSERT          false
-test           s            t              testuser   UPDATE          false
-test           s            t              testuser   ZONECONFIG      false
-test           s            t              testuser2  BACKUP          false
-test           s            t              testuser2  CHANGEFEED      false
-test           s            t              testuser2  CREATE          false
-test           s            t              testuser2  DELETE          false
-test           s            t              testuser2  DROP            false
-test           s            t              testuser2  INSERT          false
-test           s            t              testuser2  UPDATE          false
-test           s            t              testuser2  ZONECONFIG      false
-test           s2           t              testuser   BACKUP          false
-test           s2           t              testuser   CHANGEFEED      false
-test           s2           t              testuser   CREATE          false
-test           s2           t              testuser   DELETE          false
-test           s2           t              testuser   DROP            false
-test           s2           t              testuser   INSERT          false
-test           s2           t              testuser   UPDATE          false
-test           s2           t              testuser   ZONECONFIG      false
-test           s2           t              testuser2  BACKUP          false
-test           s2           t              testuser2  CHANGEFEED      false
-test           s2           t              testuser2  CREATE          false
-test           s2           t              testuser2  DELETE          false
-test           s2           t              testuser2  DROP            false
-test           s2           t              testuser2  INSERT          false
-test           s2           t              testuser2  UPDATE          false
-test           s2           t              testuser2  ZONECONFIG      false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            t            table        testuser   BACKUP          false
+test           s            t            table        testuser   CHANGEFEED      false
+test           s            t            table        testuser   CREATE          false
+test           s            t            table        testuser   DELETE          false
+test           s            t            table        testuser   DROP            false
+test           s            t            table        testuser   INSERT          false
+test           s            t            table        testuser   UPDATE          false
+test           s            t            table        testuser   ZONECONFIG      false
+test           s            t            table        testuser2  BACKUP          false
+test           s            t            table        testuser2  CHANGEFEED      false
+test           s            t            table        testuser2  CREATE          false
+test           s            t            table        testuser2  DELETE          false
+test           s            t            table        testuser2  DROP            false
+test           s            t            table        testuser2  INSERT          false
+test           s            t            table        testuser2  UPDATE          false
+test           s            t            table        testuser2  ZONECONFIG      false
+test           s2           t            table        testuser   BACKUP          false
+test           s2           t            table        testuser   CHANGEFEED      false
+test           s2           t            table        testuser   CREATE          false
+test           s2           t            table        testuser   DELETE          false
+test           s2           t            table        testuser   DROP            false
+test           s2           t            table        testuser   INSERT          false
+test           s2           t            table        testuser   UPDATE          false
+test           s2           t            table        testuser   ZONECONFIG      false
+test           s2           t            table        testuser2  BACKUP          false
+test           s2           t            table        testuser2  CHANGEFEED      false
+test           s2           t            table        testuser2  CREATE          false
+test           s2           t            table        testuser2  DELETE          false
+test           s2           t            table        testuser2  DROP            false
+test           s2           t            table        testuser2  INSERT          false
+test           s2           t            table        testuser2  UPDATE          false
+test           s2           t            table        testuser2  ZONECONFIG      false
 
 statement ok
 REVOKE ALL ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser, testuser2
 ----
-database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
 # Verify that the database name is resolved correctly if specified.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -8,17 +8,17 @@ statement ok
 CREATE USER target
 
 # Check privileges that `public` has by default, ignoring types and virtual tables.
-query TTTTTB colnames,rowsort
-SELECT * FROM [SHOW GRANTS FOR public] WHERE relation_name IS NULL
+query TTTTTTB colnames,rowsort
+SELECT * FROM [SHOW GRANTS FOR public] WHERE object_name IS NULL
 ----
-database_name  schema_name         relation_name  grantee  privilege_type  is_grantable
-test           crdb_internal       NULL           public   USAGE           false
-test           information_schema  NULL           public   USAGE           false
-test           pg_catalog          NULL           public   USAGE           false
-test           pg_extension        NULL           public   USAGE           false
-test           public              NULL           public   CREATE          false
-test           public              NULL           public   USAGE           false
-test           NULL                NULL           public   CONNECT         false
+database_name  schema_name         object_name  object_type  grantee  privilege_type  is_grantable
+test           crdb_internal       NULL         schema       public   USAGE           false
+test           information_schema  NULL         schema       public   USAGE           false
+test           pg_catalog          NULL         schema       public   USAGE           false
+test           pg_extension        NULL         schema       public   USAGE           false
+test           public              NULL         schema       public   CREATE          false
+test           public              NULL         schema       public   USAGE           false
+test           NULL                NULL         database     public   CONNECT         false
 
 statement error grant options cannot be granted to "public" role
 GRANT ALL PRIVILEGES ON TABLE t TO public WITH GRANT OPTION
@@ -60,12 +60,12 @@ user testuser
 statement ok
 GRANT SELECT, INSERT ON TABLE t TO testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           public       t              testuser2  INSERT          false
-test           public       t              testuser2  SELECT          false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       t            table        testuser2  INSERT          false
+test           public       t            table        testuser2  SELECT          false
 
 user testuser2
 
@@ -74,12 +74,12 @@ GRANT INSERT, SELECT ON TABLE t TO target
 
 user testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           public       t              testuser2  INSERT          false
-test           public       t              testuser2  SELECT          false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       t            table        testuser2  INSERT          false
+test           public       t            table        testuser2  SELECT          false
 
 statement ok
 GRANT SELECT, INSERT ON TABLE t TO testuser2 WITH GRANT OPTION
@@ -107,25 +107,25 @@ GRANT DELETE, UPDATE ON TABLE t TO testuser2 WITH GRANT OPTION
 statement ok
 REVOKE INSERT ON TABLE t FROM testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           public       t              testuser2  DELETE          true
-test           public       t              testuser2  SELECT          true
-test           public       t              testuser2  UPDATE          true
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       t            table        testuser2  DELETE          true
+test           public       t            table        testuser2  SELECT          true
+test           public       t            table        testuser2  UPDATE          true
 
 statement ok
 REVOKE GRANT OPTION FOR SELECT ON TABLE t FROM testuser2
 
 # revoking GRANT OPTION FOR does not take away the privilege for the user
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           public       t              testuser2  DELETE          true
-test           public       t              testuser2  SELECT          false
-test           public       t              testuser2  UPDATE          true
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       t            table        testuser2  DELETE          true
+test           public       t            table        testuser2  SELECT          false
+test           public       t            table        testuser2  UPDATE          true
 
 user testuser2
 
@@ -162,11 +162,11 @@ REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser2
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           public       t              testuser  ALL             false
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       t            table        testuser  ALL             false
 
 user testuser
 
@@ -178,30 +178,30 @@ user root
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
 statement ok
 GRANT UPDATE, DELETE ON TABLE t to testuser WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           public       t              testuser  DELETE          true
-test           public       t              testuser  UPDATE          true
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       t            table        testuser  DELETE          true
+test           public       t            table        testuser  UPDATE          true
 
 # test applying repeat privileges (ALL replaces individual privileges)
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t to testuser WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           public       t              testuser  ALL             true
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       t            table        testuser  ALL             true
 
 user testuser
 
@@ -213,11 +213,11 @@ user root
 statement ok
 REVOKE GRANT OPTION FOR UPDATE, DELETE ON TABLE t FROM testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           public       t              testuser  ALL             false
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       t            table        testuser  ALL             false
 
 user testuser
 
@@ -230,13 +230,13 @@ GRANT UPDATE ON TABLE t TO testuser2 WITH GRANT OPTION
 statement error user testuser missing WITH GRANT OPTION privilege on DELETE
 GRANT DELETE ON TABLE t TO testuser2 WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           public       t              testuser2  DELETE          false
-test           public       t              testuser2  SELECT          true
-test           public       t              testuser2  UPDATE          false
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       t            table        testuser2  DELETE          false
+test           public       t            table        testuser2  SELECT          true
+test           public       t            table        testuser2  UPDATE          false
 
 user testuser2
 
@@ -275,18 +275,18 @@ GRANT DELETE ON TABLE t TO testuser
 statement ok
 REVOKE DELETE ON TABLE t FROM testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           public       t              testuser  BACKUP          true
-test           public       t              testuser  CHANGEFEED      true
-test           public       t              testuser  CREATE          true
-test           public       t              testuser  DROP            true
-test           public       t              testuser  INSERT          true
-test           public       t              testuser  SELECT          true
-test           public       t              testuser  UPDATE          true
-test           public       t              testuser  ZONECONFIG      true
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       t            table        testuser  BACKUP          true
+test           public       t            table        testuser  CHANGEFEED      true
+test           public       t            table        testuser  CREATE          true
+test           public       t            table        testuser  DROP            true
+test           public       t            table        testuser  INSERT          true
+test           public       t            table        testuser  SELECT          true
+test           public       t            table        testuser  UPDATE          true
+test           public       t            table        testuser  ZONECONFIG      true
 
 statement ok
 GRANT SELECT ON TABLE t TO target
@@ -318,10 +318,10 @@ GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
 #
 # Wipe everything so far and briefly test databases, schemas, types
@@ -335,15 +335,15 @@ REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser2
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
 
 statement ok
 CREATE SCHEMA s
@@ -351,11 +351,11 @@ CREATE SCHEMA s
 statement ok
 GRANT ALL PRIVILEGES ON SCHEMA s TO testuser WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           s            NULL           testuser  ALL             true
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           s            NULL         schema       testuser  ALL             true
 
 user testuser
 
@@ -364,20 +364,20 @@ GRANT CREATE ON SCHEMA s TO testuser2 WITH GRANT OPTION
 
 user root
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser2
 ----
-database_name  schema_name  relation_name  grantee    privilege_type  is_grantable
-test           s            NULL           testuser2  CREATE          true
+database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           s            NULL         schema       testuser2  CREATE          true
 
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON SCHEMA s FROM testuser
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR testuser
 ----
-database_name  schema_name  relation_name  grantee   privilege_type  is_grantable
-test           s            NULL           testuser  ALL             false
+database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           s            NULL         schema       testuser  ALL             false
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -19,2327 +19,2327 @@ a              readwrite  ALL             false
 a              root       ALL             true
 
 # Show that by default GRANT is restricted to the current database
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS
 ----
-database_name  schema_name         relation_name                           grantee  privilege_type  is_grantable
-test           NULL                NULL                                    admin    ALL             true
-test           NULL                NULL                                    public   CONNECT         false
-test           NULL                NULL                                    root     ALL             true
-test           crdb_internal       NULL                                    public   USAGE           false
-test           crdb_internal       active_range_feeds                      public   SELECT          false
-test           crdb_internal       backward_dependencies                   public   SELECT          false
-test           crdb_internal       builtin_functions                       public   SELECT          false
-test           crdb_internal       cluster_contended_indexes               public   SELECT          false
-test           crdb_internal       cluster_contended_keys                  public   SELECT          false
-test           crdb_internal       cluster_contended_tables                public   SELECT          false
-test           crdb_internal       cluster_contention_events               public   SELECT          false
-test           crdb_internal       cluster_database_privileges             public   SELECT          false
-test           crdb_internal       cluster_distsql_flows                   public   SELECT          false
-test           crdb_internal       cluster_execution_insights              public   SELECT          false
-test           crdb_internal       cluster_inflight_traces                 public   SELECT          false
-test           crdb_internal       cluster_locks                           public   SELECT          false
-test           crdb_internal       cluster_queries                         public   SELECT          false
-test           crdb_internal       cluster_sessions                        public   SELECT          false
-test           crdb_internal       cluster_settings                        public   SELECT          false
-test           crdb_internal       cluster_statement_statistics            public   SELECT          false
-test           crdb_internal       cluster_transaction_statistics          public   SELECT          false
-test           crdb_internal       cluster_transactions                    public   SELECT          false
-test           crdb_internal       cluster_txn_execution_insights          public   SELECT          false
-test           crdb_internal       create_function_statements              public   SELECT          false
-test           crdb_internal       create_schema_statements                public   SELECT          false
-test           crdb_internal       create_statements                       public   SELECT          false
-test           crdb_internal       create_type_statements                  public   SELECT          false
-test           crdb_internal       cross_db_references                     public   SELECT          false
-test           crdb_internal       databases                               public   SELECT          false
-test           crdb_internal       default_privileges                      public   SELECT          false
-test           crdb_internal       feature_usage                           public   SELECT          false
-test           crdb_internal       forward_dependencies                    public   SELECT          false
-test           crdb_internal       gossip_alerts                           public   SELECT          false
-test           crdb_internal       gossip_liveness                         public   SELECT          false
-test           crdb_internal       gossip_network                          public   SELECT          false
-test           crdb_internal       gossip_nodes                            public   SELECT          false
-test           crdb_internal       index_columns                           public   SELECT          false
-test           crdb_internal       index_spans                             public   SELECT          false
-test           crdb_internal       index_usage_statistics                  public   SELECT          false
-test           crdb_internal       invalid_objects                         public   SELECT          false
-test           crdb_internal       jobs                                    public   SELECT          false
-test           crdb_internal       kv_builtin_function_comments            public   SELECT          false
-test           crdb_internal       kv_catalog_comments                     public   SELECT          false
-test           crdb_internal       kv_catalog_descriptor                   public   SELECT          false
-test           crdb_internal       kv_catalog_namespace                    public   SELECT          false
-test           crdb_internal       kv_catalog_zones                        public   SELECT          false
-test           crdb_internal       kv_dropped_relations                    public   SELECT          false
-test           crdb_internal       kv_inherited_role_members               public   SELECT          false
-test           crdb_internal       kv_node_liveness                        public   SELECT          false
-test           crdb_internal       kv_node_status                          public   SELECT          false
-test           crdb_internal       kv_repairable_catalog_corruptions       public   SELECT          false
-test           crdb_internal       kv_store_status                         public   SELECT          false
-test           crdb_internal       kv_system_privileges                    public   SELECT          false
-test           crdb_internal       leases                                  public   SELECT          false
-test           crdb_internal       lost_descriptors_with_data              public   SELECT          false
-test           crdb_internal       node_build_info                         public   SELECT          false
-test           crdb_internal       node_contention_events                  public   SELECT          false
-test           crdb_internal       node_distsql_flows                      public   SELECT          false
-test           crdb_internal       node_execution_insights                 public   SELECT          false
-test           crdb_internal       node_inflight_trace_spans               public   SELECT          false
-test           crdb_internal       node_memory_monitors                    public   SELECT          false
-test           crdb_internal       node_metrics                            public   SELECT          false
-test           crdb_internal       node_queries                            public   SELECT          false
-test           crdb_internal       node_runtime_info                       public   SELECT          false
-test           crdb_internal       node_sessions                           public   SELECT          false
-test           crdb_internal       node_statement_statistics               public   SELECT          false
-test           crdb_internal       node_tenant_capabilities_cache          public   SELECT          false
-test           crdb_internal       node_transaction_statistics             public   SELECT          false
-test           crdb_internal       node_transactions                       public   SELECT          false
-test           crdb_internal       node_txn_execution_insights             public   SELECT          false
-test           crdb_internal       node_txn_stats                          public   SELECT          false
-test           crdb_internal       partitions                              public   SELECT          false
-test           crdb_internal       pg_catalog_table_is_implemented         public   SELECT          false
-test           crdb_internal       ranges                                  public   SELECT          false
-test           crdb_internal       ranges_no_leases                        public   SELECT          false
-test           crdb_internal       regions                                 public   SELECT          false
-test           crdb_internal       schema_changes                          public   SELECT          false
-test           crdb_internal       session_trace                           public   SELECT          false
-test           crdb_internal       session_variables                       public   SELECT          false
-test           crdb_internal       statement_activity                      public   SELECT          false
-test           crdb_internal       statement_statistics                    public   SELECT          false
-test           crdb_internal       statement_statistics_persisted          public   SELECT          false
-test           crdb_internal       statement_statistics_persisted_v22_2    public   SELECT          false
-test           crdb_internal       super_regions                           public   SELECT          false
-test           crdb_internal       system_jobs                             public   SELECT          false
-test           crdb_internal       table_columns                           public   SELECT          false
-test           crdb_internal       table_indexes                           public   SELECT          false
-test           crdb_internal       table_row_statistics                    public   SELECT          false
-test           crdb_internal       table_spans                             public   SELECT          false
-test           crdb_internal       tables                                  public   SELECT          false
-test           crdb_internal       tenant_usage_details                    public   SELECT          false
-test           crdb_internal       transaction_activity                    public   SELECT          false
-test           crdb_internal       transaction_contention_events           public   SELECT          false
-test           crdb_internal       transaction_statistics                  public   SELECT          false
-test           crdb_internal       transaction_statistics_persisted        public   SELECT          false
-test           crdb_internal       transaction_statistics_persisted_v22_2  public   SELECT          false
-test           crdb_internal       zones                                   public   SELECT          false
-test           information_schema  NULL                                    public   USAGE           false
-test           information_schema  administrable_role_authorizations       public   SELECT          false
-test           information_schema  applicable_roles                        public   SELECT          false
-test           information_schema  attributes                              public   SELECT          false
-test           information_schema  character_sets                          public   SELECT          false
-test           information_schema  check_constraint_routine_usage          public   SELECT          false
-test           information_schema  check_constraints                       public   SELECT          false
-test           information_schema  collation_character_set_applicability   public   SELECT          false
-test           information_schema  collations                              public   SELECT          false
-test           information_schema  column_column_usage                     public   SELECT          false
-test           information_schema  column_domain_usage                     public   SELECT          false
-test           information_schema  column_options                          public   SELECT          false
-test           information_schema  column_privileges                       public   SELECT          false
-test           information_schema  column_statistics                       public   SELECT          false
-test           information_schema  column_udt_usage                        public   SELECT          false
-test           information_schema  columns                                 public   SELECT          false
-test           information_schema  columns_extensions                      public   SELECT          false
-test           information_schema  constraint_column_usage                 public   SELECT          false
-test           information_schema  constraint_table_usage                  public   SELECT          false
-test           information_schema  data_type_privileges                    public   SELECT          false
-test           information_schema  domain_constraints                      public   SELECT          false
-test           information_schema  domain_udt_usage                        public   SELECT          false
-test           information_schema  domains                                 public   SELECT          false
-test           information_schema  element_types                           public   SELECT          false
-test           information_schema  enabled_roles                           public   SELECT          false
-test           information_schema  engines                                 public   SELECT          false
-test           information_schema  events                                  public   SELECT          false
-test           information_schema  files                                   public   SELECT          false
-test           information_schema  foreign_data_wrapper_options            public   SELECT          false
-test           information_schema  foreign_data_wrappers                   public   SELECT          false
-test           information_schema  foreign_server_options                  public   SELECT          false
-test           information_schema  foreign_servers                         public   SELECT          false
-test           information_schema  foreign_table_options                   public   SELECT          false
-test           information_schema  foreign_tables                          public   SELECT          false
-test           information_schema  information_schema_catalog_name         public   SELECT          false
-test           information_schema  key_column_usage                        public   SELECT          false
-test           information_schema  keywords                                public   SELECT          false
-test           information_schema  optimizer_trace                         public   SELECT          false
-test           information_schema  parameters                              public   SELECT          false
-test           information_schema  partitions                              public   SELECT          false
-test           information_schema  plugins                                 public   SELECT          false
-test           information_schema  processlist                             public   SELECT          false
-test           information_schema  profiling                               public   SELECT          false
-test           information_schema  referential_constraints                 public   SELECT          false
-test           information_schema  resource_groups                         public   SELECT          false
-test           information_schema  role_column_grants                      public   SELECT          false
-test           information_schema  role_routine_grants                     public   SELECT          false
-test           information_schema  role_table_grants                       public   SELECT          false
-test           information_schema  role_udt_grants                         public   SELECT          false
-test           information_schema  role_usage_grants                       public   SELECT          false
-test           information_schema  routine_privileges                      public   SELECT          false
-test           information_schema  routines                                public   SELECT          false
-test           information_schema  schema_privileges                       public   SELECT          false
-test           information_schema  schemata                                public   SELECT          false
-test           information_schema  schemata_extensions                     public   SELECT          false
-test           information_schema  sequences                               public   SELECT          false
-test           information_schema  session_variables                       public   SELECT          false
-test           information_schema  sql_features                            public   SELECT          false
-test           information_schema  sql_implementation_info                 public   SELECT          false
-test           information_schema  sql_parts                               public   SELECT          false
-test           information_schema  sql_sizing                              public   SELECT          false
-test           information_schema  st_geometry_columns                     public   SELECT          false
-test           information_schema  st_spatial_reference_systems            public   SELECT          false
-test           information_schema  st_units_of_measure                     public   SELECT          false
-test           information_schema  statistics                              public   SELECT          false
-test           information_schema  table_constraints                       public   SELECT          false
-test           information_schema  table_constraints_extensions            public   SELECT          false
-test           information_schema  table_privileges                        public   SELECT          false
-test           information_schema  tables                                  public   SELECT          false
-test           information_schema  tables_extensions                       public   SELECT          false
-test           information_schema  tablespaces                             public   SELECT          false
-test           information_schema  tablespaces_extensions                  public   SELECT          false
-test           information_schema  transforms                              public   SELECT          false
-test           information_schema  triggered_update_columns                public   SELECT          false
-test           information_schema  triggers                                public   SELECT          false
-test           information_schema  type_privileges                         public   SELECT          false
-test           information_schema  udt_privileges                          public   SELECT          false
-test           information_schema  usage_privileges                        public   SELECT          false
-test           information_schema  user_attributes                         public   SELECT          false
-test           information_schema  user_defined_types                      public   SELECT          false
-test           information_schema  user_mapping_options                    public   SELECT          false
-test           information_schema  user_mappings                           public   SELECT          false
-test           information_schema  user_privileges                         public   SELECT          false
-test           information_schema  view_column_usage                       public   SELECT          false
-test           information_schema  view_routine_usage                      public   SELECT          false
-test           information_schema  view_table_usage                        public   SELECT          false
-test           information_schema  views                                   public   SELECT          false
-test           pg_catalog          NULL                                    public   USAGE           false
-test           pg_catalog          "char"                                  admin    ALL             false
-test           pg_catalog          "char"                                  public   USAGE           false
-test           pg_catalog          "char"                                  root     ALL             false
-test           pg_catalog          "char"[]                                admin    ALL             false
-test           pg_catalog          "char"[]                                public   USAGE           false
-test           pg_catalog          "char"[]                                root     ALL             false
-test           pg_catalog          anyelement                              admin    ALL             false
-test           pg_catalog          anyelement                              public   USAGE           false
-test           pg_catalog          anyelement                              root     ALL             false
-test           pg_catalog          anyelement[]                            admin    ALL             false
-test           pg_catalog          anyelement[]                            public   USAGE           false
-test           pg_catalog          anyelement[]                            root     ALL             false
-test           pg_catalog          bit                                     admin    ALL             false
-test           pg_catalog          bit                                     public   USAGE           false
-test           pg_catalog          bit                                     root     ALL             false
-test           pg_catalog          bit[]                                   admin    ALL             false
-test           pg_catalog          bit[]                                   public   USAGE           false
-test           pg_catalog          bit[]                                   root     ALL             false
-test           pg_catalog          bool                                    admin    ALL             false
-test           pg_catalog          bool                                    public   USAGE           false
-test           pg_catalog          bool                                    root     ALL             false
-test           pg_catalog          bool[]                                  admin    ALL             false
-test           pg_catalog          bool[]                                  public   USAGE           false
-test           pg_catalog          bool[]                                  root     ALL             false
-test           pg_catalog          box2d                                   admin    ALL             false
-test           pg_catalog          box2d                                   public   USAGE           false
-test           pg_catalog          box2d                                   root     ALL             false
-test           pg_catalog          box2d[]                                 admin    ALL             false
-test           pg_catalog          box2d[]                                 public   USAGE           false
-test           pg_catalog          box2d[]                                 root     ALL             false
-test           pg_catalog          bytes                                   admin    ALL             false
-test           pg_catalog          bytes                                   public   USAGE           false
-test           pg_catalog          bytes                                   root     ALL             false
-test           pg_catalog          bytes[]                                 admin    ALL             false
-test           pg_catalog          bytes[]                                 public   USAGE           false
-test           pg_catalog          bytes[]                                 root     ALL             false
-test           pg_catalog          char                                    admin    ALL             false
-test           pg_catalog          char                                    public   USAGE           false
-test           pg_catalog          char                                    root     ALL             false
-test           pg_catalog          char[]                                  admin    ALL             false
-test           pg_catalog          char[]                                  public   USAGE           false
-test           pg_catalog          char[]                                  root     ALL             false
-test           pg_catalog          date                                    admin    ALL             false
-test           pg_catalog          date                                    public   USAGE           false
-test           pg_catalog          date                                    root     ALL             false
-test           pg_catalog          date[]                                  admin    ALL             false
-test           pg_catalog          date[]                                  public   USAGE           false
-test           pg_catalog          date[]                                  root     ALL             false
-test           pg_catalog          decimal                                 admin    ALL             false
-test           pg_catalog          decimal                                 public   USAGE           false
-test           pg_catalog          decimal                                 root     ALL             false
-test           pg_catalog          decimal[]                               admin    ALL             false
-test           pg_catalog          decimal[]                               public   USAGE           false
-test           pg_catalog          decimal[]                               root     ALL             false
-test           pg_catalog          float                                   admin    ALL             false
-test           pg_catalog          float                                   public   USAGE           false
-test           pg_catalog          float                                   root     ALL             false
-test           pg_catalog          float4                                  admin    ALL             false
-test           pg_catalog          float4                                  public   USAGE           false
-test           pg_catalog          float4                                  root     ALL             false
-test           pg_catalog          float4[]                                admin    ALL             false
-test           pg_catalog          float4[]                                public   USAGE           false
-test           pg_catalog          float4[]                                root     ALL             false
-test           pg_catalog          float[]                                 admin    ALL             false
-test           pg_catalog          float[]                                 public   USAGE           false
-test           pg_catalog          float[]                                 root     ALL             false
-test           pg_catalog          geography                               admin    ALL             false
-test           pg_catalog          geography                               public   USAGE           false
-test           pg_catalog          geography                               root     ALL             false
-test           pg_catalog          geography[]                             admin    ALL             false
-test           pg_catalog          geography[]                             public   USAGE           false
-test           pg_catalog          geography[]                             root     ALL             false
-test           pg_catalog          geometry                                admin    ALL             false
-test           pg_catalog          geometry                                public   USAGE           false
-test           pg_catalog          geometry                                root     ALL             false
-test           pg_catalog          geometry[]                              admin    ALL             false
-test           pg_catalog          geometry[]                              public   USAGE           false
-test           pg_catalog          geometry[]                              root     ALL             false
-test           pg_catalog          inet                                    admin    ALL             false
-test           pg_catalog          inet                                    public   USAGE           false
-test           pg_catalog          inet                                    root     ALL             false
-test           pg_catalog          inet[]                                  admin    ALL             false
-test           pg_catalog          inet[]                                  public   USAGE           false
-test           pg_catalog          inet[]                                  root     ALL             false
-test           pg_catalog          int                                     admin    ALL             false
-test           pg_catalog          int                                     public   USAGE           false
-test           pg_catalog          int                                     root     ALL             false
-test           pg_catalog          int2                                    admin    ALL             false
-test           pg_catalog          int2                                    public   USAGE           false
-test           pg_catalog          int2                                    root     ALL             false
-test           pg_catalog          int2[]                                  admin    ALL             false
-test           pg_catalog          int2[]                                  public   USAGE           false
-test           pg_catalog          int2[]                                  root     ALL             false
-test           pg_catalog          int2vector                              admin    ALL             false
-test           pg_catalog          int2vector                              public   USAGE           false
-test           pg_catalog          int2vector                              root     ALL             false
-test           pg_catalog          int2vector[]                            admin    ALL             false
-test           pg_catalog          int2vector[]                            public   USAGE           false
-test           pg_catalog          int2vector[]                            root     ALL             false
-test           pg_catalog          int4                                    admin    ALL             false
-test           pg_catalog          int4                                    public   USAGE           false
-test           pg_catalog          int4                                    root     ALL             false
-test           pg_catalog          int4[]                                  admin    ALL             false
-test           pg_catalog          int4[]                                  public   USAGE           false
-test           pg_catalog          int4[]                                  root     ALL             false
-test           pg_catalog          int[]                                   admin    ALL             false
-test           pg_catalog          int[]                                   public   USAGE           false
-test           pg_catalog          int[]                                   root     ALL             false
-test           pg_catalog          interval                                admin    ALL             false
-test           pg_catalog          interval                                public   USAGE           false
-test           pg_catalog          interval                                root     ALL             false
-test           pg_catalog          interval[]                              admin    ALL             false
-test           pg_catalog          interval[]                              public   USAGE           false
-test           pg_catalog          interval[]                              root     ALL             false
-test           pg_catalog          jsonb                                   admin    ALL             false
-test           pg_catalog          jsonb                                   public   USAGE           false
-test           pg_catalog          jsonb                                   root     ALL             false
-test           pg_catalog          jsonb[]                                 admin    ALL             false
-test           pg_catalog          jsonb[]                                 public   USAGE           false
-test           pg_catalog          jsonb[]                                 root     ALL             false
-test           pg_catalog          name                                    admin    ALL             false
-test           pg_catalog          name                                    public   USAGE           false
-test           pg_catalog          name                                    root     ALL             false
-test           pg_catalog          name[]                                  admin    ALL             false
-test           pg_catalog          name[]                                  public   USAGE           false
-test           pg_catalog          name[]                                  root     ALL             false
-test           pg_catalog          oid                                     admin    ALL             false
-test           pg_catalog          oid                                     public   USAGE           false
-test           pg_catalog          oid                                     root     ALL             false
-test           pg_catalog          oid[]                                   admin    ALL             false
-test           pg_catalog          oid[]                                   public   USAGE           false
-test           pg_catalog          oid[]                                   root     ALL             false
-test           pg_catalog          oidvector                               admin    ALL             false
-test           pg_catalog          oidvector                               public   USAGE           false
-test           pg_catalog          oidvector                               root     ALL             false
-test           pg_catalog          oidvector[]                             admin    ALL             false
-test           pg_catalog          oidvector[]                             public   USAGE           false
-test           pg_catalog          oidvector[]                             root     ALL             false
-test           pg_catalog          pg_aggregate                            public   SELECT          false
-test           pg_catalog          pg_am                                   public   SELECT          false
-test           pg_catalog          pg_amop                                 public   SELECT          false
-test           pg_catalog          pg_amproc                               public   SELECT          false
-test           pg_catalog          pg_attrdef                              public   SELECT          false
-test           pg_catalog          pg_attribute                            public   SELECT          false
-test           pg_catalog          pg_auth_members                         public   SELECT          false
-test           pg_catalog          pg_authid                               public   SELECT          false
-test           pg_catalog          pg_available_extension_versions         public   SELECT          false
-test           pg_catalog          pg_available_extensions                 public   SELECT          false
-test           pg_catalog          pg_cast                                 public   SELECT          false
-test           pg_catalog          pg_class                                public   SELECT          false
-test           pg_catalog          pg_collation                            public   SELECT          false
-test           pg_catalog          pg_config                               public   SELECT          false
-test           pg_catalog          pg_constraint                           public   SELECT          false
-test           pg_catalog          pg_conversion                           public   SELECT          false
-test           pg_catalog          pg_cursors                              public   SELECT          false
-test           pg_catalog          pg_database                             public   SELECT          false
-test           pg_catalog          pg_db_role_setting                      public   SELECT          false
-test           pg_catalog          pg_default_acl                          public   SELECT          false
-test           pg_catalog          pg_depend                               public   SELECT          false
-test           pg_catalog          pg_description                          public   SELECT          false
-test           pg_catalog          pg_enum                                 public   SELECT          false
-test           pg_catalog          pg_event_trigger                        public   SELECT          false
-test           pg_catalog          pg_extension                            public   SELECT          false
-test           pg_catalog          pg_file_settings                        public   SELECT          false
-test           pg_catalog          pg_foreign_data_wrapper                 public   SELECT          false
-test           pg_catalog          pg_foreign_server                       public   SELECT          false
-test           pg_catalog          pg_foreign_table                        public   SELECT          false
-test           pg_catalog          pg_group                                public   SELECT          false
-test           pg_catalog          pg_hba_file_rules                       public   SELECT          false
-test           pg_catalog          pg_index                                public   SELECT          false
-test           pg_catalog          pg_indexes                              public   SELECT          false
-test           pg_catalog          pg_inherits                             public   SELECT          false
-test           pg_catalog          pg_init_privs                           public   SELECT          false
-test           pg_catalog          pg_language                             public   SELECT          false
-test           pg_catalog          pg_largeobject                          public   SELECT          false
-test           pg_catalog          pg_largeobject_metadata                 public   SELECT          false
-test           pg_catalog          pg_locks                                public   SELECT          false
-test           pg_catalog          pg_matviews                             public   SELECT          false
-test           pg_catalog          pg_namespace                            public   SELECT          false
-test           pg_catalog          pg_opclass                              public   SELECT          false
-test           pg_catalog          pg_operator                             public   SELECT          false
-test           pg_catalog          pg_opfamily                             public   SELECT          false
-test           pg_catalog          pg_partitioned_table                    public   SELECT          false
-test           pg_catalog          pg_policies                             public   SELECT          false
-test           pg_catalog          pg_policy                               public   SELECT          false
-test           pg_catalog          pg_prepared_statements                  public   SELECT          false
-test           pg_catalog          pg_prepared_xacts                       public   SELECT          false
-test           pg_catalog          pg_proc                                 public   SELECT          false
-test           pg_catalog          pg_publication                          public   SELECT          false
-test           pg_catalog          pg_publication_rel                      public   SELECT          false
-test           pg_catalog          pg_publication_tables                   public   SELECT          false
-test           pg_catalog          pg_range                                public   SELECT          false
-test           pg_catalog          pg_replication_origin                   public   SELECT          false
-test           pg_catalog          pg_replication_origin_status            public   SELECT          false
-test           pg_catalog          pg_replication_slots                    public   SELECT          false
-test           pg_catalog          pg_rewrite                              public   SELECT          false
-test           pg_catalog          pg_roles                                public   SELECT          false
-test           pg_catalog          pg_rules                                public   SELECT          false
-test           pg_catalog          pg_seclabel                             public   SELECT          false
-test           pg_catalog          pg_seclabels                            public   SELECT          false
-test           pg_catalog          pg_sequence                             public   SELECT          false
-test           pg_catalog          pg_sequences                            public   SELECT          false
-test           pg_catalog          pg_settings                             public   SELECT          false
-test           pg_catalog          pg_shadow                               public   SELECT          false
-test           pg_catalog          pg_shdepend                             public   SELECT          false
-test           pg_catalog          pg_shdescription                        public   SELECT          false
-test           pg_catalog          pg_shmem_allocations                    public   SELECT          false
-test           pg_catalog          pg_shseclabel                           public   SELECT          false
-test           pg_catalog          pg_stat_activity                        public   SELECT          false
-test           pg_catalog          pg_stat_all_indexes                     public   SELECT          false
-test           pg_catalog          pg_stat_all_tables                      public   SELECT          false
-test           pg_catalog          pg_stat_archiver                        public   SELECT          false
-test           pg_catalog          pg_stat_bgwriter                        public   SELECT          false
-test           pg_catalog          pg_stat_database                        public   SELECT          false
-test           pg_catalog          pg_stat_database_conflicts              public   SELECT          false
-test           pg_catalog          pg_stat_gssapi                          public   SELECT          false
-test           pg_catalog          pg_stat_progress_analyze                public   SELECT          false
-test           pg_catalog          pg_stat_progress_basebackup             public   SELECT          false
-test           pg_catalog          pg_stat_progress_cluster                public   SELECT          false
-test           pg_catalog          pg_stat_progress_create_index           public   SELECT          false
-test           pg_catalog          pg_stat_progress_vacuum                 public   SELECT          false
-test           pg_catalog          pg_stat_replication                     public   SELECT          false
-test           pg_catalog          pg_stat_slru                            public   SELECT          false
-test           pg_catalog          pg_stat_ssl                             public   SELECT          false
-test           pg_catalog          pg_stat_subscription                    public   SELECT          false
-test           pg_catalog          pg_stat_sys_indexes                     public   SELECT          false
-test           pg_catalog          pg_stat_sys_tables                      public   SELECT          false
-test           pg_catalog          pg_stat_user_functions                  public   SELECT          false
-test           pg_catalog          pg_stat_user_indexes                    public   SELECT          false
-test           pg_catalog          pg_stat_user_tables                     public   SELECT          false
-test           pg_catalog          pg_stat_wal_receiver                    public   SELECT          false
-test           pg_catalog          pg_stat_xact_all_tables                 public   SELECT          false
-test           pg_catalog          pg_stat_xact_sys_tables                 public   SELECT          false
-test           pg_catalog          pg_stat_xact_user_functions             public   SELECT          false
-test           pg_catalog          pg_stat_xact_user_tables                public   SELECT          false
-test           pg_catalog          pg_statio_all_indexes                   public   SELECT          false
-test           pg_catalog          pg_statio_all_sequences                 public   SELECT          false
-test           pg_catalog          pg_statio_all_tables                    public   SELECT          false
-test           pg_catalog          pg_statio_sys_indexes                   public   SELECT          false
-test           pg_catalog          pg_statio_sys_sequences                 public   SELECT          false
-test           pg_catalog          pg_statio_sys_tables                    public   SELECT          false
-test           pg_catalog          pg_statio_user_indexes                  public   SELECT          false
-test           pg_catalog          pg_statio_user_sequences                public   SELECT          false
-test           pg_catalog          pg_statio_user_tables                   public   SELECT          false
-test           pg_catalog          pg_statistic                            public   SELECT          false
-test           pg_catalog          pg_statistic_ext                        public   SELECT          false
-test           pg_catalog          pg_statistic_ext_data                   public   SELECT          false
-test           pg_catalog          pg_stats                                public   SELECT          false
-test           pg_catalog          pg_stats_ext                            public   SELECT          false
-test           pg_catalog          pg_subscription                         public   SELECT          false
-test           pg_catalog          pg_subscription_rel                     public   SELECT          false
-test           pg_catalog          pg_tables                               public   SELECT          false
-test           pg_catalog          pg_tablespace                           public   SELECT          false
-test           pg_catalog          pg_timezone_abbrevs                     public   SELECT          false
-test           pg_catalog          pg_timezone_names                       public   SELECT          false
-test           pg_catalog          pg_transform                            public   SELECT          false
-test           pg_catalog          pg_trigger                              public   SELECT          false
-test           pg_catalog          pg_ts_config                            public   SELECT          false
-test           pg_catalog          pg_ts_config_map                        public   SELECT          false
-test           pg_catalog          pg_ts_dict                              public   SELECT          false
-test           pg_catalog          pg_ts_parser                            public   SELECT          false
-test           pg_catalog          pg_ts_template                          public   SELECT          false
-test           pg_catalog          pg_type                                 public   SELECT          false
-test           pg_catalog          pg_user                                 public   SELECT          false
-test           pg_catalog          pg_user_mapping                         public   SELECT          false
-test           pg_catalog          pg_user_mappings                        public   SELECT          false
-test           pg_catalog          pg_views                                public   SELECT          false
-test           pg_catalog          record                                  admin    ALL             false
-test           pg_catalog          record                                  public   USAGE           false
-test           pg_catalog          record                                  root     ALL             false
-test           pg_catalog          record[]                                admin    ALL             false
-test           pg_catalog          record[]                                public   USAGE           false
-test           pg_catalog          record[]                                root     ALL             false
-test           pg_catalog          regclass                                admin    ALL             false
-test           pg_catalog          regclass                                public   USAGE           false
-test           pg_catalog          regclass                                root     ALL             false
-test           pg_catalog          regclass[]                              admin    ALL             false
-test           pg_catalog          regclass[]                              public   USAGE           false
-test           pg_catalog          regclass[]                              root     ALL             false
-test           pg_catalog          regnamespace                            admin    ALL             false
-test           pg_catalog          regnamespace                            public   USAGE           false
-test           pg_catalog          regnamespace                            root     ALL             false
-test           pg_catalog          regnamespace[]                          admin    ALL             false
-test           pg_catalog          regnamespace[]                          public   USAGE           false
-test           pg_catalog          regnamespace[]                          root     ALL             false
-test           pg_catalog          regproc                                 admin    ALL             false
-test           pg_catalog          regproc                                 public   USAGE           false
-test           pg_catalog          regproc                                 root     ALL             false
-test           pg_catalog          regproc[]                               admin    ALL             false
-test           pg_catalog          regproc[]                               public   USAGE           false
-test           pg_catalog          regproc[]                               root     ALL             false
-test           pg_catalog          regprocedure                            admin    ALL             false
-test           pg_catalog          regprocedure                            public   USAGE           false
-test           pg_catalog          regprocedure                            root     ALL             false
-test           pg_catalog          regprocedure[]                          admin    ALL             false
-test           pg_catalog          regprocedure[]                          public   USAGE           false
-test           pg_catalog          regprocedure[]                          root     ALL             false
-test           pg_catalog          regrole                                 admin    ALL             false
-test           pg_catalog          regrole                                 public   USAGE           false
-test           pg_catalog          regrole                                 root     ALL             false
-test           pg_catalog          regrole[]                               admin    ALL             false
-test           pg_catalog          regrole[]                               public   USAGE           false
-test           pg_catalog          regrole[]                               root     ALL             false
-test           pg_catalog          regtype                                 admin    ALL             false
-test           pg_catalog          regtype                                 public   USAGE           false
-test           pg_catalog          regtype                                 root     ALL             false
-test           pg_catalog          regtype[]                               admin    ALL             false
-test           pg_catalog          regtype[]                               public   USAGE           false
-test           pg_catalog          regtype[]                               root     ALL             false
-test           pg_catalog          string                                  admin    ALL             false
-test           pg_catalog          string                                  public   USAGE           false
-test           pg_catalog          string                                  root     ALL             false
-test           pg_catalog          string[]                                admin    ALL             false
-test           pg_catalog          string[]                                public   USAGE           false
-test           pg_catalog          string[]                                root     ALL             false
-test           pg_catalog          time                                    admin    ALL             false
-test           pg_catalog          time                                    public   USAGE           false
-test           pg_catalog          time                                    root     ALL             false
-test           pg_catalog          time[]                                  admin    ALL             false
-test           pg_catalog          time[]                                  public   USAGE           false
-test           pg_catalog          time[]                                  root     ALL             false
-test           pg_catalog          timestamp                               admin    ALL             false
-test           pg_catalog          timestamp                               public   USAGE           false
-test           pg_catalog          timestamp                               root     ALL             false
-test           pg_catalog          timestamp[]                             admin    ALL             false
-test           pg_catalog          timestamp[]                             public   USAGE           false
-test           pg_catalog          timestamp[]                             root     ALL             false
-test           pg_catalog          timestamptz                             admin    ALL             false
-test           pg_catalog          timestamptz                             public   USAGE           false
-test           pg_catalog          timestamptz                             root     ALL             false
-test           pg_catalog          timestamptz[]                           admin    ALL             false
-test           pg_catalog          timestamptz[]                           public   USAGE           false
-test           pg_catalog          timestamptz[]                           root     ALL             false
-test           pg_catalog          timetz                                  admin    ALL             false
-test           pg_catalog          timetz                                  public   USAGE           false
-test           pg_catalog          timetz                                  root     ALL             false
-test           pg_catalog          timetz[]                                admin    ALL             false
-test           pg_catalog          timetz[]                                public   USAGE           false
-test           pg_catalog          timetz[]                                root     ALL             false
-test           pg_catalog          tsquery                                 admin    ALL             false
-test           pg_catalog          tsquery                                 public   USAGE           false
-test           pg_catalog          tsquery                                 root     ALL             false
-test           pg_catalog          tsquery[]                               admin    ALL             false
-test           pg_catalog          tsquery[]                               public   USAGE           false
-test           pg_catalog          tsquery[]                               root     ALL             false
-test           pg_catalog          tsvector                                admin    ALL             false
-test           pg_catalog          tsvector                                public   USAGE           false
-test           pg_catalog          tsvector                                root     ALL             false
-test           pg_catalog          tsvector[]                              admin    ALL             false
-test           pg_catalog          tsvector[]                              public   USAGE           false
-test           pg_catalog          tsvector[]                              root     ALL             false
-test           pg_catalog          unknown                                 admin    ALL             false
-test           pg_catalog          unknown                                 public   USAGE           false
-test           pg_catalog          unknown                                 root     ALL             false
-test           pg_catalog          uuid                                    admin    ALL             false
-test           pg_catalog          uuid                                    public   USAGE           false
-test           pg_catalog          uuid                                    root     ALL             false
-test           pg_catalog          uuid[]                                  admin    ALL             false
-test           pg_catalog          uuid[]                                  public   USAGE           false
-test           pg_catalog          uuid[]                                  root     ALL             false
-test           pg_catalog          varbit                                  admin    ALL             false
-test           pg_catalog          varbit                                  public   USAGE           false
-test           pg_catalog          varbit                                  root     ALL             false
-test           pg_catalog          varbit[]                                admin    ALL             false
-test           pg_catalog          varbit[]                                public   USAGE           false
-test           pg_catalog          varbit[]                                root     ALL             false
-test           pg_catalog          varchar                                 admin    ALL             false
-test           pg_catalog          varchar                                 public   USAGE           false
-test           pg_catalog          varchar                                 root     ALL             false
-test           pg_catalog          varchar[]                               admin    ALL             false
-test           pg_catalog          varchar[]                               public   USAGE           false
-test           pg_catalog          varchar[]                               root     ALL             false
-test           pg_catalog          void                                    admin    ALL             false
-test           pg_catalog          void                                    public   USAGE           false
-test           pg_catalog          void                                    root     ALL             false
-test           pg_extension        NULL                                    public   USAGE           false
-test           pg_extension        geography_columns                       public   SELECT          false
-test           pg_extension        geometry_columns                        public   SELECT          false
-test           pg_extension        spatial_ref_sys                         public   SELECT          false
-test           public              NULL                                    admin    ALL             true
-test           public              NULL                                    public   CREATE          false
-test           public              NULL                                    public   USAGE           false
-test           public              NULL                                    root     ALL             true
+database_name  schema_name         object_name                             object_type  grantee  privilege_type  is_grantable
+test           NULL                NULL                                    database     admin    ALL             true
+test           NULL                NULL                                    database     public   CONNECT         false
+test           NULL                NULL                                    database     root     ALL             true
+test           crdb_internal       NULL                                    schema       public   USAGE           false
+test           crdb_internal       active_range_feeds                      table        public   SELECT          false
+test           crdb_internal       backward_dependencies                   table        public   SELECT          false
+test           crdb_internal       builtin_functions                       table        public   SELECT          false
+test           crdb_internal       cluster_contended_indexes               table        public   SELECT          false
+test           crdb_internal       cluster_contended_keys                  table        public   SELECT          false
+test           crdb_internal       cluster_contended_tables                table        public   SELECT          false
+test           crdb_internal       cluster_contention_events               table        public   SELECT          false
+test           crdb_internal       cluster_database_privileges             table        public   SELECT          false
+test           crdb_internal       cluster_distsql_flows                   table        public   SELECT          false
+test           crdb_internal       cluster_execution_insights              table        public   SELECT          false
+test           crdb_internal       cluster_inflight_traces                 table        public   SELECT          false
+test           crdb_internal       cluster_locks                           table        public   SELECT          false
+test           crdb_internal       cluster_queries                         table        public   SELECT          false
+test           crdb_internal       cluster_sessions                        table        public   SELECT          false
+test           crdb_internal       cluster_settings                        table        public   SELECT          false
+test           crdb_internal       cluster_statement_statistics            table        public   SELECT          false
+test           crdb_internal       cluster_transaction_statistics          table        public   SELECT          false
+test           crdb_internal       cluster_transactions                    table        public   SELECT          false
+test           crdb_internal       cluster_txn_execution_insights          table        public   SELECT          false
+test           crdb_internal       create_function_statements              table        public   SELECT          false
+test           crdb_internal       create_schema_statements                table        public   SELECT          false
+test           crdb_internal       create_statements                       table        public   SELECT          false
+test           crdb_internal       create_type_statements                  table        public   SELECT          false
+test           crdb_internal       cross_db_references                     table        public   SELECT          false
+test           crdb_internal       databases                               table        public   SELECT          false
+test           crdb_internal       default_privileges                      table        public   SELECT          false
+test           crdb_internal       feature_usage                           table        public   SELECT          false
+test           crdb_internal       forward_dependencies                    table        public   SELECT          false
+test           crdb_internal       gossip_alerts                           table        public   SELECT          false
+test           crdb_internal       gossip_liveness                         table        public   SELECT          false
+test           crdb_internal       gossip_network                          table        public   SELECT          false
+test           crdb_internal       gossip_nodes                            table        public   SELECT          false
+test           crdb_internal       index_columns                           table        public   SELECT          false
+test           crdb_internal       index_spans                             table        public   SELECT          false
+test           crdb_internal       index_usage_statistics                  table        public   SELECT          false
+test           crdb_internal       invalid_objects                         table        public   SELECT          false
+test           crdb_internal       jobs                                    table        public   SELECT          false
+test           crdb_internal       kv_builtin_function_comments            table        public   SELECT          false
+test           crdb_internal       kv_catalog_comments                     table        public   SELECT          false
+test           crdb_internal       kv_catalog_descriptor                   table        public   SELECT          false
+test           crdb_internal       kv_catalog_namespace                    table        public   SELECT          false
+test           crdb_internal       kv_catalog_zones                        table        public   SELECT          false
+test           crdb_internal       kv_dropped_relations                    table        public   SELECT          false
+test           crdb_internal       kv_inherited_role_members               table        public   SELECT          false
+test           crdb_internal       kv_node_liveness                        table        public   SELECT          false
+test           crdb_internal       kv_node_status                          table        public   SELECT          false
+test           crdb_internal       kv_repairable_catalog_corruptions       table        public   SELECT          false
+test           crdb_internal       kv_store_status                         table        public   SELECT          false
+test           crdb_internal       kv_system_privileges                    table        public   SELECT          false
+test           crdb_internal       leases                                  table        public   SELECT          false
+test           crdb_internal       lost_descriptors_with_data              table        public   SELECT          false
+test           crdb_internal       node_build_info                         table        public   SELECT          false
+test           crdb_internal       node_contention_events                  table        public   SELECT          false
+test           crdb_internal       node_distsql_flows                      table        public   SELECT          false
+test           crdb_internal       node_execution_insights                 table        public   SELECT          false
+test           crdb_internal       node_inflight_trace_spans               table        public   SELECT          false
+test           crdb_internal       node_memory_monitors                    table        public   SELECT          false
+test           crdb_internal       node_metrics                            table        public   SELECT          false
+test           crdb_internal       node_queries                            table        public   SELECT          false
+test           crdb_internal       node_runtime_info                       table        public   SELECT          false
+test           crdb_internal       node_sessions                           table        public   SELECT          false
+test           crdb_internal       node_statement_statistics               table        public   SELECT          false
+test           crdb_internal       node_tenant_capabilities_cache          table        public   SELECT          false
+test           crdb_internal       node_transaction_statistics             table        public   SELECT          false
+test           crdb_internal       node_transactions                       table        public   SELECT          false
+test           crdb_internal       node_txn_execution_insights             table        public   SELECT          false
+test           crdb_internal       node_txn_stats                          table        public   SELECT          false
+test           crdb_internal       partitions                              table        public   SELECT          false
+test           crdb_internal       pg_catalog_table_is_implemented         table        public   SELECT          false
+test           crdb_internal       ranges                                  table        public   SELECT          false
+test           crdb_internal       ranges_no_leases                        table        public   SELECT          false
+test           crdb_internal       regions                                 table        public   SELECT          false
+test           crdb_internal       schema_changes                          table        public   SELECT          false
+test           crdb_internal       session_trace                           table        public   SELECT          false
+test           crdb_internal       session_variables                       table        public   SELECT          false
+test           crdb_internal       statement_activity                      table        public   SELECT          false
+test           crdb_internal       statement_statistics                    table        public   SELECT          false
+test           crdb_internal       statement_statistics_persisted          table        public   SELECT          false
+test           crdb_internal       statement_statistics_persisted_v22_2    table        public   SELECT          false
+test           crdb_internal       super_regions                           table        public   SELECT          false
+test           crdb_internal       system_jobs                             table        public   SELECT          false
+test           crdb_internal       table_columns                           table        public   SELECT          false
+test           crdb_internal       table_indexes                           table        public   SELECT          false
+test           crdb_internal       table_row_statistics                    table        public   SELECT          false
+test           crdb_internal       table_spans                             table        public   SELECT          false
+test           crdb_internal       tables                                  table        public   SELECT          false
+test           crdb_internal       tenant_usage_details                    table        public   SELECT          false
+test           crdb_internal       transaction_activity                    table        public   SELECT          false
+test           crdb_internal       transaction_contention_events           table        public   SELECT          false
+test           crdb_internal       transaction_statistics                  table        public   SELECT          false
+test           crdb_internal       transaction_statistics_persisted        table        public   SELECT          false
+test           crdb_internal       transaction_statistics_persisted_v22_2  table        public   SELECT          false
+test           crdb_internal       zones                                   table        public   SELECT          false
+test           information_schema  NULL                                    schema       public   USAGE           false
+test           information_schema  administrable_role_authorizations       table        public   SELECT          false
+test           information_schema  applicable_roles                        table        public   SELECT          false
+test           information_schema  attributes                              table        public   SELECT          false
+test           information_schema  character_sets                          table        public   SELECT          false
+test           information_schema  check_constraint_routine_usage          table        public   SELECT          false
+test           information_schema  check_constraints                       table        public   SELECT          false
+test           information_schema  collation_character_set_applicability   table        public   SELECT          false
+test           information_schema  collations                              table        public   SELECT          false
+test           information_schema  column_column_usage                     table        public   SELECT          false
+test           information_schema  column_domain_usage                     table        public   SELECT          false
+test           information_schema  column_options                          table        public   SELECT          false
+test           information_schema  column_privileges                       table        public   SELECT          false
+test           information_schema  column_statistics                       table        public   SELECT          false
+test           information_schema  column_udt_usage                        table        public   SELECT          false
+test           information_schema  columns                                 table        public   SELECT          false
+test           information_schema  columns_extensions                      table        public   SELECT          false
+test           information_schema  constraint_column_usage                 table        public   SELECT          false
+test           information_schema  constraint_table_usage                  table        public   SELECT          false
+test           information_schema  data_type_privileges                    table        public   SELECT          false
+test           information_schema  domain_constraints                      table        public   SELECT          false
+test           information_schema  domain_udt_usage                        table        public   SELECT          false
+test           information_schema  domains                                 table        public   SELECT          false
+test           information_schema  element_types                           table        public   SELECT          false
+test           information_schema  enabled_roles                           table        public   SELECT          false
+test           information_schema  engines                                 table        public   SELECT          false
+test           information_schema  events                                  table        public   SELECT          false
+test           information_schema  files                                   table        public   SELECT          false
+test           information_schema  foreign_data_wrapper_options            table        public   SELECT          false
+test           information_schema  foreign_data_wrappers                   table        public   SELECT          false
+test           information_schema  foreign_server_options                  table        public   SELECT          false
+test           information_schema  foreign_servers                         table        public   SELECT          false
+test           information_schema  foreign_table_options                   table        public   SELECT          false
+test           information_schema  foreign_tables                          table        public   SELECT          false
+test           information_schema  information_schema_catalog_name         table        public   SELECT          false
+test           information_schema  key_column_usage                        table        public   SELECT          false
+test           information_schema  keywords                                table        public   SELECT          false
+test           information_schema  optimizer_trace                         table        public   SELECT          false
+test           information_schema  parameters                              table        public   SELECT          false
+test           information_schema  partitions                              table        public   SELECT          false
+test           information_schema  plugins                                 table        public   SELECT          false
+test           information_schema  processlist                             table        public   SELECT          false
+test           information_schema  profiling                               table        public   SELECT          false
+test           information_schema  referential_constraints                 table        public   SELECT          false
+test           information_schema  resource_groups                         table        public   SELECT          false
+test           information_schema  role_column_grants                      table        public   SELECT          false
+test           information_schema  role_routine_grants                     table        public   SELECT          false
+test           information_schema  role_table_grants                       table        public   SELECT          false
+test           information_schema  role_udt_grants                         table        public   SELECT          false
+test           information_schema  role_usage_grants                       table        public   SELECT          false
+test           information_schema  routine_privileges                      table        public   SELECT          false
+test           information_schema  routines                                table        public   SELECT          false
+test           information_schema  schema_privileges                       table        public   SELECT          false
+test           information_schema  schemata                                table        public   SELECT          false
+test           information_schema  schemata_extensions                     table        public   SELECT          false
+test           information_schema  sequences                               table        public   SELECT          false
+test           information_schema  session_variables                       table        public   SELECT          false
+test           information_schema  sql_features                            table        public   SELECT          false
+test           information_schema  sql_implementation_info                 table        public   SELECT          false
+test           information_schema  sql_parts                               table        public   SELECT          false
+test           information_schema  sql_sizing                              table        public   SELECT          false
+test           information_schema  st_geometry_columns                     table        public   SELECT          false
+test           information_schema  st_spatial_reference_systems            table        public   SELECT          false
+test           information_schema  st_units_of_measure                     table        public   SELECT          false
+test           information_schema  statistics                              table        public   SELECT          false
+test           information_schema  table_constraints                       table        public   SELECT          false
+test           information_schema  table_constraints_extensions            table        public   SELECT          false
+test           information_schema  table_privileges                        table        public   SELECT          false
+test           information_schema  tables                                  table        public   SELECT          false
+test           information_schema  tables_extensions                       table        public   SELECT          false
+test           information_schema  tablespaces                             table        public   SELECT          false
+test           information_schema  tablespaces_extensions                  table        public   SELECT          false
+test           information_schema  transforms                              table        public   SELECT          false
+test           information_schema  triggered_update_columns                table        public   SELECT          false
+test           information_schema  triggers                                table        public   SELECT          false
+test           information_schema  type_privileges                         table        public   SELECT          false
+test           information_schema  udt_privileges                          table        public   SELECT          false
+test           information_schema  usage_privileges                        table        public   SELECT          false
+test           information_schema  user_attributes                         table        public   SELECT          false
+test           information_schema  user_defined_types                      table        public   SELECT          false
+test           information_schema  user_mapping_options                    table        public   SELECT          false
+test           information_schema  user_mappings                           table        public   SELECT          false
+test           information_schema  user_privileges                         table        public   SELECT          false
+test           information_schema  view_column_usage                       table        public   SELECT          false
+test           information_schema  view_routine_usage                      table        public   SELECT          false
+test           information_schema  view_table_usage                        table        public   SELECT          false
+test           information_schema  views                                   table        public   SELECT          false
+test           pg_catalog          NULL                                    schema       public   USAGE           false
+test           pg_catalog          "char"                                  type         admin    ALL             false
+test           pg_catalog          "char"                                  type         public   USAGE           false
+test           pg_catalog          "char"                                  type         root     ALL             false
+test           pg_catalog          "char"[]                                type         admin    ALL             false
+test           pg_catalog          "char"[]                                type         public   USAGE           false
+test           pg_catalog          "char"[]                                type         root     ALL             false
+test           pg_catalog          anyelement                              type         admin    ALL             false
+test           pg_catalog          anyelement                              type         public   USAGE           false
+test           pg_catalog          anyelement                              type         root     ALL             false
+test           pg_catalog          anyelement[]                            type         admin    ALL             false
+test           pg_catalog          anyelement[]                            type         public   USAGE           false
+test           pg_catalog          anyelement[]                            type         root     ALL             false
+test           pg_catalog          bit                                     type         admin    ALL             false
+test           pg_catalog          bit                                     type         public   USAGE           false
+test           pg_catalog          bit                                     type         root     ALL             false
+test           pg_catalog          bit[]                                   type         admin    ALL             false
+test           pg_catalog          bit[]                                   type         public   USAGE           false
+test           pg_catalog          bit[]                                   type         root     ALL             false
+test           pg_catalog          bool                                    type         admin    ALL             false
+test           pg_catalog          bool                                    type         public   USAGE           false
+test           pg_catalog          bool                                    type         root     ALL             false
+test           pg_catalog          bool[]                                  type         admin    ALL             false
+test           pg_catalog          bool[]                                  type         public   USAGE           false
+test           pg_catalog          bool[]                                  type         root     ALL             false
+test           pg_catalog          box2d                                   type         admin    ALL             false
+test           pg_catalog          box2d                                   type         public   USAGE           false
+test           pg_catalog          box2d                                   type         root     ALL             false
+test           pg_catalog          box2d[]                                 type         admin    ALL             false
+test           pg_catalog          box2d[]                                 type         public   USAGE           false
+test           pg_catalog          box2d[]                                 type         root     ALL             false
+test           pg_catalog          bytes                                   type         admin    ALL             false
+test           pg_catalog          bytes                                   type         public   USAGE           false
+test           pg_catalog          bytes                                   type         root     ALL             false
+test           pg_catalog          bytes[]                                 type         admin    ALL             false
+test           pg_catalog          bytes[]                                 type         public   USAGE           false
+test           pg_catalog          bytes[]                                 type         root     ALL             false
+test           pg_catalog          char                                    type         admin    ALL             false
+test           pg_catalog          char                                    type         public   USAGE           false
+test           pg_catalog          char                                    type         root     ALL             false
+test           pg_catalog          char[]                                  type         admin    ALL             false
+test           pg_catalog          char[]                                  type         public   USAGE           false
+test           pg_catalog          char[]                                  type         root     ALL             false
+test           pg_catalog          date                                    type         admin    ALL             false
+test           pg_catalog          date                                    type         public   USAGE           false
+test           pg_catalog          date                                    type         root     ALL             false
+test           pg_catalog          date[]                                  type         admin    ALL             false
+test           pg_catalog          date[]                                  type         public   USAGE           false
+test           pg_catalog          date[]                                  type         root     ALL             false
+test           pg_catalog          decimal                                 type         admin    ALL             false
+test           pg_catalog          decimal                                 type         public   USAGE           false
+test           pg_catalog          decimal                                 type         root     ALL             false
+test           pg_catalog          decimal[]                               type         admin    ALL             false
+test           pg_catalog          decimal[]                               type         public   USAGE           false
+test           pg_catalog          decimal[]                               type         root     ALL             false
+test           pg_catalog          float                                   type         admin    ALL             false
+test           pg_catalog          float                                   type         public   USAGE           false
+test           pg_catalog          float                                   type         root     ALL             false
+test           pg_catalog          float4                                  type         admin    ALL             false
+test           pg_catalog          float4                                  type         public   USAGE           false
+test           pg_catalog          float4                                  type         root     ALL             false
+test           pg_catalog          float4[]                                type         admin    ALL             false
+test           pg_catalog          float4[]                                type         public   USAGE           false
+test           pg_catalog          float4[]                                type         root     ALL             false
+test           pg_catalog          float[]                                 type         admin    ALL             false
+test           pg_catalog          float[]                                 type         public   USAGE           false
+test           pg_catalog          float[]                                 type         root     ALL             false
+test           pg_catalog          geography                               type         admin    ALL             false
+test           pg_catalog          geography                               type         public   USAGE           false
+test           pg_catalog          geography                               type         root     ALL             false
+test           pg_catalog          geography[]                             type         admin    ALL             false
+test           pg_catalog          geography[]                             type         public   USAGE           false
+test           pg_catalog          geography[]                             type         root     ALL             false
+test           pg_catalog          geometry                                type         admin    ALL             false
+test           pg_catalog          geometry                                type         public   USAGE           false
+test           pg_catalog          geometry                                type         root     ALL             false
+test           pg_catalog          geometry[]                              type         admin    ALL             false
+test           pg_catalog          geometry[]                              type         public   USAGE           false
+test           pg_catalog          geometry[]                              type         root     ALL             false
+test           pg_catalog          inet                                    type         admin    ALL             false
+test           pg_catalog          inet                                    type         public   USAGE           false
+test           pg_catalog          inet                                    type         root     ALL             false
+test           pg_catalog          inet[]                                  type         admin    ALL             false
+test           pg_catalog          inet[]                                  type         public   USAGE           false
+test           pg_catalog          inet[]                                  type         root     ALL             false
+test           pg_catalog          int                                     type         admin    ALL             false
+test           pg_catalog          int                                     type         public   USAGE           false
+test           pg_catalog          int                                     type         root     ALL             false
+test           pg_catalog          int2                                    type         admin    ALL             false
+test           pg_catalog          int2                                    type         public   USAGE           false
+test           pg_catalog          int2                                    type         root     ALL             false
+test           pg_catalog          int2[]                                  type         admin    ALL             false
+test           pg_catalog          int2[]                                  type         public   USAGE           false
+test           pg_catalog          int2[]                                  type         root     ALL             false
+test           pg_catalog          int2vector                              type         admin    ALL             false
+test           pg_catalog          int2vector                              type         public   USAGE           false
+test           pg_catalog          int2vector                              type         root     ALL             false
+test           pg_catalog          int2vector[]                            type         admin    ALL             false
+test           pg_catalog          int2vector[]                            type         public   USAGE           false
+test           pg_catalog          int2vector[]                            type         root     ALL             false
+test           pg_catalog          int4                                    type         admin    ALL             false
+test           pg_catalog          int4                                    type         public   USAGE           false
+test           pg_catalog          int4                                    type         root     ALL             false
+test           pg_catalog          int4[]                                  type         admin    ALL             false
+test           pg_catalog          int4[]                                  type         public   USAGE           false
+test           pg_catalog          int4[]                                  type         root     ALL             false
+test           pg_catalog          int[]                                   type         admin    ALL             false
+test           pg_catalog          int[]                                   type         public   USAGE           false
+test           pg_catalog          int[]                                   type         root     ALL             false
+test           pg_catalog          interval                                type         admin    ALL             false
+test           pg_catalog          interval                                type         public   USAGE           false
+test           pg_catalog          interval                                type         root     ALL             false
+test           pg_catalog          interval[]                              type         admin    ALL             false
+test           pg_catalog          interval[]                              type         public   USAGE           false
+test           pg_catalog          interval[]                              type         root     ALL             false
+test           pg_catalog          jsonb                                   type         admin    ALL             false
+test           pg_catalog          jsonb                                   type         public   USAGE           false
+test           pg_catalog          jsonb                                   type         root     ALL             false
+test           pg_catalog          jsonb[]                                 type         admin    ALL             false
+test           pg_catalog          jsonb[]                                 type         public   USAGE           false
+test           pg_catalog          jsonb[]                                 type         root     ALL             false
+test           pg_catalog          name                                    type         admin    ALL             false
+test           pg_catalog          name                                    type         public   USAGE           false
+test           pg_catalog          name                                    type         root     ALL             false
+test           pg_catalog          name[]                                  type         admin    ALL             false
+test           pg_catalog          name[]                                  type         public   USAGE           false
+test           pg_catalog          name[]                                  type         root     ALL             false
+test           pg_catalog          oid                                     type         admin    ALL             false
+test           pg_catalog          oid                                     type         public   USAGE           false
+test           pg_catalog          oid                                     type         root     ALL             false
+test           pg_catalog          oid[]                                   type         admin    ALL             false
+test           pg_catalog          oid[]                                   type         public   USAGE           false
+test           pg_catalog          oid[]                                   type         root     ALL             false
+test           pg_catalog          oidvector                               type         admin    ALL             false
+test           pg_catalog          oidvector                               type         public   USAGE           false
+test           pg_catalog          oidvector                               type         root     ALL             false
+test           pg_catalog          oidvector[]                             type         admin    ALL             false
+test           pg_catalog          oidvector[]                             type         public   USAGE           false
+test           pg_catalog          oidvector[]                             type         root     ALL             false
+test           pg_catalog          pg_aggregate                            table        public   SELECT          false
+test           pg_catalog          pg_am                                   table        public   SELECT          false
+test           pg_catalog          pg_amop                                 table        public   SELECT          false
+test           pg_catalog          pg_amproc                               table        public   SELECT          false
+test           pg_catalog          pg_attrdef                              table        public   SELECT          false
+test           pg_catalog          pg_attribute                            table        public   SELECT          false
+test           pg_catalog          pg_auth_members                         table        public   SELECT          false
+test           pg_catalog          pg_authid                               table        public   SELECT          false
+test           pg_catalog          pg_available_extension_versions         table        public   SELECT          false
+test           pg_catalog          pg_available_extensions                 table        public   SELECT          false
+test           pg_catalog          pg_cast                                 table        public   SELECT          false
+test           pg_catalog          pg_class                                table        public   SELECT          false
+test           pg_catalog          pg_collation                            table        public   SELECT          false
+test           pg_catalog          pg_config                               table        public   SELECT          false
+test           pg_catalog          pg_constraint                           table        public   SELECT          false
+test           pg_catalog          pg_conversion                           table        public   SELECT          false
+test           pg_catalog          pg_cursors                              table        public   SELECT          false
+test           pg_catalog          pg_database                             table        public   SELECT          false
+test           pg_catalog          pg_db_role_setting                      table        public   SELECT          false
+test           pg_catalog          pg_default_acl                          table        public   SELECT          false
+test           pg_catalog          pg_depend                               table        public   SELECT          false
+test           pg_catalog          pg_description                          table        public   SELECT          false
+test           pg_catalog          pg_enum                                 table        public   SELECT          false
+test           pg_catalog          pg_event_trigger                        table        public   SELECT          false
+test           pg_catalog          pg_extension                            table        public   SELECT          false
+test           pg_catalog          pg_file_settings                        table        public   SELECT          false
+test           pg_catalog          pg_foreign_data_wrapper                 table        public   SELECT          false
+test           pg_catalog          pg_foreign_server                       table        public   SELECT          false
+test           pg_catalog          pg_foreign_table                        table        public   SELECT          false
+test           pg_catalog          pg_group                                table        public   SELECT          false
+test           pg_catalog          pg_hba_file_rules                       table        public   SELECT          false
+test           pg_catalog          pg_index                                table        public   SELECT          false
+test           pg_catalog          pg_indexes                              table        public   SELECT          false
+test           pg_catalog          pg_inherits                             table        public   SELECT          false
+test           pg_catalog          pg_init_privs                           table        public   SELECT          false
+test           pg_catalog          pg_language                             table        public   SELECT          false
+test           pg_catalog          pg_largeobject                          table        public   SELECT          false
+test           pg_catalog          pg_largeobject_metadata                 table        public   SELECT          false
+test           pg_catalog          pg_locks                                table        public   SELECT          false
+test           pg_catalog          pg_matviews                             table        public   SELECT          false
+test           pg_catalog          pg_namespace                            table        public   SELECT          false
+test           pg_catalog          pg_opclass                              table        public   SELECT          false
+test           pg_catalog          pg_operator                             table        public   SELECT          false
+test           pg_catalog          pg_opfamily                             table        public   SELECT          false
+test           pg_catalog          pg_partitioned_table                    table        public   SELECT          false
+test           pg_catalog          pg_policies                             table        public   SELECT          false
+test           pg_catalog          pg_policy                               table        public   SELECT          false
+test           pg_catalog          pg_prepared_statements                  table        public   SELECT          false
+test           pg_catalog          pg_prepared_xacts                       table        public   SELECT          false
+test           pg_catalog          pg_proc                                 table        public   SELECT          false
+test           pg_catalog          pg_publication                          table        public   SELECT          false
+test           pg_catalog          pg_publication_rel                      table        public   SELECT          false
+test           pg_catalog          pg_publication_tables                   table        public   SELECT          false
+test           pg_catalog          pg_range                                table        public   SELECT          false
+test           pg_catalog          pg_replication_origin                   table        public   SELECT          false
+test           pg_catalog          pg_replication_origin_status            table        public   SELECT          false
+test           pg_catalog          pg_replication_slots                    table        public   SELECT          false
+test           pg_catalog          pg_rewrite                              table        public   SELECT          false
+test           pg_catalog          pg_roles                                table        public   SELECT          false
+test           pg_catalog          pg_rules                                table        public   SELECT          false
+test           pg_catalog          pg_seclabel                             table        public   SELECT          false
+test           pg_catalog          pg_seclabels                            table        public   SELECT          false
+test           pg_catalog          pg_sequence                             table        public   SELECT          false
+test           pg_catalog          pg_sequences                            table        public   SELECT          false
+test           pg_catalog          pg_settings                             table        public   SELECT          false
+test           pg_catalog          pg_shadow                               table        public   SELECT          false
+test           pg_catalog          pg_shdepend                             table        public   SELECT          false
+test           pg_catalog          pg_shdescription                        table        public   SELECT          false
+test           pg_catalog          pg_shmem_allocations                    table        public   SELECT          false
+test           pg_catalog          pg_shseclabel                           table        public   SELECT          false
+test           pg_catalog          pg_stat_activity                        table        public   SELECT          false
+test           pg_catalog          pg_stat_all_indexes                     table        public   SELECT          false
+test           pg_catalog          pg_stat_all_tables                      table        public   SELECT          false
+test           pg_catalog          pg_stat_archiver                        table        public   SELECT          false
+test           pg_catalog          pg_stat_bgwriter                        table        public   SELECT          false
+test           pg_catalog          pg_stat_database                        table        public   SELECT          false
+test           pg_catalog          pg_stat_database_conflicts              table        public   SELECT          false
+test           pg_catalog          pg_stat_gssapi                          table        public   SELECT          false
+test           pg_catalog          pg_stat_progress_analyze                table        public   SELECT          false
+test           pg_catalog          pg_stat_progress_basebackup             table        public   SELECT          false
+test           pg_catalog          pg_stat_progress_cluster                table        public   SELECT          false
+test           pg_catalog          pg_stat_progress_create_index           table        public   SELECT          false
+test           pg_catalog          pg_stat_progress_vacuum                 table        public   SELECT          false
+test           pg_catalog          pg_stat_replication                     table        public   SELECT          false
+test           pg_catalog          pg_stat_slru                            table        public   SELECT          false
+test           pg_catalog          pg_stat_ssl                             table        public   SELECT          false
+test           pg_catalog          pg_stat_subscription                    table        public   SELECT          false
+test           pg_catalog          pg_stat_sys_indexes                     table        public   SELECT          false
+test           pg_catalog          pg_stat_sys_tables                      table        public   SELECT          false
+test           pg_catalog          pg_stat_user_functions                  table        public   SELECT          false
+test           pg_catalog          pg_stat_user_indexes                    table        public   SELECT          false
+test           pg_catalog          pg_stat_user_tables                     table        public   SELECT          false
+test           pg_catalog          pg_stat_wal_receiver                    table        public   SELECT          false
+test           pg_catalog          pg_stat_xact_all_tables                 table        public   SELECT          false
+test           pg_catalog          pg_stat_xact_sys_tables                 table        public   SELECT          false
+test           pg_catalog          pg_stat_xact_user_functions             table        public   SELECT          false
+test           pg_catalog          pg_stat_xact_user_tables                table        public   SELECT          false
+test           pg_catalog          pg_statio_all_indexes                   table        public   SELECT          false
+test           pg_catalog          pg_statio_all_sequences                 table        public   SELECT          false
+test           pg_catalog          pg_statio_all_tables                    table        public   SELECT          false
+test           pg_catalog          pg_statio_sys_indexes                   table        public   SELECT          false
+test           pg_catalog          pg_statio_sys_sequences                 table        public   SELECT          false
+test           pg_catalog          pg_statio_sys_tables                    table        public   SELECT          false
+test           pg_catalog          pg_statio_user_indexes                  table        public   SELECT          false
+test           pg_catalog          pg_statio_user_sequences                table        public   SELECT          false
+test           pg_catalog          pg_statio_user_tables                   table        public   SELECT          false
+test           pg_catalog          pg_statistic                            table        public   SELECT          false
+test           pg_catalog          pg_statistic_ext                        table        public   SELECT          false
+test           pg_catalog          pg_statistic_ext_data                   table        public   SELECT          false
+test           pg_catalog          pg_stats                                table        public   SELECT          false
+test           pg_catalog          pg_stats_ext                            table        public   SELECT          false
+test           pg_catalog          pg_subscription                         table        public   SELECT          false
+test           pg_catalog          pg_subscription_rel                     table        public   SELECT          false
+test           pg_catalog          pg_tables                               table        public   SELECT          false
+test           pg_catalog          pg_tablespace                           table        public   SELECT          false
+test           pg_catalog          pg_timezone_abbrevs                     table        public   SELECT          false
+test           pg_catalog          pg_timezone_names                       table        public   SELECT          false
+test           pg_catalog          pg_transform                            table        public   SELECT          false
+test           pg_catalog          pg_trigger                              table        public   SELECT          false
+test           pg_catalog          pg_ts_config                            table        public   SELECT          false
+test           pg_catalog          pg_ts_config_map                        table        public   SELECT          false
+test           pg_catalog          pg_ts_dict                              table        public   SELECT          false
+test           pg_catalog          pg_ts_parser                            table        public   SELECT          false
+test           pg_catalog          pg_ts_template                          table        public   SELECT          false
+test           pg_catalog          pg_type                                 table        public   SELECT          false
+test           pg_catalog          pg_user                                 table        public   SELECT          false
+test           pg_catalog          pg_user_mapping                         table        public   SELECT          false
+test           pg_catalog          pg_user_mappings                        table        public   SELECT          false
+test           pg_catalog          pg_views                                table        public   SELECT          false
+test           pg_catalog          record                                  type         admin    ALL             false
+test           pg_catalog          record                                  type         public   USAGE           false
+test           pg_catalog          record                                  type         root     ALL             false
+test           pg_catalog          record[]                                type         admin    ALL             false
+test           pg_catalog          record[]                                type         public   USAGE           false
+test           pg_catalog          record[]                                type         root     ALL             false
+test           pg_catalog          regclass                                type         admin    ALL             false
+test           pg_catalog          regclass                                type         public   USAGE           false
+test           pg_catalog          regclass                                type         root     ALL             false
+test           pg_catalog          regclass[]                              type         admin    ALL             false
+test           pg_catalog          regclass[]                              type         public   USAGE           false
+test           pg_catalog          regclass[]                              type         root     ALL             false
+test           pg_catalog          regnamespace                            type         admin    ALL             false
+test           pg_catalog          regnamespace                            type         public   USAGE           false
+test           pg_catalog          regnamespace                            type         root     ALL             false
+test           pg_catalog          regnamespace[]                          type         admin    ALL             false
+test           pg_catalog          regnamespace[]                          type         public   USAGE           false
+test           pg_catalog          regnamespace[]                          type         root     ALL             false
+test           pg_catalog          regproc                                 type         admin    ALL             false
+test           pg_catalog          regproc                                 type         public   USAGE           false
+test           pg_catalog          regproc                                 type         root     ALL             false
+test           pg_catalog          regproc[]                               type         admin    ALL             false
+test           pg_catalog          regproc[]                               type         public   USAGE           false
+test           pg_catalog          regproc[]                               type         root     ALL             false
+test           pg_catalog          regprocedure                            type         admin    ALL             false
+test           pg_catalog          regprocedure                            type         public   USAGE           false
+test           pg_catalog          regprocedure                            type         root     ALL             false
+test           pg_catalog          regprocedure[]                          type         admin    ALL             false
+test           pg_catalog          regprocedure[]                          type         public   USAGE           false
+test           pg_catalog          regprocedure[]                          type         root     ALL             false
+test           pg_catalog          regrole                                 type         admin    ALL             false
+test           pg_catalog          regrole                                 type         public   USAGE           false
+test           pg_catalog          regrole                                 type         root     ALL             false
+test           pg_catalog          regrole[]                               type         admin    ALL             false
+test           pg_catalog          regrole[]                               type         public   USAGE           false
+test           pg_catalog          regrole[]                               type         root     ALL             false
+test           pg_catalog          regtype                                 type         admin    ALL             false
+test           pg_catalog          regtype                                 type         public   USAGE           false
+test           pg_catalog          regtype                                 type         root     ALL             false
+test           pg_catalog          regtype[]                               type         admin    ALL             false
+test           pg_catalog          regtype[]                               type         public   USAGE           false
+test           pg_catalog          regtype[]                               type         root     ALL             false
+test           pg_catalog          string                                  type         admin    ALL             false
+test           pg_catalog          string                                  type         public   USAGE           false
+test           pg_catalog          string                                  type         root     ALL             false
+test           pg_catalog          string[]                                type         admin    ALL             false
+test           pg_catalog          string[]                                type         public   USAGE           false
+test           pg_catalog          string[]                                type         root     ALL             false
+test           pg_catalog          time                                    type         admin    ALL             false
+test           pg_catalog          time                                    type         public   USAGE           false
+test           pg_catalog          time                                    type         root     ALL             false
+test           pg_catalog          time[]                                  type         admin    ALL             false
+test           pg_catalog          time[]                                  type         public   USAGE           false
+test           pg_catalog          time[]                                  type         root     ALL             false
+test           pg_catalog          timestamp                               type         admin    ALL             false
+test           pg_catalog          timestamp                               type         public   USAGE           false
+test           pg_catalog          timestamp                               type         root     ALL             false
+test           pg_catalog          timestamp[]                             type         admin    ALL             false
+test           pg_catalog          timestamp[]                             type         public   USAGE           false
+test           pg_catalog          timestamp[]                             type         root     ALL             false
+test           pg_catalog          timestamptz                             type         admin    ALL             false
+test           pg_catalog          timestamptz                             type         public   USAGE           false
+test           pg_catalog          timestamptz                             type         root     ALL             false
+test           pg_catalog          timestamptz[]                           type         admin    ALL             false
+test           pg_catalog          timestamptz[]                           type         public   USAGE           false
+test           pg_catalog          timestamptz[]                           type         root     ALL             false
+test           pg_catalog          timetz                                  type         admin    ALL             false
+test           pg_catalog          timetz                                  type         public   USAGE           false
+test           pg_catalog          timetz                                  type         root     ALL             false
+test           pg_catalog          timetz[]                                type         admin    ALL             false
+test           pg_catalog          timetz[]                                type         public   USAGE           false
+test           pg_catalog          timetz[]                                type         root     ALL             false
+test           pg_catalog          tsquery                                 type         admin    ALL             false
+test           pg_catalog          tsquery                                 type         public   USAGE           false
+test           pg_catalog          tsquery                                 type         root     ALL             false
+test           pg_catalog          tsquery[]                               type         admin    ALL             false
+test           pg_catalog          tsquery[]                               type         public   USAGE           false
+test           pg_catalog          tsquery[]                               type         root     ALL             false
+test           pg_catalog          tsvector                                type         admin    ALL             false
+test           pg_catalog          tsvector                                type         public   USAGE           false
+test           pg_catalog          tsvector                                type         root     ALL             false
+test           pg_catalog          tsvector[]                              type         admin    ALL             false
+test           pg_catalog          tsvector[]                              type         public   USAGE           false
+test           pg_catalog          tsvector[]                              type         root     ALL             false
+test           pg_catalog          unknown                                 type         admin    ALL             false
+test           pg_catalog          unknown                                 type         public   USAGE           false
+test           pg_catalog          unknown                                 type         root     ALL             false
+test           pg_catalog          uuid                                    type         admin    ALL             false
+test           pg_catalog          uuid                                    type         public   USAGE           false
+test           pg_catalog          uuid                                    type         root     ALL             false
+test           pg_catalog          uuid[]                                  type         admin    ALL             false
+test           pg_catalog          uuid[]                                  type         public   USAGE           false
+test           pg_catalog          uuid[]                                  type         root     ALL             false
+test           pg_catalog          varbit                                  type         admin    ALL             false
+test           pg_catalog          varbit                                  type         public   USAGE           false
+test           pg_catalog          varbit                                  type         root     ALL             false
+test           pg_catalog          varbit[]                                type         admin    ALL             false
+test           pg_catalog          varbit[]                                type         public   USAGE           false
+test           pg_catalog          varbit[]                                type         root     ALL             false
+test           pg_catalog          varchar                                 type         admin    ALL             false
+test           pg_catalog          varchar                                 type         public   USAGE           false
+test           pg_catalog          varchar                                 type         root     ALL             false
+test           pg_catalog          varchar[]                               type         admin    ALL             false
+test           pg_catalog          varchar[]                               type         public   USAGE           false
+test           pg_catalog          varchar[]                               type         root     ALL             false
+test           pg_catalog          void                                    type         admin    ALL             false
+test           pg_catalog          void                                    type         public   USAGE           false
+test           pg_catalog          void                                    type         root     ALL             false
+test           pg_extension        NULL                                    schema       public   USAGE           false
+test           pg_extension        geography_columns                       table        public   SELECT          false
+test           pg_extension        geometry_columns                        table        public   SELECT          false
+test           pg_extension        spatial_ref_sys                         table        public   SELECT          false
+test           public              NULL                                    schema       admin    ALL             true
+test           public              NULL                                    schema       public   CREATE          false
+test           public              NULL                                    schema       public   USAGE           false
+test           public              NULL                                    schema       root     ALL             true
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR root
 ----
-database_name  schema_name  relation_name   grantee  privilege_type  is_grantable
-test           NULL         NULL            admin    ALL             true
-test           NULL         NULL            root     ALL             true
-test           pg_catalog   "char"          admin    ALL             false
-test           pg_catalog   "char"          root     ALL             false
-test           pg_catalog   "char"[]        admin    ALL             false
-test           pg_catalog   "char"[]        root     ALL             false
-test           pg_catalog   anyelement      admin    ALL             false
-test           pg_catalog   anyelement      root     ALL             false
-test           pg_catalog   anyelement[]    admin    ALL             false
-test           pg_catalog   anyelement[]    root     ALL             false
-test           pg_catalog   bit             admin    ALL             false
-test           pg_catalog   bit             root     ALL             false
-test           pg_catalog   bit[]           admin    ALL             false
-test           pg_catalog   bit[]           root     ALL             false
-test           pg_catalog   bool            admin    ALL             false
-test           pg_catalog   bool            root     ALL             false
-test           pg_catalog   bool[]          admin    ALL             false
-test           pg_catalog   bool[]          root     ALL             false
-test           pg_catalog   box2d           admin    ALL             false
-test           pg_catalog   box2d           root     ALL             false
-test           pg_catalog   box2d[]         admin    ALL             false
-test           pg_catalog   box2d[]         root     ALL             false
-test           pg_catalog   bytes           admin    ALL             false
-test           pg_catalog   bytes           root     ALL             false
-test           pg_catalog   bytes[]         admin    ALL             false
-test           pg_catalog   bytes[]         root     ALL             false
-test           pg_catalog   char            admin    ALL             false
-test           pg_catalog   char            root     ALL             false
-test           pg_catalog   char[]          admin    ALL             false
-test           pg_catalog   char[]          root     ALL             false
-test           pg_catalog   date            admin    ALL             false
-test           pg_catalog   date            root     ALL             false
-test           pg_catalog   date[]          admin    ALL             false
-test           pg_catalog   date[]          root     ALL             false
-test           pg_catalog   decimal         admin    ALL             false
-test           pg_catalog   decimal         root     ALL             false
-test           pg_catalog   decimal[]       admin    ALL             false
-test           pg_catalog   decimal[]       root     ALL             false
-test           pg_catalog   float           admin    ALL             false
-test           pg_catalog   float           root     ALL             false
-test           pg_catalog   float4          admin    ALL             false
-test           pg_catalog   float4          root     ALL             false
-test           pg_catalog   float4[]        admin    ALL             false
-test           pg_catalog   float4[]        root     ALL             false
-test           pg_catalog   float[]         admin    ALL             false
-test           pg_catalog   float[]         root     ALL             false
-test           pg_catalog   geography       admin    ALL             false
-test           pg_catalog   geography       root     ALL             false
-test           pg_catalog   geography[]     admin    ALL             false
-test           pg_catalog   geography[]     root     ALL             false
-test           pg_catalog   geometry        admin    ALL             false
-test           pg_catalog   geometry        root     ALL             false
-test           pg_catalog   geometry[]      admin    ALL             false
-test           pg_catalog   geometry[]      root     ALL             false
-test           pg_catalog   inet            admin    ALL             false
-test           pg_catalog   inet            root     ALL             false
-test           pg_catalog   inet[]          admin    ALL             false
-test           pg_catalog   inet[]          root     ALL             false
-test           pg_catalog   int             admin    ALL             false
-test           pg_catalog   int             root     ALL             false
-test           pg_catalog   int2            admin    ALL             false
-test           pg_catalog   int2            root     ALL             false
-test           pg_catalog   int2[]          admin    ALL             false
-test           pg_catalog   int2[]          root     ALL             false
-test           pg_catalog   int2vector      admin    ALL             false
-test           pg_catalog   int2vector      root     ALL             false
-test           pg_catalog   int2vector[]    admin    ALL             false
-test           pg_catalog   int2vector[]    root     ALL             false
-test           pg_catalog   int4            admin    ALL             false
-test           pg_catalog   int4            root     ALL             false
-test           pg_catalog   int4[]          admin    ALL             false
-test           pg_catalog   int4[]          root     ALL             false
-test           pg_catalog   int[]           admin    ALL             false
-test           pg_catalog   int[]           root     ALL             false
-test           pg_catalog   interval        admin    ALL             false
-test           pg_catalog   interval        root     ALL             false
-test           pg_catalog   interval[]      admin    ALL             false
-test           pg_catalog   interval[]      root     ALL             false
-test           pg_catalog   jsonb           admin    ALL             false
-test           pg_catalog   jsonb           root     ALL             false
-test           pg_catalog   jsonb[]         admin    ALL             false
-test           pg_catalog   jsonb[]         root     ALL             false
-test           pg_catalog   name            admin    ALL             false
-test           pg_catalog   name            root     ALL             false
-test           pg_catalog   name[]          admin    ALL             false
-test           pg_catalog   name[]          root     ALL             false
-test           pg_catalog   oid             admin    ALL             false
-test           pg_catalog   oid             root     ALL             false
-test           pg_catalog   oid[]           admin    ALL             false
-test           pg_catalog   oid[]           root     ALL             false
-test           pg_catalog   oidvector       admin    ALL             false
-test           pg_catalog   oidvector       root     ALL             false
-test           pg_catalog   oidvector[]     admin    ALL             false
-test           pg_catalog   oidvector[]     root     ALL             false
-test           pg_catalog   record          admin    ALL             false
-test           pg_catalog   record          root     ALL             false
-test           pg_catalog   record[]        admin    ALL             false
-test           pg_catalog   record[]        root     ALL             false
-test           pg_catalog   regclass        admin    ALL             false
-test           pg_catalog   regclass        root     ALL             false
-test           pg_catalog   regclass[]      admin    ALL             false
-test           pg_catalog   regclass[]      root     ALL             false
-test           pg_catalog   regnamespace    admin    ALL             false
-test           pg_catalog   regnamespace    root     ALL             false
-test           pg_catalog   regnamespace[]  admin    ALL             false
-test           pg_catalog   regnamespace[]  root     ALL             false
-test           pg_catalog   regproc         admin    ALL             false
-test           pg_catalog   regproc         root     ALL             false
-test           pg_catalog   regproc[]       admin    ALL             false
-test           pg_catalog   regproc[]       root     ALL             false
-test           pg_catalog   regprocedure    admin    ALL             false
-test           pg_catalog   regprocedure    root     ALL             false
-test           pg_catalog   regprocedure[]  admin    ALL             false
-test           pg_catalog   regprocedure[]  root     ALL             false
-test           pg_catalog   regrole         admin    ALL             false
-test           pg_catalog   regrole         root     ALL             false
-test           pg_catalog   regrole[]       admin    ALL             false
-test           pg_catalog   regrole[]       root     ALL             false
-test           pg_catalog   regtype         admin    ALL             false
-test           pg_catalog   regtype         root     ALL             false
-test           pg_catalog   regtype[]       admin    ALL             false
-test           pg_catalog   regtype[]       root     ALL             false
-test           pg_catalog   string          admin    ALL             false
-test           pg_catalog   string          root     ALL             false
-test           pg_catalog   string[]        admin    ALL             false
-test           pg_catalog   string[]        root     ALL             false
-test           pg_catalog   time            admin    ALL             false
-test           pg_catalog   time            root     ALL             false
-test           pg_catalog   time[]          admin    ALL             false
-test           pg_catalog   time[]          root     ALL             false
-test           pg_catalog   timestamp       admin    ALL             false
-test           pg_catalog   timestamp       root     ALL             false
-test           pg_catalog   timestamp[]     admin    ALL             false
-test           pg_catalog   timestamp[]     root     ALL             false
-test           pg_catalog   timestamptz     admin    ALL             false
-test           pg_catalog   timestamptz     root     ALL             false
-test           pg_catalog   timestamptz[]   admin    ALL             false
-test           pg_catalog   timestamptz[]   root     ALL             false
-test           pg_catalog   timetz          admin    ALL             false
-test           pg_catalog   timetz          root     ALL             false
-test           pg_catalog   timetz[]        admin    ALL             false
-test           pg_catalog   timetz[]        root     ALL             false
-test           pg_catalog   tsquery         admin    ALL             false
-test           pg_catalog   tsquery         root     ALL             false
-test           pg_catalog   tsquery[]       admin    ALL             false
-test           pg_catalog   tsquery[]       root     ALL             false
-test           pg_catalog   tsvector        admin    ALL             false
-test           pg_catalog   tsvector        root     ALL             false
-test           pg_catalog   tsvector[]      admin    ALL             false
-test           pg_catalog   tsvector[]      root     ALL             false
-test           pg_catalog   unknown         admin    ALL             false
-test           pg_catalog   unknown         root     ALL             false
-test           pg_catalog   uuid            admin    ALL             false
-test           pg_catalog   uuid            root     ALL             false
-test           pg_catalog   uuid[]          admin    ALL             false
-test           pg_catalog   uuid[]          root     ALL             false
-test           pg_catalog   varbit          admin    ALL             false
-test           pg_catalog   varbit          root     ALL             false
-test           pg_catalog   varbit[]        admin    ALL             false
-test           pg_catalog   varbit[]        root     ALL             false
-test           pg_catalog   varchar         admin    ALL             false
-test           pg_catalog   varchar         root     ALL             false
-test           pg_catalog   varchar[]       admin    ALL             false
-test           pg_catalog   varchar[]       root     ALL             false
-test           pg_catalog   void            admin    ALL             false
-test           pg_catalog   void            root     ALL             false
-test           public       NULL            admin    ALL             true
-test           public       NULL            root     ALL             true
+database_name  schema_name  object_name     object_type  grantee  privilege_type  is_grantable
+test           NULL         NULL            database     admin    ALL             true
+test           NULL         NULL            database     root     ALL             true
+test           pg_catalog   "char"          type         admin    ALL             false
+test           pg_catalog   "char"          type         root     ALL             false
+test           pg_catalog   "char"[]        type         admin    ALL             false
+test           pg_catalog   "char"[]        type         root     ALL             false
+test           pg_catalog   anyelement      type         admin    ALL             false
+test           pg_catalog   anyelement      type         root     ALL             false
+test           pg_catalog   anyelement[]    type         admin    ALL             false
+test           pg_catalog   anyelement[]    type         root     ALL             false
+test           pg_catalog   bit             type         admin    ALL             false
+test           pg_catalog   bit             type         root     ALL             false
+test           pg_catalog   bit[]           type         admin    ALL             false
+test           pg_catalog   bit[]           type         root     ALL             false
+test           pg_catalog   bool            type         admin    ALL             false
+test           pg_catalog   bool            type         root     ALL             false
+test           pg_catalog   bool[]          type         admin    ALL             false
+test           pg_catalog   bool[]          type         root     ALL             false
+test           pg_catalog   box2d           type         admin    ALL             false
+test           pg_catalog   box2d           type         root     ALL             false
+test           pg_catalog   box2d[]         type         admin    ALL             false
+test           pg_catalog   box2d[]         type         root     ALL             false
+test           pg_catalog   bytes           type         admin    ALL             false
+test           pg_catalog   bytes           type         root     ALL             false
+test           pg_catalog   bytes[]         type         admin    ALL             false
+test           pg_catalog   bytes[]         type         root     ALL             false
+test           pg_catalog   char            type         admin    ALL             false
+test           pg_catalog   char            type         root     ALL             false
+test           pg_catalog   char[]          type         admin    ALL             false
+test           pg_catalog   char[]          type         root     ALL             false
+test           pg_catalog   date            type         admin    ALL             false
+test           pg_catalog   date            type         root     ALL             false
+test           pg_catalog   date[]          type         admin    ALL             false
+test           pg_catalog   date[]          type         root     ALL             false
+test           pg_catalog   decimal         type         admin    ALL             false
+test           pg_catalog   decimal         type         root     ALL             false
+test           pg_catalog   decimal[]       type         admin    ALL             false
+test           pg_catalog   decimal[]       type         root     ALL             false
+test           pg_catalog   float           type         admin    ALL             false
+test           pg_catalog   float           type         root     ALL             false
+test           pg_catalog   float4          type         admin    ALL             false
+test           pg_catalog   float4          type         root     ALL             false
+test           pg_catalog   float4[]        type         admin    ALL             false
+test           pg_catalog   float4[]        type         root     ALL             false
+test           pg_catalog   float[]         type         admin    ALL             false
+test           pg_catalog   float[]         type         root     ALL             false
+test           pg_catalog   geography       type         admin    ALL             false
+test           pg_catalog   geography       type         root     ALL             false
+test           pg_catalog   geography[]     type         admin    ALL             false
+test           pg_catalog   geography[]     type         root     ALL             false
+test           pg_catalog   geometry        type         admin    ALL             false
+test           pg_catalog   geometry        type         root     ALL             false
+test           pg_catalog   geometry[]      type         admin    ALL             false
+test           pg_catalog   geometry[]      type         root     ALL             false
+test           pg_catalog   inet            type         admin    ALL             false
+test           pg_catalog   inet            type         root     ALL             false
+test           pg_catalog   inet[]          type         admin    ALL             false
+test           pg_catalog   inet[]          type         root     ALL             false
+test           pg_catalog   int             type         admin    ALL             false
+test           pg_catalog   int             type         root     ALL             false
+test           pg_catalog   int2            type         admin    ALL             false
+test           pg_catalog   int2            type         root     ALL             false
+test           pg_catalog   int2[]          type         admin    ALL             false
+test           pg_catalog   int2[]          type         root     ALL             false
+test           pg_catalog   int2vector      type         admin    ALL             false
+test           pg_catalog   int2vector      type         root     ALL             false
+test           pg_catalog   int2vector[]    type         admin    ALL             false
+test           pg_catalog   int2vector[]    type         root     ALL             false
+test           pg_catalog   int4            type         admin    ALL             false
+test           pg_catalog   int4            type         root     ALL             false
+test           pg_catalog   int4[]          type         admin    ALL             false
+test           pg_catalog   int4[]          type         root     ALL             false
+test           pg_catalog   int[]           type         admin    ALL             false
+test           pg_catalog   int[]           type         root     ALL             false
+test           pg_catalog   interval        type         admin    ALL             false
+test           pg_catalog   interval        type         root     ALL             false
+test           pg_catalog   interval[]      type         admin    ALL             false
+test           pg_catalog   interval[]      type         root     ALL             false
+test           pg_catalog   jsonb           type         admin    ALL             false
+test           pg_catalog   jsonb           type         root     ALL             false
+test           pg_catalog   jsonb[]         type         admin    ALL             false
+test           pg_catalog   jsonb[]         type         root     ALL             false
+test           pg_catalog   name            type         admin    ALL             false
+test           pg_catalog   name            type         root     ALL             false
+test           pg_catalog   name[]          type         admin    ALL             false
+test           pg_catalog   name[]          type         root     ALL             false
+test           pg_catalog   oid             type         admin    ALL             false
+test           pg_catalog   oid             type         root     ALL             false
+test           pg_catalog   oid[]           type         admin    ALL             false
+test           pg_catalog   oid[]           type         root     ALL             false
+test           pg_catalog   oidvector       type         admin    ALL             false
+test           pg_catalog   oidvector       type         root     ALL             false
+test           pg_catalog   oidvector[]     type         admin    ALL             false
+test           pg_catalog   oidvector[]     type         root     ALL             false
+test           pg_catalog   record          type         admin    ALL             false
+test           pg_catalog   record          type         root     ALL             false
+test           pg_catalog   record[]        type         admin    ALL             false
+test           pg_catalog   record[]        type         root     ALL             false
+test           pg_catalog   regclass        type         admin    ALL             false
+test           pg_catalog   regclass        type         root     ALL             false
+test           pg_catalog   regclass[]      type         admin    ALL             false
+test           pg_catalog   regclass[]      type         root     ALL             false
+test           pg_catalog   regnamespace    type         admin    ALL             false
+test           pg_catalog   regnamespace    type         root     ALL             false
+test           pg_catalog   regnamespace[]  type         admin    ALL             false
+test           pg_catalog   regnamespace[]  type         root     ALL             false
+test           pg_catalog   regproc         type         admin    ALL             false
+test           pg_catalog   regproc         type         root     ALL             false
+test           pg_catalog   regproc[]       type         admin    ALL             false
+test           pg_catalog   regproc[]       type         root     ALL             false
+test           pg_catalog   regprocedure    type         admin    ALL             false
+test           pg_catalog   regprocedure    type         root     ALL             false
+test           pg_catalog   regprocedure[]  type         admin    ALL             false
+test           pg_catalog   regprocedure[]  type         root     ALL             false
+test           pg_catalog   regrole         type         admin    ALL             false
+test           pg_catalog   regrole         type         root     ALL             false
+test           pg_catalog   regrole[]       type         admin    ALL             false
+test           pg_catalog   regrole[]       type         root     ALL             false
+test           pg_catalog   regtype         type         admin    ALL             false
+test           pg_catalog   regtype         type         root     ALL             false
+test           pg_catalog   regtype[]       type         admin    ALL             false
+test           pg_catalog   regtype[]       type         root     ALL             false
+test           pg_catalog   string          type         admin    ALL             false
+test           pg_catalog   string          type         root     ALL             false
+test           pg_catalog   string[]        type         admin    ALL             false
+test           pg_catalog   string[]        type         root     ALL             false
+test           pg_catalog   time            type         admin    ALL             false
+test           pg_catalog   time            type         root     ALL             false
+test           pg_catalog   time[]          type         admin    ALL             false
+test           pg_catalog   time[]          type         root     ALL             false
+test           pg_catalog   timestamp       type         admin    ALL             false
+test           pg_catalog   timestamp       type         root     ALL             false
+test           pg_catalog   timestamp[]     type         admin    ALL             false
+test           pg_catalog   timestamp[]     type         root     ALL             false
+test           pg_catalog   timestamptz     type         admin    ALL             false
+test           pg_catalog   timestamptz     type         root     ALL             false
+test           pg_catalog   timestamptz[]   type         admin    ALL             false
+test           pg_catalog   timestamptz[]   type         root     ALL             false
+test           pg_catalog   timetz          type         admin    ALL             false
+test           pg_catalog   timetz          type         root     ALL             false
+test           pg_catalog   timetz[]        type         admin    ALL             false
+test           pg_catalog   timetz[]        type         root     ALL             false
+test           pg_catalog   tsquery         type         admin    ALL             false
+test           pg_catalog   tsquery         type         root     ALL             false
+test           pg_catalog   tsquery[]       type         admin    ALL             false
+test           pg_catalog   tsquery[]       type         root     ALL             false
+test           pg_catalog   tsvector        type         admin    ALL             false
+test           pg_catalog   tsvector        type         root     ALL             false
+test           pg_catalog   tsvector[]      type         admin    ALL             false
+test           pg_catalog   tsvector[]      type         root     ALL             false
+test           pg_catalog   unknown         type         admin    ALL             false
+test           pg_catalog   unknown         type         root     ALL             false
+test           pg_catalog   uuid            type         admin    ALL             false
+test           pg_catalog   uuid            type         root     ALL             false
+test           pg_catalog   uuid[]          type         admin    ALL             false
+test           pg_catalog   uuid[]          type         root     ALL             false
+test           pg_catalog   varbit          type         admin    ALL             false
+test           pg_catalog   varbit          type         root     ALL             false
+test           pg_catalog   varbit[]        type         admin    ALL             false
+test           pg_catalog   varbit[]        type         root     ALL             false
+test           pg_catalog   varchar         type         admin    ALL             false
+test           pg_catalog   varchar         type         root     ALL             false
+test           pg_catalog   varchar[]       type         admin    ALL             false
+test           pg_catalog   varchar[]       type         root     ALL             false
+test           pg_catalog   void            type         admin    ALL             false
+test           pg_catalog   void            type         root     ALL             false
+test           public       NULL            schema       admin    ALL             true
+test           public       NULL            schema       root     ALL             true
 
 # With no database set, we show the grants everywhere
 statement ok
 SET DATABASE = ''
 
-query TTTTTB colnames,rowsort
+query TTTTTTB colnames,rowsort
 SELECT * FROM [SHOW GRANTS]
  WHERE schema_name NOT IN ('crdb_internal', 'pg_catalog', 'information_schema')
 ----
-database_name  schema_name   relation_name                    grantee  privilege_type  is_grantable
-system         pg_extension  geography_columns                public   SELECT          false
-system         pg_extension  geometry_columns                 public   SELECT          false
-system         pg_extension  spatial_ref_sys                  public   SELECT          false
-defaultdb      pg_extension  geography_columns                public   SELECT          false
-defaultdb      pg_extension  geometry_columns                 public   SELECT          false
-defaultdb      pg_extension  spatial_ref_sys                  public   SELECT          false
-postgres       pg_extension  geography_columns                public   SELECT          false
-postgres       pg_extension  geometry_columns                 public   SELECT          false
-postgres       pg_extension  spatial_ref_sys                  public   SELECT          false
-test           pg_extension  geography_columns                public   SELECT          false
-test           pg_extension  geometry_columns                 public   SELECT          false
-test           pg_extension  spatial_ref_sys                  public   SELECT          false
-a              pg_extension  geography_columns                public   SELECT          false
-a              pg_extension  geometry_columns                 public   SELECT          false
-a              pg_extension  spatial_ref_sys                  public   SELECT          false
-system         public        descriptor                       admin    SELECT          true
-system         public        descriptor                       root     SELECT          true
-system         public        users                            admin    DELETE          true
-system         public        users                            admin    INSERT          true
-system         public        users                            admin    SELECT          true
-system         public        users                            admin    UPDATE          true
-system         public        users                            root     DELETE          true
-system         public        users                            root     INSERT          true
-system         public        users                            root     SELECT          true
-system         public        users                            root     UPDATE          true
-system         public        zones                            admin    DELETE          true
-system         public        zones                            admin    INSERT          true
-system         public        zones                            admin    SELECT          true
-system         public        zones                            admin    UPDATE          true
-system         public        zones                            root     DELETE          true
-system         public        zones                            root     INSERT          true
-system         public        zones                            root     SELECT          true
-system         public        zones                            root     UPDATE          true
-system         public        settings                         admin    DELETE          true
-system         public        settings                         admin    INSERT          true
-system         public        settings                         admin    SELECT          true
-system         public        settings                         admin    UPDATE          true
-system         public        settings                         root     DELETE          true
-system         public        settings                         root     INSERT          true
-system         public        settings                         root     SELECT          true
-system         public        settings                         root     UPDATE          true
-system         public        descriptor_id_seq                admin    SELECT          true
-system         public        descriptor_id_seq                root     SELECT          true
-system         public        tenants                          admin    SELECT          true
-system         public        tenants                          root     SELECT          true
-system         public        lease                            admin    DELETE          true
-system         public        lease                            admin    INSERT          true
-system         public        lease                            admin    SELECT          true
-system         public        lease                            admin    UPDATE          true
-system         public        lease                            root     DELETE          true
-system         public        lease                            root     INSERT          true
-system         public        lease                            root     SELECT          true
-system         public        lease                            root     UPDATE          true
-system         public        eventlog                         admin    DELETE          true
-system         public        eventlog                         admin    INSERT          true
-system         public        eventlog                         admin    SELECT          true
-system         public        eventlog                         admin    UPDATE          true
-system         public        eventlog                         root     DELETE          true
-system         public        eventlog                         root     INSERT          true
-system         public        eventlog                         root     SELECT          true
-system         public        eventlog                         root     UPDATE          true
-system         public        rangelog                         admin    DELETE          true
-system         public        rangelog                         admin    INSERT          true
-system         public        rangelog                         admin    SELECT          true
-system         public        rangelog                         admin    UPDATE          true
-system         public        rangelog                         root     DELETE          true
-system         public        rangelog                         root     INSERT          true
-system         public        rangelog                         root     SELECT          true
-system         public        rangelog                         root     UPDATE          true
-system         public        ui                               admin    DELETE          true
-system         public        ui                               admin    INSERT          true
-system         public        ui                               admin    SELECT          true
-system         public        ui                               admin    UPDATE          true
-system         public        ui                               root     DELETE          true
-system         public        ui                               root     INSERT          true
-system         public        ui                               root     SELECT          true
-system         public        ui                               root     UPDATE          true
-system         public        jobs                             admin    DELETE          true
-system         public        jobs                             admin    INSERT          true
-system         public        jobs                             admin    SELECT          true
-system         public        jobs                             admin    UPDATE          true
-system         public        jobs                             root     DELETE          true
-system         public        jobs                             root     INSERT          true
-system         public        jobs                             root     SELECT          true
-system         public        jobs                             root     UPDATE          true
-system         public        web_sessions                     admin    DELETE          true
-system         public        web_sessions                     admin    INSERT          true
-system         public        web_sessions                     admin    SELECT          true
-system         public        web_sessions                     admin    UPDATE          true
-system         public        web_sessions                     root     DELETE          true
-system         public        web_sessions                     root     INSERT          true
-system         public        web_sessions                     root     SELECT          true
-system         public        web_sessions                     root     UPDATE          true
-system         public        table_statistics                 admin    DELETE          true
-system         public        table_statistics                 admin    INSERT          true
-system         public        table_statistics                 admin    SELECT          true
-system         public        table_statistics                 admin    UPDATE          true
-system         public        table_statistics                 root     DELETE          true
-system         public        table_statistics                 root     INSERT          true
-system         public        table_statistics                 root     SELECT          true
-system         public        table_statistics                 root     UPDATE          true
-system         public        locations                        admin    DELETE          true
-system         public        locations                        admin    INSERT          true
-system         public        locations                        admin    SELECT          true
-system         public        locations                        admin    UPDATE          true
-system         public        locations                        root     DELETE          true
-system         public        locations                        root     INSERT          true
-system         public        locations                        root     SELECT          true
-system         public        locations                        root     UPDATE          true
-system         public        role_members                     admin    DELETE          true
-system         public        role_members                     admin    INSERT          true
-system         public        role_members                     admin    SELECT          true
-system         public        role_members                     admin    UPDATE          true
-system         public        role_members                     root     DELETE          true
-system         public        role_members                     root     INSERT          true
-system         public        role_members                     root     SELECT          true
-system         public        role_members                     root     UPDATE          true
-system         public        comments                         admin    DELETE          true
-system         public        comments                         admin    INSERT          true
-system         public        comments                         admin    SELECT          true
-system         public        comments                         admin    UPDATE          true
-system         public        comments                         public   SELECT          false
-system         public        comments                         root     DELETE          true
-system         public        comments                         root     INSERT          true
-system         public        comments                         root     SELECT          true
-system         public        comments                         root     UPDATE          true
-system         public        replication_constraint_stats     admin    DELETE          true
-system         public        replication_constraint_stats     admin    INSERT          true
-system         public        replication_constraint_stats     admin    SELECT          true
-system         public        replication_constraint_stats     admin    UPDATE          true
-system         public        replication_constraint_stats     root     DELETE          true
-system         public        replication_constraint_stats     root     INSERT          true
-system         public        replication_constraint_stats     root     SELECT          true
-system         public        replication_constraint_stats     root     UPDATE          true
-system         public        replication_critical_localities  admin    DELETE          true
-system         public        replication_critical_localities  admin    INSERT          true
-system         public        replication_critical_localities  admin    SELECT          true
-system         public        replication_critical_localities  admin    UPDATE          true
-system         public        replication_critical_localities  root     DELETE          true
-system         public        replication_critical_localities  root     INSERT          true
-system         public        replication_critical_localities  root     SELECT          true
-system         public        replication_critical_localities  root     UPDATE          true
-system         public        replication_stats                admin    DELETE          true
-system         public        replication_stats                admin    INSERT          true
-system         public        replication_stats                admin    SELECT          true
-system         public        replication_stats                admin    UPDATE          true
-system         public        replication_stats                root     DELETE          true
-system         public        replication_stats                root     INSERT          true
-system         public        replication_stats                root     SELECT          true
-system         public        replication_stats                root     UPDATE          true
-system         public        reports_meta                     admin    DELETE          true
-system         public        reports_meta                     admin    INSERT          true
-system         public        reports_meta                     admin    SELECT          true
-system         public        reports_meta                     admin    UPDATE          true
-system         public        reports_meta                     root     DELETE          true
-system         public        reports_meta                     root     INSERT          true
-system         public        reports_meta                     root     SELECT          true
-system         public        reports_meta                     root     UPDATE          true
-system         public        namespace                        admin    SELECT          true
-system         public        namespace                        root     SELECT          true
-system         public        protected_ts_meta                admin    SELECT          true
-system         public        protected_ts_meta                root     SELECT          true
-system         public        protected_ts_records             admin    SELECT          true
-system         public        protected_ts_records             root     SELECT          true
-system         public        role_options                     admin    DELETE          true
-system         public        role_options                     admin    INSERT          true
-system         public        role_options                     admin    SELECT          true
-system         public        role_options                     admin    UPDATE          true
-system         public        role_options                     root     DELETE          true
-system         public        role_options                     root     INSERT          true
-system         public        role_options                     root     SELECT          true
-system         public        role_options                     root     UPDATE          true
-system         public        statement_bundle_chunks          admin    DELETE          true
-system         public        statement_bundle_chunks          admin    INSERT          true
-system         public        statement_bundle_chunks          admin    SELECT          true
-system         public        statement_bundle_chunks          admin    UPDATE          true
-system         public        statement_bundle_chunks          root     DELETE          true
-system         public        statement_bundle_chunks          root     INSERT          true
-system         public        statement_bundle_chunks          root     SELECT          true
-system         public        statement_bundle_chunks          root     UPDATE          true
-system         public        statement_diagnostics_requests   admin    DELETE          true
-system         public        statement_diagnostics_requests   admin    INSERT          true
-system         public        statement_diagnostics_requests   admin    SELECT          true
-system         public        statement_diagnostics_requests   admin    UPDATE          true
-system         public        statement_diagnostics_requests   root     DELETE          true
-system         public        statement_diagnostics_requests   root     INSERT          true
-system         public        statement_diagnostics_requests   root     SELECT          true
-system         public        statement_diagnostics_requests   root     UPDATE          true
-system         public        statement_diagnostics            admin    DELETE          true
-system         public        statement_diagnostics            admin    INSERT          true
-system         public        statement_diagnostics            admin    SELECT          true
-system         public        statement_diagnostics            admin    UPDATE          true
-system         public        statement_diagnostics            root     DELETE          true
-system         public        statement_diagnostics            root     INSERT          true
-system         public        statement_diagnostics            root     SELECT          true
-system         public        statement_diagnostics            root     UPDATE          true
-system         public        scheduled_jobs                   admin    DELETE          true
-system         public        scheduled_jobs                   admin    INSERT          true
-system         public        scheduled_jobs                   admin    SELECT          true
-system         public        scheduled_jobs                   admin    UPDATE          true
-system         public        scheduled_jobs                   root     DELETE          true
-system         public        scheduled_jobs                   root     INSERT          true
-system         public        scheduled_jobs                   root     SELECT          true
-system         public        scheduled_jobs                   root     UPDATE          true
-system         public        sqlliveness                      admin    DELETE          true
-system         public        sqlliveness                      admin    INSERT          true
-system         public        sqlliveness                      admin    SELECT          true
-system         public        sqlliveness                      admin    UPDATE          true
-system         public        sqlliveness                      root     DELETE          true
-system         public        sqlliveness                      root     INSERT          true
-system         public        sqlliveness                      root     SELECT          true
-system         public        sqlliveness                      root     UPDATE          true
-system         public        migrations                       admin    DELETE          true
-system         public        migrations                       admin    INSERT          true
-system         public        migrations                       admin    SELECT          true
-system         public        migrations                       admin    UPDATE          true
-system         public        migrations                       root     DELETE          true
-system         public        migrations                       root     INSERT          true
-system         public        migrations                       root     SELECT          true
-system         public        migrations                       root     UPDATE          true
-system         public        join_tokens                      admin    DELETE          true
-system         public        join_tokens                      admin    INSERT          true
-system         public        join_tokens                      admin    SELECT          true
-system         public        join_tokens                      admin    UPDATE          true
-system         public        join_tokens                      root     DELETE          true
-system         public        join_tokens                      root     INSERT          true
-system         public        join_tokens                      root     SELECT          true
-system         public        join_tokens                      root     UPDATE          true
-system         public        statement_statistics             admin    SELECT          true
-system         public        statement_statistics             root     SELECT          true
-system         public        transaction_statistics           admin    SELECT          true
-system         public        transaction_statistics           root     SELECT          true
-system         public        database_role_settings           admin    DELETE          true
-system         public        database_role_settings           admin    INSERT          true
-system         public        database_role_settings           admin    SELECT          true
-system         public        database_role_settings           admin    UPDATE          true
-system         public        database_role_settings           root     DELETE          true
-system         public        database_role_settings           root     INSERT          true
-system         public        database_role_settings           root     SELECT          true
-system         public        database_role_settings           root     UPDATE          true
-system         public        tenant_usage                     admin    DELETE          true
-system         public        tenant_usage                     admin    INSERT          true
-system         public        tenant_usage                     admin    SELECT          true
-system         public        tenant_usage                     admin    UPDATE          true
-system         public        tenant_usage                     root     DELETE          true
-system         public        tenant_usage                     root     INSERT          true
-system         public        tenant_usage                     root     SELECT          true
-system         public        tenant_usage                     root     UPDATE          true
-system         public        sql_instances                    admin    DELETE          true
-system         public        sql_instances                    admin    INSERT          true
-system         public        sql_instances                    admin    SELECT          true
-system         public        sql_instances                    admin    UPDATE          true
-system         public        sql_instances                    root     DELETE          true
-system         public        sql_instances                    root     INSERT          true
-system         public        sql_instances                    root     SELECT          true
-system         public        sql_instances                    root     UPDATE          true
-system         public        span_configurations              admin    DELETE          true
-system         public        span_configurations              admin    INSERT          true
-system         public        span_configurations              admin    SELECT          true
-system         public        span_configurations              admin    UPDATE          true
-system         public        span_configurations              root     DELETE          true
-system         public        span_configurations              root     INSERT          true
-system         public        span_configurations              root     SELECT          true
-system         public        span_configurations              root     UPDATE          true
-system         public        role_id_seq                      admin    SELECT          true
-system         public        role_id_seq                      admin    UPDATE          true
-system         public        role_id_seq                      admin    USAGE           true
-system         public        role_id_seq                      root     SELECT          true
-system         public        role_id_seq                      root     UPDATE          true
-system         public        role_id_seq                      root     USAGE           true
-system         public        tenant_settings                  admin    DELETE          true
-system         public        tenant_settings                  admin    INSERT          true
-system         public        tenant_settings                  admin    SELECT          true
-system         public        tenant_settings                  admin    UPDATE          true
-system         public        tenant_settings                  root     DELETE          true
-system         public        tenant_settings                  root     INSERT          true
-system         public        tenant_settings                  root     SELECT          true
-system         public        tenant_settings                  root     UPDATE          true
-system         public        privileges                       admin    DELETE          true
-system         public        privileges                       admin    INSERT          true
-system         public        privileges                       admin    SELECT          true
-system         public        privileges                       admin    UPDATE          true
-system         public        privileges                       root     DELETE          true
-system         public        privileges                       root     INSERT          true
-system         public        privileges                       root     SELECT          true
-system         public        privileges                       root     UPDATE          true
-system         public        external_connections             admin    DELETE          true
-system         public        external_connections             admin    INSERT          true
-system         public        external_connections             admin    SELECT          true
-system         public        external_connections             admin    UPDATE          true
-system         public        external_connections             root     DELETE          true
-system         public        external_connections             root     INSERT          true
-system         public        external_connections             root     SELECT          true
-system         public        external_connections             root     UPDATE          true
-system         public        job_info                         admin    DELETE          true
-system         public        job_info                         admin    INSERT          true
-system         public        job_info                         admin    SELECT          true
-system         public        job_info                         admin    UPDATE          true
-system         public        job_info                         root     DELETE          true
-system         public        job_info                         root     INSERT          true
-system         public        job_info                         root     SELECT          true
-system         public        job_info                         root     UPDATE          true
-system         public        span_stats_unique_keys           admin    DELETE          true
-system         public        span_stats_unique_keys           admin    INSERT          true
-system         public        span_stats_unique_keys           admin    SELECT          true
-system         public        span_stats_unique_keys           admin    UPDATE          true
-system         public        span_stats_unique_keys           root     DELETE          true
-system         public        span_stats_unique_keys           root     INSERT          true
-system         public        span_stats_unique_keys           root     SELECT          true
-system         public        span_stats_unique_keys           root     UPDATE          true
-system         public        span_stats_buckets               admin    DELETE          true
-system         public        span_stats_buckets               admin    INSERT          true
-system         public        span_stats_buckets               admin    SELECT          true
-system         public        span_stats_buckets               admin    UPDATE          true
-system         public        span_stats_buckets               root     DELETE          true
-system         public        span_stats_buckets               root     INSERT          true
-system         public        span_stats_buckets               root     SELECT          true
-system         public        span_stats_buckets               root     UPDATE          true
-system         public        span_stats_samples               admin    DELETE          true
-system         public        span_stats_samples               admin    INSERT          true
-system         public        span_stats_samples               admin    SELECT          true
-system         public        span_stats_samples               admin    UPDATE          true
-system         public        span_stats_samples               root     DELETE          true
-system         public        span_stats_samples               root     INSERT          true
-system         public        span_stats_samples               root     SELECT          true
-system         public        span_stats_samples               root     UPDATE          true
-system         public        span_stats_tenant_boundaries     admin    DELETE          true
-system         public        span_stats_tenant_boundaries     admin    INSERT          true
-system         public        span_stats_tenant_boundaries     admin    SELECT          true
-system         public        span_stats_tenant_boundaries     admin    UPDATE          true
-system         public        span_stats_tenant_boundaries     root     DELETE          true
-system         public        span_stats_tenant_boundaries     root     INSERT          true
-system         public        span_stats_tenant_boundaries     root     SELECT          true
-system         public        span_stats_tenant_boundaries     root     UPDATE          true
-system         public        task_payloads                    admin    DELETE          true
-system         public        task_payloads                    admin    INSERT          true
-system         public        task_payloads                    admin    SELECT          true
-system         public        task_payloads                    admin    UPDATE          true
-system         public        task_payloads                    root     DELETE          true
-system         public        task_payloads                    root     INSERT          true
-system         public        task_payloads                    root     SELECT          true
-system         public        task_payloads                    root     UPDATE          true
-system         public        tenant_tasks                     admin    DELETE          true
-system         public        tenant_tasks                     admin    INSERT          true
-system         public        tenant_tasks                     admin    SELECT          true
-system         public        tenant_tasks                     admin    UPDATE          true
-system         public        tenant_tasks                     root     DELETE          true
-system         public        tenant_tasks                     root     INSERT          true
-system         public        tenant_tasks                     root     SELECT          true
-system         public        tenant_tasks                     root     UPDATE          true
-system         public        statement_activity               admin    SELECT          true
-system         public        statement_activity               root     SELECT          true
-system         public        transaction_activity             admin    SELECT          true
-system         public        transaction_activity             root     SELECT          true
-system         public        tenant_id_seq                    admin    SELECT          true
-system         public        tenant_id_seq                    root     SELECT          true
-a              pg_extension  NULL                             public   USAGE           false
-a              public        NULL                             admin    ALL             true
-a              public        NULL                             public   CREATE          false
-a              public        NULL                             public   USAGE           false
-a              public        NULL                             root     ALL             true
-defaultdb      pg_extension  NULL                             public   USAGE           false
-defaultdb      public        NULL                             admin    ALL             true
-defaultdb      public        NULL                             public   CREATE          false
-defaultdb      public        NULL                             public   USAGE           false
-defaultdb      public        NULL                             root     ALL             true
-postgres       pg_extension  NULL                             public   USAGE           false
-postgres       public        NULL                             admin    ALL             true
-postgres       public        NULL                             public   CREATE          false
-postgres       public        NULL                             public   USAGE           false
-postgres       public        NULL                             root     ALL             true
-system         pg_extension  NULL                             public   USAGE           false
-system         public        NULL                             admin    ALL             true
-system         public        NULL                             public   CREATE          false
-system         public        NULL                             public   USAGE           false
-system         public        NULL                             root     ALL             true
-test           pg_extension  NULL                             public   USAGE           false
-test           public        NULL                             admin    ALL             true
-test           public        NULL                             public   CREATE          false
-test           public        NULL                             public   USAGE           false
-test           public        NULL                             root     ALL             true
+database_name  schema_name   object_name                      object_type  grantee  privilege_type  is_grantable
+system         public        descriptor                       table        admin    SELECT          true
+system         public        users                            table        admin    DELETE          true
+system         public        users                            table        admin    INSERT          true
+system         public        users                            table        admin    SELECT          true
+system         public        users                            table        admin    UPDATE          true
+system         public        zones                            table        admin    DELETE          true
+system         public        zones                            table        admin    INSERT          true
+system         public        zones                            table        admin    SELECT          true
+system         public        zones                            table        admin    UPDATE          true
+system         public        settings                         table        admin    DELETE          true
+system         public        settings                         table        admin    INSERT          true
+system         public        settings                         table        admin    SELECT          true
+system         public        settings                         table        admin    UPDATE          true
+system         public        descriptor_id_seq                sequence     admin    SELECT          true
+system         public        tenants                          table        admin    SELECT          true
+system         public        lease                            table        admin    DELETE          true
+system         public        lease                            table        admin    INSERT          true
+system         public        lease                            table        admin    SELECT          true
+system         public        lease                            table        admin    UPDATE          true
+system         public        eventlog                         table        admin    DELETE          true
+system         public        eventlog                         table        admin    INSERT          true
+system         public        eventlog                         table        admin    SELECT          true
+system         public        eventlog                         table        admin    UPDATE          true
+system         public        rangelog                         table        admin    DELETE          true
+system         public        rangelog                         table        admin    INSERT          true
+system         public        rangelog                         table        admin    SELECT          true
+system         public        rangelog                         table        admin    UPDATE          true
+system         public        ui                               table        admin    DELETE          true
+system         public        ui                               table        admin    INSERT          true
+system         public        ui                               table        admin    SELECT          true
+system         public        ui                               table        admin    UPDATE          true
+system         public        jobs                             table        admin    DELETE          true
+system         public        jobs                             table        admin    INSERT          true
+system         public        jobs                             table        admin    SELECT          true
+system         public        jobs                             table        admin    UPDATE          true
+system         public        web_sessions                     table        admin    DELETE          true
+system         public        web_sessions                     table        admin    INSERT          true
+system         public        web_sessions                     table        admin    SELECT          true
+system         public        web_sessions                     table        admin    UPDATE          true
+system         public        table_statistics                 table        admin    DELETE          true
+system         public        table_statistics                 table        admin    INSERT          true
+system         public        table_statistics                 table        admin    SELECT          true
+system         public        table_statistics                 table        admin    UPDATE          true
+system         public        locations                        table        admin    DELETE          true
+system         public        locations                        table        admin    INSERT          true
+system         public        locations                        table        admin    SELECT          true
+system         public        locations                        table        admin    UPDATE          true
+system         public        role_members                     table        admin    DELETE          true
+system         public        role_members                     table        admin    INSERT          true
+system         public        role_members                     table        admin    SELECT          true
+system         public        role_members                     table        admin    UPDATE          true
+system         public        comments                         table        admin    DELETE          true
+system         public        comments                         table        admin    INSERT          true
+system         public        comments                         table        admin    SELECT          true
+system         public        comments                         table        admin    UPDATE          true
+system         public        replication_constraint_stats     table        admin    DELETE          true
+system         public        replication_constraint_stats     table        admin    INSERT          true
+system         public        replication_constraint_stats     table        admin    SELECT          true
+system         public        replication_constraint_stats     table        admin    UPDATE          true
+system         public        replication_critical_localities  table        admin    DELETE          true
+system         public        replication_critical_localities  table        admin    INSERT          true
+system         public        replication_critical_localities  table        admin    SELECT          true
+system         public        replication_critical_localities  table        admin    UPDATE          true
+system         public        replication_stats                table        admin    DELETE          true
+system         public        replication_stats                table        admin    INSERT          true
+system         public        replication_stats                table        admin    SELECT          true
+system         public        replication_stats                table        admin    UPDATE          true
+system         public        reports_meta                     table        admin    DELETE          true
+system         public        reports_meta                     table        admin    INSERT          true
+system         public        reports_meta                     table        admin    SELECT          true
+system         public        reports_meta                     table        admin    UPDATE          true
+system         public        namespace                        table        admin    SELECT          true
+system         public        protected_ts_meta                table        admin    SELECT          true
+system         public        protected_ts_records             table        admin    SELECT          true
+system         public        role_options                     table        admin    DELETE          true
+system         public        role_options                     table        admin    INSERT          true
+system         public        role_options                     table        admin    SELECT          true
+system         public        role_options                     table        admin    UPDATE          true
+system         public        statement_bundle_chunks          table        admin    DELETE          true
+system         public        statement_bundle_chunks          table        admin    INSERT          true
+system         public        statement_bundle_chunks          table        admin    SELECT          true
+system         public        statement_bundle_chunks          table        admin    UPDATE          true
+system         public        statement_diagnostics_requests   table        admin    DELETE          true
+system         public        statement_diagnostics_requests   table        admin    INSERT          true
+system         public        statement_diagnostics_requests   table        admin    SELECT          true
+system         public        statement_diagnostics_requests   table        admin    UPDATE          true
+system         public        statement_diagnostics            table        admin    DELETE          true
+system         public        statement_diagnostics            table        admin    INSERT          true
+system         public        statement_diagnostics            table        admin    SELECT          true
+system         public        statement_diagnostics            table        admin    UPDATE          true
+system         public        scheduled_jobs                   table        admin    DELETE          true
+system         public        scheduled_jobs                   table        admin    INSERT          true
+system         public        scheduled_jobs                   table        admin    SELECT          true
+system         public        scheduled_jobs                   table        admin    UPDATE          true
+system         public        sqlliveness                      table        admin    DELETE          true
+system         public        sqlliveness                      table        admin    INSERT          true
+system         public        sqlliveness                      table        admin    SELECT          true
+system         public        sqlliveness                      table        admin    UPDATE          true
+system         public        migrations                       table        admin    DELETE          true
+system         public        migrations                       table        admin    INSERT          true
+system         public        migrations                       table        admin    SELECT          true
+system         public        migrations                       table        admin    UPDATE          true
+system         public        join_tokens                      table        admin    DELETE          true
+system         public        join_tokens                      table        admin    INSERT          true
+system         public        join_tokens                      table        admin    SELECT          true
+system         public        join_tokens                      table        admin    UPDATE          true
+system         public        statement_statistics             table        admin    SELECT          true
+system         public        transaction_statistics           table        admin    SELECT          true
+system         public        database_role_settings           table        admin    DELETE          true
+system         public        database_role_settings           table        admin    INSERT          true
+system         public        database_role_settings           table        admin    SELECT          true
+system         public        database_role_settings           table        admin    UPDATE          true
+system         public        tenant_usage                     table        admin    DELETE          true
+system         public        tenant_usage                     table        admin    INSERT          true
+system         public        tenant_usage                     table        admin    SELECT          true
+system         public        tenant_usage                     table        admin    UPDATE          true
+system         public        sql_instances                    table        admin    DELETE          true
+system         public        sql_instances                    table        admin    INSERT          true
+system         public        sql_instances                    table        admin    SELECT          true
+system         public        sql_instances                    table        admin    UPDATE          true
+system         public        span_configurations              table        admin    DELETE          true
+system         public        span_configurations              table        admin    INSERT          true
+system         public        span_configurations              table        admin    SELECT          true
+system         public        span_configurations              table        admin    UPDATE          true
+system         public        role_id_seq                      sequence     admin    SELECT          true
+system         public        role_id_seq                      sequence     admin    UPDATE          true
+system         public        role_id_seq                      sequence     admin    USAGE           true
+system         public        tenant_settings                  table        admin    DELETE          true
+system         public        tenant_settings                  table        admin    INSERT          true
+system         public        tenant_settings                  table        admin    SELECT          true
+system         public        tenant_settings                  table        admin    UPDATE          true
+system         public        privileges                       table        admin    DELETE          true
+system         public        privileges                       table        admin    INSERT          true
+system         public        privileges                       table        admin    SELECT          true
+system         public        privileges                       table        admin    UPDATE          true
+system         public        external_connections             table        admin    DELETE          true
+system         public        external_connections             table        admin    INSERT          true
+system         public        external_connections             table        admin    SELECT          true
+system         public        external_connections             table        admin    UPDATE          true
+system         public        job_info                         table        admin    DELETE          true
+system         public        job_info                         table        admin    INSERT          true
+system         public        job_info                         table        admin    SELECT          true
+system         public        job_info                         table        admin    UPDATE          true
+system         public        span_stats_unique_keys           table        admin    DELETE          true
+system         public        span_stats_unique_keys           table        admin    INSERT          true
+system         public        span_stats_unique_keys           table        admin    SELECT          true
+system         public        span_stats_unique_keys           table        admin    UPDATE          true
+system         public        span_stats_buckets               table        admin    DELETE          true
+system         public        span_stats_buckets               table        admin    INSERT          true
+system         public        span_stats_buckets               table        admin    SELECT          true
+system         public        span_stats_buckets               table        admin    UPDATE          true
+system         public        span_stats_samples               table        admin    DELETE          true
+system         public        span_stats_samples               table        admin    INSERT          true
+system         public        span_stats_samples               table        admin    SELECT          true
+system         public        span_stats_samples               table        admin    UPDATE          true
+system         public        span_stats_tenant_boundaries     table        admin    DELETE          true
+system         public        span_stats_tenant_boundaries     table        admin    INSERT          true
+system         public        span_stats_tenant_boundaries     table        admin    SELECT          true
+system         public        span_stats_tenant_boundaries     table        admin    UPDATE          true
+system         public        task_payloads                    table        admin    DELETE          true
+system         public        task_payloads                    table        admin    INSERT          true
+system         public        task_payloads                    table        admin    SELECT          true
+system         public        task_payloads                    table        admin    UPDATE          true
+system         public        tenant_tasks                     table        admin    DELETE          true
+system         public        tenant_tasks                     table        admin    INSERT          true
+system         public        tenant_tasks                     table        admin    SELECT          true
+system         public        tenant_tasks                     table        admin    UPDATE          true
+system         public        statement_activity               table        admin    SELECT          true
+system         public        transaction_activity             table        admin    SELECT          true
+system         public        tenant_id_seq                    sequence     admin    SELECT          true
+a              public        NULL                             schema       admin    ALL             true
+defaultdb      public        NULL                             schema       admin    ALL             true
+postgres       public        NULL                             schema       admin    ALL             true
+system         public        NULL                             schema       admin    ALL             true
+test           public        NULL                             schema       admin    ALL             true
+system         pg_extension  geography_columns                table        public   SELECT          false
+system         pg_extension  geometry_columns                 table        public   SELECT          false
+system         pg_extension  spatial_ref_sys                  table        public   SELECT          false
+defaultdb      pg_extension  geography_columns                table        public   SELECT          false
+defaultdb      pg_extension  geometry_columns                 table        public   SELECT          false
+defaultdb      pg_extension  spatial_ref_sys                  table        public   SELECT          false
+postgres       pg_extension  geography_columns                table        public   SELECT          false
+postgres       pg_extension  geometry_columns                 table        public   SELECT          false
+postgres       pg_extension  spatial_ref_sys                  table        public   SELECT          false
+test           pg_extension  geography_columns                table        public   SELECT          false
+test           pg_extension  geometry_columns                 table        public   SELECT          false
+test           pg_extension  spatial_ref_sys                  table        public   SELECT          false
+a              pg_extension  geography_columns                table        public   SELECT          false
+a              pg_extension  geometry_columns                 table        public   SELECT          false
+a              pg_extension  spatial_ref_sys                  table        public   SELECT          false
+system         public        descriptor                       table        root     SELECT          true
+system         public        users                            table        root     DELETE          true
+system         public        users                            table        root     INSERT          true
+system         public        users                            table        root     SELECT          true
+system         public        users                            table        root     UPDATE          true
+system         public        zones                            table        root     DELETE          true
+system         public        zones                            table        root     INSERT          true
+system         public        zones                            table        root     SELECT          true
+system         public        zones                            table        root     UPDATE          true
+system         public        settings                         table        root     DELETE          true
+system         public        settings                         table        root     INSERT          true
+system         public        settings                         table        root     SELECT          true
+system         public        settings                         table        root     UPDATE          true
+system         public        descriptor_id_seq                sequence     root     SELECT          true
+system         public        tenants                          table        root     SELECT          true
+system         public        lease                            table        root     DELETE          true
+system         public        lease                            table        root     INSERT          true
+system         public        lease                            table        root     SELECT          true
+system         public        lease                            table        root     UPDATE          true
+system         public        eventlog                         table        root     DELETE          true
+system         public        eventlog                         table        root     INSERT          true
+system         public        eventlog                         table        root     SELECT          true
+system         public        eventlog                         table        root     UPDATE          true
+system         public        rangelog                         table        root     DELETE          true
+system         public        rangelog                         table        root     INSERT          true
+system         public        rangelog                         table        root     SELECT          true
+system         public        rangelog                         table        root     UPDATE          true
+system         public        ui                               table        root     DELETE          true
+system         public        ui                               table        root     INSERT          true
+system         public        ui                               table        root     SELECT          true
+system         public        ui                               table        root     UPDATE          true
+system         public        jobs                             table        root     DELETE          true
+system         public        jobs                             table        root     INSERT          true
+system         public        jobs                             table        root     SELECT          true
+system         public        jobs                             table        root     UPDATE          true
+system         public        web_sessions                     table        root     DELETE          true
+system         public        web_sessions                     table        root     INSERT          true
+system         public        web_sessions                     table        root     SELECT          true
+system         public        web_sessions                     table        root     UPDATE          true
+system         public        table_statistics                 table        root     DELETE          true
+system         public        table_statistics                 table        root     INSERT          true
+system         public        table_statistics                 table        root     SELECT          true
+system         public        table_statistics                 table        root     UPDATE          true
+system         public        locations                        table        root     DELETE          true
+system         public        locations                        table        root     INSERT          true
+system         public        locations                        table        root     SELECT          true
+system         public        locations                        table        root     UPDATE          true
+system         public        role_members                     table        root     DELETE          true
+system         public        role_members                     table        root     INSERT          true
+system         public        role_members                     table        root     SELECT          true
+system         public        role_members                     table        root     UPDATE          true
+system         public        comments                         table        public   SELECT          false
+system         public        comments                         table        root     DELETE          true
+system         public        comments                         table        root     INSERT          true
+system         public        comments                         table        root     SELECT          true
+system         public        comments                         table        root     UPDATE          true
+system         public        replication_constraint_stats     table        root     DELETE          true
+system         public        replication_constraint_stats     table        root     INSERT          true
+system         public        replication_constraint_stats     table        root     SELECT          true
+system         public        replication_constraint_stats     table        root     UPDATE          true
+system         public        replication_critical_localities  table        root     DELETE          true
+system         public        replication_critical_localities  table        root     INSERT          true
+system         public        replication_critical_localities  table        root     SELECT          true
+system         public        replication_critical_localities  table        root     UPDATE          true
+system         public        replication_stats                table        root     DELETE          true
+system         public        replication_stats                table        root     INSERT          true
+system         public        replication_stats                table        root     SELECT          true
+system         public        replication_stats                table        root     UPDATE          true
+system         public        reports_meta                     table        root     DELETE          true
+system         public        reports_meta                     table        root     INSERT          true
+system         public        reports_meta                     table        root     SELECT          true
+system         public        reports_meta                     table        root     UPDATE          true
+system         public        namespace                        table        root     SELECT          true
+system         public        protected_ts_meta                table        root     SELECT          true
+system         public        protected_ts_records             table        root     SELECT          true
+system         public        role_options                     table        root     DELETE          true
+system         public        role_options                     table        root     INSERT          true
+system         public        role_options                     table        root     SELECT          true
+system         public        role_options                     table        root     UPDATE          true
+system         public        statement_bundle_chunks          table        root     DELETE          true
+system         public        statement_bundle_chunks          table        root     INSERT          true
+system         public        statement_bundle_chunks          table        root     SELECT          true
+system         public        statement_bundle_chunks          table        root     UPDATE          true
+system         public        statement_diagnostics_requests   table        root     DELETE          true
+system         public        statement_diagnostics_requests   table        root     INSERT          true
+system         public        statement_diagnostics_requests   table        root     SELECT          true
+system         public        statement_diagnostics_requests   table        root     UPDATE          true
+system         public        statement_diagnostics            table        root     DELETE          true
+system         public        statement_diagnostics            table        root     INSERT          true
+system         public        statement_diagnostics            table        root     SELECT          true
+system         public        statement_diagnostics            table        root     UPDATE          true
+system         public        scheduled_jobs                   table        root     DELETE          true
+system         public        scheduled_jobs                   table        root     INSERT          true
+system         public        scheduled_jobs                   table        root     SELECT          true
+system         public        scheduled_jobs                   table        root     UPDATE          true
+system         public        sqlliveness                      table        root     DELETE          true
+system         public        sqlliveness                      table        root     INSERT          true
+system         public        sqlliveness                      table        root     SELECT          true
+system         public        sqlliveness                      table        root     UPDATE          true
+system         public        migrations                       table        root     DELETE          true
+system         public        migrations                       table        root     INSERT          true
+system         public        migrations                       table        root     SELECT          true
+system         public        migrations                       table        root     UPDATE          true
+system         public        join_tokens                      table        root     DELETE          true
+system         public        join_tokens                      table        root     INSERT          true
+system         public        join_tokens                      table        root     SELECT          true
+system         public        join_tokens                      table        root     UPDATE          true
+system         public        statement_statistics             table        root     SELECT          true
+system         public        transaction_statistics           table        root     SELECT          true
+system         public        database_role_settings           table        root     DELETE          true
+system         public        database_role_settings           table        root     INSERT          true
+system         public        database_role_settings           table        root     SELECT          true
+system         public        database_role_settings           table        root     UPDATE          true
+system         public        tenant_usage                     table        root     DELETE          true
+system         public        tenant_usage                     table        root     INSERT          true
+system         public        tenant_usage                     table        root     SELECT          true
+system         public        tenant_usage                     table        root     UPDATE          true
+system         public        sql_instances                    table        root     DELETE          true
+system         public        sql_instances                    table        root     INSERT          true
+system         public        sql_instances                    table        root     SELECT          true
+system         public        sql_instances                    table        root     UPDATE          true
+system         public        span_configurations              table        root     DELETE          true
+system         public        span_configurations              table        root     INSERT          true
+system         public        span_configurations              table        root     SELECT          true
+system         public        span_configurations              table        root     UPDATE          true
+system         public        role_id_seq                      sequence     root     SELECT          true
+system         public        role_id_seq                      sequence     root     UPDATE          true
+system         public        role_id_seq                      sequence     root     USAGE           true
+system         public        tenant_settings                  table        root     DELETE          true
+system         public        tenant_settings                  table        root     INSERT          true
+system         public        tenant_settings                  table        root     SELECT          true
+system         public        tenant_settings                  table        root     UPDATE          true
+system         public        privileges                       table        root     DELETE          true
+system         public        privileges                       table        root     INSERT          true
+system         public        privileges                       table        root     SELECT          true
+system         public        privileges                       table        root     UPDATE          true
+system         public        external_connections             table        root     DELETE          true
+system         public        external_connections             table        root     INSERT          true
+system         public        external_connections             table        root     SELECT          true
+system         public        external_connections             table        root     UPDATE          true
+system         public        job_info                         table        root     DELETE          true
+system         public        job_info                         table        root     INSERT          true
+system         public        job_info                         table        root     SELECT          true
+system         public        job_info                         table        root     UPDATE          true
+system         public        span_stats_unique_keys           table        root     DELETE          true
+system         public        span_stats_unique_keys           table        root     INSERT          true
+system         public        span_stats_unique_keys           table        root     SELECT          true
+system         public        span_stats_unique_keys           table        root     UPDATE          true
+system         public        span_stats_buckets               table        root     DELETE          true
+system         public        span_stats_buckets               table        root     INSERT          true
+system         public        span_stats_buckets               table        root     SELECT          true
+system         public        span_stats_buckets               table        root     UPDATE          true
+system         public        span_stats_samples               table        root     DELETE          true
+system         public        span_stats_samples               table        root     INSERT          true
+system         public        span_stats_samples               table        root     SELECT          true
+system         public        span_stats_samples               table        root     UPDATE          true
+system         public        span_stats_tenant_boundaries     table        root     DELETE          true
+system         public        span_stats_tenant_boundaries     table        root     INSERT          true
+system         public        span_stats_tenant_boundaries     table        root     SELECT          true
+system         public        span_stats_tenant_boundaries     table        root     UPDATE          true
+system         public        task_payloads                    table        root     DELETE          true
+system         public        task_payloads                    table        root     INSERT          true
+system         public        task_payloads                    table        root     SELECT          true
+system         public        task_payloads                    table        root     UPDATE          true
+system         public        tenant_tasks                     table        root     DELETE          true
+system         public        tenant_tasks                     table        root     INSERT          true
+system         public        tenant_tasks                     table        root     SELECT          true
+system         public        tenant_tasks                     table        root     UPDATE          true
+system         public        statement_activity               table        root     SELECT          true
+system         public        transaction_activity             table        root     SELECT          true
+system         public        tenant_id_seq                    sequence     root     SELECT          true
+a              pg_extension  NULL                             schema       public   USAGE           false
+a              public        NULL                             schema       public   CREATE          false
+a              public        NULL                             schema       public   USAGE           false
+a              public        NULL                             schema       root     ALL             true
+defaultdb      pg_extension  NULL                             schema       public   USAGE           false
+defaultdb      public        NULL                             schema       public   CREATE          false
+defaultdb      public        NULL                             schema       public   USAGE           false
+defaultdb      public        NULL                             schema       root     ALL             true
+postgres       pg_extension  NULL                             schema       public   USAGE           false
+postgres       public        NULL                             schema       public   CREATE          false
+postgres       public        NULL                             schema       public   USAGE           false
+postgres       public        NULL                             schema       root     ALL             true
+system         pg_extension  NULL                             schema       public   USAGE           false
+system         public        NULL                             schema       public   CREATE          false
+system         public        NULL                             schema       public   USAGE           false
+system         public        NULL                             schema       root     ALL             true
+test           pg_extension  NULL                             schema       public   USAGE           false
+test           public        NULL                             schema       public   CREATE          false
+test           public        NULL                             schema       public   USAGE           false
+test           public        NULL                             schema       root     ALL             true
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR root
 ----
-database_name  schema_name  relation_name                    grantee  privilege_type  is_grantable
-a              NULL         NULL                             admin    ALL             true
-a              NULL         NULL                             root     ALL             true
-a              pg_catalog   "char"                           admin    ALL             false
-a              pg_catalog   "char"                           root     ALL             false
-a              pg_catalog   "char"[]                         admin    ALL             false
-a              pg_catalog   "char"[]                         root     ALL             false
-a              pg_catalog   anyelement                       admin    ALL             false
-a              pg_catalog   anyelement                       root     ALL             false
-a              pg_catalog   anyelement[]                     admin    ALL             false
-a              pg_catalog   anyelement[]                     root     ALL             false
-a              pg_catalog   bit                              admin    ALL             false
-a              pg_catalog   bit                              root     ALL             false
-a              pg_catalog   bit[]                            admin    ALL             false
-a              pg_catalog   bit[]                            root     ALL             false
-a              pg_catalog   bool                             admin    ALL             false
-a              pg_catalog   bool                             root     ALL             false
-a              pg_catalog   bool[]                           admin    ALL             false
-a              pg_catalog   bool[]                           root     ALL             false
-a              pg_catalog   box2d                            admin    ALL             false
-a              pg_catalog   box2d                            root     ALL             false
-a              pg_catalog   box2d[]                          admin    ALL             false
-a              pg_catalog   box2d[]                          root     ALL             false
-a              pg_catalog   bytes                            admin    ALL             false
-a              pg_catalog   bytes                            root     ALL             false
-a              pg_catalog   bytes[]                          admin    ALL             false
-a              pg_catalog   bytes[]                          root     ALL             false
-a              pg_catalog   char                             admin    ALL             false
-a              pg_catalog   char                             root     ALL             false
-a              pg_catalog   char[]                           admin    ALL             false
-a              pg_catalog   char[]                           root     ALL             false
-a              pg_catalog   date                             admin    ALL             false
-a              pg_catalog   date                             root     ALL             false
-a              pg_catalog   date[]                           admin    ALL             false
-a              pg_catalog   date[]                           root     ALL             false
-a              pg_catalog   decimal                          admin    ALL             false
-a              pg_catalog   decimal                          root     ALL             false
-a              pg_catalog   decimal[]                        admin    ALL             false
-a              pg_catalog   decimal[]                        root     ALL             false
-a              pg_catalog   float                            admin    ALL             false
-a              pg_catalog   float                            root     ALL             false
-a              pg_catalog   float4                           admin    ALL             false
-a              pg_catalog   float4                           root     ALL             false
-a              pg_catalog   float4[]                         admin    ALL             false
-a              pg_catalog   float4[]                         root     ALL             false
-a              pg_catalog   float[]                          admin    ALL             false
-a              pg_catalog   float[]                          root     ALL             false
-a              pg_catalog   geography                        admin    ALL             false
-a              pg_catalog   geography                        root     ALL             false
-a              pg_catalog   geography[]                      admin    ALL             false
-a              pg_catalog   geography[]                      root     ALL             false
-a              pg_catalog   geometry                         admin    ALL             false
-a              pg_catalog   geometry                         root     ALL             false
-a              pg_catalog   geometry[]                       admin    ALL             false
-a              pg_catalog   geometry[]                       root     ALL             false
-a              pg_catalog   inet                             admin    ALL             false
-a              pg_catalog   inet                             root     ALL             false
-a              pg_catalog   inet[]                           admin    ALL             false
-a              pg_catalog   inet[]                           root     ALL             false
-a              pg_catalog   int                              admin    ALL             false
-a              pg_catalog   int                              root     ALL             false
-a              pg_catalog   int2                             admin    ALL             false
-a              pg_catalog   int2                             root     ALL             false
-a              pg_catalog   int2[]                           admin    ALL             false
-a              pg_catalog   int2[]                           root     ALL             false
-a              pg_catalog   int2vector                       admin    ALL             false
-a              pg_catalog   int2vector                       root     ALL             false
-a              pg_catalog   int2vector[]                     admin    ALL             false
-a              pg_catalog   int2vector[]                     root     ALL             false
-a              pg_catalog   int4                             admin    ALL             false
-a              pg_catalog   int4                             root     ALL             false
-a              pg_catalog   int4[]                           admin    ALL             false
-a              pg_catalog   int4[]                           root     ALL             false
-a              pg_catalog   int[]                            admin    ALL             false
-a              pg_catalog   int[]                            root     ALL             false
-a              pg_catalog   interval                         admin    ALL             false
-a              pg_catalog   interval                         root     ALL             false
-a              pg_catalog   interval[]                       admin    ALL             false
-a              pg_catalog   interval[]                       root     ALL             false
-a              pg_catalog   jsonb                            admin    ALL             false
-a              pg_catalog   jsonb                            root     ALL             false
-a              pg_catalog   jsonb[]                          admin    ALL             false
-a              pg_catalog   jsonb[]                          root     ALL             false
-a              pg_catalog   name                             admin    ALL             false
-a              pg_catalog   name                             root     ALL             false
-a              pg_catalog   name[]                           admin    ALL             false
-a              pg_catalog   name[]                           root     ALL             false
-a              pg_catalog   oid                              admin    ALL             false
-a              pg_catalog   oid                              root     ALL             false
-a              pg_catalog   oid[]                            admin    ALL             false
-a              pg_catalog   oid[]                            root     ALL             false
-a              pg_catalog   oidvector                        admin    ALL             false
-a              pg_catalog   oidvector                        root     ALL             false
-a              pg_catalog   oidvector[]                      admin    ALL             false
-a              pg_catalog   oidvector[]                      root     ALL             false
-a              pg_catalog   record                           admin    ALL             false
-a              pg_catalog   record                           root     ALL             false
-a              pg_catalog   record[]                         admin    ALL             false
-a              pg_catalog   record[]                         root     ALL             false
-a              pg_catalog   regclass                         admin    ALL             false
-a              pg_catalog   regclass                         root     ALL             false
-a              pg_catalog   regclass[]                       admin    ALL             false
-a              pg_catalog   regclass[]                       root     ALL             false
-a              pg_catalog   regnamespace                     admin    ALL             false
-a              pg_catalog   regnamespace                     root     ALL             false
-a              pg_catalog   regnamespace[]                   admin    ALL             false
-a              pg_catalog   regnamespace[]                   root     ALL             false
-a              pg_catalog   regproc                          admin    ALL             false
-a              pg_catalog   regproc                          root     ALL             false
-a              pg_catalog   regproc[]                        admin    ALL             false
-a              pg_catalog   regproc[]                        root     ALL             false
-a              pg_catalog   regprocedure                     admin    ALL             false
-a              pg_catalog   regprocedure                     root     ALL             false
-a              pg_catalog   regprocedure[]                   admin    ALL             false
-a              pg_catalog   regprocedure[]                   root     ALL             false
-a              pg_catalog   regrole                          admin    ALL             false
-a              pg_catalog   regrole                          root     ALL             false
-a              pg_catalog   regrole[]                        admin    ALL             false
-a              pg_catalog   regrole[]                        root     ALL             false
-a              pg_catalog   regtype                          admin    ALL             false
-a              pg_catalog   regtype                          root     ALL             false
-a              pg_catalog   regtype[]                        admin    ALL             false
-a              pg_catalog   regtype[]                        root     ALL             false
-a              pg_catalog   string                           admin    ALL             false
-a              pg_catalog   string                           root     ALL             false
-a              pg_catalog   string[]                         admin    ALL             false
-a              pg_catalog   string[]                         root     ALL             false
-a              pg_catalog   time                             admin    ALL             false
-a              pg_catalog   time                             root     ALL             false
-a              pg_catalog   time[]                           admin    ALL             false
-a              pg_catalog   time[]                           root     ALL             false
-a              pg_catalog   timestamp                        admin    ALL             false
-a              pg_catalog   timestamp                        root     ALL             false
-a              pg_catalog   timestamp[]                      admin    ALL             false
-a              pg_catalog   timestamp[]                      root     ALL             false
-a              pg_catalog   timestamptz                      admin    ALL             false
-a              pg_catalog   timestamptz                      root     ALL             false
-a              pg_catalog   timestamptz[]                    admin    ALL             false
-a              pg_catalog   timestamptz[]                    root     ALL             false
-a              pg_catalog   timetz                           admin    ALL             false
-a              pg_catalog   timetz                           root     ALL             false
-a              pg_catalog   timetz[]                         admin    ALL             false
-a              pg_catalog   timetz[]                         root     ALL             false
-a              pg_catalog   tsquery                          admin    ALL             false
-a              pg_catalog   tsquery                          root     ALL             false
-a              pg_catalog   tsquery[]                        admin    ALL             false
-a              pg_catalog   tsquery[]                        root     ALL             false
-a              pg_catalog   tsvector                         admin    ALL             false
-a              pg_catalog   tsvector                         root     ALL             false
-a              pg_catalog   tsvector[]                       admin    ALL             false
-a              pg_catalog   tsvector[]                       root     ALL             false
-a              pg_catalog   unknown                          admin    ALL             false
-a              pg_catalog   unknown                          root     ALL             false
-a              pg_catalog   uuid                             admin    ALL             false
-a              pg_catalog   uuid                             root     ALL             false
-a              pg_catalog   uuid[]                           admin    ALL             false
-a              pg_catalog   uuid[]                           root     ALL             false
-a              pg_catalog   varbit                           admin    ALL             false
-a              pg_catalog   varbit                           root     ALL             false
-a              pg_catalog   varbit[]                         admin    ALL             false
-a              pg_catalog   varbit[]                         root     ALL             false
-a              pg_catalog   varchar                          admin    ALL             false
-a              pg_catalog   varchar                          root     ALL             false
-a              pg_catalog   varchar[]                        admin    ALL             false
-a              pg_catalog   varchar[]                        root     ALL             false
-a              pg_catalog   void                             admin    ALL             false
-a              pg_catalog   void                             root     ALL             false
-a              public       NULL                             admin    ALL             true
-a              public       NULL                             root     ALL             true
-defaultdb      NULL         NULL                             admin    ALL             true
-defaultdb      NULL         NULL                             root     ALL             true
-defaultdb      pg_catalog   "char"                           admin    ALL             false
-defaultdb      pg_catalog   "char"                           root     ALL             false
-defaultdb      pg_catalog   "char"[]                         admin    ALL             false
-defaultdb      pg_catalog   "char"[]                         root     ALL             false
-defaultdb      pg_catalog   anyelement                       admin    ALL             false
-defaultdb      pg_catalog   anyelement                       root     ALL             false
-defaultdb      pg_catalog   anyelement[]                     admin    ALL             false
-defaultdb      pg_catalog   anyelement[]                     root     ALL             false
-defaultdb      pg_catalog   bit                              admin    ALL             false
-defaultdb      pg_catalog   bit                              root     ALL             false
-defaultdb      pg_catalog   bit[]                            admin    ALL             false
-defaultdb      pg_catalog   bit[]                            root     ALL             false
-defaultdb      pg_catalog   bool                             admin    ALL             false
-defaultdb      pg_catalog   bool                             root     ALL             false
-defaultdb      pg_catalog   bool[]                           admin    ALL             false
-defaultdb      pg_catalog   bool[]                           root     ALL             false
-defaultdb      pg_catalog   box2d                            admin    ALL             false
-defaultdb      pg_catalog   box2d                            root     ALL             false
-defaultdb      pg_catalog   box2d[]                          admin    ALL             false
-defaultdb      pg_catalog   box2d[]                          root     ALL             false
-defaultdb      pg_catalog   bytes                            admin    ALL             false
-defaultdb      pg_catalog   bytes                            root     ALL             false
-defaultdb      pg_catalog   bytes[]                          admin    ALL             false
-defaultdb      pg_catalog   bytes[]                          root     ALL             false
-defaultdb      pg_catalog   char                             admin    ALL             false
-defaultdb      pg_catalog   char                             root     ALL             false
-defaultdb      pg_catalog   char[]                           admin    ALL             false
-defaultdb      pg_catalog   char[]                           root     ALL             false
-defaultdb      pg_catalog   date                             admin    ALL             false
-defaultdb      pg_catalog   date                             root     ALL             false
-defaultdb      pg_catalog   date[]                           admin    ALL             false
-defaultdb      pg_catalog   date[]                           root     ALL             false
-defaultdb      pg_catalog   decimal                          admin    ALL             false
-defaultdb      pg_catalog   decimal                          root     ALL             false
-defaultdb      pg_catalog   decimal[]                        admin    ALL             false
-defaultdb      pg_catalog   decimal[]                        root     ALL             false
-defaultdb      pg_catalog   float                            admin    ALL             false
-defaultdb      pg_catalog   float                            root     ALL             false
-defaultdb      pg_catalog   float4                           admin    ALL             false
-defaultdb      pg_catalog   float4                           root     ALL             false
-defaultdb      pg_catalog   float4[]                         admin    ALL             false
-defaultdb      pg_catalog   float4[]                         root     ALL             false
-defaultdb      pg_catalog   float[]                          admin    ALL             false
-defaultdb      pg_catalog   float[]                          root     ALL             false
-defaultdb      pg_catalog   geography                        admin    ALL             false
-defaultdb      pg_catalog   geography                        root     ALL             false
-defaultdb      pg_catalog   geography[]                      admin    ALL             false
-defaultdb      pg_catalog   geography[]                      root     ALL             false
-defaultdb      pg_catalog   geometry                         admin    ALL             false
-defaultdb      pg_catalog   geometry                         root     ALL             false
-defaultdb      pg_catalog   geometry[]                       admin    ALL             false
-defaultdb      pg_catalog   geometry[]                       root     ALL             false
-defaultdb      pg_catalog   inet                             admin    ALL             false
-defaultdb      pg_catalog   inet                             root     ALL             false
-defaultdb      pg_catalog   inet[]                           admin    ALL             false
-defaultdb      pg_catalog   inet[]                           root     ALL             false
-defaultdb      pg_catalog   int                              admin    ALL             false
-defaultdb      pg_catalog   int                              root     ALL             false
-defaultdb      pg_catalog   int2                             admin    ALL             false
-defaultdb      pg_catalog   int2                             root     ALL             false
-defaultdb      pg_catalog   int2[]                           admin    ALL             false
-defaultdb      pg_catalog   int2[]                           root     ALL             false
-defaultdb      pg_catalog   int2vector                       admin    ALL             false
-defaultdb      pg_catalog   int2vector                       root     ALL             false
-defaultdb      pg_catalog   int2vector[]                     admin    ALL             false
-defaultdb      pg_catalog   int2vector[]                     root     ALL             false
-defaultdb      pg_catalog   int4                             admin    ALL             false
-defaultdb      pg_catalog   int4                             root     ALL             false
-defaultdb      pg_catalog   int4[]                           admin    ALL             false
-defaultdb      pg_catalog   int4[]                           root     ALL             false
-defaultdb      pg_catalog   int[]                            admin    ALL             false
-defaultdb      pg_catalog   int[]                            root     ALL             false
-defaultdb      pg_catalog   interval                         admin    ALL             false
-defaultdb      pg_catalog   interval                         root     ALL             false
-defaultdb      pg_catalog   interval[]                       admin    ALL             false
-defaultdb      pg_catalog   interval[]                       root     ALL             false
-defaultdb      pg_catalog   jsonb                            admin    ALL             false
-defaultdb      pg_catalog   jsonb                            root     ALL             false
-defaultdb      pg_catalog   jsonb[]                          admin    ALL             false
-defaultdb      pg_catalog   jsonb[]                          root     ALL             false
-defaultdb      pg_catalog   name                             admin    ALL             false
-defaultdb      pg_catalog   name                             root     ALL             false
-defaultdb      pg_catalog   name[]                           admin    ALL             false
-defaultdb      pg_catalog   name[]                           root     ALL             false
-defaultdb      pg_catalog   oid                              admin    ALL             false
-defaultdb      pg_catalog   oid                              root     ALL             false
-defaultdb      pg_catalog   oid[]                            admin    ALL             false
-defaultdb      pg_catalog   oid[]                            root     ALL             false
-defaultdb      pg_catalog   oidvector                        admin    ALL             false
-defaultdb      pg_catalog   oidvector                        root     ALL             false
-defaultdb      pg_catalog   oidvector[]                      admin    ALL             false
-defaultdb      pg_catalog   oidvector[]                      root     ALL             false
-defaultdb      pg_catalog   record                           admin    ALL             false
-defaultdb      pg_catalog   record                           root     ALL             false
-defaultdb      pg_catalog   record[]                         admin    ALL             false
-defaultdb      pg_catalog   record[]                         root     ALL             false
-defaultdb      pg_catalog   regclass                         admin    ALL             false
-defaultdb      pg_catalog   regclass                         root     ALL             false
-defaultdb      pg_catalog   regclass[]                       admin    ALL             false
-defaultdb      pg_catalog   regclass[]                       root     ALL             false
-defaultdb      pg_catalog   regnamespace                     admin    ALL             false
-defaultdb      pg_catalog   regnamespace                     root     ALL             false
-defaultdb      pg_catalog   regnamespace[]                   admin    ALL             false
-defaultdb      pg_catalog   regnamespace[]                   root     ALL             false
-defaultdb      pg_catalog   regproc                          admin    ALL             false
-defaultdb      pg_catalog   regproc                          root     ALL             false
-defaultdb      pg_catalog   regproc[]                        admin    ALL             false
-defaultdb      pg_catalog   regproc[]                        root     ALL             false
-defaultdb      pg_catalog   regprocedure                     admin    ALL             false
-defaultdb      pg_catalog   regprocedure                     root     ALL             false
-defaultdb      pg_catalog   regprocedure[]                   admin    ALL             false
-defaultdb      pg_catalog   regprocedure[]                   root     ALL             false
-defaultdb      pg_catalog   regrole                          admin    ALL             false
-defaultdb      pg_catalog   regrole                          root     ALL             false
-defaultdb      pg_catalog   regrole[]                        admin    ALL             false
-defaultdb      pg_catalog   regrole[]                        root     ALL             false
-defaultdb      pg_catalog   regtype                          admin    ALL             false
-defaultdb      pg_catalog   regtype                          root     ALL             false
-defaultdb      pg_catalog   regtype[]                        admin    ALL             false
-defaultdb      pg_catalog   regtype[]                        root     ALL             false
-defaultdb      pg_catalog   string                           admin    ALL             false
-defaultdb      pg_catalog   string                           root     ALL             false
-defaultdb      pg_catalog   string[]                         admin    ALL             false
-defaultdb      pg_catalog   string[]                         root     ALL             false
-defaultdb      pg_catalog   time                             admin    ALL             false
-defaultdb      pg_catalog   time                             root     ALL             false
-defaultdb      pg_catalog   time[]                           admin    ALL             false
-defaultdb      pg_catalog   time[]                           root     ALL             false
-defaultdb      pg_catalog   timestamp                        admin    ALL             false
-defaultdb      pg_catalog   timestamp                        root     ALL             false
-defaultdb      pg_catalog   timestamp[]                      admin    ALL             false
-defaultdb      pg_catalog   timestamp[]                      root     ALL             false
-defaultdb      pg_catalog   timestamptz                      admin    ALL             false
-defaultdb      pg_catalog   timestamptz                      root     ALL             false
-defaultdb      pg_catalog   timestamptz[]                    admin    ALL             false
-defaultdb      pg_catalog   timestamptz[]                    root     ALL             false
-defaultdb      pg_catalog   timetz                           admin    ALL             false
-defaultdb      pg_catalog   timetz                           root     ALL             false
-defaultdb      pg_catalog   timetz[]                         admin    ALL             false
-defaultdb      pg_catalog   timetz[]                         root     ALL             false
-defaultdb      pg_catalog   tsquery                          admin    ALL             false
-defaultdb      pg_catalog   tsquery                          root     ALL             false
-defaultdb      pg_catalog   tsquery[]                        admin    ALL             false
-defaultdb      pg_catalog   tsquery[]                        root     ALL             false
-defaultdb      pg_catalog   tsvector                         admin    ALL             false
-defaultdb      pg_catalog   tsvector                         root     ALL             false
-defaultdb      pg_catalog   tsvector[]                       admin    ALL             false
-defaultdb      pg_catalog   tsvector[]                       root     ALL             false
-defaultdb      pg_catalog   unknown                          admin    ALL             false
-defaultdb      pg_catalog   unknown                          root     ALL             false
-defaultdb      pg_catalog   uuid                             admin    ALL             false
-defaultdb      pg_catalog   uuid                             root     ALL             false
-defaultdb      pg_catalog   uuid[]                           admin    ALL             false
-defaultdb      pg_catalog   uuid[]                           root     ALL             false
-defaultdb      pg_catalog   varbit                           admin    ALL             false
-defaultdb      pg_catalog   varbit                           root     ALL             false
-defaultdb      pg_catalog   varbit[]                         admin    ALL             false
-defaultdb      pg_catalog   varbit[]                         root     ALL             false
-defaultdb      pg_catalog   varchar                          admin    ALL             false
-defaultdb      pg_catalog   varchar                          root     ALL             false
-defaultdb      pg_catalog   varchar[]                        admin    ALL             false
-defaultdb      pg_catalog   varchar[]                        root     ALL             false
-defaultdb      pg_catalog   void                             admin    ALL             false
-defaultdb      pg_catalog   void                             root     ALL             false
-defaultdb      public       NULL                             admin    ALL             true
-defaultdb      public       NULL                             root     ALL             true
-postgres       NULL         NULL                             admin    ALL             true
-postgres       NULL         NULL                             root     ALL             true
-postgres       pg_catalog   "char"                           admin    ALL             false
-postgres       pg_catalog   "char"                           root     ALL             false
-postgres       pg_catalog   "char"[]                         admin    ALL             false
-postgres       pg_catalog   "char"[]                         root     ALL             false
-postgres       pg_catalog   anyelement                       admin    ALL             false
-postgres       pg_catalog   anyelement                       root     ALL             false
-postgres       pg_catalog   anyelement[]                     admin    ALL             false
-postgres       pg_catalog   anyelement[]                     root     ALL             false
-postgres       pg_catalog   bit                              admin    ALL             false
-postgres       pg_catalog   bit                              root     ALL             false
-postgres       pg_catalog   bit[]                            admin    ALL             false
-postgres       pg_catalog   bit[]                            root     ALL             false
-postgres       pg_catalog   bool                             admin    ALL             false
-postgres       pg_catalog   bool                             root     ALL             false
-postgres       pg_catalog   bool[]                           admin    ALL             false
-postgres       pg_catalog   bool[]                           root     ALL             false
-postgres       pg_catalog   box2d                            admin    ALL             false
-postgres       pg_catalog   box2d                            root     ALL             false
-postgres       pg_catalog   box2d[]                          admin    ALL             false
-postgres       pg_catalog   box2d[]                          root     ALL             false
-postgres       pg_catalog   bytes                            admin    ALL             false
-postgres       pg_catalog   bytes                            root     ALL             false
-postgres       pg_catalog   bytes[]                          admin    ALL             false
-postgres       pg_catalog   bytes[]                          root     ALL             false
-postgres       pg_catalog   char                             admin    ALL             false
-postgres       pg_catalog   char                             root     ALL             false
-postgres       pg_catalog   char[]                           admin    ALL             false
-postgres       pg_catalog   char[]                           root     ALL             false
-postgres       pg_catalog   date                             admin    ALL             false
-postgres       pg_catalog   date                             root     ALL             false
-postgres       pg_catalog   date[]                           admin    ALL             false
-postgres       pg_catalog   date[]                           root     ALL             false
-postgres       pg_catalog   decimal                          admin    ALL             false
-postgres       pg_catalog   decimal                          root     ALL             false
-postgres       pg_catalog   decimal[]                        admin    ALL             false
-postgres       pg_catalog   decimal[]                        root     ALL             false
-postgres       pg_catalog   float                            admin    ALL             false
-postgres       pg_catalog   float                            root     ALL             false
-postgres       pg_catalog   float4                           admin    ALL             false
-postgres       pg_catalog   float4                           root     ALL             false
-postgres       pg_catalog   float4[]                         admin    ALL             false
-postgres       pg_catalog   float4[]                         root     ALL             false
-postgres       pg_catalog   float[]                          admin    ALL             false
-postgres       pg_catalog   float[]                          root     ALL             false
-postgres       pg_catalog   geography                        admin    ALL             false
-postgres       pg_catalog   geography                        root     ALL             false
-postgres       pg_catalog   geography[]                      admin    ALL             false
-postgres       pg_catalog   geography[]                      root     ALL             false
-postgres       pg_catalog   geometry                         admin    ALL             false
-postgres       pg_catalog   geometry                         root     ALL             false
-postgres       pg_catalog   geometry[]                       admin    ALL             false
-postgres       pg_catalog   geometry[]                       root     ALL             false
-postgres       pg_catalog   inet                             admin    ALL             false
-postgres       pg_catalog   inet                             root     ALL             false
-postgres       pg_catalog   inet[]                           admin    ALL             false
-postgres       pg_catalog   inet[]                           root     ALL             false
-postgres       pg_catalog   int                              admin    ALL             false
-postgres       pg_catalog   int                              root     ALL             false
-postgres       pg_catalog   int2                             admin    ALL             false
-postgres       pg_catalog   int2                             root     ALL             false
-postgres       pg_catalog   int2[]                           admin    ALL             false
-postgres       pg_catalog   int2[]                           root     ALL             false
-postgres       pg_catalog   int2vector                       admin    ALL             false
-postgres       pg_catalog   int2vector                       root     ALL             false
-postgres       pg_catalog   int2vector[]                     admin    ALL             false
-postgres       pg_catalog   int2vector[]                     root     ALL             false
-postgres       pg_catalog   int4                             admin    ALL             false
-postgres       pg_catalog   int4                             root     ALL             false
-postgres       pg_catalog   int4[]                           admin    ALL             false
-postgres       pg_catalog   int4[]                           root     ALL             false
-postgres       pg_catalog   int[]                            admin    ALL             false
-postgres       pg_catalog   int[]                            root     ALL             false
-postgres       pg_catalog   interval                         admin    ALL             false
-postgres       pg_catalog   interval                         root     ALL             false
-postgres       pg_catalog   interval[]                       admin    ALL             false
-postgres       pg_catalog   interval[]                       root     ALL             false
-postgres       pg_catalog   jsonb                            admin    ALL             false
-postgres       pg_catalog   jsonb                            root     ALL             false
-postgres       pg_catalog   jsonb[]                          admin    ALL             false
-postgres       pg_catalog   jsonb[]                          root     ALL             false
-postgres       pg_catalog   name                             admin    ALL             false
-postgres       pg_catalog   name                             root     ALL             false
-postgres       pg_catalog   name[]                           admin    ALL             false
-postgres       pg_catalog   name[]                           root     ALL             false
-postgres       pg_catalog   oid                              admin    ALL             false
-postgres       pg_catalog   oid                              root     ALL             false
-postgres       pg_catalog   oid[]                            admin    ALL             false
-postgres       pg_catalog   oid[]                            root     ALL             false
-postgres       pg_catalog   oidvector                        admin    ALL             false
-postgres       pg_catalog   oidvector                        root     ALL             false
-postgres       pg_catalog   oidvector[]                      admin    ALL             false
-postgres       pg_catalog   oidvector[]                      root     ALL             false
-postgres       pg_catalog   record                           admin    ALL             false
-postgres       pg_catalog   record                           root     ALL             false
-postgres       pg_catalog   record[]                         admin    ALL             false
-postgres       pg_catalog   record[]                         root     ALL             false
-postgres       pg_catalog   regclass                         admin    ALL             false
-postgres       pg_catalog   regclass                         root     ALL             false
-postgres       pg_catalog   regclass[]                       admin    ALL             false
-postgres       pg_catalog   regclass[]                       root     ALL             false
-postgres       pg_catalog   regnamespace                     admin    ALL             false
-postgres       pg_catalog   regnamespace                     root     ALL             false
-postgres       pg_catalog   regnamespace[]                   admin    ALL             false
-postgres       pg_catalog   regnamespace[]                   root     ALL             false
-postgres       pg_catalog   regproc                          admin    ALL             false
-postgres       pg_catalog   regproc                          root     ALL             false
-postgres       pg_catalog   regproc[]                        admin    ALL             false
-postgres       pg_catalog   regproc[]                        root     ALL             false
-postgres       pg_catalog   regprocedure                     admin    ALL             false
-postgres       pg_catalog   regprocedure                     root     ALL             false
-postgres       pg_catalog   regprocedure[]                   admin    ALL             false
-postgres       pg_catalog   regprocedure[]                   root     ALL             false
-postgres       pg_catalog   regrole                          admin    ALL             false
-postgres       pg_catalog   regrole                          root     ALL             false
-postgres       pg_catalog   regrole[]                        admin    ALL             false
-postgres       pg_catalog   regrole[]                        root     ALL             false
-postgres       pg_catalog   regtype                          admin    ALL             false
-postgres       pg_catalog   regtype                          root     ALL             false
-postgres       pg_catalog   regtype[]                        admin    ALL             false
-postgres       pg_catalog   regtype[]                        root     ALL             false
-postgres       pg_catalog   string                           admin    ALL             false
-postgres       pg_catalog   string                           root     ALL             false
-postgres       pg_catalog   string[]                         admin    ALL             false
-postgres       pg_catalog   string[]                         root     ALL             false
-postgres       pg_catalog   time                             admin    ALL             false
-postgres       pg_catalog   time                             root     ALL             false
-postgres       pg_catalog   time[]                           admin    ALL             false
-postgres       pg_catalog   time[]                           root     ALL             false
-postgres       pg_catalog   timestamp                        admin    ALL             false
-postgres       pg_catalog   timestamp                        root     ALL             false
-postgres       pg_catalog   timestamp[]                      admin    ALL             false
-postgres       pg_catalog   timestamp[]                      root     ALL             false
-postgres       pg_catalog   timestamptz                      admin    ALL             false
-postgres       pg_catalog   timestamptz                      root     ALL             false
-postgres       pg_catalog   timestamptz[]                    admin    ALL             false
-postgres       pg_catalog   timestamptz[]                    root     ALL             false
-postgres       pg_catalog   timetz                           admin    ALL             false
-postgres       pg_catalog   timetz                           root     ALL             false
-postgres       pg_catalog   timetz[]                         admin    ALL             false
-postgres       pg_catalog   timetz[]                         root     ALL             false
-postgres       pg_catalog   tsquery                          admin    ALL             false
-postgres       pg_catalog   tsquery                          root     ALL             false
-postgres       pg_catalog   tsquery[]                        admin    ALL             false
-postgres       pg_catalog   tsquery[]                        root     ALL             false
-postgres       pg_catalog   tsvector                         admin    ALL             false
-postgres       pg_catalog   tsvector                         root     ALL             false
-postgres       pg_catalog   tsvector[]                       admin    ALL             false
-postgres       pg_catalog   tsvector[]                       root     ALL             false
-postgres       pg_catalog   unknown                          admin    ALL             false
-postgres       pg_catalog   unknown                          root     ALL             false
-postgres       pg_catalog   uuid                             admin    ALL             false
-postgres       pg_catalog   uuid                             root     ALL             false
-postgres       pg_catalog   uuid[]                           admin    ALL             false
-postgres       pg_catalog   uuid[]                           root     ALL             false
-postgres       pg_catalog   varbit                           admin    ALL             false
-postgres       pg_catalog   varbit                           root     ALL             false
-postgres       pg_catalog   varbit[]                         admin    ALL             false
-postgres       pg_catalog   varbit[]                         root     ALL             false
-postgres       pg_catalog   varchar                          admin    ALL             false
-postgres       pg_catalog   varchar                          root     ALL             false
-postgres       pg_catalog   varchar[]                        admin    ALL             false
-postgres       pg_catalog   varchar[]                        root     ALL             false
-postgres       pg_catalog   void                             admin    ALL             false
-postgres       pg_catalog   void                             root     ALL             false
-postgres       public       NULL                             admin    ALL             true
-postgres       public       NULL                             root     ALL             true
-system         NULL         NULL                             admin    CONNECT         true
-system         NULL         NULL                             root     CONNECT         true
-system         pg_catalog   "char"                           admin    ALL             false
-system         pg_catalog   "char"                           root     ALL             false
-system         pg_catalog   "char"[]                         admin    ALL             false
-system         pg_catalog   "char"[]                         root     ALL             false
-system         pg_catalog   anyelement                       admin    ALL             false
-system         pg_catalog   anyelement                       root     ALL             false
-system         pg_catalog   anyelement[]                     admin    ALL             false
-system         pg_catalog   anyelement[]                     root     ALL             false
-system         pg_catalog   bit                              admin    ALL             false
-system         pg_catalog   bit                              root     ALL             false
-system         pg_catalog   bit[]                            admin    ALL             false
-system         pg_catalog   bit[]                            root     ALL             false
-system         pg_catalog   bool                             admin    ALL             false
-system         pg_catalog   bool                             root     ALL             false
-system         pg_catalog   bool[]                           admin    ALL             false
-system         pg_catalog   bool[]                           root     ALL             false
-system         pg_catalog   box2d                            admin    ALL             false
-system         pg_catalog   box2d                            root     ALL             false
-system         pg_catalog   box2d[]                          admin    ALL             false
-system         pg_catalog   box2d[]                          root     ALL             false
-system         pg_catalog   bytes                            admin    ALL             false
-system         pg_catalog   bytes                            root     ALL             false
-system         pg_catalog   bytes[]                          admin    ALL             false
-system         pg_catalog   bytes[]                          root     ALL             false
-system         pg_catalog   char                             admin    ALL             false
-system         pg_catalog   char                             root     ALL             false
-system         pg_catalog   char[]                           admin    ALL             false
-system         pg_catalog   char[]                           root     ALL             false
-system         pg_catalog   date                             admin    ALL             false
-system         pg_catalog   date                             root     ALL             false
-system         pg_catalog   date[]                           admin    ALL             false
-system         pg_catalog   date[]                           root     ALL             false
-system         pg_catalog   decimal                          admin    ALL             false
-system         pg_catalog   decimal                          root     ALL             false
-system         pg_catalog   decimal[]                        admin    ALL             false
-system         pg_catalog   decimal[]                        root     ALL             false
-system         pg_catalog   float                            admin    ALL             false
-system         pg_catalog   float                            root     ALL             false
-system         pg_catalog   float4                           admin    ALL             false
-system         pg_catalog   float4                           root     ALL             false
-system         pg_catalog   float4[]                         admin    ALL             false
-system         pg_catalog   float4[]                         root     ALL             false
-system         pg_catalog   float[]                          admin    ALL             false
-system         pg_catalog   float[]                          root     ALL             false
-system         pg_catalog   geography                        admin    ALL             false
-system         pg_catalog   geography                        root     ALL             false
-system         pg_catalog   geography[]                      admin    ALL             false
-system         pg_catalog   geography[]                      root     ALL             false
-system         pg_catalog   geometry                         admin    ALL             false
-system         pg_catalog   geometry                         root     ALL             false
-system         pg_catalog   geometry[]                       admin    ALL             false
-system         pg_catalog   geometry[]                       root     ALL             false
-system         pg_catalog   inet                             admin    ALL             false
-system         pg_catalog   inet                             root     ALL             false
-system         pg_catalog   inet[]                           admin    ALL             false
-system         pg_catalog   inet[]                           root     ALL             false
-system         pg_catalog   int                              admin    ALL             false
-system         pg_catalog   int                              root     ALL             false
-system         pg_catalog   int2                             admin    ALL             false
-system         pg_catalog   int2                             root     ALL             false
-system         pg_catalog   int2[]                           admin    ALL             false
-system         pg_catalog   int2[]                           root     ALL             false
-system         pg_catalog   int2vector                       admin    ALL             false
-system         pg_catalog   int2vector                       root     ALL             false
-system         pg_catalog   int2vector[]                     admin    ALL             false
-system         pg_catalog   int2vector[]                     root     ALL             false
-system         pg_catalog   int4                             admin    ALL             false
-system         pg_catalog   int4                             root     ALL             false
-system         pg_catalog   int4[]                           admin    ALL             false
-system         pg_catalog   int4[]                           root     ALL             false
-system         pg_catalog   int[]                            admin    ALL             false
-system         pg_catalog   int[]                            root     ALL             false
-system         pg_catalog   interval                         admin    ALL             false
-system         pg_catalog   interval                         root     ALL             false
-system         pg_catalog   interval[]                       admin    ALL             false
-system         pg_catalog   interval[]                       root     ALL             false
-system         pg_catalog   jsonb                            admin    ALL             false
-system         pg_catalog   jsonb                            root     ALL             false
-system         pg_catalog   jsonb[]                          admin    ALL             false
-system         pg_catalog   jsonb[]                          root     ALL             false
-system         pg_catalog   name                             admin    ALL             false
-system         pg_catalog   name                             root     ALL             false
-system         pg_catalog   name[]                           admin    ALL             false
-system         pg_catalog   name[]                           root     ALL             false
-system         pg_catalog   oid                              admin    ALL             false
-system         pg_catalog   oid                              root     ALL             false
-system         pg_catalog   oid[]                            admin    ALL             false
-system         pg_catalog   oid[]                            root     ALL             false
-system         pg_catalog   oidvector                        admin    ALL             false
-system         pg_catalog   oidvector                        root     ALL             false
-system         pg_catalog   oidvector[]                      admin    ALL             false
-system         pg_catalog   oidvector[]                      root     ALL             false
-system         pg_catalog   record                           admin    ALL             false
-system         pg_catalog   record                           root     ALL             false
-system         pg_catalog   record[]                         admin    ALL             false
-system         pg_catalog   record[]                         root     ALL             false
-system         pg_catalog   regclass                         admin    ALL             false
-system         pg_catalog   regclass                         root     ALL             false
-system         pg_catalog   regclass[]                       admin    ALL             false
-system         pg_catalog   regclass[]                       root     ALL             false
-system         pg_catalog   regnamespace                     admin    ALL             false
-system         pg_catalog   regnamespace                     root     ALL             false
-system         pg_catalog   regnamespace[]                   admin    ALL             false
-system         pg_catalog   regnamespace[]                   root     ALL             false
-system         pg_catalog   regproc                          admin    ALL             false
-system         pg_catalog   regproc                          root     ALL             false
-system         pg_catalog   regproc[]                        admin    ALL             false
-system         pg_catalog   regproc[]                        root     ALL             false
-system         pg_catalog   regprocedure                     admin    ALL             false
-system         pg_catalog   regprocedure                     root     ALL             false
-system         pg_catalog   regprocedure[]                   admin    ALL             false
-system         pg_catalog   regprocedure[]                   root     ALL             false
-system         pg_catalog   regrole                          admin    ALL             false
-system         pg_catalog   regrole                          root     ALL             false
-system         pg_catalog   regrole[]                        admin    ALL             false
-system         pg_catalog   regrole[]                        root     ALL             false
-system         pg_catalog   regtype                          admin    ALL             false
-system         pg_catalog   regtype                          root     ALL             false
-system         pg_catalog   regtype[]                        admin    ALL             false
-system         pg_catalog   regtype[]                        root     ALL             false
-system         pg_catalog   string                           admin    ALL             false
-system         pg_catalog   string                           root     ALL             false
-system         pg_catalog   string[]                         admin    ALL             false
-system         pg_catalog   string[]                         root     ALL             false
-system         pg_catalog   time                             admin    ALL             false
-system         pg_catalog   time                             root     ALL             false
-system         pg_catalog   time[]                           admin    ALL             false
-system         pg_catalog   time[]                           root     ALL             false
-system         pg_catalog   timestamp                        admin    ALL             false
-system         pg_catalog   timestamp                        root     ALL             false
-system         pg_catalog   timestamp[]                      admin    ALL             false
-system         pg_catalog   timestamp[]                      root     ALL             false
-system         pg_catalog   timestamptz                      admin    ALL             false
-system         pg_catalog   timestamptz                      root     ALL             false
-system         pg_catalog   timestamptz[]                    admin    ALL             false
-system         pg_catalog   timestamptz[]                    root     ALL             false
-system         pg_catalog   timetz                           admin    ALL             false
-system         pg_catalog   timetz                           root     ALL             false
-system         pg_catalog   timetz[]                         admin    ALL             false
-system         pg_catalog   timetz[]                         root     ALL             false
-system         pg_catalog   tsquery                          admin    ALL             false
-system         pg_catalog   tsquery                          root     ALL             false
-system         pg_catalog   tsquery[]                        admin    ALL             false
-system         pg_catalog   tsquery[]                        root     ALL             false
-system         pg_catalog   tsvector                         admin    ALL             false
-system         pg_catalog   tsvector                         root     ALL             false
-system         pg_catalog   tsvector[]                       admin    ALL             false
-system         pg_catalog   tsvector[]                       root     ALL             false
-system         pg_catalog   unknown                          admin    ALL             false
-system         pg_catalog   unknown                          root     ALL             false
-system         pg_catalog   uuid                             admin    ALL             false
-system         pg_catalog   uuid                             root     ALL             false
-system         pg_catalog   uuid[]                           admin    ALL             false
-system         pg_catalog   uuid[]                           root     ALL             false
-system         pg_catalog   varbit                           admin    ALL             false
-system         pg_catalog   varbit                           root     ALL             false
-system         pg_catalog   varbit[]                         admin    ALL             false
-system         pg_catalog   varbit[]                         root     ALL             false
-system         pg_catalog   varchar                          admin    ALL             false
-system         pg_catalog   varchar                          root     ALL             false
-system         pg_catalog   varchar[]                        admin    ALL             false
-system         pg_catalog   varchar[]                        root     ALL             false
-system         pg_catalog   void                             admin    ALL             false
-system         pg_catalog   void                             root     ALL             false
-system         public       NULL                             admin    ALL             true
-system         public       NULL                             root     ALL             true
-system         public       comments                         admin    DELETE          true
-system         public       comments                         admin    INSERT          true
-system         public       comments                         admin    SELECT          true
-system         public       comments                         admin    UPDATE          true
-system         public       comments                         root     DELETE          true
-system         public       comments                         root     INSERT          true
-system         public       comments                         root     SELECT          true
-system         public       comments                         root     UPDATE          true
-system         public       database_role_settings           admin    DELETE          true
-system         public       database_role_settings           admin    INSERT          true
-system         public       database_role_settings           admin    SELECT          true
-system         public       database_role_settings           admin    UPDATE          true
-system         public       database_role_settings           root     DELETE          true
-system         public       database_role_settings           root     INSERT          true
-system         public       database_role_settings           root     SELECT          true
-system         public       database_role_settings           root     UPDATE          true
-system         public       descriptor                       admin    SELECT          true
-system         public       descriptor                       root     SELECT          true
-system         public       descriptor_id_seq                admin    SELECT          true
-system         public       descriptor_id_seq                root     SELECT          true
-system         public       eventlog                         admin    DELETE          true
-system         public       eventlog                         admin    INSERT          true
-system         public       eventlog                         admin    SELECT          true
-system         public       eventlog                         admin    UPDATE          true
-system         public       eventlog                         root     DELETE          true
-system         public       eventlog                         root     INSERT          true
-system         public       eventlog                         root     SELECT          true
-system         public       eventlog                         root     UPDATE          true
-system         public       external_connections             admin    DELETE          true
-system         public       external_connections             admin    INSERT          true
-system         public       external_connections             admin    SELECT          true
-system         public       external_connections             admin    UPDATE          true
-system         public       external_connections             root     DELETE          true
-system         public       external_connections             root     INSERT          true
-system         public       external_connections             root     SELECT          true
-system         public       external_connections             root     UPDATE          true
-system         public       job_info                         admin    DELETE          true
-system         public       job_info                         admin    INSERT          true
-system         public       job_info                         admin    SELECT          true
-system         public       job_info                         admin    UPDATE          true
-system         public       job_info                         root     DELETE          true
-system         public       job_info                         root     INSERT          true
-system         public       job_info                         root     SELECT          true
-system         public       job_info                         root     UPDATE          true
-system         public       jobs                             admin    DELETE          true
-system         public       jobs                             admin    INSERT          true
-system         public       jobs                             admin    SELECT          true
-system         public       jobs                             admin    UPDATE          true
-system         public       jobs                             root     DELETE          true
-system         public       jobs                             root     INSERT          true
-system         public       jobs                             root     SELECT          true
-system         public       jobs                             root     UPDATE          true
-system         public       join_tokens                      admin    DELETE          true
-system         public       join_tokens                      admin    INSERT          true
-system         public       join_tokens                      admin    SELECT          true
-system         public       join_tokens                      admin    UPDATE          true
-system         public       join_tokens                      root     DELETE          true
-system         public       join_tokens                      root     INSERT          true
-system         public       join_tokens                      root     SELECT          true
-system         public       join_tokens                      root     UPDATE          true
-system         public       lease                            admin    DELETE          true
-system         public       lease                            admin    INSERT          true
-system         public       lease                            admin    SELECT          true
-system         public       lease                            admin    UPDATE          true
-system         public       lease                            root     DELETE          true
-system         public       lease                            root     INSERT          true
-system         public       lease                            root     SELECT          true
-system         public       lease                            root     UPDATE          true
-system         public       locations                        admin    DELETE          true
-system         public       locations                        admin    INSERT          true
-system         public       locations                        admin    SELECT          true
-system         public       locations                        admin    UPDATE          true
-system         public       locations                        root     DELETE          true
-system         public       locations                        root     INSERT          true
-system         public       locations                        root     SELECT          true
-system         public       locations                        root     UPDATE          true
-system         public       migrations                       admin    DELETE          true
-system         public       migrations                       admin    INSERT          true
-system         public       migrations                       admin    SELECT          true
-system         public       migrations                       admin    UPDATE          true
-system         public       migrations                       root     DELETE          true
-system         public       migrations                       root     INSERT          true
-system         public       migrations                       root     SELECT          true
-system         public       migrations                       root     UPDATE          true
-system         public       namespace                        admin    SELECT          true
-system         public       namespace                        root     SELECT          true
-system         public       privileges                       admin    DELETE          true
-system         public       privileges                       admin    INSERT          true
-system         public       privileges                       admin    SELECT          true
-system         public       privileges                       admin    UPDATE          true
-system         public       privileges                       root     DELETE          true
-system         public       privileges                       root     INSERT          true
-system         public       privileges                       root     SELECT          true
-system         public       privileges                       root     UPDATE          true
-system         public       protected_ts_meta                admin    SELECT          true
-system         public       protected_ts_meta                root     SELECT          true
-system         public       protected_ts_records             admin    SELECT          true
-system         public       protected_ts_records             root     SELECT          true
-system         public       rangelog                         admin    DELETE          true
-system         public       rangelog                         admin    INSERT          true
-system         public       rangelog                         admin    SELECT          true
-system         public       rangelog                         admin    UPDATE          true
-system         public       rangelog                         root     DELETE          true
-system         public       rangelog                         root     INSERT          true
-system         public       rangelog                         root     SELECT          true
-system         public       rangelog                         root     UPDATE          true
-system         public       replication_constraint_stats     admin    DELETE          true
-system         public       replication_constraint_stats     admin    INSERT          true
-system         public       replication_constraint_stats     admin    SELECT          true
-system         public       replication_constraint_stats     admin    UPDATE          true
-system         public       replication_constraint_stats     root     DELETE          true
-system         public       replication_constraint_stats     root     INSERT          true
-system         public       replication_constraint_stats     root     SELECT          true
-system         public       replication_constraint_stats     root     UPDATE          true
-system         public       replication_critical_localities  admin    DELETE          true
-system         public       replication_critical_localities  admin    INSERT          true
-system         public       replication_critical_localities  admin    SELECT          true
-system         public       replication_critical_localities  admin    UPDATE          true
-system         public       replication_critical_localities  root     DELETE          true
-system         public       replication_critical_localities  root     INSERT          true
-system         public       replication_critical_localities  root     SELECT          true
-system         public       replication_critical_localities  root     UPDATE          true
-system         public       replication_stats                admin    DELETE          true
-system         public       replication_stats                admin    INSERT          true
-system         public       replication_stats                admin    SELECT          true
-system         public       replication_stats                admin    UPDATE          true
-system         public       replication_stats                root     DELETE          true
-system         public       replication_stats                root     INSERT          true
-system         public       replication_stats                root     SELECT          true
-system         public       replication_stats                root     UPDATE          true
-system         public       reports_meta                     admin    DELETE          true
-system         public       reports_meta                     admin    INSERT          true
-system         public       reports_meta                     admin    SELECT          true
-system         public       reports_meta                     admin    UPDATE          true
-system         public       reports_meta                     root     DELETE          true
-system         public       reports_meta                     root     INSERT          true
-system         public       reports_meta                     root     SELECT          true
-system         public       reports_meta                     root     UPDATE          true
-system         public       role_id_seq                      admin    SELECT          true
-system         public       role_id_seq                      admin    UPDATE          true
-system         public       role_id_seq                      admin    USAGE           true
-system         public       role_id_seq                      root     SELECT          true
-system         public       role_id_seq                      root     UPDATE          true
-system         public       role_id_seq                      root     USAGE           true
-system         public       role_members                     admin    DELETE          true
-system         public       role_members                     admin    INSERT          true
-system         public       role_members                     admin    SELECT          true
-system         public       role_members                     admin    UPDATE          true
-system         public       role_members                     root     DELETE          true
-system         public       role_members                     root     INSERT          true
-system         public       role_members                     root     SELECT          true
-system         public       role_members                     root     UPDATE          true
-system         public       role_options                     admin    DELETE          true
-system         public       role_options                     admin    INSERT          true
-system         public       role_options                     admin    SELECT          true
-system         public       role_options                     admin    UPDATE          true
-system         public       role_options                     root     DELETE          true
-system         public       role_options                     root     INSERT          true
-system         public       role_options                     root     SELECT          true
-system         public       role_options                     root     UPDATE          true
-system         public       scheduled_jobs                   admin    DELETE          true
-system         public       scheduled_jobs                   admin    INSERT          true
-system         public       scheduled_jobs                   admin    SELECT          true
-system         public       scheduled_jobs                   admin    UPDATE          true
-system         public       scheduled_jobs                   root     DELETE          true
-system         public       scheduled_jobs                   root     INSERT          true
-system         public       scheduled_jobs                   root     SELECT          true
-system         public       scheduled_jobs                   root     UPDATE          true
-system         public       settings                         admin    DELETE          true
-system         public       settings                         admin    INSERT          true
-system         public       settings                         admin    SELECT          true
-system         public       settings                         admin    UPDATE          true
-system         public       settings                         root     DELETE          true
-system         public       settings                         root     INSERT          true
-system         public       settings                         root     SELECT          true
-system         public       settings                         root     UPDATE          true
-system         public       span_configurations              admin    DELETE          true
-system         public       span_configurations              admin    INSERT          true
-system         public       span_configurations              admin    SELECT          true
-system         public       span_configurations              admin    UPDATE          true
-system         public       span_configurations              root     DELETE          true
-system         public       span_configurations              root     INSERT          true
-system         public       span_configurations              root     SELECT          true
-system         public       span_configurations              root     UPDATE          true
-system         public       span_stats_buckets               admin    DELETE          true
-system         public       span_stats_buckets               admin    INSERT          true
-system         public       span_stats_buckets               admin    SELECT          true
-system         public       span_stats_buckets               admin    UPDATE          true
-system         public       span_stats_buckets               root     DELETE          true
-system         public       span_stats_buckets               root     INSERT          true
-system         public       span_stats_buckets               root     SELECT          true
-system         public       span_stats_buckets               root     UPDATE          true
-system         public       span_stats_samples               admin    DELETE          true
-system         public       span_stats_samples               admin    INSERT          true
-system         public       span_stats_samples               admin    SELECT          true
-system         public       span_stats_samples               admin    UPDATE          true
-system         public       span_stats_samples               root     DELETE          true
-system         public       span_stats_samples               root     INSERT          true
-system         public       span_stats_samples               root     SELECT          true
-system         public       span_stats_samples               root     UPDATE          true
-system         public       span_stats_tenant_boundaries     admin    DELETE          true
-system         public       span_stats_tenant_boundaries     admin    INSERT          true
-system         public       span_stats_tenant_boundaries     admin    SELECT          true
-system         public       span_stats_tenant_boundaries     admin    UPDATE          true
-system         public       span_stats_tenant_boundaries     root     DELETE          true
-system         public       span_stats_tenant_boundaries     root     INSERT          true
-system         public       span_stats_tenant_boundaries     root     SELECT          true
-system         public       span_stats_tenant_boundaries     root     UPDATE          true
-system         public       span_stats_unique_keys           admin    DELETE          true
-system         public       span_stats_unique_keys           admin    INSERT          true
-system         public       span_stats_unique_keys           admin    SELECT          true
-system         public       span_stats_unique_keys           admin    UPDATE          true
-system         public       span_stats_unique_keys           root     DELETE          true
-system         public       span_stats_unique_keys           root     INSERT          true
-system         public       span_stats_unique_keys           root     SELECT          true
-system         public       span_stats_unique_keys           root     UPDATE          true
-system         public       sql_instances                    admin    DELETE          true
-system         public       sql_instances                    admin    INSERT          true
-system         public       sql_instances                    admin    SELECT          true
-system         public       sql_instances                    admin    UPDATE          true
-system         public       sql_instances                    root     DELETE          true
-system         public       sql_instances                    root     INSERT          true
-system         public       sql_instances                    root     SELECT          true
-system         public       sql_instances                    root     UPDATE          true
-system         public       sqlliveness                      admin    DELETE          true
-system         public       sqlliveness                      admin    INSERT          true
-system         public       sqlliveness                      admin    SELECT          true
-system         public       sqlliveness                      admin    UPDATE          true
-system         public       sqlliveness                      root     DELETE          true
-system         public       sqlliveness                      root     INSERT          true
-system         public       sqlliveness                      root     SELECT          true
-system         public       sqlliveness                      root     UPDATE          true
-system         public       statement_activity               admin    SELECT          true
-system         public       statement_activity               root     SELECT          true
-system         public       statement_bundle_chunks          admin    DELETE          true
-system         public       statement_bundle_chunks          admin    INSERT          true
-system         public       statement_bundle_chunks          admin    SELECT          true
-system         public       statement_bundle_chunks          admin    UPDATE          true
-system         public       statement_bundle_chunks          root     DELETE          true
-system         public       statement_bundle_chunks          root     INSERT          true
-system         public       statement_bundle_chunks          root     SELECT          true
-system         public       statement_bundle_chunks          root     UPDATE          true
-system         public       statement_diagnostics            admin    DELETE          true
-system         public       statement_diagnostics            admin    INSERT          true
-system         public       statement_diagnostics            admin    SELECT          true
-system         public       statement_diagnostics            admin    UPDATE          true
-system         public       statement_diagnostics            root     DELETE          true
-system         public       statement_diagnostics            root     INSERT          true
-system         public       statement_diagnostics            root     SELECT          true
-system         public       statement_diagnostics            root     UPDATE          true
-system         public       statement_diagnostics_requests   admin    DELETE          true
-system         public       statement_diagnostics_requests   admin    INSERT          true
-system         public       statement_diagnostics_requests   admin    SELECT          true
-system         public       statement_diagnostics_requests   admin    UPDATE          true
-system         public       statement_diagnostics_requests   root     DELETE          true
-system         public       statement_diagnostics_requests   root     INSERT          true
-system         public       statement_diagnostics_requests   root     SELECT          true
-system         public       statement_diagnostics_requests   root     UPDATE          true
-system         public       statement_statistics             admin    SELECT          true
-system         public       statement_statistics             root     SELECT          true
-system         public       table_statistics                 admin    DELETE          true
-system         public       table_statistics                 admin    INSERT          true
-system         public       table_statistics                 admin    SELECT          true
-system         public       table_statistics                 admin    UPDATE          true
-system         public       table_statistics                 root     DELETE          true
-system         public       table_statistics                 root     INSERT          true
-system         public       table_statistics                 root     SELECT          true
-system         public       table_statistics                 root     UPDATE          true
-system         public       task_payloads                    admin    DELETE          true
-system         public       task_payloads                    admin    INSERT          true
-system         public       task_payloads                    admin    SELECT          true
-system         public       task_payloads                    admin    UPDATE          true
-system         public       task_payloads                    root     DELETE          true
-system         public       task_payloads                    root     INSERT          true
-system         public       task_payloads                    root     SELECT          true
-system         public       task_payloads                    root     UPDATE          true
-system         public       tenant_id_seq                    admin    SELECT          true
-system         public       tenant_id_seq                    root     SELECT          true
-system         public       tenant_settings                  admin    DELETE          true
-system         public       tenant_settings                  admin    INSERT          true
-system         public       tenant_settings                  admin    SELECT          true
-system         public       tenant_settings                  admin    UPDATE          true
-system         public       tenant_settings                  root     DELETE          true
-system         public       tenant_settings                  root     INSERT          true
-system         public       tenant_settings                  root     SELECT          true
-system         public       tenant_settings                  root     UPDATE          true
-system         public       tenant_tasks                     admin    DELETE          true
-system         public       tenant_tasks                     admin    INSERT          true
-system         public       tenant_tasks                     admin    SELECT          true
-system         public       tenant_tasks                     admin    UPDATE          true
-system         public       tenant_tasks                     root     DELETE          true
-system         public       tenant_tasks                     root     INSERT          true
-system         public       tenant_tasks                     root     SELECT          true
-system         public       tenant_tasks                     root     UPDATE          true
-system         public       tenant_usage                     admin    DELETE          true
-system         public       tenant_usage                     admin    INSERT          true
-system         public       tenant_usage                     admin    SELECT          true
-system         public       tenant_usage                     admin    UPDATE          true
-system         public       tenant_usage                     root     DELETE          true
-system         public       tenant_usage                     root     INSERT          true
-system         public       tenant_usage                     root     SELECT          true
-system         public       tenant_usage                     root     UPDATE          true
-system         public       tenants                          admin    SELECT          true
-system         public       tenants                          root     SELECT          true
-system         public       transaction_activity             admin    SELECT          true
-system         public       transaction_activity             root     SELECT          true
-system         public       transaction_statistics           admin    SELECT          true
-system         public       transaction_statistics           root     SELECT          true
-system         public       ui                               admin    DELETE          true
-system         public       ui                               admin    INSERT          true
-system         public       ui                               admin    SELECT          true
-system         public       ui                               admin    UPDATE          true
-system         public       ui                               root     DELETE          true
-system         public       ui                               root     INSERT          true
-system         public       ui                               root     SELECT          true
-system         public       ui                               root     UPDATE          true
-system         public       users                            admin    DELETE          true
-system         public       users                            admin    INSERT          true
-system         public       users                            admin    SELECT          true
-system         public       users                            admin    UPDATE          true
-system         public       users                            root     DELETE          true
-system         public       users                            root     INSERT          true
-system         public       users                            root     SELECT          true
-system         public       users                            root     UPDATE          true
-system         public       web_sessions                     admin    DELETE          true
-system         public       web_sessions                     admin    INSERT          true
-system         public       web_sessions                     admin    SELECT          true
-system         public       web_sessions                     admin    UPDATE          true
-system         public       web_sessions                     root     DELETE          true
-system         public       web_sessions                     root     INSERT          true
-system         public       web_sessions                     root     SELECT          true
-system         public       web_sessions                     root     UPDATE          true
-system         public       zones                            admin    DELETE          true
-system         public       zones                            admin    INSERT          true
-system         public       zones                            admin    SELECT          true
-system         public       zones                            admin    UPDATE          true
-system         public       zones                            root     DELETE          true
-system         public       zones                            root     INSERT          true
-system         public       zones                            root     SELECT          true
-system         public       zones                            root     UPDATE          true
-test           NULL         NULL                             admin    ALL             true
-test           NULL         NULL                             root     ALL             true
-test           pg_catalog   "char"                           admin    ALL             false
-test           pg_catalog   "char"                           root     ALL             false
-test           pg_catalog   "char"[]                         admin    ALL             false
-test           pg_catalog   "char"[]                         root     ALL             false
-test           pg_catalog   anyelement                       admin    ALL             false
-test           pg_catalog   anyelement                       root     ALL             false
-test           pg_catalog   anyelement[]                     admin    ALL             false
-test           pg_catalog   anyelement[]                     root     ALL             false
-test           pg_catalog   bit                              admin    ALL             false
-test           pg_catalog   bit                              root     ALL             false
-test           pg_catalog   bit[]                            admin    ALL             false
-test           pg_catalog   bit[]                            root     ALL             false
-test           pg_catalog   bool                             admin    ALL             false
-test           pg_catalog   bool                             root     ALL             false
-test           pg_catalog   bool[]                           admin    ALL             false
-test           pg_catalog   bool[]                           root     ALL             false
-test           pg_catalog   box2d                            admin    ALL             false
-test           pg_catalog   box2d                            root     ALL             false
-test           pg_catalog   box2d[]                          admin    ALL             false
-test           pg_catalog   box2d[]                          root     ALL             false
-test           pg_catalog   bytes                            admin    ALL             false
-test           pg_catalog   bytes                            root     ALL             false
-test           pg_catalog   bytes[]                          admin    ALL             false
-test           pg_catalog   bytes[]                          root     ALL             false
-test           pg_catalog   char                             admin    ALL             false
-test           pg_catalog   char                             root     ALL             false
-test           pg_catalog   char[]                           admin    ALL             false
-test           pg_catalog   char[]                           root     ALL             false
-test           pg_catalog   date                             admin    ALL             false
-test           pg_catalog   date                             root     ALL             false
-test           pg_catalog   date[]                           admin    ALL             false
-test           pg_catalog   date[]                           root     ALL             false
-test           pg_catalog   decimal                          admin    ALL             false
-test           pg_catalog   decimal                          root     ALL             false
-test           pg_catalog   decimal[]                        admin    ALL             false
-test           pg_catalog   decimal[]                        root     ALL             false
-test           pg_catalog   float                            admin    ALL             false
-test           pg_catalog   float                            root     ALL             false
-test           pg_catalog   float4                           admin    ALL             false
-test           pg_catalog   float4                           root     ALL             false
-test           pg_catalog   float4[]                         admin    ALL             false
-test           pg_catalog   float4[]                         root     ALL             false
-test           pg_catalog   float[]                          admin    ALL             false
-test           pg_catalog   float[]                          root     ALL             false
-test           pg_catalog   geography                        admin    ALL             false
-test           pg_catalog   geography                        root     ALL             false
-test           pg_catalog   geography[]                      admin    ALL             false
-test           pg_catalog   geography[]                      root     ALL             false
-test           pg_catalog   geometry                         admin    ALL             false
-test           pg_catalog   geometry                         root     ALL             false
-test           pg_catalog   geometry[]                       admin    ALL             false
-test           pg_catalog   geometry[]                       root     ALL             false
-test           pg_catalog   inet                             admin    ALL             false
-test           pg_catalog   inet                             root     ALL             false
-test           pg_catalog   inet[]                           admin    ALL             false
-test           pg_catalog   inet[]                           root     ALL             false
-test           pg_catalog   int                              admin    ALL             false
-test           pg_catalog   int                              root     ALL             false
-test           pg_catalog   int2                             admin    ALL             false
-test           pg_catalog   int2                             root     ALL             false
-test           pg_catalog   int2[]                           admin    ALL             false
-test           pg_catalog   int2[]                           root     ALL             false
-test           pg_catalog   int2vector                       admin    ALL             false
-test           pg_catalog   int2vector                       root     ALL             false
-test           pg_catalog   int2vector[]                     admin    ALL             false
-test           pg_catalog   int2vector[]                     root     ALL             false
-test           pg_catalog   int4                             admin    ALL             false
-test           pg_catalog   int4                             root     ALL             false
-test           pg_catalog   int4[]                           admin    ALL             false
-test           pg_catalog   int4[]                           root     ALL             false
-test           pg_catalog   int[]                            admin    ALL             false
-test           pg_catalog   int[]                            root     ALL             false
-test           pg_catalog   interval                         admin    ALL             false
-test           pg_catalog   interval                         root     ALL             false
-test           pg_catalog   interval[]                       admin    ALL             false
-test           pg_catalog   interval[]                       root     ALL             false
-test           pg_catalog   jsonb                            admin    ALL             false
-test           pg_catalog   jsonb                            root     ALL             false
-test           pg_catalog   jsonb[]                          admin    ALL             false
-test           pg_catalog   jsonb[]                          root     ALL             false
-test           pg_catalog   name                             admin    ALL             false
-test           pg_catalog   name                             root     ALL             false
-test           pg_catalog   name[]                           admin    ALL             false
-test           pg_catalog   name[]                           root     ALL             false
-test           pg_catalog   oid                              admin    ALL             false
-test           pg_catalog   oid                              root     ALL             false
-test           pg_catalog   oid[]                            admin    ALL             false
-test           pg_catalog   oid[]                            root     ALL             false
-test           pg_catalog   oidvector                        admin    ALL             false
-test           pg_catalog   oidvector                        root     ALL             false
-test           pg_catalog   oidvector[]                      admin    ALL             false
-test           pg_catalog   oidvector[]                      root     ALL             false
-test           pg_catalog   record                           admin    ALL             false
-test           pg_catalog   record                           root     ALL             false
-test           pg_catalog   record[]                         admin    ALL             false
-test           pg_catalog   record[]                         root     ALL             false
-test           pg_catalog   regclass                         admin    ALL             false
-test           pg_catalog   regclass                         root     ALL             false
-test           pg_catalog   regclass[]                       admin    ALL             false
-test           pg_catalog   regclass[]                       root     ALL             false
-test           pg_catalog   regnamespace                     admin    ALL             false
-test           pg_catalog   regnamespace                     root     ALL             false
-test           pg_catalog   regnamespace[]                   admin    ALL             false
-test           pg_catalog   regnamespace[]                   root     ALL             false
-test           pg_catalog   regproc                          admin    ALL             false
-test           pg_catalog   regproc                          root     ALL             false
-test           pg_catalog   regproc[]                        admin    ALL             false
-test           pg_catalog   regproc[]                        root     ALL             false
-test           pg_catalog   regprocedure                     admin    ALL             false
-test           pg_catalog   regprocedure                     root     ALL             false
-test           pg_catalog   regprocedure[]                   admin    ALL             false
-test           pg_catalog   regprocedure[]                   root     ALL             false
-test           pg_catalog   regrole                          admin    ALL             false
-test           pg_catalog   regrole                          root     ALL             false
-test           pg_catalog   regrole[]                        admin    ALL             false
-test           pg_catalog   regrole[]                        root     ALL             false
-test           pg_catalog   regtype                          admin    ALL             false
-test           pg_catalog   regtype                          root     ALL             false
-test           pg_catalog   regtype[]                        admin    ALL             false
-test           pg_catalog   regtype[]                        root     ALL             false
-test           pg_catalog   string                           admin    ALL             false
-test           pg_catalog   string                           root     ALL             false
-test           pg_catalog   string[]                         admin    ALL             false
-test           pg_catalog   string[]                         root     ALL             false
-test           pg_catalog   time                             admin    ALL             false
-test           pg_catalog   time                             root     ALL             false
-test           pg_catalog   time[]                           admin    ALL             false
-test           pg_catalog   time[]                           root     ALL             false
-test           pg_catalog   timestamp                        admin    ALL             false
-test           pg_catalog   timestamp                        root     ALL             false
-test           pg_catalog   timestamp[]                      admin    ALL             false
-test           pg_catalog   timestamp[]                      root     ALL             false
-test           pg_catalog   timestamptz                      admin    ALL             false
-test           pg_catalog   timestamptz                      root     ALL             false
-test           pg_catalog   timestamptz[]                    admin    ALL             false
-test           pg_catalog   timestamptz[]                    root     ALL             false
-test           pg_catalog   timetz                           admin    ALL             false
-test           pg_catalog   timetz                           root     ALL             false
-test           pg_catalog   timetz[]                         admin    ALL             false
-test           pg_catalog   timetz[]                         root     ALL             false
-test           pg_catalog   tsquery                          admin    ALL             false
-test           pg_catalog   tsquery                          root     ALL             false
-test           pg_catalog   tsquery[]                        admin    ALL             false
-test           pg_catalog   tsquery[]                        root     ALL             false
-test           pg_catalog   tsvector                         admin    ALL             false
-test           pg_catalog   tsvector                         root     ALL             false
-test           pg_catalog   tsvector[]                       admin    ALL             false
-test           pg_catalog   tsvector[]                       root     ALL             false
-test           pg_catalog   unknown                          admin    ALL             false
-test           pg_catalog   unknown                          root     ALL             false
-test           pg_catalog   uuid                             admin    ALL             false
-test           pg_catalog   uuid                             root     ALL             false
-test           pg_catalog   uuid[]                           admin    ALL             false
-test           pg_catalog   uuid[]                           root     ALL             false
-test           pg_catalog   varbit                           admin    ALL             false
-test           pg_catalog   varbit                           root     ALL             false
-test           pg_catalog   varbit[]                         admin    ALL             false
-test           pg_catalog   varbit[]                         root     ALL             false
-test           pg_catalog   varchar                          admin    ALL             false
-test           pg_catalog   varchar                          root     ALL             false
-test           pg_catalog   varchar[]                        admin    ALL             false
-test           pg_catalog   varchar[]                        root     ALL             false
-test           pg_catalog   void                             admin    ALL             false
-test           pg_catalog   void                             root     ALL             false
-test           public       NULL                             admin    ALL             true
-test           public       NULL                             root     ALL             true
+database_name  schema_name  object_name                      object_type  grantee  privilege_type  is_grantable
+a              NULL         NULL                             database     admin    ALL             true
+a              NULL         NULL                             database     root     ALL             true
+a              pg_catalog   "char"                           type         admin    ALL             false
+a              pg_catalog   "char"                           type         root     ALL             false
+a              pg_catalog   "char"[]                         type         admin    ALL             false
+a              pg_catalog   "char"[]                         type         root     ALL             false
+a              pg_catalog   anyelement                       type         admin    ALL             false
+a              pg_catalog   anyelement                       type         root     ALL             false
+a              pg_catalog   anyelement[]                     type         admin    ALL             false
+a              pg_catalog   anyelement[]                     type         root     ALL             false
+a              pg_catalog   bit                              type         admin    ALL             false
+a              pg_catalog   bit                              type         root     ALL             false
+a              pg_catalog   bit[]                            type         admin    ALL             false
+a              pg_catalog   bit[]                            type         root     ALL             false
+a              pg_catalog   bool                             type         admin    ALL             false
+a              pg_catalog   bool                             type         root     ALL             false
+a              pg_catalog   bool[]                           type         admin    ALL             false
+a              pg_catalog   bool[]                           type         root     ALL             false
+a              pg_catalog   box2d                            type         admin    ALL             false
+a              pg_catalog   box2d                            type         root     ALL             false
+a              pg_catalog   box2d[]                          type         admin    ALL             false
+a              pg_catalog   box2d[]                          type         root     ALL             false
+a              pg_catalog   bytes                            type         admin    ALL             false
+a              pg_catalog   bytes                            type         root     ALL             false
+a              pg_catalog   bytes[]                          type         admin    ALL             false
+a              pg_catalog   bytes[]                          type         root     ALL             false
+a              pg_catalog   char                             type         admin    ALL             false
+a              pg_catalog   char                             type         root     ALL             false
+a              pg_catalog   char[]                           type         admin    ALL             false
+a              pg_catalog   char[]                           type         root     ALL             false
+a              pg_catalog   date                             type         admin    ALL             false
+a              pg_catalog   date                             type         root     ALL             false
+a              pg_catalog   date[]                           type         admin    ALL             false
+a              pg_catalog   date[]                           type         root     ALL             false
+a              pg_catalog   decimal                          type         admin    ALL             false
+a              pg_catalog   decimal                          type         root     ALL             false
+a              pg_catalog   decimal[]                        type         admin    ALL             false
+a              pg_catalog   decimal[]                        type         root     ALL             false
+a              pg_catalog   float                            type         admin    ALL             false
+a              pg_catalog   float                            type         root     ALL             false
+a              pg_catalog   float4                           type         admin    ALL             false
+a              pg_catalog   float4                           type         root     ALL             false
+a              pg_catalog   float4[]                         type         admin    ALL             false
+a              pg_catalog   float4[]                         type         root     ALL             false
+a              pg_catalog   float[]                          type         admin    ALL             false
+a              pg_catalog   float[]                          type         root     ALL             false
+a              pg_catalog   geography                        type         admin    ALL             false
+a              pg_catalog   geography                        type         root     ALL             false
+a              pg_catalog   geography[]                      type         admin    ALL             false
+a              pg_catalog   geography[]                      type         root     ALL             false
+a              pg_catalog   geometry                         type         admin    ALL             false
+a              pg_catalog   geometry                         type         root     ALL             false
+a              pg_catalog   geometry[]                       type         admin    ALL             false
+a              pg_catalog   geometry[]                       type         root     ALL             false
+a              pg_catalog   inet                             type         admin    ALL             false
+a              pg_catalog   inet                             type         root     ALL             false
+a              pg_catalog   inet[]                           type         admin    ALL             false
+a              pg_catalog   inet[]                           type         root     ALL             false
+a              pg_catalog   int                              type         admin    ALL             false
+a              pg_catalog   int                              type         root     ALL             false
+a              pg_catalog   int2                             type         admin    ALL             false
+a              pg_catalog   int2                             type         root     ALL             false
+a              pg_catalog   int2[]                           type         admin    ALL             false
+a              pg_catalog   int2[]                           type         root     ALL             false
+a              pg_catalog   int2vector                       type         admin    ALL             false
+a              pg_catalog   int2vector                       type         root     ALL             false
+a              pg_catalog   int2vector[]                     type         admin    ALL             false
+a              pg_catalog   int2vector[]                     type         root     ALL             false
+a              pg_catalog   int4                             type         admin    ALL             false
+a              pg_catalog   int4                             type         root     ALL             false
+a              pg_catalog   int4[]                           type         admin    ALL             false
+a              pg_catalog   int4[]                           type         root     ALL             false
+a              pg_catalog   int[]                            type         admin    ALL             false
+a              pg_catalog   int[]                            type         root     ALL             false
+a              pg_catalog   interval                         type         admin    ALL             false
+a              pg_catalog   interval                         type         root     ALL             false
+a              pg_catalog   interval[]                       type         admin    ALL             false
+a              pg_catalog   interval[]                       type         root     ALL             false
+a              pg_catalog   jsonb                            type         admin    ALL             false
+a              pg_catalog   jsonb                            type         root     ALL             false
+a              pg_catalog   jsonb[]                          type         admin    ALL             false
+a              pg_catalog   jsonb[]                          type         root     ALL             false
+a              pg_catalog   name                             type         admin    ALL             false
+a              pg_catalog   name                             type         root     ALL             false
+a              pg_catalog   name[]                           type         admin    ALL             false
+a              pg_catalog   name[]                           type         root     ALL             false
+a              pg_catalog   oid                              type         admin    ALL             false
+a              pg_catalog   oid                              type         root     ALL             false
+a              pg_catalog   oid[]                            type         admin    ALL             false
+a              pg_catalog   oid[]                            type         root     ALL             false
+a              pg_catalog   oidvector                        type         admin    ALL             false
+a              pg_catalog   oidvector                        type         root     ALL             false
+a              pg_catalog   oidvector[]                      type         admin    ALL             false
+a              pg_catalog   oidvector[]                      type         root     ALL             false
+a              pg_catalog   record                           type         admin    ALL             false
+a              pg_catalog   record                           type         root     ALL             false
+a              pg_catalog   record[]                         type         admin    ALL             false
+a              pg_catalog   record[]                         type         root     ALL             false
+a              pg_catalog   regclass                         type         admin    ALL             false
+a              pg_catalog   regclass                         type         root     ALL             false
+a              pg_catalog   regclass[]                       type         admin    ALL             false
+a              pg_catalog   regclass[]                       type         root     ALL             false
+a              pg_catalog   regnamespace                     type         admin    ALL             false
+a              pg_catalog   regnamespace                     type         root     ALL             false
+a              pg_catalog   regnamespace[]                   type         admin    ALL             false
+a              pg_catalog   regnamespace[]                   type         root     ALL             false
+a              pg_catalog   regproc                          type         admin    ALL             false
+a              pg_catalog   regproc                          type         root     ALL             false
+a              pg_catalog   regproc[]                        type         admin    ALL             false
+a              pg_catalog   regproc[]                        type         root     ALL             false
+a              pg_catalog   regprocedure                     type         admin    ALL             false
+a              pg_catalog   regprocedure                     type         root     ALL             false
+a              pg_catalog   regprocedure[]                   type         admin    ALL             false
+a              pg_catalog   regprocedure[]                   type         root     ALL             false
+a              pg_catalog   regrole                          type         admin    ALL             false
+a              pg_catalog   regrole                          type         root     ALL             false
+a              pg_catalog   regrole[]                        type         admin    ALL             false
+a              pg_catalog   regrole[]                        type         root     ALL             false
+a              pg_catalog   regtype                          type         admin    ALL             false
+a              pg_catalog   regtype                          type         root     ALL             false
+a              pg_catalog   regtype[]                        type         admin    ALL             false
+a              pg_catalog   regtype[]                        type         root     ALL             false
+a              pg_catalog   string                           type         admin    ALL             false
+a              pg_catalog   string                           type         root     ALL             false
+a              pg_catalog   string[]                         type         admin    ALL             false
+a              pg_catalog   string[]                         type         root     ALL             false
+a              pg_catalog   time                             type         admin    ALL             false
+a              pg_catalog   time                             type         root     ALL             false
+a              pg_catalog   time[]                           type         admin    ALL             false
+a              pg_catalog   time[]                           type         root     ALL             false
+a              pg_catalog   timestamp                        type         admin    ALL             false
+a              pg_catalog   timestamp                        type         root     ALL             false
+a              pg_catalog   timestamp[]                      type         admin    ALL             false
+a              pg_catalog   timestamp[]                      type         root     ALL             false
+a              pg_catalog   timestamptz                      type         admin    ALL             false
+a              pg_catalog   timestamptz                      type         root     ALL             false
+a              pg_catalog   timestamptz[]                    type         admin    ALL             false
+a              pg_catalog   timestamptz[]                    type         root     ALL             false
+a              pg_catalog   timetz                           type         admin    ALL             false
+a              pg_catalog   timetz                           type         root     ALL             false
+a              pg_catalog   timetz[]                         type         admin    ALL             false
+a              pg_catalog   timetz[]                         type         root     ALL             false
+a              pg_catalog   tsquery                          type         admin    ALL             false
+a              pg_catalog   tsquery                          type         root     ALL             false
+a              pg_catalog   tsquery[]                        type         admin    ALL             false
+a              pg_catalog   tsquery[]                        type         root     ALL             false
+a              pg_catalog   tsvector                         type         admin    ALL             false
+a              pg_catalog   tsvector                         type         root     ALL             false
+a              pg_catalog   tsvector[]                       type         admin    ALL             false
+a              pg_catalog   tsvector[]                       type         root     ALL             false
+a              pg_catalog   unknown                          type         admin    ALL             false
+a              pg_catalog   unknown                          type         root     ALL             false
+a              pg_catalog   uuid                             type         admin    ALL             false
+a              pg_catalog   uuid                             type         root     ALL             false
+a              pg_catalog   uuid[]                           type         admin    ALL             false
+a              pg_catalog   uuid[]                           type         root     ALL             false
+a              pg_catalog   varbit                           type         admin    ALL             false
+a              pg_catalog   varbit                           type         root     ALL             false
+a              pg_catalog   varbit[]                         type         admin    ALL             false
+a              pg_catalog   varbit[]                         type         root     ALL             false
+a              pg_catalog   varchar                          type         admin    ALL             false
+a              pg_catalog   varchar                          type         root     ALL             false
+a              pg_catalog   varchar[]                        type         admin    ALL             false
+a              pg_catalog   varchar[]                        type         root     ALL             false
+a              pg_catalog   void                             type         admin    ALL             false
+a              pg_catalog   void                             type         root     ALL             false
+a              public       NULL                             schema       admin    ALL             true
+a              public       NULL                             schema       root     ALL             true
+defaultdb      NULL         NULL                             database     admin    ALL             true
+defaultdb      NULL         NULL                             database     root     ALL             true
+defaultdb      pg_catalog   "char"                           type         admin    ALL             false
+defaultdb      pg_catalog   "char"                           type         root     ALL             false
+defaultdb      pg_catalog   "char"[]                         type         admin    ALL             false
+defaultdb      pg_catalog   "char"[]                         type         root     ALL             false
+defaultdb      pg_catalog   anyelement                       type         admin    ALL             false
+defaultdb      pg_catalog   anyelement                       type         root     ALL             false
+defaultdb      pg_catalog   anyelement[]                     type         admin    ALL             false
+defaultdb      pg_catalog   anyelement[]                     type         root     ALL             false
+defaultdb      pg_catalog   bit                              type         admin    ALL             false
+defaultdb      pg_catalog   bit                              type         root     ALL             false
+defaultdb      pg_catalog   bit[]                            type         admin    ALL             false
+defaultdb      pg_catalog   bit[]                            type         root     ALL             false
+defaultdb      pg_catalog   bool                             type         admin    ALL             false
+defaultdb      pg_catalog   bool                             type         root     ALL             false
+defaultdb      pg_catalog   bool[]                           type         admin    ALL             false
+defaultdb      pg_catalog   bool[]                           type         root     ALL             false
+defaultdb      pg_catalog   box2d                            type         admin    ALL             false
+defaultdb      pg_catalog   box2d                            type         root     ALL             false
+defaultdb      pg_catalog   box2d[]                          type         admin    ALL             false
+defaultdb      pg_catalog   box2d[]                          type         root     ALL             false
+defaultdb      pg_catalog   bytes                            type         admin    ALL             false
+defaultdb      pg_catalog   bytes                            type         root     ALL             false
+defaultdb      pg_catalog   bytes[]                          type         admin    ALL             false
+defaultdb      pg_catalog   bytes[]                          type         root     ALL             false
+defaultdb      pg_catalog   char                             type         admin    ALL             false
+defaultdb      pg_catalog   char                             type         root     ALL             false
+defaultdb      pg_catalog   char[]                           type         admin    ALL             false
+defaultdb      pg_catalog   char[]                           type         root     ALL             false
+defaultdb      pg_catalog   date                             type         admin    ALL             false
+defaultdb      pg_catalog   date                             type         root     ALL             false
+defaultdb      pg_catalog   date[]                           type         admin    ALL             false
+defaultdb      pg_catalog   date[]                           type         root     ALL             false
+defaultdb      pg_catalog   decimal                          type         admin    ALL             false
+defaultdb      pg_catalog   decimal                          type         root     ALL             false
+defaultdb      pg_catalog   decimal[]                        type         admin    ALL             false
+defaultdb      pg_catalog   decimal[]                        type         root     ALL             false
+defaultdb      pg_catalog   float                            type         admin    ALL             false
+defaultdb      pg_catalog   float                            type         root     ALL             false
+defaultdb      pg_catalog   float4                           type         admin    ALL             false
+defaultdb      pg_catalog   float4                           type         root     ALL             false
+defaultdb      pg_catalog   float4[]                         type         admin    ALL             false
+defaultdb      pg_catalog   float4[]                         type         root     ALL             false
+defaultdb      pg_catalog   float[]                          type         admin    ALL             false
+defaultdb      pg_catalog   float[]                          type         root     ALL             false
+defaultdb      pg_catalog   geography                        type         admin    ALL             false
+defaultdb      pg_catalog   geography                        type         root     ALL             false
+defaultdb      pg_catalog   geography[]                      type         admin    ALL             false
+defaultdb      pg_catalog   geography[]                      type         root     ALL             false
+defaultdb      pg_catalog   geometry                         type         admin    ALL             false
+defaultdb      pg_catalog   geometry                         type         root     ALL             false
+defaultdb      pg_catalog   geometry[]                       type         admin    ALL             false
+defaultdb      pg_catalog   geometry[]                       type         root     ALL             false
+defaultdb      pg_catalog   inet                             type         admin    ALL             false
+defaultdb      pg_catalog   inet                             type         root     ALL             false
+defaultdb      pg_catalog   inet[]                           type         admin    ALL             false
+defaultdb      pg_catalog   inet[]                           type         root     ALL             false
+defaultdb      pg_catalog   int                              type         admin    ALL             false
+defaultdb      pg_catalog   int                              type         root     ALL             false
+defaultdb      pg_catalog   int2                             type         admin    ALL             false
+defaultdb      pg_catalog   int2                             type         root     ALL             false
+defaultdb      pg_catalog   int2[]                           type         admin    ALL             false
+defaultdb      pg_catalog   int2[]                           type         root     ALL             false
+defaultdb      pg_catalog   int2vector                       type         admin    ALL             false
+defaultdb      pg_catalog   int2vector                       type         root     ALL             false
+defaultdb      pg_catalog   int2vector[]                     type         admin    ALL             false
+defaultdb      pg_catalog   int2vector[]                     type         root     ALL             false
+defaultdb      pg_catalog   int4                             type         admin    ALL             false
+defaultdb      pg_catalog   int4                             type         root     ALL             false
+defaultdb      pg_catalog   int4[]                           type         admin    ALL             false
+defaultdb      pg_catalog   int4[]                           type         root     ALL             false
+defaultdb      pg_catalog   int[]                            type         admin    ALL             false
+defaultdb      pg_catalog   int[]                            type         root     ALL             false
+defaultdb      pg_catalog   interval                         type         admin    ALL             false
+defaultdb      pg_catalog   interval                         type         root     ALL             false
+defaultdb      pg_catalog   interval[]                       type         admin    ALL             false
+defaultdb      pg_catalog   interval[]                       type         root     ALL             false
+defaultdb      pg_catalog   jsonb                            type         admin    ALL             false
+defaultdb      pg_catalog   jsonb                            type         root     ALL             false
+defaultdb      pg_catalog   jsonb[]                          type         admin    ALL             false
+defaultdb      pg_catalog   jsonb[]                          type         root     ALL             false
+defaultdb      pg_catalog   name                             type         admin    ALL             false
+defaultdb      pg_catalog   name                             type         root     ALL             false
+defaultdb      pg_catalog   name[]                           type         admin    ALL             false
+defaultdb      pg_catalog   name[]                           type         root     ALL             false
+defaultdb      pg_catalog   oid                              type         admin    ALL             false
+defaultdb      pg_catalog   oid                              type         root     ALL             false
+defaultdb      pg_catalog   oid[]                            type         admin    ALL             false
+defaultdb      pg_catalog   oid[]                            type         root     ALL             false
+defaultdb      pg_catalog   oidvector                        type         admin    ALL             false
+defaultdb      pg_catalog   oidvector                        type         root     ALL             false
+defaultdb      pg_catalog   oidvector[]                      type         admin    ALL             false
+defaultdb      pg_catalog   oidvector[]                      type         root     ALL             false
+defaultdb      pg_catalog   record                           type         admin    ALL             false
+defaultdb      pg_catalog   record                           type         root     ALL             false
+defaultdb      pg_catalog   record[]                         type         admin    ALL             false
+defaultdb      pg_catalog   record[]                         type         root     ALL             false
+defaultdb      pg_catalog   regclass                         type         admin    ALL             false
+defaultdb      pg_catalog   regclass                         type         root     ALL             false
+defaultdb      pg_catalog   regclass[]                       type         admin    ALL             false
+defaultdb      pg_catalog   regclass[]                       type         root     ALL             false
+defaultdb      pg_catalog   regnamespace                     type         admin    ALL             false
+defaultdb      pg_catalog   regnamespace                     type         root     ALL             false
+defaultdb      pg_catalog   regnamespace[]                   type         admin    ALL             false
+defaultdb      pg_catalog   regnamespace[]                   type         root     ALL             false
+defaultdb      pg_catalog   regproc                          type         admin    ALL             false
+defaultdb      pg_catalog   regproc                          type         root     ALL             false
+defaultdb      pg_catalog   regproc[]                        type         admin    ALL             false
+defaultdb      pg_catalog   regproc[]                        type         root     ALL             false
+defaultdb      pg_catalog   regprocedure                     type         admin    ALL             false
+defaultdb      pg_catalog   regprocedure                     type         root     ALL             false
+defaultdb      pg_catalog   regprocedure[]                   type         admin    ALL             false
+defaultdb      pg_catalog   regprocedure[]                   type         root     ALL             false
+defaultdb      pg_catalog   regrole                          type         admin    ALL             false
+defaultdb      pg_catalog   regrole                          type         root     ALL             false
+defaultdb      pg_catalog   regrole[]                        type         admin    ALL             false
+defaultdb      pg_catalog   regrole[]                        type         root     ALL             false
+defaultdb      pg_catalog   regtype                          type         admin    ALL             false
+defaultdb      pg_catalog   regtype                          type         root     ALL             false
+defaultdb      pg_catalog   regtype[]                        type         admin    ALL             false
+defaultdb      pg_catalog   regtype[]                        type         root     ALL             false
+defaultdb      pg_catalog   string                           type         admin    ALL             false
+defaultdb      pg_catalog   string                           type         root     ALL             false
+defaultdb      pg_catalog   string[]                         type         admin    ALL             false
+defaultdb      pg_catalog   string[]                         type         root     ALL             false
+defaultdb      pg_catalog   time                             type         admin    ALL             false
+defaultdb      pg_catalog   time                             type         root     ALL             false
+defaultdb      pg_catalog   time[]                           type         admin    ALL             false
+defaultdb      pg_catalog   time[]                           type         root     ALL             false
+defaultdb      pg_catalog   timestamp                        type         admin    ALL             false
+defaultdb      pg_catalog   timestamp                        type         root     ALL             false
+defaultdb      pg_catalog   timestamp[]                      type         admin    ALL             false
+defaultdb      pg_catalog   timestamp[]                      type         root     ALL             false
+defaultdb      pg_catalog   timestamptz                      type         admin    ALL             false
+defaultdb      pg_catalog   timestamptz                      type         root     ALL             false
+defaultdb      pg_catalog   timestamptz[]                    type         admin    ALL             false
+defaultdb      pg_catalog   timestamptz[]                    type         root     ALL             false
+defaultdb      pg_catalog   timetz                           type         admin    ALL             false
+defaultdb      pg_catalog   timetz                           type         root     ALL             false
+defaultdb      pg_catalog   timetz[]                         type         admin    ALL             false
+defaultdb      pg_catalog   timetz[]                         type         root     ALL             false
+defaultdb      pg_catalog   tsquery                          type         admin    ALL             false
+defaultdb      pg_catalog   tsquery                          type         root     ALL             false
+defaultdb      pg_catalog   tsquery[]                        type         admin    ALL             false
+defaultdb      pg_catalog   tsquery[]                        type         root     ALL             false
+defaultdb      pg_catalog   tsvector                         type         admin    ALL             false
+defaultdb      pg_catalog   tsvector                         type         root     ALL             false
+defaultdb      pg_catalog   tsvector[]                       type         admin    ALL             false
+defaultdb      pg_catalog   tsvector[]                       type         root     ALL             false
+defaultdb      pg_catalog   unknown                          type         admin    ALL             false
+defaultdb      pg_catalog   unknown                          type         root     ALL             false
+defaultdb      pg_catalog   uuid                             type         admin    ALL             false
+defaultdb      pg_catalog   uuid                             type         root     ALL             false
+defaultdb      pg_catalog   uuid[]                           type         admin    ALL             false
+defaultdb      pg_catalog   uuid[]                           type         root     ALL             false
+defaultdb      pg_catalog   varbit                           type         admin    ALL             false
+defaultdb      pg_catalog   varbit                           type         root     ALL             false
+defaultdb      pg_catalog   varbit[]                         type         admin    ALL             false
+defaultdb      pg_catalog   varbit[]                         type         root     ALL             false
+defaultdb      pg_catalog   varchar                          type         admin    ALL             false
+defaultdb      pg_catalog   varchar                          type         root     ALL             false
+defaultdb      pg_catalog   varchar[]                        type         admin    ALL             false
+defaultdb      pg_catalog   varchar[]                        type         root     ALL             false
+defaultdb      pg_catalog   void                             type         admin    ALL             false
+defaultdb      pg_catalog   void                             type         root     ALL             false
+defaultdb      public       NULL                             schema       admin    ALL             true
+defaultdb      public       NULL                             schema       root     ALL             true
+postgres       NULL         NULL                             database     admin    ALL             true
+postgres       NULL         NULL                             database     root     ALL             true
+postgres       pg_catalog   "char"                           type         admin    ALL             false
+postgres       pg_catalog   "char"                           type         root     ALL             false
+postgres       pg_catalog   "char"[]                         type         admin    ALL             false
+postgres       pg_catalog   "char"[]                         type         root     ALL             false
+postgres       pg_catalog   anyelement                       type         admin    ALL             false
+postgres       pg_catalog   anyelement                       type         root     ALL             false
+postgres       pg_catalog   anyelement[]                     type         admin    ALL             false
+postgres       pg_catalog   anyelement[]                     type         root     ALL             false
+postgres       pg_catalog   bit                              type         admin    ALL             false
+postgres       pg_catalog   bit                              type         root     ALL             false
+postgres       pg_catalog   bit[]                            type         admin    ALL             false
+postgres       pg_catalog   bit[]                            type         root     ALL             false
+postgres       pg_catalog   bool                             type         admin    ALL             false
+postgres       pg_catalog   bool                             type         root     ALL             false
+postgres       pg_catalog   bool[]                           type         admin    ALL             false
+postgres       pg_catalog   bool[]                           type         root     ALL             false
+postgres       pg_catalog   box2d                            type         admin    ALL             false
+postgres       pg_catalog   box2d                            type         root     ALL             false
+postgres       pg_catalog   box2d[]                          type         admin    ALL             false
+postgres       pg_catalog   box2d[]                          type         root     ALL             false
+postgres       pg_catalog   bytes                            type         admin    ALL             false
+postgres       pg_catalog   bytes                            type         root     ALL             false
+postgres       pg_catalog   bytes[]                          type         admin    ALL             false
+postgres       pg_catalog   bytes[]                          type         root     ALL             false
+postgres       pg_catalog   char                             type         admin    ALL             false
+postgres       pg_catalog   char                             type         root     ALL             false
+postgres       pg_catalog   char[]                           type         admin    ALL             false
+postgres       pg_catalog   char[]                           type         root     ALL             false
+postgres       pg_catalog   date                             type         admin    ALL             false
+postgres       pg_catalog   date                             type         root     ALL             false
+postgres       pg_catalog   date[]                           type         admin    ALL             false
+postgres       pg_catalog   date[]                           type         root     ALL             false
+postgres       pg_catalog   decimal                          type         admin    ALL             false
+postgres       pg_catalog   decimal                          type         root     ALL             false
+postgres       pg_catalog   decimal[]                        type         admin    ALL             false
+postgres       pg_catalog   decimal[]                        type         root     ALL             false
+postgres       pg_catalog   float                            type         admin    ALL             false
+postgres       pg_catalog   float                            type         root     ALL             false
+postgres       pg_catalog   float4                           type         admin    ALL             false
+postgres       pg_catalog   float4                           type         root     ALL             false
+postgres       pg_catalog   float4[]                         type         admin    ALL             false
+postgres       pg_catalog   float4[]                         type         root     ALL             false
+postgres       pg_catalog   float[]                          type         admin    ALL             false
+postgres       pg_catalog   float[]                          type         root     ALL             false
+postgres       pg_catalog   geography                        type         admin    ALL             false
+postgres       pg_catalog   geography                        type         root     ALL             false
+postgres       pg_catalog   geography[]                      type         admin    ALL             false
+postgres       pg_catalog   geography[]                      type         root     ALL             false
+postgres       pg_catalog   geometry                         type         admin    ALL             false
+postgres       pg_catalog   geometry                         type         root     ALL             false
+postgres       pg_catalog   geometry[]                       type         admin    ALL             false
+postgres       pg_catalog   geometry[]                       type         root     ALL             false
+postgres       pg_catalog   inet                             type         admin    ALL             false
+postgres       pg_catalog   inet                             type         root     ALL             false
+postgres       pg_catalog   inet[]                           type         admin    ALL             false
+postgres       pg_catalog   inet[]                           type         root     ALL             false
+postgres       pg_catalog   int                              type         admin    ALL             false
+postgres       pg_catalog   int                              type         root     ALL             false
+postgres       pg_catalog   int2                             type         admin    ALL             false
+postgres       pg_catalog   int2                             type         root     ALL             false
+postgres       pg_catalog   int2[]                           type         admin    ALL             false
+postgres       pg_catalog   int2[]                           type         root     ALL             false
+postgres       pg_catalog   int2vector                       type         admin    ALL             false
+postgres       pg_catalog   int2vector                       type         root     ALL             false
+postgres       pg_catalog   int2vector[]                     type         admin    ALL             false
+postgres       pg_catalog   int2vector[]                     type         root     ALL             false
+postgres       pg_catalog   int4                             type         admin    ALL             false
+postgres       pg_catalog   int4                             type         root     ALL             false
+postgres       pg_catalog   int4[]                           type         admin    ALL             false
+postgres       pg_catalog   int4[]                           type         root     ALL             false
+postgres       pg_catalog   int[]                            type         admin    ALL             false
+postgres       pg_catalog   int[]                            type         root     ALL             false
+postgres       pg_catalog   interval                         type         admin    ALL             false
+postgres       pg_catalog   interval                         type         root     ALL             false
+postgres       pg_catalog   interval[]                       type         admin    ALL             false
+postgres       pg_catalog   interval[]                       type         root     ALL             false
+postgres       pg_catalog   jsonb                            type         admin    ALL             false
+postgres       pg_catalog   jsonb                            type         root     ALL             false
+postgres       pg_catalog   jsonb[]                          type         admin    ALL             false
+postgres       pg_catalog   jsonb[]                          type         root     ALL             false
+postgres       pg_catalog   name                             type         admin    ALL             false
+postgres       pg_catalog   name                             type         root     ALL             false
+postgres       pg_catalog   name[]                           type         admin    ALL             false
+postgres       pg_catalog   name[]                           type         root     ALL             false
+postgres       pg_catalog   oid                              type         admin    ALL             false
+postgres       pg_catalog   oid                              type         root     ALL             false
+postgres       pg_catalog   oid[]                            type         admin    ALL             false
+postgres       pg_catalog   oid[]                            type         root     ALL             false
+postgres       pg_catalog   oidvector                        type         admin    ALL             false
+postgres       pg_catalog   oidvector                        type         root     ALL             false
+postgres       pg_catalog   oidvector[]                      type         admin    ALL             false
+postgres       pg_catalog   oidvector[]                      type         root     ALL             false
+postgres       pg_catalog   record                           type         admin    ALL             false
+postgres       pg_catalog   record                           type         root     ALL             false
+postgres       pg_catalog   record[]                         type         admin    ALL             false
+postgres       pg_catalog   record[]                         type         root     ALL             false
+postgres       pg_catalog   regclass                         type         admin    ALL             false
+postgres       pg_catalog   regclass                         type         root     ALL             false
+postgres       pg_catalog   regclass[]                       type         admin    ALL             false
+postgres       pg_catalog   regclass[]                       type         root     ALL             false
+postgres       pg_catalog   regnamespace                     type         admin    ALL             false
+postgres       pg_catalog   regnamespace                     type         root     ALL             false
+postgres       pg_catalog   regnamespace[]                   type         admin    ALL             false
+postgres       pg_catalog   regnamespace[]                   type         root     ALL             false
+postgres       pg_catalog   regproc                          type         admin    ALL             false
+postgres       pg_catalog   regproc                          type         root     ALL             false
+postgres       pg_catalog   regproc[]                        type         admin    ALL             false
+postgres       pg_catalog   regproc[]                        type         root     ALL             false
+postgres       pg_catalog   regprocedure                     type         admin    ALL             false
+postgres       pg_catalog   regprocedure                     type         root     ALL             false
+postgres       pg_catalog   regprocedure[]                   type         admin    ALL             false
+postgres       pg_catalog   regprocedure[]                   type         root     ALL             false
+postgres       pg_catalog   regrole                          type         admin    ALL             false
+postgres       pg_catalog   regrole                          type         root     ALL             false
+postgres       pg_catalog   regrole[]                        type         admin    ALL             false
+postgres       pg_catalog   regrole[]                        type         root     ALL             false
+postgres       pg_catalog   regtype                          type         admin    ALL             false
+postgres       pg_catalog   regtype                          type         root     ALL             false
+postgres       pg_catalog   regtype[]                        type         admin    ALL             false
+postgres       pg_catalog   regtype[]                        type         root     ALL             false
+postgres       pg_catalog   string                           type         admin    ALL             false
+postgres       pg_catalog   string                           type         root     ALL             false
+postgres       pg_catalog   string[]                         type         admin    ALL             false
+postgres       pg_catalog   string[]                         type         root     ALL             false
+postgres       pg_catalog   time                             type         admin    ALL             false
+postgres       pg_catalog   time                             type         root     ALL             false
+postgres       pg_catalog   time[]                           type         admin    ALL             false
+postgres       pg_catalog   time[]                           type         root     ALL             false
+postgres       pg_catalog   timestamp                        type         admin    ALL             false
+postgres       pg_catalog   timestamp                        type         root     ALL             false
+postgres       pg_catalog   timestamp[]                      type         admin    ALL             false
+postgres       pg_catalog   timestamp[]                      type         root     ALL             false
+postgres       pg_catalog   timestamptz                      type         admin    ALL             false
+postgres       pg_catalog   timestamptz                      type         root     ALL             false
+postgres       pg_catalog   timestamptz[]                    type         admin    ALL             false
+postgres       pg_catalog   timestamptz[]                    type         root     ALL             false
+postgres       pg_catalog   timetz                           type         admin    ALL             false
+postgres       pg_catalog   timetz                           type         root     ALL             false
+postgres       pg_catalog   timetz[]                         type         admin    ALL             false
+postgres       pg_catalog   timetz[]                         type         root     ALL             false
+postgres       pg_catalog   tsquery                          type         admin    ALL             false
+postgres       pg_catalog   tsquery                          type         root     ALL             false
+postgres       pg_catalog   tsquery[]                        type         admin    ALL             false
+postgres       pg_catalog   tsquery[]                        type         root     ALL             false
+postgres       pg_catalog   tsvector                         type         admin    ALL             false
+postgres       pg_catalog   tsvector                         type         root     ALL             false
+postgres       pg_catalog   tsvector[]                       type         admin    ALL             false
+postgres       pg_catalog   tsvector[]                       type         root     ALL             false
+postgres       pg_catalog   unknown                          type         admin    ALL             false
+postgres       pg_catalog   unknown                          type         root     ALL             false
+postgres       pg_catalog   uuid                             type         admin    ALL             false
+postgres       pg_catalog   uuid                             type         root     ALL             false
+postgres       pg_catalog   uuid[]                           type         admin    ALL             false
+postgres       pg_catalog   uuid[]                           type         root     ALL             false
+postgres       pg_catalog   varbit                           type         admin    ALL             false
+postgres       pg_catalog   varbit                           type         root     ALL             false
+postgres       pg_catalog   varbit[]                         type         admin    ALL             false
+postgres       pg_catalog   varbit[]                         type         root     ALL             false
+postgres       pg_catalog   varchar                          type         admin    ALL             false
+postgres       pg_catalog   varchar                          type         root     ALL             false
+postgres       pg_catalog   varchar[]                        type         admin    ALL             false
+postgres       pg_catalog   varchar[]                        type         root     ALL             false
+postgres       pg_catalog   void                             type         admin    ALL             false
+postgres       pg_catalog   void                             type         root     ALL             false
+postgres       public       NULL                             schema       admin    ALL             true
+postgres       public       NULL                             schema       root     ALL             true
+system         NULL         NULL                             database     admin    CONNECT         true
+system         NULL         NULL                             database     root     CONNECT         true
+system         pg_catalog   "char"                           type         admin    ALL             false
+system         pg_catalog   "char"                           type         root     ALL             false
+system         pg_catalog   "char"[]                         type         admin    ALL             false
+system         pg_catalog   "char"[]                         type         root     ALL             false
+system         pg_catalog   anyelement                       type         admin    ALL             false
+system         pg_catalog   anyelement                       type         root     ALL             false
+system         pg_catalog   anyelement[]                     type         admin    ALL             false
+system         pg_catalog   anyelement[]                     type         root     ALL             false
+system         pg_catalog   bit                              type         admin    ALL             false
+system         pg_catalog   bit                              type         root     ALL             false
+system         pg_catalog   bit[]                            type         admin    ALL             false
+system         pg_catalog   bit[]                            type         root     ALL             false
+system         pg_catalog   bool                             type         admin    ALL             false
+system         pg_catalog   bool                             type         root     ALL             false
+system         pg_catalog   bool[]                           type         admin    ALL             false
+system         pg_catalog   bool[]                           type         root     ALL             false
+system         pg_catalog   box2d                            type         admin    ALL             false
+system         pg_catalog   box2d                            type         root     ALL             false
+system         pg_catalog   box2d[]                          type         admin    ALL             false
+system         pg_catalog   box2d[]                          type         root     ALL             false
+system         pg_catalog   bytes                            type         admin    ALL             false
+system         pg_catalog   bytes                            type         root     ALL             false
+system         pg_catalog   bytes[]                          type         admin    ALL             false
+system         pg_catalog   bytes[]                          type         root     ALL             false
+system         pg_catalog   char                             type         admin    ALL             false
+system         pg_catalog   char                             type         root     ALL             false
+system         pg_catalog   char[]                           type         admin    ALL             false
+system         pg_catalog   char[]                           type         root     ALL             false
+system         pg_catalog   date                             type         admin    ALL             false
+system         pg_catalog   date                             type         root     ALL             false
+system         pg_catalog   date[]                           type         admin    ALL             false
+system         pg_catalog   date[]                           type         root     ALL             false
+system         pg_catalog   decimal                          type         admin    ALL             false
+system         pg_catalog   decimal                          type         root     ALL             false
+system         pg_catalog   decimal[]                        type         admin    ALL             false
+system         pg_catalog   decimal[]                        type         root     ALL             false
+system         pg_catalog   float                            type         admin    ALL             false
+system         pg_catalog   float                            type         root     ALL             false
+system         pg_catalog   float4                           type         admin    ALL             false
+system         pg_catalog   float4                           type         root     ALL             false
+system         pg_catalog   float4[]                         type         admin    ALL             false
+system         pg_catalog   float4[]                         type         root     ALL             false
+system         pg_catalog   float[]                          type         admin    ALL             false
+system         pg_catalog   float[]                          type         root     ALL             false
+system         pg_catalog   geography                        type         admin    ALL             false
+system         pg_catalog   geography                        type         root     ALL             false
+system         pg_catalog   geography[]                      type         admin    ALL             false
+system         pg_catalog   geography[]                      type         root     ALL             false
+system         pg_catalog   geometry                         type         admin    ALL             false
+system         pg_catalog   geometry                         type         root     ALL             false
+system         pg_catalog   geometry[]                       type         admin    ALL             false
+system         pg_catalog   geometry[]                       type         root     ALL             false
+system         pg_catalog   inet                             type         admin    ALL             false
+system         pg_catalog   inet                             type         root     ALL             false
+system         pg_catalog   inet[]                           type         admin    ALL             false
+system         pg_catalog   inet[]                           type         root     ALL             false
+system         pg_catalog   int                              type         admin    ALL             false
+system         pg_catalog   int                              type         root     ALL             false
+system         pg_catalog   int2                             type         admin    ALL             false
+system         pg_catalog   int2                             type         root     ALL             false
+system         pg_catalog   int2[]                           type         admin    ALL             false
+system         pg_catalog   int2[]                           type         root     ALL             false
+system         pg_catalog   int2vector                       type         admin    ALL             false
+system         pg_catalog   int2vector                       type         root     ALL             false
+system         pg_catalog   int2vector[]                     type         admin    ALL             false
+system         pg_catalog   int2vector[]                     type         root     ALL             false
+system         pg_catalog   int4                             type         admin    ALL             false
+system         pg_catalog   int4                             type         root     ALL             false
+system         pg_catalog   int4[]                           type         admin    ALL             false
+system         pg_catalog   int4[]                           type         root     ALL             false
+system         pg_catalog   int[]                            type         admin    ALL             false
+system         pg_catalog   int[]                            type         root     ALL             false
+system         pg_catalog   interval                         type         admin    ALL             false
+system         pg_catalog   interval                         type         root     ALL             false
+system         pg_catalog   interval[]                       type         admin    ALL             false
+system         pg_catalog   interval[]                       type         root     ALL             false
+system         pg_catalog   jsonb                            type         admin    ALL             false
+system         pg_catalog   jsonb                            type         root     ALL             false
+system         pg_catalog   jsonb[]                          type         admin    ALL             false
+system         pg_catalog   jsonb[]                          type         root     ALL             false
+system         pg_catalog   name                             type         admin    ALL             false
+system         pg_catalog   name                             type         root     ALL             false
+system         pg_catalog   name[]                           type         admin    ALL             false
+system         pg_catalog   name[]                           type         root     ALL             false
+system         pg_catalog   oid                              type         admin    ALL             false
+system         pg_catalog   oid                              type         root     ALL             false
+system         pg_catalog   oid[]                            type         admin    ALL             false
+system         pg_catalog   oid[]                            type         root     ALL             false
+system         pg_catalog   oidvector                        type         admin    ALL             false
+system         pg_catalog   oidvector                        type         root     ALL             false
+system         pg_catalog   oidvector[]                      type         admin    ALL             false
+system         pg_catalog   oidvector[]                      type         root     ALL             false
+system         pg_catalog   record                           type         admin    ALL             false
+system         pg_catalog   record                           type         root     ALL             false
+system         pg_catalog   record[]                         type         admin    ALL             false
+system         pg_catalog   record[]                         type         root     ALL             false
+system         pg_catalog   regclass                         type         admin    ALL             false
+system         pg_catalog   regclass                         type         root     ALL             false
+system         pg_catalog   regclass[]                       type         admin    ALL             false
+system         pg_catalog   regclass[]                       type         root     ALL             false
+system         pg_catalog   regnamespace                     type         admin    ALL             false
+system         pg_catalog   regnamespace                     type         root     ALL             false
+system         pg_catalog   regnamespace[]                   type         admin    ALL             false
+system         pg_catalog   regnamespace[]                   type         root     ALL             false
+system         pg_catalog   regproc                          type         admin    ALL             false
+system         pg_catalog   regproc                          type         root     ALL             false
+system         pg_catalog   regproc[]                        type         admin    ALL             false
+system         pg_catalog   regproc[]                        type         root     ALL             false
+system         pg_catalog   regprocedure                     type         admin    ALL             false
+system         pg_catalog   regprocedure                     type         root     ALL             false
+system         pg_catalog   regprocedure[]                   type         admin    ALL             false
+system         pg_catalog   regprocedure[]                   type         root     ALL             false
+system         pg_catalog   regrole                          type         admin    ALL             false
+system         pg_catalog   regrole                          type         root     ALL             false
+system         pg_catalog   regrole[]                        type         admin    ALL             false
+system         pg_catalog   regrole[]                        type         root     ALL             false
+system         pg_catalog   regtype                          type         admin    ALL             false
+system         pg_catalog   regtype                          type         root     ALL             false
+system         pg_catalog   regtype[]                        type         admin    ALL             false
+system         pg_catalog   regtype[]                        type         root     ALL             false
+system         pg_catalog   string                           type         admin    ALL             false
+system         pg_catalog   string                           type         root     ALL             false
+system         pg_catalog   string[]                         type         admin    ALL             false
+system         pg_catalog   string[]                         type         root     ALL             false
+system         pg_catalog   time                             type         admin    ALL             false
+system         pg_catalog   time                             type         root     ALL             false
+system         pg_catalog   time[]                           type         admin    ALL             false
+system         pg_catalog   time[]                           type         root     ALL             false
+system         pg_catalog   timestamp                        type         admin    ALL             false
+system         pg_catalog   timestamp                        type         root     ALL             false
+system         pg_catalog   timestamp[]                      type         admin    ALL             false
+system         pg_catalog   timestamp[]                      type         root     ALL             false
+system         pg_catalog   timestamptz                      type         admin    ALL             false
+system         pg_catalog   timestamptz                      type         root     ALL             false
+system         pg_catalog   timestamptz[]                    type         admin    ALL             false
+system         pg_catalog   timestamptz[]                    type         root     ALL             false
+system         pg_catalog   timetz                           type         admin    ALL             false
+system         pg_catalog   timetz                           type         root     ALL             false
+system         pg_catalog   timetz[]                         type         admin    ALL             false
+system         pg_catalog   timetz[]                         type         root     ALL             false
+system         pg_catalog   tsquery                          type         admin    ALL             false
+system         pg_catalog   tsquery                          type         root     ALL             false
+system         pg_catalog   tsquery[]                        type         admin    ALL             false
+system         pg_catalog   tsquery[]                        type         root     ALL             false
+system         pg_catalog   tsvector                         type         admin    ALL             false
+system         pg_catalog   tsvector                         type         root     ALL             false
+system         pg_catalog   tsvector[]                       type         admin    ALL             false
+system         pg_catalog   tsvector[]                       type         root     ALL             false
+system         pg_catalog   unknown                          type         admin    ALL             false
+system         pg_catalog   unknown                          type         root     ALL             false
+system         pg_catalog   uuid                             type         admin    ALL             false
+system         pg_catalog   uuid                             type         root     ALL             false
+system         pg_catalog   uuid[]                           type         admin    ALL             false
+system         pg_catalog   uuid[]                           type         root     ALL             false
+system         pg_catalog   varbit                           type         admin    ALL             false
+system         pg_catalog   varbit                           type         root     ALL             false
+system         pg_catalog   varbit[]                         type         admin    ALL             false
+system         pg_catalog   varbit[]                         type         root     ALL             false
+system         pg_catalog   varchar                          type         admin    ALL             false
+system         pg_catalog   varchar                          type         root     ALL             false
+system         pg_catalog   varchar[]                        type         admin    ALL             false
+system         pg_catalog   varchar[]                        type         root     ALL             false
+system         pg_catalog   void                             type         admin    ALL             false
+system         pg_catalog   void                             type         root     ALL             false
+system         public       NULL                             schema       admin    ALL             true
+system         public       NULL                             schema       root     ALL             true
+system         public       comments                         table        admin    DELETE          true
+system         public       comments                         table        admin    INSERT          true
+system         public       comments                         table        admin    SELECT          true
+system         public       comments                         table        admin    UPDATE          true
+system         public       comments                         table        root     DELETE          true
+system         public       comments                         table        root     INSERT          true
+system         public       comments                         table        root     SELECT          true
+system         public       comments                         table        root     UPDATE          true
+system         public       database_role_settings           table        admin    DELETE          true
+system         public       database_role_settings           table        admin    INSERT          true
+system         public       database_role_settings           table        admin    SELECT          true
+system         public       database_role_settings           table        admin    UPDATE          true
+system         public       database_role_settings           table        root     DELETE          true
+system         public       database_role_settings           table        root     INSERT          true
+system         public       database_role_settings           table        root     SELECT          true
+system         public       database_role_settings           table        root     UPDATE          true
+system         public       descriptor                       table        admin    SELECT          true
+system         public       descriptor                       table        root     SELECT          true
+system         public       descriptor_id_seq                sequence     admin    SELECT          true
+system         public       descriptor_id_seq                sequence     root     SELECT          true
+system         public       eventlog                         table        admin    DELETE          true
+system         public       eventlog                         table        admin    INSERT          true
+system         public       eventlog                         table        admin    SELECT          true
+system         public       eventlog                         table        admin    UPDATE          true
+system         public       eventlog                         table        root     DELETE          true
+system         public       eventlog                         table        root     INSERT          true
+system         public       eventlog                         table        root     SELECT          true
+system         public       eventlog                         table        root     UPDATE          true
+system         public       external_connections             table        admin    DELETE          true
+system         public       external_connections             table        admin    INSERT          true
+system         public       external_connections             table        admin    SELECT          true
+system         public       external_connections             table        admin    UPDATE          true
+system         public       external_connections             table        root     DELETE          true
+system         public       external_connections             table        root     INSERT          true
+system         public       external_connections             table        root     SELECT          true
+system         public       external_connections             table        root     UPDATE          true
+system         public       job_info                         table        admin    DELETE          true
+system         public       job_info                         table        admin    INSERT          true
+system         public       job_info                         table        admin    SELECT          true
+system         public       job_info                         table        admin    UPDATE          true
+system         public       job_info                         table        root     DELETE          true
+system         public       job_info                         table        root     INSERT          true
+system         public       job_info                         table        root     SELECT          true
+system         public       job_info                         table        root     UPDATE          true
+system         public       jobs                             table        admin    DELETE          true
+system         public       jobs                             table        admin    INSERT          true
+system         public       jobs                             table        admin    SELECT          true
+system         public       jobs                             table        admin    UPDATE          true
+system         public       jobs                             table        root     DELETE          true
+system         public       jobs                             table        root     INSERT          true
+system         public       jobs                             table        root     SELECT          true
+system         public       jobs                             table        root     UPDATE          true
+system         public       join_tokens                      table        admin    DELETE          true
+system         public       join_tokens                      table        admin    INSERT          true
+system         public       join_tokens                      table        admin    SELECT          true
+system         public       join_tokens                      table        admin    UPDATE          true
+system         public       join_tokens                      table        root     DELETE          true
+system         public       join_tokens                      table        root     INSERT          true
+system         public       join_tokens                      table        root     SELECT          true
+system         public       join_tokens                      table        root     UPDATE          true
+system         public       lease                            table        admin    DELETE          true
+system         public       lease                            table        admin    INSERT          true
+system         public       lease                            table        admin    SELECT          true
+system         public       lease                            table        admin    UPDATE          true
+system         public       lease                            table        root     DELETE          true
+system         public       lease                            table        root     INSERT          true
+system         public       lease                            table        root     SELECT          true
+system         public       lease                            table        root     UPDATE          true
+system         public       locations                        table        admin    DELETE          true
+system         public       locations                        table        admin    INSERT          true
+system         public       locations                        table        admin    SELECT          true
+system         public       locations                        table        admin    UPDATE          true
+system         public       locations                        table        root     DELETE          true
+system         public       locations                        table        root     INSERT          true
+system         public       locations                        table        root     SELECT          true
+system         public       locations                        table        root     UPDATE          true
+system         public       migrations                       table        admin    DELETE          true
+system         public       migrations                       table        admin    INSERT          true
+system         public       migrations                       table        admin    SELECT          true
+system         public       migrations                       table        admin    UPDATE          true
+system         public       migrations                       table        root     DELETE          true
+system         public       migrations                       table        root     INSERT          true
+system         public       migrations                       table        root     SELECT          true
+system         public       migrations                       table        root     UPDATE          true
+system         public       namespace                        table        admin    SELECT          true
+system         public       namespace                        table        root     SELECT          true
+system         public       privileges                       table        admin    DELETE          true
+system         public       privileges                       table        admin    INSERT          true
+system         public       privileges                       table        admin    SELECT          true
+system         public       privileges                       table        admin    UPDATE          true
+system         public       privileges                       table        root     DELETE          true
+system         public       privileges                       table        root     INSERT          true
+system         public       privileges                       table        root     SELECT          true
+system         public       privileges                       table        root     UPDATE          true
+system         public       protected_ts_meta                table        admin    SELECT          true
+system         public       protected_ts_meta                table        root     SELECT          true
+system         public       protected_ts_records             table        admin    SELECT          true
+system         public       protected_ts_records             table        root     SELECT          true
+system         public       rangelog                         table        admin    DELETE          true
+system         public       rangelog                         table        admin    INSERT          true
+system         public       rangelog                         table        admin    SELECT          true
+system         public       rangelog                         table        admin    UPDATE          true
+system         public       rangelog                         table        root     DELETE          true
+system         public       rangelog                         table        root     INSERT          true
+system         public       rangelog                         table        root     SELECT          true
+system         public       rangelog                         table        root     UPDATE          true
+system         public       replication_constraint_stats     table        admin    DELETE          true
+system         public       replication_constraint_stats     table        admin    INSERT          true
+system         public       replication_constraint_stats     table        admin    SELECT          true
+system         public       replication_constraint_stats     table        admin    UPDATE          true
+system         public       replication_constraint_stats     table        root     DELETE          true
+system         public       replication_constraint_stats     table        root     INSERT          true
+system         public       replication_constraint_stats     table        root     SELECT          true
+system         public       replication_constraint_stats     table        root     UPDATE          true
+system         public       replication_critical_localities  table        admin    DELETE          true
+system         public       replication_critical_localities  table        admin    INSERT          true
+system         public       replication_critical_localities  table        admin    SELECT          true
+system         public       replication_critical_localities  table        admin    UPDATE          true
+system         public       replication_critical_localities  table        root     DELETE          true
+system         public       replication_critical_localities  table        root     INSERT          true
+system         public       replication_critical_localities  table        root     SELECT          true
+system         public       replication_critical_localities  table        root     UPDATE          true
+system         public       replication_stats                table        admin    DELETE          true
+system         public       replication_stats                table        admin    INSERT          true
+system         public       replication_stats                table        admin    SELECT          true
+system         public       replication_stats                table        admin    UPDATE          true
+system         public       replication_stats                table        root     DELETE          true
+system         public       replication_stats                table        root     INSERT          true
+system         public       replication_stats                table        root     SELECT          true
+system         public       replication_stats                table        root     UPDATE          true
+system         public       reports_meta                     table        admin    DELETE          true
+system         public       reports_meta                     table        admin    INSERT          true
+system         public       reports_meta                     table        admin    SELECT          true
+system         public       reports_meta                     table        admin    UPDATE          true
+system         public       reports_meta                     table        root     DELETE          true
+system         public       reports_meta                     table        root     INSERT          true
+system         public       reports_meta                     table        root     SELECT          true
+system         public       reports_meta                     table        root     UPDATE          true
+system         public       role_id_seq                      sequence     admin    SELECT          true
+system         public       role_id_seq                      sequence     admin    UPDATE          true
+system         public       role_id_seq                      sequence     admin    USAGE           true
+system         public       role_id_seq                      sequence     root     SELECT          true
+system         public       role_id_seq                      sequence     root     UPDATE          true
+system         public       role_id_seq                      sequence     root     USAGE           true
+system         public       role_members                     table        admin    DELETE          true
+system         public       role_members                     table        admin    INSERT          true
+system         public       role_members                     table        admin    SELECT          true
+system         public       role_members                     table        admin    UPDATE          true
+system         public       role_members                     table        root     DELETE          true
+system         public       role_members                     table        root     INSERT          true
+system         public       role_members                     table        root     SELECT          true
+system         public       role_members                     table        root     UPDATE          true
+system         public       role_options                     table        admin    DELETE          true
+system         public       role_options                     table        admin    INSERT          true
+system         public       role_options                     table        admin    SELECT          true
+system         public       role_options                     table        admin    UPDATE          true
+system         public       role_options                     table        root     DELETE          true
+system         public       role_options                     table        root     INSERT          true
+system         public       role_options                     table        root     SELECT          true
+system         public       role_options                     table        root     UPDATE          true
+system         public       scheduled_jobs                   table        admin    DELETE          true
+system         public       scheduled_jobs                   table        admin    INSERT          true
+system         public       scheduled_jobs                   table        admin    SELECT          true
+system         public       scheduled_jobs                   table        admin    UPDATE          true
+system         public       scheduled_jobs                   table        root     DELETE          true
+system         public       scheduled_jobs                   table        root     INSERT          true
+system         public       scheduled_jobs                   table        root     SELECT          true
+system         public       scheduled_jobs                   table        root     UPDATE          true
+system         public       settings                         table        admin    DELETE          true
+system         public       settings                         table        admin    INSERT          true
+system         public       settings                         table        admin    SELECT          true
+system         public       settings                         table        admin    UPDATE          true
+system         public       settings                         table        root     DELETE          true
+system         public       settings                         table        root     INSERT          true
+system         public       settings                         table        root     SELECT          true
+system         public       settings                         table        root     UPDATE          true
+system         public       span_configurations              table        admin    DELETE          true
+system         public       span_configurations              table        admin    INSERT          true
+system         public       span_configurations              table        admin    SELECT          true
+system         public       span_configurations              table        admin    UPDATE          true
+system         public       span_configurations              table        root     DELETE          true
+system         public       span_configurations              table        root     INSERT          true
+system         public       span_configurations              table        root     SELECT          true
+system         public       span_configurations              table        root     UPDATE          true
+system         public       span_stats_buckets               table        admin    DELETE          true
+system         public       span_stats_buckets               table        admin    INSERT          true
+system         public       span_stats_buckets               table        admin    SELECT          true
+system         public       span_stats_buckets               table        admin    UPDATE          true
+system         public       span_stats_buckets               table        root     DELETE          true
+system         public       span_stats_buckets               table        root     INSERT          true
+system         public       span_stats_buckets               table        root     SELECT          true
+system         public       span_stats_buckets               table        root     UPDATE          true
+system         public       span_stats_samples               table        admin    DELETE          true
+system         public       span_stats_samples               table        admin    INSERT          true
+system         public       span_stats_samples               table        admin    SELECT          true
+system         public       span_stats_samples               table        admin    UPDATE          true
+system         public       span_stats_samples               table        root     DELETE          true
+system         public       span_stats_samples               table        root     INSERT          true
+system         public       span_stats_samples               table        root     SELECT          true
+system         public       span_stats_samples               table        root     UPDATE          true
+system         public       span_stats_tenant_boundaries     table        admin    DELETE          true
+system         public       span_stats_tenant_boundaries     table        admin    INSERT          true
+system         public       span_stats_tenant_boundaries     table        admin    SELECT          true
+system         public       span_stats_tenant_boundaries     table        admin    UPDATE          true
+system         public       span_stats_tenant_boundaries     table        root     DELETE          true
+system         public       span_stats_tenant_boundaries     table        root     INSERT          true
+system         public       span_stats_tenant_boundaries     table        root     SELECT          true
+system         public       span_stats_tenant_boundaries     table        root     UPDATE          true
+system         public       span_stats_unique_keys           table        admin    DELETE          true
+system         public       span_stats_unique_keys           table        admin    INSERT          true
+system         public       span_stats_unique_keys           table        admin    SELECT          true
+system         public       span_stats_unique_keys           table        admin    UPDATE          true
+system         public       span_stats_unique_keys           table        root     DELETE          true
+system         public       span_stats_unique_keys           table        root     INSERT          true
+system         public       span_stats_unique_keys           table        root     SELECT          true
+system         public       span_stats_unique_keys           table        root     UPDATE          true
+system         public       sql_instances                    table        admin    DELETE          true
+system         public       sql_instances                    table        admin    INSERT          true
+system         public       sql_instances                    table        admin    SELECT          true
+system         public       sql_instances                    table        admin    UPDATE          true
+system         public       sql_instances                    table        root     DELETE          true
+system         public       sql_instances                    table        root     INSERT          true
+system         public       sql_instances                    table        root     SELECT          true
+system         public       sql_instances                    table        root     UPDATE          true
+system         public       sqlliveness                      table        admin    DELETE          true
+system         public       sqlliveness                      table        admin    INSERT          true
+system         public       sqlliveness                      table        admin    SELECT          true
+system         public       sqlliveness                      table        admin    UPDATE          true
+system         public       sqlliveness                      table        root     DELETE          true
+system         public       sqlliveness                      table        root     INSERT          true
+system         public       sqlliveness                      table        root     SELECT          true
+system         public       sqlliveness                      table        root     UPDATE          true
+system         public       statement_activity               table        admin    SELECT          true
+system         public       statement_activity               table        root     SELECT          true
+system         public       statement_bundle_chunks          table        admin    DELETE          true
+system         public       statement_bundle_chunks          table        admin    INSERT          true
+system         public       statement_bundle_chunks          table        admin    SELECT          true
+system         public       statement_bundle_chunks          table        admin    UPDATE          true
+system         public       statement_bundle_chunks          table        root     DELETE          true
+system         public       statement_bundle_chunks          table        root     INSERT          true
+system         public       statement_bundle_chunks          table        root     SELECT          true
+system         public       statement_bundle_chunks          table        root     UPDATE          true
+system         public       statement_diagnostics            table        admin    DELETE          true
+system         public       statement_diagnostics            table        admin    INSERT          true
+system         public       statement_diagnostics            table        admin    SELECT          true
+system         public       statement_diagnostics            table        admin    UPDATE          true
+system         public       statement_diagnostics            table        root     DELETE          true
+system         public       statement_diagnostics            table        root     INSERT          true
+system         public       statement_diagnostics            table        root     SELECT          true
+system         public       statement_diagnostics            table        root     UPDATE          true
+system         public       statement_diagnostics_requests   table        admin    DELETE          true
+system         public       statement_diagnostics_requests   table        admin    INSERT          true
+system         public       statement_diagnostics_requests   table        admin    SELECT          true
+system         public       statement_diagnostics_requests   table        admin    UPDATE          true
+system         public       statement_diagnostics_requests   table        root     DELETE          true
+system         public       statement_diagnostics_requests   table        root     INSERT          true
+system         public       statement_diagnostics_requests   table        root     SELECT          true
+system         public       statement_diagnostics_requests   table        root     UPDATE          true
+system         public       statement_statistics             table        admin    SELECT          true
+system         public       statement_statistics             table        root     SELECT          true
+system         public       table_statistics                 table        admin    DELETE          true
+system         public       table_statistics                 table        admin    INSERT          true
+system         public       table_statistics                 table        admin    SELECT          true
+system         public       table_statistics                 table        admin    UPDATE          true
+system         public       table_statistics                 table        root     DELETE          true
+system         public       table_statistics                 table        root     INSERT          true
+system         public       table_statistics                 table        root     SELECT          true
+system         public       table_statistics                 table        root     UPDATE          true
+system         public       task_payloads                    table        admin    DELETE          true
+system         public       task_payloads                    table        admin    INSERT          true
+system         public       task_payloads                    table        admin    SELECT          true
+system         public       task_payloads                    table        admin    UPDATE          true
+system         public       task_payloads                    table        root     DELETE          true
+system         public       task_payloads                    table        root     INSERT          true
+system         public       task_payloads                    table        root     SELECT          true
+system         public       task_payloads                    table        root     UPDATE          true
+system         public       tenant_id_seq                    sequence     admin    SELECT          true
+system         public       tenant_id_seq                    sequence     root     SELECT          true
+system         public       tenant_settings                  table        admin    DELETE          true
+system         public       tenant_settings                  table        admin    INSERT          true
+system         public       tenant_settings                  table        admin    SELECT          true
+system         public       tenant_settings                  table        admin    UPDATE          true
+system         public       tenant_settings                  table        root     DELETE          true
+system         public       tenant_settings                  table        root     INSERT          true
+system         public       tenant_settings                  table        root     SELECT          true
+system         public       tenant_settings                  table        root     UPDATE          true
+system         public       tenant_tasks                     table        admin    DELETE          true
+system         public       tenant_tasks                     table        admin    INSERT          true
+system         public       tenant_tasks                     table        admin    SELECT          true
+system         public       tenant_tasks                     table        admin    UPDATE          true
+system         public       tenant_tasks                     table        root     DELETE          true
+system         public       tenant_tasks                     table        root     INSERT          true
+system         public       tenant_tasks                     table        root     SELECT          true
+system         public       tenant_tasks                     table        root     UPDATE          true
+system         public       tenant_usage                     table        admin    DELETE          true
+system         public       tenant_usage                     table        admin    INSERT          true
+system         public       tenant_usage                     table        admin    SELECT          true
+system         public       tenant_usage                     table        admin    UPDATE          true
+system         public       tenant_usage                     table        root     DELETE          true
+system         public       tenant_usage                     table        root     INSERT          true
+system         public       tenant_usage                     table        root     SELECT          true
+system         public       tenant_usage                     table        root     UPDATE          true
+system         public       tenants                          table        admin    SELECT          true
+system         public       tenants                          table        root     SELECT          true
+system         public       transaction_activity             table        admin    SELECT          true
+system         public       transaction_activity             table        root     SELECT          true
+system         public       transaction_statistics           table        admin    SELECT          true
+system         public       transaction_statistics           table        root     SELECT          true
+system         public       ui                               table        admin    DELETE          true
+system         public       ui                               table        admin    INSERT          true
+system         public       ui                               table        admin    SELECT          true
+system         public       ui                               table        admin    UPDATE          true
+system         public       ui                               table        root     DELETE          true
+system         public       ui                               table        root     INSERT          true
+system         public       ui                               table        root     SELECT          true
+system         public       ui                               table        root     UPDATE          true
+system         public       users                            table        admin    DELETE          true
+system         public       users                            table        admin    INSERT          true
+system         public       users                            table        admin    SELECT          true
+system         public       users                            table        admin    UPDATE          true
+system         public       users                            table        root     DELETE          true
+system         public       users                            table        root     INSERT          true
+system         public       users                            table        root     SELECT          true
+system         public       users                            table        root     UPDATE          true
+system         public       web_sessions                     table        admin    DELETE          true
+system         public       web_sessions                     table        admin    INSERT          true
+system         public       web_sessions                     table        admin    SELECT          true
+system         public       web_sessions                     table        admin    UPDATE          true
+system         public       web_sessions                     table        root     DELETE          true
+system         public       web_sessions                     table        root     INSERT          true
+system         public       web_sessions                     table        root     SELECT          true
+system         public       web_sessions                     table        root     UPDATE          true
+system         public       zones                            table        admin    DELETE          true
+system         public       zones                            table        admin    INSERT          true
+system         public       zones                            table        admin    SELECT          true
+system         public       zones                            table        admin    UPDATE          true
+system         public       zones                            table        root     DELETE          true
+system         public       zones                            table        root     INSERT          true
+system         public       zones                            table        root     SELECT          true
+system         public       zones                            table        root     UPDATE          true
+test           NULL         NULL                             database     admin    ALL             true
+test           NULL         NULL                             database     root     ALL             true
+test           pg_catalog   "char"                           type         admin    ALL             false
+test           pg_catalog   "char"                           type         root     ALL             false
+test           pg_catalog   "char"[]                         type         admin    ALL             false
+test           pg_catalog   "char"[]                         type         root     ALL             false
+test           pg_catalog   anyelement                       type         admin    ALL             false
+test           pg_catalog   anyelement                       type         root     ALL             false
+test           pg_catalog   anyelement[]                     type         admin    ALL             false
+test           pg_catalog   anyelement[]                     type         root     ALL             false
+test           pg_catalog   bit                              type         admin    ALL             false
+test           pg_catalog   bit                              type         root     ALL             false
+test           pg_catalog   bit[]                            type         admin    ALL             false
+test           pg_catalog   bit[]                            type         root     ALL             false
+test           pg_catalog   bool                             type         admin    ALL             false
+test           pg_catalog   bool                             type         root     ALL             false
+test           pg_catalog   bool[]                           type         admin    ALL             false
+test           pg_catalog   bool[]                           type         root     ALL             false
+test           pg_catalog   box2d                            type         admin    ALL             false
+test           pg_catalog   box2d                            type         root     ALL             false
+test           pg_catalog   box2d[]                          type         admin    ALL             false
+test           pg_catalog   box2d[]                          type         root     ALL             false
+test           pg_catalog   bytes                            type         admin    ALL             false
+test           pg_catalog   bytes                            type         root     ALL             false
+test           pg_catalog   bytes[]                          type         admin    ALL             false
+test           pg_catalog   bytes[]                          type         root     ALL             false
+test           pg_catalog   char                             type         admin    ALL             false
+test           pg_catalog   char                             type         root     ALL             false
+test           pg_catalog   char[]                           type         admin    ALL             false
+test           pg_catalog   char[]                           type         root     ALL             false
+test           pg_catalog   date                             type         admin    ALL             false
+test           pg_catalog   date                             type         root     ALL             false
+test           pg_catalog   date[]                           type         admin    ALL             false
+test           pg_catalog   date[]                           type         root     ALL             false
+test           pg_catalog   decimal                          type         admin    ALL             false
+test           pg_catalog   decimal                          type         root     ALL             false
+test           pg_catalog   decimal[]                        type         admin    ALL             false
+test           pg_catalog   decimal[]                        type         root     ALL             false
+test           pg_catalog   float                            type         admin    ALL             false
+test           pg_catalog   float                            type         root     ALL             false
+test           pg_catalog   float4                           type         admin    ALL             false
+test           pg_catalog   float4                           type         root     ALL             false
+test           pg_catalog   float4[]                         type         admin    ALL             false
+test           pg_catalog   float4[]                         type         root     ALL             false
+test           pg_catalog   float[]                          type         admin    ALL             false
+test           pg_catalog   float[]                          type         root     ALL             false
+test           pg_catalog   geography                        type         admin    ALL             false
+test           pg_catalog   geography                        type         root     ALL             false
+test           pg_catalog   geography[]                      type         admin    ALL             false
+test           pg_catalog   geography[]                      type         root     ALL             false
+test           pg_catalog   geometry                         type         admin    ALL             false
+test           pg_catalog   geometry                         type         root     ALL             false
+test           pg_catalog   geometry[]                       type         admin    ALL             false
+test           pg_catalog   geometry[]                       type         root     ALL             false
+test           pg_catalog   inet                             type         admin    ALL             false
+test           pg_catalog   inet                             type         root     ALL             false
+test           pg_catalog   inet[]                           type         admin    ALL             false
+test           pg_catalog   inet[]                           type         root     ALL             false
+test           pg_catalog   int                              type         admin    ALL             false
+test           pg_catalog   int                              type         root     ALL             false
+test           pg_catalog   int2                             type         admin    ALL             false
+test           pg_catalog   int2                             type         root     ALL             false
+test           pg_catalog   int2[]                           type         admin    ALL             false
+test           pg_catalog   int2[]                           type         root     ALL             false
+test           pg_catalog   int2vector                       type         admin    ALL             false
+test           pg_catalog   int2vector                       type         root     ALL             false
+test           pg_catalog   int2vector[]                     type         admin    ALL             false
+test           pg_catalog   int2vector[]                     type         root     ALL             false
+test           pg_catalog   int4                             type         admin    ALL             false
+test           pg_catalog   int4                             type         root     ALL             false
+test           pg_catalog   int4[]                           type         admin    ALL             false
+test           pg_catalog   int4[]                           type         root     ALL             false
+test           pg_catalog   int[]                            type         admin    ALL             false
+test           pg_catalog   int[]                            type         root     ALL             false
+test           pg_catalog   interval                         type         admin    ALL             false
+test           pg_catalog   interval                         type         root     ALL             false
+test           pg_catalog   interval[]                       type         admin    ALL             false
+test           pg_catalog   interval[]                       type         root     ALL             false
+test           pg_catalog   jsonb                            type         admin    ALL             false
+test           pg_catalog   jsonb                            type         root     ALL             false
+test           pg_catalog   jsonb[]                          type         admin    ALL             false
+test           pg_catalog   jsonb[]                          type         root     ALL             false
+test           pg_catalog   name                             type         admin    ALL             false
+test           pg_catalog   name                             type         root     ALL             false
+test           pg_catalog   name[]                           type         admin    ALL             false
+test           pg_catalog   name[]                           type         root     ALL             false
+test           pg_catalog   oid                              type         admin    ALL             false
+test           pg_catalog   oid                              type         root     ALL             false
+test           pg_catalog   oid[]                            type         admin    ALL             false
+test           pg_catalog   oid[]                            type         root     ALL             false
+test           pg_catalog   oidvector                        type         admin    ALL             false
+test           pg_catalog   oidvector                        type         root     ALL             false
+test           pg_catalog   oidvector[]                      type         admin    ALL             false
+test           pg_catalog   oidvector[]                      type         root     ALL             false
+test           pg_catalog   record                           type         admin    ALL             false
+test           pg_catalog   record                           type         root     ALL             false
+test           pg_catalog   record[]                         type         admin    ALL             false
+test           pg_catalog   record[]                         type         root     ALL             false
+test           pg_catalog   regclass                         type         admin    ALL             false
+test           pg_catalog   regclass                         type         root     ALL             false
+test           pg_catalog   regclass[]                       type         admin    ALL             false
+test           pg_catalog   regclass[]                       type         root     ALL             false
+test           pg_catalog   regnamespace                     type         admin    ALL             false
+test           pg_catalog   regnamespace                     type         root     ALL             false
+test           pg_catalog   regnamespace[]                   type         admin    ALL             false
+test           pg_catalog   regnamespace[]                   type         root     ALL             false
+test           pg_catalog   regproc                          type         admin    ALL             false
+test           pg_catalog   regproc                          type         root     ALL             false
+test           pg_catalog   regproc[]                        type         admin    ALL             false
+test           pg_catalog   regproc[]                        type         root     ALL             false
+test           pg_catalog   regprocedure                     type         admin    ALL             false
+test           pg_catalog   regprocedure                     type         root     ALL             false
+test           pg_catalog   regprocedure[]                   type         admin    ALL             false
+test           pg_catalog   regprocedure[]                   type         root     ALL             false
+test           pg_catalog   regrole                          type         admin    ALL             false
+test           pg_catalog   regrole                          type         root     ALL             false
+test           pg_catalog   regrole[]                        type         admin    ALL             false
+test           pg_catalog   regrole[]                        type         root     ALL             false
+test           pg_catalog   regtype                          type         admin    ALL             false
+test           pg_catalog   regtype                          type         root     ALL             false
+test           pg_catalog   regtype[]                        type         admin    ALL             false
+test           pg_catalog   regtype[]                        type         root     ALL             false
+test           pg_catalog   string                           type         admin    ALL             false
+test           pg_catalog   string                           type         root     ALL             false
+test           pg_catalog   string[]                         type         admin    ALL             false
+test           pg_catalog   string[]                         type         root     ALL             false
+test           pg_catalog   time                             type         admin    ALL             false
+test           pg_catalog   time                             type         root     ALL             false
+test           pg_catalog   time[]                           type         admin    ALL             false
+test           pg_catalog   time[]                           type         root     ALL             false
+test           pg_catalog   timestamp                        type         admin    ALL             false
+test           pg_catalog   timestamp                        type         root     ALL             false
+test           pg_catalog   timestamp[]                      type         admin    ALL             false
+test           pg_catalog   timestamp[]                      type         root     ALL             false
+test           pg_catalog   timestamptz                      type         admin    ALL             false
+test           pg_catalog   timestamptz                      type         root     ALL             false
+test           pg_catalog   timestamptz[]                    type         admin    ALL             false
+test           pg_catalog   timestamptz[]                    type         root     ALL             false
+test           pg_catalog   timetz                           type         admin    ALL             false
+test           pg_catalog   timetz                           type         root     ALL             false
+test           pg_catalog   timetz[]                         type         admin    ALL             false
+test           pg_catalog   timetz[]                         type         root     ALL             false
+test           pg_catalog   tsquery                          type         admin    ALL             false
+test           pg_catalog   tsquery                          type         root     ALL             false
+test           pg_catalog   tsquery[]                        type         admin    ALL             false
+test           pg_catalog   tsquery[]                        type         root     ALL             false
+test           pg_catalog   tsvector                         type         admin    ALL             false
+test           pg_catalog   tsvector                         type         root     ALL             false
+test           pg_catalog   tsvector[]                       type         admin    ALL             false
+test           pg_catalog   tsvector[]                       type         root     ALL             false
+test           pg_catalog   unknown                          type         admin    ALL             false
+test           pg_catalog   unknown                          type         root     ALL             false
+test           pg_catalog   uuid                             type         admin    ALL             false
+test           pg_catalog   uuid                             type         root     ALL             false
+test           pg_catalog   uuid[]                           type         admin    ALL             false
+test           pg_catalog   uuid[]                           type         root     ALL             false
+test           pg_catalog   varbit                           type         admin    ALL             false
+test           pg_catalog   varbit                           type         root     ALL             false
+test           pg_catalog   varbit[]                         type         admin    ALL             false
+test           pg_catalog   varbit[]                         type         root     ALL             false
+test           pg_catalog   varchar                          type         admin    ALL             false
+test           pg_catalog   varchar                          type         root     ALL             false
+test           pg_catalog   varchar[]                        type         admin    ALL             false
+test           pg_catalog   varchar[]                        type         root     ALL             false
+test           pg_catalog   void                             type         admin    ALL             false
+test           pg_catalog   void                             type         root     ALL             false
+test           public       NULL                             schema       admin    ALL             true
+test           public       NULL                             schema       root     ALL             true
 
 statement error pgcode 42P01 relation "a.t" does not exist
 SHOW GRANTS ON a.t
@@ -2602,23 +2602,23 @@ a  public  v  test-user  DROP        false
 a  public  v  test-user  UPDATE      false
 a  public  v  test-user  ZONECONFIG  false
 
-query TTTTTB
+query TTTTTTB rowsort
 SHOW GRANTS FOR readwrite, "test-user"
 ----
-a  NULL    NULL  readwrite  ALL         false
-a  public  v     readwrite  BACKUP      false
-a  public  v     readwrite  CHANGEFEED  false
-a  public  v     readwrite  CREATE      false
-a  public  v     readwrite  DROP        false
-a  public  v     readwrite  SELECT      false
-a  public  v     readwrite  UPDATE      false
-a  public  v     readwrite  ZONECONFIG  false
-a  public  v     test-user  BACKUP      false
-a  public  v     test-user  CHANGEFEED  false
-a  public  v     test-user  CREATE      false
-a  public  v     test-user  DROP        false
-a  public  v     test-user  UPDATE      false
-a  public  v     test-user  ZONECONFIG  false
+a  NULL    NULL  database  readwrite  ALL         false
+a  public  v     table     readwrite  BACKUP      false
+a  public  v     table     readwrite  CHANGEFEED  false
+a  public  v     table     readwrite  CREATE      false
+a  public  v     table     readwrite  DROP        false
+a  public  v     table     readwrite  SELECT      false
+a  public  v     table     readwrite  UPDATE      false
+a  public  v     table     readwrite  ZONECONFIG  false
+a  public  v     table     test-user  BACKUP      false
+a  public  v     table     test-user  CHANGEFEED  false
+a  public  v     table     test-user  CREATE      false
+a  public  v     table     test-user  DROP        false
+a  public  v     table     test-user  UPDATE      false
+a  public  v     table     test-user  ZONECONFIG  false
 
 statement ok
 REVOKE ALL ON v FROM readwrite,"test-user"
@@ -2633,10 +2633,10 @@ query TTTTTB
 SHOW GRANTS ON v FOR readwrite, "test-user"
 ----
 
-query TTTTTB
+query TTTTTTB
 SHOW GRANTS FOR readwrite, "test-user"
 ----
-a  NULL  NULL  readwrite  ALL  false
+a  NULL  NULL  database  readwrite  ALL  false
 
 # Verify that the DB privileges have not changed.
 query TTTB colnames

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -45,13 +45,13 @@ database_name  schema_name  type_name  grantee  privilege_type  is_grantable
 test           public       enum_a     user1    USAGE           false
 test           schema_a     enum_b     user1    ALL             false
 
-query TTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR user1
 ----
-database_name  schema_name  relation_name  grantee  privilege_type  is_grantable
-test           public       enum_a         user1    USAGE           false
-test           public       enum_a+b       user1    USAGE           false
-test           schema_a     enum_b         user1    ALL             false
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       enum_a       type         user1    USAGE           false
+test           public       enum_a+b     type         user1    USAGE           false
+test           schema_a     enum_b       type         user1    ALL             false
 
 statement error type "non_existent" does not exist
 SHOW GRANTS ON TYPE non_existent

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1828,3 +1828,18 @@ statement ok
 DROP ROLE creator_of_databases
 
 subtest end
+
+# The purpose of this test is to verify the object_type column
+statement ok
+create user roach;
+create type mood as enum ('sad','happy');
+grant usage on type mood to roach;
+create sequence test_sequence;
+grant usage on sequence test_sequence to roach;
+
+query TTTTTTB colnames,rowsort
+show grants for roach
+----
+database_name  schema_name  object_name    object_type  grantee  privilege_type  is_grantable
+test           public       mood           type         roach    USAGE           false
+test           public       test_sequence  sequence     roach    USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1937,12 +1937,12 @@ database_name  schema_name          function_id  function_signature             
 test           sc_test_show_grants  100205       f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
 test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
-query TTTTTB colnames
+query TTTTTTB colnames
 SHOW GRANTS FOR u_test_show_grants;
 ----
-database_name  schema_name          relation_name                        grantee             privilege_type  is_grantable
-test           sc_test_show_grants  f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+database_name  schema_name          object_name                          object_type  grantee             privilege_type  is_grantable
+test           sc_test_show_grants  f_test_show_grants(int8)             routine      u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  f_test_show_grants(int8, text, oid)  routine      u_test_show_grants  EXECUTE         false
 
 statement ok
 SET search_path = public;

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -609,7 +609,7 @@ vectorized: true
 │
 └── • subquery
     │ id: @S1
-    │ original sql: SELECT * FROM (SELECT table_catalog AS database_name, table_schema AS schema_name, table_name, grantee, privilege_type, is_grantable::BOOL FROM "".information_schema.table_privileges) WHERE (database_name, schema_name, table_name) IN (('test', 'public', 'foo'),)
+    │ original sql: SELECT * FROM (SELECT tp.table_catalog AS database_name, tp.table_schema AS schema_name, tp.table_name, tp.grantee, tp.privilege_type, tp.is_grantable::BOOL, CASE WHEN s.sequence_name IS NOT NULL THEN 'sequence' ELSE 'table' END AS object_type FROM "".information_schema.table_privileges AS tp LEFT JOIN "".information_schema.sequences AS s ON (((tp.table_catalog = s.sequence_catalog) AND (tp.table_schema = s.sequence_schema)) AND (tp.table_name = s.sequence_name))) WHERE (database_name, schema_name, table_name) IN (('test', 'public', 'foo'),)
     │ exec mode: all rows
     │
     └── • buffer
@@ -617,11 +617,20 @@ vectorized: true
         │
         └── • render
             │
-            └── • filter
-                │ filter: ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+            └── • merge join (left outer)
+                │ equality: (table_catalog, table_schema, table_name) = (sequence_catalog, sequence_schema, sequence_name)
                 │
-                └── • virtual table
-                      table: table_privileges@primary
+                ├── • filter
+                │   │ filter: ((table_catalog = 'test') AND (table_schema = 'public')) AND (table_name = 'foo')
+                │   │
+                │   └── • virtual table
+                │         table: table_privileges@primary
+                │
+                └── • filter
+                    │ filter: ((sequence_catalog = 'test') AND (sequence_schema = 'public')) AND (sequence_name = 'foo')
+                    │
+                    └── • virtual table
+                          table: sequences@primary
 
 query T
 EXPLAIN SHOW INDEX FROM foo

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -227,7 +227,7 @@ vectorized: true
 │
 └── • subquery
     │ id: @S1
-    │ original sql: SELECT * FROM (SELECT database_name, grantee, privilege_type, is_grantable::BOOL FROM "".crdb_internal.cluster_database_privileges) WHERE database_name IN ('t',)
+    │ original sql: SELECT * FROM (SELECT database_name, 'database' AS object_type, grantee, privilege_type, is_grantable::BOOL FROM "".crdb_internal.cluster_database_privileges) WHERE database_name IN ('t',)
     │ exec mode: all rows
     │
     └── • buffer


### PR DESCRIPTION
Backport 1/1 commits from #122197.

/cc @cockroachdb/release

---

Previously, we used the relation_name column to show all objects however we now have objects such as function and types that are not relations so the name of this column was changed to object_name in these code changes. Additionally with the larger variety in types a new column object_type is added that identifies the type of an object.

Fixes: #119775
Release note (sql change): object_type can now be seen with the show grants command and relation_name column is now shown as object_name.

Release justification: needed for a bug fix that will be backported at this link: #122556 
