### PR TITLE
storage: fix disk monitor IncrementalStats race

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3443,7 +3443,7 @@ func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
 }
 
 // computeMetrics is a common metric computation that is used by
-// ComputeMetricsPeriodically and ComputeMetrics to compute metrics
+// ComputeMetricsPeriodically and ComputeMetrics to compute metrics.
 func (s *Store) computeMetrics(ctx context.Context) (m storage.Metrics, err error) {
 	ctx = s.AnnotateCtx(ctx)
 	if err = s.updateCapacityGauges(ctx); err != nil {
@@ -3473,17 +3473,11 @@ func (s *Store) computeMetrics(ctx context.Context) (m storage.Metrics, err erro
 		s.metrics.RdbCheckpoints.Update(int64(len(dirs)))
 	}
 
-	// Get disk stats for the disk associated with this store.
-	if s.diskMonitor != nil {
-		rollingStats := s.diskMonitor.IncrementalStats()
-		s.metrics.updateDiskStats(rollingStats)
-	}
-
 	return m, nil
 }
 
 // ComputeMetricsPeriodically computes metrics that need to be computed
-// periodically along with the regular metrics
+// periodically along with the regular metrics.
 func (s *Store) ComputeMetricsPeriodically(
 	ctx context.Context, prevMetrics *storage.MetricsForInterval, tick int,
 ) (m storage.Metrics, err error) {
@@ -3491,6 +3485,13 @@ func (s *Store) ComputeMetricsPeriodically(
 	if err != nil {
 		return m, err
 	}
+
+	// Get disk stats for the disk associated with this store.
+	if s.diskMonitor != nil {
+		rollingStats := s.diskMonitor.IncrementalStats()
+		s.metrics.updateDiskStats(rollingStats)
+	}
+
 	wt := m.Flush.WriteThroughput
 
 	if prevMetrics != nil {

--- a/pkg/storage/disk/monitor_test.go
+++ b/pkg/storage/disk/monitor_test.go
@@ -109,9 +109,9 @@ func TestMonitor_IncrementalStats(t *testing.T) {
 		tracer.RecordEvent(event)
 	}
 	monitor := Monitor{
-		monitoredDisk:     &monitoredDisk{tracer: tracer},
-		lastIncrementedAt: now.Add(-3 * time.Minute),
+		monitoredDisk: &monitoredDisk{tracer: tracer},
 	}
+	monitor.mu.lastIncrementedAt = now.Add(-3 * time.Minute)
 
 	rollingWindow := monitor.IncrementalStats()
 	// Skip the event collected 4 minutes ago since we last incremented 3 minutes ago.


### PR DESCRIPTION
This change adds a mutex around `lastIncrementedAt` time to resolve a
data race. There is still the problem that the overall design assumes
a single caller, hopefully the out-of-band calls are rare enough to
not cause significant missed events.

Fixes: #123021
Release note: None