### PR TITLE
roachprod: add discard to Local SSD mount options

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1244,8 +1244,11 @@ func (p *Provider) computeInstanceArgs(
 		for i := 0; i < providerOpts.SSDCount; i++ {
 			args = append(args, "--local-ssd", "interface=NVME")
 		}
+		// Add `discard` for Local SSDs on NVMe, as is advised in:
+		// https://cloud.google.com/compute/docs/disks/add-local-ssd
+		extraMountOpts = "discard"
 		if opts.SSDOpts.NoExt4Barrier {
-			extraMountOpts = "nobarrier"
+			extraMountOpts = fmt.Sprintf("%s,nobarrier", extraMountOpts)
 		}
 	} else {
 		pdProps := []string{


### PR DESCRIPTION
Although it seems like no official GCE documentation recommends this, it is implied by the commands from https://cloud.google.com/compute/docs/disks/add-local-ssd

Epic: None
Release Note: None