### PR TITLE
github: silence SQL queries team mentions

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -37,6 +37,7 @@ cockroachdb/sql-queries:
   # there is no triage column ID.
   # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
+  silence_mentions: true
 cockroachdb/kv:
   aliases:
     cockroachdb/kv-triage: roachtest

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -74,7 +74,9 @@ func DefaultFormatter(ctx context.Context, f Failure) (issues.IssueFormatter, is
 	if len(teams) > 0 {
 		projColID = teams[0].TriageColumnID
 		for _, team := range teams {
-			mentions = append(mentions, "@"+string(team.Name()))
+			if !team.SilenceMentions {
+				mentions = append(mentions, "@"+string(team.Name()))
+			}
 			if team.Label != "" {
 				labels = append(labels, team.Label)
 			}

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -213,8 +213,11 @@ func (g *githubIssues) createPostRequest(
 	}
 
 	if sl, ok := teams.GetAliasesForPurpose(issueOwner.ToTeamAlias(), team.PurposeRoachtest); ok {
+		mentionTeam := !teams[sl[0]].SilenceMentions
 		for _, alias := range sl {
-			mention = append(mention, "@"+string(alias))
+			if mentionTeam {
+				mention = append(mention, "@"+string(alias))
+			}
 			if label := teams[alias].Label; label != "" {
 				labels = append(labels, label)
 			}

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -37,6 +37,7 @@ cockroachdb/sql-queries:
   # there is no triage column ID.
   # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
+  silence_mentions: true
 cockroachdb/kv:
   aliases:
     cockroachdb/kv-triage: roachtest

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -39,6 +39,8 @@ type Team struct {
 	Label string `yaml:"label"`
 	// TriageColumnID is the GitHub Column ID to assign issues to.
 	TriageColumnID int `yaml:"triage_column_id"`
+	// SilenceMentions is true if @-mentions should be supressed for this team.
+	SilenceMentions bool `yaml:"silence_mentions"`
 	// Email is the email address for this team.
 	//
 	// Currently unused.

--- a/pkg/internal/team/team_test.go
+++ b/pkg/internal/team/team_test.go
@@ -26,6 +26,7 @@ sql:
   email: otan@cockroachlabs.com
   slack: otan
   triage_column_id: 1
+  silence_mentions: true
 test-infra-team:
   email: jlinder@cockroachlabs.com
   slack: jlinder
@@ -39,9 +40,10 @@ test-infra-team:
 			"sql-alias":     PurposeOther,
 			"sql-roachtest": PurposeRoachtest,
 		},
-		Email:          "otan@cockroachlabs.com",
-		Slack:          "otan",
-		TriageColumnID: 1,
+		Email:           "otan@cockroachlabs.com",
+		Slack:           "otan",
+		TriageColumnID:  1,
+		SilenceMentions: true,
 	}
 	require.Equal(t, sqlTeam.TeamName, sqlTeam.Name())
 


### PR DESCRIPTION
This commit adds a new option for teams in TEAMS.yaml,
`silence_mentions`. If true, @-mentions for the team are omitted from
Github issues.

The SQL Queries Team in TEAMS.yaml has been updated to use this option.

Epic: None

Release note: None
