### PR TITLE
observability: add message_type label to grafana charts

### DIFF
--- a/pkg/cmd/roachprod/grafana/configs/changefeeds.json
+++ b/pkg/cmd/roachprod/grafana/configs/changefeeds.json
@@ -260,9 +260,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(changefeed_emitted_messages{job=\"cockroachdb\",cluster=\"$cluster\",instance=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum by (message_type) (rate(changefeed_emitted_messages{job=\"cockroachdb\",cluster=\"$cluster\",instance=~\"$node\", scope!=\"\"}[$__rate_interval]))",
           "interval": "",
-          "legendFormat": "Messages",
+          "legendFormat": "Messages ({{message_type}})",
           "refId": "B"
         },
         {
@@ -361,9 +361,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(rate(changefeed_emitted_messages{job=\"cockroachdb\",cluster=\"$cluster\",instance=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum by (message_type) (rate(changefeed_emitted_messages{job=\"cockroachdb\",cluster=\"$cluster\",instance=~\"$node\",scope!=\"\"}[$__rate_interval]))",
           "interval": "",
-          "legendFormat": "Message Emit Time",
+          "legendFormat": "Message Emit Time ({{message_type}})",
           "refId": "B"
         },
         {

--- a/pkg/cmd/roachtest/grafana/configs/changefeed-roachtest-grafana-dashboard.json
+++ b/pkg/cmd/roachtest/grafana/configs/changefeed-roachtest-grafana-dashboard.json
@@ -520,8 +520,8 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "sum by (scope) (rate(changefeed_emitted_messages{scope!=\"\"}[$__rate_interval]))",
-          "legendFormat": "__auto",
+          "expr": "sum by (scope, message_type) (rate(changefeed_emitted_messages{scope!=\"\"}[$__rate_interval]))",
+          "legendFormat": "scope={{scope}}, type={{message_type}}",
           "range": true,
           "refId": "A"
         }
@@ -766,9 +766,9 @@
             "uid": "localprom"
           },
           "editorMode": "code",
-          "expr": "sum by(node) (rate(changefeed_emitted_messages{scope!=\"\"}[$__rate_interval]))",
+          "expr": "sum by(node, message_type) (rate(changefeed_emitted_messages{scope!=\"\"}[$__rate_interval]))",
           "hide": false,
-          "legendFormat": "node={{node}}",
+          "legendFormat": "node={{node}}, type={{message_type}}",
           "range": true,
           "refId": "B"
         }


### PR DESCRIPTION
Add a breakdown by the new `message_type` label to
uses of the `changfeed_emitted_rows` metric in
grafana dashboards.

Resolves: #122800

Release note (ops change): Modified the default grafana dashboards to
include a breakdown by message type for the changefeed emitted-rows metric.