### PR TITLE
release 24.1: Revert "backupccl: allocate work on index level"

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -114,6 +114,15 @@ func countRows(raw kvpb.BulkOpSummary, pkIDs map[uint64]bool) roachpb.RowCount {
 	return res
 }
 
+// filterSpans returns the spans that represent the set difference
+// (includes - excludes).
+func filterSpans(includes []roachpb.Span, excludes []roachpb.Span) []roachpb.Span {
+	var cov roachpb.SpanGroup
+	cov.Add(includes...)
+	cov.Sub(excludes...)
+	return cov.Slice()
+}
+
 // backup exports a snapshot of every kv entry into ranged sstables.
 //
 // The output is an sstable per range with files in the following locations:
@@ -191,8 +200,8 @@ func backup(
 	}
 
 	// Subtract out any completed spans.
-	spans := roachpb.SubtractSpans(backupManifest.Spans, completedSpans)
-	introducedSpans := roachpb.SubtractSpans(backupManifest.IntroducedSpans, completedIntroducedSpans)
+	spans := filterSpans(backupManifest.Spans, completedSpans)
+	introducedSpans := filterSpans(backupManifest.IntroducedSpans, completedIntroducedSpans)
 
 	pkIDs := make(map[uint64]bool)
 	for i := range backupManifest.Descriptors {
@@ -1154,8 +1163,10 @@ func forEachPublicIndexTableSpan(
 	})
 }
 
-// spansForAllTableIndexes returns the overlappings spans for every index and
-// table passed in.
+// spansForAllTableIndexes returns non-overlapping spans for every index and
+// table passed in. They would normally overlap if any of them are interleaved.
+// Overlapping index spans are merged so as to optimize the size/number of the
+// spans we BACKUP and lay protected ts records for.
 func spansForAllTableIndexes(
 	execCfg *sql.ExecutorConfig,
 	tables []catalog.TableDescriptor,
@@ -1198,12 +1209,17 @@ func spansForAllTableIndexes(
 		return false
 	})
 
+	// Attempt to merge any contiguous spans generated from the tables and revs.
+	// No need to check if the spans are distinct, since some of the merged
+	// indexes may overlap between different revisions of the same descriptor.
+	mergedSpans, _ := roachpb.MergeSpans(&spans)
+
 	knobs := execCfg.BackupRestoreTestingKnobs
 	if knobs != nil && knobs.CaptureResolvedTableDescSpans != nil {
-		knobs.CaptureResolvedTableDescSpans(spans)
+		knobs.CaptureResolvedTableDescSpans(mergedSpans)
 	}
 
-	return spans, nil
+	return mergedSpans, nil
 }
 
 func getScheduledBackupExecutionArgsFromSchedule(
@@ -1611,11 +1627,11 @@ func createBackupManifest(
 	spans = append(spans, tenantSpans...)
 	tenants = append(tenants, tenantInfos...)
 
-	tableIndexSpans, err := spansForAllTableIndexes(execCfg, tables, revs)
+	tableSpans, err := spansForAllTableIndexes(execCfg, tables, revs)
 	if err != nil {
 		return backuppb.BackupManifest{}, err
 	}
-	spans = append(spans, tableIndexSpans...)
+	spans = append(spans, tableSpans...)
 
 	if len(prevBackups) > 0 {
 		tablesInPrev := make(map[descpb.ID]struct{})
@@ -1649,7 +1665,7 @@ func createBackupManifest(
 			}
 		}
 
-		newSpans = roachpb.SubtractSpans(spans, prevBackups[len(prevBackups)-1].Spans)
+		newSpans = filterSpans(spans, prevBackups[len(prevBackups)-1].Spans)
 	}
 
 	// if CompleteDbs is lost by a 1.x node, FormatDescriptorTrackingVersion

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -57,13 +57,13 @@ func distBackupPlanSpecs(
 	var introducedSpanPartitions []sql.SpanPartition
 	var err error
 	if len(spans) > 0 {
-		spanPartitions, err = dsp.PartitionSpansWithoutMerging(ctx, planCtx, spans)
+		spanPartitions, err = dsp.PartitionSpans(ctx, planCtx, spans)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if len(introducedSpans) > 0 {
-		introducedSpanPartitions, err = dsp.PartitionSpansWithoutMerging(ctx, planCtx, introducedSpans)
+		introducedSpanPartitions, err = dsp.PartitionSpans(ctx, planCtx, introducedSpans)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -539,7 +539,7 @@ func TestBackupManifestFileCount(t *testing.T) {
 	const numAccounts = 1000
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
-	sqlDB.Exec(t, "BACKUP DATABASE data INTO 'userfile:///backup'")
+	sqlDB.Exec(t, "BACKUP INTO 'userfile:///backup'")
 	rows := sqlDB.QueryRow(t, "SELECT count(distinct(path)) FROM [SHOW BACKUP FILES FROM LATEST IN 'userfile:///backup']")
 	var count int
 	rows.Scan(&count)
@@ -6290,7 +6290,7 @@ func TestPublicIndexTableSpans(t *testing.T) {
 			pkIndex:             getMockIndexDesc(1),
 			indexes:             []descpb.IndexDescriptor{getMockIndexDesc(1), getMockIndexDesc(2)},
 			expectedSpans:       []string{"/Table/55/{1-2}", "/Table/55/{2-3}"},
-			expectedMergedSpans: []string{"/Table/55/{1-2}", "/Table/55/{2-3}"},
+			expectedMergedSpans: []string{"/Table/55/{1-3}"},
 		},
 		{
 			name:                "dropped-span-between-two-spans",
@@ -6356,7 +6356,7 @@ func TestPublicIndexTableSpans(t *testing.T) {
 			},
 			addingIndexes:       []descpb.IndexDescriptor{getMockIndexDesc(2)},
 			expectedSpans:       []string{"/Table/61/{1-2}", "/Table/61/{3-4}", "/Table/61/{4-5}"},
-			expectedMergedSpans: []string{"/Table/61/{1-2}", "/Table/61/{3-4}", "/Table/61/{4-5}"},
+			expectedMergedSpans: []string{"/Table/61/{1-2}", "/Table/61/{3-5}"},
 		},
 	}
 
@@ -8913,7 +8913,18 @@ func TestBackupOnlyPublicIndexes(t *testing.T) {
 		inc3Loc, fullBackup, inc1Loc, inc2Loc)
 	inc3Spans := getSpansFromManifest(ctx, t, locationToDir(inc3Loc))
 	require.Equal(t, 1, len(inc3Spans))
-	require.Regexp(t, fmt.Sprintf(".*/Table/%d/{2-3}", dataBankTableID), inc3Spans[0].String())
+	// NB: When running in a tenant, we don't add a split point
+	// for an index. As a result, we end up issuing a single
+	// export request for /Table/*/1-3 and while /Table/*/1-2 has
+	// no data in it, the start key is based on the start key of
+	// our request.
+	// TODO(ssd): figure out why enabling SCATTER setting in #109449 changed the
+	// span in the default test tenant case.
+	if tc.StartedDefaultTestTenant() {
+		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{1/900-3}", dataBankTableID), inc3Spans[0].String())
+	} else {
+		require.Regexp(t, fmt.Sprintf(".*/Table/%d/{2-3}", dataBankTableID), inc3Spans[0].String())
+	}
 
 	// Drop the index.
 	sqlDB.Exec(t, `DROP INDEX new_balance_idx`)

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -94,7 +94,7 @@ var WriteMetadataSST = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.bulkio.write_metadata_sst.enabled",
 	"write experimental new format BACKUP metadata file",
-	false,
+	util.ConstantWithMetamorphicTestBool("write-metadata-sst", false),
 )
 
 // WriteMetadataWithExternalSSTsEnabled controls if we write a `BACKUP_METADATA`

--- a/pkg/ccl/backupccl/backuprand/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backuprand/backup_rand_test.go
@@ -166,7 +166,9 @@ database_name = 'rand' AND schema_name = 'public'`)
 	withOnlineRestore := func() string {
 		onlineRestoreExtension := ""
 		if rng.Intn(2) != 0 {
-			onlineRestoreExtension = ", experimental deferred copy"
+			// TODO(msbutler): once this test is deflaked, add back the online restore
+			// variant of this test.
+			onlineRestoreExtension = ""
 		}
 		return onlineRestoreExtension
 	}


### PR DESCRIPTION
This reverts commit 3f09ffe150939a69599078253a081003dc39a843

Epic: none

Release note: none

Release justification: reverts a commit that causes data corruption in backup-restore