### PR TITLE
release-23.1.20-rc: opt: fix costing of DistinctOn with limit hint

### DIFF
--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1394,7 +1394,9 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 			outputRowCount = math.Min(outputRowCount, required.LimitHint)
 		} else if grouping.Op() == opt.DistinctOnOp &&
 			c.evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting {
-			inputRowCount = distinctOnLimitHint(outputRowCount, required.LimitHint)
+			if d := distinctOnLimitHint(outputRowCount, required.LimitHint); d > 0 {
+				inputRowCount = d
+			}
 			outputRowCount = math.Min(outputRowCount, required.LimitHint)
 		}
 	}

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -233,6 +233,9 @@ func BuildChildPhysicalProps(
 // As a result, cases where this limit hint may be poor (too low or more than
 // twice as high as needed) tend to occur when distinctCount is very close to
 // neededRows.
+//
+// TODO(mgartner): This function should probably consider the input row count in
+// order to make more accurate estimates. See streamingGroupByInputLimitHint.
 func distinctOnLimitHint(distinctCount, neededRows float64) float64 {
 	// The harmonic function below is not intended for values under 1 (for one,
 	// it's not monotonic until 0.5); make sure we never return negative results.


### PR DESCRIPTION
Backport 1/1 commits from #122729.

/cc @cockroachdb/release

---

A minor bug has been fixed that affected the costing of DistinctOn
expressions with limit hints. Previously, a hash DistinctOn would have
no additional cost for the overhead of the hash table when
`distinctOnLimitHint` returned zero. As a result, hash DistinctOn
expressions were incorrectly preferred over streaming DistinctOn
expressions in some cases.

Epic: CRDB-37714

Release note: None

---

Release justification: Performance improvements gated behind a
session setting.

