### PR TITLE
sql: avoid retries for dropped descriptors in type schema changes

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1395,7 +1395,8 @@ func (t *typeChangeResumer) OnFailOrCancel(
 		return nil
 	}(); rollbackErr != nil {
 		switch {
-		case errors.Is(rollbackErr, catalog.ErrDescriptorNotFound):
+		case errors.Is(rollbackErr, catalog.ErrDescriptorNotFound) ||
+			pgerror.GetPGCode(rollbackErr) == pgcode.UndefinedObject:
 			// If the descriptor for the ID can't be found, we assume that another
 			// job executed already and dropped the type.
 			log.Infof(


### PR DESCRIPTION
Previously, when rolling back type descriptor schema changes if the descriptor was already dropped we would keep retrying the schema change. This would happen because we introduced a regression where the internal structured error was replaced with user facing pgerror based error. To address this, this patch will properly handle the UndefinedObject pgcode and avoid retrying during a rollback of a typedesc schema change.

Fixes: #122958
Fixes: #122659

Release note (bug fix): TYPEDESC SCHEMA CHANGE jobs could end up retrying forever if the descriptor targeted by them was already dropped.