### PR TITLE
opt: print "inverted" to indexes in formatted expressions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -1027,7 +1027,7 @@ EXPLAIN (OPT) SELECT t1.k FROM json_arr2_rbt AS t2 INNER INVERTED JOIN json_arr1
 project
  └── inner-join (lookup json_arr1_rbt [as=t1])
       ├── lookup columns are key
-      ├── inner-join (inverted json_arr1_rbt@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1_rbt@j_idx,inverted [as=t1])
       │    ├── flags: force inverted join (into right side)
       │    ├── inverted-expr
       │    │    └── t1.j @> t2.j
@@ -1084,7 +1084,7 @@ project
       │    ├── distribution: ap-southeast-2
       │    ├── lookup table distribution: ap-southeast-2
       │    ├── prune: (7)
-      │    ├── inner-join (inverted json_arr1_rbr@j_idx [as=t1])
+      │    ├── inner-join (inverted json_arr1_rbr@j_idx,inverted [as=t1])
       │    │    ├── columns: t2.j:3 t1.k:18 crdb_region:22
       │    │    ├── flags: force inverted join (into right side)
       │    │    ├── prefix key columns: [17] = [22]

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3213,12 +3213,12 @@ WHERE json_col->'loc' @> '{"state":"NY"}'
 ----
 index-join t88047
  └── locality-optimized-search
-      ├── scan t88047@t88047_inv_idx
+      ├── scan t88047@t88047_inv_idx,inverted
       │    ├── constraint: /11: [/'ap-southeast-2' - /'ap-southeast-2']
       │    ├── inverted constraint: /15/12
       │    │    └── spans: ["7loc\x00\x02state\x00\x01\x12NY\x00\x01", "7loc\x00\x02state\x00\x01\x12NY\x00\x01"]
       │    └── limit: 2
-      └── scan t88047@t88047_inv_idx
+      └── scan t88047@t88047_inv_idx,inverted
            ├── constraint: /18
            │    ├── [/'ca-central-1' - /'ca-central-1']
            │    └── [/'us-east-1' - /'us-east-1']

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -1778,7 +1778,7 @@ EXPLAIN (OPT, REDACT) SELECT * FROM g WHERE (g || 'abc') LIKE '%ggg%'
 ----
 select
  ├── index-join g
- │    └── scan g@g_expr_idx
+ │    └── scan g@g_expr_idx,inverted
  │         └── inverted constraint: /6/3
  │              └── spans: ‹×›
  └── filters
@@ -1798,7 +1798,7 @@ select
  │    ├── stats: [rows=111.1111]
  │    ├── cost: 810.262222
  │    ├── distribution: test
- │    └── scan g@g_expr_idx
+ │    └── scan g@g_expr_idx,inverted
  │         ├── columns: rowid:3
  │         ├── inverted constraint: /6/3
  │         │    └── spans: ‹×›
@@ -1823,7 +1823,7 @@ select
  │    ├── stats: [rows=111.1111]
  │    ├── cost: 810.262222
  │    ├── distribution: test
- │    └── scan g@g_expr_idx
+ │    └── scan g@g_expr_idx,inverted
  │         ├── columns: rowid:3(int!null)
  │         ├── inverted constraint: /6/3
  │         │    └── spans: ‹×›
@@ -1869,12 +1869,12 @@ memo (optimized, ~13KB, required=[presentation: info:7] [distribution: test])
  │         ├── best: (index-join G7 g,cols=(1))
  │         └── cost: 810.26
  ├── G6: (like G8 G9)
- ├── G7: (scan g@g_expr_idx,cols=(3),constrained inverted)
+ ├── G7: (scan g@g_expr_idx,inverted,cols=(3),constrained inverted)
  │    ├── [distribution: test]
- │    │    ├── best: (scan g@g_expr_idx,cols=(3),constrained inverted)
+ │    │    ├── best: (scan g@g_expr_idx,inverted,cols=(3),constrained inverted)
  │    │    └── cost: 135.80
  │    └── []
- │         ├── best: (scan g@g_expr_idx,cols=(3),constrained inverted)
+ │         ├── best: (scan g@g_expr_idx,inverted,cols=(3),constrained inverted)
  │         └── cost: 135.80
  ├── G8: (concat G10 G11)
  ├── G9: (const ‹×›)
@@ -1882,7 +1882,7 @@ memo (optimized, ~13KB, required=[presentation: info:7] [distribution: test])
  └── G11: (const ‹×›)
 select
  ├── index-join g
- │    └── scan g@g_expr_idx
+ │    └── scan g@g_expr_idx,inverted
  │         └── inverted constraint: /6/3
  │              └── spans: ‹×›
  └── filters

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3304,7 +3304,7 @@ inner-join (lookup geo_table)
  ├── fd: (1)-->(2), (5)-->(6)
  ├── distribution: test
  ├── prune: (1,5)
- ├── inner-join (inverted geo_table@geom_index)
+ ├── inner-join (inverted geo_table@geom_index,inverted)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
@@ -3396,7 +3396,7 @@ left-join (lookup geo_table)
  ├── fd: (1)-->(2), (5)-->(6)
  ├── distribution: test
  ├── prune: (1,5)
- ├── left-join (inverted geo_table@geom_index)
+ ├── left-join (inverted geo_table@geom_index,inverted)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11 continuation:16
  │    ├── first join in paired joiner; continuation column: continuation:16
  │    ├── inverted-expr
@@ -3435,7 +3435,7 @@ semi-join (lookup geo_table)
  ├── fd: (1)-->(2)
  ├── distribution: test
  ├── prune: (1)
- ├── inner-join (inverted geo_table@geom_index)
+ ├── inner-join (inverted geo_table@geom_index,inverted)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:12 continuation:17
  │    ├── first join in paired joiner; continuation column: continuation:17
  │    ├── inverted-expr
@@ -3475,7 +3475,7 @@ anti-join (lookup geo_table)
  ├── fd: (1)-->(2)
  ├── distribution: test
  ├── prune: (1)
- ├── left-join (inverted geo_table@geom_index)
+ ├── left-join (inverted geo_table@geom_index,inverted)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:12 continuation:17
  │    ├── first join in paired joiner; continuation column: continuation:17
  │    ├── inverted-expr
@@ -3562,7 +3562,7 @@ index-join t117979
  ├── fd: (1)-->(2)
  ├── distribution: test
  ├── prune: (1)
- └── scan t117979@idx_links [as=t]
+ └── scan t117979@idx_links,inverted [as=t]
       ├── columns: id:1
       ├── inverted constraint: /5/1
       │    └── spans: ["\x12str1\x00\x01", "\x12str1\x00\x01"]

--- a/pkg/sql/opt/indexrec/testdata/geospatial
+++ b/pkg/sql/opt/indexrec/testdata/geospatial
@@ -74,7 +74,7 @@ select
  │         │    └── st_coveredby('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:4)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -174,7 +174,7 @@ select
  │         │    └── st_covers('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom2:8)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geom2_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -318,7 +318,7 @@ select
  │         │    └── st_coveredby('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom2:8)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geom2_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -478,7 +478,7 @@ select
  │         │    └── st_intersects('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom1:4)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -579,7 +579,7 @@ select
  │         │    └── st_intersects('01030000000100000005000000000000000000F03F0000000000000040000000000000F03F00000000000010400000000000000840000000000000104000000000000008400000000000000040000000000000F03F0000000000000040', geom1:4)
  │         ├── cost: 258.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -719,7 +719,7 @@ select
  │         │    └── st_dwithinexclusive('0101000020E6100000A6272CF1807245C0A6B73F170DFC5240', geog2:9, 10.0, true)
  │         ├── cost: 238.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geog2_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -882,7 +882,7 @@ select
  │         │    └── st_covers('01030000000100000005000000000000000000F03F0000000000000040000000000000F03F00000000000010400000000000000840000000000000104000000000000008400000000000000040000000000000F03F0000000000000040', geom1:4)
  │         ├── cost: 258.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_3
+ │         └── scan t2@_hyp_3,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -1079,7 +1079,7 @@ select
  │         │    └── st_intersects('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:4)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_1
+ │         └── scan t2@_hyp_1,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -1184,7 +1184,7 @@ select
  │         │    └── st_intersects('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:4)
  │         ├── cost: 19.2177778
  │         ├── key: (11)
- │         └── scan t2@_hyp_3
+ │         └── scan t2@_hyp_3,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:15!null
  │              ├── constraint: /1: [/2 - /2]
  │              ├── inverted constraint: /15/11
@@ -1287,7 +1287,7 @@ select
  │         │    └── st_intersects('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:4)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_2
+ │         └── scan t2@_hyp_2,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -1426,7 +1426,7 @@ select
  │         │    └── st_intersects('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:4)
  │         ├── cost: 254.706667
  │         ├── key: (11)
- │         └── scan t2@_hyp_3
+ │         └── scan t2@_hyp_3,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:14!null
  │              ├── inverted constraint: /14/11
  │              │    └── spans
@@ -1631,7 +1631,7 @@ select
  │         │    └── st_intersects('01030000000100000005000000000000000000F03F0000000000000040000000000000F03F00000000000010400000000000000840000000000000104000000000000008400000000000000040000000000000F03F0000000000000040', geom1:4)
  │         ├── cost: 19.2177778
  │         ├── key: (11)
- │         └── scan t2@_hyp_3
+ │         └── scan t2@_hyp_3,inverted
  │              ├── columns: rowid:11!null geom1_inverted_key:15!null
  │              ├── constraint: /1: [/2 - /2]
  │              ├── inverted constraint: /15/11
@@ -1815,7 +1815,7 @@ select
  │         │    └── st_coveredby('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:2)
  │         ├── cost: 142.706667
  │         ├── key: (3)
- │         └── scan t2@inverted_idx
+ │         └── scan t2@inverted_idx,inverted
  │              ├── columns: rowid:3!null t2.geom1_inverted_key:6!null
  │              ├── inverted constraint: /6/3
  │              │    └── spans
@@ -1891,7 +1891,7 @@ select
  │         │    └── st_coveredby('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:2)
  │         ├── cost: 254.706667
  │         ├── key: (3)
- │         └── scan t2@_hyp_2
+ │         └── scan t2@_hyp_2,inverted
  │              ├── columns: rowid:3!null geom1_inverted_key:8!null
  │              ├── inverted constraint: /8/3
  │              │    └── spans
@@ -1962,7 +1962,7 @@ select
  │         │    └── st_coveredby('01010000C00000000000000000000000000000000000000000000000000000000000000000', geom1:2)
  │         ├── cost: 142.706667
  │         ├── key: (3)
- │         └── scan t2@inverted_idx_visible
+ │         └── scan t2@inverted_idx_visible,inverted
  │              ├── columns: rowid:3!null t2.geom1_inverted_key:8!null
  │              ├── inverted constraint: /8/3
  │              │    └── spans

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -1487,7 +1487,7 @@ project
       ├── columns: k:1 f:3 j:4
       ├── immutable
       ├── cost: 810.262222
-      └── scan t4@_hyp_1
+      └── scan t4@_hyp_1,inverted
            ├── columns: rowid:6!null
            ├── inverted constraint: /9/6
            │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
@@ -1514,7 +1514,7 @@ project
       ├── columns: k:1 f:3 j:4!null
       ├── immutable
       ├── cost: 807.928889
-      └── scan t4@_hyp_1
+      └── scan t4@_hyp_1,inverted
            ├── columns: rowid:6!null
            ├── inverted constraint: /9/6
            │    └── spans: ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
@@ -1553,7 +1553,7 @@ project
       │         │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
       │         ├── cost: 138.706667
       │         ├── key: (6)
-      │         └── scan t4@_hyp_1
+      │         └── scan t4@_hyp_1,inverted
       │              ├── columns: rowid:6!null j_inverted_key:9!null
       │              ├── inverted constraint: /9/6
       │              │    └── spans
@@ -1583,7 +1583,7 @@ inner-join (lookup t4)
  ├── lookup columns are key
  ├── immutable
  ├── cost: 245.980741
- ├── inner-join (zigzag t4@_hyp_1 t4@_hyp_1)
+ ├── inner-join (zigzag t4@_hyp_1,inverted t4@_hyp_1,inverted)
  │    ├── columns: rowid:6!null
  │    ├── eq columns: [6] = [6]
  │    ├── left fixed columns: [9] = ['\x37626172000112320001']
@@ -1628,7 +1628,7 @@ project
       │         │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
       │         ├── cost: 19.2177778
       │         ├── key: (6)
-      │         └── scan t4@_hyp_3
+      │         └── scan t4@_hyp_3,inverted
       │              ├── columns: rowid:6!null j_inverted_key:10!null
       │              ├── constraint: /1: [/1 - /1]
       │              ├── inverted constraint: /10/6
@@ -1681,7 +1681,7 @@ project
       │         │         └── ["7foo\x00\x01\x121\x00\x01", "7foo\x00\x01\x121\x00\x01"]
       │         ├── cost: 18.1482853
       │         ├── key: (6)
-      │         └── scan t4@_hyp_7
+      │         └── scan t4@_hyp_7,inverted
       │              ├── columns: rowid:6!null j_inverted_key:12!null
       │              ├── constraint: /1/2: [/1/2 - /1/2]
       │              ├── inverted constraint: /12/6
@@ -1873,7 +1873,7 @@ index-join t4
  ├── immutable
  ├── cost: 25.9622223
  ├── fd: ()-->(1)
- └── scan t4@inverted
+ └── scan t4@inverted,inverted
       ├── columns: rowid:6!null
       ├── constraint: /1: [/1 - /1]
       ├── inverted constraint: /9/6
@@ -1950,7 +1950,7 @@ project
       ├── immutable
       ├── cost: 25.9511112
       ├── fd: ()-->(2)
-      └── scan t4@partial_inverted_idx,partial
+      └── scan t4@partial_inverted_idx,inverted,partial
            ├── columns: rowid:6!null
            ├── inverted constraint: /10/6
            │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
@@ -1992,7 +1992,7 @@ index-join t4
  ├── columns: j:4
  ├── immutable
  ├── cost: 808.04
- └── scan t4@_hyp_4
+ └── scan t4@_hyp_4,inverted
       ├── columns: rowid:6!null
       ├── inverted constraint: /11/6
       │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
@@ -2428,7 +2428,7 @@ delete t109974b
       │    ├── cost: 111996.67
       │    ├── key: (6,12)
       │    ├── fd: (6)-->(7), (12)-->(11,13,14)
-      │    ├── inner-join (inverted t109974b@_hyp_2)
+      │    ├── inner-join (inverted t109974b@_hyp_2,inverted)
       │    │    ├── columns: g1:11 rowid:12!null t109974a.crdb_internal_mvcc_timestamp:13 t109974a.tableoid:14 k2:23!null
       │    │    ├── inverted-expr
       │    │    │    └── st_intersects(g1:11, g2:24)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1382,6 +1382,9 @@ func (f *ExprFmtCtx) formatIndex(tabID opt.TableID, idxOrd cat.IndexOrdinal, rev
 	if reverse {
 		f.Buffer.WriteString(",rev")
 	}
+	if index.IsInverted() {
+		f.Buffer.WriteString(",inverted")
+	}
 	if _, isPartial := index.Predicate(); isPartial {
 		f.Buffer.WriteString(",partial")
 	}

--- a/pkg/sql/opt/memo/testdata/stats/inverted-array
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-array
@@ -71,7 +71,7 @@ index-join t
       │    └── union spans: ["", ""]
       ├── stats: [rows=1020]
       ├── key: (1)
-      └── scan t@a_idx
+      └── scan t@a_idx,inverted
            ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans: ["", ""]
@@ -92,7 +92,7 @@ index-join t
  ├── stats: [rows=111.1111]
  ├── key: (1)
  ├── fd: (1)-->(2)
- └── scan t@a_idx
+ └── scan t@a_idx,inverted
       ├── columns: k:1(int!null)
       ├── inverted constraint: /5/1
       │    └── spans: ["\x8a", "\x8a"]
@@ -119,7 +119,7 @@ index-join t
       │    └── union spans: ["\x8a", "\x8c")
       ├── stats: [rows=20]
       ├── key: (1)
-      └── scan t@a_idx
+      └── scan t@a_idx,inverted
            ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans: ["\x8a", "\x8c")
@@ -145,7 +145,7 @@ select
  │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    └── scan t@a_idx
+ │    └── scan t@a_idx,inverted
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["C", "C"]
@@ -182,7 +182,7 @@ select
  │         │         └── ["\x8a", "\x8a"]
  │         ├── stats: [rows=20]
  │         ├── key: (1)
- │         └── scan t@a_idx
+ │         └── scan t@a_idx,inverted
  │              ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -221,7 +221,7 @@ select
  │         │         └── ["\x8a", "\x8c")
  │         ├── stats: [rows=30]
  │         ├── key: (1)
- │         └── scan t@a_idx
+ │         └── scan t@a_idx,inverted
  │              ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -266,7 +266,7 @@ select
  │         │              └── union spans: ["\x8b", "\x8b"]
  │         ├── stats: [rows=30]
  │         ├── key: (1)
- │         └── scan t@a_idx
+ │         └── scan t@a_idx,inverted
  │              ├── columns: k:1(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -130,9 +130,9 @@ memo (optimized, ~14KB, required=[presentation: i:1])
  │         ├── best: (inverted-filter G12 g_inverted_key)
  │         └── cost: 1272.99
  ├── G11: (scalar-list G13 G14)
- ├── G12: (scan t@t_g_idx,cols=(3,6),constrained inverted)
+ ├── G12: (scan t@t_g_idx,inverted,cols=(3,6),constrained inverted)
  │    └── []
- │         ├── best: (scan t@t_g_idx,cols=(3,6),constrained inverted)
+ │         ├── best: (scan t@t_g_idx,inverted,cols=(3,6),constrained inverted)
  │         └── cost: 1261.09
  ├── G13: (const '010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F')
  └── G14: (variable g)
@@ -180,7 +180,7 @@ project
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
       │    │              ├── stats: [rows=1.4e-06]
       │    │              ├── key: (3)
-      │    │              └── scan t@t_g_idx
+      │    │              └── scan t@t_g_idx,inverted
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
       │    │                   ├── inverted constraint: /6/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -234,9 +234,9 @@ memo (optimized, ~14KB, required=[presentation: i:1])
  │         ├── best: (inverted-filter G12 g_inverted_key)
  │         └── cost: 18.04
  ├── G11: (scalar-list G13 G14)
- ├── G12: (scan t@t_g_idx,cols=(3,6),constrained inverted)
+ ├── G12: (scan t@t_g_idx,inverted,cols=(3,6),constrained inverted)
  │    └── []
- │         ├── best: (scan t@t_g_idx,cols=(3,6),constrained inverted)
+ │         ├── best: (scan t@t_g_idx,inverted,cols=(3,6),constrained inverted)
  │         └── cost: 18.02
  ├── G13: (const '010200000002000000000000000000594000000000000059400000000000C062400000000000C06240')
  └── G14: (variable g)
@@ -400,7 +400,7 @@ project
       │    │              │    └── st_intersects('010200000002000000000000000000594000000000000059400000000000C062400000000000C06240', g:2) [type=bool]
       │    │              ├── stats: [rows=1.42e-06]
       │    │              ├── key: (3)
-      │    │              └── scan t@t_g_idx
+      │    │              └── scan t@t_g_idx,inverted
       │    │                   ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
       │    │                   ├── inverted constraint: /6/3
       │    │                   │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -479,7 +479,7 @@ select
  │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
  │         ├── stats: [rows=100]
  │         ├── key: (3)
- │         └── scan t@t_g_idx
+ │         └── scan t@t_g_idx,inverted
  │              ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
  │              ├── inverted constraint: /6/3
  │              │    └── spans
@@ -521,7 +521,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=100]
       │         ├── key: (3)
-      │         └── scan t@t_g_idx
+      │         └── scan t@t_g_idx,inverted
       │              ├── columns: rowid:3(int!null) g_inverted_key:6(encodedkey!null)
       │              ├── inverted constraint: /6/3
       │              │    └── spans

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo-multi-column
@@ -98,7 +98,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=59.37842]
       │         ├── key: (1)
-      │         └── scan t@m
+      │         └── scan t@m,inverted
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── constraint: /3: [/'banana' - /'banana']
       │              ├── inverted constraint: /7/1
@@ -150,7 +150,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=59.37842]
       │         ├── key: (1)
-      │         └── scan t@p,partial
+      │         └── scan t@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:8(encodedkey!null)
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -213,7 +213,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=118.7568]
       │         ├── key: (1)
-      │         └── scan t@m
+      │         └── scan t@m,inverted
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── constraint: /3
       │              │    ├── [/'apple' - /'apple']
@@ -268,7 +268,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
-      │         └── scan t@p,partial
+      │         └── scan t@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:9(encodedkey!null)
       │              ├── inverted constraint: /9/1
       │              │    └── spans
@@ -331,7 +331,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=2.503931]
       │         ├── key: (1)
-      │         └── scan t@mp,partial
+      │         └── scan t@mp,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:10(encodedkey!null)
       │              ├── constraint: /4: [/400 - /400]
       │              ├── inverted constraint: /10/1
@@ -387,7 +387,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=10.11106]
       │         ├── key: (1)
-      │         └── scan t@mp,partial
+      │         └── scan t@mp,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:10(encodedkey!null)
       │              ├── constraint: /4
       │              │    ├── [/200 - /200]

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -29,7 +29,7 @@ project
       ├── stats: [rows=9801]
       ├── key: (1,5)
       ├── fd: (1)-->(2), (5)-->(6)
-      ├── inner-join (inverted rtable@geom_index)
+      ├── inner-join (inverted rtable@geom_index,inverted)
       │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry) rtable.k:10(int!null)
       │    ├── inverted-expr
       │    │    └── st_intersects(ltable.geom:2, rtable.geom:11) [type=bool]
@@ -61,7 +61,7 @@ project
       ├── stats: [rows=9801]
       ├── key: (1,5)
       ├── fd: (1)-->(2), (5)-->(6)
-      ├── inner-join (inverted rtable@geom_index)
+      ├── inner-join (inverted rtable@geom_index,inverted)
       │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry) rtable.k:10(int!null)
       │    ├── inverted-expr
       │    │    └── st_intersects(ltable.geom:2, rtable.geom:11) [type=bool]
@@ -136,7 +136,7 @@ project
       ├── immutable
       ├── stats: [rows=100]
       ├── fd: (1)-->(2)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:9(jsonb) t1.k:13(int!null)
       │    ├── inverted-expr
       │    │    └── t1.j:14 @> t2.j:9 [type=bool]
@@ -165,7 +165,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── stats: [rows=3.666667]
  ├── key: (1,8)
  ├── fd: (1)-->(2,3), (8)-->(9,10)
- ├── inner-join (inverted json_arr1@a_idx [as=t1])
+ ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
  │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
  │    ├── inverted-expr
  │    │    └── (t1.a:15 @> t2.a:10) AND (t1.a:15 @> ARRAY['foo']) [type=bool]
@@ -200,7 +200,7 @@ project
       ├── immutable
       ├── stats: [rows=33.33333]
       ├── fd: (8)-->(9,10)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
       │    ├── inverted-expr
       │    │    └── t1.j:14 @> t2.j:9 [type=bool]
@@ -235,7 +235,7 @@ project
       ├── immutable
       ├── stats: [rows=3333.333]
       ├── fd: (1)-->(2)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:9(jsonb) t1.k:13(int!null)
       │    ├── inverted-expr
       │    │    └── t1.j:14 <@ t2.j:9 [type=bool]
@@ -261,7 +261,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── stats: [rows=370.3704]
  ├── key: (1,8)
  ├── fd: (1)-->(2,3), (8)-->(9,10)
- ├── inner-join (inverted json_arr1@a_idx [as=t1])
+ ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
  │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
  │    ├── inverted-expr
  │    │    └── (t1.a:15 <@ t2.a:10) AND (t1.a:15 <@ ARRAY['foo']) [type=bool]
@@ -296,7 +296,7 @@ project
       ├── immutable
       ├── stats: [rows=370.3704]
       ├── fd: (8)-->(9,10)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
       │    ├── inverted-expr
       │    │    └── t1.j:14 <@ t2.j:9 [type=bool]
@@ -370,7 +370,7 @@ project
       ├── immutable
       ├── stats: [rows=3]
       ├── fd: (1)-->(2,3)
-      ├── inner-join (inverted json_multi_col@sj_idx [as=t1])
+      ├── inner-join (inverted json_multi_col@sj_idx,inverted [as=t1])
       │    ├── columns: t2.j:9(jsonb) t1.k:14(int!null) s:16(string!null)
       │    ├── prefix key columns: [13] = [16]
       │    ├── inverted-expr
@@ -421,7 +421,7 @@ project
       ├── immutable
       ├── stats: [rows=0.3]
       ├── fd: ()-->(4), (1)-->(2,3)
-      ├── inner-join (inverted json_multi_col@sij_idx [as=t1])
+      ├── inner-join (inverted json_multi_col@sij_idx,inverted [as=t1])
       │    ├── columns: t2.j:10(jsonb) t1.k:16(int!null) s:18(string!null) i:19(int!null)
       │    ├── prefix key columns: [14 15] = [18 19]
       │    ├── inverted-expr
@@ -480,7 +480,7 @@ project
       ├── stats: [rows=10, distinct(4)=10, null(4)=0, distinct(10)=10, null(10)=0]
       ├── key: (1)
       ├── fd: (1)-->(2,4), (10)-->(11), (4)==(10), (10)==(4)
-      ├── inner-join (inverted json_multi_col@ij_idx [as=t1])
+      ├── inner-join (inverted json_multi_col@ij_idx,inverted [as=t1])
       │    ├── columns: t2.k:10(int!null) t2.j:11(jsonb) t1.k:15(int!null) i:18(int!null)
       │    ├── prefix key columns: [10] = [18]
       │    ├── inverted-expr

--- a/pkg/sql/opt/memo/testdata/stats/inverted-json
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json
@@ -99,7 +99,7 @@ index-join t
       │         └── ["7\x00\xff", "8")
       ├── stats: [rows=1110]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -122,7 +122,7 @@ index-join t
  ├── stats: [rows=222.2222]
  ├── key: (1)
  ├── fd: (1)-->(2)
- └── scan t@j_idx
+ └── scan t@j_idx,inverted
       ├── columns: k:1(int!null)
       ├── inverted constraint: /5/1
       │    └── spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
@@ -142,7 +142,7 @@ index-join t
  ├── stats: [rows=222.2222]
  ├── key: (1)
  ├── fd: (1)-->(2)
- └── scan t@j_idx
+ └── scan t@j_idx,inverted
       ├── columns: k:1(int!null)
       ├── inverted constraint: /5/1
       │    └── spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
@@ -171,7 +171,7 @@ index-join t
       │         └── ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
       ├── stats: [rows=110]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -202,7 +202,7 @@ index-join t
       │         └── ["7\x00\x03", "7\x00\x03"]
       ├── stats: [rows=1110]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -225,7 +225,7 @@ index-join t
  ├── stats: [rows=222.2222]
  ├── key: (1)
  ├── fd: (1)-->(2)
- └── scan t@j_idx
+ └── scan t@j_idx,inverted
       ├── columns: k:1(int!null)
       ├── inverted constraint: /5/1
       │    └── spans: ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
@@ -254,7 +254,7 @@ index-join t
       │         └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
       ├── stats: [rows=110]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -282,7 +282,7 @@ select
  │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    └── scan t@j_idx
+ │    └── scan t@j_idx,inverted
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["7\x00\x018", "7\x00\x018"]
@@ -309,7 +309,7 @@ select
  │    ├── stats: [rows=10]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    └── scan t@j_idx
+ │    └── scan t@j_idx,inverted
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["7\x00\x019", "7\x00\x019"]
@@ -345,7 +345,7 @@ select
  │         │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
  │         ├── stats: [rows=110]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -385,7 +385,7 @@ select
  │         │         └── ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
  │         ├── stats: [rows=120]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -430,7 +430,7 @@ select
  │         │              └── union spans: ["7e\x00\x01\x12f\x00\x01", "7e\x00\x01\x12f\x00\x01"]
  │         ├── stats: [rows=120]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -472,7 +472,7 @@ select
  │         │         └── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
  │         ├── stats: [rows=110]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -515,7 +515,7 @@ select
  │         │         └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
  │         ├── stats: [rows=120]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -566,7 +566,7 @@ select
  │         │                   └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
  │         ├── stats: [rows=120]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -658,7 +658,7 @@ index-join t
       │         └── ["7\x00\xff", "8")
       ├── stats: [rows=100]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -690,7 +690,7 @@ index-join t
       │         └── ["7\x00\x03", "7\x00\x03"]
       ├── stats: [rows=100]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -718,7 +718,7 @@ select
  │    ├── stats: [rows=4e-07]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    └── scan t@j_idx
+ │    └── scan t@j_idx,inverted
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -744,7 +744,7 @@ select
  │    ├── stats: [rows=4e-07]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    └── scan t@j_idx
+ │    └── scan t@j_idx,inverted
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /5/1
  │         │    └── spans: ["7a\x00\x02b\x00\x02c\x00\x01\x12d\x00\x01", "7a\x00\x02b\x00\x02c\x00\x01\x12d\x00\x01"]
@@ -785,7 +785,7 @@ select
  │         │              └── union spans: ["7a\x00\x02d\x00\x01\x12e\x00\x01", "7a\x00\x02d\x00\x01\x12e\x00\x01"]
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -842,7 +842,7 @@ select
  │         │              └── union spans: ["7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -895,7 +895,7 @@ select
  │         │              └── union spans: ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12e\x00\x01"]
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -934,7 +934,7 @@ select
  │         │         └── ["7a\x00\x02\x00\x03", "7a\x00\x02\x00\x03"]
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -972,7 +972,7 @@ select
  │         │         └── ["7a\x00\x02\x00\xff", "7a\x00\x03")
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -1004,7 +1004,7 @@ index-join t
       │         └── ["7a\x00\x02\x00\x03\x00\x01*\x02\x00", "7a\x00\x02\x00\x03\x00\x01*\x02\x00"]
       ├── stats: [rows=4e-07]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -1040,7 +1040,7 @@ select
  │         │         └── ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
  │         ├── stats: [rows=100]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -1073,7 +1073,7 @@ index-join t
       │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
       ├── stats: [rows=4e-07]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -1110,7 +1110,7 @@ select
  │         │         └── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
  │         ├── stats: [rows=100]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -1136,7 +1136,7 @@ index-join t
  ├── stats: [rows=222.2222]
  ├── key: (1)
  ├── fd: (1)-->(2)
- └── scan t@j_idx
+ └── scan t@j_idx,inverted
       ├── columns: k:1(int!null)
       ├── inverted constraint: /5/1
       │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -1170,7 +1170,7 @@ select
  │         │         └── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
  │         ├── stats: [rows=100]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -1215,7 +1215,7 @@ select
  │         │              └── union spans: ["7a\x00\x02\x00\x03\x00\x01*\x04\x00", "7a\x00\x02\x00\x03\x00\x01*\x04\x00"]
  │         ├── stats: [rows=4e-07]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -1257,7 +1257,7 @@ select
  │         │         └── ["7a\x00\x02\x00\x03\x00\x01*\x04\x00", "7a\x00\x02\x00\x03\x00\x01*\x04\x00"]
  │         ├── stats: [rows=100]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -1295,7 +1295,7 @@ index-join t
       │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
       ├── stats: [rows=4e-07]
       ├── key: (1)
-      └── scan t@j_idx
+      └── scan t@j_idx,inverted
            ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
            ├── inverted constraint: /5/1
            │    └── spans
@@ -1336,7 +1336,7 @@ select
  │         │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01*\x04\x00", "7a\x00\x02b\x00\x02\x00\x03\x00\x01*\x04\x00"]
  │         ├── stats: [rows=100]
  │         ├── key: (1)
- │         └── scan t@j_idx
+ │         └── scan t@j_idx,inverted
  │              ├── columns: k:1(int!null) j_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/1
  │              │    └── spans

--- a/pkg/sql/opt/memo/testdata/stats/inverted-trigram
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-trigram
@@ -33,7 +33,7 @@ select
  ├── index-join a
  │    ├── columns: a:1(string)
  │    ├── stats: [rows=111.1111]
- │    └── scan a@inv
+ │    └── scan a@inv,inverted
  │         ├── columns: rowid:2(int!null)
  │         ├── inverted constraint: /5/2
  │         │    └── spans: ["\x12foo\x00\x01", "\x12foo\x00\x01"]
@@ -108,7 +108,7 @@ select
  │         │              └── union spans: ["\x12lah\x00\x01", "\x12lah\x00\x01"]
  │         ├── stats: [rows=111.1111]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans
@@ -242,7 +242,7 @@ select
  │         │              └── union spans: ["\x12lah\x00\x01", "\x12lah\x00\x01"]
  │         ├── stats: [rows=20]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans
@@ -280,7 +280,7 @@ select
  │         │              └── union spans: ["\x12zoo\x00\x01", "\x12zoo\x00\x01"]
  │         ├── stats: [rows=1980]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans
@@ -311,7 +311,7 @@ select
  │         ├── grouping columns: rowid:2(int!null)
  │         ├── stats: [rows=8, distinct(2)=8, null(2)=0]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null)
  │              ├── constraint: /5
  │              │    ├── [/'\x1220626c0001' - /'\x1220626c0001']
@@ -339,7 +339,7 @@ select
  │         ├── grouping columns: rowid:2(int!null)
  │         ├── stats: [rows=8, distinct(2)=8, null(2)=0]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null)
  │              ├── constraint: /5
  │              │    ├── [/'\x1220626c0001' - /'\x1220626c0001']
@@ -368,7 +368,7 @@ select
  │         ├── grouping columns: rowid:2(int!null)
  │         ├── stats: [rows=2, distinct(2)=2, null(2)=0]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null)
  │              ├── constraint: /5: [/'\x126c61680001' - /'\x126c61680001']
  │              └── stats: [rows=10, distinct(2)=2, null(2)=0, distinct(5)=1, null(5)=0]
@@ -488,7 +488,7 @@ select
  │         │              └── union spans: ["\x12lah\x00\x01", "\x12lah\x00\x01"]
  │         ├── stats: [rows=20]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans
@@ -526,7 +526,7 @@ select
  │         │              └── union spans: ["\x12zoo\x00\x01", "\x12zoo\x00\x01"]
  │         ├── stats: [rows=1980]
  │         ├── key: (2)
- │         └── scan a@inv
+ │         └── scan a@inv,inverted
  │              ├── columns: rowid:2(int!null) a_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans

--- a/pkg/sql/opt/memo/testdata/stats/partial-index-scan
+++ b/pkg/sql/opt/memo/testdata/stats/partial-index-scan
@@ -867,7 +867,7 @@ project
  ├── immutable
  ├── stats: [rows=2.204409]
  ├── key: (1)
- └── scan inv@partial,partial
+ └── scan inv@partial,inverted,partial
       ├── columns: k:1(int!null)
       ├── inverted constraint: /7/1
       │    └── spans: ["7x\x00\x01\x12y\x00\x01", "7x\x00\x01\x12y\x00\x01"]
@@ -884,7 +884,7 @@ index-join inv
  ├── stats: [rows=2.204409, distinct(4)=2, null(4)=0]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- └── scan inv@partial,partial
+ └── scan inv@partial,inverted,partial
       ├── columns: k:1(int!null)
       ├── inverted constraint: /7/1
       │    └── spans: ["7x\x00\x01\x12y\x00\x01", "7x\x00\x01\x12y\x00\x01"]
@@ -911,7 +911,7 @@ project
       │    ├── stats: [rows=2.204409]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
-      │    └── scan inv@partial,partial
+      │    └── scan inv@partial,inverted,partial
       │         ├── columns: k:1(int!null)
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7x\x00\x01\x12y\x00\x01", "7x\x00\x01\x12y\x00\x01"]
@@ -935,7 +935,7 @@ select
  │    ├── stats: [rows=2.204409]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
- │    └── scan inv@partial,partial
+ │    └── scan inv@partial,inverted,partial
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7x\x00\x01\x12y\x00\x01", "7x\x00\x01\x12y\x00\x01"]
@@ -959,7 +959,7 @@ select
  │    ├── stats: [rows=2.204409]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
- │    └── scan inv@partial,partial
+ │    └── scan inv@partial,inverted,partial
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7x\x00\x01\x12y\x00\x01", "7x\x00\x01\x12y\x00\x01"]
@@ -1044,7 +1044,7 @@ project
  ├── immutable
  ├── stats: [rows=17.77778]
  ├── key: (1)
- └── scan inv_hist@partial,partial
+ └── scan inv_hist@partial,inverted,partial
       ├── columns: k:1(int!null)
       ├── inverted constraint: /7/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
@@ -1067,7 +1067,7 @@ index-join inv_hist
  │                <--- 'banana' --- 'cherry'
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- └── scan inv_hist@partial,partial
+ └── scan inv_hist@partial,inverted,partial
       ├── columns: k:1(int!null)
       ├── inverted constraint: /7/1
       │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
@@ -1100,7 +1100,7 @@ project
       │    ├── stats: [rows=20]
       │    ├── key: (1)
       │    ├── fd: (1)-->(3,4)
-      │    └── scan inv_hist@partial,partial
+      │    └── scan inv_hist@partial,inverted,partial
       │         ├── columns: k:1(int!null)
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
@@ -1130,7 +1130,7 @@ select
  │    ├── stats: [rows=20]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
- │    └── scan inv_hist@partial,partial
+ │    └── scan inv_hist@partial,inverted,partial
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
@@ -1162,7 +1162,7 @@ select
  │    ├── stats: [rows=20]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
- │    └── scan inv_hist@partial,partial
+ │    └── scan inv_hist@partial,inverted,partial
  │         ├── columns: k:1(int!null)
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7g\x00\x01*\x0e\x00", "7g\x00\x01*\x0e\x00"]
@@ -1244,7 +1244,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=16.66667]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1290,7 +1290,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=16.66667]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1357,7 +1357,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=8.547009]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1401,7 +1401,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=8.547009]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1491,7 +1491,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=118.7568]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1543,7 +1543,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=118.7568]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1631,7 +1631,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -1681,7 +1681,7 @@ project
       │         │    └── st_intersects('010200000002000000000000000000E03F000000000000E03F666666666666E63F666666666666E63F', g:2) [type=bool]
       │         ├── stats: [rows=121.5695]
       │         ├── key: (1)
-      │         └── scan spatial@p,partial
+      │         └── scan spatial@p,inverted,partial
       │              ├── columns: k:1(int!null) g_inverted_key:7(encodedkey!null)
       │              ├── inverted constraint: /7/1
       │              │    └── spans

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2210,7 +2210,7 @@ select
  │         │    └── st_covers('0101000000000000000000F03F000000000000F03F', geom:1) [type=bool]
  │         ├── stats: [rows=1]
  │         ├── key: (2)
- │         └── scan tab@tab_geom_idx
+ │         └── scan tab@tab_geom_idx,inverted
  │              ├── columns: rowid:2(int!null) geom_inverted_key:5(encodedkey!null)
  │              ├── inverted constraint: /5/2
  │              │    └── spans

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -858,7 +858,7 @@ index-join t_json_arr
  ├── stats: [rows=555.5556]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- └── scan t_json_arr@b_idx
+ └── scan t_json_arr@b_idx,inverted
       ├── columns: a:1(int!null)
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -878,7 +878,7 @@ inner-join (lookup t_json_arr)
  ├── stats: [rows=61.7284]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── inner-join (zigzag t_json_arr@b_idx t_json_arr@b_idx)
+ ├── inner-join (zigzag t_json_arr@b_idx,inverted t_json_arr@b_idx,inverted)
  │    ├── columns: a:1(int!null)
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [7] = ['\x3761000112620001']

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1023,7 +1023,7 @@ scalar-group-by
  │    │         ├── pre-filterer expression
  │    │         │    └── st_intersects('0103000020E610000001000000050000000000000000000000000000000000000000000000000000000000000000005940000000000000594000000000000059400000000000005940000000000000000000000000000000000000000000000000', geom:1)
  │    │         ├── key: (4)
- │    │         └── scan geom_geog@geom_geog_geom_idx
+ │    │         └── scan geom_geog@geom_geog_geom_idx,inverted
  │    │              ├── columns: rowid:4!null geom_inverted_key:7!null
  │    │              ├── inverted constraint: /7/4
  │    │              │    └── spans

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -203,7 +203,7 @@ inner-join (lookup g [as=g2])
  ├── cost: 1101976.47
  ├── key: (1,6)
  ├── fd: (1)-->(2), (6)-->(7)
- ├── inner-join (inverted g@g_geom_idx [as=g2])
+ ├── inner-join (inverted g@g_geom_idx,inverted [as=g2])
  │    ├── columns: g1.k:1!null g1.geom:2 g2.k:11!null
  │    ├── flags: force inverted join (into right side)
  │    ├── inverted-expr

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -705,7 +705,7 @@ index-join inv
  ├── cost: 803.595556
  ├── key: (1)
  ├── fd: (1)-->(2)
- └── scan inv@inv_j_idx
+ └── scan inv@inv_j_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /5/1
       │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]

--- a/pkg/sql/opt/xform/testdata/external/fittings
+++ b/pkg/sql/opt/xform/testdata/external/fittings
@@ -2626,7 +2626,7 @@ project
            ├── stats: [rows=0.004711281]
            ├── key: (1)
            ├── ordering: -1
-           └── scan fits@fits_items_idx
+           └── scan fits@fits_items_idx,inverted
                 ├── columns: killmail:1!null
                 ├── inverted constraint: /13/1
                 │    └── spans: ["7\x00\x03\x00\x01,\v_>\x00", "7\x00\x03\x00\x01,\v_>\x00"]

--- a/pkg/sql/opt/xform/testdata/external/planet-osm
+++ b/pkg/sql/opt/xform/testdata/external/planet-osm
@@ -1757,7 +1757,7 @@ sort
       │         │    ├── immutable
       │         │    ├── stats: [rows=3926737, distinct(69)=2632.06, null(69)=0, distinct(100)=31, null(100)=1.52957e+06]
       │         │    ├── fd: ()-->(29)
-      │         │    ├── inner-join (inverted planet_osm_line@planet_osm_line_way_idx [as=l])
+      │         │    ├── inner-join (inverted planet_osm_line@planet_osm_line_way_idx,inverted [as=l])
       │         │    │    ├── columns: p.highway:29!null p.way:69 l.rowid:218!null
       │         │    │    ├── inverted-expr
       │         │    │    │    └── st_dwithin(p.way:69, l.way:217, 100.0)

--- a/pkg/sql/opt/xform/testdata/external/postgis-tutorial-idx
+++ b/pkg/sql/opt/xform/testdata/external/postgis-tutorial-idx
@@ -42,7 +42,7 @@ sort
            │         ├── pre-filterer expression
            │         │    └── st_intersects('0101000020266900000000000026CF21410000008016315141', geom:4)
            │         ├── key: (1)
-           │         └── scan nyc_neighborhoods@nyc_neighborhoods_geom_idx
+           │         └── scan nyc_neighborhoods@nyc_neighborhoods_geom_idx,inverted
            │              ├── columns: gid:1!null geom_inverted_key:7!null
            │              ├── inverted constraint: /7/1
            │              │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -86,7 +86,7 @@ sort
            │         ├── pre-filterer expression
            │         │    └── st_dwithin('0101000020266900000000000026CF21410000008016315141', geom:6, 10.0)
            │         ├── key: (1)
-           │         └── scan nyc_streets@nyc_streets_geom_idx
+           │         └── scan nyc_streets@nyc_streets_geom_idx,inverted
            │              ├── columns: gid:1!null geom_inverted_key:9!null
            │              ├── inverted constraint: /9/1
            │              │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -132,7 +132,7 @@ sort
            │         ├── pre-filterer expression
            │         │    └── st_intersects('01020000202669000002000000000000003CE8214100000080A22E514100000000E0E8214100000000A62E5141', geom:4)
            │         ├── key: (1)
-           │         └── scan nyc_neighborhoods@nyc_neighborhoods_geom_idx
+           │         └── scan nyc_neighborhoods@nyc_neighborhoods_geom_idx,inverted
            │              ├── columns: gid:1!null geom_inverted_key:7!null
            │              ├── inverted constraint: /7/1
            │              │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -179,7 +179,7 @@ sort
            │         ├── pre-filterer expression
            │         │    └── st_dwithin('01020000202669000002000000000000003CE8214100000080A22E514100000000E0E8214100000000A62E5141', geom:6, 0.1)
            │         ├── key: (1)
-           │         └── scan nyc_streets@nyc_streets_geom_idx
+           │         └── scan nyc_streets@nyc_streets_geom_idx,inverted
            │              ├── columns: gid:1!null geom_inverted_key:9!null
            │              ├── inverted constraint: /9/1
            │              │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -223,7 +223,7 @@ scalar-group-by
  │    │         ├── pre-filterer expression
  │    │         │    └── st_dwithin('01020000202669000002000000000000003CE8214100000080A22E514100000000E0E8214100000000A62E5141', geom:10, 50.0)
  │    │         ├── key: (1)
- │    │         └── scan nyc_census_blocks@nyc_census_blocks_geom_idx
+ │    │         └── scan nyc_census_blocks@nyc_census_blocks_geom_idx,inverted
  │    │              ├── columns: gid:1!null geom_inverted_key:13!null
  │    │              ├── inverted constraint: /13/1
  │    │              │    └── spans: ["B\xfd\xff\xff\xff\xff\xff\xff\xff\xff", "B\xfd\xff\xff\xff\xff\xff\xff\xff\xff"]
@@ -265,7 +265,7 @@ sort
            ├── lookup columns are key
            ├── immutable
            ├── fd: ()-->(11)
-           ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geom_idx [as=neighborhoods])
+           ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geom_idx,inverted [as=neighborhoods])
            │    ├── columns: subways.name:11!null subways.geom:23 neighborhoods.gid:46!null
            │    ├── inverted-expr
            │    │    └── st_coveredby(subways.geom:23, neighborhoods.geom:49)
@@ -324,7 +324,7 @@ sort
       │    │    ├── lookup columns are key
       │    │    ├── immutable
       │    │    ├── fd: ()-->(2)
-      │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
+      │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx,inverted [as=census])
       │    │    │    ├── columns: neighborhoods.boroname:2!null name:3 neighborhoods.geom:4 census.gid:26!null
       │    │    │    ├── inverted-expr
       │    │    │    │    └── st_intersects(neighborhoods.geom:4, census.geom:35)
@@ -380,7 +380,7 @@ project
  │    │    ├── key columns: [57] = [1]
  │    │    ├── lookup columns are key
  │    │    ├── immutable
- │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
+ │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx,inverted [as=census])
  │    │    │    ├── columns: routes:24 subways.geom:29 census.gid:57!null
  │    │    │    ├── inverted-expr
  │    │    │    │    └── st_dwithin(subways.geom:29, census.geom:66, 200.0)
@@ -451,7 +451,7 @@ sort
       │    │    │    ├── key columns: [61] = [1]
       │    │    │    ├── lookup columns are key
       │    │    │    ├── immutable
-      │    │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=census])
+      │    │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx,inverted [as=census])
       │    │    │    │    ├── columns: routes:24 subways.geom:29 census.gid:61!null
       │    │    │    │    ├── inverted-expr
       │    │    │    │    │    └── st_dwithin(subways.geom:29, census.geom:70, 200.0)
@@ -495,7 +495,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(22)
-      ├── inner-join (inverted nyc_subway_stations@nyc_subway_stations_geom_idx [as=s])
+      ├── inner-join (inverted nyc_subway_stations@nyc_subway_stations_geom_idx,inverted [as=s])
       │    ├── columns: n.name:22!null n.geom:23 s.gid:34!null
       │    ├── inverted-expr
       │    │    └── st_contains(n.geom:23, s.geom:49)
@@ -539,7 +539,7 @@ sort
            ├── key columns: [27] = [20]
            ├── lookup columns are key
            ├── immutable
-           ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geom_idx [as=n])
+           ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geom_idx,inverted [as=n])
            │    ├── columns: routes:11 s.geom:16 n.gid:27!null
            │    ├── inverted-expr
            │    │    └── st_coveredby(s.geom:16, n.geom:30)
@@ -578,7 +578,7 @@ scalar-group-by
  │    ├── lookup columns are key
  │    ├── immutable
  │    ├── fd: ()-->(3)
- │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=c])
+ │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx,inverted [as=c])
  │    │    ├── columns: name:3!null n.geom:4 c.gid:22!null
  │    │    ├── inverted-expr
  │    │    │    └── st_intersects(n.geom:4, c.geom:31)
@@ -632,7 +632,7 @@ sort
       │    │    ├── key columns: [30] = [1]
       │    │    ├── lookup columns are key
       │    │    ├── immutable
-      │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=c])
+      │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx,inverted [as=c])
       │    │    │    ├── columns: name:16!null n.geom:17 c.gid:30!null
       │    │    │    ├── inverted-expr
       │    │    │    │    └── st_intersects(n.geom:17, c.geom:39)
@@ -671,7 +671,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(17)
-      ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx [as=blocks])
+      ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geom_idx,inverted [as=blocks])
       │    ├── columns: name:17!null subways.geom:29 blocks.gid:52!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(subways.geom:29, blocks.geom:61)

--- a/pkg/sql/opt/xform/testdata/rules/generate_trigram_similarity_inverted_index_scans
+++ b/pkg/sql/opt/xform/testdata/rules/generate_trigram_similarity_inverted_index_scans
@@ -32,7 +32,7 @@ project
       │         ├── columns: k:1!null
       │         ├── grouping columns: k:1!null
       │         ├── key: (1)
-      │         └── scan trgm@s_idx
+      │         └── scan trgm@s_idx,inverted
       │              ├── columns: k:1!null
       │              └── constraint: /7
       │                   ├── [/'\x1220666f0001' - /'\x1220666f0001']
@@ -59,7 +59,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /7
  │                   ├── [/'\x1220666f0001' - /'\x1220666f0001']
@@ -87,7 +87,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /7: [/'\x12666f6f0001' - /'\x12666f6f0001']
  └── filters
@@ -110,7 +110,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /7
  │                   ├── [/'\x1220666f0001' - /'\x1220666f0001']
@@ -136,7 +136,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /7
  │                   ├── [/'\x1220666f0001' - /'\x1220666f0001']
@@ -163,7 +163,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /7
  │                   ├── [/'\x1220666f0001' - /'\x1220666f0001']
@@ -191,7 +191,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /7
  │                   ├── [/'\x126172200001' - /'\x126172200001']
@@ -220,7 +220,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@i_j_s_idx
+ │         └── scan trgm@i_j_s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /2/3/8
  │                   ├── [/1/10/'\x1220666f0001' - /1/10/'\x1220666f0001']
@@ -253,7 +253,7 @@ select
  │         ├── columns: k:1!null
  │         ├── grouping columns: k:1!null
  │         ├── key: (1)
- │         └── scan trgm@i_j_s_idx
+ │         └── scan trgm@i_j_s_idx,inverted
  │              ├── columns: k:1!null
  │              └── constraint: /2/3/8
  │                   ├── [/1/10/'\x1220666f0001' - /1/10/'\x1220666f0001']
@@ -353,7 +353,7 @@ project
       │         │         ├── ["\x12 fo\x00\x01", "\x12 fo\x00\x01"]
       │         │         ├── ["\x12foo\x00\x01", "\x12foo\x00\x01"]
       │         │         └── ["\x12oo \x00\x01", "\x12oo \x00\x01"]
-      │         └── scan trgm@s_idx
+      │         └── scan trgm@s_idx,inverted
       │              └── inverted constraint: /7/1
       │                   └── spans
       │                        ├── ["\x12  f\x00\x01", "\x12  f\x00\x01"]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -7173,7 +7173,7 @@ project
  │    │    ├── lookup columns are key
  │    │    ├── immutable
  │    │    ├── fd: (9)==(15), (15)==(9)
- │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
+ │    │    ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geo_idx,inverted [as=c])
  │    │    │    ├── columns: n.boroname:15 name:16!null n.geom:17 c.gid:30!null
  │    │    │    ├── inverted-expr
  │    │    │    │    └── st_intersects(n.geom:17, c.geom:39)
@@ -7229,14 +7229,14 @@ memo (optimized, ~36KB, required=[presentation: name:16,popn_per_sqkm:22])
  │         ├── best: (select G16 G17)
  │         └── cost: 168.07
  ├── G9: (filters G18 G19)
- ├── G10: (inverted-join G7 G20 nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── G10: (inverted-join G7 G20 nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
  │    └── []
- │         ├── best: (inverted-join G7 G20 nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ │         ├── best: (inverted-join G7 G20 nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
  │         └── cost: 921840.85
  ├── G11: (filters G18 G19 G21)
- ├── G12: (inverted-join G8 G20 nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
+ ├── G12: (inverted-join G8 G20 nyc_census_blocks@nyc_census_blocks_geo_idx,inverted [as=c])
  │    └── []
- │         ├── best: (inverted-join G8 G20 nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
+ │         ├── best: (inverted-join G8 G20 nyc_census_blocks@nyc_census_blocks_geo_idx,inverted [as=c])
  │         └── cost: 1794.89
  ├── G13: (sum G22)
  ├── G14: (variable sum)
@@ -7280,7 +7280,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_dwithin(c.geom:10, n.geom:24, 50.0)
@@ -7306,7 +7306,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_dwithin(c.geom:10, n.geom:24, 50.0)
@@ -7331,7 +7331,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:24)
@@ -7357,7 +7357,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10, n.geom:24)
@@ -7383,7 +7383,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_dwithinexclusive(c.geom:10, n.geom:24, 50.0)
@@ -7409,7 +7409,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_dwithin(c.geom:10, n.geom:24, 50.0)
@@ -7436,7 +7436,7 @@ project
       ├── key columns: [61] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:61!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10, n.geom:64) AND (st_dwithin(c.geom:10, n.geom:64, 50.0) OR st_intersects('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', n.geom:64))
@@ -7462,7 +7462,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_dfullywithin(c.geom:10, n.geom:24, 50.0)
@@ -7487,7 +7487,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_dfullywithinexclusive(c.geom:10, n.geom:24, 50.0)
@@ -7514,7 +7514,7 @@ project
       ├── key columns: [28] = [1]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geo_idx [as=c])
+      ├── inner-join (inverted nyc_census_blocks@nyc_census_blocks_geo_idx,inverted [as=c])
       │    ├── columns: name:16 n.geom:17!null c.gid:28!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(n.geom:17, c.geom:37) AND st_coveredby('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', c.geom:37)
@@ -7532,7 +7532,7 @@ project
       │    │    │         ├── pre-filterer expression
       │    │    │         │    └── st_covers('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', n.geom:17)
       │    │    │         ├── key: (14)
-      │    │    │         └── scan nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n]
+      │    │    │         └── scan nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n]
       │    │    │              ├── columns: n.gid:14!null n.geom_inverted_key:20!null
       │    │    │              ├── inverted constraint: /20/14
       │    │    │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -7563,7 +7563,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(9)
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9!null c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:24)
@@ -7620,7 +7620,7 @@ semi-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:22!null continuation:29
  │    ├── first join in paired joiner; continuation column: continuation:29
  │    ├── inverted-expr
@@ -7654,7 +7654,7 @@ anti-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:22 continuation:29
  │    ├── first join in paired joiner; continuation column: continuation:29
  │    ├── inverted-expr
@@ -7688,7 +7688,7 @@ project
       ├── lookup columns are key
       ├── second join in paired joiner
       ├── immutable
-      ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:23 continuation:30
       │    ├── first join in paired joiner; continuation column: continuation:30
       │    ├── inverted-expr
@@ -7717,7 +7717,7 @@ left-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1,14)
  ├── fd: (1)-->(2-10), (14)-->(15-17)
- ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+ ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:21 continuation:28
  │    ├── first join in paired joiner; continuation column: continuation:28
  │    ├── inverted-expr
@@ -7771,7 +7771,7 @@ with &1 (q)
       │    │    ├── lookup columns are key
       │    │    ├── second join in paired joiner
       │    │    ├── immutable
-      │    │    ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      │    │    ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    │    │    ├── columns: geom:23 n.gid:44 continuation:51
       │    │    │    ├── first join in paired joiner; continuation column: continuation:51
       │    │    │    ├── inverted-expr
@@ -7869,7 +7869,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_intersects(c.geom:10::BOX2D::GEOMETRY, n.geom:24)
@@ -7894,7 +7894,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10::BOX2D::GEOMETRY, n.geom:24)
@@ -7919,7 +7919,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10::BOX2D::GEOMETRY, n.geom:24)
@@ -7944,7 +7944,7 @@ project
       ├── key columns: [21] = [14]
       ├── lookup columns are key
       ├── immutable
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.boroname:9 c.geom:10 n.gid:21!null
       │    ├── inverted-expr
       │    │    └── st_coveredby(c.geom:10, n.geom:24)
@@ -8033,7 +8033,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(3)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:11 t1.k:15!null
       │    ├── inverted-expr
       │    │    └── t1.j:17 @> t2.j:11
@@ -8059,7 +8059,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(3)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:11 t1.k:15!null
       │    ├── inverted-expr
       │    │    └── t1.j:17 <@ t2.j:11
@@ -8085,7 +8085,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(4)
-      ├── inner-join (inverted json_arr1@a_idx [as=t1])
+      ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
       │    ├── columns: t2.a:12 t1.k:15!null
       │    ├── inverted-expr
       │    │    └── t1.a:18 @> t2.a:12
@@ -8111,7 +8111,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(4)
-      ├── inner-join (inverted json_arr1@a_idx [as=t1])
+      ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
       │    ├── columns: t2.a:12 t1.k:15!null
       │    ├── inverted-expr
       │    │    └── t1.a:18 <@ t2.a:12
@@ -8138,7 +8138,7 @@ project
       ├── second join in paired joiner
       ├── immutable
       ├── fd: (7)-->(9)
-      ├── left-join (inverted json_arr1@j_idx [as=t1])
+      ├── left-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:15 continuation:23
       │    ├── first join in paired joiner; continuation column: continuation:23
       │    ├── inverted-expr
@@ -8167,7 +8167,7 @@ project
       ├── second join in paired joiner
       ├── immutable
       ├── fd: (7)-->(9)
-      ├── left-join (inverted json_arr1@j_idx [as=t1])
+      ├── left-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:15 continuation:23
       │    ├── first join in paired joiner; continuation column: continuation:23
       │    ├── inverted-expr
@@ -8216,7 +8216,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,9)
  ├── fd: (1)-->(2-4), (9)-->(10-12)
- ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:9!null l:10 t2.j:11 t2.a:12 t1.k:15!null
  │    ├── inverted-expr
  │    │    └── (t1.j:17 @> t2.j:11) AND (t1.j:17 @> '{"foo": "bar"}')
@@ -8246,7 +8246,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,9)
  ├── fd: (1)-->(2-4), (9)-->(10-12)
- ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:9!null l:10 t2.j:11 t2.a:12 t1.k:15!null
  │    ├── inverted-expr
  │    │    └── (t1.j:17 <@ t2.j:11) AND (t1.j:17 <@ '{"foo": "bar"}')
@@ -8276,7 +8276,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,9)
  ├── fd: (1)-->(2-4), (9)-->(10-12)
- ├── inner-join (inverted json_arr1@a_idx [as=t1])
+ ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
  │    ├── columns: t2.k:9!null l:10 t2.j:11 t2.a:12 t1.k:15!null
  │    ├── inverted-expr
  │    │    └── (t1.a:18 @> t2.a:12) AND (t1.a:18 @> ARRAY['foo'])
@@ -8306,7 +8306,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,9)
  ├── fd: (1)-->(2-4), (9)-->(10-12)
- ├── inner-join (inverted json_arr1@a_idx [as=t1])
+ ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
  │    ├── columns: t2.k:9!null l:10 t2.j:11 t2.a:12 t1.k:15!null
  │    ├── inverted-expr
  │    │    └── (t1.a:18 <@ t2.a:12) AND (t1.a:18 <@ ARRAY['foo'])
@@ -8337,7 +8337,7 @@ left-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (7)-->(8-10)
- ├── left-join (inverted json_arr1@a_idx [as=t1])
+ ├── left-join (inverted json_arr1@a_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:15 continuation:23
  │    ├── first join in paired joiner; continuation column: continuation:23
  │    ├── inverted-expr
@@ -8369,7 +8369,7 @@ left-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (7)-->(8-10)
- ├── left-join (inverted json_arr1@a_idx [as=t1])
+ ├── left-join (inverted json_arr1@a_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:15 continuation:23
  │    ├── first join in paired joiner; continuation column: continuation:23
  │    ├── inverted-expr
@@ -8401,7 +8401,7 @@ semi-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16!null continuation:24
  │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
@@ -8431,7 +8431,7 @@ semi-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16!null continuation:24
  │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
@@ -8461,7 +8461,7 @@ anti-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── left-join (inverted json_arr1@j_idx [as=t1])
+ ├── left-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16 continuation:24
  │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
@@ -8491,7 +8491,7 @@ anti-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── left-join (inverted json_arr1@j_idx [as=t1])
+ ├── left-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16 continuation:24
  │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
@@ -8566,7 +8566,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(3)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:13 t1.k:17!null
       │    ├── inverted-expr
       │    │    └── t1.j:19 @> t2.j:13
@@ -8614,7 +8614,7 @@ sort (segmented)
       ├── key: (1,5)
       ├── fd: (1)-->(2), (1,5)-->(6)
       ├── ordering: +1
-      ├── left-join (inverted j2@j2_j_idx)
+      ├── left-join (inverted j2@j2_j_idx,inverted)
       │    ├── columns: j1.k:1!null j1.j:2 j2.k:10 continuation:15
       │    ├── flags: force inverted join (into right side)
       │    ├── first join in paired joiner; continuation column: continuation:15
@@ -8682,7 +8682,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(15), (1)-->(10)
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted [as=n])
       │    ├── columns: c.gid:1!null c.geom:10 n.gid:23!null n.boroname:24!null
       │    ├── prefix key columns: [22] = [24]
       │    ├── inverted-expr
@@ -8720,7 +8720,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(7,10)
-      ├── inner-join (inverted json_arr1@a_idx [as=t1])
+      ├── inner-join (inverted json_arr1@a_idx,inverted [as=t1])
       │    ├── columns: t2.a:4 t1.k:21!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [20] = [21]
@@ -8755,7 +8755,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(7,9)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:20!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [19] = [20]
@@ -8790,7 +8790,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(7,9,10)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:20!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [19] = [20]
@@ -8825,7 +8825,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (7)-->(9)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:20!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [19] = [20]
@@ -8865,7 +8865,7 @@ project
       ├── immutable
       ├── key: (7)
       ├── fd: (1)-->(3), (7)-->(9), (1)==(7), (7)==(1)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.k:1!null t2.j:3 t1.k:19!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [1] = [19]
@@ -8897,7 +8897,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (7)-->(9)
-      ├── inner-join (inverted json_check@json_check_i_j_idx [as=t1])
+      ├── inner-join (inverted json_check@json_check_i_j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:14!null i:15!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [13] = [15]
@@ -8936,7 +8936,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(8), (7)-->(10)
-      ├── inner-join (inverted json_comp@bj_idx [as=t1])
+      ├── inner-join (inverted json_comp@bj_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:15!null b:17!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [14] = [17]
@@ -8981,7 +8981,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(8), (7)-->(10)
-      ├── inner-join (inverted json_comp@bj_partial_idx,partial [as=t1])
+      ├── inner-join (inverted json_comp@bj_partial_idx,inverted,partial [as=t1])
       │    ├── columns: t2.j:3 t1.k:16!null b:18!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [15] = [18]
@@ -9053,7 +9053,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (7)-->(8,9)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.j:3 t1.k:23!null i:24!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [21 22] = [23 24]
@@ -9103,7 +9103,7 @@ project
       ├── immutable
       ├── key: (7)
       ├── fd: (1)-->(3), (7)-->(8,9), (1)==(7), (7)==(1)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.k:1!null t2.j:3 t1.k:21!null i:22!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [1 20] = [21 22]
@@ -9147,7 +9147,7 @@ project
       ├── immutable
       ├── key: (7)
       ├── fd: (1)-->(2,3), (7)-->(8,9), (1)==(7), (7)==(1), (2)==(8), (8)==(2)
-      ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    ├── columns: t2.k:1!null l:2!null t2.j:3 t1.k:20!null i:21!null
       │    ├── flags: force inverted join (into right side)
       │    ├── prefix key columns: [1 2] = [20 21]
@@ -9232,7 +9232,7 @@ project
       │    ├── lookup columns are key
       │    ├── immutable
       │    ├── fd: (1)-->(2-4)
-      │    ├── inner-join (inverted json_arr1@j_idx [as=t1])
+      │    ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
       │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:23!null i:24!null
       │    │    ├── prefix key columns: [22] = [24]
       │    │    ├── inverted-expr
@@ -9279,7 +9279,7 @@ semi-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── inner-join (inverted json_arr1@j_idx [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22!null i:23!null continuation:36
  │    ├── prefix key columns: [1] = [23]
  │    ├── first join in paired joiner; continuation column: continuation:36
@@ -9337,7 +9337,7 @@ anti-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── left-join (inverted json_arr1@j_idx [as=t1])
+ ├── left-join (inverted json_arr1@j_idx,inverted [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22 i:23 continuation:36
  │    ├── prefix key columns: [1] = [23]
  │    ├── first join in paired joiner; continuation column: continuation:36
@@ -9456,7 +9456,7 @@ ON b.k = 1 AND b.j @> a.j AND b.i = a.k
 project
  └── inner-join (lookup t59859_b [as=b])
       ├── lookup columns are key
-      ├── inner-join (inverted t59859_b@t59859_b_k_j_idx [as=b])
+      ├── inner-join (inverted t59859_b@t59859_b_k_j_idx,inverted [as=b])
       │    ├── flags: force inverted join (into right side)
       │    ├── inverted-expr
       │    │    └── b.j @> a.j
@@ -9499,7 +9499,7 @@ ON a.k = 15 AND b.j @> a.j AND b.y = a.k
 ----
 inner-join (lookup t63735_b [as=b])
  ├── lookup columns are key
- ├── inner-join (inverted t63735_b@t63735_b_x_y_j_idx [as=b])
+ ├── inner-join (inverted t63735_b@t63735_b_x_y_j_idx,inverted [as=b])
  │    ├── flags: force inverted join (into right side)
  │    ├── inverted-expr
  │    │    └── b.j @> a.j
@@ -9549,7 +9549,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: (1)-->(10)
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted,partial [as=n])
       │    ├── columns: c.gid:1!null c.geom:10 n.gid:23!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:26)
@@ -9575,7 +9575,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (7)-->(8-10)
- ├── inner-join (inverted json_arr1@j_idx,partial [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted,partial [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22!null
  │    ├── flags: force inverted join (into right side)
  │    ├── inverted-expr
@@ -9606,7 +9606,7 @@ project
       ├── lookup columns are key
       ├── immutable
       ├── fd: ()-->(15), (1)-->(10)
-      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+      ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted,partial [as=n])
       │    ├── columns: c.gid:1!null c.geom:10 n.gid:23!null
       │    ├── inverted-expr
       │    │    └── st_covers(c.geom:10, n.geom:26)
@@ -9633,7 +9633,7 @@ inner-join (lookup json_arr1 [as=t1])
  ├── immutable
  ├── key: (1,7)
  ├── fd: (1)-->(2-4), (7)-->(8-10)
- ├── inner-join (inverted json_arr1@j_idx,partial [as=t1])
+ ├── inner-join (inverted json_arr1@j_idx,inverted,partial [as=t1])
  │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22!null
  │    ├── flags: force inverted join (into right side)
  │    ├── inverted-expr
@@ -9665,7 +9665,7 @@ semi-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+ ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted,partial [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:24!null continuation:33
  │    ├── first join in paired joiner; continuation column: continuation:33
  │    ├── inverted-expr
@@ -9697,7 +9697,7 @@ anti-join (lookup nyc_neighborhoods [as=n])
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
- ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
+ ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,inverted,partial [as=n])
  │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:24 continuation:33
  │    ├── first join in paired joiner; continuation column: continuation:33
  │    ├── inverted-expr
@@ -14316,7 +14316,7 @@ distribute
       │    ├── key: (1,8)
       │    ├── fd: (1)-->(2-4), (8)-->(9-11)
       │    ├── limit hint: 1.00
-      │    ├── inner-join (inverted parent4@nyc_census_blocks_geo_idx [as=p])
+      │    ├── inner-join (inverted parent4@nyc_census_blocks_geo_idx,inverted [as=p])
       │    │    ├── columns: c_id:1!null c_p_id:2 c.geom:3 crdb_region:4!null p_id:15!null
       │    │    ├── inverted-expr
       │    │    │    └── st_intersects(c.geom:3, p.geom:18)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -1629,7 +1629,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_intersects('010100000000000000000008400000000000000840', geom:8)
  │         ├── key: (1)
- │         └── scan index_tab@geomidx
+ │         └── scan index_tab@geomidx,inverted
  │              ├── columns: id:1!null geom_inverted_key:11!null
  │              ├── inverted constraint: /11/1
  │              │    └── spans

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -89,7 +89,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan a@j
+ └── scan a@j,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /8/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -103,7 +103,7 @@ SELECT k + 1 FROM a WHERE j @> '{"a": "b"}'
 project
  ├── columns: "?column?":9!null
  ├── immutable
- ├── scan a@j
+ ├── scan a@j,inverted
  │    ├── columns: k:1!null
  │    ├── inverted constraint: /8/1
  │    │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -120,7 +120,7 @@ SELECT j FROM a WHERE j @> '{"a": "b"}'
 index-join a
  ├── columns: j:5!null
  ├── immutable
- └── scan a@j
+ └── scan a@j,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /8/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2695,7 +2695,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -2714,9 +2714,9 @@ memo (optimized, ~9KB, required=[presentation: k:1])
  │         ├── best: (index-join G4 b,cols=(1,4))
  │         └── cost: 803.53
  ├── G3: (projections)
- ├── G4: (scan b@j_inv_idx,cols=(1),constrained inverted)
+ ├── G4: (scan b@j_inv_idx,inverted,cols=(1),constrained inverted)
  │    └── []
- │         ├── best: (scan b@j_inv_idx,cols=(1),constrained inverted)
+ │         ├── best: (scan b@j_inv_idx,inverted,cols=(1),constrained inverted)
  │         └── cost: 132.46
  ├── G5: (scan b,cols=(1,4))
  │    └── []
@@ -2765,7 +2765,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,4)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null
            ├── inverted constraint: /7/1
            │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -2779,7 +2779,7 @@ index-join b
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -2793,7 +2793,7 @@ index-join b
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -2807,7 +2807,7 @@ index-join b
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans
@@ -2833,7 +2833,7 @@ project
       │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
       │         └── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -2884,7 +2884,7 @@ select
  │         │                        ├── tight: true, unique: true
  │         │                        └── union spans: ["7\x00\x03\x00\x03\x00\x01*\b\x00", "7\x00\x03\x00\x03\x00\x01*\b\x00"]
  │         ├── key: (1)
- │         └── scan b@j_inv_idx
+ │         └── scan b@j_inv_idx,inverted
  │              ├── columns: k:1!null j_inverted_key:7!null
  │              ├── inverted constraint: /7/1
  │              │    └── spans
@@ -2913,7 +2913,7 @@ index-join b
       │         ├── ["7\x00\x03\x00\x019", "7\x00\x03\x00\x019"]
       │         └── ["7\x00\x03\x00\xff", "7\x00\x04")
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -2938,7 +2938,7 @@ index-join b
       │         ├── ["7a\x00\x019", "7a\x00\x019"]
       │         └── ["7a\x00\x02\x00\xff", "7a\x00\x03")
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -2963,7 +2963,7 @@ index-join b
       │         ├── ["7a\x00\x018", "7a\x00\x018"]
       │         └── ["7a\x00\x02\x00\x03", "7a\x00\x02\x00\x03"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -2980,7 +2980,7 @@ index-join b
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x02\x00\x03\x00\x03b\x00\x02c\x00\x02\x00\x03d\x00\x01\x12e\x00\x01", "7a\x00\x02\x00\x03\x00\x03b\x00\x02c\x00\x02\x00\x03d\x00\x01\x12e\x00\x01"]
@@ -2999,7 +2999,7 @@ select
  │    ├── columns: k:1!null u:2 v:3 j:4
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- │    └── scan b@j_inv_idx
+ │    └── scan b@j_inv_idx,inverted
  │         ├── columns: k:1!null
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7\x00\x01*\x02\x00", "7\x00\x01*\x02\x00"]
@@ -3019,7 +3019,7 @@ select
  │    ├── columns: k:1!null u:2 v:3 j:4
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- │    └── scan b@j_inv_idx
+ │    └── scan b@j_inv_idx,inverted
  │         ├── columns: k:1!null
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7\x00\x019", "7\x00\x019"]
@@ -3039,7 +3039,7 @@ select
  │    ├── columns: k:1!null u:2 v:3 j:4
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- │    └── scan b@j_inv_idx
+ │    └── scan b@j_inv_idx,inverted
  │         ├── columns: k:1!null
  │         ├── inverted constraint: /7/1
  │         │    └── spans: ["7\x00\x018", "7\x00\x018"]
@@ -3067,7 +3067,7 @@ select
  │         │         ├── ["7\x00\x019", "7\x00\x019"]
  │         │         └── ["7a\x00\x018", "7a\x00\x018"]
  │         ├── key: (1)
- │         └── scan b@j_inv_idx
+ │         └── scan b@j_inv_idx,inverted
  │              ├── columns: k:1!null j_inverted_key:7!null
  │              ├── inverted constraint: /7/1
  │              │    └── spans
@@ -3104,7 +3104,7 @@ select
  │         │         ├── ["7\x00\x03a\x00\x019", "7\x00\x03a\x00\x019"]
  │         │         └── ["7\x00\x03a\x00\x02d\x00\x01\n", "7\x00\x03a\x00\x02d\x00\x01\n"]
  │         ├── key: (1)
- │         └── scan b@j_inv_idx
+ │         └── scan b@j_inv_idx,inverted
  │              ├── columns: k:1!null j_inverted_key:7!null
  │              ├── inverted constraint: /7/1
  │              │    └── spans
@@ -3149,7 +3149,7 @@ select
  │         │         ├── ["7a\x00\x018", "7a\x00\x018"]
  │         │         └── ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
  │         ├── key: (1)
- │         └── scan b@j_inv_idx
+ │         └── scan b@j_inv_idx,inverted
  │              ├── columns: k:1!null j_inverted_key:7!null
  │              ├── inverted constraint: /7/1
  │              │    └── spans
@@ -3203,7 +3203,7 @@ select
  │         │                   ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
  │         │                   └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
  │         ├── key: (1)
- │         └── scan b@j_inv_idx
+ │         └── scan b@j_inv_idx,inverted
  │              ├── columns: k:1!null j_inverted_key:7!null
  │              ├── inverted constraint: /7/1
  │              │    └── spans
@@ -3244,7 +3244,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans
@@ -3271,7 +3271,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans
@@ -3298,7 +3298,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans
@@ -3325,7 +3325,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans
@@ -3350,7 +3350,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(4)
-      ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+      ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x37000300012a0200']
@@ -3385,7 +3385,7 @@ project
       │         │         ├── ["7\x00\x018", "7\x00\x018"]
       │         │         └── ["7\x00\x03", "7\x00\x03"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3421,7 +3421,7 @@ project
       │         │         ├── ["7\x00\x019", "7\x00\x019"]
       │         │         └── ["7\x00\xff", "8")
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3447,7 +3447,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(4)
-      ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+      ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x3761000112620001']
@@ -3464,7 +3464,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -3477,7 +3477,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -3491,7 +3491,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -3541,7 +3541,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7\x00\x03\x00\x01\x12b\x00\x01", "7\x00\x03\x00\x01\x12b\x00\x01"]
@@ -3568,7 +3568,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7\x00\x03a\x00\x01\x12b\x00\x01", "7\x00\x03a\x00\x01\x12b\x00\x01"]
@@ -3593,7 +3593,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01"]
@@ -3618,7 +3618,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
@@ -3645,7 +3645,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
-      ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+      ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x370003000300012a0200']
@@ -3672,7 +3672,7 @@ project
       │    ├── columns: k:1!null j:4
       │    ├── key: (1)
       │    ├── fd: (1)-->(4)
-      │    └── scan b@j_inv_idx
+      │    └── scan b@j_inv_idx,inverted
       │         ├── columns: k:1!null
       │         ├── inverted constraint: /7/1
       │         │    └── spans: ["7\x00\x03b\x00\x01\x12c\x00\x01", "7\x00\x03b\x00\x01\x12c\x00\x01"]
@@ -3707,7 +3707,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x019", "7\x00\x03\x00\x019"]
       │         │         └── ["7\x00\x03b\x00\x01\x12c\x00\x01", "7\x00\x03b\x00\x01\x12c\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3751,7 +3751,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x03\x00\x01*\x02\x00"]
       │         │         └── ["7\x00\x03\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x03\x00\x01*\x04\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3784,7 +3784,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
-      ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+      ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x370003000300012a0200']
@@ -3820,7 +3820,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01\x12a\x00\x01", "7\x00\x03\x00\x01\x12a\x00\x01"]
       │         │         └── ["7\x00\x03\x00\x03\x00\x01\x12a\x00\x01", "7\x00\x03\x00\x03\x00\x01\x12a\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3858,7 +3858,7 @@ project
       │         │         ├── ["7\x00\x018", "7\x00\x018"]
       │         │         └── ["7\x00\x03\x00\x01\x12a\x00\x01", "7\x00\x03\x00\x01\x12a\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3896,7 +3896,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
       │         │         └── ["7\x00\x03\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x03\x00\x01*\x02\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3934,7 +3934,7 @@ project
       │         │         ├── ["7\x00\x018", "7\x00\x018"]
       │         │         └── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -3967,7 +3967,7 @@ project
       │              ├── tight: true, unique: true
       │              └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -3992,7 +3992,7 @@ project
       │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -4021,7 +4021,7 @@ project
       │         ├── ["7a\x00\x01*\x04\x00", "7a\x00\x01*\x04\x00"]
       │         └── ["7a\x00\x01*\x06\x00", "7a\x00\x01*\x06\x00"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -4062,7 +4062,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
       │         │         └── ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4105,7 +4105,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01\x12b\x00\x01", "7\x00\x03\x00\x01\x12b\x00\x01"]
       │         │         └── ["7\x00\x03\x00\x01\x12c\x00\x01", "7\x00\x03\x00\x01\x12c\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4172,7 +4172,7 @@ project
       │         │                        ├── tight: true, unique: true
       │         │                        └── union spans: ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4234,7 +4234,7 @@ project
       │         │                        ├── tight: true, unique: true
       │         │                        └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4281,7 +4281,7 @@ project
       │         │              ├── tight: true, unique: true
       │         │              └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4317,7 +4317,7 @@ project
       │         ├── ["7a\x00\x01\x12a\x00\x01", "7a\x00\x01\x12a\x00\x01"]
       │         └── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -4355,7 +4355,7 @@ project
       │         │         ├── ["7a\x00\x02a\x00\x01\x12b\x00\x01", "7a\x00\x02a\x00\x01\x12b\x00\x01"]
       │         │         └── ["7a\x00\x02c\x00\x01\x12d\x00\x01", "7a\x00\x02c\x00\x01\x12d\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4396,7 +4396,7 @@ project
       │         │         ├── ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
       │         │         └── ["7a\x00\x02a\x00\x01\x12b\x00\x01", "7a\x00\x02a\x00\x01\x12b\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4453,7 +4453,7 @@ project
       │         │              ├── tight: true, unique: true
       │         │              └── union spans: ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4524,7 +4524,7 @@ project
       │         │                        ├── tight: true, unique: true
       │         │                        └── union spans: ["7a\x00\x02\x00\x03\x00\x01*\x06\x00", "7a\x00\x02\x00\x03\x00\x01*\x06\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4565,7 +4565,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
       │         │         └── ["7\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x01*\x04\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4604,7 +4604,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01\x12a\x00\x01", "7\x00\x03\x00\x01\x12a\x00\x01"]
       │         │         └── ["7\x00\x03\x00\x01\x12b\x00\x01", "7\x00\x03\x00\x01\x12b\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4643,7 +4643,7 @@ project
       │         │         ├── ["7\x00\x03a\x00\x01\x12b\x00\x01", "7\x00\x03a\x00\x01\x12b\x00\x01"]
       │         │         └── ["7\x00\x03c\x00\x01\x12d\x00\x01", "7\x00\x03c\x00\x01\x12d\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4851,7 +4851,7 @@ project
       │         │         ├── ["7\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x01*\x02\x00"]
       │         │         └── ["7\x00\x03a\x00\x01\x12b\x00\x01", "7\x00\x03a\x00\x01\x12b\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4919,7 +4919,7 @@ project
       │         │                        ├── tight: true, unique: true
       │         │                        └── union spans: ["7\x00\x03\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x03\x00\x01*\x06\x00"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4962,7 +4962,7 @@ project
       │         │         ├── ["7\x00\x03a\x00\x01*\x02\x00", "7\x00\x03a\x00\x01*\x02\x00"]
       │         │         └── ["7\x00\x03a\x00\x02a\x00\x01\x12b\x00\x01", "7\x00\x03a\x00\x02a\x00\x01\x12b\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -4993,7 +4993,7 @@ project
       │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -5018,7 +5018,7 @@ project
       │         ├── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       │         └── ["7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -5051,7 +5051,7 @@ project
       │         │         ├── ["7\x00\x019", "7\x00\x019"]
       │         │         └── ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -5078,7 +5078,7 @@ project
       │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
       │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -5102,7 +5102,7 @@ project
       │         ├── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
       │         └── ["7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x02\x00\x03\x00\x01\x12c\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -5136,7 +5136,7 @@ project
       │         │         ├── ["7a\x00\x019", "7a\x00\x019"]
       │         │         └── ["7a\x00\x02b\x00\x01\x12c\x00\x01", "7a\x00\x02b\x00\x01\x12c\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -5166,7 +5166,7 @@ project
       │         ├── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       │         └── ["7c\x00\x02\x00\x03\x00\x01\x12d\x00\x01", "7c\x00\x02\x00\x03\x00\x01\x12d\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -5204,7 +5204,7 @@ project
       │         │         ├── ["7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01", "7a\x00\x02\x00\x03\x00\x01\x12b\x00\x01"]
       │         │         └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -5241,7 +5241,7 @@ project
       │                   ├── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       │                   └── ["7c\x00\x02\x00\x03\x00\x01\x12d\x00\x01", "7c\x00\x02\x00\x03\x00\x01\x12d\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -5285,7 +5285,7 @@ project
       │         │                   ├── ["7\x00\x019", "7\x00\x019"]
       │         │                   └── ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       │         ├── key: (1)
-      │         └── scan b@j_inv_idx
+      │         └── scan b@j_inv_idx,inverted
       │              ├── columns: k:1!null j_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -5305,7 +5305,7 @@ project
  ├── columns: k:1!null
  ├── volatile
  ├── key: (1)
- └── scan b@j_inv_idx
+ └── scan b@j_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -5321,7 +5321,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan c@a_inv_idx
+ └── scan c@a_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /6/1
       │    └── spans: ["\x89", "\x89"]
@@ -5341,7 +5341,7 @@ project
       │    ├── tight: true, unique: false
       │    └── union spans: ["\x89", "\x8b")
       ├── key: (1)
-      └── scan c@a_inv_idx
+      └── scan c@a_inv_idx,inverted
            ├── columns: k:1!null a_inverted_key:6!null
            ├── inverted constraint: /6/1
            │    └── spans: ["\x89", "\x8b")
@@ -5361,7 +5361,7 @@ project
       │    ├── tight: true, unique: false
       │    └── union spans: ["", ""]
       ├── key: (1)
-      └── scan c@a_inv_idx
+      └── scan c@a_inv_idx,inverted
            ├── columns: k:1!null a_inverted_key:6!null
            ├── inverted constraint: /6/1
            │    └── spans: ["", ""]
@@ -5405,7 +5405,7 @@ select
  │         │         ├── ["C", "C"]
  │         │         └── ["\x89", "\x89"]
  │         ├── key: (1)
- │         └── scan c@a_inv_idx
+ │         └── scan c@a_inv_idx,inverted
  │              ├── columns: k:1!null a_inverted_key:6!null
  │              ├── inverted constraint: /6/1
  │              │    └── spans
@@ -5428,7 +5428,7 @@ select
  │    ├── columns: k:1!null a:2 u:3
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
- │    └── scan c@a_inv_idx
+ │    └── scan c@a_inv_idx,inverted
  │         ├── columns: k:1!null
  │         ├── inverted constraint: /6/1
  │         │    └── spans: ["C", "C"]
@@ -5448,7 +5448,7 @@ select
  │    ├── columns: k:1!null a:2 u:3
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
- │    └── scan c@a_inv_idx
+ │    └── scan c@a_inv_idx,inverted
  │         ├── columns: k:1!null
  │         ├── inverted constraint: /6/1
  │         │    └── spans: ["C", "C"]
@@ -5476,7 +5476,7 @@ select
  │         │         ├── ["C", "C"]
  │         │         └── ["\x89", "\x8b")
  │         ├── key: (1)
- │         └── scan c@a_inv_idx
+ │         └── scan c@a_inv_idx,inverted
  │              ├── columns: k:1!null a_inverted_key:6!null
  │              ├── inverted constraint: /6/1
  │              │    └── spans
@@ -5512,7 +5512,7 @@ select
  │         │              ├── tight: false, unique: false
  │         │              └── union spans: ["\x8a", "\x8a"]
  │         ├── key: (1)
- │         └── scan c@a_inv_idx
+ │         └── scan c@a_inv_idx,inverted
  │              ├── columns: k:1!null a_inverted_key:6!null
  │              ├── inverted constraint: /6/1
  │              │    └── spans
@@ -5532,7 +5532,7 @@ index-join c
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3)
- └── scan c@a_inv_idx
+ └── scan c@a_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /6/1
       │    └── spans: ["\x89", "\x89"]
@@ -5553,7 +5553,7 @@ index-join c
       │    ├── tight: true, unique: false
       │    └── union spans: ["\x89", "\x8b")
       ├── key: (1)
-      └── scan c@a_inv_idx
+      └── scan c@a_inv_idx,inverted
            ├── columns: k:1!null a_inverted_key:6!null
            ├── inverted constraint: /6/1
            │    └── spans: ["\x89", "\x8b")
@@ -5571,7 +5571,7 @@ inner-join (lookup c)
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3)
- ├── inner-join (zigzag c@a_inv_idx c@a_inv_idx)
+ ├── inner-join (zigzag c@a_inv_idx,inverted c@a_inv_idx,inverted)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [6] = ['\x89']
@@ -5659,7 +5659,7 @@ index-join c
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2,3)
- └── scan c@a_inv_idx
+ └── scan c@a_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["\x89", "\x89"]
@@ -5683,7 +5683,7 @@ index-join b
       │         ├── ["7\x00\x018", "7\x00\x018"]
       │         └── ["7\x00\x03", "7\x00\x03"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:8!null
            ├── inverted constraint: /8/1
            │    └── spans
@@ -5753,7 +5753,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_intersects('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4)
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -5793,7 +5793,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_intersects('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4)
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -5832,7 +5832,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -5869,7 +5869,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_covers('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -5902,7 +5902,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dwithin('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -5935,7 +5935,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dfullywithin('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -5978,7 +5978,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dwithin('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4, 2000.0)
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -6031,7 +6031,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dwithin('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4, 2000.0, false)
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -6075,7 +6075,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dwithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -6109,7 +6109,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dwithin('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -6142,7 +6142,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_dfullywithinexclusive('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:3, 2.0)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -6183,7 +6183,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4)
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -6222,7 +6222,7 @@ project
       │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x01")
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -6284,7 +6284,7 @@ project
       │         │                   ├── ["B\xfdO\x00\x00\x00\x00\x00\x00\x00", "B\xfdO\x00\x00\x00\x00\x00\x00\x00"]
       │         │                   └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -6327,7 +6327,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_overlaps('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -6378,7 +6378,7 @@ project
       │    │    │         ├── pre-filterer expression
       │    │    │         │    └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:12)
       │    │    │         ├── key: (9)
-      │    │    │         └── scan g@geog_idx
+      │    │    │         └── scan g@geog_idx,inverted
       │    │    │              ├── columns: k:9!null geog_inverted_key:16!null
       │    │    │              ├── inverted constraint: /16/9
       │    │    │              │    └── spans
@@ -6406,7 +6406,7 @@ project
       │         │         ├── pre-filterer expression
       │         │         │    └── st_touches('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:19)
       │         │         ├── key: (17)
-      │         │         └── scan g@geom_idx
+      │         │         └── scan g@geom_idx,inverted
       │         │              ├── columns: k:17!null geom_inverted_key:23!null
       │         │              ├── inverted constraint: /23/17
       │         │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -6447,7 +6447,7 @@ project
       │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
       │         │         └── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x01")
       │         ├── key: (1)
-      │         └── scan g@geog_idx
+      │         └── scan g@geog_idx,inverted
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── inverted constraint: /8/1
       │              │    └── spans
@@ -6492,7 +6492,7 @@ project
       │              ├── columns: k:1!null geog_inverted_key:8!null
       │              ├── key: (1)
       │              ├── fd: (1)-->(8)
-      │              ├── scan g@geog_idx
+      │              ├── scan g@geog_idx,inverted
       │              │    ├── columns: k:1!null geog_inverted_key:8!null
       │              │    ├── inverted constraint: /8/1
       │              │    │    └── spans
@@ -6534,7 +6534,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_covers('01030000000100000005000000000000000000F03F0000000000000040000000000000F03F00000000000010400000000000000840000000000000104000000000000008400000000000000040000000000000F03F0000000000000040', geom:3)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -6571,7 +6571,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_coveredby('01030000000100000005000000000000000000F03F0000000000000040000000000000F03F00000000000010400000000000000840000000000000104000000000000008400000000000000040000000000000F03F0000000000000040', geom:3)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -6615,7 +6615,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_coveredby('01040000000200000001010000009A999999999901409A99999999990140010100000000000000000008400000000000000840', geom:3)
       │         ├── key: (1)
-      │         └── scan g@geom_idx
+      │         └── scan g@geom_idx,inverted
       │              ├── columns: k:1!null geom_inverted_key:7!null
       │              ├── inverted constraint: /7/1
       │              │    └── spans
@@ -6651,7 +6651,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan pi@idx,partial
+ └── scan pi@idx,inverted,partial
       ├── columns: k:1!null
       ├── inverted constraint: /6/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -6674,7 +6674,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan pi@idx,partial
+ └── scan pi@idx,inverted,partial
       ├── columns: k:1!null
       ├── inverted constraint: /7/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -6698,7 +6698,7 @@ index-join pi
  ├── immutable
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3)
- └── scan pi@idx,partial
+ └── scan pi@idx,inverted,partial
       ├── columns: k:1!null
       ├── inverted constraint: /8/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -6739,7 +6739,7 @@ select
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7group\x00\x01*\x02\x00", "7group\x00\x01*\x02\x00"]
  │         ├── key: (1)
- │         └── scan pi@idx,partial
+ │         └── scan pi@idx,inverted,partial
  │              ├── columns: k:1!null j_inverted_key:9!null
  │              ├── inverted constraint: /9/1
  │              │    └── spans
@@ -6783,15 +6783,15 @@ memo (optimized, ~14KB, required=[presentation: k:1,s:2,j:3])
  │         ├── best: (index-join G9 pi,cols=(1-3))
  │         └── cost: 33.80
  ├── G5: (filters G8)
- ├── G6: (scan pi@idx2,partial,cols=(1),constrained inverted)
+ ├── G6: (scan pi@idx2,inverted,partial,cols=(1),constrained inverted)
  │    └── []
- │         ├── best: (scan pi@idx2,partial,cols=(1),constrained inverted)
+ │         ├── best: (scan pi@idx2,inverted,partial,cols=(1),constrained inverted)
  │         └── cost: 19.16
  ├── G7: (contains G10 G11)
  ├── G8: (eq G12 G13)
- ├── G9: (scan pi@idx,partial,cols=(1),constrained inverted)
+ ├── G9: (scan pi@idx,inverted,partial,cols=(1),constrained inverted)
  │    └── []
- │         ├── best: (scan pi@idx,partial,cols=(1),constrained inverted)
+ │         ├── best: (scan pi@idx,inverted,partial,cols=(1),constrained inverted)
  │         └── cost: 20.31
  ├── G10: (variable j)
  ├── G11: (const '{"a": "b"}')
@@ -6846,7 +6846,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan computed@field_inv_idx
+ └── scan computed@field_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /9/1
       │    └── spans: ["7a\x00\x01\x12b\x00\x01", "7a\x00\x01\x12b\x00\x01"]
@@ -6859,7 +6859,7 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── scan computed@field_inv_idx
+ └── scan computed@field_inv_idx,inverted
       ├── columns: k:1!null
       ├── inverted constraint: /9/1
       │    └── spans: ["7a\x00\x01*\x02\x00", "7a\x00\x01*\x02\x00"]
@@ -6902,7 +6902,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan m@multicol
+ │         └── scan m@multicol,inverted
  │              ├── columns: k:1!null geom_inverted_key:8!null
  │              ├── constraint: /2: [/'foo' - /'foo']
  │              ├── inverted constraint: /8/1
@@ -6939,7 +6939,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan m@multicol
+ │         └── scan m@multicol,inverted
  │              ├── columns: k:1!null geom_inverted_key:8!null
  │              ├── constraint: /2
  │              │    ├── [/'bar' - /'bar']
@@ -7021,7 +7021,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan m@multicol
+ │         └── scan m@multicol,inverted
  │              ├── columns: k:1!null geom_inverted_key:9!null
  │              ├── constraint: /2/3: [/'foo'/'bar' - /'foo'/'bar']
  │              ├── inverted constraint: /9/1
@@ -7058,7 +7058,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan m@multicol
+ │         └── scan m@multicol,inverted
  │              ├── columns: k:1!null geom_inverted_key:9!null
  │              ├── constraint: /2/3
  │              │    ├── [/'bar'/'baz' - /'bar'/'baz']
@@ -7202,7 +7202,7 @@ project
       │         ├── pre-filterer expression
       │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
       │         ├── key: (1)
-      │         └── scan m@multicol
+      │         └── scan m@multicol,inverted
       │              ├── columns: k:1!null geom_inverted_key:10!null
       │              ├── constraint: /4
       │              │    ├── [/1 - /1]
@@ -7257,7 +7257,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan mc@mc_idx
+ │         └── scan mc@mc_idx,inverted
  │              ├── columns: k:1!null geom_inverted_key:8!null
  │              ├── constraint: /3
  │              │    ├── [/'bar' - /'bar']
@@ -7305,7 +7305,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan mc@mc_idx
+ │         └── scan mc@mc_idx,inverted
  │              ├── columns: k:1!null geom_inverted_key:9!null
  │              ├── constraint: /2/3
  │              │    ├── [/'x'/'bar' - /'x'/'bar']
@@ -7354,7 +7354,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan mc@mc_idx
+ │         └── scan mc@mc_idx,inverted
  │              ├── columns: k:1!null geom_inverted_key:10!null
  │              ├── constraint: /4: [/'FOO' - /'FOO']
  │              ├── inverted constraint: /10/1
@@ -7393,7 +7393,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_coveredby('0103000000010000000500000000000000000000000000000000000000000000000000F03F0000000000000000000000000000F03F000000000000F03F0000000000000000000000000000F03F00000000000000000000000000000000', geom:5)
  │         ├── key: (1)
- │         └── scan mc@mc_idx
+ │         └── scan mc@mc_idx,inverted
  │              ├── columns: k:1!null geom_inverted_key:10!null
  │              ├── constraint: /4: [/'FOO' - /'FOO']
  │              ├── inverted constraint: /10/1
@@ -7503,7 +7503,7 @@ index-join t63180
       │    ├── tight: true, unique: false
       │    └── union spans: ["7a\x00\x01\x12c\x00\x01", "7a\x00\x01\x12c\x00\x01"]
       ├── key: (2)
-      └── scan t63180@j_idx
+      └── scan t63180@j_idx,inverted
            ├── columns: rowid:2!null j_inverted_key:5!null
            ├── inverted constraint: /5/2
            │    └── spans: ["7a\x00\x01\x12c\x00\x01", "7a\x00\x01\x12c\x00\x01"]
@@ -7548,7 +7548,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_intersects('010100000000000000000000000000000000000000', geom:1)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geom_idx
+ │         └── scan geom_geog@geom_geog_geom_idx,inverted
  │              ├── columns: rowid:4!null geom_inverted_key:7!null
  │              ├── inverted constraint: /7/4
  │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -7574,7 +7574,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_intersects('0101000020E610000000000000000000000000000000000000', geog:2)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geog_idx
+ │         └── scan geom_geog@geom_geog_geog_idx,inverted
  │              ├── columns: rowid:4!null geog_inverted_key:8!null
  │              ├── inverted constraint: /8/4
  │              │    └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
@@ -7640,7 +7640,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dwithin('010100000000000000000000000000000000000000', geom:1, 5.0)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geom_idx
+ │         └── scan geom_geog@geom_geog_geom_idx,inverted
  │              ├── columns: rowid:4!null geom_inverted_key:7!null
  │              ├── inverted constraint: /7/4
  │              │    └── spans
@@ -7670,7 +7670,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dwithinexclusive('010100000000000000000000000000000000000000', geom:1, 5.0)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geom_idx
+ │         └── scan geom_geog@geom_geog_geom_idx,inverted
  │              ├── columns: rowid:4!null geom_inverted_key:7!null
  │              ├── inverted constraint: /7/4
  │              │    └── spans
@@ -7754,7 +7754,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dwithin('0101000020E610000000000000000000000000000000000000', geog:2, 5.0)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geog_idx
+ │         └── scan geom_geog@geom_geog_geog_idx,inverted
  │              ├── columns: rowid:4!null geog_inverted_key:8!null
  │              ├── inverted constraint: /8/4
  │              │    └── spans
@@ -7838,7 +7838,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dwithin('0101000020E610000000000000000000000000000000000000', geog:2, 5.0)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geog_idx
+ │         └── scan geom_geog@geom_geog_geog_idx,inverted
  │              ├── columns: rowid:4!null geog_inverted_key:8!null
  │              ├── inverted constraint: /8/4
  │              │    └── spans
@@ -7925,7 +7925,7 @@ select
  │         │         ├── variable: geog:2 [type=geography]
  │         │         └── const: 5.0 [type=float]
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geog_idx
+ │         └── scan geom_geog@geom_geog_geog_idx,inverted
  │              ├── columns: rowid:4(int!null) geog_inverted_key:8(encodedkey!null)
  │              ├── inverted constraint: /8/4
  │              │    └── spans
@@ -8031,7 +8031,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dwithin('0101000020E610000000000000000000000000000000000000', geog:2, 5.0, true)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geog_idx
+ │         └── scan geom_geog@geom_geog_geog_idx,inverted
  │              ├── columns: rowid:4!null geog_inverted_key:8!null
  │              ├── inverted constraint: /8/4
  │              │    └── spans
@@ -8162,7 +8162,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dfullywithin('010100000000000000000000000000000000000000', geom:1, 5.0)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geom_idx
+ │         └── scan geom_geog@geom_geog_geom_idx,inverted
  │              ├── columns: rowid:4!null geom_inverted_key:7!null
  │              ├── inverted constraint: /7/4
  │              │    └── spans
@@ -8192,7 +8192,7 @@ select
  │         ├── pre-filterer expression
  │         │    └── st_dfullywithinexclusive('010100000000000000000000000000000000000000', geom:1, 5.0)
  │         ├── key: (4)
- │         └── scan geom_geog@geom_geog_geom_idx
+ │         └── scan geom_geog@geom_geog_geom_idx,inverted
  │              ├── columns: rowid:4!null geom_inverted_key:7!null
  │              ├── inverted constraint: /7/4
  │              │    └── spans
@@ -8310,7 +8310,7 @@ select
  │         │         ├── ["\x12foo\x00\x01", "\x12foo\x00\x01"]
  │         │         └── ["\x12oo \x00\x01", "\x12oo \x00\x01"]
  │         ├── key: (1)
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              ├── columns: k:1!null s_inverted_key:5!null
  │              ├── inverted constraint: /5/1
  │              │    └── spans
@@ -8329,7 +8329,7 @@ SELECT * FROM trgm WHERE s % 'foo'
 select
  ├── index-join trgm
  │    └── distinct-on
- │         └── scan trgm@s_idx
+ │         └── scan trgm@s_idx,inverted
  │              └── constraint: /5
  │                   ├── [/'\x1220666f0001' - /'\x1220666f0001']
  │                   ├── [/'\x12666f6f0001' - /'\x12666f6f0001']
@@ -9579,7 +9579,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
-      ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+      ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [9] = ['\x3761000112620001']
@@ -9598,7 +9598,7 @@ inner-join (lookup b)
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(4)
- ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+ ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [9] = ['\x3761000112620001']
@@ -9616,7 +9616,7 @@ inner-join (lookup b)
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+ ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [9] = ['\x3761000262000112630001']
@@ -9636,7 +9636,7 @@ inner-join (lookup b)
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+ ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [9] = ['\x37610002000362000112630001']
@@ -9717,7 +9717,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── inner-join (zigzag c@a_inv_idx c@a_inv_idx)
+      ├── inner-join (zigzag c@a_inv_idx,inverted c@a_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [8] = ['\x89']
@@ -9741,7 +9741,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
-      ├── inner-join (zigzag c@a_inv_idx c@a_inv_idx)
+      ├── inner-join (zigzag c@a_inv_idx,inverted c@a_inv_idx,inverted)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [8] = ['\x89']
@@ -9760,7 +9760,7 @@ inner-join (lookup b)
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+ ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [9] = ['\x376200012a0400']
@@ -9795,7 +9795,7 @@ select
  │         │              ├── tight: true, unique: true
  │         │              └── union spans: ["7\x00\x03\x00\x03\x00\x01*\x04\x00", "7\x00\x03\x00\x03\x00\x01*\x04\x00"]
  │         ├── key: (1)
- │         └── scan b@j_inv_idx
+ │         └── scan b@j_inv_idx,inverted
  │              ├── columns: k:1!null j_inverted_key:9!null
  │              ├── inverted constraint: /9/1
  │              │    └── spans
@@ -9819,7 +9819,7 @@ inner-join (lookup b)
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2-4), (3)~~>(1,2,4)
- ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+ ├── inner-join (zigzag b@j_inv_idx,inverted b@j_inv_idx,inverted)
  │    ├── columns: k:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [9] = ['\x376100012a0200']
@@ -9850,7 +9850,7 @@ project
       │              ├── tight: true, unique: true
       │              └── union spans: ["7c\x00\x01\x12d\x00\x01", "7c\x00\x01\x12d\x00\x01"]
       ├── key: (1)
-      └── scan b@j_inv_idx
+      └── scan b@j_inv_idx,inverted
            ├── columns: k:1!null j_inverted_key:9!null
            ├── inverted constraint: /9/1
            │    └── spans
@@ -9894,7 +9894,7 @@ project
       │              ├── tight: true, unique: true
       │              └── union spans: ["7b\x00\x01*\x04\x00", "7b\x00\x01*\x04\x00"]
       ├── key: (1)
-      └── scan inv_zz_partial@zz_idx,partial
+      └── scan inv_zz_partial@zz_idx,inverted,partial
            ├── columns: k:1!null j_inverted_key:7!null
            ├── inverted constraint: /7/1
            │    └── spans
@@ -9918,7 +9918,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(3,4), (1)-->(2)
-      ├── inner-join (zigzag inv_zz_partial@zz_idx,partial inv_zz_partial@zz_idx,partial)
+      ├── inner-join (zigzag inv_zz_partial@zz_idx,inverted,partial inv_zz_partial@zz_idx,inverted,partial)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x376100012a0200']
@@ -9955,7 +9955,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(3,4), (1)-->(2)
-      ├── inner-join (zigzag inv_zz_partial@zz_idx,partial inv_zz_partial@zz_idx,partial)
+      ├── inner-join (zigzag inv_zz_partial@zz_idx,inverted,partial inv_zz_partial@zz_idx,inverted,partial)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x376100012a0200']
@@ -9979,7 +9979,7 @@ project
       ├── immutable
       ├── key: (1)
       ├── fd: ()-->(3,4), (1)-->(2)
-      ├── inner-join (zigzag inv_zz_partial@zz_idx,partial inv_zz_partial@zz_idx,partial)
+      ├── inner-join (zigzag inv_zz_partial@zz_idx,inverted,partial inv_zz_partial@zz_idx,inverted,partial)
       │    ├── columns: k:1!null
       │    ├── eq columns: [1] = [1]
       │    ├── left fixed columns: [7] = ['\x376100012a0200']
@@ -10002,7 +10002,7 @@ opt expect-not=GenerateInvertedIndexZigzagJoins format=hide-all
 SELECT k FROM inv_zz_partial WHERE j->'a' = '1' AND j->'b' = '2'
 ----
 project
- └── scan inv_zz_partial@zz_idx,partial
+ └── scan inv_zz_partial@zz_idx,inverted,partial
       └── inverted constraint: /8/1
            └── spans: ["7b\x00\x01*\x04\x00", "7b\x00\x01*\x04\x00"]
 
@@ -10331,7 +10331,7 @@ project
       │              ├── columns: k:19!null
       │              ├── key: (19)
       │              ├── ordering: +19
-      │              └── scan b@j_inv_idx
+      │              └── scan b@j_inv_idx,inverted
       │                   ├── columns: k:19!null
       │                   ├── inverted constraint: /27/19
       │                   │    └── spans: ["7foo\x00\x01\x12bar\x00\x01", "7foo\x00\x01\x12bar\x00\x01"]
@@ -10377,7 +10377,7 @@ project
       │              ├── columns: k:17!null
       │              ├── key: (17)
       │              ├── ordering: +17
-      │              └── scan c@a_inv_idx
+      │              └── scan c@a_inv_idx,inverted
       │                   ├── columns: k:17!null
       │                   ├── inverted constraint: /24/17
       │                   │    └── spans: ["\x8a", "\x8a"]
@@ -11855,7 +11855,7 @@ project
       │              ├── columns: k:19!null
       │              ├── key: (19)
       │              ├── ordering: +19
-      │              └── scan b@j_inv_idx
+      │              └── scan b@j_inv_idx,inverted
       │                   ├── columns: k:19!null
       │                   ├── inverted constraint: /27/19
       │                   │    └── spans: ["7foo\x00\x01\x12bar\x00\x01", "7foo\x00\x01\x12bar\x00\x01"]
@@ -11907,7 +11907,7 @@ project
       │              ├── columns: k:17!null
       │              ├── key: (17)
       │              ├── ordering: +17
-      │              └── scan c@a_inv_idx
+      │              └── scan c@a_inv_idx,inverted
       │                   ├── columns: k:17!null
       │                   ├── inverted constraint: /24/17
       │                   │    └── spans: ["\x8a", "\x8a"]

--- a/pkg/sql/opt/xform/testdata/rules/select_for_update
+++ b/pkg/sql/opt/xform/testdata/rules/select_for_update
@@ -164,7 +164,7 @@ inner-join (lookup inverted)
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2,3)
- ├── inner-join (zigzag inverted@b_inv inverted@b_inv)
+ ├── inner-join (zigzag inverted@b_inv,inverted inverted@b_inv,inverted)
  │    ├── columns: a:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [6] = ['\x89']
@@ -197,7 +197,7 @@ select
  │         │         └── ["\x89", "\x8b")
  │         ├── volatile
  │         ├── key: (1)
- │         └── scan inverted@b_inv
+ │         └── scan inverted@b_inv,inverted
  │              ├── columns: a:1!null b_inverted_key:6!null
  │              ├── inverted constraint: /6/1
  │              │    └── spans
@@ -221,7 +221,7 @@ inner-join (lookup inverted [as=i1])
  ├── volatile
  ├── key: (1,7)
  ├── fd: (1)-->(2,3), (7)-->(8,9)
- ├── inner-join (inverted inverted@b_inv [as=i1])
+ ├── inner-join (inverted inverted@b_inv,inverted [as=i1])
  │    ├── columns: i2.a:7!null i2.b:8 i2.c:9 i1.a:19!null
  │    ├── inverted-expr
  │    │    └── i1.b:20 @> i2.b:8
@@ -283,7 +283,7 @@ inner-join (lookup zigzag)
  ├── volatile
  ├── key: (1)
  ├── fd: (1)-->(2-4)
- ├── inner-join (zigzag zigzag@d_idx zigzag@d_idx)
+ ├── inner-join (zigzag zigzag@d_idx,inverted zigzag@d_idx,inverted)
  │    ├── columns: a:1!null
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [7] = ['\x3761000262000112630001']


### PR DESCRIPTION
As of #121973, scans on inverted indexes can use regular constraints or
inverted constraints. Therefore, the type of constraint no longer
indicates the type of index. To avoid confusion, "inverted" is now
printed when an inverted index name is printed in a formatted optimizer
expression.

Epic: None

Release note: None
