### PR TITLE
genbzl: remove unnecessary dependencies

### DIFF
--- a/pkg/gen/genbzl/BUILD.bazel
+++ b/pkg/gen/genbzl/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/gen/genbzl",
     visibility = ["//visibility:private"],
-    deps = [
-        "//pkg/cli/exit",
-        "@com_github_cockroachdb_errors//:errors",
-    ],
 )
 
 go_binary(

--- a/pkg/gen/genbzl/main.go
+++ b/pkg/gen/genbzl/main.go
@@ -26,8 +26,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 )
 
 var (
@@ -41,7 +39,7 @@ func main() {
 	flag.Parse()
 	if err := generate(*outDir); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to generate files: %v\n", err)
-		exit.WithCode(exit.UnspecifiedError())
+		os.Exit(1)
 	}
 }
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1545,6 +1545,7 @@ func TestLint(t *testing.T) {
 			":!sql/colexec/execgen",
 			":!kv/kvpb/gen/main.go",
 			":!testutils/serverutils/fwgen/gen.go",
+			":!gen/genbzl/main.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
The `cockroachdb/errors` and `pkg/cli/exit` dependencies are quite heavy and we have them for basically no reason. Remove them and replace with stdlib analogues to remove dependencies from this binary, making `dev gen bazel` quicker to build and run.

Part of: #123159
Epic: CRDB-17171
Release note: None