### PR TITLE
sql: skip TestTenantGlobalAggregatedLivebytes under duress

### DIFF
--- a/pkg/sql/mvcc_statistics_update_job_test.go
+++ b/pkg/sql/mvcc_statistics_update_job_test.go
@@ -49,7 +49,7 @@ func TestTenantGlobalAggregatedLivebytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "test is too slow to run under race")
+	skip.UnderDuress(t, "too slow")
 
 	ctx := context.Background()
 	jobID := jobs.MVCCStatisticsJobID


### PR DESCRIPTION
Previously, this test was only skipped under race, but we just had a run under deadlock where it took more than 30 minutes to complete. I don't see why we need to run this test in any special configs, so let's skip it under duress.

Fixes: #122883.

Release note: None