### PR TITLE
changefeedccl: skip TestJSONEncoderJSONNullAsObject

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_json_test.go
+++ b/pkg/ccl/changefeedccl/encoder_json_test.go
@@ -32,6 +32,7 @@ func TestJSONEncoderJSONNullAsObject(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 123156)
 	t.Parallel() // SAFE FOR TESTING
 
 	ctx := context.Background()


### PR DESCRIPTION
This patch skips TestJSONEncoderJSONNullAsObject since it is flaky.

Release note: none
Epic: none