### PR TITLE
sql: fix bug where row-based engine could drop LIMIT with partial sort

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -362,3 +362,22 @@ SELECT oid::INT, typname FROM pg_type ORDER BY oid LIMIT 3
 # Regression test for limit hint overflowing int64 range and becoming negative.
 statement ok
 SELECT * FROM t65171 WHERE x = 1 OFFSET 1 LIMIT 9223372036854775807
+
+# Regression test for #122748. Do not drop the limit in the row-based engine when
+# a partial sort is needed.
+statement ok
+CREATE TABLE t122748 (a int, b int, INDEX t_b_idx (b ASC) STORING (a));
+INSERT INTO t122748 VALUES
+  (1, 2),
+  (3, 4),
+  (5, 6)
+
+query I
+SELECT count(*) AS col1
+FROM t122748
+GROUP BY a, b
+ORDER BY b, a DESC
+LIMIT 2
+----
+1
+1

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -164,6 +164,9 @@ func newSorter(
 		// O(n*log(k)) and a worst-case space complexity of O(k).
 		return newSortTopKProcessor(ctx, flowCtx, processorID, spec, input, post, uint64(spec.Limit))
 	}
+	if spec.Limit != 0 && (post.Limit == 0 || post.Limit > uint64(spec.Limit)) {
+		post.Limit = uint64(spec.Limit)
+	}
 	// Ordering match length is specified. We will be able to use existing
 	// ordering in order to avoid loading all the rows into memory. If we're
 	// scanning an index with a prefix matching an ordering prefix, we can only


### PR DESCRIPTION
Fixes #122748

Release note (bug fix): Fixed an issue where the row-based execution engine could drop a `LIMIT` clause when there was an `ORDER BY` clause, and the ordering was partially provided by an input operator. For example, this bug could occur with an ordering such as `ORDER BY a, b` when the scanned index was only ordered on column `a`. The impact of this bug was that more rows may have been returned than specified by the `LIMIT` clause. This bug is only present when not using the vectorized execution engine, i.e., when running with `SET vectorize = off;`. The bug has existed since CockroachDB version 22.1.