### PR TITLE
roachtest: annotate start and end of roachtests in grafana

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2880,7 +2880,7 @@ func (c *clusterImpl) AddGrafanaAnnotation(
 	// could add a lot of noise to the logs.
 	if len(c.grafanaTags) == 0 {
 		c.disableGrafanaAnnotations.Store(true)
-		return errors.New("grafana is not available for this cluster (disabled for the rest of the test)")
+		return errors.New("error adding grafana annotation: grafana is not available for this cluster (disabled for the rest of the test)")
 	}
 	// Add grafanaTags so we can filter annotations by test or by cluster.
 	req.Tags = append(req.Tags, c.grafanaTags...)
@@ -2890,7 +2890,7 @@ func (c *clusterImpl) AddGrafanaAnnotation(
 	const CentralizedGrafanaHost = "grafana.testeng.crdb.io"
 
 	// The centralized grafana instance requires auth through Google IDP.
-	return roachprod.AddGrafanaAnnotation(ctx, CentralizedGrafanaHost, true /* secure */, req)
+	return errors.Wrap(roachprod.AddGrafanaAnnotation(ctx, CentralizedGrafanaHost, true /* secure */, req), "error adding grafana annotation")
 }
 
 // AddInternalGrafanaAnnotation creates a grafana annotation for the internal grafana

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
@@ -1170,6 +1172,7 @@ func (r *testRunner) runTest(
 			}
 		}()
 
+		grafanaAnnotateTestStart(runCtx, t, c)
 		// This is the call to actually run the test.
 		s.Run(runCtx, t, c)
 	}()
@@ -1192,6 +1195,11 @@ func (r *testRunner) runTest(
 			s = "with failure(s)"
 		}
 		t.L().Printf("test completed %s", s)
+		annotationText := fmt.Sprintf("%s completed %s", t.Name(), s)
+		// Attempt to annotate the test completion on Grafana.
+		if err := c.AddGrafanaAnnotation(ctx, t.L(), grafana.AddAnnotationRequest{Text: annotationText}); err != nil {
+			t.L().Printf(errors.Wrap(err, "error adding annotation for test end").Error())
+		}
 	case <-time.After(timeout):
 		// NB: We're adding the timeout failure intentionally without cancelling the context
 		// to capture as much state as possible during artifact collection.
@@ -1785,4 +1793,19 @@ func testTimeout(spec *registry.TestSpec) time.Duration {
 		timeout = d
 	}
 	return timeout
+}
+
+// Annotate the start of the test in Grafana and the branch if applicable.
+func grafanaAnnotateTestStart(ctx context.Context, t test.Test, c cluster.Cluster) {
+	const BuildBranch = "TC_BUILD_BRANCH"
+	text := fmt.Sprintf("Starting %s", t.Name())
+	var tags []string
+	branch := os.Getenv(BuildBranch)
+	if branch != "" {
+		tags = []string{branch}
+	}
+
+	if err := c.AddGrafanaAnnotation(ctx, t.L(), grafana.AddAnnotationRequest{Text: text, Tags: tags}); err != nil {
+		t.L().Printf(errors.Wrap(err, "error adding annotation for test start").Error())
+	}
 }


### PR DESCRIPTION
This will help keeping track of which test you are looking at if you are filtering dashboards by cluster or if you are running the same test multiple times on the same cluster.

It also adds a branch tag if applicable that will help keeping track of which branch you are looking at easier.

Release note: none
Fixes: none
Epic: none