### PR TITLE
changefeedccl: fix test flake encoder_json_test

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_json_test.go
+++ b/pkg/ccl/changefeedccl/encoder_json_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -31,8 +30,6 @@ import (
 func TestJSONEncoderJSONNullAsObject(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	t.Parallel() // SAFE FOR TESTING
 
 	ctx := context.Background()
 	tableDesc, err := parseTableDesc(`CREATE TABLE foo (a JSONB PRIMARY KEY, b JSONB)`)
@@ -177,10 +174,6 @@ func TestJSONEncoderJSONNullAsObject(t *testing.T) {
 func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.WithIssue(t, 123156)
-
-	t.Parallel() // SAFE FOR TESTING
 
 	ctx := context.Background()
 	ts := hlc.Timestamp{WallTime: 1, Logical: 2}


### PR DESCRIPTION
Remove the call to t.Parallel() that results in
other failures due to shared mutable state in
TestMain

Fixes https://github.com/cockroachdb/cockroach/issues/123140, https://github.com/cockroachdb/cockroach/issues/123156
Epic: None
Release note: None