### PR TITLE
release-24.1: fs,engineccl: allow reads to continue when writes are stalled

### DIFF
--- a/pkg/ccl/storageccl/engineccl/ctr_stream.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream.go
@@ -44,7 +44,7 @@ const (
 func (c *FileCipherStreamCreator) CreateNew(
 	ctx context.Context,
 ) (*enginepbccl.EncryptionSettings, FileStream, error) {
-	key, err := c.keyManager.ActiveKey(ctx)
+	key, err := c.keyManager.ActiveKeyForWriter(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
@@ -242,10 +242,21 @@ type testKeyManager struct {
 	activeID string
 }
 
-func (m *testKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
+var _ PebbleKeyManager = &testKeyManager{}
+
+func (m *testKeyManager) ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error) {
 	key, _ := m.GetKey(m.activeID)
 	return key, nil
 }
+
+func (m *testKeyManager) ActiveKeyInfoForStats() *enginepbccl.KeyInfo {
+	key, _ := m.GetKey(m.activeID)
+	if key != nil {
+		return key.Info
+	}
+	return nil
+}
+
 func (m *testKeyManager) GetKey(id string) (*enginepbccl.SecretKey, error) {
 	key, found := m.keys[id]
 	if !found {

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -249,13 +249,8 @@ func (e *encryptionStatsHandler) GetEncryptionStatus() ([]byte, error) {
 	if e.storeKM.activeKey != nil {
 		s.ActiveStoreKey = e.storeKM.activeKey.Info
 	}
-	k, err := e.dataKM.ActiveKey(context.TODO())
-	if err != nil {
-		return nil, err
-	}
-	if k != nil {
-		s.ActiveDataKey = k.Info
-	}
+	ki := e.dataKM.ActiveKeyInfoForStats()
+	s.ActiveDataKey = ki
 	return protoutil.Marshal(&s)
 }
 
@@ -265,12 +260,9 @@ func (e *encryptionStatsHandler) GetDataKeysRegistry() ([]byte, error) {
 }
 
 func (e *encryptionStatsHandler) GetActiveDataKeyID() (string, error) {
-	k, err := e.dataKM.ActiveKey(context.TODO())
-	if err != nil {
-		return "", err
-	}
-	if k != nil {
-		return k.Info.KeyId, nil
+	ki := e.dataKM.ActiveKeyInfoForStats()
+	if ki != nil {
+		return ki.KeyId, nil
 	}
 	return "plain", nil
 }
@@ -346,7 +338,7 @@ func newEncryptedEnv(
 	}
 
 	if !readOnly {
-		key, err := storeKeyManager.ActiveKey(context.TODO())
+		key, err := storeKeyManager.ActiveKeyForWriter(context.TODO())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -59,9 +59,14 @@ const (
 // PebbleKeyManager manages encryption keys. There are two implementations. See encrypted_fs.go for
 // high-level context.
 type PebbleKeyManager interface {
-	// ActiveKey returns the currently active key. If plaintext should be used it can return nil or
-	// a key with encryption_type = Plaintext.
-	ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error)
+	// ActiveKeyForWriter returns the currently active key for a writer. If
+	// plaintext should be used it can return nil or a key with encryption_type
+	// = Plaintext.
+	ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error)
+
+	// ActiveKeyInfoForStats returns the currently active key info for stats. It
+	// returns nil for the same case(s) as documented in ActiveKeyForWriter.
+	ActiveKeyInfoForStats() *enginepbccl.KeyInfo
 
 	// GetKey gets the key for the given id. Returns an error if the key was not found.
 	GetKey(id string) (*enginepbccl.SecretKey, error)
@@ -101,9 +106,17 @@ func (m *StoreKeyManager) Load(ctx context.Context) error {
 	return nil
 }
 
-// ActiveKey implements PebbleKeyManager.ActiveKey.
-func (m *StoreKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
+// ActiveKeyForWriter implements PebbleKeyManager.
+func (m *StoreKeyManager) ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error) {
 	return m.activeKey, nil
+}
+
+// ActiveKeyInfoForStats implements PebbleKeyManager.
+func (m *StoreKeyManager) ActiveKeyInfoForStats() *enginepbccl.KeyInfo {
+	if m.activeKey != nil {
+		return m.activeKey.Info
+	}
+	return nil
 }
 
 // GetKey implements PebbleKeyManager.GetKey.
@@ -204,12 +217,25 @@ type DataKeyManager struct {
 
 	// Implementation.
 
-	mu struct {
+	writeMu struct {
 		syncutil.Mutex
-		// Non-nil after Load()
-		keyRegistry *enginepbccl.DataKeysRegistry
-		// rotationEnabled => non-nil
-		activeKey *enginepbccl.SecretKey
+		mu struct {
+			// Setters must hold both writeMu and writeMu.mu.
+			// Getters: Can hold either writeMu or writeMu.mu.
+			//
+			// writeMu > writeMu.mu, since setters hold the former when acquiring
+			// the latter. Setters should never hold the latter while doing IO. This
+			// would block getters, that are using mu, if the IO got stuck, say due
+			// to a disk stall -- we want getters (which may be doing read IO) to
+			// not get stuck due to setters being stuck, since the read IO may
+			// succeed due to the (page) cache.
+			syncutil.RWMutex
+			// Non-nil after Load(). The StoreKeys and DataKeys maps contain non-nil
+			// values.
+			keyRegistry *enginepbccl.DataKeysRegistry
+			// rotationEnabled => non-nil.
+			activeKey *enginepbccl.SecretKey
+		}
 		// Transitions to true when SetActiveStoreKeyInfo() is called for the
 		// first time.
 		rotationEnabled bool
@@ -232,9 +258,9 @@ func makeRegistryProto() *enginepbccl.DataKeysRegistry {
 
 // Close releases all of the manager's held resources.
 func (m *DataKeyManager) Close() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.mu.marker.Close()
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	return m.writeMu.marker.Close()
 }
 
 // Load must be called before calling other methods.
@@ -244,18 +270,21 @@ func (m *DataKeyManager) Load(ctx context.Context) error {
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.mu.marker = marker
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	m.writeMu.marker = marker
+	func() {
+		m.writeMu.mu.Lock()
+		defer m.writeMu.mu.Unlock()
+		m.writeMu.mu.keyRegistry = makeRegistryProto()
+	}()
 	if oserror.IsNotExist(err) {
 		// First run.
-		m.mu.keyRegistry = makeRegistryProto()
 		return nil
 	}
 
 	// Load the existing state from the file named by `filename`.
-	m.mu.filename = filename
-	m.mu.keyRegistry = makeRegistryProto()
+	m.writeMu.filename = filename
 	if filename != "" {
 		f, err := m.fs.Open(m.fs.PathJoin(m.dbDir, filename))
 		if err != nil {
@@ -266,54 +295,73 @@ func (m *DataKeyManager) Load(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err = protoutil.Unmarshal(b, m.mu.keyRegistry); err != nil {
+		func() {
+			m.writeMu.mu.Lock()
+			defer m.writeMu.mu.Unlock()
+			err = protoutil.Unmarshal(b, m.writeMu.mu.keyRegistry)
+		}()
+		if err != nil {
 			return err
 		}
-		if err = validateRegistry(m.mu.keyRegistry); err != nil {
+		if err = validateRegistry(m.writeMu.mu.keyRegistry); err != nil {
 			return err
 		}
 	}
 	// Else there is no DataKeysRegistry file yet.
 
-	if m.mu.keyRegistry.ActiveDataKeyId != "" {
-		key, found := m.mu.keyRegistry.DataKeys[m.mu.keyRegistry.ActiveDataKeyId]
+	if m.writeMu.mu.keyRegistry.ActiveDataKeyId != "" {
+		key, found := m.writeMu.mu.keyRegistry.DataKeys[m.writeMu.mu.keyRegistry.ActiveDataKeyId]
 		if !found {
 			// This should have resulted in an error in validateRegistry()
 			panic("unexpected inconsistent DataKeysRegistry")
 		}
-		m.mu.activeKey = key
-		log.Infof(ctx, "loaded active data key: %s", m.mu.activeKey.Info.String())
+		func() {
+			m.writeMu.mu.Lock()
+			defer m.writeMu.mu.Unlock()
+			m.writeMu.mu.activeKey = key
+		}()
+		log.Infof(ctx, "loaded active data key: %s", m.writeMu.mu.activeKey.Info.String())
 	} else {
 		log.Infof(ctx, "no active data key yet")
 	}
 	return nil
 }
 
-// ActiveKey implements PebbleKeyManager.ActiveKey.
+// ActiveKeyForWriter implements PebbleKeyManager.
 //
 // TODO(sbhola): do rotation via a background activity instead of in this function so that we don't
 // slow down creation of files.
-func (m *DataKeyManager) ActiveKey(ctx context.Context) (*enginepbccl.SecretKey, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.mu.rotationEnabled {
+func (m *DataKeyManager) ActiveKeyForWriter(ctx context.Context) (*enginepbccl.SecretKey, error) {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	if m.writeMu.rotationEnabled {
 		now := kmTimeNow().Unix()
-		if now-m.mu.activeKey.Info.CreationTime > m.rotationPeriod {
+		if now-m.writeMu.mu.activeKey.Info.CreationTime > m.rotationPeriod {
 			keyRegistry := makeRegistryProto()
-			proto.Merge(keyRegistry, m.mu.keyRegistry)
+			proto.Merge(keyRegistry, m.writeMu.mu.keyRegistry)
 			if err := m.rotateDataKeyAndWrite(ctx, keyRegistry); err != nil {
 				return nil, err
 			}
 		}
 	}
-	return m.mu.activeKey, nil
+	return m.writeMu.mu.activeKey, nil
+}
+
+// ActiveKeyInfoForStats implements PebbleKeyManager.
+func (m *DataKeyManager) ActiveKeyInfoForStats() *enginepbccl.KeyInfo {
+	m.writeMu.mu.RLock()
+	defer m.writeMu.mu.RUnlock()
+	if m.writeMu.mu.activeKey != nil {
+		return m.writeMu.mu.activeKey.Info
+	}
+	return nil
 }
 
 // GetKey implements PebbleKeyManager.GetKey.
 func (m *DataKeyManager) GetKey(id string) (*enginepbccl.SecretKey, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	key, found := m.mu.keyRegistry.DataKeys[id]
+	m.writeMu.mu.RLock()
+	defer m.writeMu.mu.RUnlock()
+	key, found := m.writeMu.mu.keyRegistry.DataKeys[id]
 	if !found {
 		return nil, fmt.Errorf("key %s is not found", id)
 	}
@@ -334,19 +382,20 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 	if m.readOnly {
 		return errors.New("read only")
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	// Enable data key rotation regardless of what case we go into.
-	m.mu.rotationEnabled = true
-	prevActiveStoreKey, found := m.mu.keyRegistry.StoreKeys[m.mu.keyRegistry.ActiveStoreKeyId]
-	if found && prevActiveStoreKey.KeyId == storeKeyInfo.KeyId && m.mu.activeKey != nil {
+	m.writeMu.rotationEnabled = true
+	prevActiveStoreKey, found :=
+		m.writeMu.mu.keyRegistry.StoreKeys[m.writeMu.mu.keyRegistry.ActiveStoreKeyId]
+	if found && prevActiveStoreKey.KeyId == storeKeyInfo.KeyId && m.writeMu.mu.activeKey != nil {
 		// The active store key has not changed and we already have an active data key,
 		// so no need to do anything.
 		return nil
 	}
 	// For keys other than plaintext, make sure the user is not reusing inactive keys.
 	if storeKeyInfo.EncryptionType != enginepbccl.EncryptionType_Plaintext {
-		if _, found := m.mu.keyRegistry.StoreKeys[storeKeyInfo.KeyId]; found {
+		if _, found := m.writeMu.mu.keyRegistry.StoreKeys[storeKeyInfo.KeyId]; found {
 			return fmt.Errorf("new active store key ID %s already exists as an inactive key -- this"+
 				"is really dangerous", storeKeyInfo.KeyId)
 		}
@@ -354,7 +403,7 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 
 	// The keyRegistry proto that will replace the current one.
 	keyRegistry := makeRegistryProto()
-	proto.Merge(keyRegistry, m.mu.keyRegistry)
+	proto.Merge(keyRegistry, m.writeMu.mu.keyRegistry)
 	keyRegistry.StoreKeys[storeKeyInfo.KeyId] = storeKeyInfo
 	keyRegistry.ActiveStoreKeyId = storeKeyInfo.KeyId
 	if storeKeyInfo.EncryptionType == enginepbccl.EncryptionType_Plaintext {
@@ -366,27 +415,33 @@ func (m *DataKeyManager) SetActiveStoreKeyInfo(
 	if err := m.rotateDataKeyAndWrite(ctx, keyRegistry); err != nil {
 		return err
 	}
-	m.mu.rotationEnabled = true
+	m.writeMu.rotationEnabled = true
 	return nil
 }
 
+// For stats.
 func (m *DataKeyManager) getScrubbedRegistry() *enginepbccl.DataKeysRegistry {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.writeMu.mu.RLock()
+	defer m.writeMu.mu.RUnlock()
 	r := makeRegistryProto()
-	proto.Merge(r, m.mu.keyRegistry)
+	proto.Merge(r, m.writeMu.mu.keyRegistry)
 	for _, v := range r.DataKeys {
 		v.Key = nil
 	}
 	return r
 }
 
+// validateRegistry must not modify keyRegistry.
 func validateRegistry(keyRegistry *enginepbccl.DataKeysRegistry) error {
-	if keyRegistry.ActiveStoreKeyId != "" && keyRegistry.StoreKeys[keyRegistry.ActiveStoreKeyId] == nil {
-		return fmt.Errorf("active store key %s not found", keyRegistry.ActiveStoreKeyId)
+	if keyRegistry.ActiveStoreKeyId != "" {
+		if k, ok := keyRegistry.StoreKeys[keyRegistry.ActiveStoreKeyId]; !ok || k == nil {
+			return fmt.Errorf("active store key %s not found", keyRegistry.ActiveStoreKeyId)
+		}
 	}
-	if keyRegistry.ActiveDataKeyId != "" && keyRegistry.DataKeys[keyRegistry.ActiveDataKeyId] == nil {
-		return fmt.Errorf("active data key %s not found", keyRegistry.ActiveDataKeyId)
+	if keyRegistry.ActiveDataKeyId != "" {
+		if k, ok := keyRegistry.DataKeys[keyRegistry.ActiveDataKeyId]; !ok || k == nil {
+			return fmt.Errorf("active data key %s not found", keyRegistry.ActiveDataKeyId)
+		}
 	}
 	return nil
 }
@@ -446,7 +501,7 @@ func generateAndSetNewDataKey(
 	return key, nil
 }
 
-// REQUIRES: m.mu is held.
+// REQUIRES: m.writeMu is held.
 func (m *DataKeyManager) rotateDataKeyAndWrite(
 	ctx context.Context, keyRegistry *enginepbccl.DataKeysRegistry,
 ) (err error) {
@@ -454,7 +509,8 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 		if err != nil {
 			log.Infof(ctx, "error while attempting to rotate data key: %s", err)
 		} else {
-			log.Infof(ctx, "rotated to new active data key: %s", proto.CompactTextString(m.mu.activeKey.Info))
+			log.Infof(ctx, "rotated to new active data key: %s",
+				proto.CompactTextString(m.writeMu.mu.activeKey.Info))
 		}
 	}()
 
@@ -473,7 +529,8 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 	// Write the current registry state to a new file and sync it.
 	// The new file's filename incorporates the marker's iteration
 	// number to ensure we're not overwriting the existing registry.
-	filename := fmt.Sprintf("%s_%06d_%s", keyRegistryFilename, m.mu.marker.NextIter(), registryFormatMonolith)
+	filename := fmt.Sprintf(
+		"%s_%06d_%s", keyRegistryFilename, m.writeMu.marker.NextIter(), registryFormatMonolith)
 	f, err := m.fs.Create(m.fs.PathJoin(m.dbDir, filename))
 	if err != nil {
 		return err
@@ -489,14 +546,18 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 	// the new file is active. This call to marker.Move will also sync
 	// the directory on behalf of both the marker and the registry
 	// itself.
-	if err := m.mu.marker.Move(filename); err != nil {
+	if err := m.writeMu.marker.Move(filename); err != nil {
 		return err
 	}
 
-	prevFilename := m.mu.filename
-	m.mu.filename = filename
-	m.mu.keyRegistry = keyRegistry
-	m.mu.activeKey = newKey
+	prevFilename := m.writeMu.filename
+	m.writeMu.filename = filename
+	func() {
+		m.writeMu.mu.Lock()
+		defer m.writeMu.mu.Unlock()
+		m.writeMu.mu.keyRegistry = keyRegistry
+		m.writeMu.mu.activeKey = newKey
+	}()
 
 	// Remove the previous data registry file.
 	if prevFilename != "" {

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
@@ -21,8 +21,10 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
@@ -159,7 +161,7 @@ func TestStoreKeyManager(t *testing.T) {
 	{
 		skm := &StoreKeyManager{fs: memFS, activeKeyFilename: "plain", oldKeyFilename: "plain"}
 		require.NoError(t, skm.Load(context.Background()))
-		key, err := skm.ActiveKey(context.Background())
+		key, err := skm.ActiveKeyForWriter(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, keyPlain.String(), key.String())
 		key, err = skm.GetKey("plain")
@@ -171,7 +173,7 @@ func TestStoreKeyManager(t *testing.T) {
 	{
 		skm := &StoreKeyManager{fs: memFS, activeKeyFilename: "16.key", oldKeyFilename: "24.key"}
 		require.NoError(t, skm.Load(context.Background()))
-		key, err := skm.ActiveKey(context.Background())
+		key, err := skm.ActiveKeyForWriter(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, key16.String(), key.String())
 		key, err = skm.GetKey(keyID128)
@@ -186,7 +188,7 @@ func TestStoreKeyManager(t *testing.T) {
 	{
 		skm := &StoreKeyManager{fs: memFS, activeKeyFilename: "32.key", oldKeyFilename: "plain"}
 		require.NoError(t, skm.Load(context.Background()))
-		key, err := skm.ActiveKey(context.Background())
+		key, err := skm.ActiveKeyForWriter(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, key32.String(), key.String())
 		key, err = skm.GetKey(keyID256)
@@ -333,7 +335,7 @@ func TestDataKeyManager(t *testing.T) {
 			case "check-exposed":
 				var val bool
 				d.ScanArgs(t, "val", &val)
-				for _, key := range dkm.mu.keyRegistry.DataKeys {
+				for _, key := range dkm.writeMu.mu.keyRegistry.DataKeys {
 					if key.Info.WasExposed != val {
 						return fmt.Sprintf(
 							"WasExposed: actual: %t, expected: %t\n", key.Info.WasExposed, val)
@@ -341,7 +343,7 @@ func TestDataKeyManager(t *testing.T) {
 				}
 				return ""
 			case "get-active-data-key":
-				key, err := dkm.ActiveKey(context.Background())
+				key, err := dkm.ActiveKeyForWriter(context.Background())
 				if err != nil {
 					return err.Error()
 				}
@@ -354,7 +356,7 @@ func TestDataKeyManager(t *testing.T) {
 				keyInfo.KeyId = ""
 				return strings.TrimSpace(keyInfo.String()) + "\n"
 			case "get-active-store-key":
-				id := dkm.mu.keyRegistry.ActiveStoreKeyId
+				id := dkm.writeMu.mu.keyRegistry.ActiveStoreKeyId
 				if id == "" {
 					return "none\n"
 				}
@@ -362,12 +364,12 @@ func TestDataKeyManager(t *testing.T) {
 			case "get-store-key":
 				var id string
 				d.ScanArgs(t, "id", &id)
-				if dkm.mu.keyRegistry.StoreKeys != nil && dkm.mu.keyRegistry.StoreKeys[id] != nil {
-					return strings.TrimSpace(dkm.mu.keyRegistry.StoreKeys[id].String()) + "\n"
+				if dkm.writeMu.mu.keyRegistry.StoreKeys != nil && dkm.writeMu.mu.keyRegistry.StoreKeys[id] != nil {
+					return strings.TrimSpace(dkm.writeMu.mu.keyRegistry.StoreKeys[id].String()) + "\n"
 				}
 				return "none\n"
 			case "record-active-data-key":
-				key, err := dkm.ActiveKey(context.Background())
+				key, err := dkm.ActiveKeyForWriter(context.Background())
 				if err != nil {
 					return err.Error()
 				}
@@ -376,7 +378,7 @@ func TestDataKeyManager(t *testing.T) {
 				}
 				return ""
 			case "compare-active-data-key":
-				key, err := dkm.ActiveKey(context.Background())
+				key, err := dkm.ActiveKeyForWriter(context.Background())
 				if err != nil {
 					return err.Error()
 				}
@@ -384,7 +386,7 @@ func TestDataKeyManager(t *testing.T) {
 				lastActiveDataKey = key
 				return rv
 			case "check-all-recorded-data-keys":
-				actual := fmt.Sprint(dkm.mu.keyRegistry.DataKeys)
+				actual := fmt.Sprint(dkm.writeMu.mu.keyRegistry.DataKeys)
 				expected := fmt.Sprint(keyMap)
 				require.Equal(t, expected, actual)
 				return ""
@@ -562,4 +564,30 @@ func (f loggingFile) Close() error {
 func (f loggingFile) Sync() error {
 	fmt.Fprintf(f.w, "sync(%q)\n", f.name)
 	return f.File.Sync()
+}
+
+func TestDataKeyManagerBlockedWriteAllowsRead(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	mem := vfs.NewMem()
+	fs := &fs.BlockingWriteFSForTesting{FS: mem}
+	dkm := &DataKeyManager{fs: fs, dbDir: "", rotationPeriod: 10000}
+	require.NoError(t, dkm.Load(ctx))
+	require.Equal(t, "", setActiveStoreKey(dkm, "foo", enginepbccl.EncryptionType_AES128_CTR))
+	activeKey, err := dkm.ActiveKeyForWriter(ctx)
+	require.NoError(t, err)
+	activeKeyID := activeKey.Info.KeyId
+	fs.Block()
+	go func() {
+		require.Equal(t, "", setActiveStoreKey(dkm, "bar", enginepbccl.EncryptionType_AES128_CTR))
+	}()
+	time.Sleep(time.Millisecond)
+	k, err := dkm.GetKey(activeKeyID)
+	require.NoError(t, err)
+	require.NotNil(t, k)
+	require.NotNil(t, dkm.ActiveKeyInfoForStats())
+	fs.WaitForBlockAndUnblock()
+	require.NoError(t, dkm.Close())
 }

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "safewrite.go",
         "sticky_vfs.go",
         "temp_dir.go",
+        "test_utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/storage/fs",
     visibility = ["//visibility:public"],

--- a/pkg/storage/fs/file_registry.go
+++ b/pkg/storage/fs/file_registry.go
@@ -82,10 +82,23 @@ type FileRegistry struct {
 
 	// Implementation.
 
-	mu struct {
+	writeMu struct {
 		syncutil.Mutex
-		// entries stores the current state of the file registry.
-		entries map[string]*enginepb.FileEntry
+		mu struct {
+			// Setters must hold both writeMu and writeMu.mu.
+			// Getters: Can hold either writeMu or writeMu.mu.
+			//
+			// writeMu > writeMu.mu, since setters hold the former when acquiring
+			// the latter. Setters should never hold the latter while doing IO. This
+			// would block getters, that are using mu, if the IO got stuck, say due
+			// to a disk stall -- we want getters (which may be doing read IO) to
+			// not get stuck due to setters being stuck, since the read IO may
+			// succeed due to the (page) cache.
+			syncutil.RWMutex
+			// entries stores the current state of the file registry. All values are
+			// non-nil.
+			entries map[string]*enginepb.FileEntry
+		}
 		// registryFile is the opened file for the records-based registry.
 		registryFile vfs.File
 		// registryWriter is a record.Writer for registryFile.
@@ -134,22 +147,26 @@ func checkNoRegistryFile(fs vfs.FS, dbDir string) error {
 // exists, else it is a noop.  Load should be called exactly once if the
 // file registry will be used.
 func (r *FileRegistry) Load(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
 	if r.SoftMaxSize == 0 {
 		r.SoftMaxSize = defaultSoftMaxRegistrySize
 	}
 
 	// Initialize private fields needed when the file registry will be used.
-	r.mu.entries = make(map[string]*enginepb.FileEntry)
+	func() {
+		r.writeMu.mu.Lock()
+		defer r.writeMu.mu.Unlock()
+		r.writeMu.mu.entries = make(map[string]*enginepb.FileEntry)
+	}()
 
 	if err := r.loadRegistryFromFile(); err != nil {
 		return err
 	}
 
 	// Find all old registry files, and remove some of them.
-	if r.mu.registryFilename != "" {
-		registryFileNum, err := r.parseRegistryFileName(r.mu.registryFilename)
+	if r.writeMu.registryFilename != "" {
+		registryFileNum, err := r.parseRegistryFileName(r.writeMu.registryFilename)
 		if err != nil {
 			return err
 		}
@@ -182,9 +199,9 @@ func (r *FileRegistry) Load(ctx context.Context) error {
 		sort.Slice(obsoleteFiles, func(i, j int) bool {
 			return obsoleteFiles[i] < obsoleteFiles[j]
 		})
-		r.mu.obsoleteRegistryFiles = make([]string, 0, r.NumOldRegistryFiles+1)
+		r.writeMu.obsoleteRegistryFiles = make([]string, 0, r.NumOldRegistryFiles+1)
 		for _, f := range obsoleteFiles {
-			r.mu.obsoleteRegistryFiles = append(r.mu.obsoleteRegistryFiles, makeRegistryFilename(f))
+			r.writeMu.obsoleteRegistryFiles = append(r.writeMu.obsoleteRegistryFiles, makeRegistryFilename(f))
 		}
 		if err := r.tryRemoveOldRegistryFilesLocked(); err != nil {
 			return err
@@ -208,15 +225,15 @@ func (r *FileRegistry) loadRegistryFromFile() error {
 	if err != nil {
 		return err
 	}
-	r.mu.marker = marker
+	r.writeMu.marker = marker
 	// If the marker does not exist, currentFilename may be the
 	// empty string. That's okay.
-	r.mu.registryFilename = currentFilename
+	r.writeMu.registryFilename = currentFilename
 
 	// Atomic markers may accumulate obsolete files. Remove any obsolete
 	// marker files as long as we're not in read-only mode.
 	if !r.ReadOnly {
-		if err := r.mu.marker.RemoveObsolete(); err != nil {
+		if err := r.writeMu.marker.RemoveObsolete(); err != nil {
 			return err
 		}
 	}
@@ -228,10 +245,10 @@ func (r *FileRegistry) loadRegistryFromFile() error {
 }
 
 func (r *FileRegistry) maybeLoadExistingRegistry() (bool, error) {
-	if r.mu.registryFilename == "" {
+	if r.writeMu.registryFilename == "" {
 		return false, nil
 	}
-	records, err := r.FS.Open(r.FS.PathJoin(r.DBDir, r.mu.registryFilename))
+	records, err := r.FS.Open(r.FS.PathJoin(r.DBDir, r.writeMu.registryFilename))
 	if err != nil {
 		return false, err
 	}
@@ -294,15 +311,18 @@ func (r *FileRegistry) maybeElideEntries(ctx context.Context) error {
 	// recursively List each directory and walk two lists of sorted
 	// filenames. We should test a store with many files to see how much
 	// the current approach slows node start.
-	filenames := make([]string, 0, len(r.mu.entries))
-	for filename := range r.mu.entries {
+	filenames := make([]string, 0, len(r.writeMu.mu.entries))
+	for filename := range r.writeMu.mu.entries {
 		filenames = append(filenames, filename)
 	}
 	sort.Strings(filenames)
 
 	batch := &enginepb.RegistryUpdateBatch{}
 	for _, filename := range filenames {
-		entry := r.mu.entries[filename]
+		entry, ok := r.writeMu.mu.entries[filename]
+		if !ok {
+			panic("entry disappeared from map")
+		}
 
 		// Some entries may be elided. This is used within
 		// ccl/storageccl/engineccl to elide plaintext file entries.
@@ -332,9 +352,9 @@ func (r *FileRegistry) maybeElideEntries(ctx context.Context) error {
 // GetFileEntry gets the file entry corresponding to filename, if there is one, else returns nil.
 func (r *FileRegistry) GetFileEntry(filename string) *enginepb.FileEntry {
 	filename = r.tryMakeRelativePath(filename)
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.mu.entries[filename]
+	r.writeMu.mu.RLock()
+	defer r.writeMu.mu.RUnlock()
+	return r.writeMu.mu.entries[filename]
 }
 
 // SetFileEntry sets filename => entry in the registry map and persists the registry.
@@ -348,8 +368,8 @@ func (r *FileRegistry) SetFileEntry(filename string, entry *enginepb.FileEntry) 
 
 	filename = r.tryMakeRelativePath(filename)
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
 	batch := &enginepb.RegistryUpdateBatch{}
 	batch.PutEntry(filename, entry)
 	return r.processBatchLocked(batch)
@@ -359,9 +379,9 @@ func (r *FileRegistry) SetFileEntry(filename string, entry *enginepb.FileEntry) 
 func (r *FileRegistry) MaybeDeleteEntry(filename string) error {
 	filename = r.tryMakeRelativePath(filename)
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.mu.entries[filename] == nil {
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
+	if _, ok := r.writeMu.mu.entries[filename]; !ok {
 		return nil
 	}
 	batch := &enginepb.RegistryUpdateBatch{}
@@ -377,14 +397,15 @@ func (r *FileRegistry) MaybeCopyEntry(src, dst string) error {
 	src = r.tryMakeRelativePath(src)
 	dst = r.tryMakeRelativePath(dst)
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	srcEntry := r.mu.entries[src]
-	if srcEntry == nil && r.mu.entries[dst] == nil {
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
+	srcEntry, srcFound := r.writeMu.mu.entries[src]
+	_, dstFound := r.writeMu.mu.entries[dst]
+	if !srcFound && !dstFound {
 		return nil
 	}
 	batch := &enginepb.RegistryUpdateBatch{}
-	if srcEntry == nil {
+	if !srcFound {
 		batch.DeleteEntry(dst)
 	} else {
 		batch.PutEntry(dst, srcEntry)
@@ -395,21 +416,7 @@ func (r *FileRegistry) MaybeCopyEntry(src, dst string) error {
 // MaybeLinkEntry copies the entry under src to dst, if src exists. If src does not exist, but dst
 // exists, dst is deleted. Persists the registry if changed.
 func (r *FileRegistry) MaybeLinkEntry(src, dst string) error {
-	src = r.tryMakeRelativePath(src)
-	dst = r.tryMakeRelativePath(dst)
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.mu.entries[src] == nil && r.mu.entries[dst] == nil {
-		return nil
-	}
-	batch := &enginepb.RegistryUpdateBatch{}
-	if r.mu.entries[src] == nil {
-		batch.DeleteEntry(dst)
-	} else {
-		batch.PutEntry(dst, r.mu.entries[src])
-	}
-	return r.processBatchLocked(batch)
+	return r.MaybeCopyEntry(src, dst)
 }
 
 func (r *FileRegistry) tryMakeRelativePath(filename string) string {
@@ -449,7 +456,7 @@ func (r *FileRegistry) processBatchLocked(batch *enginepb.RegistryUpdateBatch) e
 	if batch.Empty() {
 		return nil
 	}
-	if err := r.writeToRegistryFile(batch); err != nil {
+	if err := r.writeToRegistryFileLocked(batch); err != nil {
 		panic(err)
 	}
 	r.applyBatch(batch)
@@ -458,20 +465,22 @@ func (r *FileRegistry) processBatchLocked(batch *enginepb.RegistryUpdateBatch) e
 
 // processBatch processes a batch of updates to the file registry.
 func (r *FileRegistry) applyBatch(batch *enginepb.RegistryUpdateBatch) {
+	r.writeMu.mu.Lock()
+	defer r.writeMu.mu.Unlock()
 	for _, update := range batch.Updates {
 		if update.Entry == nil {
-			delete(r.mu.entries, update.Filename)
+			delete(r.writeMu.mu.entries, update.Filename)
 		} else {
-			if r.mu.entries == nil {
-				r.mu.entries = make(map[string]*enginepb.FileEntry)
+			if r.writeMu.mu.entries == nil {
+				r.writeMu.mu.entries = make(map[string]*enginepb.FileEntry)
 			}
-			r.mu.entries[update.Filename] = update.Entry
+			r.writeMu.mu.entries[update.Filename] = update.Entry
 		}
 	}
 }
 
-func (r *FileRegistry) writeToRegistryFile(batch *enginepb.RegistryUpdateBatch) error {
-	nilWriter := r.mu.registryWriter == nil
+func (r *FileRegistry) writeToRegistryFileLocked(batch *enginepb.RegistryUpdateBatch) error {
+	nilWriter := r.writeMu.registryWriter == nil
 
 	// Create a new file registry file if one doesn't exist yet, or the current
 	// one is too large.
@@ -484,20 +493,20 @@ func (r *FileRegistry) writeToRegistryFile(batch *enginepb.RegistryUpdateBatch) 
 	// is to ensure that when reopening a DB, the number of edits that need to
 	// be replayed on top of the snapshot is "sane". Rolling over to a new file
 	// registry after each edit is not relevant to that goal.
-	r.mu.rotationHelper.AddRecord(int64(len(batch.Updates)))
+	r.writeMu.rotationHelper.AddRecord(int64(len(batch.Updates)))
 
 	// If we don't have a file yet, we need to create one. If we do and its size
 	// exceeds the soft max, we may want to rotate. The record.RotationHelper
 	// implements logic to determine when we should rotate.
 	shouldRotate := nilWriter
-	if !shouldRotate && r.mu.registryWriter.Size() > r.SoftMaxSize {
-		shouldRotate = r.mu.rotationHelper.ShouldRotate(int64(len(r.mu.entries)))
+	if !shouldRotate && r.writeMu.registryWriter.Size() > r.SoftMaxSize {
+		shouldRotate = r.writeMu.rotationHelper.ShouldRotate(int64(len(r.writeMu.mu.entries)))
 	}
 
 	if shouldRotate {
 		// If !nilWriter, exceeded the size threshold: create a new file registry
 		// file to hopefully shrink the size of the file.
-		if err := r.createNewRegistryFile(); err != nil {
+		if err := r.createNewRegistryFileLocked(); err != nil {
 			if nilWriter {
 				return errors.Wrap(err, "creating new registry file")
 			} else {
@@ -505,9 +514,9 @@ func (r *FileRegistry) writeToRegistryFile(batch *enginepb.RegistryUpdateBatch) 
 			}
 		}
 		// Successfully rotated.
-		r.mu.rotationHelper.Rotate(int64(len(r.mu.entries)))
+		r.writeMu.rotationHelper.Rotate(int64(len(r.writeMu.mu.entries)))
 	}
-	w, err := r.mu.registryWriter.Next()
+	w, err := r.writeMu.registryWriter.Next()
 	if err != nil {
 		return err
 	}
@@ -518,20 +527,20 @@ func (r *FileRegistry) writeToRegistryFile(batch *enginepb.RegistryUpdateBatch) 
 	if _, err := w.Write(b); err != nil {
 		return err
 	}
-	if err := r.mu.registryWriter.Flush(); err != nil {
+	if err := r.writeMu.registryWriter.Flush(); err != nil {
 		return err
 	}
-	return r.mu.registryFile.Sync()
+	return r.writeMu.registryFile.Sync()
 }
 
 func makeRegistryFilename(iter uint64) string {
 	return fmt.Sprintf("%s_%06d", registryFilenameBase, iter)
 }
 
-func (r *FileRegistry) createNewRegistryFile() error {
+func (r *FileRegistry) createNewRegistryFileLocked() error {
 	// Create a new registry file. It won't be active until the marker
 	// is moved to the new filename.
-	filename := makeRegistryFilename(r.mu.marker.NextIter())
+	filename := makeRegistryFilename(r.writeMu.marker.NextIter())
 	filepath := r.FS.PathJoin(r.DBDir, filename)
 	f, err := r.FS.Create(filepath)
 	if err != nil {
@@ -563,7 +572,7 @@ func (r *FileRegistry) createNewRegistryFile() error {
 
 	// Write a RegistryUpdateBatch containing the current state of the registry.
 	batch := &enginepb.RegistryUpdateBatch{}
-	for filename, entry := range r.mu.entries {
+	for filename, entry := range r.writeMu.mu.entries {
 		batch.PutEntry(filename, entry)
 	}
 	b, err = protoutil.Marshal(batch)
@@ -586,7 +595,7 @@ func (r *FileRegistry) createNewRegistryFile() error {
 
 	// Moving the marker to the new filename atomically switches to the
 	// new file. Move handles syncing the data directory as well.
-	if err := r.mu.marker.Move(filename); err != nil {
+	if err := r.writeMu.marker.Move(filename); err != nil {
 		return errors.Wrap(errFunc(err), "moving marker")
 	}
 
@@ -596,8 +605,8 @@ func (r *FileRegistry) createNewRegistryFile() error {
 		// function, after we update the internal state to point to the
 		// new filename (since we've already successfully installed it).
 		err = r.closeRegistry()
-		if r.mu.registryFilename != "" {
-			r.mu.obsoleteRegistryFiles = append(r.mu.obsoleteRegistryFiles, r.mu.registryFilename)
+		if r.writeMu.registryFilename != "" {
+			r.writeMu.obsoleteRegistryFiles = append(r.writeMu.obsoleteRegistryFiles, r.writeMu.registryFilename)
 			rmErr := r.tryRemoveOldRegistryFilesLocked()
 			if rmErr != nil && !oserror.IsNotExist(rmErr) {
 				err = errors.CombineErrors(err, rmErr)
@@ -605,22 +614,22 @@ func (r *FileRegistry) createNewRegistryFile() error {
 		}
 	}
 
-	r.mu.registryFile = f
-	r.mu.registryWriter = records
-	r.mu.registryFilename = filename
+	r.writeMu.registryFile = f
+	r.writeMu.registryWriter = records
+	r.writeMu.registryFilename = filename
 	return err
 }
 
 // GetRegistrySnapshot constructs an enginepb.FileRegistry representing a
 // snapshot of the file registry state.
 func (r *FileRegistry) GetRegistrySnapshot() *enginepb.FileRegistry {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.writeMu.mu.RLock()
+	defer r.writeMu.mu.RUnlock()
 	rv := &enginepb.FileRegistry{
 		Version: enginepb.RegistryVersion_Records,
-		Files:   make(map[string]*enginepb.FileEntry, len(r.mu.entries)),
+		Files:   make(map[string]*enginepb.FileEntry, len(r.writeMu.mu.entries)),
 	}
-	for filename, entry := range r.mu.entries {
+	for filename, entry := range r.writeMu.mu.entries {
 		ev := &enginepb.FileEntry{}
 		*ev = *entry
 		rv.Files[filename] = ev
@@ -630,12 +639,12 @@ func (r *FileRegistry) GetRegistrySnapshot() *enginepb.FileRegistry {
 
 // List returns a mapping of file in the registry to their enginepb.FileEntry.
 func (r *FileRegistry) List() map[string]*enginepb.FileEntry {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.writeMu.mu.RLock()
+	defer r.writeMu.mu.RUnlock()
 	// Perform a defensive deep-copy of the internal map here, as there may be
 	// modifications to it after it has been returned to the caller.
-	m := make(map[string]*enginepb.FileEntry, len(r.mu.entries))
-	for k, v := range r.mu.entries {
+	m := make(map[string]*enginepb.FileEntry, len(r.writeMu.mu.entries))
+	for k, v := range r.writeMu.mu.entries {
 		m[k] = v
 	}
 	return m
@@ -650,13 +659,13 @@ func (r *FileRegistry) parseRegistryFileName(f string) (uint64, error) {
 }
 
 func (r *FileRegistry) tryRemoveOldRegistryFilesLocked() error {
-	n := len(r.mu.obsoleteRegistryFiles)
+	n := len(r.writeMu.obsoleteRegistryFiles)
 	if n <= r.NumOldRegistryFiles {
 		return nil
 	}
 	m := n - r.NumOldRegistryFiles
-	toDelete := r.mu.obsoleteRegistryFiles[:m]
-	r.mu.obsoleteRegistryFiles = r.mu.obsoleteRegistryFiles[m:]
+	toDelete := r.writeMu.obsoleteRegistryFiles[:m]
+	r.writeMu.obsoleteRegistryFiles = r.writeMu.obsoleteRegistryFiles[m:]
 	var err error
 	for _, f := range toDelete {
 		rmErr := r.FS.Remove(r.FS.PathJoin(r.DBDir, f))
@@ -670,22 +679,22 @@ func (r *FileRegistry) tryRemoveOldRegistryFilesLocked() error {
 // Close closes the record writer and record file used for the registry.
 // It should be called when a Pebble instance is closed.
 func (r *FileRegistry) Close() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
 	err := r.closeRegistry()
-	err = errors.CombineErrors(err, r.mu.marker.Close())
+	err = errors.CombineErrors(err, r.writeMu.marker.Close())
 	return err
 }
 
 func (r *FileRegistry) closeRegistry() error {
 	var err1, err2 error
-	if r.mu.registryWriter != nil {
-		err1 = r.mu.registryWriter.Close()
-		r.mu.registryWriter = nil
+	if r.writeMu.registryWriter != nil {
+		err1 = r.writeMu.registryWriter.Close()
+		r.writeMu.registryWriter = nil
 	}
-	if r.mu.registryFile != nil {
-		err2 = r.mu.registryFile.Close()
-		r.mu.registryFile = nil
+	if r.writeMu.registryFile != nil {
+		err2 = r.writeMu.registryFile.Close()
+		r.writeMu.registryFile = nil
 	}
 	return errors.CombineErrors(err1, err2)
 }

--- a/pkg/storage/fs/file_registry_test.go
+++ b/pkg/storage/fs/file_registry_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -102,11 +103,11 @@ func TestFileRegistryOps(t *testing.T) {
 
 		registry := &FileRegistry{FS: mem, DBDir: "/mydb"}
 		require.NoError(t, registry.Load(context.Background()))
-		registry.mu.Lock()
-		defer registry.mu.Unlock()
-		if diff := pretty.Diff(registry.mu.entries, expected); diff != nil {
+		registry.writeMu.Lock()
+		defer registry.writeMu.Unlock()
+		if diff := pretty.Diff(registry.writeMu.mu.entries, expected); diff != nil {
 			t.Log(string(debug.Stack()))
-			t.Fatalf("%s\n%v", strings.Join(diff, "\n"), registry.mu.entries)
+			t.Fatalf("%s\n%v", strings.Join(diff, "\n"), registry.writeMu.mu.entries)
 		}
 	}
 
@@ -223,7 +224,7 @@ func TestFileRegistryElideUnencrypted(t *testing.T) {
 
 	registry := &FileRegistry{FS: mem}
 	require.NoError(t, registry.Load(context.Background()))
-	require.NoError(t, registry.writeToRegistryFile(&enginepb.RegistryUpdateBatch{
+	require.NoError(t, registry.writeToRegistryFileLocked(&enginepb.RegistryUpdateBatch{
 		Updates: []*enginepb.RegistryUpdate{
 			{Filename: "test1", Entry: &enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte(nil)}},
 			{Filename: "test2", Entry: &enginepb.FileEntry{EnvType: enginepb.EnvType_Store, EncryptionSettings: []byte("foo")}},
@@ -234,8 +235,8 @@ func TestFileRegistryElideUnencrypted(t *testing.T) {
 	// Create another pebble file registry to verify that the unencrypted file is elided on startup.
 	registry2 := &FileRegistry{FS: mem}
 	require.NoError(t, registry2.Load(context.Background()))
-	require.NotContains(t, registry2.mu.entries, "test1")
-	entry := registry2.mu.entries["test2"]
+	require.NotContains(t, registry2.writeMu.mu.entries, "test1")
+	entry := registry2.writeMu.mu.entries["test2"]
 	require.NotNil(t, entry)
 	require.Equal(t, entry.EncryptionSettings, []byte("foo"))
 	require.NoError(t, registry2.Close())
@@ -252,7 +253,7 @@ func TestFileRegistryElideNonexistent(t *testing.T) {
 	{
 		registry := &FileRegistry{FS: mem}
 		require.NoError(t, registry.Load(context.Background()))
-		require.NoError(t, registry.writeToRegistryFile(&enginepb.RegistryUpdateBatch{
+		require.NoError(t, registry.writeToRegistryFileLocked(&enginepb.RegistryUpdateBatch{
 			Updates: []*enginepb.RegistryUpdate{
 				{Filename: "foo", Entry: &enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte("foo")}},
 				{Filename: "bar", Entry: &enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte("bar")}},
@@ -266,10 +267,10 @@ func TestFileRegistryElideNonexistent(t *testing.T) {
 	{
 		registry := &FileRegistry{FS: mem}
 		require.NoError(t, registry.Load(context.Background()))
-		require.NotContains(t, registry.mu.entries, "foo")
-		require.Contains(t, registry.mu.entries, "bar")
-		require.NotNil(t, registry.mu.entries["bar"])
-		require.Equal(t, []byte("bar"), registry.mu.entries["bar"].EncryptionSettings)
+		require.NotContains(t, registry.writeMu.mu.entries, "foo")
+		require.Contains(t, registry.writeMu.mu.entries, "bar")
+		require.NotNil(t, registry.writeMu.mu.entries["bar"])
+		require.Equal(t, []byte("bar"), registry.writeMu.mu.entries["bar"].EncryptionSettings)
 		require.NoError(t, registry.Close())
 	}
 }
@@ -581,12 +582,12 @@ func TestFileRegistryRollover(t *testing.T) {
 	// deleted.
 	var registryFiles []string
 	accumRegistryFiles := func() {
-		registry.mu.Lock()
-		defer registry.mu.Unlock()
+		registry.writeMu.Lock()
+		defer registry.writeMu.Unlock()
 		n := len(registryFiles)
-		if registry.mu.registryFilename != "" &&
-			(n == 0 || registry.mu.registryFilename != registryFiles[n-1]) {
-			registryFiles = append(registryFiles, registry.mu.registryFilename)
+		if registry.writeMu.registryFilename != "" &&
+			(n == 0 || registry.writeMu.registryFilename != registryFiles[n-1]) {
+			registryFiles = append(registryFiles, registry.writeMu.registryFilename)
 			n++
 		}
 	}
@@ -645,13 +646,13 @@ func TestFileRegistryKeepOldFilesAndSync(t *testing.T) {
 	// deleted.
 	var registryFiles []string
 	accumRegistryFiles := func(forceCheck bool) (totalCreated int) {
-		registry.mu.Lock()
-		defer registry.mu.Unlock()
+		registry.writeMu.Lock()
+		defer registry.writeMu.Unlock()
 		n := len(registryFiles)
 		doCheck := forceCheck
-		if registry.mu.registryFilename != "" &&
-			(n == 0 || registry.mu.registryFilename != registryFiles[n-1]) {
-			registryFiles = append(registryFiles, registry.mu.registryFilename)
+		if registry.writeMu.registryFilename != "" &&
+			(n == 0 || registry.writeMu.registryFilename != registryFiles[n-1]) {
+			registryFiles = append(registryFiles, registry.writeMu.registryFilename)
 			n++
 			doCheck = true
 		}
@@ -661,10 +662,10 @@ func TestFileRegistryKeepOldFilesAndSync(t *testing.T) {
 				numObsolete = numOldRegistryFiles
 			}
 			// The obsolete files are what we expect them to be.
-			require.Equal(t, numObsolete, len(registry.mu.obsoleteRegistryFiles))
+			require.Equal(t, numObsolete, len(registry.writeMu.obsoleteRegistryFiles))
 			var expectedFiles []string
 			for i := 0; i < numObsolete; i++ {
-				require.Equal(t, registryFiles[n-2-i], registry.mu.obsoleteRegistryFiles[numObsolete-1-i])
+				require.Equal(t, registryFiles[n-2-i], registry.writeMu.obsoleteRegistryFiles[numObsolete-1-i])
 				expectedFiles = append(expectedFiles, registryFiles[n-2-i])
 			}
 			expectedFiles = append(expectedFiles, registryFiles[n-1])
@@ -728,4 +729,28 @@ func TestFileRegistryKeepOldFilesAndSync(t *testing.T) {
 	registry = &FileRegistry{FS: mem, DBDir: dir, NumOldRegistryFiles: numOldRegistryFiles}
 	require.NoError(t, registry.Load(context.Background()))
 	registryChecker.checkEntries(registry)
+}
+
+func TestFileRegistryBlockedWriteAllowsRead(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	mem := vfs.NewMem()
+	fs := &BlockingWriteFSForTesting{FS: mem}
+
+	registry := &FileRegistry{FS: fs}
+	require.NoError(t, registry.Load(context.Background()))
+	fileEntry := &enginepb.FileEntry{EnvType: enginepb.EnvType_Store, EncryptionSettings: []byte("foo")}
+	require.NoError(t, registry.SetFileEntry("test1", fileEntry))
+	fs.Block()
+	go func() {
+		require.NoError(t, registry.SetFileEntry("test2", fileEntry))
+	}()
+	time.Sleep(time.Millisecond)
+	require.Equal(t, fileEntry, registry.GetFileEntry("test1"))
+	snap := registry.GetRegistrySnapshot()
+	require.Equal(t, 1, len(snap.Files))
+	require.Equal(t, 1, len(registry.List()))
+	fs.WaitForBlockAndUnblock()
+	require.NoError(t, registry.Close())
 }

--- a/pkg/storage/fs/test_utils.go
+++ b/pkg/storage/fs/test_utils.go
@@ -1,0 +1,47 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package fs
+
+import "github.com/cockroachdb/pebble/vfs"
+
+type BlockingWriteFSForTesting struct {
+	vfs.FS
+	block chan struct{}
+}
+
+type blockingFile struct {
+	vfs.File
+	fs *BlockingWriteFSForTesting
+}
+
+func (fs *BlockingWriteFSForTesting) Block() {
+	fs.block = make(chan struct{})
+}
+
+func (fs *BlockingWriteFSForTesting) WaitForBlockAndUnblock() {
+	fs.block <- struct{}{}
+	close(fs.block)
+}
+
+func (fs *BlockingWriteFSForTesting) Create(name string) (vfs.File, error) {
+	f, err := fs.FS.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return blockingFile{File: f, fs: fs}, nil
+}
+
+func (f blockingFile) Write(p []byte) (n int, err error) {
+	if f.fs.block != nil {
+		<-f.fs.block
+	}
+	return f.File.Write(p)
+}


### PR DESCRIPTION
Backport 1/1 commits from #123057.

/cc @cockroachdb/release

---

Both fs.FileRegistry and engineccl.DataKeyManager held an internal mutex when updating their state, that included write IO to to update persistent state. This would block readers of the state, specifically file reads that need a file registry entry and data key for the file to successfully open and read a file.

Blocking these reads due to slow or stalled write IO is not desirable, since the read could succeed if the relevant data is in the page cache. Specifically, with the new WAL failover feature, we expect the store to keep functioning when disk writes are temporarily stalled, since the WAL can failover. This expectation is not met if essential reads block on non-essential writes that are stalled.

This PR changes the locking in the FileRegistry and DataKeyManager to prevent writes from interfering with concurrent reads.

Epic: none

Fixes: #98051
Fixes: #122364

Release note: None

Release justification: High priority fix to encryption-at-rest behavior under WAL failover, which allows reads to continue.
