### PR TITLE
workflows: add staging branches to the patterns

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -1,44 +1,52 @@
 name: GitHub Actions Essential CI
 on:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
     branches:
-      - 'master'
-      - 'release-*'
-      - '!release-1.0*'
-      - '!release-1.1*'
-      - '!release-2.0*'
-      - '!release-2.1*'
-      - '!release-19.1*'
-      - '!release-19.2*'
-      - '!release-20.1*'
-      - '!release-20.2*'
-      - '!release-21.1*'
-      - '!release-21.2*'
-      - '!release-22.1*'
-      - '!release-22.2*'
-      - '!release-23.1*'
-      - '!release-23.2*'
+      - "master"
+      - "release-*"
+      - "staging-*"
+      - "!release-1.0*"
+      - "!release-1.1*"
+      - "!release-2.0*"
+      - "!release-2.1*"
+      - "!release-19.1*"
+      - "!release-19.2*"
+      - "!release-20.1*"
+      - "!release-20.2*"
+      - "!release-21.1*"
+      - "!release-21.2*"
+      - "!release-22.1*"
+      - "!release-22.2*"
+      - "!release-23.1*"
+      - "!release-23.2*"
+      - "!staging-v22.2*"
+      - "!staging-v23.1*"
+      - "!staging-v23.2*"
   push:
     branches:
-      - 'master'
-      - 'release-*'
-      - 'staging'
-      - 'trying'
-      - '!release-1.0*'
-      - '!release-1.1*'
-      - '!release-2.0*'
-      - '!release-2.1*'
-      - '!release-19.1*'
-      - '!release-19.2*'
-      - '!release-20.1*'
-      - '!release-20.2*'
-      - '!release-21.1*'
-      - '!release-21.2*'
-      - '!release-22.1*'
-      - '!release-22.2*'
-      - '!release-23.1*'
-      - '!release-23.2*'
+      - "master"
+      - "release-*"
+      - "staging-*"
+      - "staging"
+      - "trying"
+      - "!release-1.0*"
+      - "!release-1.1*"
+      - "!release-2.0*"
+      - "!release-2.1*"
+      - "!release-19.1*"
+      - "!release-19.2*"
+      - "!release-20.1*"
+      - "!release-20.2*"
+      - "!release-21.1*"
+      - "!release-21.2*"
+      - "!release-22.1*"
+      - "!release-22.2*"
+      - "!release-23.1*"
+      - "!release-23.2*"
+      - "!staging-v22.2*"
+      - "!staging-v23.1*"
+      - "!staging-v23.2*"
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Previously, the actions on the staging-* branches were ignored. These branches are used for extraordinary releases.

This PR adjusts the patterns to include the staging branches.

Epic: none
Release note: None