### PR TITLE
dev: fix staging behavior from non-default configurations

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=92
+DEV_VERSION=93
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -173,7 +173,6 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	}
 	args = append(args, additionalBazelArgs...)
 	configArgs := getConfigArgs(args)
-	configArgs = append(configArgs, getConfigArgs(additionalBazelArgs)...)
 
 	if err := d.assertNoLinkedNpmDeps(buildTargets); err != nil {
 		return err
@@ -295,7 +294,7 @@ func (d *dev) stageArtifacts(
 			}
 			var geosDir string
 			if archived != "" {
-				execRoot, err := d.getExecutionRoot(ctx)
+				execRoot, err := d.getExecutionRoot(ctx, configArgs)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -71,4 +71,4 @@ dev build tests
 bazel build //pkg:all_tests --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=test

--- a/pkg/cmd/dev/testdata/recorderdriven/dev-build
+++ b/pkg/cmd/dev/testdata/recorderdriven/dev-build
@@ -4,7 +4,7 @@ bazel query pkg/roachpb:roachpb_test --output=label_kind
 bazel build //pkg/roachpb:roachpb_test --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=test
 
 # TODO(irfansharif): This test case is skipped -- it's too verbose given it
 # scans through the sandbox for each generated file and copies them over

--- a/pkg/cmd/dev/testdata/recorderdriven/dev-build.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/dev-build.rec
@@ -8,3 +8,6 @@ bazel build //pkg/roachpb:roachpb_test --config=test --build_event_binary_file=/
 mkdir crdb-checkout/bin
 ----
 
+bazel info bazel-bin --color=no --config=test
+----
+/path/to/bazel/bin

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -104,6 +104,7 @@ func mustGetFlagDuration(cmd *cobra.Command, name string) time.Duration {
 
 func (d *dev) getBazelInfo(ctx context.Context, key string, extraArgs []string) (string, error) {
 	args := []string{"info", key, "--color=no"}
+	args = append(args, extraArgs...)
 	out, err := d.exec.CommandContextSilent(ctx, "bazel", args...)
 	if err != nil {
 		return "", err
@@ -126,8 +127,8 @@ func (d *dev) getBazelBin(ctx context.Context, configArgs []string) (string, err
 	return d.getBazelInfo(ctx, "bazel-bin", configArgs)
 }
 
-func (d *dev) getExecutionRoot(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "execution_root", []string{})
+func (d *dev) getExecutionRoot(ctx context.Context, configArgs []string) (string, error) {
+	return d.getBazelInfo(ctx, "execution_root", configArgs)
 }
 
 // getArchivedCdepString returns a non-empty string iff the force_build_cdeps


### PR DESCRIPTION
We added support for building in non-default configurations/compilation modes in a previous PR, but this was buggy and we were never actually using the configuration arguments in `bazel info`, so staging was always happening from the `fastbuild` location. This PR fixes that buggy behavior, so staging will happen from the appropriate source location.

Epic: CRDB-17171
Release note: None