### PR TITLE
roachtest: use livebytes metric for disagg-rebalance

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -120,8 +120,7 @@ func registerDisaggRebalance(r registry.Registry) {
 
 			var bytesInRanges int64
 			if err := db.QueryRow(
-				"SELECT sum(used) "+
-					"FROM crdb_internal.kv_store_status WHERE node_id = $1 GROUP BY node_id LIMIT 1",
+				"SELECT metrics['livebytes']::INT FROM crdb_internal.kv_store_status WHERE node_id = $1 LIMIT 1",
 				4,
 			).Scan(&bytesInRanges); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Previously we summed the `used` bytes in the store's info to get a sense of how many bytes there were in the store in total. If we received more data in snapshots than this, we'd fail the disagg-rebalance roachtest. This was slightly incorrect and led to flakes, as used bytes are post-compression bytes.

This change fixes this by using live bytes instead, which should be a more accurate, pre-compression accounting of bytes in this roachtest.

Fixes #122483.

Epic: none

Release note: None