### PR TITLE
release-23.2: sql: add cluster setting to change session defaults for IE

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -873,6 +873,27 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	// Add any new overrides above the MultiOverride.
 }
 
+var ieMultiOverride = settings.RegisterStringSetting(
+	settings.ApplicationLevel,
+	"sql.internal_executor.session_overrides",
+	"comma-separated list of 'variable=value' pairs that change the corresponding "+
+		"session variables used by the InternalExecutor (performed on a best-effort basis)",
+	"",
+	settings.WithValidateString(func(_ *settings.Values, val string) error {
+		if val == "" {
+			return nil
+		}
+		overrides := strings.Split(val, ",")
+		for _, override := range overrides {
+			parts := strings.Split(override, "=")
+			if len(parts) != 2 {
+				return errors.Newf("invalid override format: expected 'variable=value', found %q", override)
+			}
+		}
+		return nil
+	}),
+)
+
 func (ie *InternalExecutor) maybeRootSessionDataOverride(
 	opName string,
 ) sessiondata.InternalExecutorOverride {
@@ -1021,6 +1042,16 @@ func (ie *InternalExecutor) execInternal(
 		sd = ie.sessionDataStack.Top().Clone()
 	} else {
 		sd = NewInternalSessionData(context.Background(), ie.s.cfg.Settings, "" /* opName */)
+	}
+	if globalOverride := ieMultiOverride.Get(&ie.s.cfg.Settings.SV); globalOverride != "" {
+		globalOverride = strings.TrimSpace(globalOverride)
+		// Prepend the "global" setting overrides to ensure that caller's
+		// overrides take precedence.
+		if localOverride := sessionDataOverride.MultiOverride; localOverride != "" {
+			sessionDataOverride.MultiOverride = globalOverride + "," + localOverride
+		} else {
+			sessionDataOverride.MultiOverride = globalOverride
+		}
 	}
 
 	applyInternalExecutorSessionExceptions(sd)

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -48,6 +48,24 @@ vectorized: false
   table: t@t_pkey
   spans: FULL SCAN
 
+# Same query as above, but with overrides provided via the cluster setting.
+statement ok
+SET CLUSTER SETTING sql.internal_executor.session_overrides = 'Database=test,VectorizeMode=off';
+
+query T rowsort
+SELECT crdb_internal.execute_internally('EXPLAIN SELECT k FROM t;');
+----
+distribution: local
+vectorized: false
+·
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: FULL SCAN
+
+statement ok
+RESET CLUSTER SETTING sql.internal_executor.session_overrides;
+
 # optimizer_use_histograms is the only variable that differs from the default
 # right now (except when the internal executor is session-bound, #102954).
 query T
@@ -70,6 +88,32 @@ query T
 SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', true, 'OptimizerUseHistograms=false');
 ----
 off
+
+# Also try override via the cluster setting.
+statement ok
+SET CLUSTER SETTING sql.internal_executor.session_overrides = 'OptimizerUseHistograms=true';
+
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', false);
+----
+on
+
+statement ok
+SET CLUSTER SETTING sql.internal_executor.session_overrides = 'OptimizerUseHistograms=false';
+
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', true);
+----
+off
+
+# Local override wins.
+query T
+SELECT crdb_internal.execute_internally('SHOW optimizer_use_histograms;', false, 'OptimizerUseHistograms=true');
+----
+on
+
+statement ok
+RESET CLUSTER SETTING sql.internal_executor.session_overrides;
 
 # Some sanity checks around error handling.
 statement error unknown signature


### PR DESCRIPTION
Backport 1/1 commits from #122855.

/cc @cockroachdb/release

---

This commit adds an undocumented cluster setting `sql.internal_executor.session_overrides` that allows specifying comma-separated list of 'variable=value' pairs that will override the corresponding session variables for all InternalExecutors. This can provide an escape hatch in case we find a bug that can be disabled via a session variable.

Fixes: #122542.

Release note: None

Release justification: low-risk improvement.