### PR TITLE
schemachanger: check that primary key columns are indexable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1975,3 +1975,18 @@ idx j ASC
 t_114436_pkey j ASC
 
 subtest end
+
+subtest column_not_indexable
+
+statement ok
+CREATE TABLE tab_122871 (
+  col0_4         TSVECTOR NOT NULL,
+  col0_6         OID,
+  col0_18        REGTYPE,
+  PRIMARY KEY (col0_18 DESC)
+);
+
+statement error column col0_4 is of type tsvector and thus is not indexable
+ALTER TABLE tab_122871 ALTER PRIMARY KEY USING COLUMNS (col0_4);
+
+subtest end


### PR DESCRIPTION
This makes ALTER PRIMARY KEY always make sure that the column type is indexable. The regression was caused by 7a884414, which is not in a non-beta release, so there's no release note.

fixes https://github.com/cockroachdb/cockroach/issues/122871
Release note: None