### PR TITLE
internal/sqlsmith: make it more deterministic

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -12,6 +12,7 @@ package sqlsmith
 
 import (
 	gosql "database/sql"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -425,7 +426,7 @@ func makeDropType(s *Smither) (tree.Statement, bool) {
 	var typNames []*tree.UnresolvedObjectName
 	for len(typNames) < 1 || s.coin() {
 		// It's ok if the same type is chosen multiple times.
-		typName, ok := s.getRandUserDefinedType()
+		_, typName, ok := s.getRandUserDefinedType()
 		if !ok {
 			if len(typNames) == 0 {
 				return nil, false
@@ -458,6 +459,9 @@ func rowsToRegionList(rows *gosql.Rows) ([]string, error) {
 	for region := range regionsSet {
 		regions = append(regions, region)
 	}
+	// Make deterministic. Note that we don't need to shuffle the regions since
+	// the caller will be picking random ones from the slice.
+	sort.Strings(regions)
 	return regions, nil
 }
 

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -70,7 +70,9 @@ type Smither struct {
 	tables    []*tableRef
 	sequences []*sequenceRef
 	columns   map[tree.TableName]map[tree.Name]*tree.ColumnTableDef
-	indexes   map[tree.TableName]map[tree.Name]*tree.CreateIndex
+	// Note: consider using getAllIndexesForTable helper if you need to iterate
+	// over all indexes for a particular table.
+	indexes map[tree.TableName]map[tree.Name]*tree.CreateIndex
 	// Only one of nameCounts and nameGens will be used. nameCounts is used when
 	// simpleNames is true.
 	nameCounts       map[string]int

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -127,7 +127,8 @@ func (s *Smither) makeDesiredTypes() []*types.T {
 }
 
 type typeInfo struct {
-	udts        map[tree.TypeName]*types.T
+	udts        []*types.T
+	udtNames    []tree.TypeName
 	seedTypes   []*types.T
 	scalarTypes []*types.T
 }
@@ -137,11 +138,12 @@ func (s *Smither) ResolveType(
 	_ context.Context, name *tree.UnresolvedObjectName,
 ) (*types.T, error) {
 	key := tree.MakeSchemaQualifiedTypeName(name.Schema(), name.Object())
-	res, ok := s.types.udts[key]
-	if !ok {
-		return nil, errors.Newf("type name %s not found by smither", name.Object())
+	for i, typeName := range s.types.udtNames {
+		if typeName == key {
+			return s.types.udts[i], nil
+		}
 	}
-	return res, nil
+	return nil, errors.Newf("type name %s not found by smither", name.Object())
 }
 
 // ResolveTypeByOID implements the tree.TypeReferenceResolver interface.


### PR DESCRIPTION
This commit removes one source of non-determinism (iteration order over a map) in sqlsmith. The following parts are affected:
- list of regions for MR setup
- file names for IMPORT stmt
- table-index pairs for merge join expr
- DROP FUNCTION
- picking a random table or random index
- UDTs
- builtin functions and binary operators (here we needed to make construction of global "registries" deterministic).

Informs: #122766
Epic: None

Release note: None