### PR TITLE
roachtest/cdc: ensure hydra endpoint is up

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -69,6 +69,9 @@ import (
 // seen with a 1-5% probability
 var kafkaCreateTopicRetryDuration = 1 * time.Minute
 
+// hydraRetryDuration is the length of time we retry hydra oauth setup.
+var hydraRetryDuration = 1 * time.Minute
+
 type sinkType string
 
 const (
@@ -2398,12 +2401,20 @@ func (k kafkaManager) configureHydraOauth(ctx context.Context) (string, string) 
 		err := k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNode), `/home/ubuntu/hydra-serve.sh`)
 		return errors.Wrap(err, "hydra failed")
 	})
-	result, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), "/home/ubuntu/hydra create oauth2-client",
-		"-e", "http://localhost:4445",
-		"--grant-type", "client_credentials",
-		"--token-endpoint-auth-method", "client_secret_basic",
-		"--name", `"Test Client"`,
-	)
+
+	var result install.RunResultDetails
+	// The admin server may not be up immediately, so retry the create command
+	// until it succeeds or times out.
+
+	err = retry.ForDuration(hydraRetryDuration, func() error {
+		result, err = k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), "/home/ubuntu/hydra create oauth2-client",
+			"-e", "http://localhost:4445",
+			"--grant-type", "client_credentials",
+			"--token-endpoint-auth-method", "client_secret_basic",
+			"--name", `"Test Client"`,
+		)
+		return err
+	})
 	if err != nil {
 		k.t.Fatal(err)
 	}


### PR DESCRIPTION
When we start hydra to enable oauth during roachtest testing, the admin endpoint may not have started before the create oauth client command is called, resulting in a test failure. This PR puts the create command in a retry loop with a timeout so that the command has a chance to succeed.

Fixes: #122456
Epic: None

Release note: None