### PR TITLE
sql: remove stale distsql session var hints

### DIFF
--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -580,7 +580,7 @@ var varGen = map[string]sessionVar{
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
 			mode, ok := sessiondatapb.DistSQLExecModeFromString(s)
 			if !ok {
-				return newVarValueError(`distsql`, s, "on", "off", "auto", "always", "2.0-auto", "2.0-off")
+				return newVarValueError(`distsql`, s, "on", "off", "auto", "always")
 			}
 			m.SetDistSQLMode(mode)
 			return nil


### PR DESCRIPTION
`2.0-auto` and `2.0-off` were removed long time ago.

Epic: None

Release note: None