### PR TITLE
roachtest: fix preempted VM formatting

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1287,7 +1287,7 @@ func getPreemptedVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) 
 		return ""
 	}
 
-	preemptedVMNames := make([]string, len(preemptedVMs))
+	var preemptedVMNames []string
 	for _, preemptedVM := range preemptedVMs {
 		preemptedVMNames = append(preemptedVMNames, preemptedVM.Name)
 	}


### PR DESCRIPTION
We started seeing incorrect formatting of the preempted VM names due to an error in the way we initialized the `preemptedVMNames` slice in https://github.com/cockroachdb/cockroach/pull/122281,  particularly the line https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/test_runner.go#L1290.

`, , , , teamcity-14898257-1713505747-99-n8cpu2-0006 (us-east1-d), teamcity-14898257-1713505747-99-n8cpu2-0005 (us-east1-d), teamcity-14898257-1713505747-99-n8cpu2-0004 (us-east1-d), teamcity-14898257-1713505747-99-n8cpu2-0007 (us-east1-d)`

This PR fixes that.

Epic: none
Release note: None