### PR TITLE
ui_test: fix AWS ui test build configuration

### DIFF
--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test.sh
@@ -2,4 +2,11 @@
 
 set -euo pipefail
 
-source build/teamcity/cockroach/ci/tests/ui_test.sh
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run UI tests"
+run_bazel build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test_impl.sh
+tc_end_block "Run UI tests"

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test_impl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/bazci --config=ci
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci //pkg/ui:test


### PR DESCRIPTION
This was broken by #122048.

Epic: none
Release note: None