### PR TITLE
workload/schemachange: add comma syntax in workload

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -535,6 +535,19 @@ func (p *planner) IsConstraintActive(
 	return constraint != nil && constraint.IsEnforced(), nil
 }
 
+// IsColumnActive returns if a given column is currently active,
+// for the current transaction.
+func (p *planner) IsColumnActive(
+	ctx context.Context, tableID int, columnName string,
+) (bool, error) {
+	tableDesc, err := p.Descriptors().ByIDWithLeased(p.Txn()).WithoutNonPublic().Get().Table(ctx, descpb.ID(tableID))
+	if err != nil {
+		return false, err
+	}
+	col := catalog.FindColumnByName(tableDesc, columnName)
+	return col != nil && !col.IsMutation(), nil
+}
+
 // HasVirtualUniqueConstraints returns true if the table has one or more
 // constraints that are validated by RevalidateUniqueConstraintsInTable.
 func HasVirtualUniqueConstraints(tableDesc catalog.TableDescriptor) bool {

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -310,6 +310,13 @@ func (*DummyEvalPlanner) IsConstraintActive(
 	return false, errors.WithStack(errEvalPlanner)
 }
 
+// IsColumnActive is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) IsColumnActive(
+	ctx context.Context, tableID int, columnName string,
+) (bool, error) {
+	return false, errors.WithStack(errEvalPlanner)
+}
+
 // ValidateTTLScheduledJobsInCurrentDB is part of the Planner interface.
 func (*DummyEvalPlanner) ValidateTTLScheduledJobsInCurrentDB(ctx context.Context) error {
 	return errors.WithStack(errEvalPlanner)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7736,6 +7736,37 @@ active for the current transaction.`,
 		},
 	),
 
+	"crdb_internal.is_column_active": makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "table_name", Typ: types.String}, {Name: "column_name", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				tableName := tree.MustBeDString(args[0])
+				columnName := tree.MustBeDString(args[1])
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(tableName), types.RegClass)
+				if err != nil {
+					return nil, err
+				}
+				active, err := evalCtx.Planner.IsColumnActive(
+					ctx, int(dOid.Oid), string(columnName),
+				)
+				if err != nil {
+					return nil, err
+				}
+				if active {
+					return tree.DBoolTrue, nil
+				}
+				return tree.DBoolFalse, nil
+			},
+			Info: `This function is used to determine if a given column is currently.
+active for the current transaction.`,
+			Volatility: volatility.Volatile,
+		},
+	),
+
 	"crdb_internal.kv_set_queue_active": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategorySystemRepair,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2584,6 +2584,7 @@ var builtinOidsArray = []string{
 	2616: `crdb_internal.start_logical_replication_job(conn_str: string, table_names: string[]) -> int`,
 	2617: `crdb_internal.partition_spans(spans: bytes[]) -> bytes`,
 	2618: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
+	2619: `crdb_internal.is_column_active(table_name: string, column_name: string) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -349,6 +349,10 @@ type Planner interface {
 	// for the current transaction.
 	IsConstraintActive(ctx context.Context, tableID int, constraintName string) (bool, error)
 
+	// IsColumnActive returns if a given column is currently active,
+	// for the current transaction.
+	IsColumnActive(ctx context.Context, tableID int, columnName string) (bool, error)
+
 	// ValidateTTLScheduledJobsInCurrentDB checks scheduled jobs for each table
 	// in the database maps to a scheduled job.
 	ValidateTTLScheduledJobsInCurrentDB(ctx context.Context) error

--- a/pkg/workload/schemachange/error_code_set.go
+++ b/pkg/workload/schemachange/error_code_set.go
@@ -92,3 +92,12 @@ func (c codesWithConditions) append(code pgcode.Code) codesWithConditions {
 		},
 	}...)
 }
+
+func (c codesWithConditions) addAll(otherC codesWithConditions) codesWithConditions {
+	for _, cc := range otherC {
+		if cc.condition {
+			c = c.append(cc.code)
+		}
+	}
+	return c
+}

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -28,31 +28,32 @@ func _() {
 	_ = x[alterTableAddConstraintUnique-17]
 	_ = x[alterTableAlterColumnType-18]
 	_ = x[alterTableAlterPrimaryKey-19]
-	_ = x[alterTableDropColumn-20]
-	_ = x[alterTableDropColumnDefault-21]
-	_ = x[alterTableDropConstraint-22]
-	_ = x[alterTableDropNotNull-23]
-	_ = x[alterTableDropStored-24]
-	_ = x[alterTableLocality-25]
-	_ = x[alterTableRenameColumn-26]
-	_ = x[alterTableSetColumnDefault-27]
-	_ = x[alterTableSetColumnNotNull-28]
-	_ = x[alterTypeDropValue-29]
-	_ = x[createTypeEnum-30]
-	_ = x[createIndex-31]
-	_ = x[createSchema-32]
-	_ = x[createSequence-33]
-	_ = x[createTable-34]
-	_ = x[createTableAs-35]
-	_ = x[createView-36]
-	_ = x[createFunction-37]
-	_ = x[commentOn-38]
-	_ = x[dropFunction-39]
-	_ = x[dropIndex-40]
-	_ = x[dropSchema-41]
-	_ = x[dropSequence-42]
-	_ = x[dropTable-43]
-	_ = x[dropView-44]
+	_ = x[alterTableCommaSyntax-20]
+	_ = x[alterTableDropColumn-21]
+	_ = x[alterTableDropColumnDefault-22]
+	_ = x[alterTableDropConstraint-23]
+	_ = x[alterTableDropNotNull-24]
+	_ = x[alterTableDropStored-25]
+	_ = x[alterTableLocality-26]
+	_ = x[alterTableRenameColumn-27]
+	_ = x[alterTableSetColumnDefault-28]
+	_ = x[alterTableSetColumnNotNull-29]
+	_ = x[alterTypeDropValue-30]
+	_ = x[createTypeEnum-31]
+	_ = x[createIndex-32]
+	_ = x[createSchema-33]
+	_ = x[createSequence-34]
+	_ = x[createTable-35]
+	_ = x[createTableAs-36]
+	_ = x[createView-37]
+	_ = x[createFunction-38]
+	_ = x[commentOn-39]
+	_ = x[dropFunction-40]
+	_ = x[dropIndex-41]
+	_ = x[dropSchema-42]
+	_ = x[dropSequence-43]
+	_ = x[dropTable-44]
+	_ = x[dropView-45]
 }
 
 func (i opType) String() string {
@@ -97,6 +98,8 @@ func (i opType) String() string {
 		return "alterTableAlterColumnType"
 	case alterTableAlterPrimaryKey:
 		return "alterTableAlterPrimaryKey"
+	case alterTableCommaSyntax:
+		return "alterTableCommaSyntax"
 	case alterTableDropColumn:
 		return "alterTableDropColumn"
 	case alterTableDropColumnDefault:

--- a/pkg/workload/schemachange/query_util.go
+++ b/pkg/workload/schemachange/query_util.go
@@ -73,7 +73,7 @@ const (
 		tables.id AS table_id,
 		tables.name AS table_name,
 		tables.descriptor AS table_descriptor,
-		json_array_elements(descriptor->'columns') AS column
+		json_array_elements(descriptor->'table'->'columns') AS col
 	FROM tables`
 
 	// enumDescsQuery returns the JSONified version of all enum descriptors in
@@ -109,6 +109,14 @@ WHERE
 	d.classid = 'pg_catalog.pg_proc'::REGCLASS::INT8
 	AND d.refclassid = 'pg_catalog.pg_proc'::REGCLASS::INT8`
 )
+
+// TODO(annie): There might be a problem with how we are selecting
+// this table if we have multiple tables with the same name in different
+// schemas.
+func specificTableDescQuery(tableName string) string {
+	return fmt.Sprintf(`SELECT * FROM descriptors WHERE descriptor ? 'table' AND name = '%s' AND NOT
+(descriptor->'table' ? 'viewQuery' OR descriptor->'table' ? 'sequenceOpts')`, tableName)
+}
 
 func regionsFromDatabaseQuery(database string) string {
 	return fmt.Sprintf(`SELECT * FROM [SHOW REGIONS FROM DATABASE %q]`, database)


### PR DESCRIPTION
This patch expands the schema change workload to add support for `ALTER TABLE` statements (`DROP COLUMN`/`ADD COLUMN`/`ALTER PRIMARY KEY`) that have been enabled with our "comma syntax".

Fixes: #122249
Fixes https://github.com/cockroachdb/cockroach/issues/74084

Release note: None