### PR TITLE
sql: improve ExplainRedact tests

### DIFF
--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -551,6 +551,7 @@ func TestExplainRedact(t *testing.T) {
 	smith, err := sqlsmith.NewSmither(sqlDB, rng,
 		sqlsmith.PrefixStringConsts(pii),
 		sqlsmith.DisableDDLs(),
+		sqlsmith.SimpleNames(),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This commit improves the EXPLAIN (REDACT) tests in the following manner:
- only log successful statements with semicolon in the end
- ensure that all generated statements are sound (i.e. don't error on `EXPLAIN stmt`)
- use simple names (we can't inject the PII into the names anyway)
- include the stmt for non-internal errors.

Informs: #122766.
Epic: None

Release note: None