### PR TITLE
server: don't redact jemalloc stats

### DIFF
--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -81,6 +81,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 	"github.com/dustin/go-humanize"
 )
 
@@ -106,7 +107,7 @@ func getJemallocStats(ctx context.Context) (uint, uint, error) {
 		for i := 0; i < v.NumField(); i++ {
 			stats[i] = t.Field(i).Name + ": " + humanize.IBytes(uint64(v.Field(i).Interface().(C.size_t)))
 		}
-		log.Infof(ctx, "jemalloc stats: %s", strings.Join(stats, " "))
+		log.Infof(ctx, "jemalloc stats: %s", redact.Safe(strings.Join(stats, " ")))
 	}
 
 	// NB: the `!V(MaxInt32)` condition is a workaround to not spew this to the


### PR DESCRIPTION
These stats can be useful to debug customer issues. They can be
temporarily enabled on a node using
`SELECT crdb_internal.set_vmodule('runtime_jemalloc=3')`

There is no sensitive data in the stats, they look like this:
```
jemalloc stats: allocated: 6.0 GiB, active: 6.3 GiB, metadata: 161 MiB, resident: 7.1 GiB, mapped: 8.6 GiB
```

Release note: None
Epic: none