### PR TITLE
rangefeed: improve regression seen from memory accounting 

### DIFF
--- a/pkg/kv/kvserver/rangefeed/event_size_test.go
+++ b/pkg/kv/kvserver/rangefeed/event_size_test.go
@@ -239,7 +239,7 @@ func TestEventSizeCalculation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mem := tc.ev.MemUsage()
+			mem := MemUsage(tc.ev)
 			require.Equal(t, tc.expectedCurrMemUsage, tc.actualCurrMemUsage)
 			require.Equal(t, tc.expectedFutureMemUsage, tc.actualFutureMemUsage)
 			if tc.actualFutureMemUsage > tc.actualCurrMemUsage {
@@ -392,5 +392,5 @@ func TestMultipleLogicalOpsEventsSizeCalculation(t *testing.T) {
 	data := generateRandomTestData(rng)
 	ev, mem := generateLogicalOpEvents(rng, data)
 	t.Logf("chosen event: %v\n", &ev)
-	require.Equal(t, ev.MemUsage(), mem)
+	require.Equal(t, MemUsage(ev), mem)
 }

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -448,7 +448,7 @@ func (p *ScheduledProcessor) enqueueEventInternal(
 	// inserting value into channel.
 	var alloc *SharedBudgetAllocation
 	if p.MemBudget != nil {
-		size := e.MemUsage()
+		size := MemUsage(e)
 		if size > 0 {
 			var err error
 			// First we will try non-blocking fast path to allocate memory budget.


### PR DESCRIPTION
This patch improves the regression we saw from #123076. Note that this pr only
refactors the existing code but doesn't change any functionalities. 

Related: https://github.com/cockroachdb/cockroach/issues/123076
Epic: none
Release note: none

```
❯ benchdiff --new=a6e678fd7cb --old=13c9b9   --post-checkout='bash post-checkout.sh' --run=BenchmarkRangefeed --count=10  ./pkg/kv/kvserver/rangefeed
test binaries already exist for '13c9b9d'; skipping build
test binaries already exist for 'a6e678f'; skipping build

  pkg=1/1 iter=10/10 cockroachdb/cockroach/pkg/kv/kvserver/rangefeed /

name                                                                      old time/op    new time/op    delta
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=100-12      118µs ±14%      83µs ±62%  -29.72%  (p=0.002 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=100-12        131µs ±12%     100µs ±43%  -23.78%  (p=0.001 n=8+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=100-12        119µs ±13%     102µs ±24%  -13.96%  (p=0.015 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=1-12           561ns ±10%     524ns ± 3%   -6.55%  (p=0.001 n=10+8)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=1-12       457ns ±10%     428ns ± 6%   -6.47%  (p=0.007 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=1-12          513ns ± 3%     503ns ± 5%     ~     (p=0.113 n=10+9)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=10-12        6.15µs ±39%    5.41µs ±31%     ~     (p=0.165 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=1-12        1.40µs ± 3%    1.40µs ± 7%     ~     (p=1.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=10-12       6.07µs ±18%    6.15µs ±24%     ~     (p=0.971 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=100-12       106µs ±29%     119µs ±10%     ~     (p=0.077 n=9+9)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=10-12     5.00µs ±41%    4.77µs ±39%     ~     (p=0.670 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=100-12     119µs ±17%     117µs ±25%     ~     (p=0.604 n=10+9)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=10-12         5.59µs ±22%    5.83µs ±30%     ~     (p=0.481 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=100-12         102µs ±60%      89µs ±62%     ~     (p=0.631 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=1-12         1.63µs ± 4%    1.68µs ± 6%     ~     (p=0.108 n=9+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=10-12        6.36µs ±18%    6.07µs ± 6%     ~     (p=0.395 n=10+8)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=1-12        477ns ± 7%     460ns ± 5%     ~     (p=0.065 n=10+9)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=10-12      5.08µs ±15%    5.24µs ±22%     ~     (p=0.684 n=10+10)
RangefeedBudget/budget=false-12                                              533ns ± 7%     530ns ± 9%     ~     (p=0.631 n=10+10)
RangefeedBudget/budget=true-12                                               546ns ± 8%     535ns ± 5%     ~     (p=0.182 n=9+10)

name                                                                      old alloc/op   new alloc/op   delta
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=1-12         340B ± 2%      262B ± 2%  -22.79%  (p=0.000 n=10+9)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=1-12        359B ± 2%      285B ± 2%  -20.61%  (p=0.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=10-12       414B ± 2%      332B ± 2%  -19.81%  (p=0.000 n=10+9)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=100-12        957B ± 3%      782B ± 4%  -18.29%  (p=0.000 n=9+9)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=100-12      439B ± 5%      359B ±17%  -18.28%  (p=0.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=10-12         932B ± 4%      764B ± 6%  -18.01%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=10-12        452B ± 2%      374B ± 2%  -17.27%  (p=0.000 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=1-12          927B ± 4%      774B ± 4%  -16.56%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=1-12            473B ± 3%      395B ± 1%  -16.34%  (p=0.000 n=10+8)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=10-12          955B ± 1%      806B ± 5%  -15.65%  (p=0.000 n=8+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=1-12           944B ± 4%      797B ± 5%  -15.61%  (p=0.000 n=10+10)
RangefeedBudget/budget=true-12                                                469B ± 1%      397B ± 1%  -15.39%  (p=0.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=1-12           488B ± 1%      413B ± 1%  -15.37%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=100-12       1.01kB ± 5%    0.85kB ± 8%  -15.31%  (p=0.000 n=10+10)
RangefeedBudget/budget=false-12                                               490B ± 1%      416B ± 2%  -15.18%  (p=0.000 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=10-12          539B ± 1%      459B ± 3%  -14.86%  (p=0.000 n=8+9)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=10-12           584B ± 2%      502B ± 1%  -14.11%  (p=0.000 n=9+9)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=100-12       480B ± 8%      418B ±13%  -12.94%  (p=0.001 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=100-12         555B ± 1%      486B ± 4%  -12.47%  (p=0.000 n=8+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=100-12          601B ± 5%      534B ± 4%  -11.15%  (p=0.000 n=8+9)

name                                                                      old allocs/op  new allocs/op  delta
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=10-12       6.60 ± 9%      5.00 ± 0%  -24.24%  (p=0.000 n=10+8)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=10-12         12.0 ± 0%      10.0 ± 0%  -16.67%  (p=0.000 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=100-12        12.0 ± 0%      10.0 ± 0%  -16.67%  (p=0.000 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=1-12        6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=1-12           12.0 ± 0%      10.0 ± 0%  -16.67%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=1-12         6.00 ± 0%      5.00 ± 0%  -16.67%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=100-12         13.0 ± 0%      11.0 ± 0%  -15.38%  (p=0.000 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=commit/numRegs=1-12          11.0 ± 0%       9.4 ± 6%  -14.55%  (p=0.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=closedts/numRegs=100-12      7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=9+10)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=10-12        7.00 ± 0%      6.00 ± 0%  -14.29%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=commit/numRegs=10-12          12.0 ± 0%      10.3 ± 7%  -14.17%  (p=0.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=1-12           8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=1-12            8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=closedts/numRegs=100-12       8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.000 n=7+10)
RangefeedBudget/budget=false-12                                               8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.000 n=10+10)
RangefeedBudget/budget=true-12                                                8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.000 n=10+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=100-12         9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=10-12           9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
Rangefeed/budget=true/procType=scheduler/opType=write/numRegs=100-12          10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.000 n=9+10)
Rangefeed/budget=false/procType=scheduler/opType=write/numRegs=10-12          8.00 ± 0%      7.30 ±10%   -8.75%  (p=0.001 n=8+10)
```