### PR TITLE
sql: add randomized test for plan-gist logic

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/sql",
+        "//pkg/sql/catalog",
         "//pkg/sql/gcjob",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",

--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -313,7 +313,6 @@ SELECT '%[1]s';
 			cmd = exec.CommandContext(ctx, binary,
 				"demo",
 				"--empty",
-				"--disable-demo-license",
 				"--set=errexit=false",
 				"--format=tsv",
 			)


### PR DESCRIPTION
This commit adds a randomized test for plan-gist logic. It utilizes sqlsmith to generate random stmts, then runs EXPLAIN (GIST) for it to retrieve the gist followed by decoding that gist, and ensures that no internal errors occur. All generated stmts are also executed with a short timeout to allow for DB state to evolve. Additionally, all gists are accumulated and decoded against an empty DB.

The test is placed in the ccl package to exercise features gated behind CCL license.

The test quickly discovered bug fixed in 1315dda2d60f6064ff112c4d169cfdb8a1ce224c (when the corresponding fix is reverted) but haven't found anything new for plan-gist logic (but did hit a few issues elsewhere which are currently ignored in the test).

Fixes: #117634.

Release note: None