### PR TITLE
interval: fix BenchmarkBTreeIterPrev

### DIFF
--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
@@ -1063,7 +1063,7 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.Valid() {
-			it.First()
+			it.Last()
 		}
 		it.Prev()
 	}

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -1063,7 +1063,7 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.Valid() {
-			it.First()
+			it.Last()
 		}
 		it.Prev()
 	}

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
@@ -1063,7 +1063,7 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.Valid() {
-			it.First()
+			it.Last()
 		}
 		it.Prev()
 	}

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -1063,7 +1063,7 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.Valid() {
-			it.First()
+			it.Last()
 		}
 		it.Prev()
 	}

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -1064,7 +1064,7 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.Valid() {
-			it.First()
+			it.Last()
 		}
 		it.Prev()
 	}

--- a/pkg/util/span/btreefrontierentry_interval_btree_test.go
+++ b/pkg/util/span/btreefrontierentry_interval_btree_test.go
@@ -1063,7 +1063,7 @@ func BenchmarkBTreeIterPrev(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !it.Valid() {
-			it.First()
+			it.Last()
 		}
 		it.Prev()
 	}


### PR DESCRIPTION
Informs #122530.

This benchmark was starting the backwards iteration from the front of the tree, not the rear, so it was calling `First` on every iteration.

```
name              old time/op  new time/op  delta
BTreeIterPrev-10  12.2ns ± 1%   2.3ns ± 3%  -81.25%  (p=0.000 n=10+9)
```

Release note: None