### PR TITLE
roachprod: drop extra logging

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -359,7 +359,6 @@ func (p *Provider) GetPreemptedSpotVMs(
 		l.Printf("Error building gcloud cli command: %v\n", err)
 		return nil, err
 	}
-	l.Printf("gcloud cli for preemption : " + strings.Join(append([]string{"gcloud"}, args...), " "))
 	var logEntries []LogEntry
 	if err := runJSONCommand(args, &logEntries); err != nil {
 		l.Printf("Error running gcloud cli command: %v\n", err)
@@ -388,7 +387,6 @@ func (p *Provider) GetHostErrorVMs(
 		l.Printf("Error building gcloud cli command: %v\n", err)
 		return nil, err
 	}
-	l.Printf("gcloud cli for host error : " + strings.Join(append([]string{"gcloud"}, args...), " "))
 	var logEntries []LogEntry
 	if err := runJSONCommand(args, &logEntries); err != nil {
 		l.Printf("Error running gcloud cli command: %v\n", err)


### PR DESCRIPTION
Previously, we were unnecessarily logging `gcloud` commands for Preempted and Host Error VMs.
This patch removes those logs.

Epic: none
Release note: None