### PR TITLE
sql: exclude sequences from information_schema.columns

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -457,6 +457,9 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 		return forEachTableDesc(ctx, p, dbContext, virtualMany, func(
 			ctx context.Context, db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor,
 		) error {
+			if table.IsSequence() {
+				return nil
+			}
 			// Push all comments of columns into map.
 			commentMap := make(map[descpb.PGAttributeNum]string)
 			if err := allComments.ForEachCommentOnDescriptor(

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2837,7 +2837,6 @@ system         public        database_role_settings           role_name         
 system         public        database_role_settings           settings                                                                                                  3
 system         public        descriptor                       descriptor                                                                                                2
 system         public        descriptor                       id                                                                                                        1
-system         public        descriptor_id_seq                value                                                                                                     1
 system         public        eventlog                         eventType                                                                                                 2
 system         public        eventlog                         info                                                                                                      5
 system         public        eventlog                         reportingID                                                                                               4
@@ -2956,7 +2955,6 @@ system         public        replication_stats                under_replicated_r
 system         public        replication_stats                zone_id                                                                                                   1
 system         public        reports_meta                     generated                                                                                                 2
 system         public        reports_meta                     id                                                                                                        1
-system         public        role_id_seq                      value                                                                                                     1
 system         public        role_members                     isAdmin                                                                                                   3
 system         public        role_members                     member                                                                                                    2
 system         public        role_members                     member_id                                                                                                 5
@@ -3116,7 +3114,6 @@ system         public        task_payloads                    owner             
 system         public        task_payloads                    owner_id                                                                                                  4
 system         public        task_payloads                    type                                                                                                      7
 system         public        task_payloads                    value                                                                                                     8
-system         public        tenant_id_seq                    value                                                                                                     1
 system         public        tenant_settings                  last_updated                                                                                              4
 system         public        tenant_settings                  name                                                                                                      2
 system         public        tenant_settings                  reason                                                                                                    6

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2456,9 +2456,9 @@ statement ok
 CREATE SEQUENCE sq_119108;
 
 query T
-SELECT column_name from [SHOW COLUMNS FROM sq_119108]
+SELECT crdb_internal.pb_to_json('desc', descriptor)->'table'->'columns' FROM system.descriptor WHERE id = 'sq_119108'::REGCLASS::OID;
 ----
-value
+[{"id": 1, "name": "value", "type": {"family": "IntFamily", "oid": 20, "width": 64}}]
 
 subtest end
 


### PR DESCRIPTION
Postgres doesn't include them into this vtable. (Found this while looking into some sqlsmith improvements which uses this vtable to get a list of all tables and their columns.)

Epic: None

Release note: None