### PR TITLE
release-23.1: storage: fix TestMVCCStatsRandomized's handling of timestamps

### DIFF
--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1801,6 +1801,12 @@ func (s *randomTest) step(t *testing.T) {
 			// everything.
 			s.TS.WallTime = 0
 		}
+		// If this is a transactional request, ensure the request timestamp is the
+		// same as the transaction's read timestamp. Otherwise, writes will return
+		// an error from mvccPutInternal.
+		if s.Txn != nil {
+			s.TS = s.Txn.ReadTimestamp
+		}
 	} else {
 		s.TS = hlc.Timestamp{}
 		s.inline = true
@@ -1898,54 +1904,38 @@ func TestMVCCStatsRandomized(t *testing.T) {
 	}
 
 	actions["Put"] = func(s *state) (bool, string) {
-		ts := s.TS
-		if s.Txn != nil {
-			ts = s.Txn.ReadTimestamp
-		}
 		opts := MVCCWriteOptions{
 			Txn:   s.Txn,
 			Stats: s.MSDelta,
 		}
-		if err := MVCCPut(ctx, s.batch, s.key, ts, s.rngVal(), opts); err != nil {
+		if err := MVCCPut(ctx, s.batch, s.key, s.TS, s.rngVal(), opts); err != nil {
 			return false, err.Error()
 		}
 		return true, ""
 	}
 	actions["InitPut"] = func(s *state) (bool, string) {
-		ts := s.TS
-		if s.Txn != nil {
-			ts = s.Txn.ReadTimestamp
-		}
 		opts := MVCCWriteOptions{
 			Txn:   s.Txn,
 			Stats: s.MSDelta,
 		}
 		failOnTombstones := s.rng.Intn(2) == 0
 		desc := fmt.Sprintf("failOnTombstones=%t", failOnTombstones)
-		if err := MVCCInitPut(ctx, s.batch, s.key, ts, s.rngVal(), failOnTombstones, opts); err != nil {
+		if err := MVCCInitPut(ctx, s.batch, s.key, s.TS, s.rngVal(), failOnTombstones, opts); err != nil {
 			return false, desc + ": " + err.Error()
 		}
 		return true, desc
 	}
 	actions["Del"] = func(s *state) (bool, string) {
-		ts := s.TS
-		if s.Txn != nil {
-			ts = s.Txn.ReadTimestamp
-		}
 		opts := MVCCWriteOptions{
 			Txn:   s.Txn,
 			Stats: s.MSDelta,
 		}
-		if _, err := MVCCDelete(ctx, s.batch, s.key, ts, opts); err != nil {
+		if _, err := MVCCDelete(ctx, s.batch, s.key, s.TS, opts); err != nil {
 			return false, err.Error()
 		}
 		return true, ""
 	}
 	actions["DelRange"] = func(s *state) (bool, string) {
-		ts := s.TS
-		if s.Txn != nil {
-			ts = s.Txn.ReadTimestamp
-		}
 		opts := MVCCWriteOptions{
 			Txn:   s.Txn,
 			Stats: s.MSDelta,
@@ -1972,7 +1962,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 			}
 
 			if !s.inline && s.rng.Intn(2) == 0 {
-				predicates.StartTime.WallTime = s.rng.Int63n(ts.WallTime + 1)
+				predicates.StartTime.WallTime = s.rng.Int63n(s.TS.WallTime + 1)
 			}
 		}
 
@@ -1987,7 +1977,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		if !mvccRangeDel {
 			desc = fmt.Sprintf("mvccDeleteRange=%s, returnKeys=%t, max=%d", keySpan, returnKeys, max)
 			_, _, _, err = MVCCDeleteRange(
-				ctx, s.batch, keySpan.Key, keySpan.EndKey, max, ts, opts, returnKeys,
+				ctx, s.batch, keySpan.Key, keySpan.EndKey, max, s.TS, opts, returnKeys,
 			)
 		} else if predicates == (kvpb.DeleteRangePredicates{}) {
 			desc = fmt.Sprintf("mvccDeleteRangeUsingTombstone=%s",
@@ -1996,7 +1986,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 			const maxIntents = 0 // unlimited
 			msCovered := (*enginepb.MVCCStats)(nil)
 			err = MVCCDeleteRangeUsingTombstone(
-				ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey, ts, hlc.ClockTimestamp{}, nil, /* leftPeekBound */
+				ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey, s.TS, hlc.ClockTimestamp{}, nil, /* leftPeekBound */
 				nil /* rightPeekBound */, idempotent, maxIntents, msCovered,
 			)
 		} else {
@@ -2005,7 +1995,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 				roachpb.Span{Key: mvccRangeDelKey, EndKey: mvccRangeDelEndKey}, predicates, rangeTombstoneThreshold)
 			const maxIntents = 0 // unlimited
 			_, err = MVCCPredicateDeleteRange(ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey,
-				ts, hlc.ClockTimestamp{}, nil /* leftPeekBound */, nil, /* rightPeekBound */
+				s.TS, hlc.ClockTimestamp{}, nil /* leftPeekBound */, nil, /* rightPeekBound */
 				predicates, 0, 0, rangeTombstoneThreshold, maxIntents)
 		}
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #122976.

/cc @cockroachdb/release

---

Recently, #113306 attempted to fix an issue in TestMVCCStatsRandomized where a transactional request was silently failing because its timestamp did not match the transaction's read timestamp. That patch handled many of the types of requests in TestMVCCStatsRandomized but not all (e.g. transactional GC requests).

This patch addresses the issue by refactoring the timestamp manipulation to a single place in the test.

Fixes: #119409

Release note: None

---

Release justification: Test fix
