### PR TITLE
optbuilder: add missing continuation pop

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
@@ -676,3 +676,25 @@ NOTICE: Outer quantity here is 50
 NOTICE: Quantity here is 50
 
 subtest end
+
+# Regression test for not popping the continuation after having built the
+# corresponding block (#122873).
+statement ok
+CREATE FUNCTION func_122873() RETURNS INT4 AS $$
+DECLARE
+  decl_24 BOOL := false;
+BEGIN
+  IF decl_24 THEN
+    NULL;
+  ELSIF false THEN
+    DECLARE
+      decl_33 INT2;
+    BEGIN
+      BEGIN
+        RETURN decl_33;
+      END;
+      RETURN decl_33;
+    END;
+  END IF;
+END;
+$$ LANGUAGE PLpgSQL;

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -420,6 +420,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			}
 			b.appendPlpgSQLStmts(&blockCon, stmts[i+1:])
 			b.pushContinuation(blockCon)
+			defer b.popContinuation()
 			return b.buildBlock(t, s)
 
 		case *ast.Return:

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -6751,45 +6751,37 @@ project
                      │              │                                  └── null [type=unknown]
                      │              └── subquery [type=tuple{int, unknown, decimal}]
                      │                   └── project
-                     │                        ├── columns: post_nested_block_6:7(tuple{int, unknown, decimal})
+                     │                        ├── columns: stmt_if_1:7(tuple{int, unknown, decimal})
                      │                        ├── values
                      │                        │    └── tuple [type=tuple]
                      │                        └── projections
-                     │                             └── udf: post_nested_block_6 [as=post_nested_block_6:7, type=tuple{int, unknown, decimal}]
+                     │                             └── udf: stmt_if_1 [as=stmt_if_1:7, type=tuple{int, unknown, decimal}]
                      │                                  └── body
                      │                                       └── project
-                     │                                            ├── columns: stmt_if_1:5(tuple{int, unknown, decimal})
+                     │                                            ├── columns: "_end_of_function_2":3(tuple{int, unknown, decimal})
                      │                                            ├── values
                      │                                            │    └── tuple [type=tuple]
                      │                                            └── projections
-                     │                                                 └── udf: stmt_if_1 [as=stmt_if_1:5, type=tuple{int, unknown, decimal}]
+                     │                                                 └── udf: _end_of_function_2 [as="_end_of_function_2":3, type=tuple{int, unknown, decimal}]
                      │                                                      ├── tail-call
                      │                                                      └── body
+                     │                                                           ├── project
+                     │                                                           │    ├── columns: stmt_raise_3:1(int)
+                     │                                                           │    ├── values
+                     │                                                           │    │    └── tuple [type=tuple]
+                     │                                                           │    └── projections
+                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:1, type=int]
+                     │                                                           │              ├── const: 'ERROR' [type=string]
+                     │                                                           │              ├── const: 'control reached end of function without RETURN' [type=string]
+                     │                                                           │              ├── const: '' [type=string]
+                     │                                                           │              ├── const: '' [type=string]
+                     │                                                           │              └── const: '2F005' [type=string]
                      │                                                           └── project
-                     │                                                                ├── columns: "_end_of_function_2":3(tuple{int, unknown, decimal})
+                     │                                                                ├── columns: end_of_function_4:2(tuple{int, unknown, decimal})
                      │                                                                ├── values
                      │                                                                │    └── tuple [type=tuple]
                      │                                                                └── projections
-                     │                                                                     └── udf: _end_of_function_2 [as="_end_of_function_2":3, type=tuple{int, unknown, decimal}]
-                     │                                                                          ├── tail-call
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_3:1(int)
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple [type=tuple]
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:1, type=int]
-                     │                                                                               │              ├── const: 'ERROR' [type=string]
-                     │                                                                               │              ├── const: 'control reached end of function without RETURN' [type=string]
-                     │                                                                               │              ├── const: '' [type=string]
-                     │                                                                               │              ├── const: '' [type=string]
-                     │                                                                               │              └── const: '2F005' [type=string]
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: end_of_function_4:2(tuple{int, unknown, decimal})
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple [type=tuple]
-                     │                                                                                    └── projections
-                     │                                                                                         └── null [as=end_of_function_4:2, type=tuple{int, unknown, decimal}]
+                     │                                                                     └── null [as=end_of_function_4:2, type=tuple{int, unknown, decimal}]
                      └── const: 1 [type=int]
 
 # Regression test for #120916 - the nested call should not have the "tail-call"


### PR DESCRIPTION
This commit fixes a missing `pop` of the continuation after having built the corresponding nested block (we had 4 pushes and 3 pops). This could manifest as an internal error.

Fixes: #122873.

Release note (bug fix): Previously, CockroachDB could run in an internal error when evaluating PLpgSQL routines with nested blocks in some cases. The bug is only present in 24.1.0-beta versions and is now fixed.