### PR TITLE
release-23.1: workload/tpcc: match against correct ErrNoRows in delivery txn

### DIFF
--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -98,9 +98,9 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 				if err := del.selectNewOrder.QueryRowTx(ctx, tx, wID, dID).Scan(&oID); err != nil {
 					// If no matching order is found, the delivery of this order is skipped.
 					if !errors.Is(err, gosql.ErrNoRows) {
-						atomic.AddUint64(&del.config.auditor.skippedDelivieries, 1)
-						return err
+						return errors.Wrap(err, "select new_order failed")
 					}
+					atomic.AddUint64(&del.config.auditor.skippedDelivieries, 1)
 					continue
 				}
 				dIDoIDPairs[dID] = oID

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -12,7 +12,6 @@ package tpcc
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -97,7 +96,7 @@ func (del *delivery) run(ctx context.Context, wID int) (interface{}, error) {
 				var oID int
 				if err := del.selectNewOrder.QueryRowTx(ctx, tx, wID, dID).Scan(&oID); err != nil {
 					// If no matching order is found, the delivery of this order is skipped.
-					if !errors.Is(err, gosql.ErrNoRows) {
+					if !errors.Is(err, pgx.ErrNoRows) {
 						return errors.Wrap(err, "select new_order failed")
 					}
 					atomic.AddUint64(&del.config.auditor.skippedDelivieries, 1)


### PR DESCRIPTION
Backport 2/2 commits from #122903.

/cc @cockroachdb/release

---

Fixes #122891.

`sql.ErrNoRows` is not the same as `pgx.ErrNoRows`. As a result, this logic has been broken since TPC-C was ported to use pgx in d15637c8 (2018). This commit fixes the broken logic by matching on the correct error.

Release note: None
Release justification: low-risk, avoids test flakes.