### PR TITLE
fs,engineccl: allow reads to continue when writes are stalled

### DIFF
--- a/pkg/ccl/storageccl/engineccl/ctr_stream.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream.go
@@ -44,7 +44,7 @@ const (
 func (c *FileCipherStreamCreator) CreateNew(
 	ctx context.Context,
 ) (*enginepbccl.EncryptionSettings, FileStream, error) {
-	key, err := c.keyManager.ActiveKey(ctx)
+	key, err := c.keyManager.ActiveKeyForWriter(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
@@ -242,10 +242,21 @@ type testKeyManager struct {
 	activeID string
 }
 
-func (m *testKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
+var _ PebbleKeyManager = &testKeyManager{}
+
+func (m *testKeyManager) ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error) {
 	key, _ := m.GetKey(m.activeID)
 	return key, nil
 }
+
+func (m *testKeyManager) ActiveKeyInfoForStats() *enginepbccl.KeyInfo {
+	key, _ := m.GetKey(m.activeID)
+	if key != nil {
+		return key.Info
+	}
+	return nil
+}
+
 func (m *testKeyManager) GetKey(id string) (*enginepbccl.SecretKey, error) {
 	key, found := m.keys[id]
 	if !found {

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -251,13 +251,8 @@ func (e *encryptionStatsHandler) GetEncryptionStatus() ([]byte, error) {
 	if e.storeKM.activeKey != nil {
 		s.ActiveStoreKey = e.storeKM.activeKey.Info
 	}
-	k, err := e.dataKM.ActiveKey(context.TODO())
-	if err != nil {
-		return nil, err
-	}
-	if k != nil {
-		s.ActiveDataKey = k.Info
-	}
+	ki := e.dataKM.ActiveKeyInfoForStats()
+	s.ActiveDataKey = ki
 	return protoutil.Marshal(&s)
 }
 
@@ -267,12 +262,9 @@ func (e *encryptionStatsHandler) GetDataKeysRegistry() ([]byte, error) {
 }
 
 func (e *encryptionStatsHandler) GetActiveDataKeyID() (string, error) {
-	k, err := e.dataKM.ActiveKey(context.TODO())
-	if err != nil {
-		return "", err
-	}
-	if k != nil {
-		return k.Info.KeyId, nil
+	ki := e.dataKM.ActiveKeyInfoForStats()
+	if ki != nil {
+		return ki.KeyId, nil
 	}
 	return "plain", nil
 }
@@ -348,7 +340,7 @@ func newEncryptedEnv(
 	}
 
 	if !readOnly {
-		key, err := storeKeyManager.ActiveKey(context.TODO())
+		key, err := storeKeyManager.ActiveKeyForWriter(context.TODO())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -60,9 +60,14 @@ const (
 // PebbleKeyManager manages encryption keys. There are two implementations. See encrypted_fs.go for
 // high-level context.
 type PebbleKeyManager interface {
-	// ActiveKey returns the currently active key. If plaintext should be used it can return nil or
-	// a key with encryption_type = Plaintext.
-	ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error)
+	// ActiveKeyForWriter returns the currently active key for a writer. If
+	// plaintext should be used it can return nil or a key with encryption_type
+	// = Plaintext.
+	ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error)
+
+	// ActiveKeyInfoForStats returns the currently active key info for stats. It
+	// returns nil for the same case(s) as documented in ActiveKeyForWriter.
+	ActiveKeyInfoForStats() *enginepbccl.KeyInfo
 
 	// GetKey gets the key for the given id. Returns an error if the key was not found.
 	GetKey(id string) (*enginepbccl.SecretKey, error)
@@ -102,9 +107,17 @@ func (m *StoreKeyManager) Load(ctx context.Context) error {
 	return nil
 }
 
-// ActiveKey implements PebbleKeyManager.ActiveKey.
-func (m *StoreKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
+// ActiveKeyForWriter implements PebbleKeyManager.
+func (m *StoreKeyManager) ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error) {
 	return m.activeKey, nil
+}
+
+// ActiveKeyInfoForStats implements PebbleKeyManager.
+func (m *StoreKeyManager) ActiveKeyInfoForStats() *enginepbccl.KeyInfo {
+	if m.activeKey != nil {
+		return m.activeKey.Info
+	}
+	return nil
 }
 
 // GetKey implements PebbleKeyManager.GetKey.
@@ -205,12 +218,25 @@ type DataKeyManager struct {
 
 	// Implementation.
 
-	mu struct {
+	writeMu struct {
 		syncutil.Mutex
-		// Non-nil after Load()
-		keyRegistry *enginepbccl.DataKeysRegistry
-		// rotationEnabled => non-nil
-		activeKey *enginepbccl.SecretKey
+		mu struct {
+			// Setters must hold both writeMu and writeMu.mu.
+			// Getters: Can hold either writeMu or writeMu.mu.
+			//
+			// writeMu > writeMu.mu, since setters hold the former when acquiring
+			// the latter. Setters should never hold the latter while doing IO. This
+			// would block getters, that are using mu, if the IO got stuck, say due
+			// to a disk stall -- we want getters (which may be doing read IO) to
+			// not get stuck due to setters being stuck, since the read IO may
+			// succeed due to the (page) cache.
+			syncutil.RWMutex
+			// Non-nil after Load(). The StoreKeys and DataKeys maps contain non-nil
+			// values.
+			keyRegistry *enginepbccl.DataKeysRegistry
+			// rotationEnabled => non-nil.
+			activeKey *enginepbccl.SecretKey
+		}
 		// Transitions to true when SetActiveStoreKeyInfo() is called for the
 		// first time.
 		rotationEnabled bool
@@ -233,9 +259,9 @@ func makeRegistryProto() *enginepbccl.DataKeysRegistry {
 
 // Close releases all of the manager's held resources.
 func (m *DataKeyManager) Close() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.mu.marker.Close()
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	return m.writeMu.marker.Close()
 }
 
 // Load must be called before calling other methods.
@@ -245,18 +271,21 @@ func (m *DataKeyManager) Load(ctx context.Context) error {
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.mu.marker = marker
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	m.writeMu.marker = marker
+	func() {
+		m.writeMu.mu.Lock()
+		defer m.writeMu.mu.Unlock()
+		m.writeMu.mu.keyRegistry = makeRegistryProto()
+	}()
 	if oserror.IsNotExist(err) {
 		// First run.
-		m.mu.keyRegistry = makeRegistryProto()
 		return nil
 	}
 
 	// Load the existing state from the file named by `filename`.
-	m.mu.filename = filename
-	m.mu.keyRegistry = makeRegistryProto()
+	m.writeMu.filename = filename
 	if filename != "" {
 		f, err := m.fs.Open(m.fs.PathJoin(m.dbDir, filename))
 		if err != nil {
@@ -267,54 +296,73 @@ func (m *DataKeyManager) Load(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err = protoutil.Unmarshal(b, m.mu.keyRegistry); err != nil {
+		func() {
+			m.writeMu.mu.Lock()
+			defer m.writeMu.mu.Unlock()
+			err = protoutil.Unmarshal(b, m.writeMu.mu.keyRegistry)
+		}()
+		if err != nil {
 			return err
 		}
-		if err = validateRegistry(m.mu.keyRegistry); err != nil {
+		if err = validateRegistry(m.writeMu.mu.keyRegistry); err != nil {
 			return err
 		}
 	}
 	// Else there is no DataKeysRegistry file yet.
 
-	if m.mu.keyRegistry.ActiveDataKeyId != "" {
-		key, found := m.mu.keyRegistry.DataKeys[m.mu.keyRegistry.ActiveDataKeyId]
+	if m.writeMu.mu.keyRegistry.ActiveDataKeyId != "" {
+		key, found := m.writeMu.mu.keyRegistry.DataKeys[m.writeMu.mu.keyRegistry.ActiveDataKeyId]
 		if !found {
 			// This should have resulted in an error in validateRegistry()
 			panic("unexpected inconsistent DataKeysRegistry")
 		}
-		m.mu.activeKey = key
-		log.Infof(ctx, "loaded active data key: %s", m.mu.activeKey.Info.String())
+		func() {
+			m.writeMu.mu.Lock()
+			defer m.writeMu.mu.Unlock()
+			m.writeMu.mu.activeKey = key
+		}()
+		log.Infof(ctx, "loaded active data key: %s", m.writeMu.mu.activeKey.Info.String())
 	} else {
 		log.Infof(ctx, "no active data key yet")
 	}
 	return nil
 }
 
-// ActiveKey implements PebbleKeyManager.ActiveKey.
+// ActiveKeyForWriter implements PebbleKeyManager.
 //
 // TODO(sbhola): do rotation via a background activity instead of in this function so that we don't
 // slow down creation of files.
-func (m *DataKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.mu.rotationEnabled {
+func (m *DataKeyManager) ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error) {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	if m.writeMu.rotationEnabled {
 		now := kmTimeNow().Unix()
-		if now-m.mu.activeKey.Info.CreationTime > m.rotationPeriod {
+		if now-m.writeMu.mu.activeKey.Info.CreationTime > m.rotationPeriod {
 			keyRegistry := makeRegistryProto()
-			proto.Merge(keyRegistry, m.mu.keyRegistry)
+			proto.Merge(keyRegistry, m.writeMu.mu.keyRegistry)
 			if err := m.rotateDataKeyAndWrite(ctx, keyRegistry); err != nil {
 				return nil, err
 			}
 		}
 	}
-	return m.mu.activeKey, nil
+	return m.writeMu.mu.activeKey, nil
+}
+
+// ActiveKeyInfoForStats implements PebbleKeyManager.
+func (m *DataKeyManager) ActiveKeyInfoForStats() *enginepbccl.KeyInfo {
+	m.writeMu.mu.RLock()
+	defer m.writeMu.mu.RUnlock()
+	if m.writeMu.mu.activeKey != nil {
+		return m.writeMu.mu.activeKey.Info
+	}
+	return nil
 }
 
 // GetKey implements PebbleKeyManager.GetKey.
 func (m *DataKeyManager) GetKey(id string) (*enginepbccl.SecretKey, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	key, found := m.mu.keyRegistry.DataKeys[id]
+	m.writeMu.mu.RLock()
+	defer m.writeMu.mu.RUnlock()
+	key, found := m.writeMu.mu.keyRegistry.DataKeys[id]
 	if !found {
 		return nil, fmt.Errorf("key %s is not found", id)
 	}
@@ -335,19 +383,20 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 	if m.readOnly {
 		return errors.New("read only")
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	// Enable data key rotation regardless of what case we go into.
-	m.mu.rotationEnabled = true
-	prevActiveStoreKey, found := m.mu.keyRegistry.StoreKeys[m.mu.keyRegistry.ActiveStoreKeyId]
-	if found && prevActiveStoreKey.KeyId == storeKeyInfo.KeyId && m.mu.activeKey != nil {
+	m.writeMu.rotationEnabled = true
+	prevActiveStoreKey, found :=
+		m.writeMu.mu.keyRegistry.StoreKeys[m.writeMu.mu.keyRegistry.ActiveStoreKeyId]
+	if found && prevActiveStoreKey.KeyId == storeKeyInfo.KeyId && m.writeMu.mu.activeKey != nil {
 		// The active store key has not changed and we already have an active data key,
 		// so no need to do anything.
 		return nil
 	}
 	// For keys other than plaintext, make sure the user is not reusing inactive keys.
 	if storeKeyInfo.EncryptionType != enginepbccl.EncryptionType_Plaintext {
-		if _, found := m.mu.keyRegistry.StoreKeys[storeKeyInfo.KeyId]; found {
+		if _, found := m.writeMu.mu.keyRegistry.StoreKeys[storeKeyInfo.KeyId]; found {
 			return fmt.Errorf("new active store key ID %s already exists as an inactive key -- this"+
 				"is really dangerous", storeKeyInfo.KeyId)
 		}
@@ -355,7 +404,7 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 
 	// The keyRegistry proto that will replace the current one.
 	keyRegistry := makeRegistryProto()
-	proto.Merge(keyRegistry, m.mu.keyRegistry)
+	proto.Merge(keyRegistry, m.writeMu.mu.keyRegistry)
 	keyRegistry.StoreKeys[storeKeyInfo.KeyId] = storeKeyInfo
 	keyRegistry.ActiveStoreKeyId = storeKeyInfo.KeyId
 	if storeKeyInfo.EncryptionType == enginepbccl.EncryptionType_Plaintext {
@@ -367,27 +416,33 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 	if err := m.rotateDataKeyAndWrite(ctx, keyRegistry); err != nil {
 		return err
 	}
-	m.mu.rotationEnabled = true
+	m.writeMu.rotationEnabled = true
 	return nil
 }
 
+// For stats.
 func (m *DataKeyManager) getScrubbedRegistry() *enginepbccl.DataKeysRegistry {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.writeMu.mu.RLock()
+	defer m.writeMu.mu.RUnlock()
 	r := makeRegistryProto()
-	proto.Merge(r, m.mu.keyRegistry)
+	proto.Merge(r, m.writeMu.mu.keyRegistry)
 	for _, v := range r.DataKeys {
 		v.Key = nil
 	}
 	return r
 }
 
+// validateRegistry must not modify keyRegistry.
 func validateRegistry(keyRegistry *enginepbccl.DataKeysRegistry) error {
-	if keyRegistry.ActiveStoreKeyId != "" && keyRegistry.StoreKeys[keyRegistry.ActiveStoreKeyId] == nil {
-		return fmt.Errorf("active store key %s not found", keyRegistry.ActiveStoreKeyId)
+	if keyRegistry.ActiveStoreKeyId != "" {
+		if k, ok := keyRegistry.StoreKeys[keyRegistry.ActiveStoreKeyId]; !ok || k == nil {
+			return fmt.Errorf("active store key %s not found", keyRegistry.ActiveStoreKeyId)
+		}
 	}
-	if keyRegistry.ActiveDataKeyId != "" && keyRegistry.DataKeys[keyRegistry.ActiveDataKeyId] == nil {
-		return fmt.Errorf("active data key %s not found", keyRegistry.ActiveDataKeyId)
+	if keyRegistry.ActiveDataKeyId != "" {
+		if k, ok := keyRegistry.DataKeys[keyRegistry.ActiveDataKeyId]; !ok || k == nil {
+			return fmt.Errorf("active data key %s not found", keyRegistry.ActiveDataKeyId)
+		}
 	}
 	return nil
 }
@@ -447,7 +502,7 @@ func generateAndSetNewDataKey(
 	return key, nil
 }
 
-// REQUIRES: m.mu is held.
+// REQUIRES: m.writeMu is held.
 func (m *DataKeyManager) rotateDataKeyAndWrite(
 	ctx context.Context, keyRegistry *enginepbccl.DataKeysRegistry,
 ) (err error) {
@@ -455,7 +510,8 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 		if err != nil {
 			log.Infof(ctx, "error while attempting to rotate data key: %s", err)
 		} else {
-			log.Infof(ctx, "rotated to new active data key: %s", proto.CompactTextString(m.mu.activeKey.Info))
+			log.Infof(ctx, "rotated to new active data key: %s",
+				proto.CompactTextString(m.writeMu.mu.activeKey.Info))
 		}
 	}()
 
@@ -474,7 +530,8 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 	// Write the current registry state to a new file and sync it.
 	// The new file's filename incorporates the marker's iteration
 	// number to ensure we're not overwriting the existing registry.
-	filename := fmt.Sprintf("%s_%06d_%s", keyRegistryFilename, m.mu.marker.NextIter(), registryFormatMonolith)
+	filename := fmt.Sprintf(
+		"%s_%06d_%s", keyRegistryFilename, m.writeMu.marker.NextIter(), registryFormatMonolith)
 	f, err := m.fs.Create(m.fs.PathJoin(m.dbDir, filename), fs.EncryptionRegistryWriteCategory)
 	if err != nil {
 		return err
@@ -490,14 +547,18 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 	// the new file is active. This call to marker.Move will also sync
 	// the directory on behalf of both the marker and the registry
 	// itself.
-	if err := m.mu.marker.Move(filename); err != nil {
+	if err := m.writeMu.marker.Move(filename); err != nil {
 		return err
 	}
 
-	prevFilename := m.mu.filename
-	m.mu.filename = filename
-	m.mu.keyRegistry = keyRegistry
-	m.mu.activeKey = newKey
+	prevFilename := m.writeMu.filename
+	m.writeMu.filename = filename
+	func() {
+		m.writeMu.mu.Lock()
+		defer m.writeMu.mu.Unlock()
+		m.writeMu.mu.keyRegistry = keyRegistry
+		m.writeMu.mu.activeKey = newKey
+	}()
 
 	// Remove the previous data registry file.
 	if prevFilename != "" {

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "safewrite.go",
         "sticky_vfs.go",
         "temp_dir.go",
+        "test_utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/storage/fs",
     visibility = ["//visibility:public"],

--- a/pkg/storage/fs/test_utils.go
+++ b/pkg/storage/fs/test_utils.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fs
+
+import "github.com/cockroachdb/pebble/vfs"
+
+type BlockingWriteFSForTesting struct {
+	vfs.FS
+	block chan struct{}
+}
+
+type blockingFile struct {
+	vfs.File
+	fs *BlockingWriteFSForTesting
+}
+
+func (fs *BlockingWriteFSForTesting) Block() {
+	fs.block = make(chan struct{})
+}
+
+func (fs *BlockingWriteFSForTesting) WaitForBlockAndUnblock() {
+	fs.block <- struct{}{}
+	close(fs.block)
+}
+
+func (fs *BlockingWriteFSForTesting) Create(
+	name string, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
+	f, err := fs.FS.Create(name, category)
+	if err != nil {
+		return nil, err
+	}
+	return blockingFile{File: f, fs: fs}, nil
+}
+
+func (f blockingFile) Write(p []byte) (n int, err error) {
+	if f.fs.block != nil {
+		<-f.fs.block
+	}
+	return f.File.Write(p)
+}


### PR DESCRIPTION
Both fs.FileRegistry and engineccl.DataKeyManager held an internal mutex when updating their state, that included write IO to to update persistent state. This would block readers of the state, specifically file reads that need a file registry entry and data key for the file to successfully open and read a file.

Blocking these reads due to slow or stalled write IO is not desirable, since the read could succeed if the relevant data is in the page cache. Specifically, with the new WAL failover feature, we expect the store to keep functioning when disk writes are temporarily stalled, since the WAL can failover. This expectation is not met if essential reads block on non-essential writes that are stalled.

This PR changes the locking in the FileRegistry and DataKeyManager to prevent writes from interfering with concurrent reads.

Epic: none

Fixes: #98051
Fixes: #122364

Release note: None