### PR TITLE
opt: add comments for new trigram similarity rule

### DIFF
--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -231,6 +231,13 @@ func TryFilterInvertedIndexBySimilarity(
 	// First, we attempt to build a constraint from a similarity filter on the
 	// inverted column. We search for expressions of the form `s % 'foo'` or
 	// `'foo' % s`, where s is the indexed column.
+	//
+	// TODO(mgartner): Currently we only look for the first similarity filter.
+	// We could improve query plans in some cases by looking for multiple
+	// similarity filters and picking the one that requires the fewest trigrams
+	// to be scanned, or by building a constrained scan for each similarity
+	// filter and letting the optimizer determine the lowest cost trigrams to
+	// scan.
 	var con *constraint.Constraint
 	for i := range filters {
 		sim, isSim := filters[i].Condition.(*memo.ModExpr)

--- a/pkg/sql/opt/xform/testdata/rules/generate_trigram_similarity_inverted_index_scans
+++ b/pkg/sql/opt/xform/testdata/rules/generate_trigram_similarity_inverted_index_scans
@@ -10,6 +10,8 @@ CREATE TABLE trgm (
 )
 ----
 
+# A single trigram similarity filter can constrain an inverted index. This test
+# projects just the PK column.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT k FROM trgm WHERE s % 'foo'
 ----
@@ -39,6 +41,8 @@ project
       └── filters
            └── s:4 % 'foo' [outer=(4), stable]
 
+# A single trigram similarity filter can constrain an inverted index. This test
+# projects all columns.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE s % 'foo'
 ----
@@ -64,6 +68,7 @@ select
  └── filters
       └── s:4 % 'foo' [outer=(4), stable]
 
+# When the threshold is set to 1, only one trigram needs to be scanned.
 # TODO(#122225): The distinct-on expression is not necessary because a single
 # value is scanned, so the primary key is already unique in the scan.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans set=(pg_trgm.similarity_threshold=1)
@@ -88,6 +93,7 @@ select
  └── filters
       └── s:4 % 'foo' [outer=(4), stable]
 
+# The RHS of the triage similarity filter can be a non-STRING type.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE s % 'foo'::NAME
 ----
@@ -113,6 +119,7 @@ select
  └── filters
       └── s:4 % 'foo' [outer=(4), stable]
 
+# The filter can be commuted to constrain the index.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE 'foo' % s
 ----
@@ -138,6 +145,8 @@ select
  └── filters
       └── 'foo' % s:4 [outer=(4), stable]
 
+# Conjunctions are naively supported by scanning just the trigrams from one of
+# the conjucts.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE s % 'foo' AND s % 'bar'
 ----
@@ -164,6 +173,8 @@ select
       ├── s:4 % 'foo' [outer=(4), stable]
       └── s:4 % 'bar' [outer=(4), stable]
 
+# A trigram similarity filter with a longer constant string can constrain an
+# inverted index.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE s % 'foobar'
 ----
@@ -191,6 +202,8 @@ select
  └── filters
       └── s:4 % 'foobar' [outer=(4), stable]
 
+# A multi-column inverted index can be constrained by a trigram similarity
+# filter. Optional filters constrain the first column.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE j = 10 AND s % 'foo'
 ----
@@ -222,6 +235,8 @@ select
  └── filters
       └── s:4 % 'foo' [outer=(4), stable]
 
+# A multi-column inverted index can be constrained by a trigram similarity
+# filter. The second column is constrained by an IN expression.
 opt expect=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE j IN (10, 20) AND s % 'foo'
 ----
@@ -262,6 +277,7 @@ select
  └── filters
       └── s:4 % 'foo' [outer=(4), stable]
 
+# The RHS cannot be NULL.
 opt expect-not=GenerateTrigramSimilarityInvertedIndexScans disable=(FoldNullBinaryRight) format=show-scalars
 SELECT * FROM trgm WHERE s % NULL::STRING
 ----
@@ -286,6 +302,7 @@ select
            ├── variable: s:4
            └── null
 
+# Do not explore this rule if the threshold is 0.
 opt expect-not=GenerateTrigramSimilarityInvertedIndexScans set=(pg_trgm.similarity_threshold=0)
 SELECT * FROM trgm WHERE s % 'foo'
 ----
@@ -303,6 +320,7 @@ select
  └── filters
       └── s:4 % 'foo' [outer=(4), stable]
 
+# The RHS cannot be the empty string.
 opt expect-not=GenerateTrigramSimilarityInvertedIndexScans
 SELECT * FROM trgm WHERE s % ''
 ----
@@ -320,6 +338,7 @@ select
  └── filters
       └── s:4 % '' [outer=(4), stable]
 
+# The corresponding session setting must be enabled.
 opt expect-not=GenerateTrigramSimilarityInvertedIndexScans set=(optimizer_use_trigram_similarity_optimization=off) format=hide-all
 SELECT k FROM trgm WHERE s % 'foo'
 ----


### PR DESCRIPTION
This commit adds a few comments to explain the test cases for the new
trigram similarity rule, `GenerateTrigramSimilarityInvertedIndexScans`.
It also adds a TODO explaining an improvement for the rule.

Epic: None

Release note: None
