### PR TITLE
changefeedccl: skip TestChangefeedWithSimpleDistributionStrategy

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -501,6 +501,7 @@ func TestChangefeedWithSimpleDistributionStrategy(t *testing.T) {
 	// The test is slow and will time out under deadlock/race/stress.
 	skip.UnderShort(t)
 	skip.UnderDuress(t)
+	skip.WithIssue(t, 121408)
 
 	noLocality := func(i int) []roachpb.Tier {
 		return make([]roachpb.Tier, 0)


### PR DESCRIPTION
This patch TestChangefeedWithSimpleDistributionStrategy since it is still flaky.

Epic: none
Release note: none