### PR TITLE
streamingccl: replicate manual split points

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/client_helpers.go
+++ b/pkg/ccl/streamingccl/streamclient/client_helpers.go
@@ -89,12 +89,16 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 		case len(streamEvent.Batch.SpanConfigs) > 0:
 			event = streamingccl.MakeSpanConfigEvent(streamEvent.Batch.SpanConfigs[0])
 			streamEvent.Batch.SpanConfigs = streamEvent.Batch.SpanConfigs[1:]
+		case len(streamEvent.Batch.SplitPoints) > 0:
+			event = streamingccl.MakeSplitEvent(streamEvent.Batch.SplitPoints[0])
+			streamEvent.Batch.SplitPoints = streamEvent.Batch.SplitPoints[1:]
 		}
 
 		if len(streamEvent.Batch.KeyValues) == 0 &&
 			len(streamEvent.Batch.Ssts) == 0 &&
 			len(streamEvent.Batch.DelRanges) == 0 &&
-			len(streamEvent.Batch.SpanConfigs) == 0 {
+			len(streamEvent.Batch.SpanConfigs) == 0 &&
+			len(streamEvent.Batch.SplitPoints) == 0 {
 			streamEvent.Batch = nil
 		}
 	}

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -81,6 +81,13 @@ var quantize = settings.RegisterDurationSettingWithExplicitUnit(
 	5*time.Second,
 )
 
+var emitMetadata = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"physical_replication.producer.emit_metadata.enabled",
+	"whether to emit metadata events",
+	true,
+)
+
 var _ eval.ValueGenerator = (*eventStream)(nil)
 
 var eventStreamReturnType = types.MakeLabeledTuple(
@@ -135,6 +142,9 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 		rangefeed.WithOnDeleteRange(s.onDeleteRange),
 		rangefeed.WithFrontierQuantized(quantize.Get(&s.execCfg.Settings.SV)),
 		rangefeed.WithOnValues(s.onValues),
+	}
+	if emitMetadata.Get(&s.execCfg.Settings.SV) {
+		opts = append(opts, rangefeed.WithOnMetadata(s.onMetadata))
 	}
 
 	initialTimestamp := s.spec.InitialScanTimestamp
@@ -290,6 +300,14 @@ func (s *eventStream) onSSTable(
 func (s *eventStream) onDeleteRange(ctx context.Context, delRange *kvpb.RangeFeedDeleteRange) {
 	s.seb.addDelRange(*delRange)
 	s.setErr(s.maybeFlushBatch(ctx))
+}
+func (s *eventStream) onMetadata(ctx context.Context, metadata *kvpb.RangeFeedMetadata) {
+	log.VInfof(ctx, 2, "received metadata event: %s, fromManualSplit: %t, parent start key %s", metadata.Span, metadata.FromManualSplit, metadata.ParentStartKey)
+	if metadata.FromManualSplit && !metadata.Span.Key.Equal(metadata.ParentStartKey) {
+		// Only send new manual split keys (i.e. a child rangefeed start key that
+		// differs from the parent start key)
+		s.seb.addSplitPoint(metadata.Span.Key)
+	}
 }
 
 func (s *eventStream) maybeCheckpoint(

--- a/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
@@ -33,6 +33,7 @@ func (seb *streamEventBatcher) reset() {
 	seb.batch.Ssts = seb.batch.Ssts[:0]
 	seb.batch.DelRanges = seb.batch.DelRanges[:0]
 	seb.batch.SpanConfigs = seb.batch.SpanConfigs[:0]
+	seb.batch.SplitPoints = seb.batch.SplitPoints[:0]
 }
 
 func (seb *streamEventBatcher) addSST(sst kvpb.RangeFeedSSTable) {
@@ -50,6 +51,11 @@ func (seb *streamEventBatcher) addDelRange(d kvpb.RangeFeedDeleteRange) {
 	// the subscribed span, just emit it.
 	seb.batch.DelRanges = append(seb.batch.DelRanges, d)
 	seb.size += d.Size()
+}
+
+func (seb *streamEventBatcher) addSplitPoint(k roachpb.Key) {
+	seb.batch.SplitPoints = append(seb.batch.SplitPoints, k)
+	seb.size += len(k)
 }
 
 // addSpanConfigs adds a slice of spanConfig entries that were recently flushed

--- a/pkg/ccl/streamingccl/streamproducer/stream_event_batcher_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_event_batcher_test.go
@@ -49,6 +49,13 @@ func TestStreamEventBatcher(t *testing.T) {
 	require.Equal(t, 1, len(seb.batch.Ssts))
 	require.Equal(t, runningSize, seb.getSize())
 
+	splitKey := roachpb.Key("1")
+	runningSize += len(splitKey)
+	seb.addSplitPoint(splitKey)
+	require.Equal(t, 1, len(seb.batch.SplitPoints))
+	require.Equal(t, runningSize, seb.getSize())
+
+	// Reset should clear the batch.
 	seb.reset()
 	require.Equal(t, 0, seb.getSize())
 	require.Equal(t, 0, len(seb.batch.KeyValues))

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -171,6 +171,7 @@ message StreamEvent {
     repeated roachpb.RangeFeedSSTable ssts = 2 [(gogoproto.nullable) = false];
     repeated roachpb.RangeFeedDeleteRange del_ranges = 3 [(gogoproto.nullable) = false];
     repeated StreamedSpanConfigEntry span_configs = 4 [(gogoproto.nullable) = false];
+    repeated bytes split_points = 5 [(gogoproto.casttype) =  "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
   }
 
   // Checkpoint represents stream checkpoint.


### PR DESCRIPTION
This patch teaches PCR to replicate source cluster manual split points to the
destination cluster. Specifically, this patch configures the event_stream
rangefeeds to emit rangefeed metadata events that indicate if a rangefeed
spawned due to a manual split. Then, the event stream sends the manual split
key over to the destination cluster.

Informs #122846

Release note: none