### PR TITLE
opt: improve partial index implication with virtual columns

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3770,6 +3770,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedMultiColumnSelectivityEstima
 	m.data.OptimizerUseImprovedMultiColumnSelectivityEstimate = val
 }
 
+func (m *sessionDataMutator) SetOptimizerProveImplicationWithVirtualComputedColumns(val bool) {
+	m.data.OptimizerProveImplicationWithVirtualComputedColumns = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6159,6 +6159,7 @@ optimizer                                                  on
 optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
+optimizer_prove_implication_with_virtual_computed_columns  on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2888,6 +2888,7 @@ opt_split_scan_limit                                       2048                N
 optimizer_always_use_histograms                            on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
+optimizer_prove_implication_with_virtual_computed_columns  on                  NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL      NULL        NULL        string
@@ -3071,6 +3072,7 @@ opt_split_scan_limit                                       2048                N
 optimizer_always_use_histograms                            on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
+optimizer_prove_implication_with_virtual_computed_columns  on                  NULL  user     NULL      on                  on
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL  user     NULL      on                  on
@@ -3253,6 +3255,7 @@ optimizer                                                  NULL    NULL     NULL
 optimizer_always_use_histograms                            NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
+optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -125,6 +125,7 @@ opt_split_scan_limit                                       2048
 optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
+optimizer_prove_implication_with_virtual_computed_columns  on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -737,6 +737,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 	h.evalCtx.SessionData().TrigramSimilarityThreshold = 0.3
 	h.evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = true
 	h.evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
+	h.evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = true
 
 	// Set up the test catalog.
 	h.testCat = testcat.New()

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -196,6 +196,7 @@ type Memo struct {
 	splitScanLimit                             int32
 	useImprovedZigzagJoinCosting               bool
 	useImprovedMultiColumnSelectivityEstimate  bool
+	proveImplicationWithVirtualComputedCols    bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -278,6 +279,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		splitScanLimit:                             evalCtx.SessionData().OptSplitScanLimit,
 		useImprovedZigzagJoinCosting:               evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting,
 		useImprovedMultiColumnSelectivityEstimate:  evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate,
+		proveImplicationWithVirtualComputedCols:    evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -438,6 +440,7 @@ func (m *Memo) IsStale(
 		m.splitScanLimit != evalCtx.SessionData().OptSplitScanLimit ||
 		m.useImprovedZigzagJoinCosting != evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting ||
 		m.useImprovedMultiColumnSelectivityEstimate != evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate ||
+		m.proveImplicationWithVirtualComputedCols != evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -454,7 +454,7 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedDistinctOnLimitHintCosting = false
 	notStale()
 
-	// Stale optimizer_use_distinct_on_limit_hint_costing.
+	// Stale optimizer_use_improved_trigram_similarity_selectivity.
 	evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = true
 	stale()
 	evalCtx.SessionData().OptimizerUseImprovedTrigramSimilaritySelectivity = false
@@ -481,6 +481,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
 	stale()
 	evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = false
+	notStale()
+
+	// Stale optimizer_prove_implication_with_virtual_computed_columns.
+	evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = true
+	stale()
+	evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = false
 	notStale()
 
 	// User no longer has access to view.

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -767,6 +767,8 @@ func (h *arbiterPredicateHelper) predicateIsImpliedByArbiterPredicate(pred memo.
 		return false
 	}
 
-	_, ok = h.im.FiltersImplyPredicate(arbiterFilters, pred)
+	// TODO(mgartner): Determine if we should pass the computed columns map
+	// here.
+	_, ok = h.im.FiltersImplyPredicate(arbiterFilters, pred, nil /* computedCols */)
 	return ok
 }

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -230,6 +230,36 @@ func BenchmarkImplicator(b *testing.B) {
 			filters: "a < 0 OR b > 10 OR c >= 10 OR d = 4 OR e = 'foo'",
 			pred:    "b > 0 OR e = 'foo'",
 		},
+		{
+			name:    "single-exact-match-virtual",
+			vars:    "a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual, d int as ((a->>'z')::INT) virtual",
+			filters: "(a->>'z')::INT >= 10",
+			pred:    "(a->>'z')::INT >= 10",
+		},
+		{
+			name:    "single-inexact-match-virtual",
+			vars:    "a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual, d int as ((a->>'z')::INT) virtual",
+			filters: "(a->>'z')::INT > 10",
+			pred:    "(a->>'z')::INT > 0",
+		},
+		{
+			name:    "single-no-match-virtual",
+			vars:    "a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual, d int as ((a->>'z')::INT) virtual",
+			filters: "(a->>'a')::INT >= 10",
+			pred:    "(a->>'b')::INT >= 10",
+		},
+		{
+			name:    "and-filters-virtual",
+			vars:    "a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual, d int as ((a->>'z')::INT) virtual, e string",
+			filters: "(a->>'x')::INT > 10 AND (a->>'y')::INT = 10 AND (a->>'z')::INT = 4 AND e = 'foo'",
+			pred:    "(a->>'y')::INT > 0 AND e = 'bar'",
+		},
+		{
+			name:    "or-filters-virtual",
+			vars:    "a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual, d int as ((a->>'z')::INT) virtual, e string",
+			filters: "(a->>'x')::INT > 10 OR (a->>'y')::INT = 10 OR (a->>'z')::INT = 4 OR e = 'foo'",
+			pred:    "(a->>'y')::INT > 0 OR e = 'bar'",
+		},
 	}
 	// Generate a few test cases with many columns to show how performance
 	// scales with respect to the number of columns.

--- a/pkg/sql/opt/partialidx/testdata/implicator/false-negative
+++ b/pkg/sql/opt/partialidx/testdata/implicator/false-negative
@@ -49,3 +49,12 @@ a >= 2 AND b > 0
 (a, b) > (2, 0)
 ----
 false
+
+# We do not prove implication in this case because a + 10 > 4 is normalized to
+# a > -6 before a + 10 can be replaced with b.
+predtest vars=(a int, b int as (a + 10) virtual)
+a + 10 > 4
+=>
+a + 10 IS NOT NULL
+----
+false

--- a/pkg/sql/opt/partialidx/testdata/implicator/virtual
+++ b/pkg/sql/opt/partialidx/testdata/implicator/virtual
@@ -1,0 +1,397 @@
+# Tests for filters and predicates with virtual computed column expressions.
+
+# Atoms with no computed column references.
+#
+# These cases best simulate filter-predicate implication in practice, compared
+# to tests below that contain computed column references. Filters referencing
+# virtual computed columns are rewritten with the computed expression so that
+# they can be pushed into Projects and filter directly above Scans, allowing
+# constrained scans to be generated. Similarly, predicates referencing virtual
+# computed columns are rewritten to reference only non-virtual columns.
+
+predtest vars=(a int, b int as (a + 10) virtual)
+a + 10 IS NOT NULL
+=>
+a + 10 IS NOT NULL
+----
+true
+└── remaining filters: none
+
+predtest vars=(a int, b int as (a + 10) virtual, c int)
+c > 4
+=>
+a + 10 IS NOT NULL
+----
+false
+
+predtest vars=(a int, b int as (a + 10) virtual)
+a + 10 > 4
+=>
+a + 10 > 0
+----
+true
+└── remaining filters: a > -6
+
+predtest vars=(a int, b int as (a + 10) virtual)
+a + 10 > 4
+=>
+a + 10 > 4
+----
+true
+└── remaining filters: none
+
+predtest vars=(a int, b int as (a + 10) virtual)
+a + 10 > 0
+=>
+a + 10 > 4
+----
+false
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IS NOT NULL
+=>
+(a->>'x')::INT IS NOT NULL
+----
+true
+└── remaining filters: none
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 4
+=>
+(a->>'x')::INT IS NOT NULL
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'y')::INT IS NOT NULL
+=>
+(a->>'x')::INT IS NOT NULL
+----
+false
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 4
+=>
+(a->>'x')::INT > 4
+----
+true
+└── remaining filters: none
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 4
+=>
+(a->>'x')::INT > 0
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT >= 4
+=>
+(a->>'x')::INT > 3
+----
+true
+└── remaining filters: (a->>'x')::INT8 >= 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 3
+=>
+(a->>'x')::INT >= 4
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 3
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 0
+=>
+(a->>'x')::INT > 4
+----
+false
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IN (1, 2, 3)
+=>
+(a->>'x')::INT IN (1, 2, 3)
+----
+true
+└── remaining filters: none
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IN (2, 6)
+=>
+(a->>'x')::INT IN (0, 2, 5, 6)
+----
+true
+└── remaining filters: (a->>'x')::INT8 IN (2, 6)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IN (2, 4)
+=>
+(a->>'x')::INT > 1
+----
+true
+└── remaining filters: (a->>'x')::INT8 IN (2, 4)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IN (2, 6)
+=>
+(a->>'x')::INT IN (2, 4)
+----
+false
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IN (1, 2, 3)
+=>
+(a->>'x')::INT IN (1, 2)
+----
+false
+
+# Atoms with virtual computed columns referenced in the filter. This should
+# never happen in practice because virtual computed column references should be
+# replaced with their computed expression.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+b IS NOT NULL
+=>
+(a->>'x')::INT IS NOT NULL
+----
+true
+└── remaining filters: b IS NOT NULL
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+b > 4
+=>
+(a->>'x')::INT IS NOT NULL
+----
+true
+└── remaining filters: b > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+b > 4
+=>
+(a->>'x')::INT > 0
+----
+true
+└── remaining filters: b > 4
+
+# Atoms with virtual computed columns referenced in the predicate. This should
+# never happen in practice because virtual computed column references should be
+# replaced with their computed expression.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT IS NOT NULL
+=>
+b IS NOT NULL
+----
+true
+└── remaining filters: (a->>'x')::INT8 IS NOT NULL
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 4
+=>
+b IS NOT NULL
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+(a->>'x')::INT > 4
+=>
+b > 0
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 4
+
+# Atoms with virtual computed columns referenced in the filter and predicate.
+# This should never happen in practice because virtual computed column
+# references should be replaced with their computed expression.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+b IS NOT NULL
+=>
+b IS NOT NULL
+----
+true
+└── remaining filters: none
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+b > 4
+=>
+b IS NOT NULL
+----
+true
+└── remaining filters: b > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual)
+b > 4
+=>
+b > 0
+----
+true
+└── remaining filters: b > 4
+
+# Predicates with disjunctions.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+(a->>'x')::INT > 4
+=>
+(a->>'x')::INT > 0 OR c > 0
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+(a->>'x')::INT > 4
+=>
+c > 0 OR (a->>'x')::INT > 0
+----
+true
+└── remaining filters: (a->>'x')::INT8 > 4
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+(a->>'x')::INT > 4 AND d > 0
+=>
+(a->>'x')::INT > 0 OR c > 0
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 4) AND (d > 0)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+d > 0 AND (a->>'x')::INT > 4
+=>
+(a->>'x')::INT > 0 OR c > 0
+----
+true
+└── remaining filters: (d > 0) AND ((a->>'x')::INT8 > 4)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+(a->>'x')::INT > 4 OR c > 0
+=>
+(a->>'x')::INT > 0 OR c > 0
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 4) OR (c > 0)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+(a->>'x')::INT > 4 OR d > 0
+=>
+(a->>'x')::INT > 0 OR c > 0
+----
+false
+
+# Predicates with conjunctions.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+(a->>'x')::INT > 4 AND c > 10
+=>
+(a->>'x')::INT > 0 AND c > 0
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 4) AND (c > 10)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+c > 10 AND (a->>'x')::INT > 4
+=>
+(a->>'x')::INT > 0 AND c > 0
+----
+true
+└── remaining filters: (c > 10) AND ((a->>'x')::INT8 > 4)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+(a->>'x')::INT > 4 AND c > 10
+=>
+(a->>'x')::INT> 0 AND c > 0
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 4) AND (c > 10)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+(a->>'x')::INT > 0 AND c > 0 AND d > 10
+=>
+(a->>'x')::INT> 0 AND c > 0
+----
+true
+└── remaining filters: d > 10
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+(a->>'x')::INT > 4 AND c > 0 AND d > 10
+=>
+(a->>'x')::INT> 0 AND c > 0
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 4) AND (d > 10)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int, d int)
+(a->>'x')::INT > 4 AND d > 10
+=>
+(a->>'x')::INT> 0 AND c > 0
+----
+false
+
+# Combinations.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+((a->>'x')::INT < 1 OR (a->>'x')::INT > 10) AND (c < 2 OR c > 20)
+=>
+((a->>'x')::INT < 3 OR (a->>'x')::INT > 9) AND (c < 4 OR c > 19)
+----
+true
+└── remaining filters: (((a->>'x')::INT8 < 1) OR ((a->>'x')::INT8 > 10)) AND ((c < 2) OR (c > 20))
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int)
+((a->>'x')::INT < 1 OR (a->>'x')::INT > 10) AND (c < 2 OR c > 20)
+=>
+(c < 4 OR c > 19) AND ((a->>'x')::INT > 9 OR (a->>'x')::INT < 3)
+----
+true
+└── remaining filters: (((a->>'x')::INT8 < 1) OR ((a->>'x')::INT8 > 10)) AND ((c < 2) OR (c > 20))
+
+# Complex computed column expressions.
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual)
+(a->>'x')::INT > 1 AND (a->>'y')::INT > 2
+=>
+(a->>'x')::INT IS NOT NULL AND (a->>'y')::INT IS NOT NULL
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 1) AND ((a->>'y')::INT8 > 2)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual)
+(a->>'x')::INT > 1 AND (a->>'y')::INT > 2
+=>
+(a->>'x')::INT > 1 AND (a->>'y')::INT > 2
+----
+true
+└── remaining filters: none
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual)
+(a->>'x')::INT > 1 OR (a->>'y')::INT > 2
+=>
+(a->>'x')::INT > 1 AND (a->>'y')::INT > 2
+----
+false
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual)
+(a->>'x')::INT > 1 OR (a->>'y')::INT > 2
+=>
+(a->>'x')::INT > 1 OR (a->>'y')::INT > 2
+----
+true
+└── remaining filters: none
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual)
+(a->>'x')::INT > 10 OR (a->>'y')::INT > 20
+=>
+(a->>'x')::INT > 1 OR (a->>'y')::INT > 2
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 10) OR ((a->>'y')::INT8 > 20)
+
+predtest vars=(a jsonb, b int as ((a->>'x')::INT) virtual, c int as ((a->>'y')::INT) virtual)
+(a->>'x')::INT > 1 AND (a->>'y')::INT > 2
+=>
+(a->>'x')::INT > 1 OR (a->>'y')::INT > 2
+----
+true
+└── remaining filters: ((a->>'x')::INT8 > 1) AND ((a->>'y')::INT8 > 2)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -319,6 +319,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().TrigramSimilarityThreshold = 0.3
 	ot.evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = true
 	ot.evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
+	ot.evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = true
 
 	return ot
 }

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -321,8 +321,12 @@ func (it *scanIndexIter) filtersImplyPredicate(
 	pred memo.FiltersExpr,
 ) (remainingFilters memo.FiltersExpr, ok bool) {
 	// Return the remaining filters if the filters imply the predicate.
+	var computedCols map[opt.ColumnID]opt.ScalarExpr
+	if it.e.evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns {
+		computedCols = it.tabMeta.ComputedCols
+	}
 	if remainingFilters, ok =
-		it.im.FiltersImplyPredicate(it.filters, pred, it.tabMeta.ComputedCols); ok {
+		it.im.FiltersImplyPredicate(it.filters, pred, computedCols); ok {
 		return remainingFilters, true
 	}
 
@@ -335,7 +339,7 @@ func (it *scanIndexIter) filtersImplyPredicate(
 	// originalFilters-implication.
 	if it.originalFilters != nil {
 		if remainingFilters, ok =
-			it.im.FiltersImplyPredicate(it.originalFilters, pred, it.tabMeta.ComputedCols); ok {
+			it.im.FiltersImplyPredicate(it.originalFilters, pred, computedCols); ok {
 			return remainingFilters, true
 		}
 	}

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -321,7 +321,8 @@ func (it *scanIndexIter) filtersImplyPredicate(
 	pred memo.FiltersExpr,
 ) (remainingFilters memo.FiltersExpr, ok bool) {
 	// Return the remaining filters if the filters imply the predicate.
-	if remainingFilters, ok = it.im.FiltersImplyPredicate(it.filters, pred); ok {
+	if remainingFilters, ok =
+		it.im.FiltersImplyPredicate(it.filters, pred, it.tabMeta.ComputedCols); ok {
 		return remainingFilters, true
 	}
 
@@ -333,7 +334,8 @@ func (it *scanIndexIter) filtersImplyPredicate(
 	// filters-implication are a subset of the remaining filters from
 	// originalFilters-implication.
 	if it.originalFilters != nil {
-		if remainingFilters, ok = it.im.FiltersImplyPredicate(it.originalFilters, pred); ok {
+		if remainingFilters, ok =
+			it.im.FiltersImplyPredicate(it.originalFilters, pred, it.tabMeta.ComputedCols); ok {
 			return remainingFilters, true
 		}
 	}

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2037,6 +2037,42 @@ project
       └── filters
            └── upper(s:5) > 'FOO' [outer=(5), immutable]
 
+opt expect-not=GenerateConstrainedScans set=(optimizer_prove_implication_with_virtual_computed_columns=false)
+SELECT k FROM virtual WHERE b = 10 AND upper_s = 'FOO'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null b:3!null s:5
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(5)
+      ├── scan virtual
+      │    ├── columns: k:1!null b:3 s:5
+      │    ├── computed column expressions
+      │    │    ├── c:4
+      │    │    │    └── b:3 + 10
+      │    │    ├── lower_s:6
+      │    │    │    └── lower(s:5)
+      │    │    └── upper_s:7
+      │    │         └── upper(s:5)
+      │    ├── partial index predicates
+      │    │    ├── virtual_a_idx: filters
+      │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
+      │    │    ├── virtual_a_idx1: filters
+      │    │    │    └── upper(s:5) = 'FOO' [outer=(5), immutable]
+      │    │    ├── virtual_c_idx: filters
+      │    │    │    └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
+      │    │    └── virtual_b_idx: filters
+      │    │         └── upper(s:5) IS NOT NULL [outer=(5), immutable]
+      │    ├── key: (1)
+      │    └── fd: (1)-->(3,5)
+      └── filters
+           ├── upper(s:5) = 'FOO' [outer=(5), immutable]
+           └── b:3 = 10 [outer=(3), constraints=(/3: [/10 - /10]; tight), fd=()-->(3)]
+
 # TODO(mgartner): The normalization of the query filter from (c = 20) to ((b +
 # 10) = 20) to (b = 10) and the lack of constraints for the partial index
 # predicate ((b + 10) IN (10, 20, 30)) prevents implication from being proven. A

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -137,7 +137,8 @@ CREATE TABLE virtual (
     INDEX (a) WHERE c IN (10, 20, 30),
     INDEX (lower_s),
     INDEX (a) WHERE upper_s = 'FOO',
-    INDEX (c) WHERE c > 100
+    INDEX (c) WHERE c > 100,
+    INDEX (b) WHERE upper_s IS NOT NULL
 )
 ----
 
@@ -536,8 +537,10 @@ project
       │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
       │    │    ├── virtual_a_idx1: filters
       │    │    │    └── upper(s:5) = 'FOO' [outer=(5), immutable]
-      │    │    └── virtual_c_idx: filters
-      │    │         └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
+      │    │    ├── virtual_c_idx: filters
+      │    │    │    └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
+      │    │    └── virtual_b_idx: filters
+      │    │         └── upper(s:5) IS NOT NULL [outer=(5), immutable]
       │    ├── key: (1)
       │    └── fd: (1)-->(3)
       └── filters
@@ -1973,7 +1976,7 @@ DROP INDEX idx
 
 # Constrained partial index scan with a virtual computed column in the
 # predicate.
-opt
+opt expect=GenerateConstrainedScans
 SELECT k FROM virtual WHERE a > 10 AND a < 20 AND c IN (10, 20, 30)
 ----
 project
@@ -1985,6 +1988,54 @@ project
       ├── constraint: /2/1: [/11 - /19]
       ├── key: (1)
       └── fd: (1)-->(2)
+
+opt expect=GenerateConstrainedScans
+SELECT k FROM virtual WHERE b = 10 AND upper_s = 'FOO'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null b:3!null s:5
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(5)
+      ├── index-join virtual
+      │    ├── columns: k:1!null b:3 s:5
+      │    ├── key: (1)
+      │    ├── fd: ()-->(3), (1)-->(5)
+      │    └── scan virtual@virtual_b_idx,partial
+      │         ├── columns: k:1!null b:3!null
+      │         ├── constraint: /3/1: [/10 - /10]
+      │         ├── key: (1)
+      │         └── fd: ()-->(3)
+      └── filters
+           └── upper(s:5) = 'FOO' [outer=(5), immutable]
+
+opt expect=GenerateConstrainedScans
+SELECT k FROM virtual WHERE b = 10 AND upper_s > 'FOO'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null b:3!null s:5
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(5)
+      ├── index-join virtual
+      │    ├── columns: k:1!null b:3 s:5
+      │    ├── key: (1)
+      │    ├── fd: ()-->(3), (1)-->(5)
+      │    └── scan virtual@virtual_b_idx,partial
+      │         ├── columns: k:1!null b:3!null
+      │         ├── constraint: /3/1: [/10 - /10]
+      │         ├── key: (1)
+      │         └── fd: ()-->(3)
+      └── filters
+           └── upper(s:5) > 'FOO' [outer=(5), immutable]
 
 # TODO(mgartner): The normalization of the query filter from (c = 20) to ((b +
 # 10) = 20) to (b = 10) and the lack of constraints for the partial index
@@ -2017,8 +2068,10 @@ project
       │    │    │    └── (b:3 + 10) IN (10, 20, 30) [outer=(3), immutable]
       │    │    ├── virtual_a_idx1: filters
       │    │    │    └── upper(s:5) = 'FOO' [outer=(5), immutable]
-      │    │    └── virtual_c_idx: filters
-      │    │         └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
+      │    │    ├── virtual_c_idx: filters
+      │    │    │    └── b:3 > 90 [outer=(3), constraints=(/3: [/91 - ]; tight)]
+      │    │    └── virtual_b_idx: filters
+      │    │         └── upper(s:5) IS NOT NULL [outer=(5), immutable]
       │    ├── key: (1)
       │    └── fd: (1)-->(2,3)
       └── filters

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -512,6 +512,10 @@ message LocalOnlySessionData {
   // that the optimizer should use an improved selectivity estimate for
   // multi-column predicates.
   bool optimizer_use_improved_multi_column_selectivity_estimate = 129;
+  // OptimizerProveImplicationWithVirtualComputedColumns, when true, indicates
+  // that the optimizer should use virtual computed columns to prove partial
+  // index implication.
+  bool optimizer_prove_implication_with_virtual_computed_columns = 130;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3344,6 +3344,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_prove_implication_with_virtual_computed_columns`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_prove_implication_with_virtual_computed_columns`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_prove_implication_with_virtual_computed_columns", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerProveImplicationWithVirtualComputedColumns(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### opt: add Implicator benchmarks with virtual columns

Release note: None

#### opt: improve partial index implication with virtual columns

The partial index implicator is now aware of computed columns and their
expressions. This allows implication to be proven in more cases. For
example, consider the table and query:

    CREATE TABLE (
      j JSONB,
      i INT AS ((j->>'x')::INT) VIRTUAL,
      INDEX (i) WHERE i IS NOT NULL
    );

    SELECT * FROM t WHERE i = 10;

Prior to this commit, the optimizer would not plan a constrained scan
over the partial index because the implicator could not prove that the
query filters, pushed into the projection as `(j->>'x')::INT = 10`,
imply the partial index predicate, built as
`(j->>'x')::INT IS NOT NULL`. To prove implication cases like this where
the expressions are not exact matches, the implicator must build
constraints to check if the predicate contains the filter. Constraints
cannot be built from these expressions, so verifying containment was
impossible.

Now that the implicator is aware of computed columns and their
expressions, it converts the filter and predicate into expressions
referencing virtual computed columns: `i = 10` and `i IS NOT NULL`.
Constraints can be built from expressions in this forms, containment can
be checked, and implication can be proven.

Fixes #122352

Release note (sql change): The optimizer can now plan constrained scans
over partial indexes in more cases, particularly on partial indexes with
predicates referencing virtual computed columns.

#### opt: add session setting for virtual computed column implication

The `optimizer_prove_implication_with_virtual_computed_columns` has been
added which, when enabled, indicates that virtual computed columns
should be considered during partial index implication to try to prove
that a filter implies a predicate.

Release note: None
