### PR TITLE
streamingccl/streamingest: consume all kvs in event

### DIFF
--- a/pkg/ccl/cmdccl/clusterrepl/main.go
+++ b/pkg/ccl/cmdccl/clusterrepl/main.go
@@ -246,8 +246,10 @@ func subscriptionConsumer(
 				}
 				switch event.Type() {
 				case streamingccl.KVEvent:
-					kv := event.GetKV()
-					sz = kv.Size()
+					sz = 0
+					for _, kv := range event.GetKVs() {
+						sz += kv.Size()
+					}
 				case streamingccl.SSTableEvent:
 					ssTab := event.GetSSTable()
 					sz = ssTab.Size()

--- a/pkg/ccl/streamingccl/event.go
+++ b/pkg/ccl/streamingccl/event.go
@@ -46,8 +46,8 @@ type Event interface {
 	// Type specifies which accessor will be meaningful.
 	Type() EventType
 
-	// GetKV returns a KV event if the EventType is KVEvent.
-	GetKV() *roachpb.KeyValue
+	// GetKVs returns a KV event if the EventType is KVEvent.
+	GetKVs() []roachpb.KeyValue
 
 	// GetSSTable returns a AddSSTable event if the EventType is SSTableEvent.
 	GetSSTable() *kvpb.RangeFeedSSTable
@@ -68,7 +68,7 @@ type Event interface {
 
 // kvEvent is a key value pair that needs to be ingested.
 type kvEvent struct {
-	kv roachpb.KeyValue
+	kv []roachpb.KeyValue
 }
 
 var _ Event = kvEvent{}
@@ -78,9 +78,9 @@ func (kve kvEvent) Type() EventType {
 	return KVEvent
 }
 
-// GetKV implements the Event interface.
-func (kve kvEvent) GetKV() *roachpb.KeyValue {
-	return &kve.kv
+// GetKVs implements the Event interface.
+func (kve kvEvent) GetKVs() []roachpb.KeyValue {
+	return kve.kv
 }
 
 // GetSSTable implements the Event interface.
@@ -118,8 +118,8 @@ func (sste sstableEvent) Type() EventType {
 	return SSTableEvent
 }
 
-// GetKV implements the Event interface.
-func (sste sstableEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (sste sstableEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -160,8 +160,8 @@ func (dre delRangeEvent) Type() EventType {
 	return DeleteRangeEvent
 }
 
-// GetKV implements the Event interface.
-func (dre delRangeEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (dre delRangeEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -205,8 +205,8 @@ func (ce checkpointEvent) Type() EventType {
 	return CheckpointEvent
 }
 
-// GetKV implements the Event interface.
-func (ce checkpointEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (ce checkpointEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -246,8 +246,8 @@ func (spe spanConfigEvent) Type() EventType {
 	return SpanConfigEvent
 }
 
-// GetKV implements the Event interface.
-func (spe spanConfigEvent) GetKV() *roachpb.KeyValue {
+// GetKVs implements the Event interface.
+func (spe spanConfigEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -288,7 +288,7 @@ func (se splitEvent) Type() EventType {
 }
 
 // GetKV implements the Event interface.
-func (se splitEvent) GetKV() *roachpb.KeyValue {
+func (se splitEvent) GetKVs() []roachpb.KeyValue {
 	return nil
 }
 
@@ -318,7 +318,7 @@ func (se splitEvent) GetSplitEvent() *roachpb.Key {
 }
 
 // MakeKVEvent creates an Event from a KV.
-func MakeKVEvent(kv roachpb.KeyValue) Event {
+func MakeKVEvent(kv []roachpb.KeyValue) Event {
 	return kvEvent{kv: kv}
 }
 

--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/tree",
+        "//pkg/util/bufalloc",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/ccl/streamingccl/streamclient/client_helpers.go
+++ b/pkg/ccl/streamingccl/streamclient/client_helpers.go
@@ -18,7 +18,7 @@ import (
 )
 
 func subscribeInternal(
-	ctx context.Context, feed pgx.Rows, eventsChan chan streamingccl.Event, closeChan chan struct{},
+	ctx context.Context, feed pgx.Rows, eventCh chan streamingccl.Event, closeCh chan struct{},
 ) error {
 	// Get the next event from the cursor.
 	var bufferedEvent *streampb.StreamEvent
@@ -51,8 +51,8 @@ func subscribeInternal(
 			return err
 		}
 		select {
-		case eventsChan <- event:
-		case <-closeChan:
+		case eventCh <- event:
+		case <-closeCh:
 			// Exit quietly to not cause other subscriptions in the same
 			// ctxgroup.Group to exit.
 			return nil
@@ -81,8 +81,8 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 			event = streamingccl.MakeSSTableEvent(streamEvent.Batch.Ssts[0])
 			streamEvent.Batch.Ssts = streamEvent.Batch.Ssts[1:]
 		case len(streamEvent.Batch.KeyValues) > 0:
-			event = streamingccl.MakeKVEvent(streamEvent.Batch.KeyValues[0])
-			streamEvent.Batch.KeyValues = streamEvent.Batch.KeyValues[1:]
+			event = streamingccl.MakeKVEvent(streamEvent.Batch.KeyValues)
+			streamEvent.Batch.KeyValues = nil
 		case len(streamEvent.Batch.DelRanges) > 0:
 			event = streamingccl.MakeDeleteRangeEvent(streamEvent.Batch.DelRanges[0])
 			streamEvent.Batch.DelRanges = streamEvent.Batch.DelRanges[1:]

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -102,7 +102,7 @@ func (sc testStreamClient) Subscribe(
 	}
 
 	events := make(chan streamingccl.Event, 2)
-	events <- streamingccl.MakeKVEvent(sampleKV)
+	events <- streamingccl.MakeKVEvent([]roachpb.KeyValue{sampleKV})
 	events <- streamingccl.MakeCheckpointEvent([]jobspb.ResolvedSpan{sampleResolvedSpan})
 	close(events)
 
@@ -303,8 +303,10 @@ func ExampleClient() {
 			for event := range sub.Events() {
 				switch event.Type() {
 				case streamingccl.KVEvent:
-					kv := event.GetKV()
-					fmt.Printf("kv: %s->%s@%d\n", kv.Key.String(), string(kv.Value.RawBytes), kv.Value.Timestamp.WallTime)
+					kvs := event.GetKVs()
+					for _, kv := range kvs {
+						fmt.Printf("kv: %s->%s@%d\n", kv.Key.String(), string(kv.Value.RawBytes), kv.Value.Timestamp.WallTime)
+					}
 				case streamingccl.SSTableEvent:
 					sst := event.GetSSTable()
 					fmt.Printf("sst: %s->%s@%d\n", sst.Span.String(), string(sst.Data), sst.WriteTS.WallTime)

--- a/pkg/ccl/streamingccl/streamingest/merged_subscription_test.go
+++ b/pkg/ccl/streamingccl/streamingest/merged_subscription_test.go
@@ -30,12 +30,12 @@ func TestMergeSubscriptionsRun(t *testing.T) {
 	ctx := context.Background()
 	events := func(partition string) []streamingccl.Event {
 		return []streamingccl.Event{
-			streamingccl.MakeKVEvent(roachpb.KeyValue{
+			streamingccl.MakeKVEvent([]roachpb.KeyValue{{
 				Key: []byte(partition + "_key1"),
-			}),
-			streamingccl.MakeKVEvent(roachpb.KeyValue{
+			}}),
+			streamingccl.MakeKVEvent([]roachpb.KeyValue{{
 				Key: []byte(partition + "_key2"),
-			}),
+			}}),
 		}
 	}
 	mockClient := &mockStreamClient{
@@ -67,7 +67,7 @@ func TestMergeSubscriptionsRun(t *testing.T) {
 		events := []string{}
 		g.Go(func() error {
 			for ev := range merged.Events() {
-				events = append(events, string(ev.GetKV().Key))
+				events = append(events, string(ev.GetKVs()[0].Key))
 			}
 			return nil
 		})

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -115,7 +115,7 @@ func (d *partitionStreamDecoder) pop() streamingccl.Event {
 	}
 
 	if d.e.Batch != nil {
-		event := streamingccl.MakeKVEvent(d.e.Batch.KeyValues[0])
+		event := streamingccl.MakeKVEvent([]roachpb.KeyValue{d.e.Batch.KeyValues[0]})
 		d.e.Batch.KeyValues = d.e.Batch.KeyValues[1:]
 		if len(d.e.Batch.KeyValues) == 0 {
 			d.e.Batch = nil


### PR DESCRIPTION
This switching from passing single KV events from the subscription to the ingest processor to passing batches of KVs. This avoids needing to go back to the channel and select for each KV, but rather for each batch of KVs.

Release note: none.
Epic: none.