### PR TITLE
ui: Highlight unavailable ranges in red on the summary bar with nonzero

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -140,6 +140,7 @@ export default function (props: ClusterSummaryProps) {
         <SummaryStat
           title="Unavailable ranges"
           value={nodeSums.unavailableRanges}
+          numberAlert={nodeSums.unavailableRanges > 0}
         />
         <SummaryMetricStat
           id="qps"

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/summaryBar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/summaryBar/index.tsx
@@ -36,6 +36,7 @@ interface SummaryStatProps {
   value?: number;
   format?: (n: number) => string;
   aggregator?: SummaryMetricsAggregator;
+  numberAlert?: boolean;
 }
 
 interface SummaryHeadlineStatProps extends SummaryStatProps {
@@ -109,11 +110,12 @@ export function SummaryValue(
 export function SummaryStat(
   props: SummaryStatProps & { children?: React.ReactNode },
 ) {
+  const classModifier = props.numberAlert ? "number-alert" : "number";
   return (
     <SummaryValue
       title={props.title}
       value={formatNumberForDisplay(props.value, props.format)}
-      classModifier="number"
+      classModifier={classModifier}
     >
       {props.children}
     </SummaryValue>

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/summaryBar/summarybar.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/summaryBar/summarybar.styl
@@ -100,6 +100,9 @@
   &--number &__value
     color $colors--primary-green-3
 
+  &--number-alert  &__value
+    color $alert-color
+
   &--dead &__value
     color $alert-color
     text-transform capitalize


### PR DESCRIPTION
Modify the summary bar to change the color of unavailable ranges. When the unavailable range is greater than zero, it will be displayed in red; if it is zero, it will be green.

Fix: #122014

Release note (ui): Changed the color of unavailable ranges on the summary bar to red when nonzero; ranges are green when zero.