### PR TITLE
roachprod: LB expanders fallback to defaults

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2668,8 +2668,8 @@ func (c *SyncedCluster) loadBalancerURL(
 	if err != nil {
 		return "", err
 	}
-	var port int
-	serviceMode := ServiceModeShared
+	port := config.DefaultSQLPort
+	serviceMode := ServiceModeExternal
 	for _, service := range services {
 		if service.VirtualClusterName == virtualClusterName && service.Instance == sqlInstance {
 			serviceMode = service.ServiceMode

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
 )
@@ -192,16 +193,18 @@ func (e *expander) maybeExpandPgHost(
 		if err != nil {
 			return "", false, err
 		}
+		port := config.DefaultSQLPort
 		for _, svc := range services {
 			if svc.VirtualClusterName == virtualClusterName && svc.Instance == sqlInstance {
-				addr, err := c.FindLoadBalancer(l, svc.Port)
-				if err != nil {
-					return "", false, err
-				}
-				return addr.IP, true, nil
+				port = svc.Port
+				break
 			}
 		}
-		return "", false, err
+		addr, err := c.FindLoadBalancer(l, port)
+		if err != nil {
+			return "", false, err
+		}
+		return addr.IP, true, nil
 	default:
 		if e.pgHosts == nil {
 			var err error


### PR DESCRIPTION
In the event that no services are registered when using a custom Google project, but a load balancer has been created for the default SQL port, `loadBalancerURL` and the `pghost` expander should be able to handle the case.

Epic: None
Release Note: None