### PR TITLE
plpgsql: remove invalid assertion when using default arg within routines

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_call
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_call
@@ -427,7 +427,7 @@ CREATE PROCEDURE p() AS $$
 $$ LANGUAGE PLpgSQL;
 
 # CALL with non-variable argument in OUT parameter position.
-statement error pgcode 42601 pq: procedure parameter \"b - 1\" is an output parameter but corresponding argument is not writable
+statement error pgcode 42601 pq: procedure parameter "y" is an output parameter but corresponding argument is not writable
 CREATE PROCEDURE p() AS $$
   DECLARE
     a INT;
@@ -437,7 +437,7 @@ CREATE PROCEDURE p() AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-statement error pgcode 42601 pq: procedure parameter \"b::INT8\" is an output parameter but corresponding argument is not writable
+statement error pgcode 42601 pq: procedure parameter "y" is an output parameter but corresponding argument is not writable
 CREATE PROCEDURE p() AS $$
   DECLARE
     a INT;

--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_params
@@ -870,4 +870,27 @@ DROP PROCEDURE p;
 statement ok
 DROP SEQUENCE seq;
 
+# Regression test for invalid assertion when using the default argument for
+# INOUT parameter when invoking the procedure (#122263).
+statement ok
+CREATE PROCEDURE p(INOUT a int DEFAULT 11) AS $$
+BEGIN
+  RAISE NOTICE 'a: %', a;
+  a := a * 10;
+END;
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42601 procedure parameter "a" is an output parameter but corresponding argument is not writable
+CREATE PROCEDURE foo() AS $$
+DECLARE _a int;
+BEGIN
+  _a := 10;
+  CALL p();  -- fail, no output argument for a
+  RAISE NOTICE '_a: %', _a;
+END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p;
+
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_params
@@ -1022,4 +1022,27 @@ DROP FUNCTION f;
 statement ok
 DROP SEQUENCE seq;
 
+# Regression test for invalid assertion when using the default argument for
+# INOUT parameter when invoking the procedure (#122263).
+statement ok
+CREATE PROCEDURE p(INOUT a int DEFAULT 11) AS $$
+BEGIN
+  RAISE NOTICE 'a: %', a;
+  a := a * 10;
+END;
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42601 procedure parameter "a" is an output parameter but corresponding argument is not writable
+CREATE FUNCTION foo() RETURNS VOID AS $$
+DECLARE _a int;
+BEGIN
+  _a := 10;
+  CALL p();  -- fail, no output argument for a
+  RAISE NOTICE '_a: %', _a;
+END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+DROP PROCEDURE p;
+
 subtest end


### PR DESCRIPTION
This commit removes the assertion that we have the same number of arguments as parameters when invoking a procedure within PLpgSQL routines. In particular, it might be the case that some DEFAULT arguments are used, so the check is not as strict as initially envisioned. Additionally, it adjusts the error message to use the parameter name rather than argument expression in a related error in order to match postgres.

Fixes: #122263.

Release note (bug fix): CockroachDB could previously run into an assertion error when evaluating PLpgSQL routines that invoke procedures while using DEFAULT arguments. The bug is present in 24.1.0-beta releases and is now fixed.