### PR TITLE
release-23.2: changefeedccl: redact `client_key` in from SHOW JOBS output

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -111,6 +111,7 @@ func init() {
 			m.SinkURI, err = cloud.SanitizeExternalStorageURI(m.SinkURI, []string{
 				changefeedbase.SinkParamSASLPassword,
 				changefeedbase.SinkParamCACert,
+				changefeedbase.SinkParamClientKey,
 				changefeedbase.SinkParamClientCert,
 				changefeedbase.SinkParamConfluentAPISecret,
 			})

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -995,6 +995,7 @@ func changefeedJobDescription(
 		changefeedbase.SinkParamSASLPassword,
 		changefeedbase.SinkParamCACert,
 		changefeedbase.SinkParamClientCert,
+		changefeedbase.SinkParamClientKey,
 		changefeedbase.SinkParamConfluentAPISecret,
 	})
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #122529.

/cc @cockroachdb/release

---

Previously, SHOW CHANGEFEED JOB revealed sensitive user data like `client_key`.
This patch now redacts it in the job description and sinkURI output column.

Epic: none

Release note (enterprise change): SHOW CHANGEFEED JOB, SHOW CHANGEFEED JOBS,
and SHOW JOBS no longer expose user sensitive information like `client_key`.

----

Release justification: low risk bug fix to redact user-sensitive info for SQL output