### PR TITLE
backupccl: copy spans before SubtractSpans calls

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -191,8 +191,8 @@ func backup(
 	}
 
 	// Subtract out any completed spans.
-	spans := roachpb.SubtractSpans(backupManifest.Spans, completedSpans)
-	introducedSpans := roachpb.SubtractSpans(backupManifest.IntroducedSpans, completedIntroducedSpans)
+	spans := roachpb.SubtractSpansWithCopy(backupManifest.Spans, completedSpans)
+	introducedSpans := roachpb.SubtractSpansWithCopy(backupManifest.IntroducedSpans, completedIntroducedSpans)
 
 	pkIDs := make(map[uint64]bool)
 	for i := range backupManifest.Descriptors {
@@ -1649,7 +1649,7 @@ func createBackupManifest(
 			}
 		}
 
-		newSpans = roachpb.SubtractSpans(spans, prevBackups[len(prevBackups)-1].Spans)
+		newSpans = roachpb.SubtractSpansWithCopy(spans, prevBackups[len(prevBackups)-1].Spans)
 	}
 
 	// if CompleteDbs is lost by a 1.x node, FormatDescriptorTrackingVersion

--- a/pkg/roachpb/merge_spans.go
+++ b/pkg/roachpb/merge_spans.go
@@ -101,6 +101,16 @@ func MergeSpans(spans *[]Span) ([]Span, bool) {
 	return r, distinct
 }
 
+// SubtractSpansWithCopy is the same thing as Subtract spans, but copies the
+// todo span first so it can be used after this function call.
+func SubtractSpansWithCopy(todo, done Spans) Spans {
+	newTodo := make(Spans, 0, len(todo))
+	for i := range todo {
+		newTodo = append(newTodo, todo[i].Clone())
+	}
+	return SubtractSpans(newTodo, done)
+}
+
 // SubtractSpans subtracts the subspans covered by a set of non-overlapping
 // spans from another set of non-overlapping spans.
 //


### PR DESCRIPTION
Previously, backup assumed arguments to roachpb.SubtractSpans could be used, but the first arg is modified in place. This patch adds a wrapper to roachpb.SubtractSpans to copy the input spans before use.

Informs #122672
Informs #122734
Informs #122754
Informs #122764

Release note: none