### PR TITLE
kvstreamer: speed up TestStreamerVaryingResponseSizes

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/rowcontainer",
+        "//pkg/sql/sem/eval",
         "//pkg/storage",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",


### PR DESCRIPTION
We just saw a test timeout due to BatchBytesLimit randomization, so this commit disables batch randomizations for `TestStreamerVaryingResponseSizes`.

Fixes: #123007.

Release note: None