### PR TITLE
roachtest: add backup-restore/online-restore test

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -50,6 +50,7 @@ const numFullBackups = 5
 type roundTripSpecs struct {
 	name                 string
 	metamorphicRangeSize bool
+	onlineRestore        bool
 	mock                 bool
 	skip                 string
 }
@@ -64,6 +65,12 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 		{
 			name:                 "backup-restore/small-ranges",
 			metamorphicRangeSize: true,
+		},
+		{
+			name:                 "backup-restore/online-restore",
+			metamorphicRangeSize: false,
+			onlineRestore:        true,
+			skip:                 "it fails consistently",
 		},
 		{
 			name: "backup-restore/mock",
@@ -115,7 +122,7 @@ func backupRestoreRoundTrip(
 	m := c.NewMonitor(ctx, roachNodes)
 
 	m.Go(func(ctx context.Context) error {
-		testUtils, err := newCommonTestUtils(ctx, t, c, roachNodes, sp.mock)
+		testUtils, err := newCommonTestUtils(ctx, t, c, roachNodes, sp.mock, sp.onlineRestore)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -467,10 +467,11 @@ func (ep encryptionPassphrase) String() string {
 // newBackupOptions returns a list of backup options to be used when
 // creating a new backup. Each backup option has a 50% chance of being
 // included.
-func newBackupOptions(rng *rand.Rand) []backupOption {
-	possibleOpts := []backupOption{
-		revisionHistory{},
-		newEncryptionPassphrase(rng),
+func newBackupOptions(rng *rand.Rand, onlineRestoreExpected bool) []backupOption {
+	possibleOpts := []backupOption{}
+	if !onlineRestoreExpected {
+		possibleOpts = append(possibleOpts, revisionHistory{})
+		possibleOpts = append(possibleOpts, newEncryptionPassphrase(rng))
 	}
 
 	var options []backupOption
@@ -1788,7 +1789,7 @@ func (d *BackupRestoreTestDriver) runBackup(
 	case fullBackup:
 		btype := d.newBackupScope(rng)
 		name := d.backupCollectionName(d.nextBackupID(), b.namePrefix, btype)
-		createOptions := newBackupOptions(rng)
+		createOptions := newBackupOptions(rng, d.testUtils.onlineRestore)
 		collection = newBackupCollection(name, btype, createOptions, d.cluster.IsLocal())
 		l.Printf("creating full backup for %s", collection.name)
 	case incrementalBackup:
@@ -1952,6 +1953,9 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	numIncrementals := possibleNumIncrementalBackups[rng.Intn(len(possibleNumIncrementalBackups))]
 	if d.testUtils.mock {
 		numIncrementals = 1
+	}
+	if d.testUtils.onlineRestore {
+		numIncrementals = 0
 	}
 	l.Printf("creating %d incremental backups", numIncrementals)
 	for i := 0; i < numIncrementals; i++ {
@@ -2242,6 +2246,9 @@ func (bc *backupCollection) verifyBackupCollection(
 	// need to include it when restoring as well.
 	if opt := bc.encryptionOption(); opt != nil {
 		restoreOptions = append(restoreOptions, opt.String())
+	}
+	if d.testUtils.onlineRestore {
+		restoreOptions = append(restoreOptions, "experimental deferred copy")
 	}
 
 	var optionsStr string
@@ -2637,10 +2644,11 @@ func prepSchemaChangeWorkload(
 }
 
 type CommonTestUtils struct {
-	t          test.Test
-	cluster    cluster.Cluster
-	roachNodes option.NodeListOption
-	mock       bool
+	t             test.Test
+	cluster       cluster.Cluster
+	roachNodes    option.NodeListOption
+	mock          bool
+	onlineRestore bool
 
 	connCache struct {
 		mu    syncutil.Mutex
@@ -2652,7 +2660,12 @@ type CommonTestUtils struct {
 // and puts these connections in a cache for reuse. The caller should remember to close all connections
 // once done with them to prevent any goroutine leaks (CloseConnections).
 func newCommonTestUtils(
-	ctx context.Context, t test.Test, c cluster.Cluster, nodes option.NodeListOption, mock bool,
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	nodes option.NodeListOption,
+	mock bool,
+	onlineRestore bool,
 ) (*CommonTestUtils, error) {
 	cc := make([]*gosql.DB, len(nodes))
 	for _, node := range nodes {
@@ -2669,10 +2682,11 @@ func newCommonTestUtils(
 	}
 
 	u := &CommonTestUtils{
-		t:          t,
-		cluster:    c,
-		roachNodes: nodes,
-		mock:       mock,
+		t:             t,
+		cluster:       c,
+		roachNodes:    nodes,
+		mock:          mock,
+		onlineRestore: onlineRestore,
 	}
 	u.connCache.cache = cc
 	return u, nil
@@ -2681,7 +2695,7 @@ func newCommonTestUtils(
 func (mvb *mixedVersionBackup) CommonTestUtils(ctx context.Context) (*CommonTestUtils, error) {
 	var err error
 	mvb.utilsOnce.Do(func() {
-		mvb.commonTestUtils, err = newCommonTestUtils(ctx, mvb.t, mvb.cluster, mvb.roachNodes, false)
+		mvb.commonTestUtils, err = newCommonTestUtils(ctx, mvb.t, mvb.cluster, mvb.roachNodes, false, false)
 	})
 	return mvb.commonTestUtils, err
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -85,7 +85,7 @@ func executeSupportedDDLs(
 			nodes = helper.Context.NodesInPreviousVersion() // N.B. this is the set of oldNodes.
 		}
 	}
-	testUtils, err := newCommonTestUtils(ctx, t, c, helper.Context.CockroachNodes, false)
+	testUtils, err := newCommonTestUtils(ctx, t, c, helper.Context.CockroachNodes, false, false)
 	defer testUtils.CloseConnections()
 	if err != nil {
 		return err


### PR DESCRIPTION
This patch adds a new variant of the backup-restore roundtrip framework which only runs online restore. Due to OR limitations, this test never runs incremental backups, revision history backups, or encrypted backups.

Epic: none

Release note: none