### PR TITLE
internal/sqlsmith: remove unused DisableDivision

### DIFF
--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -70,7 +70,6 @@ var (
 		"DisableCrossJoins":          sqlsmith.DisableCrossJoins(),
 		"DisableDDLs":                sqlsmith.DisableDDLs(),
 		"DisableDecimals":            sqlsmith.DisableDecimals(),
-		"DisableDivision":            sqlsmith.DisableDivision(),
 		"DisableEverything":          sqlsmith.DisableEverything(),
 		"DisableIndexHints":          sqlsmith.DisableIndexHints(),
 		"DisableInsertSelect":        sqlsmith.DisableInsertSelect(),
@@ -101,6 +100,7 @@ var (
 		"UnlikelyConstantPredicate":  sqlsmith.UnlikelyConstantPredicate(),
 		"UnlikelyRandomNulls":        sqlsmith.UnlikelyRandomNulls(),
 
+		"DisableNondeterministicLimits":           sqlsmith.DisableNondeterministicLimits(),
 		"LowProbabilityWhereClauseWithJoinTables": sqlsmith.LowProbabilityWhereClauseWithJoinTables(),
 	}
 	smitherOpts []string
@@ -203,11 +203,10 @@ func main() {
 	} else {
 		for i := 0; i < *num; i++ {
 			stmt := smither.Generate()
-			fmt.Print("\n", stmt, ";\n")
+			fmt.Print(sep, stmt, ";\n")
 			if db != nil && *execStmts {
 				_, _ = db.Exec(stmt)
 			}
-			fmt.Print(sep, smither.Generate(), ";\n")
 		}
 	}
 }
@@ -223,7 +222,7 @@ func parseSchemaDefinition(schemaPath string) (opts []sqlsmith.SmitherOption, _ 
 	}
 	stmts, err := parser.Parse(string(schema))
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not parse schema definition")
+		return nil, errors.Wrap(err, "could not parse schema definition")
 	}
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -57,6 +57,8 @@ func WithTableDescriptor(tn tree.TableName, desc descpb.TableDescriptor) Smither
 	return option{
 		name: fmt.Sprintf("inject table %s", tn.FQString()),
 		apply: func(s *Smither) {
+			s.lock.Lock()
+			defer s.lock.Unlock()
 			if tn.SchemaName != "" {
 				if !slices.ContainsFunc(s.schemas, func(ref *schemaRef) bool {
 					return ref.SchemaName == tn.SchemaName

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -425,7 +425,7 @@ var SimpleDatums = simpleOption("simple datums", func(s *Smither) {
 	s.simpleDatums = true
 })
 
-// SimpleScalarTypes causes the Smither to use simpler scalar types (e.g. avoid Geometry)
+// SimpleScalarTypes causes the Smither to use simpler scalar types (e.g. avoid Geometry).
 var SimpleScalarTypes = simpleOption("simple scalar types", func(s *Smither) {
 	s.simpleScalarTypes = true
 })
@@ -501,9 +501,9 @@ var OutputSort = simpleOption("output sort", func(s *Smither) {
 	s.outputSort = true
 })
 
-// MaybeSortOutput probabilistically adds ORDER by clause
+// MaybeSortOutput probabilistically adds ORDER by clause.
 var MaybeSortOutput = simpleOption("maybe output sort", func(s *Smither) {
-	s.outputSort = false
+	s.outputSort = s.coin()
 })
 
 // UnlikelyConstantPredicate causes the Smither to make generation of constant
@@ -567,13 +567,6 @@ var LowProbabilityWhereClauseWithJoinTables = simpleOption("low probability wher
 // source expression is nullable and the target column is not.
 var DisableInsertSelect = simpleOption("disable insert select", func(s *Smither) {
 	s.disableInsertSelect = true
-})
-
-// DisableDivision disables generation of the division operator (/) and the
-// floor division operator (//).
-// TODO(mgartner): Remove this once #86790 is addressed.
-var DisableDivision = simpleOption("disable division", func(s *Smither) {
-	s.disableDivision = true
 })
 
 // DisableDecimals disables use of decimal type columns in the query.


### PR DESCRIPTION
It references an issue that was closed long time ago.

Additionally, it fixes a few nits I noticed while looking at recently merged 19d693f337820243c37bc3dc3047a3a16ab4e446.

Epic: None

Release note: None