### PR TITLE
streamingest: assign one partition per proc

### DIFF
--- a/pkg/ccl/cmdccl/clusterrepl/main.go
+++ b/pkg/ccl/cmdccl/clusterrepl/main.go
@@ -246,8 +246,10 @@ func subscriptionConsumer(
 				}
 				switch event.Type() {
 				case streamingccl.KVEvent:
-					kv := event.GetKV()
-					sz = kv.Size()
+					sz = 0
+					for _, kv := range event.GetKVs() {
+						sz += kv.Size()
+					}
 				case streamingccl.SSTableEvent:
 					ssTab := event.GetSSTable()
 					sz = ssTab.Size()

--- a/pkg/ccl/streamingccl/event.go
+++ b/pkg/ccl/streamingccl/event.go
@@ -46,8 +46,8 @@ type Event interface {
 	// Type specifies which accessor will be meaningful.
 	Type() EventType
 
-	// GetKV returns a KV event if the EventType is KVEvent.
-	GetKV() *roachpb.KeyValue
+	// GetKVs returns a KV event if the EventType is KVEvent.
+	GetKVs() []roachpb.KeyValue
 
 	// GetSSTable returns a AddSSTable event if the EventType is SSTableEvent.
 	GetSSTable() *kvpb.RangeFeedSSTable
@@ -68,7 +68,7 @@ type Event interface {
 
 // kvEvent is a key value pair that needs to be ingested.
 type kvEvent struct {
-	kv roachpb.KeyValue
+	kv []roachpb.KeyValue
 }
 
 var _ Event = kvEvent{}
@@ -78,9 +78,9 @@ func (kve kvEvent) Type() EventType {
 	return KVEvent
 }
 
-// GetKV implements the Event interface.
-func (kve kvEvent) GetKV() *roachpb.KeyValue {
-	return &kve.kv
+// GetKVs implements the Event interface.
+func (kve kvEvent) GetKVs() []roachpb.KeyValue {
+	return kve.kv
 }
 
 // GetSSTable implements the Event interface.
@@ -118,8 +118,8 @@ func (sste sstableEvent) Type() EventType {
 	return SSTableEvent
 }
 
-// GetKV implements the Event interface.
-func (sste sstableEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (sste sstableEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -160,8 +160,8 @@ func (dre delRangeEvent) Type() EventType {
 	return DeleteRangeEvent
 }
 
-// GetKV implements the Event interface.
-func (dre delRangeEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (dre delRangeEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -205,8 +205,8 @@ func (ce checkpointEvent) Type() EventType {
 	return CheckpointEvent
 }
 
-// GetKV implements the Event interface.
-func (ce checkpointEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (ce checkpointEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -246,8 +246,8 @@ func (spe spanConfigEvent) Type() EventType {
 	return SpanConfigEvent
 }
 
-// GetKV implements the Event interface.
-func (spe spanConfigEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (spe spanConfigEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -288,7 +288,7 @@ func (se splitEvent) Type() EventType {
 }
 
 // GetKV implements the Event interface.
-func (se splitEvent) GetKV() *roachpb.KeyValue {
+func (se splitEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -318,7 +318,7 @@ func (se splitEvent) GetSplitEvent() *roachpb.Key {
 }
 
 // MakeKVEvent creates an Event from a KV.
-func MakeKVEvent(kv roachpb.KeyValue) Event {
+func MakeKVEvent(kv []roachpb.KeyValue) Event {
 	return kvEvent{kv: kv}
 }
 

--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/tree",
+        "//pkg/util/bufalloc",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/ccl/streamingccl/streamclient/client_helpers.go
+++ b/pkg/ccl/streamingccl/streamclient/client_helpers.go
@@ -18,7 +18,7 @@ import (
 )
 
 func subscribeInternal(
-	ctx context.Context, feed pgx.Rows, eventsChan chan streamingccl.Event, closeChan chan struct{},
+	ctx context.Context, feed pgx.Rows, eventCh chan streamingccl.Event, closeCh chan struct{},
 ) error {
 	// Get the next event from the cursor.
 	var bufferedEvent *streampb.StreamEvent
@@ -51,8 +51,8 @@ func subscribeInternal(
 			return err
 		}
 		select {
-		case eventsChan <- event:
-		case <-closeChan:
+		case eventCh <- event:
+		case <-closeCh:
 			// Exit quietly to not cause other subscriptions in the same
 			// ctxgroup.Group to exit.
 			return nil
@@ -81,8 +81,8 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 			event = streamingccl.MakeSSTableEvent(streamEvent.Batch.Ssts[0])
 			streamEvent.Batch.Ssts = streamEvent.Batch.Ssts[1:]
 		case len(streamEvent.Batch.KeyValues) > 0:
-			event = streamingccl.MakeKVEvent(streamEvent.Batch.KeyValues[0])
-			streamEvent.Batch.KeyValues = streamEvent.Batch.KeyValues[1:]
+			event = streamingccl.MakeKVEvent(streamEvent.Batch.KeyValues)
+			streamEvent.Batch.KeyValues = nil
 		case len(streamEvent.Batch.DelRanges) > 0:
 			event = streamingccl.MakeDeleteRangeEvent(streamEvent.Batch.DelRanges[0])
 			streamEvent.Batch.DelRanges = streamEvent.Batch.DelRanges[1:]

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -102,7 +102,7 @@ func (sc testStreamClient) Subscribe(
 	}
 
 	events := make(chan streamingccl.Event, 2)
-	events <- streamingccl.MakeKVEvent(sampleKV)
+	events <- streamingccl.MakeKVEvent([]roachpb.KeyValue{sampleKV})
 	events <- streamingccl.MakeCheckpointEvent([]jobspb.ResolvedSpan{sampleResolvedSpan})
 	close(events)
 
@@ -303,8 +303,10 @@ func ExampleClient() {
 			for event := range sub.Events() {
 				switch event.Type() {
 				case streamingccl.KVEvent:
-					kv := event.GetKV()
-					fmt.Printf("kv: %s->%s@%d\n", kv.Key.String(), string(kv.Value.RawBytes), kv.Value.Timestamp.WallTime)
+					kvs := event.GetKVs()
+					for _, kv := range kvs {
+						fmt.Printf("kv: %s->%s@%d\n", kv.Key.String(), string(kv.Value.RawBytes), kv.Value.Timestamp.WallTime)
+					}
 				case streamingccl.SSTableEvent:
 					sst := event.GetSSTable()
 					fmt.Printf("sst: %s->%s@%d\n", sst.Span.String(), string(sst.Data), sst.WriteTS.WallTime)

--- a/pkg/ccl/streamingccl/streamingest/merged_subscription_test.go
+++ b/pkg/ccl/streamingccl/streamingest/merged_subscription_test.go
@@ -30,12 +30,12 @@ func TestMergeSubscriptionsRun(t *testing.T) {
 	ctx := context.Background()
 	events := func(partition string) []streamingccl.Event {
 		return []streamingccl.Event{
-			streamingccl.MakeKVEvent(roachpb.KeyValue{
+			streamingccl.MakeKVEvent([]roachpb.KeyValue{{
 				Key: []byte(partition + "_key1"),
-			}),
-			streamingccl.MakeKVEvent(roachpb.KeyValue{
+			}}),
+			streamingccl.MakeKVEvent([]roachpb.KeyValue{{
 				Key: []byte(partition + "_key2"),
-			}),
+			}}),
 		}
 	}
 	mockClient := &mockStreamClient{
@@ -67,7 +67,7 @@ func TestMergeSubscriptionsRun(t *testing.T) {
 		events := []string{}
 		g.Go(func() error {
 			for ev := range merged.Events() {
-				events = append(events, string(ev.GetKV().Key))
+				events = append(events, string(ev.GetKVs()[0].Key))
 			}
 			return nil
 		})

--- a/pkg/ccl/streamingccl/streamingest/replication_execution_details.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_execution_details.go
@@ -170,13 +170,15 @@ func generateSpanFrontierExecutionDetailFile(
 }
 
 func repackagePartitionSpecs(
-	streamIngestionSpecs map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+	streamIngestionSpecs map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec,
 ) execinfrapb.StreamIngestionPartitionSpecs {
 	specs := make([]*execinfrapb.StreamIngestionPartitionSpec, 0)
 	partitionSpecs := execinfrapb.StreamIngestionPartitionSpecs{Specs: specs}
-	for _, d := range streamIngestionSpecs {
-		for _, partitionSpec := range d.PartitionSpecs {
-			partitionSpecs.Specs = append(partitionSpecs.Specs, &partitionSpec)
+	for _, nodeProcs := range streamIngestionSpecs {
+		for _, proc := range nodeProcs {
+			for _, partitionSpec := range proc.PartitionSpecs {
+				partitionSpecs.Specs = append(partitionSpecs.Specs, &partitionSpec)
+			}
 		}
 	}
 	return partitionSpecs
@@ -190,7 +192,7 @@ func persistStreamIngestionPartitionSpecs(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	ingestionJobID jobspb.JobID,
-	streamIngestionSpecs map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+	streamIngestionSpecs map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec,
 ) error {
 	partitionSpecs := repackagePartitionSpecs(streamIngestionSpecs)
 	specBytes, err := protoutil.Marshal(&partitionSpecs)

--- a/pkg/ccl/streamingccl/streamingest/replication_execution_details_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_execution_details_test.go
@@ -303,8 +303,8 @@ func TestEndToEndFrontierExecutionDetailFile(t *testing.T) {
 	ctx := context.Background()
 
 	// First, let's persist some partitions specs.
-	streamIngestionsSpecs := map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec{
-		1: {
+	streamIngestionsSpecs := map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec{
+		1: {{
 			PartitionSpecs: map[string]execinfrapb.StreamIngestionPartitionSpec{
 				"1": {
 					SrcInstanceID:  2,
@@ -314,8 +314,8 @@ func TestEndToEndFrontierExecutionDetailFile(t *testing.T) {
 					},
 				},
 			},
-		},
-		2: {
+		}},
+		2: {{
 			PartitionSpecs: map[string]execinfrapb.StreamIngestionPartitionSpec{
 				"1": {
 					SrcInstanceID:  1,
@@ -325,8 +325,8 @@ func TestEndToEndFrontierExecutionDetailFile(t *testing.T) {
 					},
 				},
 			},
-		},
-		3: {
+		}},
+		3: {{
 			PartitionSpecs: map[string]execinfrapb.StreamIngestionPartitionSpec{
 				"1": {
 					SrcInstanceID:  3,
@@ -336,7 +336,7 @@ func TestEndToEndFrontierExecutionDetailFile(t *testing.T) {
 					},
 				},
 			},
-		},
+		}},
 	}
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -740,7 +740,7 @@ func TestSpecsPersistedOnlyAfterInitialPlan(t *testing.T) {
 	var replanCandidateCount int
 	replannedThreeTimes := make(chan struct{})
 	args.TestingKnobs = &sql.StreamingTestingKnobs{
-		AfterReplicationFlowPlan: func(ingestionSpecs map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+		AfterReplicationFlowPlan: func(ingestionSpecs map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec,
 			frontierSpec *execinfrapb.StreamIngestionFrontierSpec) {
 			replanCandidateCount++
 			if replanCandidateCount > 2 {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist_test.go
@@ -192,17 +192,19 @@ func TestSourceDestMatching(t *testing.T) {
 
 	// validatePairs tests that src-dst assignments are expected.
 	validatePairs := func(t *testing.T,
-		sipSpecs map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+		sipSpecs map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec,
 		expected map[pair]struct{}) {
-		for dstID, spec := range sipSpecs {
-			require.True(t, len(spec.PartitionSpecs) > 0, "empty node %s included in partition specs", dstID)
-			for srcID := range spec.PartitionSpecs {
-				srcIDNum, err := strconv.Atoi(srcID)
-				require.NoError(t, err)
-				expectKey := pair{srcIDNum, int(dstID)}
-				_, ok := expected[expectKey]
-				require.True(t, ok, "Src %s,Dst %d do not match", srcID, dstID)
-				delete(expected, expectKey)
+		for dstID, sips := range sipSpecs {
+			for _, spec := range sips {
+				require.True(t, len(spec.PartitionSpecs) > 0, "empty node %s included in partition specs", dstID)
+				for srcID := range spec.PartitionSpecs {
+					srcIDNum, err := strconv.Atoi(srcID)
+					require.NoError(t, err)
+					expectKey := pair{srcIDNum, int(dstID)}
+					_, ok := expected[expectKey]
+					require.True(t, ok, "Src %s,Dst %d do not match", srcID, dstID)
+					delete(expected, expectKey)
+				}
 			}
 		}
 		require.Equal(t, 0, len(expected), "expected matches not included")
@@ -211,13 +213,15 @@ func TestSourceDestMatching(t *testing.T) {
 	// validateEvenDistribution tests that source node assignments were evenly
 	// distributed across destination nodes. This function is only called on test
 	// cases without an expected exact src-dst node match.
-	validateEvenDistribution := func(t *testing.T, sipSpecs map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec, dstNodes []sql.InstanceLocality) {
+	validateEvenDistribution := func(t *testing.T, sipSpecs map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec, dstNodes []sql.InstanceLocality) {
 		require.Equal(t, len(sipSpecs), len(dstNodes))
 		dstNodeAssignmentCount := make(map[base.SQLInstanceID]int, len(dstNodes))
-		for dstID, spec := range sipSpecs {
+		for dstID, specs := range sipSpecs {
 			dstNodeAssignmentCount[dstID] = 0
-			for range spec.PartitionSpecs {
-				dstNodeAssignmentCount[dstID]++
+			for _, spec := range specs {
+				for range spec.PartitionSpecs {
+					dstNodeAssignmentCount[dstID]++
+				}
 			}
 		}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -300,10 +300,10 @@ func TestReplicationJobResumptionStartTime(t *testing.T) {
 	canContinue := make(chan struct{})
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
 
-	replicationSpecs := make(map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec, 0)
+	replicationSpecs := make(map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec, 0)
 	frontier := &execinfrapb.StreamIngestionFrontierSpec{}
 	args.TestingKnobs = &sql.StreamingTestingKnobs{
-		AfterReplicationFlowPlan: func(ingestionSpecs map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+		AfterReplicationFlowPlan: func(ingestionSpecs map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec,
 			frontierSpec *execinfrapb.StreamIngestionFrontierSpec) {
 			replicationSpecs = ingestionSpecs
 			frontier = frontierSpec
@@ -339,9 +339,11 @@ func TestReplicationJobResumptionStartTime(t *testing.T) {
 	startTime := replicationJobDetails.ReplicationStartTime
 	require.NotEmpty(t, startTime)
 
-	for _, r := range replicationSpecs {
-		require.Equal(t, startTime, r.InitialScanTimestamp)
-		require.Empty(t, r.PreviousReplicatedTimestamp)
+	for _, spec := range replicationSpecs {
+		for _, r := range spec {
+			require.Equal(t, startTime, r.InitialScanTimestamp)
+			require.Empty(t, r.PreviousReplicatedTimestamp)
+		}
 	}
 	require.Empty(t, frontier.ReplicatedTimeAtStart)
 
@@ -369,13 +371,15 @@ func TestReplicationJobResumptionStartTime(t *testing.T) {
 	// Assert that the previous highwater mark is greater than the replication
 	// start time.
 	var previousReplicatedTimestamp hlc.Timestamp
-	for _, r := range replicationSpecs {
-		require.Equal(t, startTime, r.InitialScanTimestamp)
-		require.True(t, r.InitialScanTimestamp.Less(r.PreviousReplicatedTimestamp))
-		if previousReplicatedTimestamp.IsEmpty() {
-			previousReplicatedTimestamp = r.PreviousReplicatedTimestamp
-		} else {
-			require.Equal(t, r.PreviousReplicatedTimestamp, previousReplicatedTimestamp)
+	for _, spec := range replicationSpecs {
+		for _, r := range spec {
+			require.Equal(t, startTime, r.InitialScanTimestamp)
+			require.True(t, r.InitialScanTimestamp.Less(r.PreviousReplicatedTimestamp))
+			if previousReplicatedTimestamp.IsEmpty() {
+				previousReplicatedTimestamp = r.PreviousReplicatedTimestamp
+			} else {
+				require.Equal(t, r.PreviousReplicatedTimestamp, previousReplicatedTimestamp)
+			}
 		}
 	}
 	require.Equal(t, frontier.ReplicatedTimeAtStart, previousReplicatedTimestamp)

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -115,7 +115,7 @@ func (d *partitionStreamDecoder) pop() streamingccl.Event {
 	}
 
 	if d.e.Batch != nil {
-		event := streamingccl.MakeKVEvent(d.e.Batch.KeyValues[0])
+		event := streamingccl.MakeKVEvent([]roachpb.KeyValue{d.e.Batch.KeyValues[0]})
 		d.e.Batch.KeyValues = d.e.Batch.KeyValues[1:]
 		if len(d.e.Batch.KeyValues) == 0 {
 			d.e.Batch = nil

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1806,7 +1806,7 @@ type StreamingTestingKnobs struct {
 
 	// AfterReplicationFlowPlan allows the caller to inspect the ingestion and
 	// frontier specs generated for the replication job.
-	AfterReplicationFlowPlan func(map[base.SQLInstanceID]*execinfrapb.StreamIngestionDataSpec,
+	AfterReplicationFlowPlan func(map[base.SQLInstanceID][]execinfrapb.StreamIngestionDataSpec,
 		*execinfrapb.StreamIngestionFrontierSpec)
 
 	AfterPersistingPartitionSpecs func()


### PR DESCRIPTION
Combining multiple partitions into a single proc's spec reduces the parallelism at which those partitions are subscribed and the subscriptions are buffered and ingested. Rather than make a single proc able to consume many partitions in parallel -- including buffering them separately to avoid overlapping key ranges during ingestions -- we can instead just change planning to plan one proc per partition, as each proc already has a subscription and buffer.

Release note: none.
Epic: none.