### PR TITLE
sql: remove single usage of PlanHookState.Txn

### DIFF
--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -69,7 +69,7 @@ type ShowCreateDisplayOptions struct {
 // current database.
 func ShowCreateTable(
 	ctx context.Context,
-	p PlanHookState,
+	p *planner,
 	tn *tree.TableName,
 	dbPrefix string,
 	desc catalog.TableDescriptor,

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -58,7 +58,7 @@ type comment struct {
 // can just fetch comments from collection cache instead of firing extra query.
 // An alternative approach would be to leverage a virtual table which internally
 // uses the collection.
-func selectComment(ctx context.Context, p PlanHookState, tableID descpb.ID) (tc *tableComments) {
+func selectComment(ctx context.Context, p *planner, tableID descpb.ID) (tc *tableComments) {
 	query := fmt.Sprintf("SELECT type, object_id, sub_id, comment FROM system.comments WHERE object_id = %d ORDER BY type, sub_id", tableID)
 
 	txn := p.Txn()


### PR DESCRIPTION
There is no reason to hide `*planner` behind `PlanHookState` interface.

Epic: None

Release note: None