### PR TITLE
release-23.1: sql: disable Streamer in some illegal cases

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -324,7 +324,7 @@ func runPlanInsidePlan(
 		plannerCopy.curPlan.subqueryPlans = params.p.curPlan.subqueryPlans
 	}
 
-	distributePlan := getPlanDistribution(
+	distributePlan, distSQLProhibitedErr := getPlanDistribution(
 		ctx, plannerCopy.Descriptors().HasUncommittedTypes(),
 		plannerCopy.SessionData().DistSQLMode, plan.main,
 	)
@@ -334,6 +334,7 @@ func runPlanInsidePlan(
 	}
 	evalCtx := evalCtxFactory()
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, &plannerCopy, plannerCopy.txn, distributeType)
+	planCtx.distSQLProhibitedErr = distSQLProhibitedErr
 	planCtx.stmtType = recv.stmtType
 	planCtx.mustUseLeafTxn = atomic.LoadUint32(&params.p.atomic.innerPlansMustUseLeafTxn) == 1
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3043,7 +3043,10 @@ func (ex *connExecutor) execCopyIn(
 			// execInsertPlan
 			func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
 				defer p.curPlan.close(ctx)
-				_, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, DistributionTypeNone, nil /* progressAtomic */)
+				_, err := ex.execWithDistSQLEngine(
+					ctx, p, tree.RowsAffected, res, DistributionTypeNone,
+					nil /* progressAtomic */, nil, /* distSQLProhibitedErr */
+				)
 				return err
 			},
 		)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1704,7 +1704,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			}
 		}
 	}
-	distributePlan := getPlanDistribution(
+	distributePlan, distSQLProhibitedErr := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		distSQLMode, planner.curPlan.main,
 	)
@@ -1762,7 +1762,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 	ex.sessionTracing.TraceExecStart(ctx, "distributed")
 	stats, err = ex.execWithDistSQLEngine(
-		ctx, planner, stmt.AST.StatementReturnType(), res, distribute, progAtomic,
+		ctx, planner, stmt.AST.StatementReturnType(), res, distribute, progAtomic, distSQLProhibitedErr,
 	)
 	if ppInfo := getPausablePortalInfo(); ppInfo != nil {
 		// For pausable portals, we log the stats when closing the portal, so we need
@@ -2152,6 +2152,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	res RestrictedCommandResult,
 	distribute DistributionType,
 	progressAtomic *uint64,
+	distSQLProhibitedErr error,
 ) (topLevelQueryStats, error) {
 	defer planner.curPlan.savePlanInfo()
 	recv := MakeDistSQLReceiver(
@@ -2175,6 +2176,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		evalCtx := planner.ExtendedEvalContext()
 		planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner,
 			planner.txn, distribute)
+		planCtx.distSQLProhibitedErr = distSQLProhibitedErr
 		planCtx.stmtType = recv.stmtType
 		// Skip the diagram generation since on this "main" query path we can get it
 		// via the statement bundle.

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -820,7 +820,10 @@ type PlanningCtx struct {
 
 	// isLocal is set to true if we're planning this query on a single node.
 	isLocal bool
-	planner *planner
+	// distSQLProhibitedErr, if set, indicates why the plan couldn't be
+	// distributed.
+	distSQLProhibitedErr error
+	planner              *planner
 
 	// usePlannerDescriptorsForLocalFlow may be set to true to force
 	// planner.Descriptors() use for local flows.

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -765,7 +765,21 @@ func (dsp *DistSQLPlanner) Run(
 				}
 				return false
 			}()
-			if !containsNonDefaultLocking && !mustUseRootTxn {
+			// We disable the usage of the Streamer API whenever usage of
+			// DistSQL was prohibited with an error. The thinking behind it is
+			// that we might have a plan where some expression (e.g. a cast to
+			// an Oid type) uses the planner's txn (which is the RootTxn), so
+			// it'd be illegal to use LeafTxns for a part of such plan.
+			// TODO(yuzefovich): this check is both excessive and insufficient.
+			// For example:
+			// - it disables the usage of the Streamer when a subquery has an
+			// Oid type, but that would have no impact on usage of the Streamer
+			// in the main query;
+			// - it might allow the usage of the Streamer even when the internal
+			// executor is used by a part of the plan, and the IE would use the
+			// RootTxn. Arguably, this would be a bug in not prohibiting the
+			// DistSQL altogether.
+			if !containsNonDefaultLocking && !mustUseRootTxn && planCtx.distSQLProhibitedErr == nil {
 				if evalCtx.SessionData().StreamerEnabled {
 					for _, proc := range plan.Processors {
 						if jr := proc.Spec.Core.JoinReader; jr != nil {
@@ -1720,15 +1734,16 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	skipDistSQLDiagramGeneration bool,
 	mustUseLeafTxn bool,
 ) error {
-	distributeSubquery := getPlanDistribution(
+	subqueryDistribution, distSQLProhibitedErr := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		planner.SessionData().DistSQLMode, subqueryPlan.plan,
-	).WillDistribute()
+	)
 	distribute := DistributionType(DistributionTypeNone)
-	if distributeSubquery {
+	if subqueryDistribution.WillDistribute() {
 		distribute = DistributionTypeAlways
 	}
 	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
+	subqueryPlanCtx.distSQLProhibitedErr = distSQLProhibitedErr
 	subqueryPlanCtx.stmtType = tree.Rows
 	subqueryPlanCtx.skipDistSQLDiagramGeneration = skipDistSQLDiagramGeneration
 	subqueryPlanCtx.subOrPostQuery = true
@@ -2108,15 +2123,16 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	associateNodeWithComponents func(exec.Node, execComponents),
 	addTopLevelQueryStats func(stats *topLevelQueryStats),
 ) error {
-	distributePostquery := getPlanDistribution(
+	postqueryDistribution, distSQLProhibitedErr := getPlanDistribution(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		planner.SessionData().DistSQLMode, postqueryPlan,
-	).WillDistribute()
+	)
 	distribute := DistributionType(DistributionTypeNone)
-	if distributePostquery {
+	if postqueryDistribution.WillDistribute() {
 		distribute = DistributionTypeAlways
 	}
 	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
+	postqueryPlanCtx.distSQLProhibitedErr = distSQLProhibitedErr
 	postqueryPlanCtx.stmtType = tree.Rows
 	// Postqueries are only executed on the main query path where we skip the
 	// diagram generation.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1807,6 +1807,10 @@ func shouldDistributeGivenRecAndMode(
 // is reused, but if plan has logical representation (i.e. it is a planNode
 // tree), then we traverse that tree in order to determine the distribution of
 // the plan.
+//
+// The returned error, if any, indicates why we couldn't distribute the plan.
+// Note that it's possible that we choose to not distribute the plan while
+// nil error is returned.
 // WARNING: in some cases when this method returns
 // physicalplan.FullyDistributedPlan, the plan might actually run locally. This
 // is the case when
@@ -1821,38 +1825,40 @@ func getPlanDistribution(
 	txnHasUncommittedTypes bool,
 	distSQLMode sessiondatapb.DistSQLExecMode,
 	plan planMaybePhysical,
-) physicalplan.PlanDistribution {
+) (_ physicalplan.PlanDistribution, distSQLProhibitedErr error) {
 	if plan.isPhysicalPlan() {
-		return plan.physPlan.Distribution
+		// TODO(#47473): store the distSQLProhibitedErr for DistSQL spec factory
+		// too.
+		return plan.physPlan.Distribution, nil
 	}
 
 	// If this transaction has modified or created any types, it is not safe to
 	// distribute due to limitations around leasing descriptors modified in the
 	// current transaction.
 	if txnHasUncommittedTypes {
-		return physicalplan.LocalPlan
+		return physicalplan.LocalPlan, nil
 	}
 
 	if distSQLMode == sessiondatapb.DistSQLOff {
-		return physicalplan.LocalPlan
+		return physicalplan.LocalPlan, nil
 	}
 
 	// Don't try to run empty nodes (e.g. SET commands) with distSQL.
 	if _, ok := plan.planNode.(*zeroNode); ok {
-		return physicalplan.LocalPlan
+		return physicalplan.LocalPlan, nil
 	}
 
 	rec, err := checkSupportForPlanNode(plan.planNode)
 	if err != nil {
 		// Don't use distSQL for this request.
 		log.VEventf(ctx, 1, "query not supported for distSQL: %s", err)
-		return physicalplan.LocalPlan
+		return physicalplan.LocalPlan, err
 	}
 
 	if shouldDistributeGivenRecAndMode(rec, distSQLMode) {
-		return physicalplan.FullyDistributedPlan
+		return physicalplan.FullyDistributedPlan, nil
 	}
-	return physicalplan.LocalPlan
+	return physicalplan.LocalPlan, nil
 }
 
 // golangFillQueryArguments transforms Go values into datums.

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -62,7 +62,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// Note that we delay adding the annotation about the distribution until
 		// after the plan is finalized (when the physical plan is successfully
 		// created).
-		distribution := getPlanDistribution(
+		distribution, _ := getPlanDistribution(
 			params.ctx, params.p.Descriptors().HasUncommittedTypes(),
 			params.extendedEvalCtx.SessionData().DistSQLMode, plan.main,
 		)

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -41,7 +41,7 @@ type explainVecNode struct {
 func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
-	distribution := getPlanDistribution(
+	distribution, _ := getPlanDistribution(
 		params.ctx, params.p.Descriptors().HasUncommittedTypes(),
 		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main,
 	)

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -104,6 +104,52 @@ regions: <hidden>
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0U9FqE0EUffcrLvdJYUx38yAyIARDhdQ2KWnpiwSZnbnENbNz15m7mBDyWf6AXya700JrrKjYx3Pm3HsP5zB7TF88arw6PT-dXoMdGXi3XFyAhbPFbA4OFnNwowregB1VqDCwo7lpKKH-gCWuFLaRLaXEsaf2g2DmtqgLhXVoO-nplULLkVDvUWrxhBqvTeVpScZRPClQoSMxtR_W2kkiiwqn7LsmJA1GQX_7qjU9eokK39-A1A1pKL5_SxlbDkJBag5HT5G_JohknIZxZqqd0B1VvoK3mV0vL6dgjfcpCy9uplNIQi1Y7oLAc9rKSR3khYZiMJ0FRJvHBI3ZQkMNxx0Y79kaIaehGA5WRuwnSsCdtJ1o6PWD0ztijKuDwoxuU0xi1oS6PKg_T_qM63AbdPkwaDdxH9sN7VDhOfOma-Ez1wE4aJiM7xfQp7_oLU36DcOxIdQcU8ZJjPdH0f9bS-VxS69_VVL5X0rqEjlIEsk0FFEhbcl2xxafqMvx33S5pNRySPSgx8c2F4eVQnJryj8zcRctXUa2w5kMF8PcQDhKkl_LDGYhP_UG7w-Xvx0e_zS8Ojz7EQAA__9vVGhb
 
+# Regression test for using the Streamer API when we have a cast to an Oid type
+# for which DistSQL is prohibited (#122274). (Note that, unlike above, we don't
+# have 'lookup join (streamer)' here - that's the test.)
+query T
+EXPLAIN ANALYZE (DISTSQL) SELECT c.a::REGNAMESPACE FROM c JOIN d ON d.b = c.b
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+rows read from KV: 3 (24 B, 3 gRPC calls)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+·
+• render
+│
+└── • lookup join
+    │ nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 2
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows read: 1
+    │ KV bytes read: 8 B
+    │ KV gRPC calls: 1
+    │ estimated max memory allocated: 0 B
+    │ table: d@d_pkey
+    │ equality: (b) = (b)
+    │
+    └── • scan
+          nodes: <hidden>
+          regions: <hidden>
+          actual row count: 2
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows read: 2
+          KV bytes read: 16 B
+          KV gRPC calls: 2
+          estimated max memory allocated: 0 B
+          estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+          table: c@sec
+          spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0k8-KE0EQxu8-RVEnhXZ3JgeRBiHrECXr5g-TZS8SpNNdxDE9XWN3DyaEPJYv4JPJTGdhY1xR0eP3VVVX8f1m9hg-W5S4GN2MilvQF0rKcvR2ejUZLeZXxQjelLMJaLiejadgYDYFc7GCV6AvVijQsaGpqimgfI85LgU2njWFwL6z9n3D2GxRZgIr17Sxs5cCNXtCucdYRUso8VatLJWkDPnLDAUaiqqy_bN6GEijwIJtW7sgQQnodi8a1annKPDdHcSqJgnZt68hac0ukosVu7OS5y8BPCkjYZCc1S7SvZW_gNfJXZfzArSyNqTGyV1RQIjUgObWRXhK23hZufhMQtYfnRqINo811GoLNdXsd6CsZa0iGQlZv3Clov5IAbiNTRsldP39pffGAJcHgUkdUwxRrQllfhC_n_Q1V-4YdH4atBmaD82GdijwhnnTNvCJKwfsJAwHDwF06ZfkDHkJw_z0e8Hj9j7llFvSISprz1j8Hbb8HNvLn1HL_wk12pJuz0_6TzAHfwKzpNCwC3QC8rGXs8NSIJk1pV8zcOs1zT3rfk2Ss36uNwyFmKp5EmOXSt2BD4fzXw4PfhheHp58DwAA__96rGud
+
 query T
 EXPLAIN (OPT, VERBOSE) SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b
 ----

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -410,10 +410,11 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				}
 			}
 
-			isLocal := !getPlanDistribution(
+			planDistribution, _ := getPlanDistribution(
 				ctx, localPlanner.Descriptors().HasUncommittedTypes(),
 				localPlanner.extendedEvalCtx.SessionData().DistSQLMode, localPlanner.curPlan.main,
-			).WillDistribute()
+			)
+			isLocal := !planDistribution.WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
 				Table: *table.TableDesc(),
 			}}


### PR DESCRIPTION
Backport 1/1 commits from #123111.

/cc @cockroachdb/release

---

Previously, it was possible to run into an internal error due to the usage of the Streamer API in the main query while part of the query (e.g. a cast to an Oid type) uses the Internal Executor with the RootTxn. This is illegal and might trigger `attempting to append refresh spans after the tracked timestamp has moved forward` error. We fix this by disabling the Streamer whenever usage of DistSQL was prohibited.

This seems reasonable because both DistSQL and Streamer provide concurrency (but in different forms) and require usage of the LeafTxns, so if we couldn't distribute the plan, then we likely can't use the Streamer either. Note that this check might be stricter than necessary (DistSQL could be prohibited due to some serialization issues that Streamer wouldn't be affected by). Additionally, if the plan is not distributed because `distsql=off` is used, then we don't know whether it would have been prohibited or not, so we might not disable the Streamer when we should.

Still, this seems like a reasonable improvement.

Fixes: #122274.

Release note (bug fix): CockroachDB could previously run into `attempting to append refresh spans after the tracked timestamp has moved forward` internal error in some edge cases, and this is now fixed. The bug has been present since 22.2 version.

Release justification: bug fix.