### PR TITLE
sql/schemachanger: support creating temporary sequences

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -312,6 +312,13 @@ func TestBackupRollbacks_base_create_sequence_drop_sequence(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -722,6 +729,13 @@ func TestBackupRollbacksMixedVersion_base_create_sequence_drop_sequence(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1138,6 +1152,13 @@ func TestBackupSuccess_base_create_sequence_drop_sequence(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1548,6 +1569,13 @@ func TestBackupSuccessMixedVersion_base_create_sequence_drop_sequence(t *testing
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -563,6 +563,13 @@ func (ep *DummyEvalPlanner) AutoCommit() bool {
 	return false
 }
 
+// InsertTemporarySchema is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) InsertTemporarySchema(
+	tempSchemaName string, databaseID descpb.ID, schemaID descpb.ID,
+) {
+
+}
+
 // DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
 type DummyPrivilegedAccessor struct{}
 

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1375,3 +1375,14 @@ SELECT database_name, schema_name, grantee, privilege_type FROM [SHOW GRANTS ON 
 should_not_have_create  public  public  USAGE
 
 subtest end
+
+
+subtest schema_with_temp_in_name
+
+statement ok
+CREATE SCHEMA my_pg_temp_123_123;
+
+statement ok
+DROP SCHEMA  my_pg_temp_123_123;
+
+subtest end

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -673,6 +673,7 @@ func (p *planner) User() username.SQLUsername {
 	return p.SessionData().User()
 }
 
+// TemporarySchemaName implements scbuildstmt.TemporarySchemaProvider.
 func (p *planner) TemporarySchemaName() string {
 	return temporarySchemaName(p.ExtendedEvalContext().SessionID)
 }

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -113,6 +113,7 @@ func (p *planner) newSchemaChangeBuilderDependencies(statements []string) scbuil
 		NewSchemaChangerBuildEventLogger(p.InternalSQLTxn(), p.ExecCfg()),
 		NewReferenceProviderFactory(p),
 		p.EvalContext().DescIDGenerator,
+		p,
 	)
 }
 
@@ -293,6 +294,7 @@ func newSchemaChangerTxnRunDependencies(
 		execCfg.Validator,
 		scdeps.NewConstantClock(evalContext.GetTxnTimestamp(time.Microsecond).Time),
 		metaDataUpdater,
+		evalContext.Planner,
 		execCfg.StatsRefresher,
 		execCfg.DeclarativeSchemaChangerTestingKnobs,
 		kvTrace,

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -89,12 +89,13 @@ func Build(
 		return scpb.CurrentState{}, stubLogSchemaChangerEventsFn, err
 	}
 	b := buildCtx{
-		Context:              ctx,
-		Dependencies:         dependencies,
-		BuilderState:         bs,
-		EventLogState:        els,
-		TreeAnnotator:        an,
-		SchemaFeatureChecker: dependencies.FeatureChecker(),
+		Context:                 ctx,
+		Dependencies:            dependencies,
+		BuilderState:            bs,
+		EventLogState:           els,
+		TreeAnnotator:           an,
+		SchemaFeatureChecker:    dependencies.FeatureChecker(),
+		TemporarySchemaProvider: dependencies.TemporarySchemaProvider(),
 	}
 	scbuildstmt.Process(b, an.GetStatement())
 
@@ -420,6 +421,7 @@ type buildCtx struct {
 	scbuildstmt.EventLogState
 	scbuildstmt.TreeAnnotator
 	scbuildstmt.SchemaFeatureChecker
+	TemporarySchemaProvider
 }
 
 var _ scbuildstmt.BuildCtx = buildCtx{}

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -941,7 +941,9 @@ func (b *builderState) checkOwnershipOrPrivilegesOnSchemaDesc(
 	name tree.ObjectNamePrefix, sc catalog.SchemaDescriptor, p scbuildstmt.ResolveParams,
 ) {
 	switch sc.SchemaKind() {
-	case catalog.SchemaPublic, catalog.SchemaVirtual, catalog.SchemaTemporary:
+	case catalog.SchemaTemporary:
+		// Nothing needs to be done.
+	case catalog.SchemaPublic, catalog.SchemaVirtual:
 		panic(pgerror.Newf(pgcode.InsufficientPrivilege,
 			"%s permission denied for schema %q", p.RequiredPrivilege.DisplayName(), name))
 	case catalog.SchemaUserDefined:
@@ -1503,7 +1505,7 @@ func (b *builderState) BuildUserPrivilegesFromDefaultPrivileges(
 	dbDefaultPrivDesc := dbDesc.GetDefaultPrivilegeDescriptor()
 
 	var scDefaultPrivDesc catalog.DefaultPrivilegeDescriptor
-	if sc != nil {
+	if sc != nil && !sc.IsTemporary {
 		b.ensureDescriptor(sc.SchemaID)
 		scDesc, err := catalog.AsSchemaDescriptor(b.descCache[sc.SchemaID].desc)
 		if err != nil {

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -89,6 +89,8 @@ type Dependencies interface {
 
 	// ReferenceProviderFactory returns a ReferenceProviderFactory.
 	ReferenceProviderFactory() ReferenceProviderFactory
+
+	TemporarySchemaProvider() TemporarySchemaProvider
 }
 
 // CreatePartitioningCCLCallback is the type of the CCL callback for creating
@@ -261,4 +263,6 @@ type (
 	// FeatureChecker contains operations for checking if a schema change
 	// feature is allowed by the database administrator.
 	FeatureChecker = scbuildstmt.SchemaFeatureChecker
+
+	TemporarySchemaProvider = scbuildstmt.TemporarySchemaProvider
 )

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_sequence.go
@@ -73,9 +73,9 @@ func CreateSequence(b BuildCtx, n *tree.CreateSequence) {
 				"sql.schema.temp_tables_disabled",
 			))
 		}
-
-		panic(scerrors.NotImplementedErrorf(n, "temporary sequences are not yet "+
-			"implemented in the declarative schema changer"))
+		// Resolve the temporary schema element.
+		scElts = MaybeCreateOrResolveTemporarySchema(b)
+		schemaElem = scElts.FilterSchema().MustGetOneElement()
 	}
 
 	// Sanity check for duplication options on the sequence.
@@ -123,7 +123,7 @@ func CreateSequence(b BuildCtx, n *tree.CreateSequence) {
 	sequenceID := b.GenerateUniqueDescID()
 	sequenceElem := &scpb.Sequence{
 		SequenceID:  sequenceID,
-		IsTemporary: false,
+		IsTemporary: n.Persistence.IsTemporary(),
 	}
 	if restartWith != nil {
 		sequenceElem.RestartWith = *restartWith

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -37,6 +37,7 @@ type BuildCtx interface {
 	context.Context
 	ClusterAndSessionInfo
 	SchemaFeatureChecker
+	TemporarySchemaProvider
 	BuilderState
 	EventLogState
 	TreeAnnotator
@@ -433,4 +434,12 @@ type ReferenceProvider interface {
 	ReferencedTypes() catalog.DescriptorIDSet
 	// ReferencedRelationIDs Returns all referenced relation IDs.
 	ReferencedRelationIDs() catalog.DescriptorIDSet
+}
+
+// TemporarySchemaProvider provides functions needed to help support
+// temporary schemas.
+type TemporarySchemaProvider interface {
+	// TemporarySchemaName gets the name of the temporary schema for the current
+	// session.
+	TemporarySchemaName() string
 }

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -55,6 +55,7 @@ func NewBuilderDependencies(
 	eventLogger scbuild.EventLogger,
 	referenceProviderFactory scbuild.ReferenceProviderFactory,
 	descIDGenerator eval.DescIDGenerator,
+	temporarySchemaProvider scbuild.TemporarySchemaProvider,
 ) scbuild.Dependencies {
 	return &buildDeps{
 		clusterID:       clusterID,
@@ -74,6 +75,7 @@ func NewBuilderDependencies(
 		eventLogger:              eventLogger,
 		descIDGenerator:          descIDGenerator,
 		referenceProviderFactory: referenceProviderFactory,
+		temporarySchemaProvider:  temporarySchemaProvider,
 	}
 }
 
@@ -93,6 +95,7 @@ type buildDeps struct {
 	eventLogger              scbuild.EventLogger
 	referenceProviderFactory scbuild.ReferenceProviderFactory
 	descIDGenerator          eval.DescIDGenerator
+	temporarySchemaProvider  scbuild.TemporarySchemaProvider
 }
 
 var _ scbuild.CatalogReader = (*buildDeps)(nil)
@@ -486,4 +489,8 @@ func (d *buildDeps) DescIDGenerator() eval.DescIDGenerator {
 
 func (d *buildDeps) ReferenceProviderFactory() scbuild.ReferenceProviderFactory {
 	return d.referenceProviderFactory
+}
+
+func (d *buildDeps) TemporarySchemaProvider() scbuild.TemporarySchemaProvider {
+	return d.temporarySchemaProvider
 }

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -72,6 +72,7 @@ func WithBuilderDependenciesFromTestServer(
 		scbuild.AuthorizationAccessor
 		scbuild.AstFormatter
 		scbuild.FeatureChecker
+		scbuild.TemporarySchemaProvider
 	})
 
 	refProviderFactory, refCleanup := sql.NewReferenceProviderFactoryForTest(
@@ -100,6 +101,7 @@ func WithBuilderDependenciesFromTestServer(
 		sql.NewSchemaChangerBuildEventLogger(planner.InternalSQLTxn(), &execCfg),
 		refProviderFactory,
 		descidgen.NewGenerator(s.ClusterSettings(), s.Codec(), s.DB()),
+		planner,
 	))
 }
 

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -57,6 +57,7 @@ type Dependencies interface {
 type Catalog interface {
 	scmutationexec.NameResolver
 	scmutationexec.DescriptorReader
+	TemporarySchemaCreator
 
 	// CreateOrUpdateDescriptor upserts a descriptor.
 	CreateOrUpdateDescriptor(ctx context.Context, desc catalog.MutableDescriptor) error
@@ -349,6 +350,14 @@ type DescriptorMetadataUpdater interface {
 	// UpdateTTLScheduleLabel updates the schedule_name for the TTL Scheduled Job
 	// of the given table.
 	UpdateTTLScheduleLabel(ctx context.Context, tbl *tabledesc.Mutable) error
+}
+
+type TemporarySchemaCreator interface {
+	// InsertTemporarySchema inserts a temporary schema into the current session
+	// data.
+	InsertTemporarySchema(
+		tempSchemaName string, databaseID descpb.ID, schemaID descpb.ID,
+	)
 }
 
 // StatsRefreshQueue queues table for stats refreshes.

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -78,6 +78,7 @@ func (ti testInfra) newExecDeps(txn descs.Txn) scexec.Dependencies {
 		noopValidator{},
 		scdeps.NewConstantClock(timeutil.Now()),
 		noopMetadataUpdater{},
+		noopTemporarySchemaCreator{},
 		noopStatsReferesher{},
 		&scexec.TestingKnobs{},
 		kvTrace,
@@ -529,4 +530,15 @@ func (noopMetadataUpdater) UpdateTTLScheduleLabel(
 	ctx context.Context, tbl *tabledesc.Mutable,
 ) error {
 	return nil
+}
+
+type noopTemporarySchemaCreator struct{}
+
+var _ scexec.TemporarySchemaCreator = noopTemporarySchemaCreator{}
+
+// InsertTemporarySchema implements scexec.TemporarySchemaCreator.
+func (noopTemporarySchemaCreator) InsertTemporarySchema(
+	tempSchemaName string, databaseID descpb.ID, schemaID descpb.ID,
+) {
+
 }

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -154,6 +154,18 @@ func (mr *MockCatalogMockRecorder) InitializeSequence(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeSequence", reflect.TypeOf((*MockCatalog)(nil).InitializeSequence), arg0, arg1)
 }
 
+// InsertTemporarySchema mocks base method.
+func (m *MockCatalog) InsertTemporarySchema(arg0 string, arg1, arg2 catid.DescID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InsertTemporarySchema", arg0, arg1, arg2)
+}
+
+// InsertTemporarySchema indicates an expected call of InsertTemporarySchema.
+func (mr *MockCatalogMockRecorder) InsertTemporarySchema(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertTemporarySchema", reflect.TypeOf((*MockCatalog)(nil).InsertTemporarySchema), arg0, arg1, arg2)
+}
+
 // MustReadImmutableDescriptors mocks base method.
 func (m *MockCatalog) MustReadImmutableDescriptors(arg0 context.Context, arg1 ...catid.DescID) ([]catalog.Descriptor, error) {
 	m.ctrl.T.Helper()

--- a/pkg/sql/schemachanger/scexec/scmutationexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/sql/privilege",
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scpb",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -85,6 +85,13 @@ type ImmediateMutationStateUpdater interface {
 	// Reset schedules a reset of the in-txn catalog state
 	// to undo the modifications from earlier stages.
 	Reset()
+
+	// AddTemporarySchema adds the temporary schema in the current session.
+	AddTemporarySchema(id descpb.ID)
+
+	// AddTemporarySchemaParent registers the parent database for an added
+	// temporary schema.
+	AddTemporarySchemaParent(id descpb.ID, databaseID descpb.ID)
 }
 
 type DeferredMutationStateUpdater interface {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -609,17 +609,16 @@ func updateBackReferencesInRelation(
 }
 
 func (i *immediateVisitor) SetObjectParentID(ctx context.Context, op scop.SetObjectParentID) error {
-	sc, err := i.checkOutSchema(ctx, op.ObjParent.SchemaID)
-	if err != nil {
-		return err
-	}
-
 	obj, err := i.checkOutDescriptor(ctx, op.ObjParent.ChildObjectID)
 	if err != nil {
 		return err
 	}
 	switch t := obj.(type) {
 	case *funcdesc.Mutable:
+		sc, err := i.checkOutSchema(ctx, op.ObjParent.SchemaID)
+		if err != nil {
+			return err
+		}
 		if t.ParentSchemaID != descpb.InvalidID {
 			sc.RemoveFunction(t.GetName(), t.GetID())
 		}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/sequence.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/sequence.go
@@ -33,6 +33,7 @@ func (i *immediateVisitor) CreateSequenceDescriptor(
 		Privileges:    &catpb.PrivilegeDescriptor{Version: catpb.Version23_2}, // Populated by `UserPrivileges` elements and `Owner` element
 		Version:       1,
 		FormatVersion: descpb.InterleavedFormatVersion,
+		Temporary:     op.Temporary,
 	}).BuildCreatedMutable()
 	tabledDesc := mut.(*tabledesc.Mutable)
 	tabledDesc.State = descpb.DescriptorState_ADD

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -141,6 +141,17 @@ type MarkDescriptorAsPublic struct {
 	DescriptorID descpb.ID
 }
 
+type InsertTemporarySchema struct {
+	immediateMutationOp
+	DescriptorID descpb.ID
+}
+
+type InsertTemporarySchemaParent struct {
+	immediateMutationOp
+	SchemaID   descpb.ID
+	DatabaseID descpb.ID
+}
+
 // MarkDescriptorAsDropped changes the descriptor's state to DROPPED.
 type MarkDescriptorAsDropped struct {
 	immediateMutationOp
@@ -839,6 +850,7 @@ type CreateSchemaDescriptor struct {
 type CreateSequenceDescriptor struct {
 	immediateMutationOp
 	SequenceID descpb.ID
+	Temporary  bool
 }
 
 type SetSequenceOptions struct {

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -36,6 +36,8 @@ type ImmediateMutationVisitor interface {
 	MakeValidatedPrimaryIndexPublic(context.Context, MakeValidatedPrimaryIndexPublic) error
 	MakePublicPrimaryIndexWriteOnly(context.Context, MakePublicPrimaryIndexWriteOnly) error
 	MarkDescriptorAsPublic(context.Context, MarkDescriptorAsPublic) error
+	InsertTemporarySchema(context.Context, InsertTemporarySchema) error
+	InsertTemporarySchemaParent(context.Context, InsertTemporarySchemaParent) error
 	MarkDescriptorAsDropped(context.Context, MarkDescriptorAsDropped) error
 	DrainDescriptorName(context.Context, DrainDescriptorName) error
 	AddDescriptorName(context.Context, AddDescriptorName) error
@@ -200,6 +202,16 @@ func (op MakePublicPrimaryIndexWriteOnly) Visit(ctx context.Context, v Immediate
 // Visit is part of the ImmediateMutationOp interface.
 func (op MarkDescriptorAsPublic) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.MarkDescriptorAsPublic(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op InsertTemporarySchema) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.InsertTemporarySchema(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op InsertTemporarySchemaParent) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.InsertTemporarySchemaParent(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/util/iterutil",
         "//pkg/util/log",

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_namespace.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_namespace.go
@@ -11,8 +11,11 @@
 package opgen
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
@@ -23,6 +26,9 @@ func init() {
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.Namespace) *scop.SetNameInDescriptor {
+					if strings.HasPrefix(this.Name, catconstants.PgTempSchemaName) {
+						return nil
+					}
 					return &scop.SetNameInDescriptor{
 						DescriptorID: this.DescriptorID,
 						Name:         this.Name,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema.go
@@ -22,14 +22,28 @@ func init() {
 			equiv(scpb.Status_DROPPED),
 			to(scpb.Status_DESCRIPTOR_ADDED,
 				emit(func(this *scpb.Schema) *scop.CreateSchemaDescriptor {
+					if this.IsTemporary {
+						return nil
+					}
 					return &scop.CreateSchemaDescriptor{
 						SchemaID: this.SchemaID,
+					}
+				}),
+				emit(func(this *scpb.Schema) *scop.InsertTemporarySchema {
+					if !this.IsTemporary {
+						return nil
+					}
+					return &scop.InsertTemporarySchema{
+						DescriptorID: this.SchemaID,
 					}
 				}),
 			),
 			to(scpb.Status_PUBLIC,
 				revertible(false),
 				emit(func(this *scpb.Schema) *scop.MarkDescriptorAsPublic {
+					if this.IsTemporary {
+						return nil
+					}
 					return &scop.MarkDescriptorAsPublic{
 						DescriptorID: this.SchemaID,
 					}

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema_parent.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema_parent.go
@@ -11,8 +11,11 @@
 package opgen
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
@@ -21,9 +24,24 @@ func init() {
 		toPublic(
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.SchemaParent) *scop.AddSchemaParent {
+				emit(func(this *scpb.SchemaParent, md *opGenContext) *scop.AddSchemaParent {
+					// Skip adding a parent in the parent database for temporary schemas.
+					if strings.HasPrefix(md.Name(this.SchemaID), catconstants.PgTempSchemaName) {
+						return nil
+					}
 					return &scop.AddSchemaParent{
 						Parent: *protoutil.Clone(this).(*scpb.SchemaParent),
+					}
+				}),
+				emit(func(this *scpb.SchemaParent, md *opGenContext) *scop.InsertTemporarySchemaParent {
+					// If its not temporary schema then we don't need to register it in
+					// the session data.
+					if !strings.HasPrefix(md.Name(this.SchemaID), catconstants.PgTempSchemaName) {
+						return nil
+					}
+					return &scop.InsertTemporarySchemaParent{
+						SchemaID:   this.SchemaID,
+						DatabaseID: this.ParentDatabaseID,
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
@@ -26,6 +26,7 @@ func init() {
 				emit(func(this *scpb.Sequence) *scop.CreateSequenceDescriptor {
 					return &scop.CreateSequenceDescriptor{
 						SequenceID: this.SequenceID,
+						Temporary:  this.IsTemporary,
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -140,6 +140,7 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 						// For setting up a builder inside tests we will ensure that the new schema
 						// changer will allow non-fully implemented operations.
 						sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafe
+						sd.TempTablesEnabled = true
 						sd.ApplicationName = ""
 						sd.EnableUniqueWithoutIndexConstraints = true // this allows `ADD UNIQUE WITHOUT INDEX` in the testing suite.
 					})),

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -874,6 +874,9 @@ func executeSchemaChangeTxn(
 			_, err = conn.ExecContext(
 				ctx, "SET use_declarative_schema_changer = 'unsafe_always'",
 			)
+			_, err = conn.ExecContext(
+				ctx, "SET experimental_enable_temp_tables=true",
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -314,6 +314,13 @@ func TestEndToEndSideEffects_create_sequence_drop_sequence(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -724,6 +731,13 @@ func TestExecuteWithDMLInjection_create_sequence_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1140,6 +1154,13 @@ func TestGenerateSchemaChangeCorpus_create_sequence_drop_sequence(t *testing.T) 
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1550,6 +1571,13 @@ func TestPause_create_sequence_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1966,6 +1994,13 @@ func TestPauseMixedVersion_create_sequence_drop_sequence(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2376,6 +2411,13 @@ func TestRollback_create_sequence_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_create_temp_sequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex.side_effects
@@ -237,8 +237,6 @@ upsert descriptor #108
   +    start: "32"
   +  unexposedParentSchemaId: 106
   +  version: "1"
-upsert descriptor #106
-  ...
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
@@ -109,8 +109,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "2"
-  +  version: "3"
+  -  version: "1"
+  +  version: "2"
 upsert descriptor #104
   ...
        - 1
@@ -252,8 +252,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "2"
-  +  version: "3"
+  -  version: "1"
+  +  version: "2"
 upsert descriptor #104
   ...
        - 1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.side_effects
@@ -110,8 +110,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "4"
-  +  version: "5"
+  -  version: "3"
+  +  version: "4"
 upsert descriptor #107
   ...
      - 110
@@ -221,8 +221,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "4"
-  +  version: "5"
+  -  version: "3"
+  +  version: "4"
 upsert descriptor #107
   ...
      - 110

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
@@ -82,12 +82,6 @@ upsert descriptor #105
   +    start: "32"
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.add_column
@@ -306,12 +300,6 @@ upsert descriptor #105
   +  state: ADD
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 upsert descriptor #104
   ...
      createAsOfTime:

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence.side_effects
@@ -80,12 +80,6 @@ upsert descriptor #104
   +    start: "32"
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 checking for feature: DROP SEQUENCE
 increment telemetry for sql.schema.drop_sequence
 write *eventpb.DropSequence to event log:

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.definition
@@ -1,0 +1,7 @@
+setup
+SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true;
+----
+
+test
+CREATE TEMPORARY SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
@@ -1,0 +1,127 @@
+/* setup */
+SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true;
+
+/* test */
+EXPLAIN (DDL) CREATE TEMPORARY SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+----
+Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 18 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (pg_temp_123_456+)}
+ │         │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
+ │         │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START"}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 105 (sq1+), ColumnID: 1 (value+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 105 (sq1+), ColumnFamilyID: 0, ColumnID: 1 (value+)}
+ │         │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 105 (sq1+), Name: "value", ColumnID: 1 (value+)}
+ │         │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 105 (sq1+), IndexID: 1 (primary+)}
+ │         │    ├── ABSENT → PUBLIC IndexName:{DescID: 105 (sq1+), Name: "primary", IndexID: 1 (primary+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 1 (primary+)}
+ │         │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sq1+)}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
+ │         │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
+ │         └── 27 Mutation operations
+ │              ├── InsertTemporarySchema {"DescriptorID":104}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"pg_temp_123_456"}}
+ │              ├── CreateSequenceDescriptor {"SequenceID":105,"Temporary":true}
+ │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"sq1"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"sq1","SchemaID":104}}
+ │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":104}}
+ │              ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":105}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":105}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"TableID":105}
+ │              ├── UpdateOwner {"Owner":{"DescriptorID":105,"Owner":"root"}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":105,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":105,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+ │              ├── InsertTemporarySchemaParent {"DatabaseID":100,"SchemaID":104}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":105}
+ │              ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":1,"TableID":105}
+ │              ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":105}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":105}
+ │              ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":105}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":105}
+ │              ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":105}
+ │              ├── SetIndexName {"IndexID":1,"Name":"primary","TableID":105}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":105}
+ │              ├── InitSequence {"SequenceID":105}
+ │              └── MarkDescriptorAsPublic {"DescriptorID":105}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 18 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Schema:{DescID: 104 (pg_temp_123_456+)}
+      │    │    ├── PUBLIC → ABSENT SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT Sequence:{DescID: 105 (sq1+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
+      │    │    ├── PUBLIC → ABSENT TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
+      │    │    ├── PUBLIC → ABSENT SequenceOption:{DescID: 105 (sq1+), Name: "START"}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 105 (sq1+), ColumnID: 1 (value+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 105 (sq1+), ColumnFamilyID: 0, ColumnID: 1 (value+)}
+      │    │    ├── PUBLIC → ABSENT ColumnNotNull:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 0}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 105 (sq1+), Name: "value", ColumnID: 1 (value+)}
+      │    │    ├── PUBLIC → ABSENT PrimaryIndex:{DescID: 105 (sq1+), IndexID: 1 (primary+)}
+      │    │    ├── PUBLIC → ABSENT IndexName:{DescID: 105 (sq1+), Name: "primary", IndexID: 1 (primary+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 1 (primary+)}
+      │    │    ├── PUBLIC → ABSENT Owner:{DescID: 105 (sq1+)}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
+      │    │    └── PUBLIC → ABSENT UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 18 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Schema:{DescID: 104 (pg_temp_123_456+)}
+           │    ├── ABSENT → PUBLIC SchemaParent:{DescID: 104 (pg_temp_123_456+), ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (pg_temp_123_456+), Name: "pg_temp_123_456", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC Sequence:{DescID: 105 (sq1+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 104 (pg_temp_123_456+)}
+           │    ├── ABSENT → PUBLIC TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
+           │    ├── ABSENT → PUBLIC SequenceOption:{DescID: 105 (sq1+), Name: "START"}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 105 (sq1+), ColumnID: 1 (value+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 105 (sq1+), ColumnFamilyID: 0, ColumnID: 1 (value+)}
+           │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 0}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 105 (sq1+), Name: "value", ColumnID: 1 (value+)}
+           │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 105 (sq1+), IndexID: 1 (primary+)}
+           │    ├── ABSENT → PUBLIC IndexName:{DescID: 105 (sq1+), Name: "primary", IndexID: 1 (primary+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 1 (primary+)}
+           │    ├── ABSENT → PUBLIC Owner:{DescID: 105 (sq1+)}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
+           │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
+           └── 27 Mutation operations
+                ├── InsertTemporarySchema {"DescriptorID":104}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"pg_temp_123_456"}}
+                ├── CreateSequenceDescriptor {"SequenceID":105,"Temporary":true}
+                ├── SetNameInDescriptor {"DescriptorID":105,"Name":"sq1"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"sq1","SchemaID":104}}
+                ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":104}}
+                ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":105}}
+                ├── SetAddedColumnType {"ColumnType":{"ColumnID":1,"TableID":105}}
+                ├── SetColumnName {"ColumnID":1,"Name":"value","TableID":105}
+                ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":105}}
+                ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"TableID":105}
+                ├── UpdateOwner {"Owner":{"DescriptorID":105,"Owner":"root"}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":105,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":105,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+                ├── InsertTemporarySchemaParent {"DatabaseID":100,"SchemaID":104}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":105}
+                ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":1,"TableID":105}
+                ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":105}
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":105}
+                ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":105}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":105}
+                ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":105}
+                ├── SetIndexName {"IndexID":1,"Name":"primary","TableID":105}
+                ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":105}
+                ├── InitSequence {"SequenceID":105}
+                └── MarkDescriptorAsPublic {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true;
+
+/* test */
+EXPLAIN (DDL, SHAPE) CREATE TEMPORARY SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+----
+Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.side_effects
@@ -1,24 +1,26 @@
 /* setup */
+SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true;
 ----
-
+...
 
 /* test */
-CREATE SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+CREATE TEMPORARY SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
 ----
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE SEQUENCE
 write *eventpb.CreateSequence to event log:
-  sequenceName: defaultdb.public.sq1
+  sequenceName: defaultdb.pg_temp_123_456.sq1
   sql:
-    descriptorId: 104
-    statement: CREATE SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
+    descriptorId: 105
+    statement: CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
     tag: CREATE SEQUENCE
     user: root
-## StatementPhase stage 1 of 1 with 24 MutationType ops
-initializing sequence 104 with starting value of 31
-add object namespace entry {100 101 sq1} -> 104
-upsert descriptor #104
+## StatementPhase stage 1 of 1 with 27 MutationType ops
+initializing sequence 105 with starting value of 31
+add schema namespace entry {100 0 pg_temp_123_456} -> 104
+add object namespace entry {100 104 sq1} -> 105
+upsert descriptor #105
   -
   +table:
   +  checks: []
@@ -31,7 +33,7 @@ upsert descriptor #104
   +      width: 64
   +  createAsOfTime: {}
   +  formatVersion: 3
-  +  id: 104
+  +  id: 105
   +  modificationTime: {}
   +  mutations: []
   +  name: sq1
@@ -77,17 +79,19 @@ upsert descriptor #104
   +    minValue: "1"
   +    sequenceOwner: {}
   +    start: "32"
-  +  unexposedParentSchemaId: 101
+  +  temporary: true
+  +  unexposedParentSchemaId: 104
   +  version: "1"
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 24 MutationType ops
-initializing sequence 104 with starting value of 31
-add object namespace entry {100 101 sq1} -> 104
-upsert descriptor #104
+## PreCommitPhase stage 2 of 2 with 27 MutationType ops
+initializing sequence 105 with starting value of 31
+add schema namespace entry {100 0 pg_temp_123_456} -> 104
+add object namespace entry {100 104 sq1} -> 105
+upsert descriptor #105
   -
   +table:
   +  checks: []
@@ -100,7 +104,7 @@ upsert descriptor #104
   +      width: 64
   +  createAsOfTime: {}
   +  formatVersion: 3
-  +  id: 104
+  +  id: 105
   +  modificationTime: {}
   +  mutations: []
   +  name: sq1
@@ -146,7 +150,8 @@ upsert descriptor #104
   +    minValue: "1"
   +    sequenceOwner: {}
   +    start: "32"
-  +  unexposedParentSchemaId: 101
+  +  temporary: true
+  +  unexposedParentSchemaId: 104
   +  version: "1"
 persist all catalog changes to storage
 # end PreCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.side_effects
@@ -61,8 +61,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "3"
-  +  version: "4"
+  -  version: "2"
+  +  version: "3"
 upsert descriptor #104
   ...
        - 1
@@ -165,8 +165,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "3"
-  +  version: "4"
+  -  version: "2"
+  +  version: "3"
 upsert descriptor #104
   ...
      createAsOfTime:

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -442,9 +442,15 @@ type Planner interface {
 	// and a job that owns it.
 	StartHistoryRetentionJob(ctx context.Context, desc string, protectTS hlc.Timestamp, expiration time.Duration) (jobspb.JobID, error)
 
-	// ExtendHistoryRetentionJob extends the lifetime of a a cluster-level
+	// ExtendHistoryRetention extends the lifetime of a a cluster-level
 	// protected timestamp.
 	ExtendHistoryRetention(ctx context.Context, id jobspb.JobID) error
+
+	// InsertTemporarySchema inserts a temporary schema into the current session
+	// data.
+	InsertTemporarySchema(
+		tempSchemaName string, databaseID descpb.ID, schemaID descpb.ID,
+	)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal


### PR DESCRIPTION
Previously, the declarative schema changer did not handle creating temporary sequences because it had no way of creating temporary schemas or resolving them. To address this, this patch adds support for creating temporary sequences and resolving / creating temporary sequences.

Fixes: #121377

Release note: None