### PR TITLE
roleoption: fix error message for SUBJECT option

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/subject
+++ b/pkg/ccl/logictestccl/testdata/logic_test/subject
@@ -1,7 +1,7 @@
 # LogicTest: !local-mixed-23.2
 # Tests for parsing/validation of the SUBJECT role option.
 
-statement error role "root" cannot have a SUBJECT
+statement error role "root" cannot have a SUBJECT\n.*use the --root-cert-distinguished-name CLI flag
 ALTER ROLE root SUBJECT 'O=US, CN=John Doe'
 
 statement error failed to parse distinguished name foo: DN ended with incomplete type, value pair

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -222,9 +222,11 @@ func MakeListFromKVOptions(
 					return err
 				}
 				if u.IsRootUser() {
-					return pgerror.Newf(pgcode.InvalidParameterValue, "role %q cannot have a SUBJECT", u,
+					return errors.WithDetailf(
+						pgerror.Newf(pgcode.InvalidParameterValue, "role %q cannot have a SUBJECT", u),
 						"use the --%s CLI flag to configure root",
-						cliflags.RootCertDistinguishedName.Name)
+						cliflags.RootCertDistinguishedName.Name,
+					)
 				}
 				if err := distinguishedname.ValidateDN(s); err != nil {
 					return pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)


### PR DESCRIPTION
The string formatting logic was incorrect before.

fixes https://github.com/cockroachdb/cockroach/issues/123062
Release note: None