### PR TITLE
workload: patch fake-time unknown flag for workload fixtures import

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -230,6 +230,7 @@ var tpccMeta = workload.Meta{
 			`replicate-static-columns`: {RuntimeOnly: true},
 			`deprecated-fk-indexes`:    {RuntimeOnly: true},
 			`query-trace-file`:         {RuntimeOnly: true},
+			`fake-time`:                {RuntimeOnly: true},
 		}
 
 		g.flags.IntVar(&g.warehouses, `warehouses`, 1, `Number of warehouses for loading`)


### PR DESCRIPTION
Change introduced in #122648 added `fake-time` flag, which should be a runtime-only flag. This caused issues in fixture imports for TPCC as it was not being handled properly. Added `RuntimeOnly` flag to `fake-time` option

Fixes #122877

Release note: none