### PR TITLE
kvcoord: correctly handle errors that indicate successful evaluation

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -214,6 +214,7 @@ go_test(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/caller",
+        "//pkg/util/circuit",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/grpcutil",

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -714,6 +714,11 @@ type DistSender struct {
 
 	routeToLeaseholderFirst bool
 
+	// replicaCircuitBreakerTokenFilter, if set, is invoked with the replica
+	// circuit breaker token before each request is tracked by its dist sender
+	// circuit breaker.
+	replicaCircuitBreakerTokenFilter func(token *replicaCircuitBreakerToken)
+
 	// dontConsiderConnHealth, if set, makes the GRPCTransport not take into
 	// consideration the connection health when deciding the ordering for
 	// replicas. When not set, replicas on nodes with unhealthy connections are
@@ -836,6 +841,7 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 	}
 	ds.dontReorderReplicas = cfg.TestingKnobs.DontReorderReplicas
 	ds.routeToLeaseholderFirst = cfg.TestingKnobs.RouteToLeaseholderFirst || metamorphicRouteToLeaseholderFirst
+	ds.replicaCircuitBreakerTokenFilter = cfg.TestingKnobs.ReplicaCircuitBreakerTokenFilter
 	ds.dontConsiderConnHealth = cfg.TestingKnobs.DontConsiderConnHealth
 	ds.rpcRetryOptions = base.DefaultRetryOptions()
 	// TODO(arul): The rpcRetryOptions passed in here from server/tenant don't
@@ -2750,6 +2756,9 @@ func (ds *DistSender) sendToReplicas(
 		tBegin := timeutil.Now() // for slow log message
 		sendCtx, cbToken, cbErr := ds.circuitBreakers.ForReplica(desc, &curReplica).
 			Track(ctx, ba, withCommit, tBegin.UnixNano())
+		if ds.replicaCircuitBreakerTokenFilter != nil {
+			ds.replicaCircuitBreakerTokenFilter(&cbToken)
+		}
 		if cbErr != nil {
 			// Circuit breaker is tripped. err will be handled below.
 			err = cbErr
@@ -3109,7 +3118,12 @@ func (ds *DistSender) sendToReplicas(
 					inTransferRetry.Next()
 				}
 			default:
-				if ambiguousError != nil {
+				// Check whether the error on the batch response indicates the request
+				// successfully evaluated on the server. If that's the case, we don't
+				// need to propagate ambiguity from prior attempts.
+				if ds.detectErrorIndicatesSuccessfulEvaluation(br.Error) {
+					return br, nil
+				} else if ambiguousError != nil {
 					return nil, kvpb.NewAmbiguousResultErrorf("error=%v [propagate] (last error: %v)",
 						ambiguousError, br.Error.GoError())
 				}
@@ -3139,6 +3153,25 @@ func (ds *DistSender) sendToReplicas(
 			return nil, err
 		}
 	}
+}
+
+// detectErrorIndicatesSuccessfulEvaluation detects whether the supplied error
+// corresponds to a request successfully evaluating on the server or not.
+// Returning an error is a legit response in a variety of cases[1]; in such
+// cases, the request doesn't need to be re-evaluated on other replicas.
+// Moreover, any ambiguity from previous evaluation attempts can be safely
+// ignored.
+//
+// [1] E.g. A QueryIntent request can be configured to return an error if the
+// intent it was looking for is not found.
+func (ds *DistSender) detectErrorIndicatesSuccessfulEvaluation(pErr *kvpb.Error) bool {
+	// TODO(arul): This should be extended to include other errors, such as
+	// TransactionRetryErrors.
+	switch pErr.GetDetail().(type) {
+	case *kvpb.IntentMissingError:
+		return true
+	}
+	return false
 }
 
 // getLocalityComparison takes two nodeIDs as input and returns the locality

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
@@ -1091,3 +1091,9 @@ func (r *ReplicaCircuitBreaker) OnProbeDone(b *circuit.Breaker) {
 	log.VEventf(ctx, 2, "stopping circuit breaker probe for %s (tripped=%t lastRequest=%s)",
 		r.id(), tripped, lastRequest)
 }
+
+// TestingCancelInflight...
+// TODO(arul): comment.
+func (r *ReplicaCircuitBreaker) TestingCancelInflight() {
+
+}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -6026,6 +6026,146 @@ func TestDistSenderNLHEFromUninitializedReplicaDoesNotCauseUnboundedBackoff(t *t
 	require.Equal(t, 1, rangeLookups)
 }
 
+// TestElideUnnecessaryAmbiguousErrors ensures the DistSender does not
+// unnecessarily wrap terminal errors resulting from successful request
+// evaluation when a previous evaluation attempt has caused ambiguity. We trip
+// the circuit breaker on a replica to cause ambiguity.
+//
+// Serves as a regression test for
+// https://github.com/cockroachdb/cockroach/issues/122439.
+func TestElideUnnecessaryAmbiguousError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ns := &mockNodeStore{
+		nodes: []roachpb.NodeDescriptor{
+			{
+				NodeID:  1,
+				Address: util.UnresolvedAddr{},
+			},
+			{
+				NodeID:  2,
+				Address: util.UnresolvedAddr{},
+			},
+			{
+				NodeID:  3,
+				Address: util.UnresolvedAddr{},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	clock := hlc.NewClockForTesting(nil)
+	tr := tracing.NewTracer()
+	st := cluster.MakeTestingClusterSettings()
+	getRangeDescCacheSize := func() int64 {
+		return 1 << 20
+	}
+
+	desc := roachpb.RangeDescriptor{
+		RangeID:    roachpb.RangeID(1),
+		Generation: 1,
+		StartKey:   roachpb.RKeyMin,
+		EndKey:     roachpb.RKeyMax,
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{NodeID: 1, StoreID: 1, ReplicaID: 1},
+			{NodeID: 2, StoreID: 2, ReplicaID: 2},
+			{NodeID: 3, StoreID: 3, ReplicaID: 3},
+		},
+	}
+	keyA := roachpb.Key("a")
+
+	rc := rangecache.NewRangeCache(st, nil /* db */, getRangeDescCacheSize, stopper)
+	rc.Insert(ctx, roachpb.RangeInfo{
+		Desc: desc,
+		Lease: roachpb.Lease{
+			Replica: roachpb.ReplicaDescriptor{
+				NodeID: 3, StoreID: 3, ReplicaID: 3,
+			},
+		},
+	})
+
+	reqSent := make(chan struct{})
+	ctxCancelled := make(chan struct{})
+	numCalled := 0
+	transportFn := func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+		numCalled++
+
+		br := &kvpb.BatchResponse{}
+		switch numCalled {
+		case 1:
+			require.Equal(t, roachpb.ReplicaID(3), ba.Replica.ReplicaID)
+			close(reqSent)
+			br.Error = kvpb.NewError(errors.New("inconsequential server side error"))
+			<-ctxCancelled
+		case 2:
+			require.Equal(t, ba.Replica.ReplicaID, roachpb.ReplicaID(1))
+			br.Error = kvpb.NewError(kvpb.NewIntentMissingError(keyA, nil))
+		default:
+			t.Fatal("unexpected call")
+		}
+		return br, nil
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	cfg := DistSenderConfig{
+		AmbientCtx: log.MakeTestingAmbientContext(tr),
+		Clock:      clock,
+		NodeDescs:  ns,
+		Stopper:    stopper,
+		RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, reverse bool) (
+			[]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error,
+		) {
+			// These tests only deal with the low-level sendToReplicas(). Nobody
+			// should be reading descriptor from the database, but the DistSender
+			// insists on having a non-nil one.
+			return nil, nil, errors.New("range desc db unexpectedly used")
+		}),
+		TransportFactory: adaptSimpleTransport(transportFn),
+		Settings:         st,
+		TestingKnobs: ClientTestingKnobs{
+			ReplicaCircuitBreakerTokenFilter: func(token *replicaCircuitBreakerToken) {
+				if token.r != nil && token.r.rangeID == desc.RangeID && token.r.desc.ReplicaID == 3 {
+					// First request; wait for the request to be sent before hijacking the
+					// cancelCtx and replacing it with a cancelled context.
+					go func() {
+						defer wg.Done()
+						<-reqSent
+						ctx, cancel := context.WithCancel(context.Background())
+						cancel()
+						token.cancelCtx = ctx
+						close(ctxCancelled)
+					}()
+				}
+			},
+			RouteToLeaseholderFirst: true,
+		},
+	}
+	ds := NewDistSender(cfg)
+	tok, err := rc.LookupWithEvictionToken(ctx, roachpb.RKeyMin, rangecache.EvictionToken{}, false)
+	require.NoError(t, err)
+
+	ba := &kvpb.BatchRequest{}
+	txn := roachpb.MakeTransaction(
+		"test", keyA, 0, 0, clock.Now(), 0, 0, 0, false, /* omitInRangefeeds */
+	)
+	ba.Add(&kvpb.QueryIntentRequest{
+		RequestHeader: kvpb.RequestHeader{
+			Key: keyA,
+		},
+		Txn:            txn.TxnMeta,
+		Strength:       lock.Intent,
+		ErrorIfMissing: true,
+	})
+	br, err := ds.sendToReplicas(ctx, ba, tok, true /* withCommit */)
+	require.NoError(t, err)
+	require.NotNil(t, br.Error)
+	testutils.IsPError(br.Error, "intent missing")
+	wg.Wait()
+}
+
 // TestOptimisticRangeDescriptorLookups tests the integration of optimistic
 // range descriptor lookups with the DistSender. It uses rather low-level
 // dependency injection to validate the combined behavior of the DistSender,

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -58,6 +58,11 @@ type ClientTestingKnobs struct {
 	// metamorphicRouteToLeaseholderFirst.
 	RouteToLeaseholderFirst bool
 
+	// ReplicaCircuitBreakerTokenFilter, if set, is invoked with the replica
+	// circuit breaker token before each request is tracked by its dist sender
+	// circuit breaker.
+	ReplicaCircuitBreakerTokenFilter func(token *replicaCircuitBreakerToken)
+
 	// CommitWaitFilter allows tests to instrument the beginning of a transaction
 	// commit wait sleep.
 	CommitWaitFilter func()


### PR DESCRIPTION
In certain cases, requests may return an error after successful evaluation. One example is `IntentMissingErrors` returned by `QueryIntent` requests when the queried intent is missing. In such cases, from the perspective of the client, the request is successful. It shouldn't be retried on another replica and any state maintained from prior attempts should be forgotten.

The former was already handled, likely by unintentionally. This patch fixes the latter. In particular, any ambiguous error tracking from previous attempts is forgotten, and in cases where the request evaluated successfully but returned an error, the error is no longer wrapped as ambiguous.

Fixes #122439

Epic: none

Release note: None