### PR TITLE
cli: fix up recently added info message

### DIFF
--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -194,7 +194,7 @@ func (zc *debugZipContext) collectFileList(
 		for _, file := range files.Files {
 			ctime := extractTimeFromFileName(file.Name)
 			if !zipCtx.files.isIncluded(file.Name, ctime, ctime) {
-				nodePrinter.info("skipping excluded %s: %s", file.Name, fileKind)
+				nodePrinter.info("skipping excluded %s: %s", fileKind, file.Name)
 				continue
 			}
 


### PR DESCRIPTION
Noticed that "heap profile" and "heap.pprof" were misplaced (when doing the backport).

Epic: None

Release note: None