### PR TITLE
roachprod: debug setup-ssh & print ssh logs from cli

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1367,14 +1367,16 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 			var err error
 			cmd := "test -e /mnt/data1/.roachprod-initialized"
 			opts := defaultCmdOpts("wait-init")
-			for j := 0; j < 600; j++ {
+			for j := 0; j < 30; j++ {
 				res, err = c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 				if err != nil {
 					return nil, err
 				}
 
 				if res.Err != nil {
-					time.Sleep(500 * time.Millisecond)
+					// DEBUG(herko): Log issues
+					l.Printf("SSH-DEBUG: %2d: %v\n\n", node, res.Err)
+					time.Sleep(5000 * time.Millisecond)
 					continue
 				}
 				return res, nil

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -73,8 +73,10 @@ func withDebugName(name string) remoteSessionOption {
 func newRemoteSession(l *logger.Logger, command *remoteCommand) *remoteSession {
 	var loggingArgs []string
 
-	// NB: -q suppresses -E, at least on *nix.
-	loggingArgs = []string{"-q"}
+	// DEBUG(herko): Force SSH logs from CLI
+	loggingArgs = []string{
+		"-vvv", "-E", fmt.Sprintf("./ssh_%s.log", timeutil.Now().Format(`150405.000000000`)),
+	}
 	logfile := ""
 	if !command.debugDisabled {
 		var debugName = command.debugName


### PR DESCRIPTION
Prints out more debugging information with `setup-ssh` and enables logs for `ssh` to `pwd`

Do not merge