### PR TITLE
release-24.1: sqlstats: fix memory leak when writing statement insights and no transaction insights

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -873,6 +873,7 @@ go_test(
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
+        "//pkg/sql/sqlstats/sslocal",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/stats",
         "//pkg/sql/stmtdiagnostics",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1644,7 +1644,7 @@ type connExecutor struct {
 
 	// statsCollector is used to collect statistics about SQL statements and
 	// transactions.
-	statsCollector sqlstats.StatsCollector
+	statsCollector *sslocal.StatsCollector
 
 	// cpuStatsCollector is used to estimate RU consumption due to CPU usage for
 	// tenants.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1137,10 +1137,12 @@ func (s *Server) newConnExecutor(
 	}
 
 	ex.applicationName.Store(ex.sessionData().ApplicationName)
+
 	ex.applicationStats = applicationStats
 	ex.statsCollector = sslocal.NewStatsCollector(
 		s.cfg.Settings,
 		applicationStats,
+		ex.server.insights.Writer(ex.sessionData().Internal),
 		ex.phaseTimes,
 		s.cfg.SQLStatsTestingKnobs,
 	)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3411,6 +3411,8 @@ func (ex *connExecutor) recordTransactionFinish(
 		)
 	}
 
+	ex.statsCollector.ObserveTransaction(ctx, transactionFingerprintID, recordedTxnStats)
+
 	return ex.statsCollector.RecordTransaction(
 		ctx,
 		transactionFingerprintID,

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -143,7 +144,7 @@ func (p *planner) maybeLogStatement(
 	telemetryLoggingMetrics *telemetryLoggingMetrics,
 	stmtFingerprintID appstatspb.StmtFingerprintID,
 	queryStats *topLevelQueryStats,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	shouldLogToTelemetry bool,
 ) {
 	p.maybeAuditRoleBasedAuditEvent(ctx, execType)
@@ -164,7 +165,7 @@ func (p *planner) maybeLogStatementInternal(
 	telemetryMetrics *telemetryLoggingMetrics,
 	stmtFingerprintID appstatspb.StmtFingerprintID,
 	topLevelQueryStats *topLevelQueryStats,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	shouldLogToTelemetry bool,
 ) {
 	// Note: if you find the code below crashing because p.execCfg == nil,

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -257,6 +257,10 @@ func (ex *connExecutor) recordStatementSummary(
 		}
 	}
 
+	if stmtFingerprintID != 0 {
+		ex.statsCollector.ObserveStatement(stmtFingerprintID, recordedStmtStats)
+	}
+
 	// Do some transaction level accounting for the transaction this statement is
 	// a part of.
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -407,7 +408,7 @@ func (ih *instrumentationHelper) finalizeSetup(ctx context.Context, cfg *Executo
 func (ih *instrumentationHelper) Setup(
 	ctx context.Context,
 	cfg *ExecutorConfig,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	p *planner,
 	stmtDiagnosticsRecorder *stmtdiagnostics.Registry,
 	fingerprint string,
@@ -561,7 +562,7 @@ func (ih *instrumentationHelper) setupWithPlanGist(
 
 func (ih *instrumentationHelper) Finish(
 	cfg *ExecutorConfig,
-	statsCollector sqlstats.StatsCollector,
+	statsCollector *sslocal.StatsCollector,
 	txnStats *execstats.QueryLevelStats,
 	collectExecStats bool,
 	p *planner,

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql/execstats",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats/insights",
         "//pkg/util/stop",
         "//pkg/util/uuid",

--- a/pkg/sql/sqlstats/insights/ingester.go
+++ b/pkg/sql/sqlstats/insights/ingester.go
@@ -145,7 +145,7 @@ func (i *concurrentBufferIngester) ingest(events *eventBuffer) {
 		}
 		if e.statement != nil {
 			i.registry.ObserveStatement(e.sessionID, e.statement)
-		} else {
+		} else if e.transaction != nil {
 			i.registry.ObserveTransaction(e.sessionID, e.transaction)
 		}
 		events[idx] = event{}

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/insights",
@@ -30,6 +31,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -461,6 +461,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 	statsCollector := sslocal.NewStatsCollector(
 		st,
 		appStats,
+		insightsProvider.Writer(false /* internal */),
 		sessionphase.NewTimes(),
 		nil, /* knobs */
 	)
@@ -586,6 +587,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 		statsCollector := sslocal.NewStatsCollector(
 			st,
 			appStats,
+			insightsProvider.Writer(false /* internal */),
 			sessionphase.NewTimes(),
 			nil, /* knobs */
 		)

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -12,12 +12,15 @@ package sslocal
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
+	"github.com/cockroachdb/redact"
 )
 
 // StatsCollector is used to collect statistics for transactions and
@@ -34,6 +37,11 @@ type StatsCollector struct {
 	// previousPhaseTimes tracks the session-level phase times for the previous
 	// query. This enables the `SHOW LAST QUERY STATISTICS` observer statement.
 	previousPhaseTimes *sessionphase.Times
+
+	// sendInsights is true if we should send statement and transaction stats to
+	// the insights system for the current transaction. This value is reset for
+	// every new transaction.
+	sendInsights bool
 
 	flushTarget sqlstats.ApplicationStats
 	st          *cluster.Settings
@@ -84,6 +92,7 @@ func (s *StatsCollector) Reset(appStats sqlstats.ApplicationStats, phaseTime *se
 // StartTransaction sets up the StatsCollector for a new transaction.
 // The current application stats are reset for the new transaction.
 func (s *StatsCollector) StartTransaction() {
+	s.sendInsights = s.shouldObserveInsights()
 	s.flushTarget = s.ApplicationStats
 	s.ApplicationStats = s.flushTarget.NewApplicationStatsWithInheritedOptions()
 }
@@ -155,4 +164,73 @@ func (s *StatsCollector) UpgradeImplicitTxn(ctx context.Context) error {
 		})
 
 	return err
+}
+
+func getInsightStatus(statementError error) insights.Statement_Status {
+	if statementError == nil {
+		return insights.Statement_Completed
+	}
+
+	return insights.Statement_Failed
+}
+
+func (s *StatsCollector) shouldObserveInsights() bool {
+	return sqlstats.StmtStatsEnable.Get(&s.st.SV) && sqlstats.TxnStatsEnable.Get(&s.st.SV)
+}
+
+// ObserveStatement sends the recorded statement stats to the insights system
+// for further processing.
+func (s *StatsCollector) ObserveStatement(
+	stmtFingerprintID appstatspb.StmtFingerprintID, value sqlstats.RecordedStmtStats,
+) {
+	if !s.sendInsights {
+		return
+	}
+
+	var autoRetryReason string
+	if value.AutoRetryReason != nil {
+		autoRetryReason = value.AutoRetryReason.Error()
+	}
+
+	var contention *time.Duration
+	var cpuSQLNanos int64
+	if value.ExecStats != nil {
+		contention = &value.ExecStats.ContentionTime
+		cpuSQLNanos = value.ExecStats.CPUTime.Nanoseconds()
+	}
+
+	var errorCode string
+	var errorMsg redact.RedactableString
+	if value.StatementError != nil {
+		errorCode = pgerror.GetPGCode(value.StatementError).String()
+		errorMsg = redact.Sprint(value.StatementError)
+	}
+
+	insight := insights.Statement{
+		ID:                   value.StatementID,
+		FingerprintID:        stmtFingerprintID,
+		LatencyInSeconds:     value.ServiceLatencySec,
+		Query:                value.Query,
+		Status:               getInsightStatus(value.StatementError),
+		StartTime:            value.StartTime,
+		EndTime:              value.EndTime,
+		FullScan:             value.FullScan,
+		PlanGist:             value.PlanGist,
+		Retries:              int64(value.AutoRetryCount),
+		AutoRetryReason:      autoRetryReason,
+		RowsRead:             value.RowsRead,
+		RowsWritten:          value.RowsWritten,
+		Nodes:                value.Nodes,
+		Contention:           contention,
+		IndexRecommendations: value.IndexRecommendations,
+		Database:             value.Database,
+		CPUSQLNanos:          cpuSQLNanos,
+		ErrorCode:            errorCode,
+		ErrorMsg:             errorMsg,
+	}
+	if s.knobs != nil && s.knobs.InsightsWriterStmtInterceptor != nil {
+		s.knobs.InsightsWriterStmtInterceptor(value.SessionID, &insight)
+	} else {
+		s.insightsWriter.ObserveStatement(value.SessionID, &insight)
+	}
 }

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -41,6 +41,9 @@ type StatsCollector struct {
 	// sendInsights is true if we should send statement and transaction stats to
 	// the insights system for the current transaction. This value is reset for
 	// every new transaction.
+	// It is important that if we send statement insights, we also send transaction
+	// insights, as the transaction insight event will free the memory used by
+	// statement insights.
 	sendInsights bool
 
 	flushTarget sqlstats.ApplicationStats
@@ -232,5 +235,64 @@ func (s *StatsCollector) ObserveStatement(
 		s.knobs.InsightsWriterStmtInterceptor(value.SessionID, &insight)
 	} else {
 		s.insightsWriter.ObserveStatement(value.SessionID, &insight)
+	}
+}
+
+// ObserveTransaction sends the recorded transaction stats to the insights system
+// for further processing.
+func (s *StatsCollector) ObserveTransaction(
+	ctx context.Context,
+	txnFingerprintID appstatspb.TransactionFingerprintID,
+	value sqlstats.RecordedTxnStats,
+) {
+	if !s.sendInsights {
+		return
+	}
+
+	var retryReason string
+	if value.AutoRetryReason != nil {
+		retryReason = value.AutoRetryReason.Error()
+	}
+
+	var cpuSQLNanos int64
+	if value.ExecStats.CPUTime.Nanoseconds() >= 0 {
+		cpuSQLNanos = value.ExecStats.CPUTime.Nanoseconds()
+	}
+
+	var errorCode string
+	var errorMsg redact.RedactableString
+	if value.TxnErr != nil {
+		errorCode = pgerror.GetPGCode(value.TxnErr).String()
+		errorMsg = redact.Sprint(value.TxnErr)
+	}
+
+	status := insights.Transaction_Failed
+	if value.Committed {
+		status = insights.Transaction_Completed
+	}
+
+	insight := insights.Transaction{
+		ID:              value.TransactionID,
+		FingerprintID:   txnFingerprintID,
+		UserPriority:    value.Priority.String(),
+		ImplicitTxn:     value.ImplicitTxn,
+		Contention:      &value.ExecStats.ContentionTime,
+		StartTime:       value.StartTime,
+		EndTime:         value.EndTime,
+		User:            value.SessionData.User().Normalized(),
+		ApplicationName: value.SessionData.ApplicationName,
+		RowsRead:        value.RowsRead,
+		RowsWritten:     value.RowsWritten,
+		RetryCount:      value.RetryCount,
+		AutoRetryReason: retryReason,
+		CPUSQLNanos:     cpuSQLNanos,
+		LastErrorCode:   errorCode,
+		LastErrorMsg:    errorMsg,
+		Status:          status,
+	}
+	if s.knobs != nil && s.knobs.InsightsWriterTxnInterceptor != nil {
+		s.knobs.InsightsWriterTxnInterceptor(ctx, value.SessionID, &insight)
+	} else {
+		s.insightsWriter.ObserveTransaction(value.SessionID, &insight)
 	}
 }

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -17,12 +17,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 )
 
 // StatsCollector is used to collect statistics for transactions and
 // statements for the entire lifetime of a session.
 type StatsCollector struct {
 	sqlstats.ApplicationStats
+
+	// Allows StatsCollector to send statement and transaction stats to the insights system.
+	insightsWriter insights.Writer
 
 	// phaseTimes tracks session-level phase times.
 	phaseTimes *sessionphase.Times
@@ -42,11 +46,13 @@ var _ sqlstats.ApplicationStats = &StatsCollector{}
 func NewStatsCollector(
 	st *cluster.Settings,
 	appStats sqlstats.ApplicationStats,
+	insights insights.Writer,
 	phaseTime *sessionphase.Times,
 	knobs *sqlstats.TestingKnobs,
 ) *StatsCollector {
 	return &StatsCollector{
 		ApplicationStats: appStats,
+		insightsWriter:   insights,
 		phaseTimes:       phaseTime.Clone(),
 		st:               st,
 		knobs:            knobs,

--- a/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -43,14 +42,6 @@ var (
 var timestampSize = int64(unsafe.Sizeof(time.Time{}))
 
 var _ sqlstats.Writer = &Container{}
-
-func getStatus(statementError error) insights.Statement_Status {
-	if statementError == nil {
-		return insights.Statement_Completed
-	}
-
-	return insights.Statement_Failed
-}
 
 // RecordStatement implements sqlstats.Writer interface.
 // RecordStatement saves per-statement statistics.
@@ -191,58 +182,6 @@ func (s *Container) RecordStatement(
 		if err := s.mu.acc.Grow(ctx, estimatedMemoryAllocBytes); err != nil {
 			delete(s.mu.stmts, statementKey)
 			return stats.ID, ErrMemoryPressure
-		}
-	}
-
-	var autoRetryReason string
-	if value.AutoRetryReason != nil {
-		autoRetryReason = value.AutoRetryReason.Error()
-	}
-
-	var contention *time.Duration
-	var cpuSQLNanos int64
-	if value.ExecStats != nil {
-		contention = &value.ExecStats.ContentionTime
-		cpuSQLNanos = value.ExecStats.CPUTime.Nanoseconds()
-	}
-
-	var errorCode string
-	var errorMsg redact.RedactableString
-	if value.StatementError != nil {
-		errorCode = pgerror.GetPGCode(value.StatementError).String()
-		errorMsg = redact.Sprint(value.StatementError)
-	}
-
-	// Without TxnStatsEnable enabled, sending statements to the insights
-	// system creates a memory leak. Avoid doing so if disabled.
-	// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
-	if sqlstats.TxnStatsEnable.Get(&s.st.SV) {
-		insight := insights.Statement{
-			ID:                   value.StatementID,
-			FingerprintID:        stmtFingerprintID,
-			LatencyInSeconds:     value.ServiceLatencySec,
-			Query:                value.Query,
-			Status:               getStatus(value.StatementError),
-			StartTime:            value.StartTime,
-			EndTime:              value.EndTime,
-			FullScan:             value.FullScan,
-			PlanGist:             value.PlanGist,
-			Retries:              int64(value.AutoRetryCount),
-			AutoRetryReason:      autoRetryReason,
-			RowsRead:             value.RowsRead,
-			RowsWritten:          value.RowsWritten,
-			Nodes:                value.Nodes,
-			Contention:           contention,
-			IndexRecommendations: value.IndexRecommendations,
-			Database:             value.Database,
-			CPUSQLNanos:          cpuSQLNanos,
-			ErrorCode:            errorCode,
-			ErrorMsg:             errorMsg,
-		}
-		if s.knobs != nil && s.knobs.InsightsWriterStmtInterceptor != nil {
-			s.knobs.InsightsWriterStmtInterceptor(value.SessionID, &insight)
-		} else {
-			s.insights.ObserveStatement(value.SessionID, &insight)
 		}
 	}
 

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -137,39 +136,6 @@ type TransactionVisitor func(context.Context, *appstatspb.CollectedTransactionSt
 // IterateAggregatedTransactionStats(). If an error is encountered when calling
 // the visitor, the iteration is aborted.
 type AggregatedTransactionVisitor func(appName string, statistics *appstatspb.TxnStats) error
-
-// StatsCollector is an interface that collects statistics for transactions and
-// statements for the entire lifetime of a session.
-type StatsCollector interface {
-	Writer
-
-	// PhaseTimes returns the sessionphase.Times that this StatsCollector is
-	// currently tracking.
-	PhaseTimes() *sessionphase.Times
-
-	// PreviousPhaseTimes returns the sessionphase.Times that this StatsCollector
-	// was previously tracking before being Reset.
-	PreviousPhaseTimes() *sessionphase.Times
-
-	// Reset resets the StatsCollector with a new ApplicationStats and a new copy
-	// of the sessionphase.Times.
-	Reset(ApplicationStats, *sessionphase.Times)
-
-	// StartTransaction sets up the StatsCollector for a new transaction.
-	StartTransaction()
-
-	// EndTransaction informs the StatsCollector that the current txn has
-	// finished execution. (Either COMMITTED or ABORTED). This means the txn's
-	// fingerprint ID is now available. StatsCollector will now go back to update
-	// the transaction fingerprint ID field of all the statement statistics for that
-	// txn.
-	EndTransaction(ctx context.Context, transactionFingerprintID appstatspb.TransactionFingerprintID)
-
-	// UpgradeImplicitTxn informs the StatsCollector that the current txn has been
-	// upgraded to an explicit transaction, thus all previously recorded statements
-	// should be updated accordingly.
-	UpgradeImplicitTxn(ctx context.Context) error
-}
 
 // Storage provides clients with interface to perform read and write operations
 // to sql statistics.

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -117,7 +117,7 @@ func TestTelemetryLogging(t *testing.T) {
 		queryLevelStats         execstats.QueryLevelStats
 		enableTracing           bool
 		enableInjectTxErrors    bool
-		expectedStatsCollector  sqlstats.StatsCollector
+		expectedStatsCollector  *sslocal.StatsCollector
 	}{
 		{
 			// Test case with statement that is not of type DML.


### PR DESCRIPTION
Backport 1/1 commits from #122128

Backport 3/3 commits from #122699

/cc @cockroachdb/release

Release justification: bug fix

----

**sqlstats: delete sqlstats.StatsCollector interface**

There is one implementation of this interface. Let us
simply use the concrete type.

Epic: none

Release note: None

**sqlstats: introduce insights writer to StatsCollector**

This commit adds the insights writer to the `StatsCollector` struct. This
is in an effort to shift the responsibility of writing insights from being
owned by the `ssmemstorage.Container` to `sslocal.StatsCollector`. It makes
more sense for the StatsCollector, which is already responsible for
coordinating the writing of sql stats for a conn executor, to also
orchestrate insights collection operations. The sql stats application
container's intended purpose is to store per-application sql statistics.

Epic: none
Release note: None

**sqlstats,insights: use StatsCollector to record stmt insights**

This commit moves the recording of statement insights one layer up.
This decouples the writing of statement insights from the writing
of statement statistics to the sql stats containers. Previously,
if writing statement stats was throttled we also skipped writing
statement insights. The two processes may now occur independently.
Additionally, we introduce the flag `sendInsights` to the stats
collector, which is set at the start of every transaction. This
flag will be used to determine whether to observe insights for the
entire transaction. This ensures that writing statement insights
-> writing transaction insights so that the statement insight memory
will be freed.

Epic: none
Release note: None

**sqlstats,insights: use StatsCollector to record txn insights**

This commit moves the recording of transaction insights one layer up.
This decouples the writing of transaction insights from the writing
of transaction statistics to the sql stats containers. Previously,
if writing transaction stats was throttled we also skipped writing
transaction insights. This can lead to a memory leak if we've already
recorded statement insights for this transaction, as that memory is only
released once the corresponding transaction insight is sent. The two
processes may now occur independently.

This fixes a memory leak in the scenario where we continue to send
statement insights to the insights ingester without sending any
transaction insights. The ingester frees the memory used by statement
insights once it receives a transaction event. Previously, due to the
coupling of writing sql stats and insights, if we transaction stats
were throttled (e.g. due to in-memory capacities), we would start
accumulating statement insights.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/121803
Release note: None

----

Release justification: