### PR TITLE
plpgsql: add barrier after volatile assignment

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
@@ -695,4 +695,124 @@ statement ok
 DROP PROCEDURE p_inner_o;
 DROP PROCEDURE p_inner_io;
 
+# Regression test for dropping the side effects from a variable assignment when
+# the variable is never used.
+subtest regression_122318
+
+statement ok
+CREATE SEQUENCE s1;
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+<<outer>>
+DECLARE
+   x INT = 0;
+BEGIN
+   LOOP
+       x = x + 1;
+       <<inner>>
+       DECLARE
+           y INT = x + 1;
+           b INT;
+       BEGIN
+           RAISE NOTICE 'x=% y=%', x, y;
+           b := nextval('s1');
+       END inner;
+       EXIT WHEN x > 3;
+   END LOOP;
+END outer;
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: x=1 y=2
+NOTICE: x=2 y=3
+NOTICE: x=3 y=4
+NOTICE: x=4 y=5
+
+query I
+SELECT nextval('s1');
+----
+5
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+<<outer>>
+DECLARE
+   x INT = 0;
+BEGIN
+   LOOP
+       x = x + 1;
+       <<inner>>
+       DECLARE
+           y INT = x + 1;
+           b INT;
+       BEGIN
+           RAISE NOTICE 'x=% y=%', x, y;
+           SELECT nextval('s1') INTO b;
+       END inner;
+       EXIT WHEN x > 3;
+   END LOOP;
+END outer;
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: x=1 y=2
+NOTICE: x=2 y=3
+NOTICE: x=3 y=4
+NOTICE: x=4 y=5
+
+query I
+SELECT nextval('s1');
+----
+10
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+<<outer>>
+DECLARE
+   x INT = 0;
+   curs REFCURSOR := 'foo';
+BEGIN
+   OPEN curs FOR SELECT 1;
+   LOOP
+       x = x + 1;
+       <<inner>>
+       DECLARE
+           y INT = x + 1;
+           b INT;
+       BEGIN
+           RAISE NOTICE 'x=% y=%', x, y;
+           FETCH curs INTO b;
+       END inner;
+       EXIT WHEN x > 3;
+   END LOOP;
+END outer;
+$$;
+
+statement ok
+BEGIN;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: x=1 y=2
+NOTICE: x=2 y=3
+NOTICE: x=3 y=4
+NOTICE: x=4 y=5
+
+# The cursor should already be exhausted.
+query I
+FETCH foo;
+----
+
+statement ok
+ROLLBACK;
+
 subtest end

--- a/pkg/sql/opt/memo/testdata/logprops/tail-calls
+++ b/pkg/sql/opt/memo/testdata/logprops/tail-calls
@@ -389,14 +389,17 @@ values
                                     │              ├── const: ''
                                     │              ├── const: ''
                                     │              └── const: '00000'
-                                    └── values
-                                         └── tuple
-                                              └── udf: nested
-                                                   ├── tail-call
-                                                   └── body
-                                                        └── values
-                                                             └── tuple
-                                                                  └── const: 1
+                                    └── project
+                                         ├── barrier
+                                         │    └── values
+                                         │         └── tuple
+                                         │              └── udf: nested
+                                         │                   └── body
+                                         │                        └── values
+                                         │                             └── tuple
+                                         │                                  └── const: 1
+                                         └── projections
+                                              └── variable: x
 
 # Not a tail-call because of the second RAISE statement.
 exec-ddl
@@ -441,13 +444,14 @@ values
                                     │              └── const: '00000'
                                     └── project
                                          ├── barrier
-                                         │    └── values
-                                         │         └── tuple
-                                         │              └── udf: nested
-                                         │                   └── body
-                                         │                        └── values
-                                         │                             └── tuple
-                                         │                                  └── const: 1
+                                         │    └── barrier
+                                         │         └── values
+                                         │              └── tuple
+                                         │                   └── udf: nested
+                                         │                        └── body
+                                         │                             └── values
+                                         │                                  └── tuple
+                                         │                                       └── const: 1
                                          └── projections
                                               └── udf: _stmt_raise_3
                                                    ├── tail-call
@@ -974,17 +978,18 @@ values
                                          ├── left-join (cross)
                                          │    ├── values
                                          │    │    └── tuple
-                                         │    ├── limit
-                                         │    │    ├── project-set
-                                         │    │    │    ├── values
-                                         │    │    │    │    └── tuple
-                                         │    │    │    └── zip
-                                         │    │    │         └── udf: nested
-                                         │    │    │              └── body
-                                         │    │    │                   └── values
-                                         │    │    │                        └── tuple
-                                         │    │    │                             └── const: 1
-                                         │    │    └── const: 1
+                                         │    ├── barrier
+                                         │    │    └── limit
+                                         │    │         ├── project-set
+                                         │    │         │    ├── values
+                                         │    │         │    │    └── tuple
+                                         │    │         │    └── zip
+                                         │    │         │         └── udf: nested
+                                         │    │         │              └── body
+                                         │    │         │                   └── values
+                                         │    │         │                        └── tuple
+                                         │    │         │                             └── const: 1
+                                         │    │         └── const: 1
                                          │    └── filters (true)
                                          └── projections
                                               └── variable: nested

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -5766,7 +5766,7 @@ project
                      │                                                                ├── stats: [rows=1]
                      │                                                                ├── key: ()
                      │                                                                ├── fd: ()-->(17)
-                     │                                                                ├── project
+                     │                                                                ├── barrier
                      │                                                                │    ├── columns: x:13(int)
                      │                                                                │    ├── outer: (10)
                      │                                                                │    ├── cardinality: [1 - 1]
@@ -5774,31 +5774,38 @@ project
                      │                                                                │    ├── stats: [rows=1]
                      │                                                                │    ├── key: ()
                      │                                                                │    ├── fd: ()-->(13)
-                     │                                                                │    ├── prune: (13)
-                     │                                                                │    ├── project
-                     │                                                                │    │    ├── columns: stmt_fetch_3:12(tuple{int})
-                     │                                                                │    │    ├── outer: (10)
-                     │                                                                │    │    ├── cardinality: [1 - 1]
-                     │                                                                │    │    ├── volatile
-                     │                                                                │    │    ├── stats: [rows=1]
-                     │                                                                │    │    ├── key: ()
-                     │                                                                │    │    ├── fd: ()-->(12)
-                     │                                                                │    │    ├── prune: (12)
-                     │                                                                │    │    ├── values
-                     │                                                                │    │    │    ├── cardinality: [1 - 1]
-                     │                                                                │    │    │    ├── stats: [rows=1]
-                     │                                                                │    │    │    ├── key: ()
-                     │                                                                │    │    │    └── tuple [type=tuple]
-                     │                                                                │    │    └── projections
-                     │                                                                │    │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:12, type=tuple{int}, outer=(10), volatile]
-                     │                                                                │    │              ├── variable: curs:10 [type=refcursor]
-                     │                                                                │    │              ├── const: 0 [type=int]
-                     │                                                                │    │              ├── const: 1 [type=int]
-                     │                                                                │    │              └── tuple [type=tuple{int}]
-                     │                                                                │    │                   └── null [type=int]
-                     │                                                                │    └── projections
-                     │                                                                │         └── column-access: 0 [as=x:13, type=int, outer=(12)]
-                     │                                                                │              └── variable: stmt_fetch_3:12 [type=tuple{int}]
+                     │                                                                │    └── project
+                     │                                                                │         ├── columns: x:13(int)
+                     │                                                                │         ├── outer: (10)
+                     │                                                                │         ├── cardinality: [1 - 1]
+                     │                                                                │         ├── volatile
+                     │                                                                │         ├── stats: [rows=1]
+                     │                                                                │         ├── key: ()
+                     │                                                                │         ├── fd: ()-->(13)
+                     │                                                                │         ├── project
+                     │                                                                │         │    ├── columns: stmt_fetch_3:12(tuple{int})
+                     │                                                                │         │    ├── outer: (10)
+                     │                                                                │         │    ├── cardinality: [1 - 1]
+                     │                                                                │         │    ├── volatile
+                     │                                                                │         │    ├── stats: [rows=1]
+                     │                                                                │         │    ├── key: ()
+                     │                                                                │         │    ├── fd: ()-->(12)
+                     │                                                                │         │    ├── prune: (12)
+                     │                                                                │         │    ├── values
+                     │                                                                │         │    │    ├── cardinality: [1 - 1]
+                     │                                                                │         │    │    ├── stats: [rows=1]
+                     │                                                                │         │    │    ├── key: ()
+                     │                                                                │         │    │    └── tuple [type=tuple]
+                     │                                                                │         │    └── projections
+                     │                                                                │         │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:12, type=tuple{int}, outer=(10), volatile]
+                     │                                                                │         │              ├── variable: curs:10 [type=refcursor]
+                     │                                                                │         │              ├── const: 0 [type=int]
+                     │                                                                │         │              ├── const: 1 [type=int]
+                     │                                                                │         │              └── tuple [type=tuple{int}]
+                     │                                                                │         │                   └── null [type=int]
+                     │                                                                │         └── projections
+                     │                                                                │              └── column-access: 0 [as=x:13, type=int, outer=(12)]
+                     │                                                                │                   └── variable: stmt_fetch_3:12 [type=tuple{int}]
                      │                                                                └── projections
                      │                                                                     └── udf: _stmt_fetch_ret_4 [as="_stmt_fetch_ret_4":17, type=int, outer=(10,13), udf]
                      │                                                                          ├── tail-call
@@ -6325,27 +6332,29 @@ project
                      │                                                                                                        │         ├── columns: found:27
                      │                                                                                                        │         ├── right-join (cross)
                      │                                                                                                        │         │    ├── columns: a:13
-                     │                                                                                                        │         │    ├── limit
+                     │                                                                                                        │         │    ├── barrier
                      │                                                                                                        │         │    │    ├── columns: a:13
-                     │                                                                                                        │         │    │    ├── project
-                     │                                                                                                        │         │    │    │    ├── columns: a:13
-                     │                                                                                                        │         │    │    │    └── insert t114826
-                     │                                                                                                        │         │    │    │         ├── columns: a:13 rowid:14!null
-                     │                                                                                                        │         │    │    │         ├── insert-mapping:
-                     │                                                                                                        │         │    │    │         │    ├── a:17 => a:13
-                     │                                                                                                        │         │    │    │         │    └── rowid_default:21 => rowid:14
-                     │                                                                                                        │         │    │    │         ├── return-mapping:
-                     │                                                                                                        │         │    │    │         │    ├── a:17 => a:13
-                     │                                                                                                        │         │    │    │         │    └── rowid_default:21 => rowid:14
-                     │                                                                                                        │         │    │    │         └── project
-                     │                                                                                                        │         │    │    │              ├── columns: rowid_default:21 a:17
-                     │                                                                                                        │         │    │    │              ├── project
-                     │                                                                                                        │         │    │    │              │    ├── columns: a:17
-                     │                                                                                                        │         │    │    │              │    └── scan t114826
-                     │                                                                                                        │         │    │    │              │         └── columns: a:17 rowid:18!null crdb_internal_mvcc_timestamp:19 tableoid:20
-                     │                                                                                                        │         │    │    │              └── projections
-                     │                                                                                                        │         │    │    │                   └── function: unique_rowid [as=rowid_default:21]
-                     │                                                                                                        │         │    │    └── const: 1
+                     │                                                                                                        │         │    │    └── limit
+                     │                                                                                                        │         │    │         ├── columns: a:13
+                     │                                                                                                        │         │    │         ├── project
+                     │                                                                                                        │         │    │         │    ├── columns: a:13
+                     │                                                                                                        │         │    │         │    └── insert t114826
+                     │                                                                                                        │         │    │         │         ├── columns: a:13 rowid:14!null
+                     │                                                                                                        │         │    │         │         ├── insert-mapping:
+                     │                                                                                                        │         │    │         │         │    ├── a:17 => a:13
+                     │                                                                                                        │         │    │         │         │    └── rowid_default:21 => rowid:14
+                     │                                                                                                        │         │    │         │         ├── return-mapping:
+                     │                                                                                                        │         │    │         │         │    ├── a:17 => a:13
+                     │                                                                                                        │         │    │         │         │    └── rowid_default:21 => rowid:14
+                     │                                                                                                        │         │    │         │         └── project
+                     │                                                                                                        │         │    │         │              ├── columns: rowid_default:21 a:17
+                     │                                                                                                        │         │    │         │              ├── project
+                     │                                                                                                        │         │    │         │              │    ├── columns: a:17
+                     │                                                                                                        │         │    │         │              │    └── scan t114826
+                     │                                                                                                        │         │    │         │              │         └── columns: a:17 rowid:18!null crdb_internal_mvcc_timestamp:19 tableoid:20
+                     │                                                                                                        │         │    │         │              └── projections
+                     │                                                                                                        │         │    │         │                   └── function: unique_rowid [as=rowid_default:21]
+                     │                                                                                                        │         │    │         └── const: 1
                      │                                                                                                        │         │    ├── values
                      │                                                                                                        │         │    │    └── tuple
                      │                                                                                                        │         │    └── filters (true)
@@ -6825,37 +6834,39 @@ project-set
                      │    │    ├── columns: "_stmt_raise_1":9
                      │    │    ├── barrier
                      │    │    │    ├── columns: a:5
-                     │    │    │    └── project
+                     │    │    │    └── barrier
                      │    │    │         ├── columns: a:5
-                     │    │    │         ├── barrier
-                     │    │    │         │    ├── columns: a:1!null
-                     │    │    │         │    └── project
-                     │    │    │         │         ├── columns: a:1!null
-                     │    │    │         │         ├── values
-                     │    │    │         │         │    └── tuple
-                     │    │    │         │         └── projections
-                     │    │    │         │              └── const: -2 [as=a:1]
-                     │    │    │         └── projections
-                     │    │    │              └── udf: f_nested [as=a:5]
-                     │    │    │                   ├── args
-                     │    │    │                   │    └── variable: a:1
-                     │    │    │                   ├── params: x:2
-                     │    │    │                   └── body
-                     │    │    │                        └── limit
-                     │    │    │                             ├── columns: stmt_return_1:4
-                     │    │    │                             ├── project
-                     │    │    │                             │    ├── columns: stmt_return_1:4
-                     │    │    │                             │    ├── project
-                     │    │    │                             │    │    ├── columns: x:3
-                     │    │    │                             │    │    ├── values
-                     │    │    │                             │    │    │    └── tuple
-                     │    │    │                             │    │    └── projections
-                     │    │    │                             │    │         └── mult [as=x:3]
-                     │    │    │                             │    │              ├── variable: x:2
-                     │    │    │                             │    │              └── const: 2
-                     │    │    │                             │    └── projections
-                     │    │    │                             │         └── variable: x:3 [as=stmt_return_1:4]
-                     │    │    │                             └── const: 1
+                     │    │    │         └── project
+                     │    │    │              ├── columns: a:5
+                     │    │    │              ├── barrier
+                     │    │    │              │    ├── columns: a:1!null
+                     │    │    │              │    └── project
+                     │    │    │              │         ├── columns: a:1!null
+                     │    │    │              │         ├── values
+                     │    │    │              │         │    └── tuple
+                     │    │    │              │         └── projections
+                     │    │    │              │              └── const: -2 [as=a:1]
+                     │    │    │              └── projections
+                     │    │    │                   └── udf: f_nested [as=a:5]
+                     │    │    │                        ├── args
+                     │    │    │                        │    └── variable: a:1
+                     │    │    │                        ├── params: x:2
+                     │    │    │                        └── body
+                     │    │    │                             └── limit
+                     │    │    │                                  ├── columns: stmt_return_1:4
+                     │    │    │                                  ├── project
+                     │    │    │                                  │    ├── columns: stmt_return_1:4
+                     │    │    │                                  │    ├── project
+                     │    │    │                                  │    │    ├── columns: x:3
+                     │    │    │                                  │    │    ├── values
+                     │    │    │                                  │    │    │    └── tuple
+                     │    │    │                                  │    │    └── projections
+                     │    │    │                                  │    │         └── mult [as=x:3]
+                     │    │    │                                  │    │              ├── variable: x:2
+                     │    │    │                                  │    │              └── const: 2
+                     │    │    │                                  │    └── projections
+                     │    │    │                                  │         └── variable: x:3 [as=stmt_return_1:4]
+                     │    │    │                                  └── const: 1
                      │    │    └── projections
                      │    │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":9]
                      │    │              ├── args


### PR DESCRIPTION
This commit adds an optimization barrier after a PL/pgSQL variable assignment with a volatile expression for regular assignments `:=`, `FETCH`, and `SELECT ... INTO`. This is necessary because it is possible to assign to a variable, but never reference it again. This situation could previously cause the assignment to be dropped if all continuations from that point on were inlined, which would in turn cause any side effects of the assignment to be dropped.

Fixes #122318

Release note (bug fix): Fixed a bug introduced in v23.2 that could cause a PL/pgSQL variable assignment to not be executed if the variable was never referenced after the assignment.