### PR TITLE
release-23.1: *: remove all mentions of T-multitenant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,7 +138,7 @@
 /pkg/server/api_v2*.go                   @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/api_v2_auth*.go              @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/authentication*.go           @cockroachdb/server-prs  @cockroachdb/prodsec
-/pkg/server/autoconfig/                  @cockroachdb/jobs-prs    @cockroachdb/multi-tenant
+/pkg/server/autoconfig/                  @cockroachdb/jobs-prs
 /pkg/server/auto_tls_init*go             @cockroachdb/server-prs  @cockroachdb/prodsec
 /pkg/server/clock_monotonicity.go        @cockroachdb/kv-prs
 /pkg/server/combined_statement_stats*.go @cockroachdb/obs-prs @cockroachdb/obs-prs
@@ -152,7 +152,7 @@
 /pkg/server/init_handshake.go            @cockroachdb/server-prs  @cockroachdb/prodsec
 /pkg/server/loss_of_quorum*.go           @cockroachdb/kv-prs
 /pkg/server/node_http*.go                @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/node_tenant*go               @cockroachdb/obs-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/server/node_tenant*go               @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/node_tombstone*.go           @cockroachdb/kv-prs      @cockroachdb/server-prs
 /pkg/server/pgurl/                       @cockroachdb/sql-foundations @cockroachdb/cli-prs
 /pkg/server/server_http*.go              @cockroachdb/obs-prs @cockroachdb/server-prs
@@ -163,18 +163,18 @@
 /pkg/server/serverpb/authentication*     @cockroachdb/obs-prs @cockroachdb/prodsec @cockroachdb/server-prs
 /pkg/server/serverpb/index_reco*         @cockroachdb/obs-prs @cockroachdb/obs-prs
 /pkg/server/serverrules/                 @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/settingswatcher/             @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/server/settingswatcher/             @cockroachdb/server-prs
 /pkg/server/statements*.go               @cockroachdb/obs-prs @cockroachdb/obs-prs
 /pkg/server/status*go                    @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/status*go                    @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/status/                      @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs      @cockroachdb/multi-tenant
-/pkg/server/tenant*.go                   @cockroachdb/obs-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/server/tenantsettingswatcher/       @cockroachdb/multi-tenant
+/pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs
+/pkg/server/tenant*.go                   @cockroachdb/obs-prs @cockroachdb/server-prs
+/pkg/server/tenantsettingswatcher/       @cockroachdb/server-prs
 /pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
 /pkg/server/tracedumper/                 @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/user*.go                     @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/configprofiles/                     @cockroachdb/multi-tenant @cockroachdb/server-prs
+/pkg/configprofiles/                     @cockroachdb/server-prs
 
 
 /pkg/ccl/jobsccl/            @cockroachdb/jobs-prs
@@ -307,18 +307,18 @@
 #!/pkg/ccl/gssapiccl/        @cockroachdb/unowned
 /pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
 #!/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
-/pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/multi-tenant
+/pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/server-prs
 #!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/sql-foundations
-/pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
+/pkg/ccl/multitenantccl/     @cockroachdb/server-prs
 #!/pkg/ccl/oidcccl/          @cockroachdb/unowned
 /pkg/ccl/partitionccl/       @cockroachdb/sql-foundations
 /pkg/ccl/serverccl/          @cockroachdb/server-prs
-/pkg/ccl/serverccl/server_sql* @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/ccl/serverccl/tenant_*  @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/ccl/serverccl/statusccl @cockroachdb/obs-prs @cockroachdb/multi-tenant
+/pkg/ccl/serverccl/server_sql* @cockroachdb/server-prs
+/pkg/ccl/serverccl/tenant_*  @cockroachdb/server-prs
+/pkg/ccl/serverccl/statusccl @cockroachdb/obs-prs
 /pkg/ccl/telemetryccl/       @cockroachdb/obs-prs
 /pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries-prs
@@ -416,7 +416,7 @@
 #!/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
 /pkg/upgrade/                @cockroachdb/release-eng
 /pkg/keyvisualizer/          @cockroachdb/obs-prs
-/pkg/multitenant/            @cockroachdb/multi-tenant
+/pkg/multitenant/            @cockroachdb/server-prs
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/.gitattributes  @cockroachdb/dev-inf
 #!/pkg/roachpb/BUILD.bazel     @cockroachdb/kv-prs-noreview

--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -12,14 +12,6 @@ jobs:
       - uses: actions/add-to-project@v0.4.0
         with:
           # URL of the project to add issues to
-          project-url: https://github.com/orgs/cockroachdb/projects/36
-          # A GitHub personal access token with write access to the project
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          # A comma-separated list of labels to use as a filter for issue to be added
-          labeled: T-multitenant
-      - uses: actions/add-to-project@v0.4.0
-        with:
-          # URL of the project to add issues to
           project-url: https://github.com/orgs/cockroachdb/projects/38
           # A GitHub personal access token with write access to the project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -81,8 +81,6 @@ cockroachdb/server:
 cockroachdb/obs-prs:
   # The observability team uses Jira for managing issues. So there is no triage column ID.
   label: T-observability
-cockroachdb/multi-tenant:
-  label: T-multitenant
 cockroachdb/jobs:
   aliases:
     cockroachdb/jobs-prs: other

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -37,7 +37,6 @@ const (
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`
 	OwnerDevInf           Owner = `dev-inf`
-	OwnerMultiTenant      Owner = `multi-tenant`
 )
 
 // IsValid returns true if the owner is valid, i.e. it has a corresponding team

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -49,12 +49,6 @@ func registerAcceptance(r registry.Registry) {
 			{name: "cluster-init", fn: runClusterInit},
 			{name: "rapid-restart", fn: runRapidRestart},
 		},
-		registry.OwnerMultiTenant: {
-			{
-				name: "multitenant",
-				fn:   runAcceptanceMultitenant,
-			},
-		},
 		registry.OwnerObservability: {
 			{name: "status-server", fn: runStatusServer},
 		},
@@ -75,6 +69,10 @@ func registerAcceptance(r registry.Registry) {
 				name:     "c2c",
 				fn:       runAcceptanceClusterReplication,
 				numNodes: 3,
+			},
+			{
+				name: "multitenant",
+				fn:   runAcceptanceMultitenant,
 			},
 		},
 		registry.OwnerSQLFoundations: {

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -28,7 +28,7 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "multitenant/shared-process/basic",
-		Owner:            registry.OwnerMultiTenant,
+		Owner:            registry.OwnerDisasterRecovery,
 		Cluster:          r.MakeClusterSpec(crdbNodeCount + 1),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -35,7 +35,7 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 		Cluster:           r.MakeClusterSpec(2),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
-		Owner:             registry.OwnerMultiTenant,
+		Owner:             registry.OwnerDisasterRecovery,
 		NonReleaseBlocker: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantUpgrade(ctx, t, c, t.BuildVersion())

--- a/pkg/cmd/roachtest/tests/smoketest_secure.go
+++ b/pkg/cmd/roachtest/tests/smoketest_secure.go
@@ -45,7 +45,7 @@ func registerSecure(r registry.Registry) {
 	}
 	r.Add(registry.TestSpec{
 		Name:             "smoketest/secure/multitenant",
-		Owner:            registry.OwnerMultiTenant,
+		Owner:            registry.OwnerDisasterRecovery,
 		Cluster:          r.MakeClusterSpec(2),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
Backport 3/3 commits from #118603.

/cc @cockroachdb/release

---

**: remove all mentions of T-multitenant**

Release note: None

**roachtest: reassign ownership from MultiTenant to DisasterRecovery**

This commit reassigns ownership of the following roachtests:
- `acceptance/multitenant/`
- `multitenant/shared-process/basic`
- `multitenant-upgrade`

to Disaster Recovery team (which is temporary until the Shared Services team if staffed).

Release note: None

**CODEOWNERS: remove cockroachdb/multi-tenant**

This commit removes all mentions of cockroachdb/multi-tenant in favor of cockroachdb/server-prs.

Release note: None

Epic: None

Release justification: infra-only change.