### PR TITLE
release-23.2: sql/delegate: don't include external connections in SHOW SYSTEM GRANTS

### DIFF
--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -88,6 +88,7 @@ SELECT a.username AS grantee,
   FROM (
         SELECT username, unnest(privileges) AS privilege
           FROM crdb_internal.kv_system_privileges
+          WHERE path LIKE '/global%'
        ) AS a`
 	const externalConnectionPrivilegeQuery = `
 SELECT *

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -671,3 +671,33 @@ test           public       owner_grant_option  admin                     ALL   
 test           public       owner_grant_option  other_owner               ALL             true
 test           public       owner_grant_option  owner_grant_option_child  SELECT          false
 test           public       owner_grant_option  root                      ALL             true
+
+statement ok
+CREATE USER roach;
+CREATE TYPE mood AS enum ('sad','happy');
+GRANT USAGE ON TYPE mood TO roach;
+CREATE SEQUENCE test_sequence;
+GRANT SELECT ON SEQUENCE test_sequence TO roach;
+CREATE EXTERNAL CONNECTION connection1 AS 'nodelocal://1/foo';
+GRANT USAGE ON EXTERNAL CONNECTION connection1 TO roach WITH GRANT OPTION;
+GRANT SYSTEM VIEWCLUSTERSETTING TO roach WITH GRANT OPTION;
+GRANT SYSTEM VIEWACTIVITY TO roach;
+
+# The purpose of this test is to verify the object_type column.
+query TTTTTTB colnames,rowsort
+SHOW GRANTS FOR roach
+----
+database_name  schema_name  object_name    object_type          grantee  privilege_type  is_grantable
+NULL           NULL         connection1    external_connection  roach    USAGE           true
+test           public       mood           type                 roach    USAGE           false
+test           public       test_sequence  sequence             roach    SELECT          false
+
+# Verify that only system grants appear in SHOW SYSTEM GRANTS. Previously,
+# there was a bug that would cause external connection privileges to appear
+# also, since those privileges are also implemented with synthetic privileges.
+query TTB colnames,rowsort
+SHOW SYSTEM GRANTS FOR roach
+----
+grantee  privilege_type      is_grantable
+roach    VIEWACTIVITY        false
+roach    VIEWCLUSTERSETTING  true

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1865,21 +1865,3 @@ statement ok
 DROP ROLE creator_of_databases
 
 subtest end
-
-# The purpose of this test is to verify the object_type column
-statement ok
-create user roach;
-create type mood as enum ('sad','happy');
-grant usage on type mood to roach;
-create sequence test_sequence;
-grant usage on sequence test_sequence to roach;
-CREATE EXTERNAL CONNECTION connection1 AS 'nodelocal://1/foo';
-grant usage on EXTERNAL CONNECTION connection1 to roach;
-
-query TTTTTTB colnames,rowsort
-show grants for roach
-----
-database_name  schema_name  object_name    object_type          grantee  privilege_type  is_grantable
-NULL           NULL         connection1    external_connection  roach    USAGE           false
-test           public       mood           type                 roach    USAGE           false
-test           public       test_sequence  sequence             roach    USAGE           false


### PR DESCRIPTION
Backport 1/1 commits from #122720.

/cc @cockroachdb/release

Release justification: bug fix

---

Epic: None
Release note (bug fix): Privileges granted for external connections were incorrectly showing up in SHOW SYSTEM GRANTS, but were not useful since there is no associated object name. Now they do not appear there. Instead, the SHOW GRANTS ON EXTERNAL CONNECTION syntax should be used.
