### PR TITLE
profiler: allow 0 value for CPU threshold

### DIFF
--- a/pkg/server/profiler/cpuprofiler.go
+++ b/pkg/server/profiler/cpuprofiler.go
@@ -41,7 +41,7 @@ var cpuUsageCombined = settings.RegisterIntSetting(
 		"of 0 is set, a profile will be taken every time the cpu profile"+
 		"interval has passed or the provided usage is increasing",
 	65,
-	settings.PositiveInt,
+	settings.NonNegativeInt,
 )
 
 var cpuProfileInterval = settings.RegisterDurationSetting(


### PR DESCRIPTION
In 9036430018ff369b44a87b7be0ea79d768b54036 we added positive int validation for `server.cpu_profile.cpu_usage_combined_threshold`, but a value of zero also seems reasonable in some cases (the comment on the setting also mentions it), so this commit switches to non-negative int validation instead.

Epic: None

Release note: None