### PR TITLE
catalog/lease: make some tests work with test tenant

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1014,7 +1014,10 @@ func TestTxnObeysTableModificationTime(t *testing.T) {
 
 	var params base.TestServerArgs
 	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
-	params.DefaultTestTenant = base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(109385)
+	// This test focuses on the transaction timestamps and when running in
+	// a non-system tenant there may be uncertainty on them (since the gateway and
+	// KV store would be seperate).
+	params.DefaultTestTenant = base.TestIsSpecificToStorageLayerAndNeedsASystemTenant
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.Background())
 

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2049,60 +2049,57 @@ func TestTableCreationPushesTxnsInRecentPast(t *testing.T) {
 					MaxOffset: time.Second,
 				},
 			},
-			DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(109385),
 		},
 		ReplicationMode: base.ReplicationManual,
 	})
 	defer tc.Stopper().Stop(context.Background())
 	sqlDB := tc.ApplicationLayer(0).SQLConn(t)
 
-	if _, err := sqlDB.Exec(`
+	_, err := sqlDB.Exec(`
  CREATE DATABASE t;
  CREATE TABLE t.timestamp (k CHAR PRIMARY KEY, v CHAR);
- `); err != nil {
-		t.Fatal(err)
-	}
+ `)
+	require.NoError(t, err)
 
 	// Create a transaction before the table is created.
 	tx, err := sqlDB.Begin()
-	if err != nil {
-		t.Fatal(err)
+	require.NoError(t, err)
+	// For multi-tenant environments the replica for node 1 and tenant on
+	// node 1 are seperate. So, the uncertainty interval is not predictable enough
+	// to guarantee if we will always see the table as "missing". So, intentionally
+	// lock the timestamp on multi-tenant.
+	if tc.StartedDefaultTestTenant() {
+		_, err = tx.Exec("SET TRANSACTION AS OF SYSTEM TIME '-1ms'")
+		require.NoError(t, err)
 	}
 
 	// Create a transaction before the table is created. Use a different
 	// node so that clock uncertainty is presumed and it gets pushed.
 	tx1, err := tc.ApplicationLayer(1).SQLConn(t, serverutils.DBName("t")).Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if _, err := sqlDB.Exec(`
+	_, err = sqlDB.Exec(`
 CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
-`); err != nil {
-		t.Fatal(err)
-	}
+`)
+	require.NoError(t, err)
 
 	// Was actually run in the past and so doesn't see the table.
-	if _, err := tx.Exec(`
+	_, err = tx.Exec(`
 INSERT INTO t.kv VALUES ('a', 'b');
-`); !testutils.IsError(err, "does not exist") {
-		t.Fatal(err)
-	}
+`)
+	require.ErrorContains(t, err, "does not exist")
 
 	// Not sure whether run in the past and so sees clock uncertainty push.
-	if _, err := tx1.Exec(`
+	_, err = tx1.Exec(`
 INSERT INTO t.kv VALUES ('c', 'd');
-`); err != nil {
-		t.Fatal(err)
-	}
+`)
+	require.NoError(t, err)
 
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	err = tx.Rollback()
+	require.NoError(t, err)
 
-	if err := tx1.Commit(); err != nil {
-		t.Fatal(err)
-	}
+	err = tx1.Commit()
+	require.NoError(t, err)
 }
 
 // Tests that DeleteOrphanedLeases() deletes only orphaned leases.


### PR DESCRIPTION
Previously, the following tests had tenant support disabled:

- TestReadBeforeDrop
- TestTableCreationPushesTxnsInRecentPast
- TestTxnObeysTableModificationTime

This was because these tests would be impacted by the uncertainty interval of running inside a tenant versus directly running on a system tenant co-located with the KV storage node. To avoid problems some the first two tests will use a fixed timestamp intentionally to remove this factor. The last test which has writes will be explicitly disabled for multi-tenant.

Fixes: #109385