### PR TITLE
kvserver: opt manual splits out of estimated MVCC stats

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5832,11 +5832,7 @@ func TestRaftSnapshotsWithMVCCRangeKeys(t *testing.T) {
 		require.Len(t, ccResp.Result, 1)
 		result := ccResp.Result[0]
 		require.Equal(t, desc.RangeID, result.RangeID)
-		if kvserver.EnableEstimatedMVCCStatsInSplit.Get(&ts.ClusterSettings().SV) {
-			require.Equal(t, kvpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_ESTIMATED, result.Status, "%+v", result)
-		} else {
-			require.Equal(t, kvpb.CheckConsistencyResponse_RANGE_CONSISTENT, result.Status, "%+v", result)
-		}
+		require.Equal(t, kvpb.CheckConsistencyResponse_RANGE_CONSISTENT, result.Status, "%+v", result)
 	}
 
 	checkConsistency(descA)

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -815,7 +815,9 @@ func TestStoreRangeSplitMergeStats(t *testing.T) {
 	require.Equal(t, repl.GetMVCCStats(), ms, "in-memory and on-disk stats diverge")
 
 	// Split the range at approximate halfway point.
-	_, pErr = kv.SendWrapped(ctx, store.TestSender(), adminSplitArgs(splitKey))
+	// Call AdminSplit on the replica directly so that we can pass a
+	// reason. Splits with reason "manual" bypass estimated stats.
+	_, pErr = repl.AdminSplit(ctx, *adminSplitArgs(splitKey), "test")
 	require.NoError(t, pErr.GoError())
 
 	snap = store.TODOEngine().NewSnapshot()
@@ -977,7 +979,9 @@ func TestStoreRangeSplitWithConcurrentWrites(t *testing.T) {
 					// Split the range.
 					g := ctxgroup.WithContext(ctx)
 					g.GoCtx(func(ctx context.Context) error {
-						_, pErr = kv.SendWrapped(ctx, store.TestSender(), adminSplitArgs(splitKey))
+						// Call AdminSplit on the replica directly so that we can pass a
+						// reason. Splits with reason "manual" bypass estimated stats.
+						_, pErr := lhsRepl.AdminSplit(ctx, *adminSplitArgs(splitKey), "test")
 						return pErr.GoError()
 					})
 
@@ -1024,12 +1028,12 @@ func TestStoreRangeSplitWithConcurrentWrites(t *testing.T) {
 					splitKeyLeft := roachpb.Key("aa")
 					splitKeyLeftAddr, err := keys.Addr(splitKeyLeft)
 					require.NoError(t, err)
-					_, pErr = kv.SendWrapped(ctx, store.TestSender(), adminSplitArgs(splitKeyLeft))
+					_, pErr = lhsRepl.AdminSplit(ctx, *adminSplitArgs(splitKeyLeft), "test")
 					require.NoError(t, pErr.GoError())
 					splitKeyRight := roachpb.Key("bb")
 					splitKeyRightAddr, err := keys.Addr(splitKeyRight)
 					require.NoError(t, err)
-					_, pErr = kv.SendWrapped(ctx, store.TestSender(), adminSplitArgs(splitKeyRight))
+					_, pErr = rhsRepl.AdminSplit(ctx, *adminSplitArgs(splitKeyRight), "test")
 					require.NoError(t, pErr.GoError())
 
 					snap = store.TODOEngine().NewSnapshot()
@@ -1187,9 +1191,10 @@ func TestStoreRangeSplitWithTracing(t *testing.T) {
 
 // TestStoreRangeSplitWithMismatchedDesc ensures that if a RecomputeRequest
 // during a split fails due to a range descriptor mismatch, the split doesn't
-// return an error to the client.
+// return a non-retryable error, which can be surfaced to the client.
 // The test works by splitting a range and concurrently subsuming that range via
-// a range merge. The split doesn't return an error to the client.
+// a range merge. The split returns a RangeNotFoundError, which will be retried
+// by the DistSender.
 func TestStoreRangeSplitWithMismatchedDesc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1243,17 +1248,20 @@ func TestStoreRangeSplitWithMismatchedDesc(t *testing.T) {
 	_, pErr = kv.SendWrapped(ctx, store.TestSender(), putArgs([]byte("d"), []byte("bar")))
 	require.NoError(t, pErr.GoError())
 
+	lhsRepl := store.LookupReplica(roachpb.RKey("a"))
 	// Split the range at "b".
-	_, pErr = kv.SendWrapped(ctx, store.TestSender(), adminSplitArgs(roachpb.Key("b")))
+	_, pErr = lhsRepl.AdminSplit(ctx, *adminSplitArgs(roachpb.Key("b")), "test")
 	require.NoError(t, pErr.GoError())
 
+	rhsRepl := store.LookupReplica(roachpb.RKey("b"))
 	// Split the new RHS at "c". This split will be blocked by the above filter
 	// because the range we're splitting starts at key "b".
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
 		// Use AdminSplit with a non-test sender here to reproduce exactly what will
 		// be returned to the client.
-		return store.DB().AdminSplit(ctx, roachpb.Key("c"), hlc.MaxTimestamp)
+		_, pErr = rhsRepl.AdminSplit(ctx, *adminSplitArgs(roachpb.Key("c")), "test")
+		return pErr.GoError()
 	})
 
 	// Wait until split is underway.
@@ -1266,11 +1274,11 @@ func TestStoreRangeSplitWithMismatchedDesc(t *testing.T) {
 	// Unblock the split.
 	splitBlocked <- struct{}{}
 
-	// Wait for the split to complete and ensure no error is returned to the client.
-	// The split will hit a benign error because the range descriptor changed, and
-	// will be retried. The second time around, the split is a no-op because the
-	// range "b" - "d" was subsumed.
-	require.Nil(t, g.Wait())
+	// Wait for the split to complete and ensure a RangeNotFoundError is returned.
+	// The split will hit a benign error because the range descriptor changed.
+	// The DistSender will retry the RangeNotFoundError. The second time around,
+	// the split is a no-op because the range "b" - "d" was subsumed.
+	require.IsType(t, &kvpb.RangeNotFoundError{}, g.Wait())
 }
 
 // RaftMessageHandlerInterceptor wraps a storage.IncomingRaftMessageHandler. It
@@ -1407,10 +1415,9 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	midKey := writeRandomTimeSeriesDataToRange(t, store, repl.RangeID, keyPrefix)
 
 	// Split the range at approximate halfway point.
-	args = adminSplitArgs(midKey)
-	_, pErr = kv.SendWrappedWith(ctx, store.TestSender(), kvpb.Header{
-		RangeID: repl.RangeID,
-	}, args)
+	// Call AdminSplit on the replica directly so that we can pass a
+	// reason. Splits with reason "manual" bypass estimated stats.
+	_, pErr = repl.AdminSplit(ctx, *adminSplitArgs(midKey), "test")
 	require.NoError(t, pErr.GoError())
 
 	snap := store.TODOEngine().NewSnapshot()

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -506,6 +506,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	var totalStats enginepb.MVCCStats
 	if EnableEstimatedMVCCStatsInSplit.Get(&r.store.ClusterSettings().SV) &&
 		r.ClusterSettings().Version.IsActive(ctx, clusterversion.V24_1_EstimatedMVCCStatsInSplit) &&
+		reason != manualAdminReason &&
 		!useEstimatedStatsForExternalBytes {
 		// If the stats contain estimates, re-compute them to prevent estimates
 		// from compounding across splits. See makeEstimatedSplitStatsHelper for more


### PR DESCRIPTION
Manual splits issued via AdminSplit are used in bulk operations, like import, and tests to split many ranges out of the same original range. Pre-computing the LHS user stats for each of these ranges concurrently causes CPU spikes and split slowness; issuing repeated RecomputeStats requests for the same range contributes even more and can cause contention on the range descriptor.

Estimating MVCC stats during a split is an improvement targeted at size-based splits, so in this patch we revert the manual-split behavior back to computing accurate MVCC stats.

Fixes: #122309

Release note: None