### PR TITLE
roachtest/multitenant-multiregion: fix flaky validation RBR distribution

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -78,8 +78,9 @@ func registerAcceptance(r registry.Registry) {
 				numNodes: 3,
 			},
 			{
-				name: "multitenant",
-				fn:   runAcceptanceMultitenant,
+				name:    "multitenant",
+				fn:      runAcceptanceMultitenant,
+				timeout: time.Minute * 20,
 			},
 		},
 		registry.OwnerSQLFoundations: {


### PR DESCRIPTION
Previously, we only validated non-RBR tables were distributed correctly and used that to determine if the span configuration / zone configuration was compliant at the KV level. This did not ensure the more important factor that the RBR tables need to be distributed into their target regions. As a result this test could flake when those tables were not distributed sanely. To address this, this patch will instead only focus on RBR tables and ensure that they are split by region based on the voting replicas for those ranges.

Fixes: #122174
Release note: None