### PR TITLE
release-23.2: plpgsql: add barrier after volatile assignment

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/procedure_plpgsql
@@ -198,4 +198,88 @@ CALL p(1);
 ----
 NOTICE: foo 1
 
+# Regression test for dropping the side effects from a variable assignment when
+# the variable is never used.
+subtest regression_122318
+
+statement ok
+CREATE SEQUENCE s1;
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+DECLARE
+  x INT = 1;
+  y INT = x + 1;
+  b INT;
+BEGIN
+  RAISE NOTICE 'x=% y=%', x, y;
+  b := nextval('s1');
+END;
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: x=1 y=2
+
+query I
+SELECT nextval('s1');
+----
+2
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+DECLARE
+  x INT = 1;
+  y INT = x + 1;
+  b INT;
+BEGIN
+  RAISE NOTICE 'x=% y=%', x, y;
+  SELECT nextval('s1') INTO b;
+END;
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: x=1 y=2
+
+query I
+SELECT nextval('s1');
+----
+4
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+DECLARE
+  x INT = 1;
+  y INT = x + 1;
+  b INT;
+  curs REFCURSOR := 'foo';
+BEGIN
+  OPEN curs FOR SELECT 1;
+  RAISE NOTICE 'x=% y=%', x, y;
+  FETCH curs INTO b;
+END;
+$$;
+
+statement ok
+BEGIN;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: x=1 y=2
+
+# The cursor should already be exhausted.
+query I
+FETCH foo;
+----
+
+statement ok
+ROLLBACK;
+
 subtest end

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -5463,7 +5463,7 @@ project
                      │                                                                ├── stats: [rows=1]
                      │                                                                ├── key: ()
                      │                                                                ├── fd: ()-->(17)
-                     │                                                                ├── project
+                     │                                                                ├── barrier
                      │                                                                │    ├── columns: x:13(int)
                      │                                                                │    ├── outer: (10)
                      │                                                                │    ├── cardinality: [1 - 1]
@@ -5471,31 +5471,38 @@ project
                      │                                                                │    ├── stats: [rows=1]
                      │                                                                │    ├── key: ()
                      │                                                                │    ├── fd: ()-->(13)
-                     │                                                                │    ├── prune: (13)
-                     │                                                                │    ├── project
-                     │                                                                │    │    ├── columns: stmt_fetch_3:12(tuple{int})
-                     │                                                                │    │    ├── outer: (10)
-                     │                                                                │    │    ├── cardinality: [1 - 1]
-                     │                                                                │    │    ├── volatile
-                     │                                                                │    │    ├── stats: [rows=1]
-                     │                                                                │    │    ├── key: ()
-                     │                                                                │    │    ├── fd: ()-->(12)
-                     │                                                                │    │    ├── prune: (12)
-                     │                                                                │    │    ├── values
-                     │                                                                │    │    │    ├── cardinality: [1 - 1]
-                     │                                                                │    │    │    ├── stats: [rows=1]
-                     │                                                                │    │    │    ├── key: ()
-                     │                                                                │    │    │    └── tuple [type=tuple]
-                     │                                                                │    │    └── projections
-                     │                                                                │    │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:12, type=tuple{int}, outer=(10), volatile]
-                     │                                                                │    │              ├── variable: curs:10 [type=refcursor]
-                     │                                                                │    │              ├── const: 0 [type=int]
-                     │                                                                │    │              ├── const: 1 [type=int]
-                     │                                                                │    │              └── tuple [type=tuple{int}]
-                     │                                                                │    │                   └── null [type=int]
-                     │                                                                │    └── projections
-                     │                                                                │         └── column-access: 0 [as=x:13, type=int, outer=(12)]
-                     │                                                                │              └── variable: stmt_fetch_3:12 [type=tuple{int}]
+                     │                                                                │    └── project
+                     │                                                                │         ├── columns: x:13(int)
+                     │                                                                │         ├── outer: (10)
+                     │                                                                │         ├── cardinality: [1 - 1]
+                     │                                                                │         ├── volatile
+                     │                                                                │         ├── stats: [rows=1]
+                     │                                                                │         ├── key: ()
+                     │                                                                │         ├── fd: ()-->(13)
+                     │                                                                │         ├── project
+                     │                                                                │         │    ├── columns: stmt_fetch_3:12(tuple{int})
+                     │                                                                │         │    ├── outer: (10)
+                     │                                                                │         │    ├── cardinality: [1 - 1]
+                     │                                                                │         │    ├── volatile
+                     │                                                                │         │    ├── stats: [rows=1]
+                     │                                                                │         │    ├── key: ()
+                     │                                                                │         │    ├── fd: ()-->(12)
+                     │                                                                │         │    ├── prune: (12)
+                     │                                                                │         │    ├── values
+                     │                                                                │         │    │    ├── cardinality: [1 - 1]
+                     │                                                                │         │    │    ├── stats: [rows=1]
+                     │                                                                │         │    │    ├── key: ()
+                     │                                                                │         │    │    └── tuple [type=tuple]
+                     │                                                                │         │    └── projections
+                     │                                                                │         │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:12, type=tuple{int}, outer=(10), volatile]
+                     │                                                                │         │              ├── variable: curs:10 [type=refcursor]
+                     │                                                                │         │              ├── const: 0 [type=int]
+                     │                                                                │         │              ├── const: 1 [type=int]
+                     │                                                                │         │              └── tuple [type=tuple{int}]
+                     │                                                                │         │                   └── null [type=int]
+                     │                                                                │         └── projections
+                     │                                                                │              └── column-access: 0 [as=x:13, type=int, outer=(12)]
+                     │                                                                │                   └── variable: stmt_fetch_3:12 [type=tuple{int}]
                      │                                                                └── projections
                      │                                                                     └── udf: _stmt_exec_ret_4 [as="_stmt_exec_ret_4":17, type=int, outer=(10,13), udf]
                      │                                                                          ├── args
@@ -6009,32 +6016,34 @@ project
                      │                                                                                                        │    ├── columns: found:27
                      │                                                                                                        │    └── project
                      │                                                                                                        │         ├── columns: found:27
-                     │                                                                                                        │         ├── right-join (cross)
+                     │                                                                                                        │         ├── barrier
                      │                                                                                                        │         │    ├── columns: a:13
-                     │                                                                                                        │         │    ├── limit
-                     │                                                                                                        │         │    │    ├── columns: a:13
-                     │                                                                                                        │         │    │    ├── project
-                     │                                                                                                        │         │    │    │    ├── columns: a:13
-                     │                                                                                                        │         │    │    │    └── insert t114826
-                     │                                                                                                        │         │    │    │         ├── columns: a:13 rowid:14!null
-                     │                                                                                                        │         │    │    │         ├── insert-mapping:
-                     │                                                                                                        │         │    │    │         │    ├── a:17 => a:13
-                     │                                                                                                        │         │    │    │         │    └── rowid_default:21 => rowid:14
-                     │                                                                                                        │         │    │    │         ├── return-mapping:
-                     │                                                                                                        │         │    │    │         │    ├── a:17 => a:13
-                     │                                                                                                        │         │    │    │         │    └── rowid_default:21 => rowid:14
-                     │                                                                                                        │         │    │    │         └── project
-                     │                                                                                                        │         │    │    │              ├── columns: rowid_default:21 a:17
-                     │                                                                                                        │         │    │    │              ├── project
-                     │                                                                                                        │         │    │    │              │    ├── columns: a:17
-                     │                                                                                                        │         │    │    │              │    └── scan t114826
-                     │                                                                                                        │         │    │    │              │         └── columns: a:17 rowid:18!null crdb_internal_mvcc_timestamp:19 tableoid:20
-                     │                                                                                                        │         │    │    │              └── projections
-                     │                                                                                                        │         │    │    │                   └── function: unique_rowid [as=rowid_default:21]
-                     │                                                                                                        │         │    │    └── const: 1
-                     │                                                                                                        │         │    ├── values
-                     │                                                                                                        │         │    │    └── tuple
-                     │                                                                                                        │         │    └── filters (true)
+                     │                                                                                                        │         │    └── right-join (cross)
+                     │                                                                                                        │         │         ├── columns: a:13
+                     │                                                                                                        │         │         ├── limit
+                     │                                                                                                        │         │         │    ├── columns: a:13
+                     │                                                                                                        │         │         │    ├── project
+                     │                                                                                                        │         │         │    │    ├── columns: a:13
+                     │                                                                                                        │         │         │    │    └── insert t114826
+                     │                                                                                                        │         │         │    │         ├── columns: a:13 rowid:14!null
+                     │                                                                                                        │         │         │    │         ├── insert-mapping:
+                     │                                                                                                        │         │         │    │         │    ├── a:17 => a:13
+                     │                                                                                                        │         │         │    │         │    └── rowid_default:21 => rowid:14
+                     │                                                                                                        │         │         │    │         ├── return-mapping:
+                     │                                                                                                        │         │         │    │         │    ├── a:17 => a:13
+                     │                                                                                                        │         │         │    │         │    └── rowid_default:21 => rowid:14
+                     │                                                                                                        │         │         │    │         └── project
+                     │                                                                                                        │         │         │    │              ├── columns: rowid_default:21 a:17
+                     │                                                                                                        │         │         │    │              ├── project
+                     │                                                                                                        │         │         │    │              │    ├── columns: a:17
+                     │                                                                                                        │         │         │    │              │    └── scan t114826
+                     │                                                                                                        │         │         │    │              │         └── columns: a:17 rowid:18!null crdb_internal_mvcc_timestamp:19 tableoid:20
+                     │                                                                                                        │         │         │    │              └── projections
+                     │                                                                                                        │         │         │    │                   └── function: unique_rowid [as=rowid_default:21]
+                     │                                                                                                        │         │         │    └── const: 1
+                     │                                                                                                        │         │         ├── values
+                     │                                                                                                        │         │         │    └── tuple
+                     │                                                                                                        │         │         └── filters (true)
                      │                                                                                                        │         └── projections
                      │                                                                                                        │              └── variable: a:13 [as=found:27]
                      │                                                                                                        └── projections


### PR DESCRIPTION
Backport 1/1 commits from #122938.

/cc @cockroachdb/release

---

This commit adds an optimization barrier after a PL/pgSQL variable assignment with a volatile expression for regular assignments `:=`, `FETCH`, and `SELECT ... INTO`. This is necessary because it is possible to assign to a variable, but never reference it again. This situation could previously cause the assignment to be dropped if all continuations from that point on were inlined, which would in turn cause any side effects of the assignment to be dropped.

Fixes #122318

Release note (bug fix): Fixed a bug introduced in v23.2 that could cause a PL/pgSQL variable assignment to not be executed if the variable was never referenced after the assignment.

Release justification: correctness bug fix