### PR TITLE
concurrency: deflake TestLockTableConcurrentRequests

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/skip",
+        "//pkg/util",
         "//pkg/util/allstacks",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1593,9 +1594,9 @@ func TestLockTableConcurrentRequests(t *testing.T) {
 	probDupAccessWithWeakerStr := 0.5
 	probOnlyRead := possibleProbOnlyRead[rng.Intn(len(possibleProbOnlyRead))]
 
-	if syncutil.DeadlockEnabled {
-		// We've seen 10,000 requests to be too much when running a deadlock build.
-		// Override numRequests to the lowest option (1,000) for deadlock builds.
+	if syncutil.DeadlockEnabled || util.RaceEnabled {
+		// We've seen 10,000 requests to be too much when running a deadlock/race
+		// build. Override numRequests to the lowest option (1,000) for such builds.
 		numRequests = 1000
 	}
 


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/123196.
Closes https://github.com/cockroachdb/cockroach/issues/123280.
Closes https://github.com/cockroachdb/cockroach/issues/123550.

Epic: none

Release note: None