### PR TITLE
jobs: add TestingRegisterConstructor

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5909,12 +5909,12 @@ func TestBatchedInsertStats(t *testing.T) {
 
 	unblockCh := make(chan struct{})
 	doneCh := make(chan struct{})
-	jobs.RegisterConstructor(jobspb.TypeRestore, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+	defer jobs.TestingRegisterConstructor(jobspb.TypeRestore, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return &fakeResumer{
 			unblockCh: unblockCh,
 			doneCh:    doneCh,
 		}
-	}, jobs.UsesTenantCostControl)
+	}, jobs.UsesTenantCostControl)()
 	params := base.TestServerArgs{Knobs: base.TestingKnobs{
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}}

--- a/pkg/cli/debug_job_trace_test.go
+++ b/pkg/cli/debug_job_trace_test.go
@@ -97,7 +97,7 @@ func TestDebugJobTrace(t *testing.T) {
 	defer close(completeResumerCh)
 	defer close(recordedSpanCh)
 
-	jobs.RegisterConstructor(
+	defer jobs.TestingRegisterConstructor(
 		jobspb.TypeBackup,
 		func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 			return &traceSpanResumer{
@@ -107,7 +107,7 @@ func TestDebugJobTrace(t *testing.T) {
 			}
 		},
 		jobs.UsesTenantCostControl,
-	)
+	)()
 
 	// Create a "backup job" but we have overridden the resumer constructor above
 	// to inject our traceSpanResumer.

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -929,7 +929,7 @@ func TestZipJobTrace(t *testing.T) {
 	})
 	defer s.Stopper().Stop(context.Background())
 	blockCh := make(chan struct{})
-	jobs.RegisterConstructor(jobspb.TypeImport,
+	defer jobs.TestingRegisterConstructor(jobspb.TypeImport,
 		func(j *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 			return jobstest.FakeResumer{
 				OnResume: func(ctx context.Context) error {
@@ -937,7 +937,7 @@ func TestZipJobTrace(t *testing.T) {
 					return nil
 				},
 			}
-		}, jobs.UsesTenantCostControl)
+		}, jobs.UsesTenantCostControl)()
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()

--- a/pkg/jobs/delegate_control_test.go
+++ b/pkg/jobs/delegate_control_test.go
@@ -158,14 +158,14 @@ func TestJobsControlForSchedules(t *testing.T) {
 	// Our resume never completes any jobs, until this test completes.
 	// As such, the job does not undergo usual job state transitions
 	// (e.g. pause-request -> paused).
-	RegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
+	defer TestingRegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
 		return jobstest.FakeResumer{
 			OnResume: func(_ context.Context) error {
 				<-blockResume
 				return nil
 			},
 		}
-	}, UsesTenantCostControl)
+	}, UsesTenantCostControl)()
 
 	record := Record{
 		Description: "fake job",
@@ -272,14 +272,14 @@ func TestFilterJobsControlForSchedules(t *testing.T) {
 	defer close(blockResume)
 
 	// Our resume never completes any jobs, until this test completes.
-	RegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
+	defer TestingRegisterConstructor(jobspb.TypeImport, func(job *Job, _ *cluster.Settings) Resumer {
 		return jobstest.FakeResumer{
 			OnResume: func(_ context.Context) error {
 				<-blockResume
 				return nil
 			},
 		}
-	}, UsesTenantCostControl)
+	}, UsesTenantCostControl)()
 
 	record := Record{
 		Description: "fake job",
@@ -405,14 +405,14 @@ func TestJobControlByType(t *testing.T) {
 
 	// Make the jobs of each type controllable.
 	for _, jobType := range allJobTypes {
-		RegisterConstructor(jobType, func(job *Job, _ *cluster.Settings) Resumer {
+		defer TestingRegisterConstructor(jobType, func(job *Job, _ *cluster.Settings) Resumer {
 			return jobstest.FakeResumer{
 				OnResume: func(ctx context.Context) error {
 					<-ctx.Done()
 					return nil
 				},
 			}
-		}, UsesTenantCostControl)
+		}, UsesTenantCostControl)()
 	}
 
 	for _, jobType := range allJobTypes {

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -372,9 +372,9 @@ func TestGCDurationControl(t *testing.T) {
 		},
 	}
 
-	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, cs *cluster.Settings) jobs.Resumer {
+	defer jobs.TestingRegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, cs *cluster.Settings) jobs.Resumer {
 		return jobstest.FakeResumer{}
-	}, jobs.UsesTenantCostControl)
+	}, jobs.UsesTenantCostControl)()
 	s, sqlDB, _ := serverutils.StartServer(t, args)
 	defer s.Stopper().Stop(ctx)
 	registry := s.JobRegistry().(*jobs.Registry)
@@ -437,7 +437,7 @@ func TestErrorsPopulatedOnRetry(t *testing.T) {
 		return event{id: j.ID(), resume: make(chan error)}
 	}
 	evChan := make(chan event)
-	jobs.RegisterConstructor(jobspb.TypeImport, func(j *jobs.Job, cs *cluster.Settings) jobs.Resumer {
+	defer jobs.TestingRegisterConstructor(jobspb.TypeImport, func(j *jobs.Job, cs *cluster.Settings) jobs.Resumer {
 		execFn := func(ctx context.Context) error {
 			ev := mkEvent(j)
 			select {
@@ -456,7 +456,7 @@ func TestErrorsPopulatedOnRetry(t *testing.T) {
 			OnResume:     execFn,
 			FailOrCancel: execFn,
 		}
-	}, jobs.UsesTenantCostControl)
+	}, jobs.UsesTenantCostControl)()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -771,9 +771,9 @@ func TestWaitWithRetryableError(t *testing.T) {
 		},
 	}
 
-	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, cs *cluster.Settings) jobs.Resumer {
+	defer jobs.TestingRegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, cs *cluster.Settings) jobs.Resumer {
 		return jobstest.FakeResumer{}
-	}, jobs.UsesTenantCostControl)
+	}, jobs.UsesTenantCostControl)()
 	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(ctx)
 	ts := s.ApplicationLayer()

--- a/pkg/server/job_profiler_test.go
+++ b/pkg/server/job_profiler_test.go
@@ -74,7 +74,7 @@ func TestJobExecutionDetailsRouting(t *testing.T) {
 	hasStartedCh := make(chan struct{})
 	defer close(hasStartedCh)
 	canContinueCh := make(chan struct{})
-	jobs.RegisterConstructor(jobspb.TypeImport, func(j *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+	defer jobs.TestingRegisterConstructor(jobspb.TypeImport, func(j *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return fakeExecResumer{
 			OnResume: func(ctx context.Context) error {
 				hasStartedCh <- struct{}{}
@@ -82,7 +82,7 @@ func TestJobExecutionDetailsRouting(t *testing.T) {
 				return nil
 			},
 		}
-	}, jobs.UsesTenantCostControl)
+	}, jobs.UsesTenantCostControl)()
 	defer jobs.ResetConstructors()()
 
 	dialedNodeID := roachpb.NodeID(-1)

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5224,7 +5224,7 @@ func TestImportControlJobRBAC(t *testing.T) {
 	done := make(chan struct{})
 	defer close(done)
 
-	jobs.RegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+	defer jobs.TestingRegisterConstructor(jobspb.TypeImport, func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return fakeResumer{
 			OnResume: func(ctx context.Context) error {
 				<-done
@@ -5235,7 +5235,7 @@ func TestImportControlJobRBAC(t *testing.T) {
 				return nil
 			},
 		}
-	}, jobs.UsesTenantCostControl)
+	}, jobs.UsesTenantCostControl)()
 
 	startLeasedJob := func(t *testing.T, record jobs.Record) *jobs.StartableJob {
 		job, err := jobs.TestingCreateAndStartJob(


### PR DESCRIPTION
The constructor registry is global. Previously, many tests would leave the global test registry modified. Typically this doesn't cause a problem, but in at least one case we were replacing the schema change resumer, which prevented a subsequent test from running CREATE USER.

Epic: none

Release note: None