### PR TITLE
loqrecovery: parallelize data collection across nodes and stores

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -7689,6 +7689,10 @@ Support status: [reserved](#support-status)
 
 
 
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| max_concurrency | [int32](#cockroach.server.serverpb.RecoveryCollectReplicaInfoRequest-int32) |  | MaxConcurrency is the maximum parallelism that will be used when fanning out RPCs to nodes in the cluster while servicing this request. A value of 0 disables concurrency. A negative value configures no limit for concurrency. | [reserved](#support-status) |
+
 
 
 
@@ -7799,6 +7803,7 @@ Support status: [reserved](#support-status)
 | all_nodes | [bool](#cockroach.server.serverpb.RecoveryStagePlanRequest-bool) |  | If all nodes is true, then receiver should act as a coordinator and perform a fan-out to stage plan on all nodes of the cluster. | [reserved](#support-status) |
 | force_plan | [bool](#cockroach.server.serverpb.RecoveryStagePlanRequest-bool) |  | ForcePlan tells receiver to ignore any plan already staged on the node if it is present and replace it with new plan (including empty one). | [reserved](#support-status) |
 | force_local_internal_version | [bool](#cockroach.server.serverpb.RecoveryStagePlanRequest-bool) |  | ForceLocalInternalVersion tells server to update internal component of plan version to the one of active cluster version. This option needs to be set if target cluster is stuck in recovery where only part of nodes were successfully migrated. | [reserved](#support-status) |
+| max_concurrency | [int32](#cockroach.server.serverpb.RecoveryStagePlanRequest-int32) |  | MaxConcurrency is the maximum parallelism that will be used when fanning out RPCs to nodes in the cluster while servicing this request. A value of 0 disables concurrency. A negative value configures no limit for concurrency. | [reserved](#support-status) |
 
 
 
@@ -7888,6 +7893,7 @@ Support status: [reserved](#support-status)
 | plan_id | [bytes](#cockroach.server.serverpb.RecoveryVerifyRequest-bytes) |  | PlanID is ID of the plan to verify. | [reserved](#support-status) |
 | decommissioned_node_ids | [int32](#cockroach.server.serverpb.RecoveryVerifyRequest-int32) | repeated | DecommissionedNodeIDs is a set of nodes that should be marked as decommissioned in the cluster when loss of quorum recovery successfully applies. | [reserved](#support-status) |
 | max_reported_ranges | [int32](#cockroach.server.serverpb.RecoveryVerifyRequest-int32) |  | MaxReportedRanges is the maximum number of failed ranges to report. If more unhealthy ranges are found, error will be returned alongside range to indicate that ranges were cut short. | [reserved](#support-status) |
+| max_concurrency | [int32](#cockroach.server.serverpb.RecoveryVerifyRequest-int32) |  | MaxConcurrency is the maximum parallelism that will be used when fanning out RPCs to nodes in the cluster while servicing this request. A value of 0 disables concurrency. A negative value configures no limit for concurrency. | [reserved](#support-status) |
 
 
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1515,6 +1515,8 @@ func init() {
 
 	f = debugRecoverCollectInfoCmd.Flags()
 	f.VarP(&debugRecoverCollectInfoOpts.Stores, cliflags.RecoverStore.Name, cliflags.RecoverStore.Shorthand, cliflags.RecoverStore.Usage())
+	f.IntVarP(&debugRecoverCollectInfoOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
+		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 
 	f = debugRecoverPlanCmd.Flags()
 	f.StringVarP(&debugRecoverPlanOpts.outputFileName, "plan", "o", "",
@@ -1528,6 +1530,8 @@ func init() {
 	f.BoolVar(&debugRecoverPlanOpts.force, "force", false,
 		"force creation of plan even when problems were encountered; applying this plan may "+
 			"result in additional problems and should be done only with care and as a last resort")
+	f.IntVarP(&debugRecoverPlanOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
+		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 	f.UintVar(&formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Name,
 		formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Usage())
 
@@ -1539,6 +1543,12 @@ func init() {
 		formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Usage())
 	f.BoolVar(&debugRecoverExecuteOpts.ignoreInternalVersion, cliflags.RecoverIgnoreInternalVersion.Name,
 		debugRecoverExecuteOpts.ignoreInternalVersion, cliflags.RecoverIgnoreInternalVersion.Usage())
+	f.IntVarP(&debugRecoverExecuteOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
+		"maximum concurrency when fanning out RPCs to nodes in the cluster")
+
+	f = debugRecoverVerifyCmd.Flags()
+	f.IntVarP(&debugRecoverVerifyOpts.maxConcurrency, "max-concurrency", "c", debugRecoverDefaultMaxConcurrency,
+		"maximum concurrency when fanning out RPCs to nodes in the cluster")
 
 	f = debugMergeLogsCmd.Flags()
 	f.Var(flagutil.Time(&debugMergeLogsOpts.from), "from",

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -392,6 +392,7 @@ func TestStageVersionCheck(t *testing.T) {
 		AllNodes:                  true,
 		ForcePlan:                 false,
 		ForceLocalInternalVersion: false,
+		MaxConcurrency:            -1, // no limit
 	})
 	require.ErrorContains(t, err, "doesn't match cluster active version")
 	// Enable "stuck upgrade bypass" to stage plan on the cluster.
@@ -400,6 +401,7 @@ func TestStageVersionCheck(t *testing.T) {
 		AllNodes:                  true,
 		ForcePlan:                 false,
 		ForceLocalInternalVersion: true,
+		MaxConcurrency:            -1, // no limit
 	})
 	require.NoError(t, err, "force local must fix incorrect version")
 	// Check that stored plan has version matching cluster version.

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -45,11 +45,13 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/retry",
         "//pkg/util/strutil",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -55,45 +56,45 @@ func CollectRemoteReplicaInfo(
 	}
 	stores := make(map[roachpb.StoreID]struct{})
 	nodes := make(map[roachpb.NodeID]struct{})
+	replInfoMap := make(map[roachpb.NodeID][]loqrecoverypb.ReplicaInfo)
 	var descriptors []roachpb.RangeDescriptor
-	var clusterReplInfo []loqrecoverypb.NodeReplicaInfo
-	var nodeReplicas []loqrecoverypb.ReplicaInfo
-	var currentNode roachpb.NodeID
 	var metadata loqrecoverypb.ClusterMetadata
 	for {
 		info, err := cc.Recv()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				if len(nodeReplicas) > 0 {
-					clusterReplInfo = append(clusterReplInfo, loqrecoverypb.NodeReplicaInfo{Replicas: nodeReplicas})
-				}
 				break
 			}
 			return loqrecoverypb.ClusterReplicaInfo{}, CollectionStats{}, err
 		}
 		if r := info.GetReplicaInfo(); r != nil {
-			if currentNode != r.NodeID {
-				currentNode = r.NodeID
-				if len(nodeReplicas) > 0 {
-					clusterReplInfo = append(clusterReplInfo, loqrecoverypb.NodeReplicaInfo{Replicas: nodeReplicas})
-					nodeReplicas = nil
-				}
-			}
-			nodeReplicas = append(nodeReplicas, *r)
 			stores[r.StoreID] = struct{}{}
 			nodes[r.NodeID] = struct{}{}
+			replInfoMap[r.NodeID] = append(replInfoMap[r.NodeID], *r)
 		} else if d := info.GetRangeDescriptor(); d != nil {
 			descriptors = append(descriptors, *d)
 		} else if s := info.GetNodeStreamRestarted(); s != nil {
 			// If server had to restart a fan-out work because of error and retried,
 			// then we discard partial data for the node.
-			if s.NodeID == currentNode {
-				nodeReplicas = nil
-			}
+			delete(replInfoMap, s.NodeID)
 		} else if m := info.GetMetadata(); m != nil {
 			metadata = *m
+		} else {
+			return loqrecoverypb.ClusterReplicaInfo{}, CollectionStats{}, errors.AssertionFailedf(
+				"unknown info type: %T", info.GetInfo())
 		}
 	}
+	// Collapse the ReplicaInfos map into a slice, sorted by node ID.
+	replInfos := make([]loqrecoverypb.NodeReplicaInfo, 0, len(replInfoMap))
+	for _, replInfo := range replInfoMap {
+		if len(replInfo) == 0 {
+			continue
+		}
+		replInfos = append(replInfos, loqrecoverypb.NodeReplicaInfo{Replicas: replInfo})
+	}
+	sort.Slice(replInfos, func(i, j int) bool {
+		return replInfos[i].Replicas[0].NodeID < replInfos[j].Replicas[0].NodeID
+	})
 	// We don't want to process data outside of safe version range for this CLI
 	// binary. RPC allows us to communicate with a cluster that is newer than
 	// the binary, but it will not version gate the data to binary version so we
@@ -105,7 +106,7 @@ func CollectRemoteReplicaInfo(
 	return loqrecoverypb.ClusterReplicaInfo{
 			ClusterID:   metadata.ClusterID,
 			Descriptors: descriptors,
-			LocalInfo:   clusterReplInfo,
+			LocalInfo:   replInfos,
 			Version:     metadata.Version,
 		}, CollectionStats{
 			Nodes:       len(nodes),

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -35,10 +35,21 @@ type CollectionStats struct {
 	Descriptors int
 }
 
+// CollectRemoteReplicaInfo retrieves information about:
+//  1. range descriptors contained in cluster meta ranges if meta ranges
+//     are readable;
+//  2. replica information from all live nodes that have connection to
+//     the target node.
+//
+// maxConcurrency is the maximum parallelism that will be used when fanning out
+// RPCs to nodes in the cluster. A value of 0 disables concurrency. A negative
+// value configures no limit for concurrency.
 func CollectRemoteReplicaInfo(
-	ctx context.Context, c serverpb.AdminClient,
+	ctx context.Context, c serverpb.AdminClient, maxConcurrency int,
 ) (loqrecoverypb.ClusterReplicaInfo, CollectionStats, error) {
-	cc, err := c.RecoveryCollectReplicaInfo(ctx, &serverpb.RecoveryCollectReplicaInfoRequest{})
+	cc, err := c.RecoveryCollectReplicaInfo(ctx, &serverpb.RecoveryCollectReplicaInfoRequest{
+		MaxConcurrency: int32(maxConcurrency),
+	})
 	if err != nil {
 		return loqrecoverypb.ClusterReplicaInfo{}, CollectionStats{}, err
 	}

--- a/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
+++ b/pkg/kv/kvserver/loqrecovery/collect_raft_log_test.go
@@ -255,7 +255,7 @@ func TestCollectLeaseholderStatus(t *testing.T) {
 	// Note: we need to retry because replica collection is not atomic and
 	// leaseholder could move around so we could see none or more than one.
 	testutils.SucceedsSoon(t, func() error {
-		replicas, _, err := loqrecovery.CollectRemoteReplicaInfo(ctx, adm)
+		replicas, _, err := loqrecovery.CollectRemoteReplicaInfo(ctx, adm, -1 /* maxConcurrency */)
 		require.NoError(t, err, "failed to collect replica info")
 
 		foundLeaseholders := 0

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -36,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
 
@@ -56,9 +58,11 @@ func IsRetryableError(err error) bool {
 	return errors.Is(err, errMarkRetry)
 }
 
-type visitNodeAdminFn func(ctx context.Context, retryOpts retry.Options,
+type visitNodeAdminFn func(nodeID roachpb.NodeID, client serverpb.AdminClient) error
+
+type visitNodesAdminFn func(ctx context.Context, retryOpts retry.Options, maxConcurrency int32,
 	nodeFilter func(nodeID roachpb.NodeID) bool,
-	visitor func(nodeID roachpb.NodeID, client serverpb.AdminClient) error,
+	visitor visitNodeAdminFn,
 ) error
 
 type visitNodeStatusFn func(ctx context.Context, nodeID roachpb.NodeID, retryOpts retry.Options,
@@ -70,7 +74,7 @@ type Server struct {
 	clusterIDContainer *base.ClusterIDContainer
 	settings           *cluster.Settings
 	stores             *kvserver.Stores
-	visitAdminNodes    visitNodeAdminFn
+	visitAdminNodes    visitNodesAdminFn
 	visitStatusNode    visitNodeStatusFn
 	planStore          PlanStore
 	decommissionFn     func(context.Context, roachpb.NodeID) error
@@ -106,7 +110,7 @@ func NewServer(
 		clusterIDContainer:   rpcCtx.StorageClusterID,
 		settings:             settings,
 		stores:               stores,
-		visitAdminNodes:      makeVisitAvailableNodes(g, loc, rpcCtx),
+		visitAdminNodes:      makeVisitAvailableNodesInParallel(g, loc, rpcCtx),
 		visitStatusNode:      makeVisitNode(g, loc, rpcCtx),
 		planStore:            planStore,
 		decommissionFn:       decommission,
@@ -133,7 +137,7 @@ func (s Server) ServeLocalReplicas(
 
 func (s Server) ServeClusterReplicas(
 	ctx context.Context,
-	_ *serverpb.RecoveryCollectReplicaInfoRequest,
+	req *serverpb.RecoveryCollectReplicaInfoRequest,
 	outStream serverpb.Admin_RecoveryCollectReplicaInfoServer,
 	kvDB *kv.DB,
 ) (err error) {
@@ -145,13 +149,11 @@ func (s Server) ServeClusterReplicas(
 		return errors.Newf("loss of quorum recovery service requires cluster upgraded to 23.1")
 	}
 
-	var (
-		descriptors, nodes, replicas int
-	)
+	var descriptors, nodes, replicas atomic.Int64
 	defer func() {
 		if err == nil {
-			log.Infof(ctx, "streamed info: range descriptors %d, nodes %d, replica infos %d", descriptors,
-				nodes, replicas)
+			log.Infof(ctx, "streamed info: range descriptors %d, nodes %d, replica infos %d",
+				descriptors.Load(), nodes.Load(), replicas.Load())
 		}
 	}()
 
@@ -189,7 +191,7 @@ func (s Server) ServeClusterReplicas(
 						}); err != nil {
 							return err
 						}
-						descriptors++
+						descriptors.Add(1)
 					}
 					return nil
 				})
@@ -206,56 +208,68 @@ func (s Server) ServeClusterReplicas(
 	}
 
 	// Stream local replica info from all nodes wrapping them in response stream.
-	return s.visitAdminNodes(ctx,
+	syncOutStream := makeThreadSafeStream[*serverpb.RecoveryCollectReplicaInfoResponse](outStream)
+	return s.visitAdminNodes(
+		ctx,
 		fanOutConnectionRetryOptions,
+		req.MaxConcurrency,
 		allNodes,
-		func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
-			log.Infof(ctx, "trying to get info from node n%d", nodeID)
-			nodeReplicas := 0
-			inStream, err := client.RecoveryCollectLocalReplicaInfo(ctx,
-				&serverpb.RecoveryCollectLocalReplicaInfoRequest{})
-			if err != nil {
-				return errors.Mark(errors.Wrapf(err,
-					"failed retrieving replicas from node n%d during fan-out", nodeID), errMarkRetry)
+		serveClusterReplicasParallelFn(ctx, syncOutStream, s.forwardReplicaFilter, &replicas, &nodes))
+}
+
+func serveClusterReplicasParallelFn(
+	ctx context.Context,
+	outStream *threadSafeStream[*serverpb.RecoveryCollectReplicaInfoResponse],
+	forwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error,
+	replicas, nodes *atomic.Int64,
+) visitNodeAdminFn {
+	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+		log.Infof(ctx, "trying to get info from node n%d", nodeID)
+		var nodeReplicas int64
+		inStream, err := client.RecoveryCollectLocalReplicaInfo(ctx,
+			&serverpb.RecoveryCollectLocalReplicaInfoRequest{})
+		if err != nil {
+			return errors.Mark(errors.Wrapf(err,
+				"failed retrieving replicas from node n%d during fan-out", nodeID), errMarkRetry)
+		}
+		for {
+			r, err := inStream.Recv()
+			if err == io.EOF {
+				break
 			}
-			for {
-				r, err := inStream.Recv()
-				if err == io.EOF {
-					break
-				}
-				if s.forwardReplicaFilter != nil {
-					err = s.forwardReplicaFilter(r)
-				}
-				if err != nil {
-					// Some replicas were already sent back, need to notify client of stream
-					// restart.
-					if err := outStream.Send(&serverpb.RecoveryCollectReplicaInfoResponse{
-						Info: &serverpb.RecoveryCollectReplicaInfoResponse_NodeStreamRestarted{
-							NodeStreamRestarted: &serverpb.RecoveryCollectReplicaRestartNodeStream{
-								NodeID: nodeID,
-							},
-						},
-					}); err != nil {
-						return err
-					}
-					return errors.Mark(errors.Wrapf(err,
-						"failed retrieving replicas from node n%d during fan-out",
-						nodeID), errMarkRetry)
-				}
+			if forwardReplicaFilter != nil {
+				err = forwardReplicaFilter(r)
+			}
+			if err != nil {
+				// Some replicas were already sent back, need to notify client of stream
+				// restart.
 				if err := outStream.Send(&serverpb.RecoveryCollectReplicaInfoResponse{
-					Info: &serverpb.RecoveryCollectReplicaInfoResponse_ReplicaInfo{
-						ReplicaInfo: r.ReplicaInfo,
+					Info: &serverpb.RecoveryCollectReplicaInfoResponse_NodeStreamRestarted{
+						NodeStreamRestarted: &serverpb.RecoveryCollectReplicaRestartNodeStream{
+							NodeID: nodeID,
+						},
 					},
 				}); err != nil {
 					return err
 				}
-				nodeReplicas++
+				return errors.Mark(errors.Wrapf(err,
+					"failed retrieving replicas from node n%d during fan-out",
+					nodeID), errMarkRetry)
 			}
+			if err := outStream.Send(&serverpb.RecoveryCollectReplicaInfoResponse{
+				Info: &serverpb.RecoveryCollectReplicaInfoResponse_ReplicaInfo{
+					ReplicaInfo: r.ReplicaInfo,
+				},
+			}); err != nil {
+				return err
+			}
+			nodeReplicas++
+		}
 
-			replicas += nodeReplicas
-			nodes++
-			return nil
-		})
+		replicas.Add(nodeReplicas)
+		nodes.Add(1)
+		return nil
+	}
 }
 
 func (s Server) StagePlan(
@@ -297,84 +311,57 @@ func (s Server) StagePlan(
 	if req.AllNodes {
 		// Scan cluster for conflicting recovery plans and for stray nodes that are
 		// planned for forced decommission, but rejoined cluster.
-		foundNodes := make(map[roachpb.NodeID]bool)
+		foundNodes := makeThreadSafeMap[roachpb.NodeID, bool]()
 		err := s.visitAdminNodes(
 			ctx,
 			fanOutConnectionRetryOptions,
+			req.MaxConcurrency,
 			allNodes,
-			func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
-				res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
-				if err != nil {
-					return errors.Mark(err, errMarkRetry)
-				}
-				// If operation fails here, we don't want to find all remaining
-				// violating nodes because cli must ensure that cluster is safe for
-				// staging.
-				if !req.ForcePlan && res.Status.PendingPlanID != nil && !res.Status.PendingPlanID.Equal(plan.PlanID) {
-					return errors.Newf("plan %s is already staged on node n%d", res.Status.PendingPlanID, nodeID)
-				}
-				foundNodes[nodeID] = true
-				return nil
-			})
+			stagePlanRecoveryNodeStatusParallelFn(ctx, req, plan, foundNodes))
 		if err != nil {
 			return nil, err
 		}
 
 		// Check that no nodes that must be decommissioned are present.
 		for _, dID := range plan.DecommissionedNodeIDs {
-			if foundNodes[dID] {
+			if foundNodes.Get(dID) {
 				return nil, errors.Newf("node n%d was planned for decommission, but is present in cluster", dID)
 			}
 		}
 
 		// Check out that all nodes that should save plan are present.
 		for _, u := range plan.Updates {
-			if !foundNodes[u.NodeID()] {
+			if !foundNodes.Get(u.NodeID()) {
 				return nil, errors.Newf("node n%d has planned changed but is unreachable in the cluster", u.NodeID())
 			}
 		}
 		for _, n := range plan.StaleLeaseholderNodeIDs {
-			if !foundNodes[n] {
+			if !foundNodes.Get(n) {
 				return nil, errors.Newf("node n%d has planned restart but is unreachable in the cluster", n)
 			}
 		}
 
 		// Distribute plan - this should not use fan out to available, but use
 		// list from previous step.
-		var nodeErrors []string
+		var nodeErrors threadSafeSlice[string]
 		err = s.visitAdminNodes(
 			ctx,
 			fanOutConnectionRetryOptions,
-			onlyListed(foundNodes),
-			func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
-				delete(foundNodes, nodeID)
-				res, err := client.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{
-					Plan:                      req.Plan,
-					AllNodes:                  false,
-					ForcePlan:                 req.ForcePlan,
-					ForceLocalInternalVersion: req.ForceLocalInternalVersion,
-				})
-				if err != nil {
-					nodeErrors = append(nodeErrors,
-						errors.Wrapf(err, "failed staging the plan on node n%d", nodeID).Error())
-					return nil
-				}
-				nodeErrors = append(nodeErrors, res.Errors...)
-				return nil
-			})
+			req.MaxConcurrency,
+			onlyListed(foundNodes.Clone()),
+			stagePlanRecoveryStagePlanParallelFn(ctx, req, foundNodes, &nodeErrors))
 		if err != nil {
-			nodeErrors = append(nodeErrors,
-				errors.Wrapf(err, "failed to perform fan-out to cluster nodes from n%d",
-					localNodeID).Error())
+			nodeErrors.Append(
+				errors.Wrapf(err, "failed to perform fan-out to cluster nodes from n%d", localNodeID).Error())
 		}
-		if len(foundNodes) > 0 {
+		if foundNodes.Len() > 0 {
 			// We didn't talk to some of originally found nodes. Need to report
 			// disappeared nodes as we don't know what is happening with the cluster.
-			for n := range foundNodes {
-				nodeErrors = append(nodeErrors, fmt.Sprintf("node n%d disappeared while performing plan staging operation", n))
+			for n := range foundNodes.Clone() {
+				nodeErrors.Append(fmt.Sprintf("node n%d disappeared while performing plan staging operation", n))
 			}
 		}
-		return &serverpb.RecoveryStagePlanResponse{Errors: nodeErrors}, nil
+		return &serverpb.RecoveryStagePlanResponse{Errors: nodeErrors.Clone()}, nil
 	}
 
 	log.Infof(ctx, "attempting to stage loss of quorum recovery plan")
@@ -432,6 +419,53 @@ func (s Server) StagePlan(
 	return &serverpb.RecoveryStagePlanResponse{}, nil
 }
 
+func stagePlanRecoveryNodeStatusParallelFn(
+	ctx context.Context,
+	req *serverpb.RecoveryStagePlanRequest,
+	plan loqrecoverypb.ReplicaUpdatePlan,
+	foundNodes *threadSafeMap[roachpb.NodeID, bool],
+) visitNodeAdminFn {
+	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+		res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
+		if err != nil {
+			return errors.Mark(err, errMarkRetry)
+		}
+		// If operation fails here, we don't want to find all remaining
+		// violating nodes because cli must ensure that cluster is safe for
+		// staging.
+		if !req.ForcePlan && res.Status.PendingPlanID != nil && !res.Status.PendingPlanID.Equal(plan.PlanID) {
+			return errors.Newf("plan %s is already staged on node n%d", res.Status.PendingPlanID, nodeID)
+		}
+		foundNodes.Set(nodeID, true)
+		return nil
+	}
+}
+
+func stagePlanRecoveryStagePlanParallelFn(
+	ctx context.Context,
+	req *serverpb.RecoveryStagePlanRequest,
+	foundNodes *threadSafeMap[roachpb.NodeID, bool],
+	nodeErrors *threadSafeSlice[string],
+) visitNodeAdminFn {
+	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+		foundNodes.Delete(nodeID)
+		res, err := client.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{
+			Plan:                      req.Plan,
+			AllNodes:                  false,
+			ForcePlan:                 req.ForcePlan,
+			ForceLocalInternalVersion: req.ForceLocalInternalVersion,
+			MaxConcurrency:            req.MaxConcurrency,
+		})
+		if err != nil {
+			nodeErrors.Append(
+				errors.Wrapf(err, "failed staging the plan on node n%d", nodeID).Error())
+			return nil
+		}
+		nodeErrors.Append(res.Errors...)
+		return nil
+	}
+}
+
 func (s Server) NodeStatus(
 	ctx context.Context, _ *serverpb.RecoveryNodeStatusRequest,
 ) (*serverpb.RecoveryNodeStatusResponse, error) {
@@ -476,22 +510,13 @@ func (s Server) Verify(
 		return nil, errors.Newf("loss of quorum recovery service requires cluster upgraded to 23.1")
 	}
 
-	var nss []loqrecoverypb.NodeRecoveryStatus
-	err := s.visitAdminNodes(ctx, fanOutConnectionRetryOptions,
+	var nss threadSafeSlice[loqrecoverypb.NodeRecoveryStatus]
+	err := s.visitAdminNodes(
+		ctx,
+		fanOutConnectionRetryOptions,
+		req.MaxConcurrency,
 		notListed(req.DecommissionedNodeIDs),
-		func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
-			return timeutil.RunWithTimeout(ctx, fmt.Sprintf("retrieve status of n%d", nodeID),
-				retrieveNodeStatusTimeout,
-				func(ctx context.Context) error {
-					res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
-					if err != nil {
-						return errors.Mark(errors.Wrapf(err, "failed to retrieve status of n%d", nodeID),
-							errMarkRetry)
-					}
-					nss = append(nss, res.Status)
-					return nil
-				})
-		})
+		verifyRecoveryNodeStatusParallelFn(ctx, &nss))
 	if err != nil {
 		return nil, err
 	}
@@ -591,10 +616,28 @@ func (s Server) Verify(
 	}
 
 	return &serverpb.RecoveryVerifyResponse{
-		Statuses:                   nss,
+		Statuses:                   nss.Clone(),
 		DecommissionedNodeStatuses: decomStatus,
 		UnavailableRanges:          rangeHealth,
 	}, nil
+}
+
+func verifyRecoveryNodeStatusParallelFn(
+	ctx context.Context, nss *threadSafeSlice[loqrecoverypb.NodeRecoveryStatus],
+) visitNodeAdminFn {
+	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+		return timeutil.RunWithTimeout(ctx, fmt.Sprintf("retrieve status of n%d", nodeID),
+			retrieveNodeStatusTimeout,
+			func(ctx context.Context) error {
+				res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
+				if err != nil {
+					return errors.Mark(errors.Wrapf(err, "failed to retrieve status of n%d", nodeID),
+						errMarkRetry)
+				}
+				nss.Append(res.Status)
+				return nil
+			})
+	}
 }
 
 func checkRangeHealth(
@@ -637,7 +680,8 @@ func checkRangeHealth(
 	return loqrecoverypb.RangeHealth_LOSS_OF_QUORUM
 }
 
-// makeVisitAvailableNodes creates a function to visit available remote nodes.
+// makeVisitAvailableNodesInParallel creates a function to visit available
+// remote nodes, in parallel.
 //
 // Returned function would dial all cluster nodes from gossip and executes
 // visitor function with admin client after connection is established. Function
@@ -650,48 +694,19 @@ func checkRangeHealth(
 //
 // For latter, errors marked with errMarkRetry marker are retried. It is up
 // to the visitor to mark appropriate errors are retryable.
-func makeVisitAvailableNodes(
+//
+// Nodes may be visited in parallel, so the visitor function must be safe for
+// concurrent use.
+func makeVisitAvailableNodesInParallel(
 	g *gossip.Gossip, loc roachpb.Locality, rpcCtx *rpc.Context,
-) visitNodeAdminFn {
-	return func(ctx context.Context, retryOpts retry.Options,
+) visitNodesAdminFn {
+	return func(
+		ctx context.Context,
+		retryOpts retry.Options,
+		maxConcurrency int32,
 		nodeFilter func(nodeID roachpb.NodeID) bool,
-		visitor func(nodeID roachpb.NodeID, client serverpb.AdminClient) error,
+		visitor visitNodeAdminFn,
 	) error {
-		visitWithRetry := func(node roachpb.NodeDescriptor) error {
-			var err error
-			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
-				log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
-				addr := node.AddressForLocality(loc)
-				var conn *grpc.ClientConn
-				// Note that we use ConnectNoBreaker here to avoid any race with probe
-				// running on current node and target node restarting. Errors from circuit
-				// breaker probes could confuse us and present node as unavailable.
-				conn, err = rpcCtx.GRPCDialNode(addr.String(), node.NodeID, rpc.DefaultClass).ConnectNoBreaker(ctx)
-				// Nodes would contain dead nodes that we don't need to visit. We can skip
-				// them and let caller handle incomplete info.
-				if err != nil {
-					if grpcutil.IsConnectionUnavailable(err) {
-						log.Infof(ctx, "rejecting node n%d because of suspected un-retryable error: %s",
-							node.NodeID, err)
-						return nil
-					}
-					// This was an initial heartbeat type error, we must retry as node seems
-					// live.
-					continue
-				}
-				client := serverpb.NewAdminClient(conn)
-				err = visitor(node.NodeID, client)
-				if err == nil {
-					return nil
-				}
-				log.Infof(ctx, "failed calling a visitor for node n%d: %s", node.NodeID, err)
-				if !IsRetryableError(err) {
-					return err
-				}
-			}
-			return err
-		}
-
 		var nodes []roachpb.NodeDescriptor
 		if err := g.IterateInfos(gossip.KeyNodeDescPrefix, func(key string, i gossip.Info) error {
 			b, err := i.Value.GetBytes()
@@ -715,13 +730,62 @@ func makeVisitAvailableNodes(
 			return err
 		}
 
-		for _, node := range nodes {
-			if err := visitWithRetry(node); err != nil {
-				return err
-			}
+		var g errgroup.Group
+		if maxConcurrency == 0 {
+			// "A value of 0 disables concurrency."
+			maxConcurrency = 1
 		}
-		return nil
+		g.SetLimit(int(maxConcurrency))
+		for _, node := range nodes {
+			node := node // copy for closure
+			g.Go(func() error {
+				return visitNodeWithRetry(ctx, loc, rpcCtx, retryOpts, visitor, node)
+			})
+		}
+		return g.Wait()
 	}
+}
+
+func visitNodeWithRetry(
+	ctx context.Context,
+	loc roachpb.Locality,
+	rpcCtx *rpc.Context,
+	retryOpts retry.Options,
+	visitor visitNodeAdminFn,
+	node roachpb.NodeDescriptor,
+) error {
+	var err error
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
+		addr := node.AddressForLocality(loc)
+		var conn *grpc.ClientConn
+		// Note that we use ConnectNoBreaker here to avoid any race with probe
+		// running on current node and target node restarting. Errors from circuit
+		// breaker probes could confuse us and present node as unavailable.
+		conn, err = rpcCtx.GRPCDialNode(addr.String(), node.NodeID, rpc.DefaultClass).ConnectNoBreaker(ctx)
+		// Nodes would contain dead nodes that we don't need to visit. We can skip
+		// them and let caller handle incomplete info.
+		if err != nil {
+			if grpcutil.IsConnectionUnavailable(err) {
+				log.Infof(ctx, "rejecting node n%d because of suspected un-retryable error: %s",
+					node.NodeID, err)
+				return nil
+			}
+			// This was an initial heartbeat type error, we must retry as node seems
+			// live.
+			continue
+		}
+		client := serverpb.NewAdminClient(conn)
+		err = visitor(node.NodeID, client)
+		if err == nil {
+			return nil
+		}
+		log.Infof(ctx, "failed calling a visitor for node n%d: %s", node.NodeID, err)
+		if !IsRetryableError(err) {
+			return err
+		}
+	}
+	return err
 }
 
 // makeVisitNode creates a function to visit a remote node.

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -125,14 +125,28 @@ func (s Server) ServeLocalReplicas(
 	stream serverpb.Admin_RecoveryCollectLocalReplicaInfoServer,
 ) error {
 	v := s.settings.Version.ActiveVersion(ctx)
-	return s.stores.VisitStores(func(s *kvserver.Store) error {
-		reader := s.TODOEngine().NewSnapshot()
-		defer reader.Close()
-		return visitStoreReplicas(ctx, reader, s.StoreID(), s.NodeID(), v,
-			func(info loqrecoverypb.ReplicaInfo) error {
-				return stream.Send(&serverpb.RecoveryCollectLocalReplicaInfoResponse{ReplicaInfo: &info})
-			})
-	})
+	var stores []*kvserver.Store
+	if err := s.stores.VisitStores(func(s *kvserver.Store) error {
+		stores = append(stores, s)
+		return nil
+	}); err != nil {
+		return err
+	}
+	syncStream := makeThreadSafeStream[*serverpb.RecoveryCollectLocalReplicaInfoResponse](stream)
+	stream = nil // prevent misuse
+	var g errgroup.Group
+	for _, s := range stores {
+		s := s // copy for closure
+		g.Go(func() error {
+			reader := s.TODOEngine().NewSnapshot()
+			defer reader.Close()
+			return visitStoreReplicas(ctx, reader, s.StoreID(), s.NodeID(), v,
+				func(info loqrecoverypb.ReplicaInfo) error {
+					return syncStream.Send(&serverpb.RecoveryCollectLocalReplicaInfoResponse{ReplicaInfo: &info})
+				})
+		})
+	}
+	return g.Wait()
 }
 
 func (s Server) ServeClusterReplicas(

--- a/pkg/kv/kvserver/loqrecovery/testing_knobs.go
+++ b/pkg/kv/kvserver/loqrecovery/testing_knobs.go
@@ -23,6 +23,7 @@ type TestingKnobs struct {
 	MetadataScanTimeout time.Duration
 
 	// Replica filter for forwarded replica info when collecting fan-out data.
+	// It can be called concurrently, so must be safe for concurrent use.
 	ForwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
 }
 

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -888,7 +888,12 @@ message ChartCatalogResponse {
   repeated cockroach.ts.catalog.ChartSection catalog = 1 [(gogoproto.nullable) = false];
 }
 
-message RecoveryCollectReplicaInfoRequest {}
+message RecoveryCollectReplicaInfoRequest {
+  // MaxConcurrency is the maximum parallelism that will be used when fanning
+  // out RPCs to nodes in the cluster while servicing this request. A value of 0
+  // disables concurrency. A negative value configures no limit for concurrency.
+  int32 max_concurrency = 1;
+}
 
 // RecoveryCollectReplicaRestartNodeStream is sent by collector node to client
 // if it experiences a transient failure collecting data from one of the nodes.
@@ -933,6 +938,10 @@ message RecoveryStagePlanRequest {
   // if target cluster is stuck in recovery where only part of nodes were
   // successfully migrated.
   bool force_local_internal_version = 4;
+  // MaxConcurrency is the maximum parallelism that will be used when fanning
+  // out RPCs to nodes in the cluster while servicing this request. A value of 0
+  // disables concurrency. A negative value configures no limit for concurrency.
+  int32 max_concurrency = 5;
 }
 
 message RecoveryStagePlanResponse {
@@ -961,6 +970,10 @@ message RecoveryVerifyRequest {
   // If more unhealthy ranges are found, error will be returned alongside range
   // to indicate that ranges were cut short.
   int32 max_reported_ranges = 3;
+  // MaxConcurrency is the maximum parallelism that will be used when fanning
+  // out RPCs to nodes in the cluster while servicing this request. A value of 0
+  // disables concurrency. A negative value configures no limit for concurrency.
+  int32 max_concurrency = 4;
 }
 
 message RecoveryVerifyResponse {


### PR DESCRIPTION
Fixes #122639.

This PR adds a `--max-concurrency` flag to the following `debug recover` commands:
- `debug recover collect-info`
- `debug recover make-plan`
- `debug recover apply-plan`
- `debug recover verify`

The flag controls the maximum concurrency when fanning out RPCs to nodes in the cluster while servicing the command. It defaults to `2 x num_cpus`, which is a decent proxy for how much fannout the process can tolerate without overloading itself.

The PR then uses this maximum concurrency flag to control the parallelism for the RPC fanout to nodes in the cluster during the data collection phase of LoQ.

The PR also parallelizes the fanout of store iteration during the data collection phase of LoQ. This fanout is not limited, as we expect nodes to have a sufficiently high cpu-to-store ratio to handle the fanout.

### Experiment

We measure the time it takes to recover from loss-of-quorum on a 16 (32vCPU) node x 4 store-per-node cluster with 200k ranges.

```bash
roachprod create nathan-loq -n 16 --gce-machine-type=n2-standard-32 --local-ssd=true --gce-local-ssd-count=4 --gce-enable-multiple-stores
roachprod stage  nathan-loq cockroach
roachprod start  nathan-loq --store-count=4
roachprod run    nathan-loq:1 -- './cockroach workload init kv --splits=200000 {pgurl:1}'

# create some range descriptor churn to build up multiple versions of each descriptor.
# wait for full replication between steps.
roachprod sql nathan-loq:1 -- -e "ALTER RANGE default CONFIGURE ZONE USING num_replicas = 9"
roachprod sql nathan-loq:1 -- -e "ALTER RANGE default CONFIGURE ZONE USING num_replicas = 3"

# import and run a workload for a bit to push range descriptors out of cache.
roachprod run nathan-loq:1 -- './cockroach workload init tpcc --warehouses=10000 {pgurl:1}'
roachprod run nathan-loq:1 -- './cockroach workload run kv --min-block-bytes=40000 --max-block-bytes=40000 --concurrency=256 --read-percent=50 --duration=5m {pgurl:1-9}'

# create range unavailability.
roachprod stop nathan-loq:6,9

# create LoQ recovery plan while measuring how long this takes.
time roachprod run nathan-loq:1 -- './cockroach debug recover make-plan --confirm y --insecure --port={pgport:1} > plan.json'
```

Before this change, the `cockroach debug recover make-plan` command took **2m37.265s**.

After this change, the `cockroach debug recover make-plan` command takes **0m7.520s**, a **95.2%** speedup.

----

Release note (cli change): Added `--max-concurrency` flag to `debug recover` commands to control the maximum concurrency when fanning out RPCs to nodes in the cluster. The flag defaults to `2 x num_cpus`.