### PR TITLE
release-24.1: roachtest: VM hostError should be flagged as an infra flake

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/cmd/roachtest/tests",
         "//pkg/internal/team",
         "//pkg/roachprod",
+        "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
         "//pkg/roachprod/install",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -3010,6 +3011,32 @@ func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSp
 	return arch
 }
 
+// bucketVMsByProvider buckets cachedCluster.VMs by provider.
+func bucketVMsByProvider(cachedCluster *cloud.Cluster) map[string][]vm.VM {
+	providerToVMs := make(map[string][]vm.VM)
+	for _, vm := range cachedCluster.VMs {
+		providerToVMs[vm.Provider] = append(providerToVMs[vm.Provider], vm)
+	}
+	return providerToVMs
+}
+
+// getCachedCluster checks if the passed cluster name is present in cached clusters
+// and returns an error if not found.
+func getCachedCluster(clusterName string) (*cloud.Cluster, error) {
+	cachedCluster, ok := roachprod.CachedCluster(clusterName)
+	if !ok {
+		var availableClusters []string
+		roachprod.CachedClusters(func(name string, _ int) {
+			availableClusters = append(availableClusters, name)
+		})
+
+		err := errors.Wrapf(errClusterNotFound, "%q", clusterName)
+		return nil, errors.WithHintf(err, "\nAvailable clusters:\n%s", strings.Join(availableClusters, "\n"))
+	}
+
+	return cachedCluster, nil
+}
+
 // GetPreemptedVMs gets any VMs that were part of the cluster but preempted by cloud vendor.
 func (c *clusterImpl) GetPreemptedVMs(
 	ctx context.Context, l *logger.Logger,
@@ -3018,22 +3045,11 @@ func (c *clusterImpl) GetPreemptedVMs(
 		return nil, nil
 	}
 
-	cachedCluster, ok := roachprod.CachedCluster(c.name)
-	if !ok {
-		var availableClusters []string
-		roachprod.CachedClusters(func(name string, _ int) {
-			availableClusters = append(availableClusters, name)
-		})
-
-		err := errors.Wrapf(errClusterNotFound, "%q", c.name)
-		return nil, errors.WithHintf(err, "\nAvailable clusters:\n%s", strings.Join(availableClusters, "\n"))
+	cachedCluster, err := getCachedCluster(c.name)
+	if err != nil {
+		return nil, err
 	}
-
-	// Bucket cachedCluster.VMs by provider.
-	providerToVMs := make(map[string][]vm.VM)
-	for _, vm := range cachedCluster.VMs {
-		providerToVMs[vm.Provider] = append(providerToVMs[vm.Provider], vm)
-	}
+	providerToVMs := bucketVMsByProvider(cachedCluster)
 
 	var allPreemptedVMs []vm.PreemptedVM
 	for provider, vms := range providerToVMs {
@@ -3048,4 +3064,29 @@ func (c *clusterImpl) GetPreemptedVMs(
 		}
 	}
 	return allPreemptedVMs, nil
+}
+
+// GetHostErrorVMs gets any VMs that were part of the cluster but has a host error.
+func (c *clusterImpl) GetHostErrorVMs(ctx context.Context, l *logger.Logger) ([]string, error) {
+	if c.IsLocal() {
+		return nil, nil
+	}
+
+	cachedCluster, err := getCachedCluster(c.name)
+	if err != nil {
+		return nil, err
+	}
+	providerToVMs := bucketVMsByProvider(cachedCluster)
+
+	var allHostErrorVMs []string
+	for provider, vms := range providerToVMs {
+		p := vm.Providers[provider]
+		hostErrorVMS, err := p.GetHostErrorVMs(l, vms, cachedCluster.CreatedAt)
+		if err != nil {
+			l.Errorf("failed to get hostError VMs for provider %s: %s", provider, err)
+			continue
+		}
+		allHostErrorVMs = append(allHostErrorVMs, hostErrorVMS...)
+	}
+	return allHostErrorVMs, nil
 }

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -348,6 +348,30 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
+		// 13. Verify hostError failure are routed to test-eng and marked as infra-flake, when the
+		// first failure is a non-handled error.
+		{
+			nonReleaseBlocker:     true,
+			failures:              []failure{createFailure(errors.New("random")), createFailure(vmHostError("my_VM"))},
+			expectedPost:          true,
+			expectedTeam:          "@cockroachdb/test-eng",
+			expectedName:          "vm_host_error",
+			expectedMessagePrefix: testName + " failed",
+			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
+		},
+		// 14. Verify hostError failure are routed to test-eng and marked as infra-flake, when the only error is
+		// hostError failure
+		{
+			nonReleaseBlocker: true,
+			failures: []failure{
+				{errors: []error{vmHostError("my_VM")}},
+			},
+			expectedPost:          true,
+			expectedTeam:          "@cockroachdb/test-eng",
+			expectedName:          "vm_host_error",
+			expectedMessagePrefix: testName + " failed",
+			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
+		},
 	}
 
 	reg := makeTestRegistry()

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1287,7 +1287,7 @@ func getPreemptedVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) 
 		return ""
 	}
 
-	preemptedVMNames := make([]string, len(preemptedVMs))
+	var preemptedVMNames []string
 	for _, preemptedVM := range preemptedVMs {
 		preemptedVMNames = append(preemptedVMNames, preemptedVM.Name)
 	}

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_13.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_13.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_14.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_14.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -272,6 +272,12 @@ func (p *Provider) GetPreemptedSpotVMs(
 	return nil, nil
 }
 
+func (p *Provider) GetHostErrorVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]string, error) {
+	return nil, nil
+}
+
 const (
 	defaultSSDMachineType = "m6id.xlarge"
 	defaultMachineType    = "m6i.xlarge"

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -106,6 +106,12 @@ func (p *Provider) GetPreemptedSpotVMs(
 	return nil, nil
 }
 
+func (p *Provider) GetHostErrorVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]string, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -42,6 +42,12 @@ func (p *provider) GetPreemptedSpotVMs(
 	return nil, nil
 }
 
+func (p *provider) GetHostErrorVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]string, error) {
+	return nil, nil
+}
+
 func (p *provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -359,7 +359,6 @@ func (p *Provider) GetPreemptedSpotVMs(
 		l.Printf("Error building gcloud cli command: %v\n", err)
 		return nil, err
 	}
-	l.Printf("gcloud cli for preemption : " + strings.Join(append([]string{"gcloud"}, args...), " "))
 	var logEntries []LogEntry
 	if err := runJSONCommand(args, &logEntries); err != nil {
 		l.Printf("Error running gcloud cli command: %v\n", err)
@@ -388,7 +387,6 @@ func (p *Provider) GetHostErrorVMs(
 		l.Printf("Error building gcloud cli command: %v\n", err)
 		return nil, err
 	}
-	l.Printf("gcloud cli for host error : " + strings.Join(append([]string{"gcloud"}, args...), " "))
 	var logEntries []LogEntry
 	if err := runJSONCommand(args, &logEntries); err != nil {
 		l.Printf("Error running gcloud cli command: %v\n", err)

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -135,6 +135,12 @@ func (p *Provider) GetPreemptedSpotVMs(
 	return nil, nil
 }
 
+func (p *Provider) GetHostErrorVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]string, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -495,6 +495,8 @@ type Provider interface {
 	// GetPreemptedSpotVMs returns a list of Spot VMs that were preempted since the time specified.
 	// Returns nil, nil when SupportsSpotVMs() is false.
 	GetPreemptedSpotVMs(l *logger.Logger, vms List, since time.Time) ([]PreemptedVM, error)
+	// GetHostErrorVMs returns a list of Spot VMs that had host error since the time specified.
+	GetHostErrorVMs(l *logger.Logger, vms List, since time.Time) ([]string, error)
 
 	// CreateLoadBalancer creates a load balancer, for a specific port, that
 	// delegates to the given cluster.


### PR DESCRIPTION
Backport 2/2 commits from #122281.

/cc @cockroachdb/release

---

Previously, we were seeing roachtest failures due to `compute.instances.hostError`. These were being wrongly directed to different engineering teams while in reality the VM hostError is an infra flake.

This PR flags the `compute.instances.hostError` as an infra flake and avoids the unnecessary noise.

Epic: none
Fixes: #101223
Release note: None

---

Release justification: This backport ensures that we label VM host errors as an infra flake
