### PR TITLE
internal/sqlsmith: allow UDFs to call other UDFs

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -886,7 +886,7 @@ func (s *Smither) makeSelectList(
 }
 
 func makeCreateFunc(s *Smither) (tree.Statement, bool) {
-	if s.disableUDFs {
+	if s.disableUDFCreation {
 		return nil, false
 	}
 	return s.makeCreateFunc()
@@ -1018,16 +1018,16 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 
 	// Disable CTEs temporarily, since they are not currently supported in UDFs.
 	// TODO(92961): Allow CTEs in generated statements in UDF bodies.
-	// TODO(93049): Allow UDFs to call other UDFs, as well as create other UDFs.
+	// TODO(93049): Allow UDFs to create other UDFs.
 	oldDisableWith := s.disableWith
 	oldDisableMutations := s.disableMutations
 	defer func() {
 		s.disableWith = oldDisableWith
-		s.disableUDFs = false
+		s.disableUDFCreation = false
 		s.disableMutations = oldDisableMutations
 	}()
 	s.disableWith = true
-	s.disableUDFs = true
+	s.disableUDFCreation = true
 	s.disableMutations = (funcVol != tree.RoutineVolatile) || s.disableMutations
 
 	// RoutineBodyStr

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -426,9 +426,6 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 		return nil, false
 	}
 	fn := fns[s.rnd.Intn(len(fns))]
-	if s.disableUDFs && fn.overload.Type == tree.UDFRoutine {
-		return nil, false
-	}
 	if s.disableNondeterministicFns && fn.overload.Volatility > volatility.Immutable {
 		return nil, false
 	}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -115,7 +115,10 @@ type Smither struct {
 	disableDivision               bool
 	disableDecimals               bool
 	disableOIDs                   bool
-	disableUDFs                   bool
+	// disableUDFCreation indicates whether we're not allowed to create UDFs.
+	// It follows that if we haven't created any UDFs, we have no UDFs to invoke
+	// too.
+	disableUDFCreation bool
 
 	bulkSrv     *httptest.Server
 	bulkFiles   map[string][]byte
@@ -553,7 +556,7 @@ var DisableOIDs = simpleOption("disable OIDs", func(s *Smither) {
 
 // DisableUDFs causes the Smither to disable user-defined functions.
 var DisableUDFs = simpleOption("disable udfs", func(s *Smither) {
-	s.disableUDFs = true
+	s.disableUDFCreation = true
 })
 
 // CompareMode causes the Smither to generate statements that have


### PR DESCRIPTION
This commit clarifies that `disableUDFs` flag is now only about creation of UDFs which allows UDFs to be invoked from within other UDFs.

Epic: None

Release note: None