### PR TITLE
mixedversion: split cockroach addressing into services

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
         "//pkg/roachpb",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/testutils/datapathutils",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
@@ -15,16 +15,18 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 )
 
 type (
-	// Context wraps the context passed to predicate functions that
-	// dictate when a mixed-version hook will run during a test
-	Context struct {
-		// CockroachNodes is the set of cockroach nodes in the cluster
-		// that are being part of the upgrade being performed.
-		CockroachNodes option.NodeListOption
+	// ServiceContext contains the mixed-version context data for a
+	// specific service deployed during the test. A service can be the
+	// system tenant itself, or a secondary tenant created for the
+	// purposes of the test.
+	ServiceContext struct {
+		// Descriptor is the descriptor associated with this context.
+		Descriptor *ServiceDescriptor
 		// Stage is the UpgradeStage when the step is scheduled to run.
 		Stage UpgradeStage
 		// FromVersion is the version the nodes are migrating from.
@@ -41,88 +43,54 @@ type (
 		// currently running that version.
 		nodesByVersion map[clusterupgrade.Version]*intsets.Fast
 	}
+
+	// Context wraps the context passed to predicate functions that
+	// dictate when a mixed-version hook will run during a test. Both
+	// the system tenant and a secondary tenant (when available) have
+	// their own mixed-version context.
+	Context struct {
+		System *ServiceContext
+		Tenant *ServiceContext
+	}
 )
 
-func newInitialContext(
-	initialRelease *clusterupgrade.Version, crdbNodes option.NodeListOption,
-) *Context {
-	return &Context{
-		CockroachNodes: crdbNodes,
-		FromVersion:    initialRelease,
-		ToVersion:      initialRelease,
-		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
-			*initialRelease: intSetP(crdbNodes...),
-		},
+// clone creates a copy of the caller service context.
+func (sc *ServiceContext) clone() *ServiceContext {
+	// This allows us to call clone on `nil` instances of this struct,
+	// which is useful in tests that don't deploy a tenant (in which
+	// case the tenant context is nil).
+	if sc == nil {
+		return nil
 	}
-}
 
-// newLongRunningContext is the test context passed to long running
-// tasks (background functions and the like). In these scenarios,
-// `FromVersion` and `ToVersion` correspond to, respectively, the
-// initial version the cluster is started at, and the final version
-// once the test finishes. Background functions should *not* rely on
-// context functions since the context is not dynamically updated as
-// the test makes progress during the background function's execution.
-func newLongRunningContext(
-	from, to *clusterupgrade.Version, crdbNodes option.NodeListOption, stage UpgradeStage,
-) *Context {
-	return &Context{
-		CockroachNodes: crdbNodes,
-		Stage:          stage,
-		FromVersion:    from,
-		ToVersion:      to,
-		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
-			*from: intSetP(crdbNodes...),
-		},
+	newDescriptor := &ServiceDescriptor{
+		Name:  sc.Descriptor.Name,
+		Nodes: append(option.NodeListOption{}, sc.Descriptor.Nodes...),
 	}
-}
 
-// clone copies the caller Context and returns the copy.
-func (c *Context) clone() Context {
 	nodesByVersion := make(map[clusterupgrade.Version]*intsets.Fast)
-	for v, nodes := range c.nodesByVersion {
+	for v, nodes := range sc.nodesByVersion {
 		newSet := nodes.Copy()
 		nodesByVersion[v] = &newSet
 	}
 
-	fromVersion := c.FromVersion.Version
-	toVersion := c.ToVersion.Version
+	fromVersion := sc.FromVersion.Version
+	toVersion := sc.ToVersion.Version
 
-	return Context{
-		CockroachNodes: append(option.NodeListOption{}, c.CockroachNodes...),
-		Stage:          c.Stage,
+	return &ServiceContext{
+		Descriptor:     newDescriptor,
+		Stage:          sc.Stage,
 		FromVersion:    &clusterupgrade.Version{Version: fromVersion},
 		ToVersion:      &clusterupgrade.Version{Version: toVersion},
-		Finalizing:     c.Finalizing,
+		Finalizing:     sc.Finalizing,
 		nodesByVersion: nodesByVersion,
 	}
 }
 
-// startUpgrade is called when the test is starting the upgrade to the
-// given version. This should be called once every node is already
-// running that version and the cluster version has finished reaching
-// the logical version corresponding to that release.
-func (c *Context) startUpgrade(nextRelease *clusterupgrade.Version) {
-	c.FromVersion = c.ToVersion
-	c.ToVersion = nextRelease
-}
-
-// changeVersion is used to indicate that the given `node` is now
-// running release version `v`.
-func (c *Context) changeVersion(node int, v *clusterupgrade.Version) {
-	currentVersion := c.NodeVersion(node)
-	c.nodesByVersion[*currentVersion].Remove(node)
-	if _, exists := c.nodesByVersion[*v]; !exists {
-		c.nodesByVersion[*v] = intSetP()
-	}
-
-	c.nodesByVersion[*v].Add(node)
-}
-
 // nodesInVersion returns a list of all nodes running the version
 // passed, if any.
-func (c *Context) nodesInVersion(v *clusterupgrade.Version) option.NodeListOption {
-	set, ok := c.nodesByVersion[*v]
+func (sc *ServiceContext) nodesInVersion(v *clusterupgrade.Version) option.NodeListOption {
+	set, ok := sc.nodesByVersion[*v]
 	if !ok {
 		return nil
 	}
@@ -130,35 +98,188 @@ func (c *Context) nodesInVersion(v *clusterupgrade.Version) option.NodeListOptio
 	return set.Ordered()
 }
 
+// startUpgrade is called when the test is starting the upgrade to the
+// given version. This should be called once every node is already
+// running that version and the cluster version has finished reaching
+// the logical version corresponding to that release.
+func (sc *ServiceContext) startUpgrade(nextRelease *clusterupgrade.Version) {
+	sc.FromVersion = sc.ToVersion
+	sc.ToVersion = nextRelease
+}
+
+// changeVersion is used to indicate that the given `node` is now
+// running release version `v`.
+func (sc *ServiceContext) changeVersion(node int, v *clusterupgrade.Version) error {
+	currentVersion, err := sc.NodeVersion(node)
+	if err != nil {
+		return err
+	}
+
+	sc.nodesByVersion[*currentVersion].Remove(node)
+	if _, exists := sc.nodesByVersion[*v]; !exists {
+		sc.nodesByVersion[*v] = intSetP()
+	}
+
+	sc.nodesByVersion[*v].Add(node)
+	return nil
+}
+
 // NodeVersion returns the release version the given `node` is
-// currently running. Panics if the node is not valid.
-func (c *Context) NodeVersion(node int) *clusterupgrade.Version {
-	for version, nodes := range c.nodesByVersion {
+// currently running. Returns an error if the node is not valid (i.e.,
+// the underlying service is not deployed on the node passed).
+func (sc *ServiceContext) NodeVersion(node int) (*clusterupgrade.Version, error) {
+	for version, nodes := range sc.nodesByVersion {
 		if nodes.Contains(node) {
-			return &version
+			return &version, nil
 		}
 	}
 
-	panic(fmt.Errorf("NodeVersion error: invalid node %d, cockroach nodes: %v", node, c.CockroachNodes))
+	return nil, fmt.Errorf(
+		"invalid node %d, %s nodes: %v",
+		node, sc.Descriptor.Name, sc.Descriptor.Nodes,
+	)
 }
 
 // NodesInPreviousVersion returns a list of nodes running the version
 // we are upgrading from.
-func (c *Context) NodesInPreviousVersion() option.NodeListOption {
-	return c.nodesInVersion(c.FromVersion)
+func (sc *ServiceContext) NodesInPreviousVersion() option.NodeListOption {
+	return sc.nodesInVersion(sc.FromVersion)
 }
 
 // NodesInNextVersion returns the list of nodes running the version we
 // are upgrading to.
-func (c *Context) NodesInNextVersion() option.NodeListOption {
-	return c.nodesInVersion(c.ToVersion)
+func (sc *ServiceContext) NodesInNextVersion() option.NodeListOption {
+	return sc.nodesInVersion(sc.ToVersion)
 }
 
 // MixedBinary indicates if the cluster is currently in mixed-binary
 // mode, i.e., not all nodes in the cluster are running the same
 // released binary version.
+func (sc *ServiceContext) MixedBinary() bool {
+	return len(sc.NodesInPreviousVersion()) > 0 && len(sc.NodesInNextVersion()) > 0
+}
+
+// newContext creates a new mixed-version context for an upgrade
+// `from` a given version `to` another version. `systemNodes` is the
+// set of nodes where the system tenant is running. If this test sets
+// up a virtual cluster (tenant) as well, callers should pass a
+// ServiceDescriptor for that tenant.
+func newContext(
+	from, to *clusterupgrade.Version,
+	stage UpgradeStage,
+	systemNodes option.NodeListOption,
+	tenant *ServiceDescriptor,
+) *Context {
+	makeContext := func(name string, nodes option.NodeListOption) *ServiceContext {
+		return &ServiceContext{
+			Descriptor: &ServiceDescriptor{
+				Name:  install.SystemInterfaceName,
+				Nodes: systemNodes,
+			},
+			Stage:       stage,
+			FromVersion: from,
+			ToVersion:   to,
+			nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+				*from: intSetP(nodes...),
+			},
+		}
+	}
+
+	var tenantContext *ServiceContext
+	if tenant != nil {
+		tenantContext = makeContext(tenant.Name, tenant.Nodes)
+	}
+
+	return &Context{
+		System: makeContext(install.SystemInterfaceName, systemNodes),
+		Tenant: tenantContext,
+	}
+}
+
+// newInitialContext creates the context to be used when starting a
+// new mixed-version test. Both `from` and `to` versions are set to
+// the `initialRelease`, as they are changed by the planner as the
+// upgrades plans are generated.
+func newInitialContext(
+	initialRelease *clusterupgrade.Version,
+	systemNodes option.NodeListOption,
+	tenant *ServiceDescriptor,
+) *Context {
+	return newContext(
+		initialRelease, initialRelease, ClusterSetupStage, systemNodes, tenant,
+	)
+}
+
+func (c *Context) NodeVersion(node int) (*clusterupgrade.Version, error) {
+	return c.DefaultService().NodeVersion(node)
+}
+
+func (c *Context) NodesInPreviousVersion() option.NodeListOption {
+	return c.DefaultService().NodesInPreviousVersion()
+}
+
+func (c *Context) NodesInNextVersion() option.NodeListOption {
+	return c.DefaultService().NodesInNextVersion()
+}
+
 func (c *Context) MixedBinary() bool {
-	return len(c.NodesInPreviousVersion()) > 0 && len(c.NodesInNextVersion()) > 0
+	return c.DefaultService().MixedBinary()
+}
+
+func (c *Context) FromVersion() *clusterupgrade.Version {
+	return c.DefaultService().FromVersion
+}
+
+func (c *Context) ToVersion() *clusterupgrade.Version {
+	return c.DefaultService().ToVersion
+}
+
+func (c *Context) Nodes() option.NodeListOption {
+	return c.DefaultService().Descriptor.Nodes
+}
+
+// Finalizing returns whether the cluster is known to be
+// finalizing. Since virtual clusters rely on the system tenant for
+// various operations, this function returns `true` if either the
+// system or virtual cluster are in the process of finalizing the
+// upgrade.
+func (c *Context) Finalizing() bool {
+	systemFinalizing := c.System.Finalizing
+
+	var tenantFinalizing bool
+	if c.Tenant != nil {
+		tenantFinalizing = c.Tenant.Finalizing
+	}
+
+	return systemFinalizing || tenantFinalizing
+}
+
+// DefaultService returns the `ServiceContext` associated with the
+// "default" service in the test. If a virtual cluster was created, it
+// is the default service, otherwise we use the system service.
+func (c *Context) DefaultService() *ServiceContext {
+	if c.Tenant == nil {
+		return c.System
+	}
+
+	return c.Tenant
+}
+
+// SetStage is a helper function to set the upgrade stage on all
+// services available.
+func (c *Context) SetStage(stage UpgradeStage) {
+	c.System.Stage = stage
+	if c.Tenant != nil {
+		c.Tenant.Stage = stage
+	}
+}
+
+// clone copies the caller Context and returns the copy.
+func (c *Context) clone() Context {
+	return Context{
+		System: c.System.clone(),
+		Tenant: c.Tenant.clone(),
+	}
 }
 
 func intSetP(ns ...int) *intsets.Fast {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -74,9 +74,9 @@ func TestClusterVersionAtLeast(t *testing.T) {
 			var clusterVersions atomic.Value
 			clusterVersions.Store([]roachpb.Version{currentVersion})
 			runner := testTestRunner()
-			runner.clusterVersions = clusterVersions
+			runner.clusterVersions = &clusterVersions
 
-			h := runner.newHelper(ctx, nilLogger, Context{Finalizing: false})
+			h := runner.newHelper(ctx, nilLogger, Context{System: &ServiceContext{Finalizing: false}})
 
 			supportedFeature, err := h.ClusterVersionAtLeast(rng, tc.minVersion)
 			if tc.expectedErr == "" {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators_test.go
@@ -74,8 +74,10 @@ func TestClusterSettingMutator(t *testing.T) {
 
 		var nodesInValidVersion option.NodeListOption
 		stepContext := m.reference.context
-		for _, node := range stepContext.CockroachNodes {
-			if stepContext.NodeVersion(node).AtLeast(minVersion) {
+		for _, node := range stepContext.System.Descriptor.Nodes {
+			nodeV, err := stepContext.NodeVersion(node)
+			require.NoError(t, err)
+			if nodeV.AtLeast(minVersion) {
 				nodesInValidVersion = append(nodesInValidVersion, node)
 			}
 		}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
@@ -26,7 +26,7 @@ plan
 mixed-version test plan for upgrading from "v22.2.8" to "<current>":
 ├── install fixtures for version "v22.2.8" (1)
 ├── start cluster at version "v22.2.8" (2)
-├── wait for nodes :1-4 to reach cluster version '22.2' (3)
+├── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (3)
 ├── run startup hooks concurrently
 │   ├── run "initialize bank workload", after 0s delay (4)
 │   └── run "initialize rand workload", after 3m0s delay (5)
@@ -35,7 +35,7 @@ mixed-version test plan for upgrading from "v22.2.8" to "<current>":
 │   ├── run "rand workload", after 0s delay (7)
 │   └── run "csv server", after 0s delay (8)
 └── upgrade cluster from "v22.2.8" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (9)
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (9)
    ├── upgrade nodes :1-4 from "v22.2.8" to "<current>"
    │   ├── restart node 2 with binary version <current> (10)
    │   ├── run mixed-version hooks concurrently
@@ -63,4 +63,4 @@ mixed-version test plan for upgrading from "v22.2.8" to "<current>":
    ├── run mixed-version hooks concurrently
    │   ├── run "mixed-version 1", after 30s delay (29)
    │   └── run "mixed-version 2", after 5s delay (30)
-   └── wait for nodes :1-4 to reach cluster version <current> (31)
+   └── wait for system tenant on nodes :1-4 to reach cluster version <current> (31)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/cluster_setting
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/cluster_setting
@@ -21,10 +21,10 @@ plan
 mixed-version test plan for upgrading from "v22.2.3" to "v23.1.10" to "v23.2.4" to "<current>" with mutators {cluster_setting[test_cluster_setting]}:
 ├── install fixtures for version "v22.2.3" (1)
 ├── start cluster at version "v22.2.3" (2)
-├── wait for nodes :1-4 to reach cluster version '22.2' (3)
+├── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (3)
 ├── run "do something" (4)
 ├── upgrade cluster from "v22.2.3" to "v23.1.10"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (5)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (5)
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.10"
 │   │   ├── restart node 3 with binary version v23.1.10 (6)
 │   │   ├── restart node 2 with binary version v23.1.10 (7)
@@ -33,14 +33,14 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.10" to "v23.2.4" 
 │   │   └── restart node 1 with binary version v23.1.10 (10)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (11)
 │   ├── run "my mixed-version feature" (12)
-│   └── wait for nodes :1-4 to reach cluster version '23.1' (13)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (13)
 ├── upgrade cluster from "v23.1.10" to "v23.2.4"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (14)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (14)
 │   ├── upgrade nodes :1-4 from "v23.1.10" to "v23.2.4"
 │   │   ├── restart node 1 with binary version v23.2.4 (15)
 │   │   ├── run following steps concurrently
 │   │   │   ├── run "my mixed-version feature", after 500ms delay (16)
-│   │   │   └── set cluster setting "test_cluster_setting" to 1, after 3m0s delay (17)
+│   │   │   └── set cluster setting "test_cluster_setting" to 1 on system tenant, after 3m0s delay (17)
 │   │   ├── restart node 3 with binary version v23.2.4 (18)
 │   │   ├── restart node 4 with binary version v23.2.4 (19)
 │   │   └── restart node 2 with binary version v23.2.4 (20)
@@ -48,7 +48,7 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.10" to "v23.2.4" 
 │   │   ├── restart node 1 with binary version v23.1.10 (21)
 │   │   ├── restart node 3 with binary version v23.1.10 (22)
 │   │   ├── run "my mixed-version feature" (23)
-│   │   ├── reset cluster setting "test_cluster_setting" (24)
+│   │   ├── reset cluster setting "test_cluster_setting" on system tenant (24)
 │   │   ├── restart node 4 with binary version v23.1.10 (25)
 │   │   └── restart node 2 with binary version v23.1.10 (26)
 │   ├── upgrade nodes :1-4 from "v23.1.10" to "v23.2.4"
@@ -56,14 +56,14 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.10" to "v23.2.4" 
 │   │   ├── restart node 3 with binary version v23.2.4 (28)
 │   │   ├── restart node 4 with binary version v23.2.4 (29)
 │   │   ├── run "my mixed-version feature" (30)
-│   │   ├── set cluster setting "test_cluster_setting" to 1 (31)
+│   │   ├── set cluster setting "test_cluster_setting" to 1 on system tenant (31)
 │   │   └── restart node 2 with binary version v23.2.4 (32)
-│   ├── reset cluster setting "test_cluster_setting" (33)
+│   ├── reset cluster setting "test_cluster_setting" on system tenant (33)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (34)
-│   ├── wait for nodes :1-4 to reach cluster version '23.2' (35)
-│   └── set cluster setting "test_cluster_setting" to 2 (36)
+│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (35)
+│   └── set cluster setting "test_cluster_setting" to 2 on system tenant (36)
 └── upgrade cluster from "v23.2.4" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (37)
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (37)
    ├── upgrade nodes :1-4 from "v23.2.4" to "<current>"
    │   ├── restart node 2 with binary version <current> (38)
    │   ├── run "my mixed-version feature" (39)
@@ -83,4 +83,4 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.10" to "v23.2.4" 
    │   └── restart node 1 with binary version <current> (51)
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (52)
    ├── run "my mixed-version feature" (53)
-   └── wait for nodes :1-4 to reach cluster version <current> (54)
+   └── wait for system tenant on nodes :1-4 to reach cluster version <current> (54)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/conflicting_mutators
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/conflicting_mutators
@@ -22,9 +22,9 @@ plan debug=true
 mixed-version test plan for upgrading from "v22.2.8" to "<current>" with mutators {concurrent_user_hooks_mutator, remove_user_hooks_mutator}:
 ├── install fixtures for version "v22.2.8" (1) [stage=cluster-setup]
 ├── start cluster at version "v22.2.8" (2) [stage=cluster-setup]
-├── wait for nodes :1-4 to reach cluster version '22.2' (3) [stage=cluster-setup]
+├── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (3) [stage=cluster-setup]
 └── upgrade cluster from "v22.2.8" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (4) [stage=init]
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (4) [stage=init]
    ├── upgrade nodes :1-4 from "v22.2.8" to "<current>"
    │   ├── restart node 3 with binary version <current> (5) [stage=temporary-upgrade]
    │   ├── restart node 2 with binary version <current> (6) [stage=temporary-upgrade]
@@ -44,4 +44,4 @@ mixed-version test plan for upgrading from "v22.2.8" to "<current>" with mutator
    │   ├── testSingleStep (18) [stage=last-upgrade]
    │   └── restart node 3 with binary version <current> (19) [stage=last-upgrade]
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (20) [stage=running-upgrade-migrations,finalizing]
-   └── wait for nodes :1-4 to reach cluster version <current> (21) [stage=running-upgrade-migrations,finalizing]
+   └── wait for system tenant on nodes :1-4 to reach cluster version <current> (21) [stage=running-upgrade-migrations,finalizing]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
@@ -29,9 +29,9 @@ plan
 ----
 mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
 ├── start cluster at version "v22.2.3" (1)
-├── wait for nodes :1-4 to reach cluster version '22.2' (2)
+├── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (2)
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (3)
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
 │   │   ├── restart node 3 with binary version v23.1.4 (4)
 │   │   ├── restart node 2 with binary version v23.1.4 (5)
@@ -39,13 +39,13 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
 │   │   ├── restart node 4 with binary version v23.1.4 (7)
 │   │   └── restart node 1 with binary version v23.1.4 (8)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (9)
-│   └── wait for nodes :1-4 to reach cluster version '23.1' (10)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (10)
 ├── run "initialize bank workload" (11)
 ├── start background hooks concurrently
 │   ├── run "bank workload", after 50ms delay (12)
 │   └── run "csv server", after 18s delay (13)
 ├── upgrade cluster from "v23.1.4" to "v23.2.0"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (14)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (14)
 │   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
 │   │   ├── restart node 1 with binary version v23.2.0 (15)
 │   │   ├── run mixed-version hooks concurrently
@@ -69,10 +69,10 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
 │   │   └── restart node 1 with binary version v23.2.0 (31)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (32)
 │   ├── run "mixed-version 2" (33)
-│   ├── wait for nodes :1-4 to reach cluster version '23.2' (34)
+│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (34)
 │   └── run "validate upgrade" (35)
 └── upgrade cluster from "v23.2.0" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (36)
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (36)
    ├── upgrade nodes :1-4 from "v23.2.0" to "<current>"
    │   ├── restart node 3 with binary version <current> (37)
    │   ├── run "mixed-version 2" (38)
@@ -95,5 +95,5 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
    │   ├── restart node 4 with binary version <current> (53)
    │   └── run "mixed-version 2" (54)
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (55)
-   ├── wait for nodes :1-4 to reach cluster version <current> (56)
+   ├── wait for system tenant on nodes :1-4 to reach cluster version <current> (56)
    └── run "validate upgrade" (57)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/minimum_supported_version
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/minimum_supported_version
@@ -29,9 +29,9 @@ plan
 ----
 mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
 ├── start cluster at version "v21.2.11" (1)
-├── wait for nodes :1-4 to reach cluster version '21.2' (2)
+├── wait for system tenant on nodes :1-4 to reach cluster version '21.2' (2)
 ├── upgrade cluster from "v21.2.11" to "v22.1.8"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (3)
 │   ├── upgrade nodes :1-4 from "v21.2.11" to "v22.1.8"
 │   │   ├── restart node 3 with binary version v22.1.8 (4)
 │   │   ├── restart node 2 with binary version v22.1.8 (5)
@@ -39,9 +39,9 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 4 with binary version v22.1.8 (7)
 │   │   └── restart node 1 with binary version v22.1.8 (8)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (9)
-│   └── wait for nodes :1-4 to reach cluster version '22.1' (10)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.1' (10)
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (11)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (11)
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
 │   │   ├── restart node 1 with binary version v22.2.3 (12)
 │   │   ├── restart node 3 with binary version v22.2.3 (13)
@@ -59,9 +59,9 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 3 with binary version v22.2.3 (23)
 │   │   └── wait for 1m0s (24)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (25)
-│   └── wait for nodes :1-4 to reach cluster version '22.2' (26)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (26)
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (27)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (27)
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
 │   │   ├── restart node 4 with binary version v23.1.4 (28)
 │   │   ├── restart node 1 with binary version v23.1.4 (29)
@@ -69,13 +69,13 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 2 with binary version v23.1.4 (31)
 │   │   └── restart node 3 with binary version v23.1.4 (32)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (33)
-│   └── wait for nodes :1-4 to reach cluster version '23.1' (34)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (34)
 ├── run "initialize bank workload" (35)
 ├── start background hooks concurrently
 │   ├── run "bank workload", after 100ms delay (36)
 │   └── run "csv server", after 5s delay (37)
 ├── upgrade cluster from "v23.1.4" to "v23.2.0"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (38)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (38)
 │   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
 │   │   ├── restart node 1 with binary version v23.2.0 (39)
 │   │   ├── restart node 3 with binary version v23.2.0 (40)
@@ -98,10 +98,10 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   └── restart node 2 with binary version v23.2.0 (55)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (56)
 │   ├── run "mixed-version 2" (57)
-│   ├── wait for nodes :1-4 to reach cluster version '23.2' (58)
+│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (58)
 │   └── run "validate upgrade" (59)
 └── upgrade cluster from "v23.2.0" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (60)
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (60)
    ├── upgrade nodes :1-4 from "v23.2.0" to "<current>"
    │   ├── restart node 4 with binary version <current> (61)
    │   ├── restart node 1 with binary version <current> (62)
@@ -125,5 +125,5 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
    │   └── restart node 4 with binary version <current> (77)
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (78)
    ├── run "mixed-version 2" (79)
-   ├── wait for nodes :1-4 to reach cluster version <current> (80)
+   ├── wait for system tenant on nodes :1-4 to reach cluster version <current> (80)
    └── run "validate upgrade" (81)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/multiple_upgrades
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/multiple_upgrades
@@ -17,9 +17,9 @@ plan
 ----
 mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" to "<current>":
 ├── start cluster at version "v22.1.8" (1)
-├── wait for nodes :1-4 to reach cluster version '22.1' (2)
+├── wait for system tenant on nodes :1-4 to reach cluster version '22.1' (2)
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (3)
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
 │   │   ├── restart node 3 with binary version v22.2.3 (4)
 │   │   ├── restart node 2 with binary version v22.2.3 (5)
@@ -27,11 +27,11 @@ mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" t
 │   │   ├── restart node 4 with binary version v22.2.3 (7)
 │   │   └── restart node 1 with binary version v22.2.3 (8)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (9)
-│   └── wait for nodes :1-4 to reach cluster version '22.2' (10)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (10)
 ├── run "initialize bank workload" (11)
 ├── run "bank workload" (12)
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (13)
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (13)
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
 │   │   ├── restart node 1 with binary version v23.1.4 (14)
 │   │   ├── run "mixed-version 1" (15)
@@ -51,9 +51,9 @@ mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" t
 │   │   ├── run "mixed-version 1" (27)
 │   │   └── restart node 2 with binary version v23.1.4 (28)
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (29)
-│   └── wait for nodes :1-4 to reach cluster version '23.1' (30)
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (30)
 └── upgrade cluster from "v23.1.4" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (31)
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (31)
    ├── upgrade nodes :1-4 from "v23.1.4" to "<current>"
    │   ├── restart node 2 with binary version <current> (32)
    │   ├── run "mixed-version 1" (33)
@@ -73,4 +73,4 @@ mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" t
    │   └── restart node 1 with binary version <current> (45)
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (46)
    ├── run "mixed-version 1" (47)
-   └── wait for nodes :1-4 to reach cluster version <current> (48)
+   └── wait for system tenant on nodes :1-4 to reach cluster version <current> (48)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/mutator_probabilities
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/mutator_probabilities
@@ -18,9 +18,9 @@ plan debug=true
 mixed-version test plan for upgrading from "v22.2.8" to "<current>" with mutators {concurrent_user_hooks_mutator}:
 ├── install fixtures for version "v22.2.8" (1) [stage=cluster-setup]
 ├── start cluster at version "v22.2.8" (2) [stage=cluster-setup]
-├── wait for nodes :1-4 to reach cluster version '22.2' (3) [stage=cluster-setup]
+├── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (3) [stage=cluster-setup]
 └── upgrade cluster from "v22.2.8" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (4) [stage=init]
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (4) [stage=init]
    ├── upgrade nodes :1-4 from "v22.2.8" to "<current>"
    │   ├── restart node 3 with binary version <current> (5) [stage=temporary-upgrade]
    │   ├── restart node 2 with binary version <current> (6) [stage=temporary-upgrade]
@@ -46,4 +46,4 @@ mixed-version test plan for upgrading from "v22.2.8" to "<current>" with mutator
    │   │   └── testSingleStep, after 0s delay (21) [stage=last-upgrade]
    │   └── restart node 3 with binary version <current> (22) [stage=last-upgrade]
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (23) [stage=running-upgrade-migrations,finalizing]
-   └── wait for nodes :1-4 to reach cluster version <current> (24) [stage=running-upgrade-migrations,finalizing]
+   └── wait for system tenant on nodes :1-4 to reach cluster version <current> (24) [stage=running-upgrade-migrations,finalizing]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/preserve_downgrade_option_randomizer
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/preserve_downgrade_option_randomizer
@@ -21,9 +21,9 @@ plan debug=true
 mixed-version test plan for upgrading from "v21.2.29" to "v22.1.8" to "v22.2.3" to "v23.1.10" to "v23.2.4" to "<current>" with mutators {preserve_downgrade_option_randomizer}:
 ├── install fixtures for version "v21.2.29" (1) [stage=cluster-setup]
 ├── start cluster at version "v21.2.29" (2) [stage=cluster-setup]
-├── wait for nodes :1-4 to reach cluster version '21.2' (3) [stage=cluster-setup]
+├── wait for system tenant on nodes :1-4 to reach cluster version '21.2' (3) [stage=cluster-setup]
 ├── upgrade cluster from "v21.2.29" to "v22.1.8"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (4) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (4) [stage=init]
 │   ├── upgrade nodes :1-4 from "v21.2.29" to "v22.1.8"
 │   │   ├── restart node 3 with binary version v22.1.8 (5) [stage=last-upgrade]
 │   │   ├── restart node 2 with binary version v22.1.8 (6) [stage=last-upgrade]
@@ -31,9 +31,9 @@ mixed-version test plan for upgrading from "v21.2.29" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 4 with binary version v22.1.8 (8) [stage=last-upgrade]
 │   │   └── restart node 1 with binary version v22.1.8 (9) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (10) [stage=running-upgrade-migrations,finalizing]
-│   └── wait for nodes :1-4 to reach cluster version '22.1' (11) [stage=running-upgrade-migrations,finalizing]
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.1' (11) [stage=running-upgrade-migrations,finalizing]
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (12) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (12) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
 │   │   ├── restart node 1 with binary version v22.2.3 (13) [stage=temporary-upgrade]
 │   │   ├── restart node 3 with binary version v22.2.3 (14) [stage=temporary-upgrade]
@@ -51,10 +51,10 @@ mixed-version test plan for upgrading from "v21.2.29" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 3 with binary version v22.2.3 (24) [stage=last-upgrade]
 │   │   └── wait for 1m0s (25) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (26) [stage=running-upgrade-migrations,finalizing]
-│   └── wait for nodes :1-4 to reach cluster version '22.2' (27) [stage=running-upgrade-migrations,finalizing]
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (27) [stage=running-upgrade-migrations,finalizing]
 ├── run "do something" (28) [stage=on-startup]
 ├── upgrade cluster from "v22.2.3" to "v23.1.10"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (29) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (29) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.10"
 │   │   ├── restart node 4 with binary version v23.1.10 (30) [stage=last-upgrade]
 │   │   ├── restart node 1 with binary version v23.1.10 (31) [stage=last-upgrade]
@@ -62,9 +62,9 @@ mixed-version test plan for upgrading from "v21.2.29" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 2 with binary version v23.1.10 (33) [stage=last-upgrade]
 │   │   └── restart node 3 with binary version v23.1.10 (34) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (35) [stage=running-upgrade-migrations,finalizing]
-│   └── wait for nodes :1-4 to reach cluster version '23.1' (36) [stage=running-upgrade-migrations,finalizing]
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (36) [stage=running-upgrade-migrations,finalizing]
 ├── upgrade cluster from "v23.1.10" to "v23.2.4"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (37) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (37) [stage=init]
 │   ├── upgrade nodes :1-4 from "v23.1.10" to "v23.2.4"
 │   │   ├── restart node 3 with binary version v23.2.4 (38) [stage=temporary-upgrade]
 │   │   ├── run "my mixed-version feature" (39) [stage=temporary-upgrade]
@@ -85,9 +85,9 @@ mixed-version test plan for upgrading from "v21.2.29" to "v22.1.8" to "v22.2.3" 
 │   │   └── restart node 2 with binary version v23.2.4 (52) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (53) [stage=running-upgrade-migrations,finalizing]
 │   ├── run "my mixed-version feature" (54) [stage=running-upgrade-migrations,finalizing]
-│   └── wait for nodes :1-4 to reach cluster version '23.2' (55) [stage=running-upgrade-migrations,finalizing]
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (55) [stage=running-upgrade-migrations,finalizing]
 └── upgrade cluster from "v23.2.4" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (56) [stage=init]
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (56) [stage=init]
    ├── upgrade nodes :1-4 from "v23.2.4" to "<current>"
    │   ├── restart node 2 with binary version <current> (57) [stage=temporary-upgrade]
    │   ├── restart node 1 with binary version <current> (58) [stage=temporary-upgrade]
@@ -107,4 +107,4 @@ mixed-version test plan for upgrading from "v21.2.29" to "v22.1.8" to "v22.2.3" 
    │   ├── restart node 3 with binary version <current> (70) [stage=last-upgrade]
    │   └── run "my mixed-version feature" (71) [stage=last-upgrade,finalizing]
    ├── run "my mixed-version feature" (72) [stage=running-upgrade-migrations,finalizing]
-   └── wait for nodes :1-4 to reach cluster version <current> (73) [stage=running-upgrade-migrations,finalizing]
+   └── wait for system tenant on nodes :1-4 to reach cluster version <current> (73) [stage=running-upgrade-migrations,finalizing]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
@@ -29,9 +29,9 @@ plan debug=true
 ----
 mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
 ├── start cluster at version "v21.2.11" (1) [stage=cluster-setup]
-├── wait for nodes :1-4 to reach cluster version '21.2' (2) [stage=cluster-setup]
+├── wait for system tenant on nodes :1-4 to reach cluster version '21.2' (2) [stage=cluster-setup]
 ├── upgrade cluster from "v21.2.11" to "v22.1.8"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (3) [stage=init]
 │   ├── upgrade nodes :1-4 from "v21.2.11" to "v22.1.8"
 │   │   ├── restart node 3 with binary version v22.1.8 (4) [stage=last-upgrade]
 │   │   ├── restart node 2 with binary version v22.1.8 (5) [stage=last-upgrade]
@@ -39,9 +39,9 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 4 with binary version v22.1.8 (7) [stage=last-upgrade]
 │   │   └── restart node 1 with binary version v22.1.8 (8) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (9) [stage=running-upgrade-migrations,finalizing]
-│   └── wait for nodes :1-4 to reach cluster version '22.1' (10) [stage=running-upgrade-migrations,finalizing]
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.1' (10) [stage=running-upgrade-migrations,finalizing]
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (11) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (11) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
 │   │   ├── restart node 1 with binary version v22.2.3 (12) [stage=temporary-upgrade]
 │   │   ├── restart node 3 with binary version v22.2.3 (13) [stage=temporary-upgrade]
@@ -59,13 +59,13 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 3 with binary version v22.2.3 (23) [stage=last-upgrade]
 │   │   └── wait for 1m0s (24) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (25) [stage=running-upgrade-migrations,finalizing]
-│   └── wait for nodes :1-4 to reach cluster version '22.2' (26) [stage=running-upgrade-migrations,finalizing]
+│   └── wait for system tenant on nodes :1-4 to reach cluster version '22.2' (26) [stage=running-upgrade-migrations,finalizing]
 ├── run "initialize bank workload" (27) [stage=on-startup]
 ├── start background hooks concurrently
 │   ├── run "bank workload", after 100ms delay (28) [stage=background]
 │   └── run "csv server", after 100ms delay (29) [stage=background]
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (30) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (30) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
 │   │   ├── restart node 4 with binary version v23.1.4 (31) [stage=last-upgrade]
 │   │   ├── run "mixed-version 2" (32) [stage=last-upgrade]
@@ -75,10 +75,10 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   └── restart node 3 with binary version v23.1.4 (36) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (37) [stage=running-upgrade-migrations,finalizing]
 │   ├── run "mixed-version 2" (38) [stage=running-upgrade-migrations,finalizing]
-│   ├── wait for nodes :1-4 to reach cluster version '23.1' (39) [stage=running-upgrade-migrations,finalizing]
+│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (39) [stage=running-upgrade-migrations,finalizing]
 │   └── run "validate upgrade" (40) [stage=after-upgrade-finished]
 ├── upgrade cluster from "v23.1.4" to "v23.2.0"
-│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (41) [stage=init]
+│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (41) [stage=init]
 │   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
 │   │   ├── restart node 3 with binary version v23.2.0 (42) [stage=temporary-upgrade]
 │   │   ├── restart node 4 with binary version v23.2.0 (43) [stage=temporary-upgrade]
@@ -102,10 +102,10 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   └── run "mixed-version 2" (59) [stage=last-upgrade]
 │   ├── allow upgrade to happen by resetting `preserve_downgrade_option` (60) [stage=running-upgrade-migrations,finalizing]
 │   ├── run "mixed-version 1" (61) [stage=running-upgrade-migrations,finalizing]
-│   ├── wait for nodes :1-4 to reach cluster version '23.2' (62) [stage=running-upgrade-migrations,finalizing]
+│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (62) [stage=running-upgrade-migrations,finalizing]
 │   └── run "validate upgrade" (63) [stage=after-upgrade-finished]
 └── upgrade cluster from "v23.2.0" to "<current>"
-   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (64) [stage=init]
+   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (64) [stage=init]
    ├── upgrade nodes :1-4 from "v23.2.0" to "<current>"
    │   ├── restart node 2 with binary version <current> (65) [stage=last-upgrade]
    │   ├── restart node 3 with binary version <current> (66) [stage=last-upgrade]
@@ -115,5 +115,5 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
    │   └── run "mixed-version 2" (70) [stage=last-upgrade]
    ├── allow upgrade to happen by resetting `preserve_downgrade_option` (71) [stage=running-upgrade-migrations,finalizing]
    ├── run "mixed-version 2" (72) [stage=running-upgrade-migrations,finalizing]
-   ├── wait for nodes :1-4 to reach cluster version <current> (73) [stage=running-upgrade-migrations,finalizing]
+   ├── wait for system tenant on nodes :1-4 to reach cluster version <current> (73) [stage=running-upgrade-migrations,finalizing]
    └── run "validate upgrade" (74) [stage=after-upgrade-finished]

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -54,7 +54,7 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 		if err := h.Exec(r, `CREATE TABLE test (id INT PRIMARY KEY)`); err != nil {
 			return err
 		}
-		_, db := h.RandomDB(r, c.All())
+		_, db := h.RandomDB(r)
 		if err := WaitFor3XReplication(ctx, t, l, db); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -48,7 +48,7 @@ func runImportMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster,
 		if err := h.Exec(r, "DROP DATABASE IF EXISTS tpcc CASCADE;"); err != nil {
 			return err
 		}
-		node := h.RandomNode(r, c.All())
+		node := c.All().SeededRandNode(r)[0]
 		cmd := tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, "", warehouses) + fmt.Sprintf(" {pgurl%s}", c.Node(node))
 		l.Printf("executing %q on node %d", cmd, node)
 		return c.RunE(ctx, option.WithNodes(c.Node(node)), cmd)

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -72,20 +72,20 @@ func executeSupportedDDLs(
 	r *rand.Rand,
 	testingUpgradedNodes bool,
 ) error {
-	nodes := option.NodeListOption{helper.RandomNode(r, c.All())}
+	nodes := c.All().SeededRandNode(r)
 	// We are not always guaranteed to be in a mixed-version binary state.
 	// If we are, update the set of nodes; otherwise, we will choose a random
 	// node.
-	if helper.Context.MixedBinary() {
+	if helper.Context().MixedBinary() {
 		if testingUpgradedNodes {
 			// In this case, we test that older nodes are able to adopt desc. jobs from newer nodes.
-			nodes = helper.Context.NodesInNextVersion() // N.B. this is the set of upgradedNodes.
+			nodes = helper.Context().NodesInNextVersion() // N.B. this is the set of upgradedNodes.
 		} else {
 			// In this case, we test that newer nodes are able to adopt desc. jobs from older nodes.
-			nodes = helper.Context.NodesInPreviousVersion() // N.B. this is the set of oldNodes.
+			nodes = helper.Context().NodesInPreviousVersion() // N.B. this is the set of oldNodes.
 		}
 	}
-	testUtils, err := newCommonTestUtils(ctx, t, c, helper.Context.CockroachNodes, false, false)
+	testUtils, err := newCommonTestUtils(ctx, t, c, helper.DefaultService().Descriptor.Nodes, false, false)
 	defer testUtils.CloseConnections()
 	if err != nil {
 		return err

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	//"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -80,7 +79,7 @@ func runSchemaChangeMixedVersions(
 			return err
 		}
 
-		randomNode := h.RandomNode(r, c.All())
+		randomNode := c.All().SeededRandNode(r)
 		doctorURL := fmt.Sprintf("{pgurl:%d}", randomNode)
 		// Now we validate that nothing is broken after the random schema changes have been run.
 		runCmd = roachtestutil.NewCommand("%s debug doctor examine cluster", test.DefaultCockroachPath).

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -67,8 +67,8 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 			// Run the following statements in a node running the next
 			// version, if any; otherwise, pick a random node.
 			nodes := c.All()
-			if h.Context.MixedBinary() {
-				nodes = h.Context.NodesInNextVersion()
+			if h.Context().MixedBinary() {
+				nodes = h.Context().NodesInNextVersion()
 			}
 
 			if err := h.ExecWithGateway(r, nodes, `DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -83,7 +83,7 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	mvt.AfterUpgradeFinalized(
 		"obtain system schema from the upgraded cluster",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			if !h.Context.ToVersion.IsCurrent() {
+			if !h.Context().ToVersion.IsCurrent() {
 				// Only validate the system schema if we're upgrading to the version
 				// under test.
 				return nil

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -117,9 +117,9 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.OnStartup(
 		"setup schema changer workload",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			node := h.RandomNode(rng, c.All())
+			node := c.All().SeededRandNode(rng)[0]
 			workloadPath, _, err := clusterupgrade.UploadWorkload(
-				ctx, t, l, c, c.Node(node), h.Context.ToVersion,
+				ctx, t, l, c, c.Node(node), h.Context().ToVersion,
 			)
 			if err != nil {
 				return errors.Wrap(err, "uploading workload binary")
@@ -155,12 +155,12 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"test schema change step",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			randomNode := h.RandomNode(rng, c.All())
+			randomNode := c.All().SeededRandNode(rng)[0]
 			// The schemachange workload is designed to work up to one
 			// version back. Therefore, we upload a compatible `workload`
 			// binary to `randomNode`, where the workload will run.
 			workloadPath, uploaded, err := clusterupgrade.UploadWorkload(
-				ctx, t, l, c, c.Node(randomNode), h.Context.ToVersion,
+				ctx, t, l, c, c.Node(randomNode), h.Context().ToVersion,
 			)
 			if err != nil {
 				return errors.Wrap(err, "uploading workload binary")


### PR DESCRIPTION
This commit introduces the notion of `services` to the mixedversion framework. Previously, callers would reference a server by a node in the cluster. However, we want to move to a direction where there might be multiple services running in the cluster (i.e., not only the system tenant, but application tenant(s) as well). The service abstraction allows callers to perform operations either on the service that is serving application requests or directly on the system tenant.

The framework exposes the test's "default service". This represents the service that is responsible for handling application requests in a test. For traditional, non-UA deployments, this is the system tenant as usual. For UA deployments (not yet implemented), this will point to a tenant service created during test setup.

This reorganization should have no observable behavioural change for tests. However, it lays the foundation on which UA deployments will be implemented in the framework.

Epic: none

Release note: None