### PR TITLE
sql/logictest: add udf test to rename database

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -276,3 +276,30 @@ USE defaultdb
 
 statement ok
 DROP DATABASE db1 CASCADE
+
+statement ok
+CREATE FUNCTION identity1(n INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT n;
+$$
+
+skipif config local-mixed-23.2
+statement ok
+CREATE FUNCTION identity2(n INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT identity1(n);
+$$
+
+statement ok
+ALTER DATABASE defaultdb RENAME TO db;
+USE db;
+
+query I
+SELECT identity1(2);
+----
+2
+
+skipif config local-mixed-23.2
+query I
+SELECT identity2(2);
+----
+2
+


### PR DESCRIPTION
This patch adds a logic test to assert that renaming a database that contains UDFs works as expected.

Epic: none

Release note: None