### PR TITLE
opt: improve trigram similarity filter selectivity

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3757,6 +3757,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedDistinctOnLimitHintCosting(v
 	m.data.OptimizerUseImprovedDistinctOnLimitHintCosting = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseImprovedTrigramSimilaritySelectivity(val bool) {
+	m.data.OptimizerUseImprovedTrigramSimilaritySelectivity = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6169,6 +6169,7 @@ optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_distinct_on_limit_hint_costing      on
 optimizer_use_improved_join_elimination                    on
 optimizer_use_improved_split_disjunction_for_joins         on
+optimizer_use_improved_trigram_similarity_selectivity      on
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2895,6 +2895,7 @@ optimizer_use_improved_disjunction_stats                   on                  N
 optimizer_use_improved_distinct_on_limit_hint_costing      on                  NULL      NULL        NULL        string
 optimizer_use_improved_join_elimination                    on                  NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL      NULL        NULL        string
+optimizer_use_improved_trigram_similarity_selectivity      on                  NULL      NULL        NULL        string
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL      NULL        NULL        string
 optimizer_use_lock_op_for_serializable                     off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
@@ -3075,6 +3076,7 @@ optimizer_use_improved_disjunction_stats                   on                  N
 optimizer_use_improved_distinct_on_limit_hint_costing      on                  NULL  user     NULL      on                  on
 optimizer_use_improved_join_elimination                    on                  NULL  user     NULL      on                  on
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL  user     NULL      on                  on
+optimizer_use_improved_trigram_similarity_selectivity      on                  NULL  user     NULL      on                  on
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL  user     NULL      on                  on
 optimizer_use_lock_op_for_serializable                     off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
@@ -3254,6 +3256,7 @@ optimizer_use_improved_disjunction_stats                   NULL    NULL     NULL
 optimizer_use_improved_distinct_on_limit_hint_costing      NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_join_elimination                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_split_disjunction_for_joins         NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_trigram_similarity_selectivity      NULL    NULL     NULL     NULL        NULL
 optimizer_use_limit_ordering_for_streaming_group_by        NULL    NULL     NULL     NULL        NULL
 optimizer_use_lock_op_for_serializable                     NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -132,6 +132,7 @@ optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_distinct_on_limit_hint_costing      on
 optimizer_use_improved_join_elimination                    on
 optimizer_use_improved_split_disjunction_for_joins         on
+optimizer_use_improved_trigram_similarity_selectivity      on
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -733,6 +733,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 	h.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
 	h.evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization = true
 	h.evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting = true
+	h.evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = true
 
 	// Set up the test catalog.
 	h.testCat = testcat.New()

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -191,6 +191,7 @@ type Memo struct {
 	useVirtualComputedColumnStats              bool
 	useTrigramSimilarityOptimization           bool
 	useImprovedDistinctOnLimitHintCosting      bool
+	useImprovedTrigramSimilaritySelectivity    bool
 	trigramSimilarityThreshold                 float64
 	splitScanLimit                             int32
 
@@ -270,6 +271,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useVirtualComputedColumnStats:              evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats,
 		useTrigramSimilarityOptimization:           evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization,
 		useImprovedDistinctOnLimitHintCosting:      evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting,
+		useImprovedTrigramSimilaritySelectivity:    evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity,
 		trigramSimilarityThreshold:                 evalCtx.SessionData().TrigramSimilarityThreshold,
 		splitScanLimit:                             evalCtx.SessionData().OptSplitScanLimit,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
@@ -427,6 +429,7 @@ func (m *Memo) IsStale(
 		m.useVirtualComputedColumnStats != evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats ||
 		m.useTrigramSimilarityOptimization != evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization ||
 		m.useImprovedDistinctOnLimitHintCosting != evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting ||
+		m.useImprovedTrigramSimilaritySelectivity != evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity ||
 		m.trigramSimilarityThreshold != evalCtx.SessionData().TrigramSimilarityThreshold ||
 		m.splitScanLimit != evalCtx.SessionData().OptSplitScanLimit ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -454,6 +454,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting = false
 	notStale()
 
+	// Stale optimizer_use_distinct_on_limit_hint_costing.
+	evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = true
+	stale()
+	evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = false
+	notStale()
+
 	// Stale pg_trgm.similarity_threshold.
 	evalCtx.SessionData().TrigramSimilarityThreshold = 0.5
 	stale()

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -41,6 +41,10 @@ const (
 	// by Pat Selinger et al.
 	unknownFilterSelectivity = 1.0 / 3.0
 
+	// This is the selectivity used for trigram similarity filters, like s %
+	// 'foo'.
+	similarityFilterSelectivity = 1.0 / 100.0
+
 	// TODO(rytaft): Add other selectivities for other types of predicates.
 
 	// This is an arbitrary row count used in the absence of any real statistics.
@@ -3384,6 +3388,13 @@ func (sb *statisticsBuilder) applyFiltersItem(
 		return opt.ColSet{}, opt.ColSet{}
 	}
 
+	// Special case: a trigram similarity filter.
+	if isSimilarityFilter(filter.Condition) &&
+		sb.evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity {
+		unapplied.similarity++
+		return opt.ColSet{}, opt.ColSet{}
+	}
+
 	// Special case: The current conjunct is an inverted join condition which is
 	// handled by selectivityFromInvertedJoinCondition.
 	if isInvertedJoinCond(filter.Condition) {
@@ -4724,8 +4735,9 @@ func (sb *statisticsBuilder) selectivityFromInvertedJoinCondition(
 func (sb *statisticsBuilder) selectivityFromUnappliedConjuncts(
 	c filterCount,
 ) (selectivity props.Selectivity) {
-	selectivity = props.MakeSelectivity(math.Pow(unknownFilterSelectivity, float64(c.unknown)))
-	return selectivity
+	s := math.Pow(unknownFilterSelectivity, float64(c.unknown)) *
+		math.Pow(similarityFilterSelectivity, float64(c.similarity))
+	return props.MakeSelectivity(s)
 }
 
 // tryReduceCols is used to determine which columns to use for selectivity
@@ -4781,6 +4793,16 @@ func (sb *statisticsBuilder) tryReduceJoinCols(
 func isEqualityWithTwoVars(cond opt.ScalarExpr) bool {
 	if eq, ok := cond.(*EqExpr); ok {
 		return eq.Left.Op() == opt.VariableOp && eq.Right.Op() == opt.VariableOp
+	}
+	return false
+}
+
+// isSimilarityFilter returns true if the given condition is a trigram
+// similarity filter.
+func isSimilarityFilter(e opt.ScalarExpr) bool {
+	if sim, ok := e.(*ModExpr); ok {
+		return sim.Left.DataType().Family() == types.StringFamily &&
+			sim.Right.DataType().Family() == types.StringFamily
 	}
 	return false
 }
@@ -5088,10 +5110,12 @@ func (sb *statisticsBuilder) factorOutVirtualCols(
 // the number of filters which are not applied to selectivities via more exact
 // means like constraints and histogram filtering.
 type filterCount struct {
-	unknown int
+	unknown    int
+	similarity int
 }
 
 // add adds the counts of other to c.
 func (c *filterCount) add(other filterCount) {
 	c.unknown += other.unknown
+	c.similarity += other.similarity
 }

--- a/pkg/sql/opt/memo/testdata/stats/inverted-trigram
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-trigram
@@ -302,6 +302,34 @@ SELECT * FROM a WHERE a % 'blah'
 select
  ├── columns: a:1(string)
  ├── stable
+ ├── stats: [rows=10]
+ ├── index-join a
+ │    ├── columns: a:1(string)
+ │    ├── stats: [rows=8]
+ │    └── distinct-on
+ │         ├── columns: rowid:2(int!null)
+ │         ├── grouping columns: rowid:2(int!null)
+ │         ├── stats: [rows=8, distinct(2)=8, null(2)=0]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null)
+ │              ├── constraint: /5
+ │              │    ├── [/'\x1220626c0001' - /'\x1220626c0001']
+ │              │    ├── [/'\x126168200001' - /'\x126168200001']
+ │              │    ├── [/'\x12626c610001' - /'\x12626c610001']
+ │              │    └── [/'\x126c61680001' - /'\x126c61680001']
+ │              └── stats: [rows=40, distinct(2)=8, null(2)=0, distinct(5)=4, null(5)=0]
+ │                  histogram(5)=  0         10         0         10         0         10         0         10
+ │                               <--- '\x1220626c0001' --- '\x126168200001' --- '\x12626c610001' --- '\x126c61680001'
+ └── filters
+      └── a:1 % 'blah' [type=bool, outer=(1), stable]
+
+opt set=(optimizer_use_improved_trigram_similarity_selectivity=false)
+SELECT * FROM a WHERE a % 'blah'
+----
+select
+ ├── columns: a:1(string)
+ ├── stable
  ├── stats: [rows=333.3333]
  ├── index-join a
  │    ├── columns: a:1(string)
@@ -331,7 +359,7 @@ SELECT * FROM a WHERE a % 'blah'
 select
  ├── columns: a:1(string)
  ├── stable
- ├── stats: [rows=333.3333]
+ ├── stats: [rows=10]
  ├── index-join a
  │    ├── columns: a:1(string)
  │    ├── stats: [rows=2]

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -316,6 +316,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
 	ot.evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization = true
 	ot.evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting = true
+	ot.evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = true
 	ot.evalCtx.SessionData().TrigramSimilarityThreshold = 0.3
 
 	return ot

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -501,6 +501,10 @@ message LocalOnlySessionData {
   // optimizer should use an improved costing estimate for DistinctOn operators
   // with limit hints.
   bool optimizer_use_improved_distinct_on_limit_hint_costing = 126;
+  // OptimizerUseImprovedTrigramSimilaritySelectivity indicates whether the
+  // optimizer should use an improved selectivitiy estimate for trigram
+  // similarity filters.
+  bool optimizer_use_improved_trigram_similarity_selectivity = 127;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3293,6 +3293,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_improved_trigram_similarity_selectivity`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_trigram_similarity_selectivity`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_trigram_similarity_selectivity", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedTrigramSimilaritySelectivity(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### opt: refactor unapplied conjunction counter

This commit refactors unapplied conjunction counts from a single
`float64` into a struct. For now, the struct has a single field, but in
the future it can be expanded to track counts of different types of
unapplied filters. This will make it easier to apply different
selectivities to different types of filters.

Release note: None

#### opt: improve trigram similarity filter selectivity

Trigram similarity filters, like `s % 'foo'`, are now given a
selectivity of 1/100 instead of the default unknown selectivity of 1/3.
This makes plans that utilize trigram inverted indexes more attractive
than full table scans when a `LIMIT` is present.

There's nothing particularly special about the 1/100 value. For the
majority of workloads it should be closer to the true selectivity than
1/3.

This change can be disabled by setting the
`optimizer_use_improved_trigram_similarity_selectivity` to `off`. It is
enabled by default.

Epic: CRDB-37714

Release note: None
