### PR TITLE
sql: don't print stack on NULL record in procedure call

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -520,3 +520,28 @@ statement error pgcode 42P13 pq: return type mismatch in function declared to re
 CREATE PROCEDURE p(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT ROW(ROW(1, 2)); $$;
 
 subtest end
+
+# Regression test for printing the stack trace for an internal error (#122911).
+statement ok
+CREATE TABLE bank (accountno INT PRIMARY KEY, balance NUMERIC);
+CREATE PROCEDURE withdraw(accountno INT, debit NUMERIC, OUT new_balance NUMERIC) AS $$
+    UPDATE bank
+        SET balance = balance - debit
+        WHERE bank.accountno = accountno
+    RETURNING balance;
+$$ LANGUAGE SQL;
+
+statement error pgcode XX000 internal error: procedure returned null record
+CALL withdraw(17, 100.0, NULL);
+
+statement ok
+INSERT INTO bank VALUES (17, 1000.0);
+
+query R
+CALL withdraw(17, 100.0, NULL);
+----
+900.0
+
+statement ok
+DROP PROCEDURE withdraw;
+DROP TABLE bank;

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -56,6 +56,12 @@ func (d *callNode) startExec(params runParams) error {
 		}
 		return nil
 	}
+	if d.proc.Typ.Family() != types.TupleFamily {
+		return errors.AssertionFailedf("expected VOID or RECORD type for procedures, got %s", d.proc.Typ.SQLStringForError())
+	}
+	if res == tree.DNull {
+		return pgerror.New(pgcode.Internal, "procedure returned null record")
+	}
 	tuple, ok := tree.AsDTuple(res)
 	if !ok {
 		return errors.AssertionFailedf("expected a tuple, got %T", res)


### PR DESCRIPTION
Postgres returns an error with XX000 code (`Internal`) when procedure invocation produces a NULL record, and we do so now too, removing the scary stack trace.

Fixes: #122911.

Release note: None