### PR TITLE
server: clarify info message on server controller close

### DIFF
--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -410,9 +410,7 @@ func (c *serverController) newServerForOrchestrator(
 // Close implements the stop.Closer interface.
 func (c *serverController) Close() {
 	ctx := c.AnnotateCtx(context.Background())
-	log.Infof(ctx, "server controller shutting down ungracefully")
-	// Note Close() is only called in the case of expedited shutdown.
-	// It should not invoke the graceful drain process.
+	log.Infof(ctx, "server controller shutting down")
 	entries := c.getAllEntries()
 	// Request immediate shutdown. This is probably not needed; the
 	// server should already be sensitive to the parent stopper


### PR DESCRIPTION
`serverController.Close` is added into the `parentStopper`, so it's always invoked on the server shutdown. Previously, we would log an info message about "ungraceful" shutdown even though it might have been graceful actually, so this patch clarifies the message to remove possible confusion.

See https://cockroachlabs.slack.com/archives/CHVV403F0/p1713973519952929 for an example of the confusion.

Epic: None

Release note: None