### PR TITLE
obs: export metrics about non-GC-related stop-the-world pauses

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -1642,12 +1642,15 @@
 <tr><td>SERVER</td><td>sys.gc.count</td><td>Total number of GC runs</td><td>GC Runs</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.gc.pause.ns</td><td>Total GC pause</td><td>GC Pause</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.gc.pause.percent</td><td>Current GC pause percentage</td><td>GC Pause</td><td>GAUGE</td><td>PERCENT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>SERVER</td><td>sys.gc.stop.ns</td><td>Estimated GC stop-the-world stopping latencies</td><td>GC Stopping</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.allocbytes</td><td>Current bytes of memory allocated by go</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.heap.allocbytes</td><td>Cumulative bytes allocated for heap objects.</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.heap.heapfragmentbytes</td><td>Total heap fragmentation bytes, derived from bytes in in-use spans minus bytes allocated</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.heap.heapreleasedbytes</td><td>Total bytes returned to the OS from heap.</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.heap.heapreservedbytes</td><td>Total bytes reserved by heap, derived from bytes in idle (unused) spans subtracts bytes returned to the OS</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>SERVER</td><td>sys.go.pause.other.ns</td><td>Estimated non-GC-related total pause time</td><td>Non-GC Pause</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.stack.systembytes</td><td>Stack memory obtained from the OS.</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>SERVER</td><td>sys.go.stop.other.ns</td><td>Estimated non-GC-related stop-the-world stopping latencies</td><td>Non-GC Stopping</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.go.totalbytes</td><td>Total bytes of memory allocated by go, but not released</td><td>Memory</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.goroutines</td><td>Current number of goroutines</td><td>goroutines</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>SERVER</td><td>sys.host.disk.io.time</td><td>Time spent reading from or writing to all disks since this process started (as reported by the OS)</td><td>Time</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -161,6 +161,24 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="GC Stopping Time"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`The time it takes from deciding to
+      stop-the-world (gc related) until all Ps are stopped
+        ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Duration} label="pause time">
+        <Metric
+          name="cr.node.sys.gc.stop.ns"
+          title="GC Stopping Time"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="GC Assist Time"
       sources={nodeSources}
       tenantSource={tenantSource}
@@ -172,6 +190,41 @@ export default function (props: GraphDashboardProps) {
         <Metric
           name="cr.node.sys.gc.assist.ns"
           title="GC Assist Time"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Non-GC Pause Time"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`The stop-the-world pause time during
+      non-gc process ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Duration} label="pause time">
+        <Metric
+          name="cr.node.sys.go.pause.other.ns"
+          title="Non-GC Pause Time"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Non-GC Stopping Time"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`The time it takes from deciding to stop-the-world 
+      (non-gc-related) until all Ps are stopped
+      ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Duration} label="pause time">
+        <Metric
+          name="cr.node.sys.go.stop.other.ns"
+          title="Non-GC Stopping Time"
           nonNegativeRate
         />
       </Axis>


### PR DESCRIPTION
This commit exposes more insights on pauses/stops based on runtime metrics.
The following metrics are added:
/sched/pauses/stopping/gc:seconds
/sched/pauses/stopping/other:seconds
/sched/pauses/total/other:seconds
New metrics are added in runtime dashboard as line charts.

Fixes: https://github.com/cockroachdb/cockroach/issues/119319

Release note: None