### PR TITLE
amazon: mark returned errors with context's error

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//pkg/util/leaktest",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/credentials",
+        "@com_github_aws_aws_sdk_go//aws/request",
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1257,7 +1257,7 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	// We prefer cfg.sharedStorage, since the Locator -> Storage mapping contained
 	// in it is needed for CRDB to function properly.
 	if cfg.sharedStorage != nil {
-		esWrapper := &externalStorageWrapper{p: p, es: cfg.sharedStorage, ctx: ctx}
+		esWrapper := &externalStorageWrapper{p: p, es: cfg.sharedStorage, ctx: logCtx}
 		if ConfigureForSharedStorage == nil {
 			return nil, errors.New("shared storage requires CCL features")
 		}
@@ -1266,7 +1266,7 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		}
 	} else {
 		if cfg.remoteStorageFactory != nil {
-			cfg.opts.Experimental.RemoteStorage = remoteStorageAdaptor{p: p, ctx: ctx, factory: cfg.remoteStorageFactory}
+			cfg.opts.Experimental.RemoteStorage = remoteStorageAdaptor{p: p, ctx: logCtx, factory: cfg.remoteStorageFactory}
 		}
 	}
 


### PR DESCRIPTION
The code in s3_storage.go is now also used by Pebble's disaggregated storage, and context cancellation gets propagated to the s3 library (as desired). There are callers in CockroachDB that use the returned error and decide whether it represents corruption, and need to realize that an error due to context cancellation is not corruption. The immediate motivator for this change is kvpb.MaybeWrapReplicaCorruptionError, used when the abort span read returns an error. It was mistaking these s3 errors as corruption
https://gist.github.com/sumeerbhola/1527ec97d0c8d834f68c7382bcd2d1fe.

Epic: none

Release note: None