### PR TITLE
release-23.2: plpgsql: avoid internal error when parsing variable type

### DIFF
--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -473,10 +473,6 @@ func (l *lexer) Unimplemented(feature string) {
 	}
 }
 
-func (l *lexer) GetTypeFromValidSQLSyntax(sqlStr string) (tree.ResolvableTypeReference, error) {
-	return parser.GetTypeFromValidSQLSyntax(sqlStr)
-}
-
 func (l *lexer) ParseExpr(sqlStr string) (plpgsqltree.Expr, error) {
 	// Use ParseExprs instead of ParseExpr in order to correctly handle the case
 	// when multiple expressions are incorrectly passed.

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -6,6 +6,7 @@ import (
   "github.com/cockroachdb/cockroach/pkg/sql/scanner"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
+  "github.com/cockroachdb/cockroach/pkg/sql/types"
   "github.com/cockroachdb/errors"
   "github.com/cockroachdb/redact"
 )
@@ -552,11 +553,20 @@ decl_datatype:
     if err != nil {
       return setErr(plpgsqllex, err)
     }
-    typ, err := plpgsqllex.(*lexer).GetTypeFromValidSQLSyntax(sqlStr)
+    // This is an inlined version of GetTypeFromValidSQLSyntax which doesn't
+    // return an assertion failure.
+    castExpr, err := plpgsqllex.(*lexer).ParseExpr("1::" + sqlStr)
     if err != nil {
-      return setErr(plpgsqllex, err)
+      return setErr(plpgsqllex, errors.New("unable to parse type of variable declaration"))
     }
-    $$.val = typ
+    switch t := castExpr.(type) {
+    case *tree.CollateExpr:
+      $$.val = types.MakeCollatedString(types.String, t.Locale)
+    case *tree.CastExpr:
+      $$.val = t.Type
+    default:
+      return setErr(plpgsqllex, errors.New("unable to parse type of variable declaration"))
+    }
   }
 ;
 

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -165,16 +165,11 @@ DECLARE
 BEGIN
 END
 ----
-at or near "four": at or near ".": syntax error
+at or near "four": syntax error: unable to parse type of variable declaration
 DETAIL: source SQL:
-SET ROW (1::one.two.three.four)
-                         ^
---
-source SQL:
 DECLARE
   var1 one.two.three.four;
                      ^
-HINT: try \h SET SESSION
 
 error
 DECLARE
@@ -182,13 +177,58 @@ DECLARE
 BEGIN
 END
 ----
-at or near "four": at or near ".": syntax error
+at or near "four": syntax error: unable to parse type of variable declaration
 DETAIL: source SQL:
-SET ROW (1::one.two.three.four )
-                         ^
---
-source SQL:
 DECLARE
   var1 one.two.three.four := 0;
                      ^
-HINT: try \h SET SESSION
+
+error
+DECLARE
+  var1 1;
+BEGIN
+END
+----
+at or near "1": syntax error: unable to parse type of variable declaration
+DETAIL: source SQL:
+DECLARE
+  var1 1;
+       ^
+
+error
+DECLARE
+  var1 'foo';
+BEGIN
+END
+----
+at or near "foo": syntax error: unable to parse type of variable declaration
+DETAIL: source SQL:
+DECLARE
+  var1 'foo';
+       ^
+
+error
+DECLARE
+  var1 xy%ROWTYPE;
+BEGIN
+END
+----
+at or near "rowtype": syntax error: unable to parse type of variable declaration
+DETAIL: source SQL:
+DECLARE
+  var1 xy%ROWTYPE;
+          ^
+
+error
+DECLARE
+  var1 INT;
+  var2 var1%TYPE;
+BEGIN
+END
+----
+at or near "type": syntax error: unable to parse type of variable declaration
+DETAIL: source SQL:
+DECLARE
+  var1 INT;
+  var2 var1%TYPE;
+            ^


### PR DESCRIPTION
Backport 1/1 commits from #122660.

/cc @cockroachdb/release

---

Previously, when parsing the type of a declared PL/pgSQL variable, the parser could return an internal error when attempting to parse an expression like `xy@ROWTYPE`. This syntax, isn't currently supported in CRDB, but shouldn't result in an internal error, either. Now, the parser has inlined some logic from `GetTypeFromCastOrCollate` and will now return an expected syntax error instead.

Informs #114676

Release note (bug fix): Fixed a bug that could result in an internal error when attempting to create a PL/pgSQL routine using the (currently unsupported) `%ROWTYPE` syntax for a variable declaration.

Release justification: replace internal parsing error with user-facing error