### PR TITLE
concurrency: deflake TestLockTableConcurrentRequests

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -1114,6 +1114,8 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 				g = nil
 			}
 		}()
+		var timer timeutil.Timer
+		defer timer.Stop()
 		var err error
 		for {
 			// Since we can't do a select involving latch acquisition and context
@@ -1137,10 +1139,18 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 			var lastID uuid.UUID
 		L:
 			for {
+				timer.Reset(time.Minute * 5)
 				select {
 				case <-g.NewStateChan():
 				case <-ctx.Done():
 					return ctx.Err()
+				case <-timer.C:
+					timer.Read = true
+					return errors.AssertionFailedf(
+						"request %d has been waiting for more than 5 minutes; lock table state:\n%s\n",
+						g.(*lockTableGuardImpl).seqNum,
+						e.lt.String(),
+					)
 				}
 				state, err := g.CurState()
 				if err != nil {
@@ -1582,6 +1592,13 @@ func TestLockTableConcurrentRequests(t *testing.T) {
 	probCreateNewTxn := possibleProbCreateNewTxn[rng.Intn(len(possibleProbTxnalReq))]
 	probDupAccessWithWeakerStr := 0.5
 	probOnlyRead := possibleProbOnlyRead[rng.Intn(len(possibleProbOnlyRead))]
+
+	if syncutil.DeadlockEnabled {
+		// We've seen 10,000 requests to be too much when running a deadlock build.
+		// Override numRequests to the lowest option (1,000) for deadlock builds.
+		numRequests = 1000
+	}
+
 	testLockTableConcurrentRequests(
 		t, numActiveTxns, numRequests, probTxnalReq, probCreateNewTxn,
 		probDupAccessWithWeakerStr, probOnlyRead,


### PR DESCRIPTION
The failure modes on master have changed for this test since https://github.com/cockroachdb/cockroach/pull/122325 landed. Previously, this test was failing because all requests were waiting on a lock to be released, but because the concurrency bound was reached, we'd never get to the lock release.

The patch above bumped the maximum permitted concurrency to the number of requests generated by the test. This avoids the scenario above. However, the test also introduced a variant which increased the number of requests by a factor of 10. All failures on master since the patch landed have involved this variant. The stack traces don't indicate any blocked requests, which indicates the test is chugging along albeit slowly. This patch avoids this by overriding the number of requests the test will create to a lower number (1,000) for deadlock builds. This is the same number of requests we'd create before #122325 landed.

While here, also improve debugging to fail the test if a single request is blocked for more than 5 minutes. In doing so, we also dump out the lock table state.

Closes https://github.com/cockroachdb/cockroach/issues/122089

Release note: None