### PR TITLE
kv: check tscache update against latest lease, and only in tests

### DIFF
--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1349,7 +1349,7 @@ func (ec *endCmds) done(
 	// do so if the request is consistent and was operating on the leaseholder
 	// under a valid range lease.
 	if ba.ReadConsistency == kvpb.CONSISTENT && ec.st.State == kvserverpb.LeaseState_VALID {
-		ec.repl.updateTimestampCache(ctx, &ec.st, ba, br, pErr)
+		ec.repl.updateTimestampCache(ctx, ba, br, pErr)
 	}
 
 	if ts := ec.replicatingSince; !ts.IsZero() {


### PR DESCRIPTION
Fixes #121887.
Fixes #121843.
Fixes #119522.

This commit updates the assertion in Replica.addToTSCacheChecked to check the timestamp cache update against the latest version of the lease, instead of the copy of the lease that the request originally saw when it grabbed latches. This avoids the assertion false positive that can happen when the lease is extended after the request has grabbed latches, as is described in https://github.com/cockroachdb/cockroach/issues/121887#issuecomment-2084131200.

The commit also makes this assertion test-only. This is in part because the assertion is now more expensive to perform. It is also in part because the assertion has a history of false positives, so it is not a good candidate for a production assertion.

Release note: None