### PR TITLE
release-23.1: sql: add a metric for cumulative contention time

### DIFF
--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -516,6 +516,7 @@ func TestDistSQLReceiverReportsContention(t *testing.T) {
 
 		metrics := s.DistSQLServer().(*distsql.ServerImpl).Metrics
 		metrics.ContendedQueriesCount.Clear()
+		metrics.CumulativeContentionNanos.Clear()
 		contentionRegistry := s.ExecutorConfig().(ExecutorConfig).ContentionRegistry
 		otherConn, err := db.Conn(ctx)
 		require.NoError(t, err)
@@ -538,12 +539,14 @@ func TestDistSQLReceiverReportsContention(t *testing.T) {
 			// Soft check to protect against flakiness where an internal query
 			// causes the contention metric to increment.
 			require.GreaterOrEqual(t, metrics.ContendedQueriesCount.Count(), int64(1))
+			require.Positive(t, metrics.CumulativeContentionNanos.Count())
 		} else {
 			require.Zero(
 				t,
 				metrics.ContendedQueriesCount.Count(),
 				"contention metric unexpectedly non-zero when no contention events are produced",
 			)
+			require.Zero(t, metrics.CumulativeContentionNanos.Count())
 		}
 
 		require.Equal(t, contention, strings.Contains(contentionRegistry.String(), contentionEventSubstring))

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -243,6 +243,7 @@ func (ex *connExecutor) recordStatementSummary(
 
 		if queryLevelStats.ContentionTime > 0 {
 			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.ContendedQueriesCount.Inc(1)
+			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.CumulativeContentionNanos.Inc(queryLevelStats.ContentionTime.Nanoseconds())
 		}
 
 		err = ex.statsCollector.RecordStatementExecStats(recordedStmtStatsKey, *queryLevelStats)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2462,6 +2462,10 @@ var charts = []sectionDescription{
 				Metrics: []string{"sql.distsql.contended_queries.count"},
 			},
 			{
+				Title:   "Cumulative Contention (nanos)",
+				Metrics: []string{"sql.distsql.cumulative_contention_nanos"},
+			},
+			{
 				Title:   "Vectorized Temporary Storage Open File Descriptors",
 				Metrics: []string{"sql.distsql.vec.openfds"},
 			},


### PR DESCRIPTION
Backport 1/1 commits from #122829.

/cc @cockroachdb/release

---

This commit adds another metric to the DistSQL metric to track the cumulative contention time experienced by all queries that used a particular node as the gateway. This can be helpful in understanding how severe a contention was at a particular point in time (previously, we only had the number of queries that have experienced contention).

This idea was suggested by Rafi as a result of an ongoing investigation.

Epic: None

Release note: None

Release justification: low-risk observability improvement.