### PR TITLE
sqlstats: rewrite SELECT FOR UDPATE in flush as INSERT UPDATE ON CONFLICT

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -190,41 +190,9 @@ func (s *PersistedSQLStats) doFlushSingleTxnStats(
 	ctx context.Context, stats *appstatspb.CollectedTransactionStatistics, aggregatedTs time.Time,
 ) error {
 	return s.cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		// Explicitly copy the stats variable so the txn closure is retryable.
-		scopedStats := *stats
-
 		serializedFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.TransactionFingerprintID))
 
-		insertFn := func(ctx context.Context, txn isql.Txn) (alreadyExists bool, err error) {
-			rowsAffected, err := s.insertTransactionStats(ctx, txn, aggregatedTs, serializedFingerprintID, &scopedStats)
-
-			if err != nil {
-				return false /* alreadyExists */, err
-			}
-
-			if rowsAffected == 0 {
-				return true /* alreadyExists */, nil /* err */
-			}
-
-			return false /* alreadyExists */, nil /* err */
-		}
-
-		readFn := func(ctx context.Context, txn isql.Txn) error {
-			persistedData := appstatspb.TransactionStatistics{}
-			err := s.fetchPersistedTransactionStats(ctx, txn, aggregatedTs, serializedFingerprintID, scopedStats.App, &persistedData)
-			if err != nil {
-				return err
-			}
-
-			scopedStats.Stats.Add(&persistedData)
-			return nil
-		}
-
-		updateFn := func(ctx context.Context, txn isql.Txn) error {
-			return s.updateTransactionStats(ctx, txn, aggregatedTs, serializedFingerprintID, &scopedStats)
-		}
-
-		err := s.doInsertElseDoUpdate(ctx, txn, insertFn, readFn, updateFn)
+		err := s.upsertTransactionStats(ctx, txn, aggregatedTs, serializedFingerprintID, stats)
 		if err != nil {
 			return errors.Wrapf(err, "flushing transaction %d's statistics", stats.TransactionFingerprintID)
 		}
@@ -236,100 +204,24 @@ func (s *PersistedSQLStats) doFlushSingleStmtStats(
 	ctx context.Context, stats *appstatspb.CollectedStatementStatistics, aggregatedTs time.Time,
 ) error {
 	return s.cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		// Explicitly copy the stats so that this closure is retryable.
-		scopedStats := *stats
+		serializedFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.ID))
+		serializedTransactionFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.Key.TransactionFingerprintID))
+		serializedPlanHash := sqlstatsutil.EncodeUint64ToBytes(stats.Key.PlanHash)
 
-		serializedFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(scopedStats.ID))
-		serializedTransactionFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(scopedStats.Key.TransactionFingerprintID))
-		serializedPlanHash := sqlstatsutil.EncodeUint64ToBytes(scopedStats.Key.PlanHash)
-
-		insertFn := func(ctx context.Context, txn isql.Txn) (alreadyExists bool, err error) {
-			rowsAffected, err := s.insertStatementStats(
-				ctx,
-				txn,
-				aggregatedTs,
-				serializedFingerprintID,
-				serializedTransactionFingerprintID,
-				serializedPlanHash,
-				&scopedStats,
-			)
-
-			if err != nil {
-				return false /* alreadyExists */, err
-			}
-
-			if rowsAffected == 0 {
-				return true /* alreadyExists */, nil /* err */
-			}
-
-			return false /* alreadyExists */, nil /* err */
-		}
-
-		readFn := func(ctx context.Context, txn isql.Txn) error {
-			persistedData := appstatspb.StatementStatistics{}
-			err := s.fetchPersistedStatementStats(
-				ctx,
-				txn,
-				aggregatedTs,
-				serializedFingerprintID,
-				serializedTransactionFingerprintID,
-				serializedPlanHash,
-				&scopedStats.Key,
-				&persistedData,
-			)
-			if err != nil {
-				return err
-			}
-
-			scopedStats.Stats.Add(&persistedData)
-			return nil
-		}
-
-		updateFn := func(ctx context.Context, txn isql.Txn) error {
-			return s.updateStatementStats(
-				ctx,
-				txn,
-				aggregatedTs,
-				serializedFingerprintID,
-				serializedTransactionFingerprintID,
-				serializedPlanHash,
-				&scopedStats,
-			)
-		}
-
-		err := s.doInsertElseDoUpdate(ctx, txn, insertFn, readFn, updateFn)
+		err := s.upsertStatementStats(
+			ctx,
+			txn,
+			aggregatedTs,
+			serializedFingerprintID,
+			serializedTransactionFingerprintID,
+			serializedPlanHash,
+			stats,
+		)
 		if err != nil {
-			return errors.Wrapf(err, "flush statement %d's statistics", scopedStats.ID)
+			return errors.Wrapf(err, "flush statement %d's statistics", stats.ID)
 		}
 		return nil
 	})
-}
-
-func (s *PersistedSQLStats) doInsertElseDoUpdate(
-	ctx context.Context,
-	txn isql.Txn,
-	insertFn func(context.Context, isql.Txn) (alreadyExists bool, err error),
-	readFn func(context.Context, isql.Txn) error,
-	updateFn func(context.Context, isql.Txn) error,
-) error {
-	alreadyExists, err := insertFn(ctx, txn)
-	if err != nil {
-		return err
-	}
-
-	if alreadyExists {
-		err = readFn(ctx, txn)
-		if err != nil {
-			return err
-		}
-
-		err = updateFn(ctx, txn)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // ComputeAggregatedTs returns the aggregation timestamp to assign
@@ -357,18 +249,20 @@ func (s *PersistedSQLStats) getTimeNow() time.Time {
 	return timeutil.Now()
 }
 
-func (s *PersistedSQLStats) insertTransactionStats(
+func (s *PersistedSQLStats) upsertTransactionStats(
 	ctx context.Context,
 	txn isql.Txn,
 	aggregatedTs time.Time,
 	serializedFingerprintID []byte,
 	stats *appstatspb.CollectedTransactionStatistics,
-) (rowsAffected int, err error) {
-	insertStmt := `
-INSERT INTO system.transaction_statistics
+) error {
+	const upsertStmt = `
+INSERT INTO system.transaction_statistics as t
 VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id)
-DO NOTHING
+DO UPDATE
+SET
+  statistics = crdb_internal.merge_transaction_stats(ARRAY(t.statistics, EXCLUDED.statistics))
 `
 
 	aggInterval := s.GetAggregationInterval()
@@ -376,23 +270,23 @@ DO NOTHING
 	// Prepare data for insertion.
 	metadataJSON, err := sqlstatsutil.BuildTxnMetadataJSON(stats)
 	if err != nil {
-		return 0 /* rowsAffected */, err
+		return err
 	}
 	metadata := tree.NewDJSON(metadataJSON)
 
 	statisticsJSON, err := sqlstatsutil.BuildTxnStatisticsJSON(stats)
 	if err != nil {
-		return 0 /* rowsAffected */, err
+		return err
 	}
 	statistics := tree.NewDJSON(statisticsJSON)
 
 	nodeID := s.GetEnabledSQLInstanceID()
-	rowsAffected, err = txn.ExecEx(
+	_, err = txn.ExecEx(
 		ctx,
-		"insert-txn-stats",
+		"upsert-txn-stats",
 		txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		insertStmt,
+		upsertStmt,
 		aggregatedTs,            // aggregated_ts
 		serializedFingerprintID, // fingerprint_id
 		stats.App,               // app_name
@@ -402,57 +296,10 @@ DO NOTHING
 		statistics,              // statistics
 	)
 
-	return rowsAffected, err
-}
-func (s *PersistedSQLStats) updateTransactionStats(
-	ctx context.Context,
-	txn isql.Txn,
-	aggregatedTs time.Time,
-	serializedFingerprintID []byte,
-	stats *appstatspb.CollectedTransactionStatistics,
-) error {
-	updateStmt := `
-UPDATE system.transaction_statistics
-SET statistics = $1
-WHERE fingerprint_id = $2
-	AND aggregated_ts = $3
-  AND app_name = $4
-  AND node_id = $5
-`
-
-	statisticsJSON, err := sqlstatsutil.BuildTxnStatisticsJSON(stats)
-	if err != nil {
-		return err
-	}
-	statistics := tree.NewDJSON(statisticsJSON)
-
-	nodeID := s.GetEnabledSQLInstanceID()
-	rowsAffected, err := txn.ExecEx(
-		ctx,
-		"update-stmt-stats",
-		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		updateStmt,
-		statistics,              // statistics
-		serializedFingerprintID, // fingerprint_id
-		aggregatedTs,            // aggregated_ts
-		stats.App,               // app_name
-		nodeID,                  // node_id
-	)
-
-	if err != nil {
-		return err
-	}
-
-	if rowsAffected == 0 {
-		return errors.AssertionFailedf("failed to update transaction statistics for  fingerprint_id: %s, app: %s, aggregated_ts: %s, node_id: %d",
-			serializedFingerprintID, stats.App, aggregatedTs, nodeID)
-	}
-
-	return nil
+	return err
 }
 
-func (s *PersistedSQLStats) updateStatementStats(
+func (s *PersistedSQLStats) upsertStatementStats(
 	ctx context.Context,
 	txn isql.Txn,
 	aggregatedTs time.Time,
@@ -461,87 +308,18 @@ func (s *PersistedSQLStats) updateStatementStats(
 	serializedPlanHash []byte,
 	stats *appstatspb.CollectedStatementStatistics,
 ) error {
-	updateStmt := `
-UPDATE system.statement_statistics
-SET statistics = $1,
-index_recommendations = $2
-WHERE fingerprint_id = $3
-  AND transaction_fingerprint_id = $4
-	AND aggregated_ts = $5
-  AND app_name = $6
-  AND plan_hash = $7
-  AND node_id = $8
-`
-	statisticsJSON, err := sqlstatsutil.BuildStmtStatisticsJSON(&stats.Stats)
-	if err != nil {
-		return err
-	}
-	statistics := tree.NewDJSON(statisticsJSON)
-	indexRecommendations := tree.NewDArray(types.String)
-	for _, recommendation := range stats.Stats.IndexRecommendations {
-		if err := indexRecommendations.Append(tree.NewDString(recommendation)); err != nil {
-			return err
-		}
-	}
-
-	nodeID := s.GetEnabledSQLInstanceID()
-	rowsAffected, err := txn.ExecEx(
-		ctx,
-		"update-stmt-stats",
-		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		updateStmt,
-		statistics,                         // statistics
-		indexRecommendations,               // index_recommendations
-		serializedFingerprintID,            // fingerprint_id
-		serializedTransactionFingerprintID, // transaction_fingerprint_id
-		aggregatedTs,                       // aggregated_ts
-		stats.Key.App,                      // app_name
-		serializedPlanHash,                 // plan_hash
-		nodeID,                             // node_id
-	)
-
-	if err != nil {
-		return err
-	}
-
-	if rowsAffected == 0 {
-		return errors.AssertionFailedf("failed to update statement statistics "+
-			"for fingerprint_id: %s, "+
-			"transaction_fingerprint_id: %s, "+
-			"app: %s, "+
-			"aggregated_ts: %s, "+
-			"plan_hash: %d, "+
-			"node_id: %d",
-			serializedFingerprintID, serializedTransactionFingerprintID, stats.Key.App,
-			aggregatedTs, serializedPlanHash, nodeID)
-	}
-
-	return nil
-}
-
-func (s *PersistedSQLStats) insertStatementStats(
-	ctx context.Context,
-	txn isql.Txn,
-	aggregatedTs time.Time,
-	serializedFingerprintID []byte,
-	serializedTransactionFingerprintID []byte,
-	serializedPlanHash []byte,
-	stats *appstatspb.CollectedStatementStatistics,
-) (rowsAffected int, err error) {
-
 	aggInterval := s.GetAggregationInterval()
 
 	// Prepare data for insertion.
 	metadataJSON, err := sqlstatsutil.BuildStmtMetadataJSON(stats)
 	if err != nil {
-		return 0 /* rowsAffected */, err
+		return err
 	}
 	metadata := tree.NewDJSON(metadataJSON)
 
 	statisticsJSON, err := sqlstatsutil.BuildStmtStatisticsJSON(&stats.Stats)
 	if err != nil {
-		return 0 /* rowsAffected */, err
+		return err
 	}
 	statistics := tree.NewDJSON(statisticsJSON)
 
@@ -551,11 +329,10 @@ func (s *PersistedSQLStats) insertStatementStats(
 	indexRecommendations := tree.NewDArray(types.String)
 	for _, recommendation := range stats.Stats.IndexRecommendations {
 		if err := indexRecommendations.Append(tree.NewDString(recommendation)); err != nil {
-			return 0, err
+			return err
 		}
 	}
 
-	values := "$1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10, $11"
 	args := append(make([]interface{}, 0, 11),
 		aggregatedTs,                       // aggregated_ts
 		serializedFingerprintID,            // fingerprint_id
@@ -570,134 +347,24 @@ func (s *PersistedSQLStats) insertStatementStats(
 		indexRecommendations,               // index_recommendations
 	)
 
-	insertStmt := fmt.Sprintf(`
-INSERT INTO system.statement_statistics
-VALUES (%s)
+	const upsertStmt = `
+INSERT INTO system.statement_statistics as s
+VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 ON CONFLICT (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,
              aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, plan_hash, node_id)
-DO NOTHING
-`, values)
-	rowsAffected, err = txn.ExecEx(
+DO UPDATE
+SET
+  statistics = crdb_internal.merge_statement_stats(ARRAY(s.statistics, EXCLUDED.statistics)),
+  index_recommendations = EXCLUDED.index_recommendations
+`
+	_, err = txn.ExecEx(
 		ctx,
-		"insert-stmt-stats",
+		"upsert-stmt-stats",
 		txn.KV(), /* txn */
 		sessiondata.NodeUserSessionDataOverride,
-		insertStmt,
+		upsertStmt,
 		args...,
 	)
 
-	return rowsAffected, err
-}
-
-func (s *PersistedSQLStats) fetchPersistedTransactionStats(
-	ctx context.Context,
-	txn isql.Txn,
-	aggregatedTs time.Time,
-	serializedFingerprintID []byte,
-	appName string,
-	result *appstatspb.TransactionStatistics,
-) error {
-	// We use `SELECT ... FOR UPDATE` statement because we are going to perform
-	// and `UPDATE` on the stats for the given fingerprint later.
-	readStmt := `
-SELECT
-    statistics
-FROM
-    system.transaction_statistics
-WHERE fingerprint_id = $1
-    AND app_name = $2
-	  AND aggregated_ts = $3
-    AND node_id = $4
-FOR UPDATE
-`
-
-	nodeID := s.GetEnabledSQLInstanceID()
-	row, err := txn.QueryRowEx(
-		ctx,
-		"fetch-txn-stats",
-		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		readStmt,                // stmt
-		serializedFingerprintID, // fingerprint_id
-		appName,                 // app_name
-		aggregatedTs,            // aggregated_ts
-		nodeID,                  // node_id
-	)
-
-	if err != nil {
-		return err
-	}
-
-	if row == nil {
-		return errors.AssertionFailedf("transaction statistics not found for fingerprint_id: %s, app: %s, aggregated_ts: %s, node_id: %d",
-			serializedFingerprintID, appName, aggregatedTs,
-			nodeID)
-	}
-
-	if len(row) != 1 {
-		return errors.AssertionFailedf("unexpectedly found %d returning columns for fingerprint_id: %s, app: %s, aggregated_ts: %s, node_id: %d",
-			len(row), serializedFingerprintID, appName, aggregatedTs,
-			nodeID)
-	}
-
-	statistics := tree.MustBeDJSON(row[0])
-	return sqlstatsutil.DecodeTxnStatsStatisticsJSON(statistics.JSON, result)
-}
-
-func (s *PersistedSQLStats) fetchPersistedStatementStats(
-	ctx context.Context,
-	txn isql.Txn,
-	aggregatedTs time.Time,
-	serializedFingerprintID []byte,
-	serializedTransactionFingerprintID []byte,
-	serializedPlanHash []byte,
-	key *appstatspb.StatementStatisticsKey,
-	result *appstatspb.StatementStatistics,
-) error {
-	readStmt := `
-SELECT
-    statistics
-FROM
-    system.statement_statistics
-WHERE fingerprint_id = $1
-    AND transaction_fingerprint_id = $2
-    AND app_name = $3
-	  AND aggregated_ts = $4
-    AND plan_hash = $5
-    AND node_id = $6
-FOR UPDATE
-`
-	nodeID := s.GetEnabledSQLInstanceID()
-	row, err := txn.QueryRowEx(
-		ctx,
-		"fetch-stmt-stats",
-		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
-		readStmt,                           // stmt
-		serializedFingerprintID,            // fingerprint_id
-		serializedTransactionFingerprintID, // transaction_fingerprint_id
-		key.App,                            // app_name
-		aggregatedTs,                       // aggregated_ts
-		serializedPlanHash,                 // plan_hash
-		nodeID,                             // node_id
-	)
-
-	if err != nil {
-		return err
-	}
-
-	if row == nil {
-		return errors.AssertionFailedf(
-			"statement statistics not found fingerprint_id: %s, app: %s, aggregated_ts: %s, plan_hash: %d, node_id: %d",
-			serializedFingerprintID, key.App, aggregatedTs, serializedPlanHash, nodeID)
-	}
-
-	if len(row) != 1 {
-		return errors.AssertionFailedf("unexpectedly found %d returning columns for fingerprint_id: %s, app: %s, aggregated_ts: %s, plan_hash %d, node_id: %d",
-			len(row), serializedFingerprintID, key.App, aggregatedTs, serializedPlanHash, nodeID)
-	}
-
-	statistics := tree.MustBeDJSON(row[0])
-
-	return sqlstatsutil.DecodeStmtStatsStatisticsJSON(statistics.JSON, result)
+	return err
 }


### PR DESCRIPTION
Please note only the latest commit is for review in this comment.

-------------------

Previously, the UPDATE logic for flushing sql stats
was split into a 3 part transaction due to using
SELECT FOR UPDATE -
1. Attempt to INSERT
2. SELECT row FOR UPDATE
3. UPDATE

We can make this faster by using INSERT .. ON CONFLICT UPDATE.

```
Previous:
BenchmarkSqlStatsMaxFlushTime/single-application/writes=update/10000-fingerprints-10    1     32487051083 ns/op

New:
BenchmarkSqlStatsMaxFlushTime/single-application/writes=update/10000-fingerprints-10    1     13356979917 ns/op
```

Epic: none
Fixes: #123476
Release note: None