### PR TITLE
release-23.1: opt/memo: improve zigzag join cost and selectivity estimation with multi-column stats

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
@@ -155,7 +155,10 @@ SELECT * FROM b2.me.baz;
 
 
 query-sql
-SELECT table_name,index_name,non_unique,seq_in_index,column_name FROM [SHOW INDEX FROM b2.me.baz] WHERE index_name = 'greeting_idx';
+SELECT table_name,index_name,non_unique,seq_in_index,column_name
+FROM [SHOW INDEX FROM b2.me.baz]
+WHERE index_name = 'greeting_idx'
+ORDER BY seq_in_index;
 ----
 baz greeting_idx true 1 y
 baz greeting_idx true 2 rowid

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3568,8 +3568,7 @@ ALTER TABLE xyz INJECT STATISTICS '[
   }
 ]';
 
-# Regression test for #105942
-# The following should produce 2 lookup joins with a local distribution.
+# Regression test for #105942.
 query T retry
 EXPLAIN SELECT
   xyz.str,
@@ -3612,7 +3611,7 @@ vectorized: true
               table: xyz@xyz_id2_str_abc_id_idx
               spans: [/'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b' - /'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b']
 
-# The following should use a string of 4 lookup joins with a cost under 200.
+# The following should use a string of 4 lookup/index joins with a cost under 200.
 query T retry
 EXPLAIN(opt,verbose) SELECT
   x.str,
@@ -3717,4 +3716,3 @@ project
       │         ├── x.id2:12 = '68088706-02c6-47d1-b993-a421cd761f2b' [outer=(12), constraints=(/12: [/'68088706-02c6-47d1-b993-a421cd761f2b' - /'68088706-02c6-47d1-b993-a421cd761f2b']; tight), fd=()-->(12)]
       │         └── x.crdb_region:13 = 'ap-southeast-2' [outer=(13), immutable, constraints=(/13: [/'ap-southeast-2' - /'ap-southeast-2']; tight), fd=()-->(13)]
       └── filters (true)
-

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3607,6 +3607,14 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedTrigramSimilaritySelectivity
 	m.data.OptimizerUseImprovedTrigramSimilaritySelectivity = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseImprovedZigzagJoinCosting(val bool) {
+	m.data.OptimizerUseImprovedZigzagJoinCosting = val
+}
+
+func (m *sessionDataMutator) SetOptimizerUseImprovedMultiColumnSelectivityEstimate(val bool) {
+	m.data.OptimizerUseImprovedMultiColumnSelectivityEstimate = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5341,8 +5341,10 @@ optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  off
 optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_distinct_on_limit_hint_costing      off
+optimizer_use_improved_multi_column_selectivity_estimate   off
 optimizer_use_improved_split_disjunction_for_joins         on
 optimizer_use_improved_trigram_similarity_selectivity      off
+optimizer_use_improved_zigzag_join_costing                 off
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2826,8 +2826,10 @@ optimizer_use_histograms                                   on                  N
 optimizer_use_improved_computed_column_filters_derivation  off                 NULL      NULL        NULL        string
 optimizer_use_improved_disjunction_stats                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_distinct_on_limit_hint_costing      off                 NULL      NULL        NULL        string
+optimizer_use_improved_multi_column_selectivity_estimate   off                 NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL      NULL        NULL        string
 optimizer_use_improved_trigram_similarity_selectivity      off                 NULL      NULL        NULL        string
+optimizer_use_improved_zigzag_join_costing                 off                 NULL      NULL        NULL        string
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                          off                 NULL      NULL        NULL        string
@@ -2991,8 +2993,10 @@ optimizer_use_histograms                                   on                  N
 optimizer_use_improved_computed_column_filters_derivation  off                 NULL  user     NULL      off                 off
 optimizer_use_improved_disjunction_stats                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_distinct_on_limit_hint_costing      off                 NULL  user     NULL      off                 off
+optimizer_use_improved_multi_column_selectivity_estimate   off                 NULL  user     NULL      off                 off
 optimizer_use_improved_split_disjunction_for_joins         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_trigram_similarity_selectivity      off                 NULL  user     NULL      off                 off
+optimizer_use_improved_zigzag_join_costing                 off                 NULL  user     NULL      off                 off
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                          off                 NULL  user     NULL      off                 off
@@ -3155,8 +3159,10 @@ optimizer_use_histograms                                   NULL    NULL     NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_disjunction_stats                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_distinct_on_limit_hint_costing      NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_multi_column_selectivity_estimate   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_split_disjunction_for_joins         NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_trigram_similarity_selectivity      NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_zigzag_join_costing                 NULL    NULL     NULL     NULL        NULL
 optimizer_use_limit_ordering_for_streaming_group_by        NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                               NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -119,8 +119,10 @@ optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  off
 optimizer_use_improved_disjunction_stats                   on
 optimizer_use_improved_distinct_on_limit_hint_costing      off
+optimizer_use_improved_multi_column_selectivity_estimate   off
 optimizer_use_improved_split_disjunction_for_joins         on
 optimizer_use_improved_trigram_similarity_selectivity      off
+optimizer_use_improved_zigzag_join_costing                 off
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -171,6 +171,8 @@ type Memo struct {
 	useImprovedDistinctOnLimitHintCosting      bool
 	useImprovedTrigramSimilaritySelectivity    bool
 	trigramSimilarityThreshold                 float64
+	useImprovedZigzagJoinCosting               bool
+	useImprovedMultiColumnSelectivityEstimate  bool
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -237,6 +239,8 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useImprovedDistinctOnLimitHintCosting:      evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting,
 		useImprovedTrigramSimilaritySelectivity:    evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity,
 		trigramSimilarityThreshold:                 evalCtx.SessionData().TrigramSimilarityThreshold,
+		useImprovedZigzagJoinCosting:               evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting,
+		useImprovedMultiColumnSelectivityEstimate:  evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(ctx, evalCtx, m)
@@ -386,7 +390,9 @@ func (m *Memo) IsStale(
 		m.useTrigramSimilarityOptimization != evalCtx.SessionData().OptimizerUseTrigramSimilarityOptimization ||
 		m.useImprovedDistinctOnLimitHintCosting != evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting ||
 		m.useImprovedTrigramSimilaritySelectivity != evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity ||
-		m.trigramSimilarityThreshold != evalCtx.SessionData().TrigramSimilarityThreshold {
+		m.trigramSimilarityThreshold != evalCtx.SessionData().TrigramSimilarityThreshold ||
+		m.useImprovedZigzagJoinCosting != evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting ||
+		m.useImprovedMultiColumnSelectivityEstimate != evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -403,6 +403,18 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().TrigramSimilarityThreshold = 0
 	notStale()
 
+	// Stale optimizer_use_improved_zigzag_join_costing.
+	evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = true
+	stale()
+	evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = false
+	notStale()
+
+	// Stale optimizer_use_improved_multi_column_selectivity_estimate.
+	evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
+	stale()
+	evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3789,13 +3789,13 @@ func (sb *statisticsBuilder) updateDistinctNullCountsFromEquivalency(
 //	3 or 4. We estimate the new distinct count as follows, using the concept
 //	of "soft functional dependency (FD) strength" as defined in [1]:
 //
-//	  new_distinct({x,y}) = min_value + range * (1 - FD_strength_scaled)
+//	  new_distinct({x,y}) = min_distinct + distinct_range * (1 - FD_strength_scaled)
 //
 //	where
 //
-//	  min_value = max(new_distinct(x), new_distinct(y))
-//	  max_value = new_distinct(x) * new_distinct(y)
-//	  range     = max_value - min_value
+//	  min_distinct   = max(new_distinct(x), new_distinct(y))
+//	  max_distinct   = new_distinct(x) * new_distinct(y)
+//	  distinct_range = max_distinct - min_distinct
 //
 //	                ⎛ max(old_distinct(x),old_distinct(y)) ⎞
 //	  FD_strength = ⎜ ------------------------------------ ⎟
@@ -3843,7 +3843,7 @@ func (sb *statisticsBuilder) updateDistinctNullCountsFromEquivalency(
 // completely correlated. It is equal to the minimum selectivity of any single
 // column. selectivityLowerBound would be the value of equation (2) if the
 // columns were completely independent. It is the minimum new distinct count
-// (min_value) divided by the product of the old single column distinct counts
+// (min_distinct) divided by the product of the old single column distinct counts
 // (or the old row count, whichever is smaller). These values will be used later
 // to measure the level of correlation.
 //
@@ -3864,72 +3864,78 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 
 	// First calculate the selectivity from equation (1) (see function comment),
 	// and collect the inputs to equation (2).
-	singleColSelectivity := props.OneSelectivity
-	newDistinctProduct, oldDistinctProduct := 1.0, 1.0
-	maxNewDistinct, maxOldDistinct := float64(0), float64(0)
+	multiColSelWithIndepAssumption := props.OneSelectivity
+	newSingleColDistinctProduct, oldSingleColDistinctProduct := 1.0, 1.0
+	maxNewSingleColDistinct, maxOldSingleColDistinct := float64(0), float64(0)
 	multiColNullCount := -1.0
-	minLocalSel := props.OneSelectivity
+	minSingleColSel := props.OneSelectivity
 	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
-		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
+		singleColStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
 		if !ok {
 			multiColSet.Remove(col)
 			continue
 		}
 
-		inputColStat, inputStats := sb.colStatFromInput(colStat.Cols, e)
-		localSel := sb.selectivityFromDistinctCount(colStat, inputColStat, inputStats.RowCount)
-		singleColSelectivity.Multiply(localSel)
+		inputSingleColStat, inputStats := sb.colStatFromInput(singleColStat.Cols, e)
+		singleColSel := sb.selectivityFromDistinctCount(singleColStat, inputSingleColStat, inputStats.RowCount)
+		multiColSelWithIndepAssumption.Multiply(singleColSel)
 
 		// Don't bother including columns in the multi-column calculation that
 		// don't contribute to the selectivity.
-		if localSel == props.OneSelectivity {
+		if singleColSel == props.OneSelectivity {
 			multiColSet.Remove(col)
 			continue
 		}
 
 		// Calculate values needed for the multi-column stats calculation below.
-		newDistinctProduct *= colStat.DistinctCount
-		oldDistinctProduct *= inputColStat.DistinctCount
-		if colStat.DistinctCount > maxNewDistinct {
-			maxNewDistinct = colStat.DistinctCount
+		newSingleColDistinctProduct *= singleColStat.DistinctCount
+		oldSingleColDistinctProduct *= inputSingleColStat.DistinctCount
+		if singleColStat.DistinctCount > maxNewSingleColDistinct {
+			maxNewSingleColDistinct = singleColStat.DistinctCount
 		}
-		if inputColStat.DistinctCount > maxOldDistinct {
-			maxOldDistinct = inputColStat.DistinctCount
+		if inputSingleColStat.DistinctCount > maxOldSingleColDistinct {
+			maxOldSingleColDistinct = inputSingleColStat.DistinctCount
 		}
-		minLocalSel = props.MinSelectivity(localSel, minLocalSel)
+		minSingleColSel = props.MinSelectivity(singleColSel, minSingleColSel)
 		if multiColNullCount < 0 {
 			multiColNullCount = inputStats.RowCount
 		}
 		// Multiply by the expected chance of collisions with nulls already
 		// collected.
-		multiColNullCount *= colStat.NullCount / inputStats.RowCount
+		multiColNullCount *= singleColStat.NullCount / inputStats.RowCount
 	}
 
 	// If we don't need to use a multi-column statistic, we're done.
 	if multiColSet.Len() <= 1 {
-		return singleColSelectivity, minLocalSel, singleColSelectivity
+		return multiColSelWithIndepAssumption, minSingleColSel, multiColSelWithIndepAssumption
 	}
 
 	// Otherwise, calculate the selectivity using multi-column stats from
 	// equation (2). See the comment above the function definition for details
 	// about the formula.
-	inputColStat, inputStats := sb.colStatFromInput(multiColSet, e)
-	fdStrength := min(maxOldDistinct/inputColStat.DistinctCount, 1.0)
-	minFdStrength := min(maxOldDistinct/oldDistinctProduct, fdStrength)
+	inputMultiColStat, inputStats := sb.colStatFromInput(multiColSet, e)
+	fdStrength := min(maxOldSingleColDistinct/inputMultiColStat.DistinctCount, 1.0)
+	minFdStrength := min(maxOldSingleColDistinct/oldSingleColDistinctProduct, fdStrength)
 	if minFdStrength < 1 {
 		// Scale the fdStrength so it ranges between 0 and 1.
 		fdStrength = (fdStrength - minFdStrength) / (1 - minFdStrength)
 	}
-	distinctCountRange := max(newDistinctProduct-maxNewDistinct, 0)
 
-	colStat, _ := s.ColStats.Add(multiColSet)
-	colStat.DistinctCount = maxNewDistinct + distinctCountRange*(1-fdStrength)
-	colStat.NullCount = multiColNullCount
-	multiColSelectivity := sb.selectivityFromDistinctCount(colStat, inputColStat, inputStats.RowCount)
+	// These variables correspond to min_distinct, max_distinct, and distinct_range
+	// in the comment above the function definition.
+	minNewMultiColDistinct := maxNewSingleColDistinct
+	maxNewMultiColDistinct := newSingleColDistinctProduct
+	multiColDistinctRange := max(maxNewMultiColDistinct-minNewMultiColDistinct, 0)
 
-	// multiColSelectivity must be at least as large as singleColSelectivity,
-	// since singleColSelectivity corresponds to equation (1).
-	multiColSelectivity = props.MaxSelectivity(multiColSelectivity, singleColSelectivity)
+	multiColStat, _ := s.ColStats.Add(multiColSet)
+	multiColStat.DistinctCount = minNewMultiColDistinct + multiColDistinctRange*(1-fdStrength)
+	multiColStat.NullCount = multiColNullCount
+	multiColSelectivity := sb.selectivityFromDistinctCount(multiColStat, inputMultiColStat, inputStats.RowCount)
+
+	// multiColSelectivity must be at least as large as
+	// multiColSelWithIndepAssumption, since multiColSelWithIndepAssumption
+	// corresponds to equation (1).
+	multiColSelectivity = props.MaxSelectivity(multiColSelectivity, multiColSelWithIndepAssumption)
 
 	// Now, we must adjust multiColSelectivity so that it is not greater than
 	// the selectivity of any subset of the columns in multiColSet. This would
@@ -3937,8 +3943,8 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 	// x=1 AND y=1 should always be considered more selective (i.e., with lower
 	// selectivity) than x=1 alone.
 	//
-	// We have already found the minimum selectivity of all the individual
-	// columns (subsets of size 1) above and stored it in minLocalSel. It's not
+	// We have already found the minimum selectivity of all the individual columns
+	// (subsets of size 1) above and stored it in minSingleColSel. It's not
 	// practical, however, to calculate the minimum selectivity for all subsets
 	// larger than size 1.
 	//
@@ -3950,7 +3956,7 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 	//
 	// In this case, adjust multiColSelectivity as needed.
 	//
-	if maxNewDistinct > 1 && multiColSet.Len() > 2 {
+	if maxNewSingleColDistinct > 1 && multiColSet.Len() > 2 {
 		var lowDistinctCountCols opt.ColSet
 		multiColSet.ForEach(func(col opt.ColumnID) {
 			// We already know the column stat exists if it's in multiColSet.
@@ -3976,14 +3982,15 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 			multiColSelectivity = props.MinSelectivity(multiColSelectivity, selLowDistinctCountCols)
 		}
 	}
-	multiColSelectivity = props.MinSelectivity(multiColSelectivity, minLocalSel)
+	multiColSelectivity = props.MinSelectivity(multiColSelectivity, minSingleColSel)
 
 	// multiColSelectivityLowerBound is the minimum multi-column selectivity, which
 	// is the minimum possible new multi-col distinct count divided by the maximum
 	// old multi-column distinct count (either the product of the old single column
 	// distinct counts or the old row count, whichever is smaller).
+	maxOldMultiColDistinct := min(inputStats.RowCount, oldSingleColDistinctProduct)
 	multiColSelectivityLowerBound := props.MakeSelectivityFromFraction(
-		maxNewDistinct, min(inputStats.RowCount, oldDistinctProduct),
+		minNewMultiColDistinct, maxOldMultiColDistinct,
 	)
 	// Ensure that multiColSelectivityLowerBound is not larger than
 	// multiColSelectivity.
@@ -3991,19 +3998,19 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 		multiColSelectivityLowerBound, multiColSelectivity,
 	)
 
-	// As described in the function comment, we actually return a weighted sum
-	// of multi-column and single-column selectivity estimates. To ensure
-	// selectivityLowerBound is not larger than this selectivity, use the same
-	// weighting scheme.
+	// As described in the function comment, we actually return a weighted sum of
+	// multi-column selectivity estimates with and without an independence
+	// assumption. To ensure selectivityLowerBound is not larger than this
+	// selectivity, use the same weighting scheme.
 	//
 	// Use MaxSelectivity to handle floating point rounding errors.
 	w := multiColWeight
-	return props.MaxSelectivity(singleColSelectivity, props.MakeSelectivity(
-			(1-w)*singleColSelectivity.AsFloat()+w*multiColSelectivity.AsFloat(),
+	return props.MaxSelectivity(multiColSelWithIndepAssumption, props.MakeSelectivity(
+			(1-w)*multiColSelWithIndepAssumption.AsFloat()+w*multiColSelectivity.AsFloat(),
 		)),
-		minLocalSel,
-		props.MaxSelectivity(singleColSelectivity, props.MakeSelectivity(
-			(1-w)*singleColSelectivity.AsFloat()+w*multiColSelectivityLowerBound.AsFloat(),
+		minSingleColSel,
+		props.MaxSelectivity(multiColSelWithIndepAssumption, props.MakeSelectivity(
+			(1-w)*multiColSelWithIndepAssumption.AsFloat()+w*multiColSelectivityLowerBound.AsFloat(),
 		))
 }
 

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -123,7 +123,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 
 		// Calculate row count and selectivity.
 		s.RowCount = scan.Relational().Statistics().RowCount
-		selectivity, _ := sb.selectivityFromMultiColDistinctCounts(cols, sel, s)
+		selectivity, _, _ := sb.selectivityFromMultiColDistinctCounts(cols, sel, s)
 		s.ApplySelectivity(selectivity)
 
 		// Update null counts.

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2075,10 +2075,6 @@ select
  └── filters
       └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
 
-# Without stats with histograms, zig-zag join may not be chosen.
-# This is OK because it can be expensive when many rows are qualified.
-# This case shows less than 1 qualified row in the constrained scan of
-# multi_col@bef_idx, so it should beat zig-zag join.
 opt
 SELECT * FROM multi_col
 WHERE a = '37685f26-4b07-40ba-9bbf-42916ed9bc61'

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3458,7 +3458,6 @@ ALTER TABLE t1821 INJECT STATISTICS '[
 ]';
 ----
 
-# Zig-zag join should not be picked due to high selectivity.
 opt
 SELECT count(*) FROM t1821 WHERE a = 1 AND b = 1
 ----
@@ -3645,6 +3644,469 @@ project
       │                     <--- 0 --- 1 --- Infinity
       └── filters
            └── d:3 >= 2 [type=bool, outer=(3), immutable, constraints=(/3: [/2 - ]; tight)]
+
+# Regression test for #121397. Do not over-estimate the selectivity of multi-column
+# filters when the multi-column distinct count is high.
+exec-ddl
+CREATE TABLE table1 (
+  col1 STRING NOT NULL,
+  col2 STRING NOT NULL,
+  col3 INT8 NOT NULL,
+  PRIMARY KEY (col1 ASC, col2 ASC)
+)
+----
+
+exec-ddl
+CREATE TABLE table2 (
+  col1 STRING NOT NULL,
+  col2 STRING NOT NULL,
+  col3 INT8 NOT NULL,
+  col4 STRING NOT NULL,
+  col5 STRING NOT NULL,
+  col6 STRING NOT NULL,
+  col7 STRING NOT NULL,
+  PRIMARY KEY (col1 ASC, col2 ASC, col4 ASC, col5 ASC, col6 ASC, col7 ASC),
+  FOREIGN KEY (col4, col5) REFERENCES table1(col1, col2) ON DELETE CASCADE,
+  FOREIGN KEY (col6, col7) REFERENCES table1(col1, col2) ON DELETE CASCADE,
+  INDEX (col4 ASC, col5 ASC),
+  INDEX (col6 ASC, col7 ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE table2 INJECT STATISTICS '[
+    {
+        "avg_size": 40,
+        "columns": [
+            "col1"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 3,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 2000000,
+                "num_range": 0,
+                "upper_bound": "a"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 5000,
+                "num_range": 0,
+                "upper_bound": "b"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 500000,
+                "num_range": 0,
+                "upper_bound": "c"
+            }
+        ],
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 43,
+        "columns": [
+            "col1",
+            "col2"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 3,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 60,
+        "columns": [
+            "col1",
+            "col2",
+            "col4"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 4,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 130,
+        "columns": [
+            "col1",
+            "col2",
+            "col4",
+            "col5"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2455000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 150,
+        "columns": [
+            "col1",
+            "col2",
+            "col4",
+            "col5",
+            "col6"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2465000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 160,
+        "columns": [
+            "col1",
+            "col2",
+            "col4",
+            "col5",
+            "col6",
+            "col7"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2505000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 3,
+        "columns": [
+            "col2"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 20,
+        "columns": [
+            "col4"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 4,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 90,
+        "columns": [
+            "col4",
+            "col5"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2505000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 70,
+        "columns": [
+            "col5"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2405000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 19,
+        "columns": [
+            "col6"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 3,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 2000000,
+                "num_range": 0,
+                "upper_bound": "d"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 5000,
+                "num_range": 0,
+                "upper_bound": "e"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 500000,
+                "num_range": 0,
+                "upper_bound": "f"
+            }
+        ],
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 30,
+        "columns": [
+            "col6",
+            "col7"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2355000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 15,
+        "columns": [
+            "col7"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 2355000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 3000,
+                "num_range": 0,
+                "upper_bound": "x"
+            },
+            {
+                "distinct_range": 2354998,
+                "num_eq": 500,
+                "num_range": 2401500,
+                "upper_bound": "y"
+            }
+        ],
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    },
+    {
+        "avg_size": 2,
+        "columns": [
+            "col3"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 2505000
+    }
+]';
+----
+
+exec-ddl
+ALTER TABLE table1 INJECT STATISTICS '[
+    {
+        "avg_size": 20,
+        "columns": [
+            "col1"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 9,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 6000,
+                "num_range": 0,
+                "upper_bound": "d"
+            },
+            {
+                "distinct_range": 6,
+                "num_eq": 2000,
+                "num_range": 20000000,
+                "upper_bound": "e"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 2000,
+                "num_range": 0,
+                "upper_bound": "f"
+            }
+        ],
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 20010000
+    },
+    {
+        "avg_size": 50,
+        "columns": [
+            "col1",
+            "col2"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 20009000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 20010000
+    },
+    {
+        "avg_size": 40,
+        "columns": [
+            "col2"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 20009000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 20010000
+    },
+    {
+        "avg_size": 2,
+        "columns": [
+            "col3"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 20010000
+    }
+]';
+----
+
+opt set=optimizer_use_improved_multi_column_selectivity_estimate=true
+SELECT
+  table1.col1,
+  table1.col2,
+  table1.col3,
+  table2.col1,
+  table2.col2,
+  table2.col3,
+  table2.col4,
+  table2.col5,
+  table2.col6,
+  table2.col7
+FROM
+  (SELECT * FROM table2 WHERE table2.col1 = 'b') AS table2
+  LEFT JOIN (SELECT * FROM table1 WHERE table1.col1  = 'e') AS table1 ON
+      table1.col1 = table2.col4 AND table1.col2 = table2.col5
+WHERE
+  (table2.col6, table2.col7) IN (('f', 'x'))
+----
+left-join (lookup table1)
+ ├── columns: col1:10(string) col2:11(string) col3:12(int) col1:1(string!null) col2:2(string!null) col3:3(int!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
+ ├── key columns: [4 5] = [10 11]
+ ├── lookup columns are key
+ ├── stats: [rows=1.245162, distinct(10)=1, null(10)=0.0814548, distinct(11)=1.16371, null(11)=0.0814548]
+ ├── key: (2,4,5)
+ ├── fd: ()-->(1,6,7), (2,4,5)-->(3,10-12), (11)-->(12)
+ ├── index-join table2
+ │    ├── columns: table2.col1:1(string!null) table2.col2:2(string!null) table2.col3:3(int!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
+ │    ├── stats: [rows=1.245162, distinct(1)=1, null(1)=0, distinct(2)=0.712106, null(2)=0, distinct(3)=0.712106, null(3)=0, distinct(4)=1.07, null(4)=0, distinct(5)=1.24516, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(1,6,7)=1, null(1,6,7)=0]
+ │    │   histogram(1)=  0 1.2452
+ │    │                <--- 'b' -
+ │    │   histogram(6)=  0 1.2452
+ │    │                <--- 'f' -
+ │    │   histogram(7)=  0 1.2452
+ │    │                <--- 'x' -
+ │    ├── key: (2,4,5)
+ │    ├── fd: ()-->(1,6,7), (2,4,5)-->(3)
+ │    └── scan table2@table2_col6_col7_idx
+ │         ├── columns: table2.col1:1(string!null) table2.col2:2(string!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
+ │         ├── constraint: /6/7/1/2/4/5: [/'f'/'x'/'b' - /'f'/'x'/'b']
+ │         ├── stats: [rows=1.245162, distinct(1)=1, null(1)=0, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(1,6,7)=1, null(1,6,7)=0]
+ │         │   histogram(1)=  0 1.2452
+ │         │                <--- 'b' -
+ │         │   histogram(6)=  0 1.2452
+ │         │                <--- 'f' -
+ │         │   histogram(7)=  0 1.2452
+ │         │                <--- 'x' -
+ │         ├── key: (2,4,5)
+ │         └── fd: ()-->(1,6,7)
+ └── filters
+      └── table1.col1:10 = 'e' [type=bool, outer=(10), constraints=(/10: [/'e' - /'e']; tight), fd=()-->(10)]
+
+# Choose a hash join instead of a lookup join if using the legacy multi-column
+# stats selectivity estimate.
+opt set=optimizer_use_improved_multi_column_selectivity_estimate=false
+SELECT
+  table1.col1,
+  table1.col2,
+  table1.col3,
+  table2.col1,
+  table2.col2,
+  table2.col3,
+  table2.col4,
+  table2.col5,
+  table2.col6,
+  table2.col7
+FROM
+  (SELECT * FROM table2 WHERE table2.col1 = 'b') AS table2
+  LEFT JOIN (SELECT * FROM table1 WHERE table1.col1  = 'e') AS table1 ON
+      table1.col1 = table2.col4 AND table1.col2 = table2.col5
+WHERE
+  (table2.col6, table2.col7) IN (('f', 'x'))
+----
+left-join (hash)
+ ├── columns: col1:10(string) col2:11(string) col3:12(int) col1:1(string!null) col2:2(string!null) col3:3(int!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── stats: [rows=2623.017, distinct(10)=1, null(10)=2123.01, distinct(11)=500.011, null(11)=2123.01]
+ ├── key: (2,4,5)
+ ├── fd: ()-->(1,6,7), (2,4,5)-->(3,10-12), (11)-->(12)
+ ├── select
+ │    ├── columns: table2.col1:1(string!null) table2.col2:2(string!null) table2.col3:3(int!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
+ │    ├── stats: [rows=2623.017, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=4, null(4)=0, distinct(5)=2622.96, null(5)=0, distinct(6)=1, null(6)=0, distinct(7)=1, null(7)=0, distinct(1,6,7)=1, null(1,6,7)=0]
+ │    │   histogram(1)=  0 2623
+ │    │                <--- 'b'
+ │    │   histogram(6)=  0 2623
+ │    │                <--- 'f'
+ │    │   histogram(7)=  0 2623
+ │    │                <--- 'x'
+ │    ├── key: (2,4,5)
+ │    ├── fd: ()-->(1,6,7), (2,4,5)-->(3)
+ │    ├── scan table2
+ │    │    ├── columns: table2.col1:1(string!null) table2.col2:2(string!null) table2.col3:3(int!null) col4:4(string!null) col5:5(string!null) col6:6(string!null) col7:7(string!null)
+ │    │    ├── constraint: /1/2/4/5/6/7: [/'b' - /'b']
+ │    │    ├── stats: [rows=5000, distinct(1)=1, null(1)=0]
+ │    │    │   histogram(1)=  0 5000
+ │    │    │                <--- 'b'
+ │    │    ├── key: (2,4-7)
+ │    │    └── fd: ()-->(1), (2,4-7)-->(3)
+ │    └── filters
+ │         ├── col6:6 = 'f' [type=bool, outer=(6), constraints=(/6: [/'f' - /'f']; tight), fd=()-->(6)]
+ │         └── col7:7 = 'x' [type=bool, outer=(7), constraints=(/7: [/'x' - /'x']; tight), fd=()-->(7)]
+ ├── scan table1
+ │    ├── columns: table1.col1:10(string!null) table1.col2:11(string!null) table1.col3:12(int!null)
+ │    ├── constraint: /10/11: [/'e' - /'e']
+ │    ├── stats: [rows=2000.002, distinct(10)=1, null(10)=0, distinct(11)=2000, null(11)=0]
+ │    │   histogram(10)=  0 2000
+ │    │                 <--- 'e'
+ │    ├── key: (11)
+ │    └── fd: ()-->(10), (11)-->(12)
+ └── filters
+      ├── table1.col1:10 = col4:4 [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
+      └── table1.col2:11 = col5:5 [type=bool, outer=(5,11), constraints=(/5: (/NULL - ]; /11: (/NULL - ]), fd=(5)==(11), (11)==(5)]
 
 # Tests for selectivity of disjunctions
 

--- a/pkg/sql/opt/testutils/opttester/testdata/inject-stats.json
+++ b/pkg/sql/opt/testutils/opttester/testdata/inject-stats.json
@@ -266,5 +266,17 @@
     "name": "foo",
     "null_count": 0,
     "row_count": 500
+  },
+  {
+    "columns": [
+      "city",
+      "vehicle_city"
+    ],
+    "created_at": "2020-05-06 17:47:28.557622+00:00",
+    "distinct_count": 9,
+    "histo_col_type": "",
+    "name": "foo",
+    "null_count": 0,
+    "row_count": 500
   }
 ]

--- a/pkg/sql/opt/testutils/opttester/testdata/use-multi-col-stats
+++ b/pkg/sql/opt/testutils/opttester/testdata/use-multi-col-stats
@@ -13,8 +13,8 @@ CREATE TABLE rides (
     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
     INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),
     INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),
-    FAMILY "primary" (id, city, vehicle_city, rider_id, vehicle_id, start_address, end_address, start_time, end_time, revenue),
-    CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)
+    INDEX rides_city_vehicle_city (city ASC, vehicle_city ASC),
+    FAMILY "primary" (id, city, vehicle_city, rider_id, vehicle_id, start_address, end_address, start_time, end_time, revenue)
 )
 ----
 
@@ -22,27 +22,49 @@ inject-stats file=inject-stats.json table=rides
 ----
 
 opt format=show-stats set=optimizer_use_multicol_stats=true
-SELECT * FROM rides WHERE city = 'rome' and id = '17198184-b24f-4aa8-9933-64a72ff6665f'
+SELECT * FROM rides WHERE city = 'rome' and vehicle_city = 'rome'
 ----
-scan rides
- ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
- ├── constraint: /2/1: [/'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f' - /'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f']
- ├── cardinality: [0 - 1]
- ├── stats: [rows=0.911, distinct(1)=0.911, null(1)=0, distinct(2)=0.911, null(2)=0, distinct(1,2)=0.911, null(1,2)=0]
- │   histogram(2)=  0  0.911
+select
+ ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar!null) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
+ ├── stats: [rows=50.105, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1, null(2,3)=0]
+ │   histogram(2)=  0  50.105
  │                <--- 'rome'
- ├── key: ()
- └── fd: ()-->(1-10)
+ │   histogram(3)=  0  50.105
+ │                <--- 'rome'
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4-10)
+ ├── scan rides
+ │    ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
+ │    ├── constraint: /2/1: [/'rome' - /'rome']
+ │    ├── stats: [rows=55, distinct(2)=1, null(2)=0]
+ │    │   histogram(2)=  0    55
+ │    │                <--- 'rome'
+ │    ├── key: (1)
+ │    └── fd: ()-->(2), (1)-->(3-10)
+ └── filters
+      └── eq [type=bool, outer=(3), constraints=(/3: [/'rome' - /'rome']; tight), fd=()-->(3)]
+           ├── variable: vehicle_city:3 [type=varchar]
+           └── const: 'rome' [type=string]
 
 opt format=show-stats set=optimizer_use_multicol_stats=false
-SELECT * FROM rides WHERE city = 'rome' and id = '17198184-b24f-4aa8-9933-64a72ff6665f'
+SELECT * FROM rides WHERE city = 'rome' and vehicle_city = 'rome'
 ----
-scan rides
- ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
- ├── constraint: /2/1: [/'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f' - /'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f']
- ├── cardinality: [0 - 1]
- ├── stats: [rows=0.1100001, distinct(1)=0.11, null(1)=0, distinct(2)=0.11, null(2)=0]
- │   histogram(2)=  0   0.11
+index-join rides
+ ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar!null) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
+ ├── stats: [rows=6.05, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+ │   histogram(2)=  0   6.05
  │                <--- 'rome'
- ├── key: ()
- └── fd: ()-->(1-10)
+ │   histogram(3)=  0   6.05
+ │                <--- 'rome'
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4-10)
+ └── scan rides@rides_city_vehicle_city
+      ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar!null)
+      ├── constraint: /2/3/1: [/'rome'/'rome' - /'rome'/'rome']
+      ├── stats: [rows=6.05, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+      │   histogram(2)=  0   6.05
+      │                <--- 'rome'
+      │   histogram(3)=  0   6.05
+      │                <--- 'rome'
+      ├── key: (1)
+      └── fd: ()-->(2,3)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1310,6 +1310,19 @@ func (c *coster) computeZigzagJoinCost(join *memo.ZigzagJoinExpr) memo.Cost {
 	// the zigzag join. See issue #68556.
 	cost += c.largeCardinalityCostPenalty(join.Relational().Cardinality, rowCount)
 
+	if c.evalCtx != nil && c.evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting {
+		// Add one randIOCostFactor of additional seek cost so the cost is at least as
+		// much as a scan if rowCount is less than one.
+		cost += randIOCostFactor
+
+		// TODO(rytaft): We don't capture distribution info in zigzag joins, so pass
+		// an empty distribution. We need to add some distribution cost to prevent the
+		// coster from always preferring zigzag joins over scans. If we ever want to
+		// make zigzag joins a priority again, we should store a real distribution
+		// value on the zigzag join, similar to scans.
+		cost += c.distributionCost(physical.Distribution{})
+	}
+
 	return cost
 }
 

--- a/pkg/sql/opt/xform/testdata/coster/zigzag
+++ b/pkg/sql/opt/xform/testdata/coster/zigzag
@@ -1,0 +1,62 @@
+exec-ddl
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  INDEX a_idx(a) STORING (b),
+  INDEX c_idx(c) STORING (d)
+)
+----
+
+opt set=optimizer_use_improved_zigzag_join_costing=false
+SELECT count(*) FROM abcd WHERE a = 0 AND b = 1 AND c = 2
+----
+scalar-group-by
+ ├── columns: count:8!null
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 21.00913
+ ├── key: ()
+ ├── fd: ()-->(8)
+ ├── inner-join (zigzag abcd@a_idx abcd@c_idx)
+ │    ├── columns: a:1!null b:2!null c:3!null
+ │    ├── eq columns: [5] = [5]
+ │    ├── left fixed columns: [1] = [0]
+ │    ├── right fixed columns: [3] = [2]
+ │    ├── stats: [rows=0.901, distinct(1)=0.901, null(1)=0, distinct(2)=0.901, null(2)=0, distinct(3)=0.901, null(3)=0, distinct(1-3)=0.901, null(1-3)=0]
+ │    ├── cost: 20.97012
+ │    ├── fd: ()-->(1-3)
+ │    └── filters
+ │         ├── a:1 = 0 [outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
+ │         ├── b:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │         └── c:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
+ └── aggregations
+      └── count-rows [as=count_rows:8]
+
+# With optimizer_use_improved_zigzag_join_costing enabled, we should
+# see extra cost for seeking and distribution.
+opt set=optimizer_use_improved_zigzag_join_costing=true
+SELECT count(*) FROM abcd WHERE a = 0 AND b = 1 AND c = 2
+----
+scalar-group-by
+ ├── columns: count:8!null
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── cost: 29.00913
+ ├── key: ()
+ ├── fd: ()-->(8)
+ ├── inner-join (zigzag abcd@a_idx abcd@c_idx)
+ │    ├── columns: a:1!null b:2!null c:3!null
+ │    ├── eq columns: [5] = [5]
+ │    ├── left fixed columns: [1] = [0]
+ │    ├── right fixed columns: [3] = [2]
+ │    ├── stats: [rows=0.901, distinct(1)=0.901, null(1)=0, distinct(2)=0.901, null(2)=0, distinct(3)=0.901, null(3)=0, distinct(1-3)=0.901, null(1-3)=0]
+ │    ├── cost: 28.97012
+ │    ├── fd: ()-->(1-3)
+ │    └── filters
+ │         ├── a:1 = 0 [outer=(1), constraints=(/1: [/0 - /0]; tight), fd=()-->(1)]
+ │         ├── b:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │         └── c:3 = 2 [outer=(3), constraints=(/3: [/2 - /2]; tight), fd=()-->(3)]
+ └── aggregations
+      └── count-rows [as=count_rows:8]

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -408,6 +408,13 @@ message LocalOnlySessionData {
   // optimizer should use an improved selectivitiy estimate for trigram
   // similarity filters.
   bool optimizer_use_improved_trigram_similarity_selectivity = 127;
+  // OptimizerUseImprovedZigzagJoinCosting, when true, indicates that the
+  // optimizer should use improved logic in the cost model for zigzag joins.
+  bool optimizer_use_improved_zigzag_join_costing = 128;
+  // OptimizerUseImprovedMultiColumnSelectivityEstimate, when true, indicates
+  // that the optimizer should use an improved selectivity estimate for
+  // multi-column predicates.
+  bool optimizer_use_improved_multi_column_selectivity_estimate = 129;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2868,6 +2868,40 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_improved_zigzag_join_costing`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_zigzag_join_costing`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_zigzag_join_costing", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedZigzagJoinCosting(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
+	`optimizer_use_improved_multi_column_selectivity_estimate`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_multi_column_selectivity_estimate`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_multi_column_selectivity_estimate", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedMultiColumnSelectivityEstimate(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
Backport 4/4 commits from #120805.

/cc @cockroachdb/release

---

**opt: update seek and distribution cost of zigzag join to match scan**

Prior to this commit, the optimizer could prefer a zigzag join over a
scan even if they produced the same number of rows. This was because scans
always included the cost of at least one seek (involving random I/O) and
some distribution cost, while zigzag joins did not. This commit updates
the cost of zigzag joins to include seek and distribution costs so they
will never be chosen over scans unless they produce fewer rows.

This change is behind the setting `optimizer_use_improved_zigzag_join_costing`.

Release note (performance improvement): Added a new setting
`optimizer_use_improved_zigzag_join_costing`. When enabled, the cost of zigzag
joins is updated so they will be never be chosen over scans unless they
produce fewer rows. This change only matters if the setting `enable_zigzag_join`
is also true.

**opt/memo: improve selectivity estimation with multi-column stats**

This commit updates `correlationFromMultiColDistinctCounts` in `statisticsBuilder`
to use a tighter lower bound for the multi-column selectivity. This avoids
cases where we significantly over-estimate the selectivity of a multi-column
predicate.

Fixes https://github.com/cockroachdb/cockroach/issues/121397

Release note (performance improvement): Improved the selectivity estimation of
multi-column filters when the multi-column distinct count is high. This avoids
cases where we significantly over-estimate the selectivity of a multi-column
predicate and as a result can prevent the optimizer from choosing a bad query
plan.

**sql: add setting optimizer_use_improved_multi_column_selectivity_estimate**

Informs https://github.com/cockroachdb/cockroach/issues/121397

Release note (sql change): Added a setting
`optimizer_use_improved_multi_column_selectivity_estimate`, which if enabled,
causes the optimizer to use an improved selectivity estimate for multi-column
predicates. This setting will default to true on versions 24.2+, and false
on prior versions.

**opt: improve variable names in selectivityFromMultiColDistinctCounts**

This commit improves the variable names in
`selectivityFromMultiColDistinctCounts` in `statisticsBuilder` to be more
self-documenting.

Release note: None

---

Release justification: low-risk, high benefit change to existing functionality to unblock a customer
