### PR TITLE
release-23.1: ccl, cli,server, sql, testutils: fix IdMap setting + client cert auth

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -335,7 +335,7 @@ SELECT checkpoint > extract(epoch from after)
 		require.NoError(t, err)
 		pgURL, cleanup, err := sqlutils.PGUrlWithOptionalClientCertsE(
 			tenant.SQLAddr(), "tenantdata", url.UserPassword("foo", password),
-			false, // withClientCerts
+			false, "", // withClientCerts
 		)
 		if !assert.NoError(t, err) {
 			return

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -298,7 +298,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 					// However, certs are only generated for users "root" and "testuser" specifically.
 					sqlURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(
 						t, s.ServingSQLAddr(), t.Name(), url.User(user),
-						forceCerts || user == username.RootUser || user == username.TestUser /* withClientCerts */)
+						forceCerts || user == username.RootUser || user == username.TestUser /* withClientCerts */, "")
 					defer cleanupFn()
 
 					var host, port string

--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -32,7 +32,7 @@ eexpect "interrupted"
 eexpect $prompt
 end_test
 
-start_test "Check that the server reports no warning if the avertise addr is in the cert."
+start_test "Check that the server reports no warning if the advertise addr is in the cert."
 send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --advertise-addr=localhost\r"
 expect {
   "not in node certificate" {
@@ -78,3 +78,35 @@ send "$argv cert list --certs-dir=$certs_dir --cert-principal-map=foo.bar:node\r
 eexpect "Certificate directory:"
 expect $prompt
 end_test
+
+send "rm -f $certs_dir/node.*\r"
+eexpect $prompt
+send "$argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+send "$argv cert create-client foo --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+send "$argv start-single-node --host=localhost --socket-dir=. --store=$db_dir --certs-dir=$certs_dir --cert-principal-map=foo:root --pid-file=server_pid --background\r"
+eexpect $prompt
+start_test "Check that the cert principal map can authenticate root user using non-db user cert CN."
+send "$argv sql --certs-dir=$certs_dir --url=\"postgresql://root@localhost:26257?sslcert=$certs_dir/client.foo.crt&sslkey=$certs_dir/client.foo.key\" -e 'select 1'\r";
+eexpect "(1 row)"
+eexpect $prompt
+end_test
+stop_server $argv
+
+send "$argv cert create-client root --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
+eexpect $prompt
+send "$argv start-single-node --host=localhost --socket-dir=. --store=$db_dir --certs-dir=$certs_dir --cert-principal-map=foo:bar --pid-file=server_pid --background\r"
+eexpect $prompt
+send "$argv sql --certs-dir=$certs_dir -e 'create user bar'\r"
+eexpect $prompt
+start_test "Check that cert auth fails when cert-principal-map and HBAconf(name-remapping) setting are both set for same db user."
+set id_map_stmt "SET CLUSTER SETTING server.identity_map.configuration='crdb foo bar'"
+set hba_conf_stmt "SET CLUSTER SETTING server.host_based_authentication.configuration='hostssl all bar all cert map=crdb'"
+send "$argv sql --certs-dir=$certs_dir --user=root -e \"$id_map_stmt\" \r"
+send "$argv sql --certs-dir=$certs_dir --user=root -e \"$hba_conf_stmt\" \r"
+set auth_url "postgresql://bar@localhost:26257?sslcert=$certs_dir/client.foo.crt&sslkey=$certs_dir/client.foo.key"
+send "$argv sql --certs-dir=$certs_dir --url=\"$auth_url\" -e 'select 1'\r";
+eexpect "ERROR: certificate authentication failed for user \"foo\""
+end_test
+stop_server $argv

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -860,7 +860,7 @@ func TestUsernameUserfileInteraction(t *testing.T) {
 			require.NoError(t, err)
 
 			userURL, cleanup2 := sqlutils.PGUrlWithOptionalClientCerts(t, c.ServingSQLAddr(), t.Name(),
-				url.UserPassword(tc.username, "a"), false)
+				url.UserPassword(tc.username, "a"), false, "")
 			defer cleanup2()
 
 			_, err := c.RunWithCapture(fmt.Sprintf("userfile upload %s %s --url=%s",

--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -685,7 +685,7 @@ func TestCopyInReleasesLeases(t *testing.T) {
 
 	userURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
 		s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"),
-		false /* withClientCerts */)
+		false /* withClientCerts */, "")
 	defer cleanupFn()
 	conn, err := sqltestutils.PGXConn(t, userURL)
 	require.NoError(t, err)

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -448,6 +448,14 @@ func authCert(
 		}
 		return hook(ctx, systemIdentity, clientConnection)
 	})
+	if len(tlsState.PeerCertificates) > 0 && hbaEntry.GetOption("map") != "" {
+		// The common name in the certificate is set as the system identity in case we have an HBAEntry for db user.
+		commonName, err := username.MakeSQLUsernameFromUserInput(tlsState.PeerCertificates[0].Subject.CommonName, username.PurposeValidation)
+		if err != nil {
+			return nil, err
+		}
+		b.SetReplacementIdentity(commonName)
+	}
 	return b, nil
 }
 

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -474,6 +474,12 @@ func hbaRunTest(t *testing.T, insecure bool) {
 						showSystemIdentity = true
 					}
 
+					certName := ""
+					if td.HasArg("cert_name") {
+						td.ScanArgs(t, "cert_name", &certName)
+						rmArg("cert_name")
+					}
+
 					systemIdentity := user
 					explicitSystemIdentity := td.HasArg("system_identity")
 					if explicitSystemIdentity {
@@ -485,9 +491,8 @@ func hbaRunTest(t *testing.T, insecure bool) {
 					// However, certs are only generated for users "root" and "testuser" specifically.
 					sqlURL, cleanupFn := sqlutils.PGUrlWithOptionalClientCerts(
 						t, s.ServingSQLAddr(), t.Name(), url.User(systemIdentity),
-						forceCerts ||
-							systemIdentity == username.RootUser ||
-							systemIdentity == username.TestUser /* withClientCerts */)
+						forceCerts || systemIdentity == username.RootUser ||
+							systemIdentity == username.TestUser, certName)
 					defer cleanupFn()
 
 					var host, port string
@@ -794,12 +799,12 @@ func TestSSLSessionVar(t *testing.T) {
 	}
 
 	pgURLWithCerts, cleanupFuncCerts := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.ServingSQLAddr(), "TestSSLSessionVarCerts" /* prefix */, url.User(username.TestUser), true,
+		t, s.ServingSQLAddr(), "TestSSLSessionVarCerts" /* prefix */, url.User(username.TestUser), true, "",
 	)
 	defer cleanupFuncCerts()
 
 	pgURLWithoutCerts, cleanupFuncWithoutCerts := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.ServingSQLAddr(), "TestSSLSessionVarNoCerts" /* prefix */, url.UserPassword(username.TestUser, "abc"), false,
+		t, s.ServingSQLAddr(), "TestSSLSessionVarNoCerts" /* prefix */, url.UserPassword(username.TestUser, "abc"), false, "",
 	)
 	defer cleanupFuncWithoutCerts()
 	q := pgURLWithoutCerts.Query()

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -2007,6 +2007,7 @@ func TestPGWireRejectsNewConnIfTooManyConns(t *testing.T) {
 			t.Name(),
 			url.UserPassword(user, user),
 			user == rootUser,
+			"",
 		)
 		defer cleanup()
 		conn, err := pgx.Connect(ctx, pgURL.String())

--- a/pkg/sql/pgwire/testdata/auth/identity_map
+++ b/pkg/sql/pgwire/testdata/auth/identity_map
@@ -131,9 +131,9 @@ subtest end
 # Connect as the magic "testuser" since that comes pre-equipped with a cert.
 subtest certificate_good
 
-connect user=carl database=mydb system_identity=testuser
+connect user=carl database=mydb system_identity=testuser force_certs show_system_identity
 ----
-ok mydb
+ok mydb testuser
 
 authlog 6
 .*client_connection_end
@@ -166,6 +166,26 @@ authlog 6
 38 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
 39 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 40 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+
+subtest end
+
+# Connect with carl is dbuser and pass testuser as cert to be used, dont pass explicit system-identity, so that the
+# system-identity is picked from the cert by auth method.
+subtest certificate_with_user_mapping_no_explicit_system_identity
+
+connect user=carl database=mydb cert_name=testuser force_certs show_system_identity
+----
+ok mydb testuser
+
+authlog 6
+.*client_connection_end
+----
+41 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+42 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+43 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+45 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+46 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+47 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 

--- a/pkg/sql/tests/allow_role_memberships_to_change_during_transaction_test.go
+++ b/pkg/sql/tests/allow_role_memberships_to_change_during_transaction_test.go
@@ -42,7 +42,7 @@ func TestAllowRoleMembershipsToChangeDuringTransaction(t *testing.T) {
 		pgURL, testuserCleanupFunc := sqlutils.PGUrlWithOptionalClientCerts(
 			t, s.ServingSQLAddr(), username,
 			url.UserPassword(username, username),
-			false, /* withClientCerts */
+			false /* withClientCerts */, "",
 		)
 		pgURL.Path = dbName
 		db, err := gosql.Open("postgres", pgURL.String())

--- a/pkg/sql/tests/copy_file_upload_test.go
+++ b/pkg/sql/tests/copy_file_upload_test.go
@@ -280,7 +280,7 @@ func TestNodelocalNotAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	pgURL, cleanupGoDB := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.ServingSQLAddr(), "notAdmin", url.User(smithUser), false, /* withCerts */
+		t, s.ServingSQLAddr(), "notAdmin", url.User(smithUser), false /* withCerts */, "",
 	)
 	defer cleanupGoDB()
 	pgURL.RawQuery = "sslmode=disable"
@@ -322,7 +322,7 @@ func TestUserfileNotAdmin(t *testing.T) {
 	require.NoError(t, err)
 
 	pgURL, cleanupGoDB := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.ServingSQLAddr(), "notAdmin", url.User(smithUser), false, /* withCerts */
+		t, s.ServingSQLAddr(), "notAdmin", url.User(smithUser), false /* withCerts */, "",
 	)
 	defer cleanupGoDB()
 	pgURL.RawQuery = "sslmode=disable"

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -60,8 +60,7 @@ func TestUserLoginAfterGC(t *testing.T) {
 
 	// Verify that newuser can still log in.
 	newUserURL, cleanup := sqlutils.PGUrlWithOptionalClientCerts(
-		t, s.ServingSQLAddr(), t.Name(), url.UserPassword("newuser", "123"), false, /* withClientCerts */
-	)
+		t, s.ServingSQLAddr(), t.Name(), url.UserPassword("newuser", "123"), false /* withClientCerts */, "")
 	defer cleanup()
 
 	newUserConn, err := sqltestutils.PGXConn(t, newUserURL)
@@ -120,10 +119,10 @@ GRANT admin TO foo`); err != nil {
 
 		// We'll attempt connections on gateway node 0.
 		fooURL, fooCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-			s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false, "" /* withClientCerts */)
 		defer fooCleanupFn()
 		barURL, barCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-			s.ServingSQLAddr(), t.Name(), url.UserPassword("bar", "testabc"), false /* withClientCerts */)
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("bar", "testabc"), false, "" /* withClientCerts */)
 		defer barCleanupFn()
 		rootURL, rootCleanupFn := sqlutils.PGUrl(t,
 			s.ServingSQLAddr(), t.Name(), url.User(username.RootUser))


### PR DESCRIPTION
Backport 1/1 commits from #120432.

/cc @cockroachdb/release

---

[ccl, cli,server, sql, testutils: fix IdMap setting + client cert auth](https://github.com/cockroachdb/cockroach/pull/120432/commits/7e1014de0510e72961976ecf0de857f8d725bdb1) 

This update fixes the logic for matching certificate names in the identity map.

In version 22.2, client certificate authentication combined with
auth-username-maps diverged from PostgreSQL's implementation. For instance,
PostgreSQL required the connection string
`postgresql://db_user@localhost:26257?sslcert=certs/client.cert_user.crt&sslkey=certs/client.cert_user.key&sslmode=verify-full&sslrootcert=certs/ca.crt`
for authentication with a certificate issued to CN=cert_user, whereas
CockroachDB 22.2 accepted
`postgresql://cert_user@localhost:26257?sslcert=certs/client.cert_user.crt&sslkey=certs/client.cert_user.key&sslmode=verify-full&sslrootcert=certs/ca.crt`
This discrepancy arose because CockroachDB previously did not check if the
client-provided username was a valid database user, leading to an automatic
overwrite with the mapped database user.

In version 23.1, an attempt to align with PostgreSQL's behavior was made by
verifying that the client-provided username matches at least one of the mappings
for the system identity inferred from the certificate, as detailed in PR
https://github.com/cockroachdb/cockroach/pull/94915. This introduced a backward incompatible change, requiring the
connection string to specify a valid database user while presenting a
certificate issued to CN=cert_user, like so:
`postgresql://db_user@localhost:26257?sslcert=certs/client.cert_user.crt&sslkey=certs/client.cert_user.key&sslmode=verify-full&sslrootcert=certs/ca.crt`
However, this approach failed because we did not correctly extract and use the
CN from the presented certificate as the system identity, preventing successful
authentication.

This commit resolves this issue by implementing the correct logic to extract the
CN from presented certificates and utilize it as the system identity, ensuring
the intended authentication flow works as expected.

Fixes https://github.com/cockroachdb/cockroach/issues/120034 , CRDB-36439

Release note (bug fix): Client Certificate Auth combined with identity
maps(server.identity_map.configuration) was broken in 23.1. This bug is fixed;
note that the feature to work correctly, the client must specify a valid db user
in connection string.

---
Release justification: the fix needs to go in for addressing bug related to the issue
