### PR TITLE
workload: retry errors when tolerate-errors is set

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -259,9 +259,7 @@ func workerRun(
 	limiter *rate.Limiter,
 	workFn func(context.Context) error,
 ) {
-	if wg != nil {
-		defer wg.Done()
-	}
+	defer wg.Done()
 
 	for {
 		if ctx.Err() != nil {


### PR DESCRIPTION
Previously if tolerate errors was set, the workload would log and drop errors. Now it will retry the errors. This more closely simulates how clients would use our system.

Informs: #123304

Epic: none

Release note: None