### PR TITLE
release-23.2: opt: improve trigram similarity filter selectivity

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3769,6 +3769,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedDistinctOnLimitHintCosting(v
 	m.data.OptimizerUseImprovedDistinctOnLimitHintCosting = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseImprovedTrigramSimilaritySelectivity(val bool) {
+	m.data.OptimizerUseImprovedTrigramSimilaritySelectivity = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5574,6 +5574,7 @@ optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_distinct_on_limit_hint_costing      off
 optimizer_use_improved_join_elimination                    on
 optimizer_use_improved_split_disjunction_for_joins         on
+optimizer_use_improved_trigram_similarity_selectivity      off
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2891,6 +2891,7 @@ optimizer_use_improved_disjunction_stats                   on                  N
 optimizer_use_improved_distinct_on_limit_hint_costing      off                 NULL      NULL        NULL        string
 optimizer_use_improved_join_elimination                    on                  NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL      NULL        NULL        string
+optimizer_use_improved_trigram_similarity_selectivity      off                 NULL      NULL        NULL        string
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL      NULL        NULL        string
 optimizer_use_lock_op_for_serializable                     off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
@@ -3067,6 +3068,7 @@ optimizer_use_improved_disjunction_stats                   on                  N
 optimizer_use_improved_distinct_on_limit_hint_costing      off                 NULL  user     NULL      off                 off
 optimizer_use_improved_join_elimination                    on                  NULL  user     NULL      on                  on
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL  user     NULL      on                  on
+optimizer_use_improved_trigram_similarity_selectivity      off                 NULL  user     NULL      off                 off
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL  user     NULL      on                  on
 optimizer_use_lock_op_for_serializable                     off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
@@ -3242,6 +3244,7 @@ optimizer_use_improved_disjunction_stats                   NULL    NULL     NULL
 optimizer_use_improved_distinct_on_limit_hint_costing      NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_join_elimination                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_split_disjunction_for_joins         NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_trigram_similarity_selectivity      NULL    NULL     NULL     NULL        NULL
 optimizer_use_limit_ordering_for_streaming_group_by        NULL    NULL     NULL     NULL        NULL
 optimizer_use_lock_op_for_serializable                     NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -129,6 +129,7 @@ optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_distinct_on_limit_hint_costing      off
 optimizer_use_improved_join_elimination                    on
 optimizer_use_improved_split_disjunction_for_joins         on
+optimizer_use_improved_trigram_similarity_selectivity      off
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
 optimizer_use_multicol_stats                               on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -189,6 +189,7 @@ type Memo struct {
 	useVirtualComputedColumnStats              bool
 	useTrigramSimilarityOptimization           bool
 	useImprovedDistinctOnLimitHintCosting      bool
+	useImprovedTrigramSimilaritySelectivity    bool
 	trigramSimilarityThreshold                 float64
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
@@ -265,6 +266,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useVirtualComputedColumnStats:              evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats,
 		useTrigramSimilarityOptimization:           evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization,
 		useImprovedDistinctOnLimitHintCosting:      evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting,
+		useImprovedTrigramSimilaritySelectivity:    evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity,
 		trigramSimilarityThreshold:                 evalCtx.SessionData().TrigramSimilarityThreshold,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
@@ -419,6 +421,7 @@ func (m *Memo) IsStale(
 		m.useVirtualComputedColumnStats != evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats ||
 		m.useTrigramSimilarityOptimization != evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization ||
 		m.useImprovedDistinctOnLimitHintCosting != evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting ||
+		m.useImprovedTrigramSimilaritySelectivity != evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity ||
 		m.trigramSimilarityThreshold != evalCtx.SessionData().TrigramSimilarityThreshold ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -442,6 +442,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting = false
 	notStale()
 
+	// Stale optimizer_use_distinct_on_limit_hint_costing.
+	evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = true
+	stale()
+	evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = false
+	notStale()
+
 	// Stale pg_trgm.similarity_threshold.
 	evalCtx.SessionData().TrigramSimilarityThreshold = 0.5
 	stale()

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -950,7 +950,7 @@ func (sb *statisticsBuilder) constrainScan(
 	relProps *props.Relational,
 	s *props.Statistics,
 ) {
-	var numUnappliedConjuncts float64
+	var unapplied filterCount
 	var constrainedCols, histCols opt.ColSet
 	idx := sb.md.Table(scan.Table).Index(scan.Index)
 
@@ -987,11 +987,11 @@ func (sb *statisticsBuilder) constrainScan(
 				// Just assume a single closed span such as ["\xfd", "\xfe").
 				// This corresponds to two "conjuncts" as defined in
 				// numConjunctsInConstraint.
-				numUnappliedConjuncts += 2
+				unapplied.unknown += 2
 			}
 		} else {
 			// Assume a single closed span.
-			numUnappliedConjuncts += 2
+			unapplied.unknown += 2
 		}
 	}
 
@@ -1006,9 +1006,8 @@ func (sb *statisticsBuilder) constrainScan(
 	// Calculate distinct counts and histograms for the partial index predicate
 	// ------------------------------------------------------------------------
 	if pred != nil {
-		predUnappliedConjucts, predConstrainedCols, predHistCols :=
-			sb.applyFilters(pred, scan, relProps, false /* skipOrTermAccounting */)
-		numUnappliedConjuncts += predUnappliedConjucts
+		predConstrainedCols, predHistCols :=
+			sb.applyFilters(pred, scan, relProps, false /* skipOrTermAccounting */, &unapplied)
 		constrainedCols.UnionWith(predConstrainedCols)
 		constrainedCols = sb.tryReduceCols(constrainedCols, s, MakeTableFuncDep(sb.md, scan.Table))
 		histCols.UnionWith(predHistCols)
@@ -1033,7 +1032,7 @@ func (sb *statisticsBuilder) constrainScan(
 	// -----------------------------------
 	corr := sb.correlationFromMultiColDistinctCounts(constrainedCols, scan, s)
 	s.ApplySelectivity(sb.selectivityFromConstrainedCols(constrainedCols, histCols, scan, s, corr))
-	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
+	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(unapplied))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(scan, notNullCols, constrainedCols))
 }
 
@@ -1356,8 +1355,9 @@ func (sb *statisticsBuilder) buildJoin(
 
 	// Calculate distinct counts for constrained columns in the ON conditions
 	// ----------------------------------------------------------------------
-	numUnappliedConjuncts, constrainedCols, histCols :=
-		sb.applyFilters(h.filters, join, relProps, true /* skipOrTermAccounting */)
+	var unapplied filterCount
+	constrainedCols, histCols :=
+		sb.applyFilters(h.filters, join, relProps, true /* skipOrTermAccounting */, &unapplied)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -1385,8 +1385,8 @@ func (sb *statisticsBuilder) buildJoin(
 			equivReps, leftCols, rightCols, &h.filtersFD, join, s,
 		))
 		var oredTermSelectivity props.Selectivity
-		oredTermSelectivity, numUnappliedConjuncts =
-			sb.selectivityFromOredEquivalencies(h, join, s, numUnappliedConjuncts, true /* semiJoin */)
+		oredTermSelectivity =
+			sb.selectivityFromOredEquivalencies(h, join, s, &unapplied, true /* semiJoin */)
 		s.ApplySelectivity(oredTermSelectivity)
 
 	default:
@@ -1405,8 +1405,7 @@ func (sb *statisticsBuilder) buildJoin(
 
 		s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &h.filtersFD, join, s))
 		var oredTermSelectivity props.Selectivity
-		oredTermSelectivity, numUnappliedConjuncts =
-			sb.selectivityFromOredEquivalencies(h, join, s, numUnappliedConjuncts, false /* semiJoin */)
+		oredTermSelectivity = sb.selectivityFromOredEquivalencies(h, join, s, &unapplied, false /* semiJoin */)
 		s.ApplySelectivity(oredTermSelectivity)
 	}
 
@@ -1415,7 +1414,7 @@ func (sb *statisticsBuilder) buildJoin(
 	}
 	corr := sb.correlationFromMultiColDistinctCountsForJoin(constrainedCols, leftCols, rightCols, join, s)
 	s.ApplySelectivity(sb.selectivityFromConstrainedCols(constrainedCols, histCols, join, s, corr))
-	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
+	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(unapplied))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(join, relProps.NotNullCols, constrainedCols))
 
 	// Update distinct counts based on equivalencies; this should happen after
@@ -1891,8 +1890,9 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 	// still have corresponding filters in zigzag.On. So we don't need
 	// to iterate through FixedCols here if we are already processing the ON
 	// clause.
-	numUnappliedConjuncts, constrainedCols, histCols :=
-		sb.applyFilters(zigzag.On, zigzag, relProps, false /* skipOrTermAccounting */)
+	var unapplied filterCount
+	constrainedCols, histCols :=
+		sb.applyFilters(zigzag.On, zigzag, relProps, false /* skipOrTermAccounting */, &unapplied)
 
 	// Application of constraints on inverted indexes needs to be handled a
 	// little differently since a constraint on an inverted index key column
@@ -1913,10 +1913,10 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 	leftIndexInverted := tab.Index(zigzag.LeftIndex).IsInverted()
 	rightIndexInverted := tab.Index(zigzag.RightIndex).IsInverted()
 	if leftIndexInverted {
-		numUnappliedConjuncts += float64(len(zigzag.LeftFixedCols) * 2)
+		unapplied.unknown += len(zigzag.LeftFixedCols) * 2
 	}
 	if rightIndexInverted {
-		numUnappliedConjuncts += float64(len(zigzag.RightFixedCols) * 2)
+		unapplied.unknown += len(zigzag.RightFixedCols) * 2
 	}
 
 	// Try to reduce the number of columns used for selectivity
@@ -1949,7 +1949,7 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 		s.ApplySelectivity(multiColSelectivity)
 	}
 	s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &relProps.FuncDeps, zigzag, s))
-	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
+	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(unapplied))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(zigzag, relProps.NotNullCols, constrainedCols))
 
 	// Update distinct counts based on equivalencies; this should happen after
@@ -3228,8 +3228,9 @@ func (sb *statisticsBuilder) filterRelExpr(
 
 	// Calculate distinct counts and histograms for constrained columns
 	// ----------------------------------------------------------------
-	numUnappliedConjuncts, constrainedCols, histCols :=
-		sb.applyFilters(filters, e, relProps, false /* skipOrTermAccounting */)
+	var unapplied filterCount
+	constrainedCols, histCols :=
+		sb.applyFilters(filters, e, relProps, false /* skipOrTermAccounting */, &unapplied)
 
 	// Try to reduce the number of columns used for selectivity
 	// calculation based on functional dependencies.
@@ -3244,7 +3245,7 @@ func (sb *statisticsBuilder) filterRelExpr(
 	corr := sb.correlationFromMultiColDistinctCounts(constrainedCols, e, s)
 	s.ApplySelectivity(sb.selectivityFromConstrainedCols(constrainedCols, histCols, e, s, corr))
 	s.ApplySelectivity(sb.selectivityFromEquivalencies(equivReps, &relProps.FuncDeps, e, s))
-	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(numUnappliedConjuncts))
+	s.ApplySelectivity(sb.selectivityFromUnappliedConjuncts(unapplied))
 	s.ApplySelectivity(sb.selectivityFromNullsRemoved(e, notNullCols, constrainedCols))
 
 	// Update distinct and null counts based on equivalencies; this should
@@ -3261,8 +3262,12 @@ func (sb *statisticsBuilder) filterRelExpr(
 //
 // See applyFiltersItem for more details.
 func (sb *statisticsBuilder) applyFilters(
-	filters FiltersExpr, e RelExpr, relProps *props.Relational, skipOrTermAccounting bool,
-) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
+	filters FiltersExpr,
+	e RelExpr,
+	relProps *props.Relational,
+	skipOrTermAccounting bool,
+	unapplied *filterCount,
+) (constrainedCols, histCols opt.ColSet) {
 	// Special hack for inverted joins. Add constant filters from the equality
 	// conditions.
 	// TODO(rytaft): the correct way to do this is probably to fully implement
@@ -3274,18 +3279,19 @@ func (sb *statisticsBuilder) applyFilters(
 	}
 
 	for i := range filters {
-		numUnappliedConjunctsLocal, constrainedColsLocal, histColsLocal :=
-			sb.applyFiltersItem(&filters[i], e, relProps)
+		var unappliedLocal filterCount
+		constrainedColsLocal, histColsLocal :=
+			sb.applyFiltersItem(&filters[i], e, relProps, &unappliedLocal)
 		// Selectivity from OrExprs is computed elsewhere when skipOrTermAccounting
 		// is true.
 		if _, ok := filters[i].Condition.(*OrExpr); !skipOrTermAccounting || !ok {
-			numUnappliedConjuncts += numUnappliedConjunctsLocal
+			unapplied.add(unappliedLocal)
 		}
 		constrainedCols.UnionWith(constrainedColsLocal)
 		histCols.UnionWith(histColsLocal)
 	}
 
-	return numUnappliedConjuncts, constrainedCols, histCols
+	return constrainedCols, histCols
 }
 
 // applyFiltersItem uses constraints to update the distinct counts and
@@ -3309,8 +3315,8 @@ func (sb *statisticsBuilder) applyFilters(
 // Inverted join conditions are handled separately. See
 // selectivityFromInvertedJoinCondition.
 func (sb *statisticsBuilder) applyFiltersItem(
-	filter *FiltersItem, e RelExpr, relProps *props.Relational,
-) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
+	filter *FiltersItem, e RelExpr, relProps *props.Relational, unapplied *filterCount,
+) (constrainedCols, histCols opt.ColSet) {
 	// Before checking anything, try to replace any virtual computed column
 	// expressions with the corresponding virtual column.
 	if sb.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats &&
@@ -3326,13 +3332,13 @@ func (sb *statisticsBuilder) applyFiltersItem(
 
 	if isEqualityWithTwoVars(filter.Condition) {
 		// Equalities are handled by applyEquivalencies.
-		return 0, opt.ColSet{}, opt.ColSet{}
+		return opt.ColSet{}, opt.ColSet{}
 	}
 
 	// Special case: The current conjunct is an inverted join condition which is
 	// handled by selectivityFromInvertedJoinCondition.
 	if isInvertedJoinCond(filter.Condition) {
-		return 0, opt.ColSet{}, opt.ColSet{}
+		return opt.ColSet{}, opt.ColSet{}
 	}
 
 	// Special case: The current conjunct is a JSON or Array Contains
@@ -3349,7 +3355,7 @@ func (sb *statisticsBuilder) applyFiltersItem(
 		(filterOp == opt.EqOp && filter.Condition.Child(0).Op() == opt.FetchValOp) {
 		numPaths := countPaths(filter)
 		if numPaths == 0 {
-			numUnappliedConjuncts++
+			unapplied.unknown++
 		} else {
 			// Multiply the number of paths by 2 to mimic the logic in
 			// numConjunctsInConstraint, for constraints like
@@ -3357,9 +3363,9 @@ func (sb *statisticsBuilder) applyFiltersItem(
 			// this as 2 conjuncts, and to keep row counts as consistent
 			// as possible between competing filtered selects and
 			// constrained scans, we apply the same logic here.
-			numUnappliedConjuncts += 2 * float64(numPaths)
+			unapplied.unknown += 2 * numPaths
 		}
-		return numUnappliedConjuncts, opt.ColSet{}, opt.ColSet{}
+		return opt.ColSet{}, opt.ColSet{}
 	}
 
 	// Update constrainedCols after the above check for isEqualityWithTwoVars.
@@ -3377,15 +3383,18 @@ func (sb *statisticsBuilder) applyFiltersItem(
 		)
 		histCols.UnionWith(histColsLocal)
 		if !scalarProps.TightConstraints {
-			numUnappliedConjuncts++
+			unapplied.unknown++
 			// Mimic constrainScan in the case of no histogram information
 			// that assumes a geo function is a single closed span that
 			// corresponds to two "conjuncts".
 			if isGeoIndexScanCond(filter.Condition) {
-				numUnappliedConjuncts++
+				unapplied.unknown++
 			}
 		}
-	} else if constraintUnion, numUnappliedDisjuncts := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
+		return constrainedCols, histCols
+	}
+
+	if constraintUnion, numUnappliedDisjuncts := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
 		if sb.evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats {
 			// The filters are one or more disjuncts and tight constraint sets
 			// could be built for at least one disjunct. numUnappliedDisjuncts
@@ -3433,13 +3442,13 @@ func (sb *statisticsBuilder) applyFiltersItem(
 			s.Selectivity = props.MinSelectivity(s.Selectivity, unionStats.Selectivity)
 			s.RowCount = min(s.RowCount, unionStats.RowCount)
 		} else {
-			numUnappliedConjuncts++
+			unapplied.unknown++
 		}
 	} else {
-		numUnappliedConjuncts++
+		unapplied.unknown++
 	}
 
-	return numUnappliedConjuncts, constrainedCols, histCols
+	return constrainedCols, histCols
 }
 
 // buildDisjunctionConstraints returns a slice of tight constraint sets that are
@@ -4406,13 +4415,8 @@ func (sb *statisticsBuilder) selectivityFromEquivalencies(
 // estimation is improved, this method can be updated to handle those predicates
 // as well.
 func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
-	h *joinPropsHelper,
-	e RelExpr,
-	s *props.Statistics,
-	numUnappliedConjunctsIn float64,
-	semiJoin bool,
-) (selectivity props.Selectivity, numUnappliedConjuncts float64) {
-	numUnappliedConjuncts = numUnappliedConjunctsIn
+	h *joinPropsHelper, e RelExpr, s *props.Statistics, unapplied *filterCount, semiJoin bool,
+) (selectivity props.Selectivity) {
 	selectivity = props.OneSelectivity
 	var conjunctSelectivity props.Selectivity
 
@@ -4442,19 +4446,19 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 			switch disjuncts[i].(type) {
 			case *EqExpr, *AndExpr:
 				if andFilters, ok = addEqExprConjuncts(disjuncts[i], andFilters, e.Memo()); !ok {
-					numUnappliedConjuncts++
+					unapplied.unknown++
 					continue
 				}
 				e.Memo().logPropsBuilder.addFiltersToFuncDep(andFilters, &filtersFD)
 			default:
-				numUnappliedConjuncts++
+				unapplied.unknown++
 				ok = false
 				continue
 			}
 			// If no column equivalencies are found, we know nothing about this term,
 			// so should skip selectivity estimation on the entire conjunct.
 			if filtersFD.Empty() || filtersFD.EquivReps().Empty() {
-				numUnappliedConjuncts++
+				unapplied.unknown++
 				ok = false
 				break
 			}
@@ -4489,7 +4493,7 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 		// Combine this disjunction's selectivity with that of other disjunctions.
 		selectivity.Multiply(conjunctSelectivity)
 	}
-	return selectivity, numUnappliedConjuncts
+	return selectivity
 }
 
 // combineOredSelectivities iteratively applies the General Disjunction Rule
@@ -4672,10 +4676,9 @@ func (sb *statisticsBuilder) selectivityFromInvertedJoinCondition(
 }
 
 func (sb *statisticsBuilder) selectivityFromUnappliedConjuncts(
-	numUnappliedConjuncts float64,
+	c filterCount,
 ) (selectivity props.Selectivity) {
-	selectivity = props.MakeSelectivity(math.Pow(unknownFilterSelectivity, numUnappliedConjuncts))
-
+	selectivity = props.MakeSelectivity(math.Pow(unknownFilterSelectivity, float64(c.unknown)))
 	return selectivity
 }
 
@@ -5030,4 +5033,16 @@ func (sb *statisticsBuilder) factorOutVirtualCols(
 		return m.replacer(e, replace)
 	}
 	return replace(e)
+}
+
+// filterCount tracks counts of different types of filters. It is used to track
+// the number of filters which are not applied to selectivities via more exact
+// means like constraints and histogram filtering.
+type filterCount struct {
+	unknown int
+}
+
+// add adds the counts of other to c.
+func (c *filterCount) add(other filterCount) {
+	c.unknown += other.unknown
 }

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -41,6 +41,10 @@ const (
 	// by Pat Selinger et al.
 	unknownFilterSelectivity = 1.0 / 3.0
 
+	// This is the selectivity used for trigram similarity filters, like s %
+	// 'foo'.
+	similarityFilterSelectivity = 1.0 / 100.0
+
 	// TODO(rytaft): Add other selectivities for other types of predicates.
 
 	// This is an arbitrary row count used in the absence of any real statistics.
@@ -3335,6 +3339,13 @@ func (sb *statisticsBuilder) applyFiltersItem(
 		return opt.ColSet{}, opt.ColSet{}
 	}
 
+	// Special case: a trigram similarity filter.
+	if isSimilarityFilter(filter.Condition) &&
+		sb.evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity {
+		unapplied.similarity++
+		return opt.ColSet{}, opt.ColSet{}
+	}
+
 	// Special case: The current conjunct is an inverted join condition which is
 	// handled by selectivityFromInvertedJoinCondition.
 	if isInvertedJoinCond(filter.Condition) {
@@ -4678,8 +4689,9 @@ func (sb *statisticsBuilder) selectivityFromInvertedJoinCondition(
 func (sb *statisticsBuilder) selectivityFromUnappliedConjuncts(
 	c filterCount,
 ) (selectivity props.Selectivity) {
-	selectivity = props.MakeSelectivity(math.Pow(unknownFilterSelectivity, float64(c.unknown)))
-	return selectivity
+	s := math.Pow(unknownFilterSelectivity, float64(c.unknown)) *
+		math.Pow(similarityFilterSelectivity, float64(c.similarity))
+	return props.MakeSelectivity(s)
 }
 
 // tryReduceCols is used to determine which columns to use for selectivity
@@ -4735,6 +4747,16 @@ func (sb *statisticsBuilder) tryReduceJoinCols(
 func isEqualityWithTwoVars(cond opt.ScalarExpr) bool {
 	if eq, ok := cond.(*EqExpr); ok {
 		return eq.Left.Op() == opt.VariableOp && eq.Right.Op() == opt.VariableOp
+	}
+	return false
+}
+
+// isSimilarityFilter returns true if the given condition is a trigram
+// similarity filter.
+func isSimilarityFilter(e opt.ScalarExpr) bool {
+	if sim, ok := e.(*ModExpr); ok {
+		return sim.Left.DataType().Family() == types.StringFamily &&
+			sim.Right.DataType().Family() == types.StringFamily
 	}
 	return false
 }
@@ -5039,10 +5061,12 @@ func (sb *statisticsBuilder) factorOutVirtualCols(
 // the number of filters which are not applied to selectivities via more exact
 // means like constraints and histogram filtering.
 type filterCount struct {
-	unknown int
+	unknown    int
+	similarity int
 }
 
 // add adds the counts of other to c.
 func (c *filterCount) add(other filterCount) {
 	c.unknown += other.unknown
+	c.similarity += other.similarity
 }

--- a/pkg/sql/opt/memo/testdata/stats/inverted-trigram
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-trigram
@@ -296,13 +296,13 @@ select
       └── a:1 LIKE '%zooo%' [type=bool, outer=(1), constraints=(/1: (/NULL - ])]
 
 # Test a trigram similarity filter.
-opt set=(optimizer_use_trigram_similarity_optimization=on)
+opt set=(optimizer_use_trigram_similarity_optimization=on,optimizer_use_improved_trigram_similarity_selectivity=on)
 SELECT * FROM a WHERE a % 'blah'
 ----
 select
  ├── columns: a:1(string)
  ├── stable
- ├── stats: [rows=333.3333]
+ ├── stats: [rows=10]
  ├── index-join a
  │    ├── columns: a:1(string)
  │    ├── stats: [rows=8]
@@ -321,6 +321,45 @@ select
  │              └── stats: [rows=40, distinct(2)=8, null(2)=0, distinct(5)=4, null(5)=0]
  │                  histogram(5)=  0         10         0         10         0         10         0         10
  │                               <--- '\x1220626c0001' --- '\x126168200001' --- '\x12626c610001' --- '\x126c61680001'
+ └── filters
+      └── a:1 % 'blah' [type=bool, outer=(1), stable]
+
+opt
+SELECT * FROM a WHERE a % 'blah'
+----
+select
+ ├── columns: a:1(string)
+ ├── stable
+ ├── stats: [rows=333.3333]
+ ├── index-join a
+ │    ├── columns: a:1(string)
+ │    ├── stats: [rows=50]
+ │    └── inverted-filter
+ │         ├── columns: rowid:2(int!null)
+ │         ├── inverted expression: /5
+ │         │    ├── tight: false, unique: false
+ │         │    └── union spans
+ │         │         ├── ["\x12  b\x00\x01", "\x12  b\x00\x01"]
+ │         │         ├── ["\x12 bl\x00\x01", "\x12 bl\x00\x01"]
+ │         │         ├── ["\x12ah \x00\x01", "\x12ah \x00\x01"]
+ │         │         ├── ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │         │         └── ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │         ├── stats: [rows=50]
+ │         ├── key: (2)
+ │         └── scan a@inv
+ │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
+ │              ├── inverted constraint: /5/2
+ │              │    └── spans
+ │              │         ├── ["\x12  b\x00\x01", "\x12  b\x00\x01"]
+ │              │         ├── ["\x12 bl\x00\x01", "\x12 bl\x00\x01"]
+ │              │         ├── ["\x12ah \x00\x01", "\x12ah \x00\x01"]
+ │              │         ├── ["\x12bla\x00\x01", "\x12bla\x00\x01"]
+ │              │         └── ["\x12lah\x00\x01", "\x12lah\x00\x01"]
+ │              ├── stats: [rows=50, distinct(2)=10, null(2)=0, distinct(5)=5, null(5)=0]
+ │              │   histogram(5)=  0         10         0         10         0         10         0         10         0         10         0         0
+ │              │                <--- '\x122020620001' --- '\x1220626c0001' --- '\x126168200001' --- '\x12626c610001' --- '\x126c61680001' --- '\x126c61680002'
+ │              ├── key: (2)
+ │              └── fd: (2)-->(5)
  └── filters
       └── a:1 % 'blah' [type=bool, outer=(1), stable]
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -485,6 +485,10 @@ message LocalOnlySessionData {
   // optimizer should use an improved costing estimate for DistinctOn operators
   // with limit hints.
   bool optimizer_use_improved_distinct_on_limit_hint_costing = 126;
+  // OptimizerUseImprovedTrigramSimilaritySelectivity indicates whether the
+  // optimizer should use an improved selectivitiy estimate for trigram
+  // similarity filters.
+  bool optimizer_use_improved_trigram_similarity_selectivity = 127;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3247,6 +3247,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_improved_trigram_similarity_selectivity`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_trigram_similarity_selectivity`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_trigram_similarity_selectivity", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedTrigramSimilaritySelectivity(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 2/2 commits from #122665.

/cc @cockroachdb/release

---

#### opt: refactor unapplied conjunction counter

This commit refactors unapplied conjunction counts from a single
`float64` into a struct. For now, the struct has a single field, but in
the future it can be expanded to track counts of different types of
unapplied filters. This will make it easier to apply different
selectivities to different types of filters.

Release note: None

#### opt: improve trigram similarity filter selectivity

Trigram similarity filters, like `s % 'foo'`, are now given a
selectivity of 1/100 instead of the default unknown selectivity of 1/3.
This makes plans that utilize trigram inverted indexes more attractive
than full table scans when a `LIMIT` is present.

There's nothing particularly special about the 1/100 value. For the
majority of workloads it should be closer to the true selectivity than
1/3.

This change can be disabled by setting the
`optimizer_use_improved_trigram_similarity_selectivity` to `off`. It is
disabled by default.

Epic: CRDB-37714

Release note: None

---

Release justification: Performance improvements gated behind a
session setting.

