### PR TITLE
plpgsql: improve error message for %TYPE and %ROWTYPE syntax

### DIFF
--- a/pkg/sql/plpgsql/parser/BUILD.bazel
+++ b/pkg/sql/plpgsql/parser/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",  # keep
         "//pkg/sql/parser",
         "//pkg/sql/parser/statements",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -255,6 +255,9 @@ DETAIL: source SQL:
 DECLARE
   var1 xy%ROWTYPE;
           ^
+HINT: you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
+--
+See: https://go.crdb.dev/issue-v/114676/
 
 error
 DECLARE
@@ -269,3 +272,6 @@ DECLARE
   var1 INT;
   var2 var1%TYPE;
             ^
+HINT: you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
+--
+See: https://go.crdb.dev/issue-v/114676/


### PR DESCRIPTION
Postgres allows using `%TYPE` and `%ROWTYPE` syntax to refer to the type of a table or variable when declaring a PL/pgSQL variable. This is currently unsupported in CRDB. This commit augments the error message when a user attempts to use this syntax with a pointer to the tracking issue.

Informs #114676

Release note: None