### PR TITLE
release-23.2: server: enable continuous CPU profiler

### DIFF
--- a/pkg/server/profiler/cpuprofiler.go
+++ b/pkg/server/profiler/cpuprofiler.go
@@ -12,7 +12,6 @@ package profiler
 
 import (
 	"context"
-	"math"
 	"os"
 	"runtime/pprof"
 	"time"
@@ -41,7 +40,8 @@ var cpuUsageCombined = settings.RegisterIntSetting(
 		"the profiler will never take a profile and conversely, if a value"+
 		"of 0 is set, a profile will be taken every time the cpu profile"+
 		"interval has passed or the provided usage is increasing",
-	math.MaxInt64,
+	65,
+	settings.PositiveInt,
 )
 
 var cpuProfileInterval = settings.RegisterDurationSetting(
@@ -51,14 +51,16 @@ var cpuProfileInterval = settings.RegisterDurationSetting(
 	// account the high water mark seen. Without this, if CPU ever reaches 100%,
 	// we'll never take another profile.
 	"duration after which the high water mark resets and a new cpu profile can be taken",
-	5*time.Minute, settings.PositiveDuration,
+	20*time.Minute,
+	settings.PositiveDuration,
 )
 
 var cpuProfileDuration = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"server.cpu_profile.duration",
 	"the duration for how long a cpu profile is taken",
-	10*time.Second, settings.PositiveDuration,
+	10*time.Second,
+	settings.PositiveDuration,
 )
 
 const cpuProfFileNamePrefix = "cpuprof"

--- a/pkg/server/profiler/cpuprofiler.go
+++ b/pkg/server/profiler/cpuprofiler.go
@@ -41,7 +41,7 @@ var cpuUsageCombined = settings.RegisterIntSetting(
 		"of 0 is set, a profile will be taken every time the cpu profile"+
 		"interval has passed or the provided usage is increasing",
 	65,
-	settings.PositiveInt,
+	settings.NonNegativeInt,
 )
 
 var cpuProfileInterval = settings.RegisterDurationSetting(


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server: enable continuous CPU profiler" (#118850)
  * 1/1 commits from "profiler: allow 0 value for CPU threshold" (#123224)

Please see individual PRs for details.

/cc @cockroachdb/release

----

Release justification: high-priority need for functionality in production deployments