### PR TITLE
sql: disable Streamer in some illegal cases

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -340,7 +340,7 @@ func runPlanInsidePlan(
 		}()
 	}
 
-	distributePlan := getPlanDistribution(
+	distributePlan, distSQLProhibitedErr := getPlanDistribution(
 		ctx, plannerCopy.Descriptors().HasUncommittedTypes(),
 		plannerCopy.SessionData().DistSQLMode, plan.main, &plannerCopy.distSQLVisitor,
 	)
@@ -350,6 +350,7 @@ func runPlanInsidePlan(
 	}
 	evalCtx := evalCtxFactory()
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, &plannerCopy, plannerCopy.txn, distributeType)
+	planCtx.distSQLProhibitedErr = distSQLProhibitedErr
 	planCtx.stmtType = recv.stmtType
 	planCtx.mustUseLeafTxn = params.p.mustUseLeafTxn()
 	planCtx.stmtForDistSQLDiagram = stmtForDistSQLDiagram

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3169,7 +3169,10 @@ func (ex *connExecutor) execCopyIn(
 			// execInsertPlan
 			func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
 				defer p.curPlan.close(ctx)
-				_, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, LocalDistribution, nil /* progressAtomic */)
+				_, err := ex.execWithDistSQLEngine(
+					ctx, p, tree.RowsAffected, res, LocalDistribution,
+					nil /* progressAtomic */, nil, /* distSQLProhibitedErr */
+				)
 				return err
 			},
 		)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -861,7 +861,10 @@ type PlanningCtx struct {
 
 	// isLocal is set to true if we're planning this query on a single node.
 	isLocal bool
-	planner *planner
+	// distSQLProhibitedErr, if set, indicates why the plan couldn't be
+	// distributed.
+	distSQLProhibitedErr error
+	planner              *planner
 
 	stmtType tree.StatementReturnType
 	// planDepth is set to the current depth of the planNode tree. It's used to

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -768,7 +768,21 @@ func (dsp *DistSQLPlanner) Run(
 				}
 				return false
 			}()
-			if !containsLocking && !mustUseRootTxn {
+			// We disable the usage of the Streamer API whenever usage of
+			// DistSQL was prohibited with an error. The thinking behind it is
+			// that we might have a plan where some expression (e.g. a cast to
+			// an Oid type) uses the planner's txn (which is the RootTxn), so
+			// it'd be illegal to use LeafTxns for a part of such plan.
+			// TODO(yuzefovich): this check is both excessive and insufficient.
+			// For example:
+			// - it disables the usage of the Streamer when a subquery has an
+			// Oid type, but that would have no impact on usage of the Streamer
+			// in the main query;
+			// - it might allow the usage of the Streamer even when the internal
+			// executor is used by a part of the plan, and the IE would use the
+			// RootTxn. Arguably, this would be a bug in not prohibiting the
+			// DistSQL altogether.
+			if !containsLocking && !mustUseRootTxn && planCtx.distSQLProhibitedErr == nil {
 				if evalCtx.SessionData().StreamerEnabled {
 					for _, proc := range plan.Processors {
 						if jr := proc.Spec.Core.JoinReader; jr != nil {
@@ -1780,15 +1794,16 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	skipDistSQLDiagramGeneration bool,
 	mustUseLeafTxn bool,
 ) error {
-	distributeSubquery := getPlanDistribution(
+	subqueryDistribution, distSQLProhibitedErr := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		planner.SessionData().DistSQLMode, subqueryPlan.plan, &planner.distSQLVisitor,
-	).WillDistribute()
+	)
 	distribute := DistributionType(LocalDistribution)
-	if distributeSubquery {
+	if subqueryDistribution.WillDistribute() {
 		distribute = FullDistribution
 	}
 	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
+	subqueryPlanCtx.distSQLProhibitedErr = distSQLProhibitedErr
 	subqueryPlanCtx.stmtType = tree.Rows
 	subqueryPlanCtx.skipDistSQLDiagramGeneration = skipDistSQLDiagramGeneration
 	subqueryPlanCtx.subOrPostQuery = true
@@ -2276,15 +2291,16 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	associateNodeWithComponents func(exec.Node, execComponents),
 	addTopLevelQueryStats func(stats *topLevelQueryStats),
 ) error {
-	distributePostquery := getPlanDistribution(
+	postqueryDistribution, distSQLProhibitedErr := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		planner.SessionData().DistSQLMode, postqueryPlan, &planner.distSQLVisitor,
-	).WillDistribute()
+	)
 	distribute := DistributionType(LocalDistribution)
-	if distributePostquery {
+	if postqueryDistribution.WillDistribute() {
 		distribute = FullDistribution
 	}
 	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
+	postqueryPlanCtx.distSQLProhibitedErr = distSQLProhibitedErr
 	postqueryPlanCtx.stmtType = tree.Rows
 	// Postqueries are only executed on the main query path where we skip the
 	// diagram generation.

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -62,7 +62,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// Note that we delay adding the annotation about the distribution until
 		// after the plan is finalized (when the physical plan is successfully
 		// created).
-		distribution := getPlanDistribution(
+		distribution, _ := getPlanDistribution(
 			params.ctx, params.p.Descriptors().HasUncommittedTypes(),
 			params.extendedEvalCtx.SessionData().DistSQLMode, plan.main, &params.p.distSQLVisitor,
 		)

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -40,7 +40,7 @@ type explainVecNode struct {
 func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	distribution := getPlanDistribution(
+	distribution, _ := getPlanDistribution(
 		params.ctx, params.p.Descriptors().HasUncommittedTypes(),
 		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main, &params.p.distSQLVisitor,
 	)

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -113,6 +113,57 @@ quality of service: regular
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k9FqGzsQhu_PUwxzdQpKsruUUgQFUycFp0kcnJCbYoIsTRzVWmkrabGN8WP1BfpkRSs7OHES2tLqYmFm_v1nNN_uCsM3gxyvTs5O-tcgDwV8Gg3PQcLpcHABCoYXoA4n8AHk4QQZWqfoQtQUkH_BEscMG-8kheB8Sq06wUAtkBcMtW3amNJjhtJ5Qr7CqKMh5HgtJoZGJBT5owIZKopCm85W9gJJZNh3pq1t4CAYpN5XjUjRATL8fANR18Sh-PE95Fg6G8lG7exeybt5AEXSKVIcqpycLCMF8CQUh_IdfMzZ6eiyD1IYEx6EjdB-K3yLDM9v-n0IkRqQrrUR_qdFPNI2vuFQdFfJAqLZS4JaLKCm2vklCGOcFDHNVXQzTESU9xTAtbFpI4ek7-bfJiocrxnmaLPbEMWUkJc7MAbHyIs1-3Uep07bDY7yMQ7VU7fNjJbI8My5WdvAV6ctOMuhV-1iSoyGacRecuiadavPm8xxiMKYPUB_zLLcZ_n-OZTlPsrqr6BsAykI0ZOoySNDWpBs9wf_R8SrJ8TL3yE-otA4G-gR7Zc6FU86HZTrMUNSU8q_fXCtl3Tpney0ORx2Rl1CUYi5WuZgYLelvL2HD3bXqXzVqXrNaczwzrj5rVbIsdicg2ce24PpBTENaUVX927e2V4vm3TBO2ECMTwXMzqmSL7WVoeoJfLoW1qv__sZAAD__9uqrY8=
 
+# Regression test for using the Streamer API when we have a cast to an Oid type
+# for which DistSQL is prohibited (#122274). (Note that, unlike above, we don't
+# have 'lookup join (streamer)' here - that's the test.)
+query T
+EXPLAIN ANALYZE (DISTSQL) SELECT c.a::REGNAMESPACE FROM c JOIN d ON d.b = c.b
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• render
+│
+└── • lookup join
+    │ nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 2
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 1
+    │ KV pairs read: 2
+    │ KV bytes read: 8 B
+    │ KV gRPC calls: 1
+    │ estimated max memory allocated: 0 B
+    │ table: d@d_pkey
+    │ equality: (b) = (b)
+    │
+    └── • scan
+          nodes: <hidden>
+          regions: <hidden>
+          actual row count: 2
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 2
+          KV pairs read: 4
+          KV bytes read: 16 B
+          KV gRPC calls: 2
+          estimated max memory allocated: 0 B
+          estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+          table: c@sec
+          spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k9Fq2zAUhu_3FIdztYHa2maMIRikc7ORrkmKU3ozQlGk01SLLHmSTBNKHmsvsCcbtpPSNG3ZxqaLwPn15z9H-uQ7DN8Ncpz0z_r5BchDwXnR_zw6HvYn58d5Hz4V4yFIOB0PRqBgPAJ1OIMPIA9nyNA6RSNRUkD-FVOcMqy8kxSC84101xoGaok8YahtVcdGnjKUzhPyO4w6GkKOF2JmqCChyB8lyFBRFNq0sbIXSCLD3Jm6tIGDYND0nlSiqQ6Q4ZdLiLokDsnPH6GrpbORbNTO7m15dxtAkXSKFIesE2erSAE8CcUhfQcfO3VenOcghTHh3lgJ7bfGt8hweJnnECJVIF1tI7ymZTzSNr7hkLRH6QxEi-cMpVhCSaXzKxDGOCliM1fSzjATUd5QAFfHqo4cGn87_1bIcLpm2FWbuw1RzAl5-gDG4AR5sma_z-PUabvBke7iUD11VS1ohQzPnFvUFXxz2oKzHHrZQ0wNo4KsIs-hl-6-Ktx0b1l0V9vVIQpj9oj9Ndx0H-77p9im-2yzf8KWliTr_UH_E_LsEfL0T5AXFCpnA-3gfq5T8qjTQbqeMiQ1p-67D672ks69k623K8dtUCsoCrHbTbtiYLdbIXoS5f2LfZiUvpiUvZQ0ZXht3O2VVsgx2ayDJ362C5s_iHlormhy427b2ItV1RzwWphADIdiQScUyZfa6hC1RB59Tev1q18BAAD___qmsNE=
+
 query T
 EXPLAIN (OPT, VERBOSE) SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b
 ----

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -458,11 +458,12 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				}
 			}
 
-			isLocal := !getPlanDistribution(
+			planDistribution, _ := getPlanDistribution(
 				ctx, localPlanner.Descriptors().HasUncommittedTypes(),
 				localPlanner.extendedEvalCtx.SessionData().DistSQLMode,
 				localPlanner.curPlan.main, &localPlanner.distSQLVisitor,
-			).WillDistribute()
+			)
+			isLocal := !planDistribution.WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
 				Table: *table.TableDesc(),
 			}}


### PR DESCRIPTION
Previously, it was possible to run into an internal error due to the usage of the Streamer API in the main query while part of the query (e.g. a cast to an Oid type) uses the Internal Executor with the RootTxn. This is illegal and might trigger `attempting to append refresh spans after the tracked timestamp has moved forward` error. We fix this by disabling the Streamer whenever usage of DistSQL was prohibited.

This seems reasonable because both DistSQL and Streamer provide concurrency (but in different forms) and require usage of the LeafTxns, so if we couldn't distribute the plan, then we likely can't use the Streamer either. Note that this check might be stricter than necessary (DistSQL could be prohibited due to some serialization issues that Streamer wouldn't be affected by). Additionally, if the plan is not distributed because `distsql=off` is used, then we don't know whether it would have been prohibited or not, so we might not disable the Streamer when we should.

Still, this seems like a reasonable improvement.

Fixes: #122274.

Release note (bug fix): CockroachDB could previously run into `attempting to append refresh spans after the tracked timestamp has moved forward` internal error in some edge cases, and this is now fixed. The bug has been present since 22.2 version.