### PR TITLE
roachprod: implement azure addLabels and removeLabels

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1433,9 +1433,27 @@ func AddLabels(l *logger.Logger, clusterName string, labels map[string]string) e
 		return err
 	}
 
-	return vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
+	err = vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
 		return p.AddLabels(l, vms, labels)
 	})
+	if err != nil {
+		return err
+	}
+
+	// Adding labels is not supported for local clusters, we don't
+	// need to update the local cluster cache.
+	if config.IsLocalClusterName(clusterName) {
+		return nil
+	}
+
+	// Update the tags in the local cluster cache.
+	for _, m := range c.Cluster.VMs {
+		for k, v := range labels {
+			m.Labels[k] = v
+		}
+	}
+
+	return saveCluster(l, &c.Cluster)
 }
 
 func RemoveLabels(l *logger.Logger, clusterName string, labels []string) error {
@@ -1447,9 +1465,20 @@ func RemoveLabels(l *logger.Logger, clusterName string, labels []string) error {
 		return err
 	}
 
-	return vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
+	err = vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
 		return p.RemoveLabels(l, vms, labels)
 	})
+	if err != nil {
+		return err
+	}
+
+	// Update the tags in the local cluster cache.
+	for _, m := range c.Cluster.VMs {
+		for _, label := range labels {
+			delete(m.Labels, label)
+		}
+	}
+	return saveCluster(l, &c.Cluster)
 }
 
 // Create TODO

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -153,7 +153,7 @@ func (jsonVM *jsonVM) toVM(
 
 	// Check "lifetime" label.
 	var lifetime time.Duration
-	if lifetimeStr, ok := jsonVM.Labels["lifetime"]; ok {
+	if lifetimeStr, ok := jsonVM.Labels[vm.TagLifetime]; ok {
 		if lifetime, err = time.ParseDuration(lifetimeStr); err != nil {
 			vmErrors = append(vmErrors, vm.ErrNoExpiration)
 		}
@@ -2300,7 +2300,7 @@ func (p *Provider) Reset(l *logger.Logger, vms vm.List) error {
 // Extend TODO(peter): document
 func (p *Provider) Extend(l *logger.Logger, vms vm.List, lifetime time.Duration) error {
 	return p.AddLabels(l, vms, map[string]string{
-		"lifetime": lifetime.String(),
+		vm.TagLifetime: lifetime.String(),
 	})
 }
 


### PR DESCRIPTION
These were previously noops, which prevented adding the test_run_id and test_name as tags.

Release note: none
Epic: none
Fixes: #111885

----------

This doesn't do anything for us yet as we don't have prom set up for azure, but seemed like a quick win to slightly reduce some of the log spam in the test runner.

Roachprod now also starts updating the local cluster cache with labels when added/removed. This is because the Azure API doesn't support adding/removing individual tags like GCE does, you can only redeclare all the tags a VM should have 😢. So we have to keep track of old tags.