### PR TITLE
changefeed: add option to differentiate JSON nulls and SQL nulls

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -193,6 +193,7 @@ go_test(
         "changefeed_dist_test.go",
         "changefeed_test.go",
         "csv_test.go",
+        "encoder_json_test.go",
         "encoder_test.go",
         "event_processing_test.go",
         "helpers_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1170,7 +1170,7 @@ func newChangeFrontierProcessor(
 	}
 
 	if cf.encoder, err = getEncoder(
-		encodingOpts, AllTargets(spec.Feed), spec.Feed.Select != "",
+		ctx, encodingOpts, AllTargets(spec.Feed), spec.Feed.Select != "",
 		makeExternalConnectionProvider(ctx, flowCtx.Cfg.DB), sliMertics,
 	); err != nil {
 		return nil, err

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -583,7 +583,7 @@ func createChangefeedJobRecord(
 	if err != nil {
 		return nil, err
 	}
-	if _, err := getEncoder(encodingOpts, AllTargets(details), details.Select != "",
+	if _, err := getEncoder(ctx, encodingOpts, AllTargets(details), details.Select != "",
 		makeExternalConnectionProvider(ctx, p.ExecCfg().InternalDB), nil); err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -58,6 +58,35 @@ func TestOptionsValidations(t *testing.T) {
 	}
 }
 
+func TestEncodingOptionsValidations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cases := []struct {
+		opts      EncodingOptions
+		expectErr string
+	}{
+		{EncodingOptions{Envelope: OptEnvelopeRow, Format: OptFormatAvro}, "envelope=row is not supported with format=avro"},
+		{EncodingOptions{Format: OptFormatAvro, EncodeJSONValueNullAsObject: true}, "is only usable with format=json"},
+		{EncodingOptions{Format: OptFormatAvro, Envelope: OptEnvelopeBare, KeyInValue: true}, "is only usable with envelope=wrapped"},
+		{EncodingOptions{Format: OptFormatAvro, Envelope: OptEnvelopeBare, TopicInValue: true}, "is only usable with envelope=wrapped"},
+		{EncodingOptions{Format: OptFormatAvro, Envelope: OptEnvelopeBare, UpdatedTimestamps: true}, "is only usable with envelope=wrapped"},
+		{EncodingOptions{Format: OptFormatAvro, Envelope: OptEnvelopeBare, MVCCTimestamps: true}, "is only usable with envelope=wrapped"},
+		{EncodingOptions{Format: OptFormatAvro, Envelope: OptEnvelopeBare, Diff: true}, "is only usable with envelope=wrapped"},
+	}
+
+	for _, c := range cases {
+		err := c.opts.Validate()
+		if c.expectErr == "" {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.expectErr)
+		}
+	}
+
+}
+
 func TestLaggingRangesVersionGate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -42,6 +42,7 @@ type Encoder interface {
 }
 
 func getEncoder(
+	ctx context.Context,
 	opts changefeedbase.EncodingOptions,
 	targets changefeedbase.Targets,
 	encodeForQuery bool,
@@ -50,7 +51,7 @@ func getEncoder(
 ) (Encoder, error) {
 	switch opts.Format {
 	case changefeedbase.OptFormatJSON:
-		return makeJSONEncoder(jsonEncoderOptions{EncodingOptions: opts, encodeForQuery: encodeForQuery})
+		return makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts, encodeForQuery: encodeForQuery})
 	case changefeedbase.OptFormatAvro, changefeedbase.DeprecatedOptFormatAvro:
 		return newConfluentAvroEncoder(opts, targets, p, sliMetrics)
 	case changefeedbase.OptFormatCSV:

--- a/pkg/ccl/changefeedccl/encoder_json_test.go
+++ b/pkg/ccl/changefeedccl/encoder_json_test.go
@@ -1,0 +1,311 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	gojson "encoding/json"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONEncoderJSONNullAsObject(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Parallel() // SAFE FOR TESTING
+
+	ctx := context.Background()
+	tableDesc, err := parseTableDesc(`CREATE TABLE foo (a JSONB PRIMARY KEY, b JSONB)`)
+	require.NoError(t, err)
+
+	objb := json.NewObjectBuilder(1)
+	objb.Add("foo", json.FromString("bar"))
+	obj := objb.Build()
+
+	rowWithData := rowenc.EncDatumRow{
+		rowenc.EncDatum{Datum: tree.NewDJSON(json.FromInt(1))},
+		rowenc.EncDatum{Datum: tree.NewDJSON(obj)},
+	}
+	rowWithSQLNull := rowenc.EncDatumRow{
+		rowenc.EncDatum{Datum: tree.NewDJSON(json.FromInt(1))},
+		rowenc.EncDatum{Datum: tree.DNull},
+	}
+	rowWithJSONNull := rowenc.EncDatumRow{
+		rowenc.EncDatum{Datum: tree.NewDJSON(json.FromInt(1))},
+		rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+	}
+	rowWithJSONNullKey := rowenc.EncDatumRow{
+		rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+		rowenc.EncDatum{Datum: tree.NewDJSON(obj)},
+	}
+
+	ts := hlc.Timestamp{WallTime: 1, Logical: 2}
+	evCtx := eventContext{updated: ts}
+
+	targets := mkTargets(tableDesc)
+
+	cases := []struct {
+		name                       string
+		envelope                   changefeedbase.EnvelopeType
+		row, prevRow               rowenc.EncDatumRow
+		expectedKey, expectedValue []byte
+	}{
+		{
+			name:          "wrapped: data",
+			envelope:      changefeedbase.OptEnvelopeWrapped,
+			row:           rowWithData,
+			expectedKey:   []byte(`[1]`),
+			expectedValue: []byte(`{"after": {"a":1,"b":{"foo":"bar"}}, "before": null}`),
+		},
+		{
+			name:          "wrapped: sql null",
+			envelope:      changefeedbase.OptEnvelopeWrapped,
+			row:           rowWithSQLNull,
+			expectedKey:   []byte(`[1]`),
+			expectedValue: []byte(`{"after": {"a":1,"b":null}, "before": null}`),
+		},
+		{
+			name:          "wrapped: json null",
+			envelope:      changefeedbase.OptEnvelopeWrapped,
+			row:           rowWithJSONNull,
+			expectedKey:   []byte(`[1]`),
+			expectedValue: []byte(`{"after": {"a":1,"b":{"__crdb_json_null__":true}}, "before": null}`),
+		},
+		{
+			name:          "wrapped: json null key",
+			envelope:      changefeedbase.OptEnvelopeWrapped,
+			row:           rowWithJSONNullKey,
+			expectedKey:   []byte(`[{"__crdb_json_null__":true}]`),
+			expectedValue: []byte(`{"after": {"a":{"__crdb_json_null__":true},"b":{"foo":"bar"}}, "before": null}`),
+		},
+		{
+			name:          "wrapped: prev sql null",
+			envelope:      changefeedbase.OptEnvelopeWrapped,
+			row:           rowWithData,
+			prevRow:       rowWithSQLNull,
+			expectedValue: []byte(`{"before": {"a":1,"b":null}, "after": {"a":1,"b":{"foo":"bar"}}}`),
+		},
+		{
+			name:          "wrapped: prev json null",
+			envelope:      changefeedbase.OptEnvelopeWrapped,
+			row:           rowWithData,
+			prevRow:       rowWithJSONNull,
+			expectedValue: []byte(`{"after": {"a":1,"b":{"foo":"bar"}}, "before": {"a":1,"b":{"__crdb_json_null__":true}}}`),
+		},
+
+		{
+			name:          "bare: data",
+			envelope:      changefeedbase.OptEnvelopeBare,
+			row:           rowWithData,
+			expectedKey:   []byte(`[1]`),
+			expectedValue: []byte(`{"a":1,"b":{"foo":"bar"}}`),
+		},
+		{
+			name:          "bare: sql null",
+			envelope:      changefeedbase.OptEnvelopeBare,
+			row:           rowWithSQLNull,
+			expectedKey:   []byte(`[1]`),
+			expectedValue: []byte(`{"a":1,"b":null}`),
+		},
+		{
+			name:          "bare: json null",
+			envelope:      changefeedbase.OptEnvelopeBare,
+			row:           rowWithJSONNull,
+			expectedKey:   []byte(`[1]`),
+			expectedValue: []byte(`{"a":1,"b":{"__crdb_json_null__":true}}`),
+		},
+		{
+			name:          "bare: json null key",
+			envelope:      changefeedbase.OptEnvelopeBare,
+			row:           rowWithJSONNullKey,
+			expectedKey:   []byte(`[{"__crdb_json_null__":true}]`),
+			expectedValue: []byte(`{"a":{"__crdb_json_null__":true},"b":{"foo":"bar"}}`),
+		},
+	}
+
+	for _, c := range cases {
+		opts := changefeedbase.EncodingOptions{
+			Format: changefeedbase.OptFormatJSON, Envelope: c.envelope, Diff: true, EncodeJSONValueNullAsObject: true,
+		}
+		require.NoError(t, opts.Validate())
+
+		// NOTE: This is no longer required in go 1.22+, but bazel still requires it. See https://github.com/bazelbuild/rules_go/issues/3924
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			e, err := getEncoder(ctx, opts, targets, false, nil, nil)
+			require.NoError(t, err)
+
+			row := cdcevent.TestingMakeEventRow(tableDesc, 0, c.row, false)
+			prevRow := cdcevent.TestingMakeEventRow(tableDesc, 0, c.prevRow, false)
+
+			key, err := e.EncodeKey(ctx, row)
+			require.NoError(t, err)
+			key = append([]byte(nil), key...)
+			value, err := e.EncodeValue(ctx, evCtx, row, prevRow)
+			require.NoError(t, err)
+
+			if c.expectedKey != nil {
+				assert.Equal(t, string(normalizeJson(t, c.expectedKey)), string(normalizeJson(t, key)))
+			}
+			if c.expectedValue != nil {
+				assert.Equal(t, string(normalizeJson(t, c.expectedValue)), string(normalizeJson(t, value)))
+			}
+		})
+	}
+}
+
+func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Parallel() // SAFE FOR TESTING
+
+	ctx := context.Background()
+	ts := hlc.Timestamp{WallTime: 1, Logical: 2}
+	evCtx := eventContext{updated: ts}
+	opts := changefeedbase.EncodingOptions{
+		Format: changefeedbase.OptFormatJSON, Envelope: changefeedbase.OptEnvelopeWrapped, Diff: true, EncodeJSONValueNullAsObject: true,
+	}
+	require.NoError(t, opts.Validate())
+
+	t.Run("table with column name __crdb_json_null__", func(t *testing.T) {
+		tableDesc, err := parseTableDesc(`CREATE TABLE foo (a int PRIMARY KEY, __crdb_json_null__ bool, b jsonb)`)
+		require.NoError(t, err)
+		targets := mkTargets(tableDesc)
+
+		eRow := rowenc.EncDatumRow{
+			rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(1))},
+			rowenc.EncDatum{Datum: tree.DBoolTrue},
+			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+		}
+		e, err := getEncoder(ctx, opts, targets, false, nil, nil)
+		require.NoError(t, err)
+
+		row := cdcevent.TestingMakeEventRow(tableDesc, 0, eRow, false)
+		prevRow := cdcevent.TestingMakeEventRow(tableDesc, 0, nil, false)
+
+		value, err := e.EncodeValue(ctx, evCtx, row, prevRow)
+		require.NoError(t, err)
+		expected := `{"before": null, "after": {"a": 1, "__crdb_json_null__": true, "b": {"__crdb_json_null__": true}}}`
+		assert.Equal(t, string(normalizeJson(t, []byte(expected))), string(normalizeJson(t, value)))
+	})
+
+	twoJSONsTableDesc, err := parseTableDesc(`CREATE TABLE foo (a int PRIMARY KEY, b jsonb, c jsonb)`)
+	require.NoError(t, err)
+	twoJSONsTargets := mkTargets(twoJSONsTableDesc)
+	prevNilRow := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, nil, false)
+
+	t.Run("test with sql null and json null in the same row", func(t *testing.T) {
+		eRow := rowenc.EncDatumRow{
+			rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(1))},
+			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+			rowenc.EncDatum{Datum: tree.DNull},
+		}
+		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil)
+		require.NoError(t, err)
+
+		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
+
+		value, err := e.EncodeValue(ctx, evCtx, row, prevNilRow)
+		require.NoError(t, err)
+		expected := `{"before": null, "after": {"a": 1, "b": {"__crdb_json_null__": true}, "c": null}}`
+		assert.Equal(t, string(normalizeJson(t, []byte(expected))), string(normalizeJson(t, value)))
+	})
+
+	t.Run("test with two json nulls in the same row", func(t *testing.T) {
+		eRow := rowenc.EncDatumRow{
+			rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(1))},
+			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+		}
+		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil)
+		require.NoError(t, err)
+
+		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
+
+		value, err := e.EncodeValue(ctx, evCtx, row, prevNilRow)
+		require.NoError(t, err)
+		expected := `{"before": null, "after": {"a": 1, "b": {"__crdb_json_null__": true}, "c": {"__crdb_json_null__": true}}}`
+		assert.Equal(t, string(normalizeJson(t, []byte(expected))), string(normalizeJson(t, value)))
+	})
+
+	t.Run("demonstrate nulls encoded the same without this option look the same", func(t *testing.T) {
+		disabledOpts := changefeedbase.EncodingOptions{
+			Format: changefeedbase.OptFormatJSON, Envelope: changefeedbase.OptEnvelopeWrapped, Diff: true,
+		}
+		require.NoError(t, disabledOpts.Validate())
+		eRow := rowenc.EncDatumRow{
+			rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(1))},
+			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+			rowenc.EncDatum{Datum: tree.DNull},
+		}
+		e, err := getEncoder(ctx, disabledOpts, twoJSONsTargets, false, nil, nil)
+		require.NoError(t, err)
+
+		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
+
+		value, err := e.EncodeValue(ctx, evCtx, row, prevNilRow)
+		require.NoError(t, err)
+		expected := `{"before": null, "after": {"a": 1, "b": null, "c": null}}`
+		assert.Equal(t, string(normalizeJson(t, []byte(expected))), string(normalizeJson(t, value)))
+	})
+
+	t.Run("test with json null and an object with the same format as our sentinel - confusing but correct", func(t *testing.T) {
+		objb := json.NewObjectBuilder(1)
+		objb.Add(jsonNullAsObjectKey, json.FromBool(true))
+		obj := objb.Build()
+
+		eRow := rowenc.EncDatumRow{
+			rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(1))},
+			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
+			rowenc.EncDatum{Datum: tree.NewDJSON(obj)},
+		}
+		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil)
+		require.NoError(t, err)
+
+		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
+
+		value, err := e.EncodeValue(ctx, evCtx, row, prevNilRow)
+		require.NoError(t, err)
+		expected := `{"before": null, "after": {"a": 1, "b": {"__crdb_json_null__": true}, "c": {"__crdb_json_null__": true}}}`
+		assert.Equal(t, string(normalizeJson(t, []byte(expected))), string(normalizeJson(t, value)))
+	})
+
+}
+
+func normalizeJson(t *testing.T, b []byte) []byte {
+	var v interface{}
+	require.NoError(t, gojson.Unmarshal(b, &v))
+	norm, err := gojson.Marshal(v)
+	require.NoError(t, err)
+	return norm
+}
+
+func mkTargets(tableDesc catalog.TableDescriptor) changefeedbase.Targets {
+	targets := changefeedbase.Targets{}
+	targets.Add(changefeedbase.Target{
+		Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
+		TableID:           tableDesc.GetID(),
+		StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
+	})
+	return targets
+}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -103,7 +103,7 @@ func newEventConsumer(
 
 	makeConsumer := func(s EventSink, frontier frontier) (eventConsumer, error) {
 		var err error
-		encoder, err := getEncoder(encodingOpts, feed.Targets, spec.Select.Expr != "",
+		encoder, err := getEncoder(ctx, encodingOpts, feed.Targets, spec.Select.Expr != "",
 			makeExternalConnectionProvider(ctx, cfg.DB), sliMetrics)
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -167,7 +167,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// NB: compression added in single-node subtest.
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
-	e, err := makeJSONEncoder(jsonEncoderOptions{EncodingOptions: opts})
+	e, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts})
 	require.NoError(t, err)
 
 	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -131,7 +131,7 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 
 	opts, err := getGenericWebhookSinkOptions().GetEncodingOptions()
 	require.NoError(t, err)
-	enc, err := makeJSONEncoder(jsonEncoderOptions{EncodingOptions: opts})
+	enc, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts})
 	require.NoError(t, err)
 
 	// test a resolved timestamp entry


### PR DESCRIPTION
Add a new option to JSON-formatted changefeeds
(`encode_json_value_null_as_object`) that outputs
`'null'::jsonb` as `{"__crdb_json_null__": true}`
instead of `null`.

Resolves: https://github.com/cockroachdb/cockroach/issues/103289

Release note (enterprise change): Added a new
option to JSON-formatted changefeeds
(`encode_json_value_null_as_object`) that outputs
`'null'::jsonb` as `{"__crdb_json_null__": true}`
instead of `null`, to disambiguate between
SQL-null and JSON-null. Note that with this option
enabled, if the literal value
`{"__crdb_json_null__": true}` is present in a
JSON value, it will have the same representation
as JSON-null with this option enabled. If such a
value is encountered in a changefeed, a
(rate-limited) warning will be printed to the DEV
channel.

