### PR TITLE
release-23.2: *: remove all mentions of T-multitenant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -168,7 +168,7 @@
 /pkg/server/api_v2_auth*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/authentication*.go           @cockroachdb/prodsec     @cockroachdb/server-prs
 /pkg/server/auto_tls_init*go             @cockroachdb/prodsec     @cockroachdb/server-prs
-/pkg/server/autoconfig/                  @cockroachdb/jobs-prs    @cockroachdb/multi-tenant
+/pkg/server/autoconfig/                  @cockroachdb/jobs-prs
 /pkg/server/clock_monotonicity.go        @cockroachdb/kv-prs
 /pkg/server/combined_statement_stats*.go @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
 /pkg/server/critical_nodes*.go           @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
@@ -194,13 +194,13 @@
 /pkg/server/multi_store*                 @cockroachdb/kv-prs      @cockroachdb/storage
 /pkg/server/node*                        @cockroachdb/kv-prs      @cockroachdb/server-prs
 /pkg/server/node_http*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/pgurl/                       @cockroachdb/sql-foundations @cockroachdb/cli-prs
 /pkg/server/pagination*                  @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/problem_ranges*.go           @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
 /pkg/server/profiler/                    @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
 /pkg/server/purge_auth_*                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/server_controller_*.go       @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/server/server_controller_*.go       @cockroachdb/server-prs
 /pkg/server/server_controller_http.go    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/server_controller_sql.go     @cockroachdb/sql-foundations @cockroachdb/server-prs
 /pkg/server/server_http*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs
@@ -211,8 +211,8 @@
 /pkg/server/serverpb/authentication*     @cockroachdb/obs-inf-prs @cockroachdb/prodsec @cockroachdb/server-prs
 /pkg/server/serverpb/index_reco*         @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
 /pkg/server/serverrules/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/settings_cache*.go           @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/server/settingswatcher/             @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/server/settings_cache*.go           @cockroachdb/server-prs
+/pkg/server/settingswatcher/             @cockroachdb/server-prs
 /pkg/server/span_stats*.go               @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
 /pkg/server/sql_stats*.go                @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
 /pkg/server/statement*.go                @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
@@ -221,16 +221,16 @@
 /pkg/server/status/                      @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/sticky_vfs*                  @cockroachdb/storage
 /pkg/server/structlogging/               @cockroachdb/cluster-observability @cockroachdb/obs-inf-prs
-/pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs      @cockroachdb/multi-tenant
+/pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs
 /pkg/server/telemetry/                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/tenant*.go                   @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/server/tenantsettingswatcher/       @cockroachdb/multi-tenant
+/pkg/server/tenant*.go                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
+/pkg/server/tenantsettingswatcher/       @cockroachdb/server-prs
 /pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
 /pkg/server/tracedumper/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/user*.go                     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/version_cluster*.go          @cockroachdb/dev-inf
 
-/pkg/configprofiles/                     @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/configprofiles/                     @cockroachdb/server-prs
 
 
 /pkg/ccl/jobsccl/            @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
@@ -369,12 +369,12 @@
 #!/pkg/ccl/gssapiccl/        @cockroachdb/unowned
 /pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
 #!/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
-/pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/multi-tenant
+/pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/server-prs
 #!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/sql-foundations
-/pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
+/pkg/ccl/multitenantccl/     @cockroachdb/server-prs
 /pkg/ccl/multitenant/tenantcostclient/ @cockroachdb/sqlproxy-prs
 /pkg/ccl/multitenant/tenantcostserver/ @cockroachdb/sqlproxy-prs
 /pkg/ccl/oidcccl/            @cockroachdb/obs-inf-prs
@@ -384,10 +384,10 @@
 
 #!/pkg/ccl/serverccl/        @cockroachdb/unowned
 /pkg/ccl/serverccl/diagnosticsccl/ @cockroachdb/obs-inf-prs
-/pkg/ccl/serverccl/server_sql* @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/ccl/serverccl/server_controller* @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/ccl/serverccl/tenant_*  @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/ccl/serverccl/statusccl/ @cockroachdb/cluster-observability @cockroachdb/multi-tenant
+/pkg/ccl/serverccl/server_sql* @cockroachdb/server-prs
+/pkg/ccl/serverccl/server_controller* @cockroachdb/server-prs
+/pkg/ccl/serverccl/tenant_*  @cockroachdb/server-prs
+/pkg/ccl/serverccl/statusccl/ @cockroachdb/cluster-observability
 /pkg/ccl/serverccl/admin_*   @cockroachdb/cluster-observability
 /pkg/ccl/serverccl/api_*     @cockroachdb/cluster-observability
 /pkg/ccl/serverccl/chart_*   @cockroachdb/obs-inf-prs
@@ -493,7 +493,7 @@
 #!/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
 /pkg/upgrade/                @cockroachdb/release-eng
 /pkg/keyvisualizer/          @cockroachdb/cluster-observability
-/pkg/multitenant/            @cockroachdb/multi-tenant
+/pkg/multitenant/            @cockroachdb/server-prs
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/.gitattributes  @cockroachdb/dev-inf
 #!/pkg/roachpb/BUILD.bazel     @cockroachdb/kv-prs-noreview
@@ -512,7 +512,7 @@
 /pkg/roachprod/              @cockroachdb/test-eng
 /pkg/rpc/                    @cockroachdb/kv-prs
 /pkg/rpc/auth.go             @cockroachdb/kv-prs @cockroachdb/prodsec
-/pkg/rpc/auth_tenant.go      @cockroachdb/multi-tenant @cockroachdb/prodsec
+/pkg/rpc/auth_tenant.go      @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/scheduledjobs/          @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/security/               @cockroachdb/prodsec @cockroachdb/server-prs
 /pkg/security/clientsecopts/ @cockroachdb/sql-foundations @cockroachdb/prodsec

--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -35,11 +35,6 @@ jobs:
           labeled: T-jobs
       - uses: actions/add-to-project@v0.4.0
         with:
-          project-url: https://github.com/orgs/cockroachdb/projects/36
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          labeled: T-multitenant
-      - uses: actions/add-to-project@v0.4.0
-        with:
           project-url: https://github.com/orgs/cockroachdb/projects/45
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: T-sql-queries

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -98,10 +98,6 @@ cockroachdb/obs-inf-prs:
     cockroachdb/http-api-prs: other
   triage_column_id: 14196277
   label: T-observability-inf
-cockroachdb/multi-tenant:
-  # Multi-tenant team uses GH projects v2, which doesn't have a REST API, so no triage column ID
-  # see .github/workflows/add-issues-to-project.yml
-  label: T-multitenant
 cockroachdb/jobs:
   aliases:
     cockroachdb/jobs-prs: other

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -37,7 +37,6 @@ const (
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`
 	OwnerDevInf           Owner = `dev-inf`
-	OwnerMultiTenant      Owner = `multi-tenant`
 	OwnerClusterObs       Owner = `cluster-observability`
 )
 

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -48,12 +48,6 @@ func registerAcceptance(r registry.Registry) {
 			{name: "cluster-init", fn: runClusterInit},
 			{name: "rapid-restart", fn: runRapidRestart},
 		},
-		registry.OwnerMultiTenant: {
-			{
-				name: "multitenant",
-				fn:   runAcceptanceMultitenant,
-			},
-		},
 		registry.OwnerObsInf: {
 			{name: "status-server", fn: runStatusServer},
 		},
@@ -74,6 +68,10 @@ func registerAcceptance(r registry.Registry) {
 				name:     "c2c",
 				fn:       runAcceptanceClusterReplication,
 				numNodes: 3,
+			},
+			{
+				name: "multitenant",
+				fn:   runAcceptanceMultitenant,
 			},
 		},
 		registry.OwnerSQLFoundations: {

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -27,7 +27,7 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "multitenant/shared-process/basic",
-		Owner:            registry.OwnerMultiTenant,
+		Owner:            registry.OwnerDisasterRecovery,
 		Cluster:          r.MakeClusterSpec(crdbNodeCount + 1),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -36,7 +36,7 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 		Cluster:           r.MakeClusterSpec(2),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
-		Owner:             registry.OwnerMultiTenant,
+		Owner:             registry.OwnerDisasterRecovery,
 		NonReleaseBlocker: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantUpgrade(ctx, t, c, t.BuildVersion())


### PR DESCRIPTION
Backport 3/3 commits from #118603.

/cc @cockroachdb/release

---

**: remove all mentions of T-multitenant**

Release note: None

**roachtest: reassign ownership from MultiTenant to DisasterRecovery**

This commit reassigns ownership of the following roachtests:
- `acceptance/multitenant/`
- `multitenant/shared-process/basic`
- `multitenant-upgrade`

to Disaster Recovery team (which is temporary until the Shared Services team if staffed).

Release note: None

**CODEOWNERS: remove cockroachdb/multi-tenant**

This commit removes all mentions of cockroachdb/multi-tenant in favor of cockroachdb/server-prs.

Release note: None

Epic: None

Release justification: infra-only change.