### PR TITLE
sql: link to issue for DDL inside of routines

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -92,13 +92,13 @@ subtest end
 subtest ddl
 
 # DDL is not currently supported in UDF bodies.
-statement error pgcode 0A000 unimplemented: CREATE TABLE usage inside a function definition
+statement error pgcode 0A000 unimplemented: CREATE TABLE usage inside a function definition.*\n.*\n.*issue-v/110080
 CREATE FUNCTION err() RETURNS VOID LANGUAGE SQL AS 'CREATE TABLE t (a INT)'
 
-statement error pgcode 0A000 unimplemented: ALTER TABLE usage inside a function definition
+statement error pgcode 0A000 unimplemented: ALTER TABLE usage inside a function definition.*\n.*\n.*issue-v/110080
 CREATE FUNCTION err() RETURNS VOID LANGUAGE SQL AS 'ALTER TABLE t ADD COLUMN b BOOL'
 
-statement error pgcode 0A000 unimplemented: DROP TABLE usage inside a function definition
+statement error pgcode 0A000 unimplemented: DROP TABLE usage inside a function definition.*\n.*\n.*issue-v/110080
 CREATE FUNCTION err() RETURNS VOID LANGUAGE SQL AS 'DROP TABLE t'
 
 subtest end

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -369,6 +369,11 @@ func (b *Builder) buildStmt(
 				panic(doBlockVersionErr)
 			}
 		default:
+			if tree.CanModifySchema(stmt) {
+				panic(unimplemented.NewWithIssuef(110080,
+					"%s usage inside a function definition is not supported", stmt.StatementTag(),
+				))
+			}
 			panic(unimplemented.Newf("user-defined functions", "%s usage inside a function definition", stmt.StatementTag()))
 		}
 	}


### PR DESCRIPTION
This commit adds an issue link to the "unsupported" error message when a user attempts to use a DDL statement from within a routine.

Informs #110080

Release note: None