### PR TITLE
roachtest: changes to reuse spot VM clusters

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -328,7 +328,21 @@ func (r *testRunner) Run(
 		// Don't spin up more workers than necessary.
 		parallelism = n * count
 	}
+	for _, testSpec := range tests {
+		//  TODO(babusrithar): remove this once we see enough data in
+		//  nightly runs. This is a temp logic to test spot VMs.
+		if roachtestflags.Cloud == spec.GCE &&
+			testSpec.Benchmark &&
+			!testSpec.Suites.Contains(registry.Weekly) &&
+			rand.Float64() <= 0.5 {
+			lopt.l.PrintfCtx(ctx, "using spot VMs to run test %s", testSpec.Name)
+			testSpec.Cluster.UseSpotVMs = true
+		}
 
+		if roachtestflags.UseSpotVM {
+			testSpec.Cluster.UseSpotVMs = true
+		}
+	}
 	r.status.running = make(map[*testImpl]struct{})
 	r.status.pass = make(map[*testImpl]struct{})
 	r.status.fail = make(map[*testImpl]struct{})
@@ -675,20 +689,6 @@ func (r *testRunner) runWorker(
 				// Switch architecture of local cluster (see above).
 				c.arch = arch
 			}
-		}
-
-		//  TODO(babusrithar): remove this once we see enough data in
-		//  nightly runs. This is a temp logic to test spot VMs.
-		if roachtestflags.Cloud == spec.GCE &&
-			testToRun.spec.Benchmark &&
-			!testToRun.spec.Suites.Contains(registry.Weekly) &&
-			rand.Float64() <= 0.5 {
-			l.PrintfCtx(ctx, "using spot VMs to run test %s", testToRun.spec.Name)
-			testToRun.spec.Cluster.UseSpotVMs = true
-		}
-
-		if roachtestflags.UseSpotVM {
-			testToRun.spec.Cluster.UseSpotVMs = true
 		}
 
 		// Verify that required native libraries are available.


### PR DESCRIPTION
We have a provision to use spot VMs for running tests by setting a flag. This flag is set when the test is selected for running, after a cluster is selected. This ends up creating a new cluster with spot VM every time a test is marked to use spot VM.
The change is to set the testspec to use spot Vm before the tests gets registered to the worker.

Fixes: #116778
Epic: none