### PR TITLE
changefeedccl: disable drain watcher by default

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -137,7 +137,7 @@ var aggregatorEmitsShutdownCheckpoint = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"changefeed.shutdown_checkpoint.enabled",
 	"upon shutdown aggregator attempts to emit an up-to-date checkpoint",
-	true,
+	false,
 )
 
 type drainWatcher <-chan struct{}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6224,6 +6224,7 @@ func TestChangefeedHandlesRollingRestart(t *testing.T) {
 
 	db := tc.ServerConn(1)
 	sqlDB := sqlutils.MakeSQLRunner(db)
+	serverutils.SetClusterSetting(t, tc, "changefeed.shutdown_checkpoint.enabled", true)
 	serverutils.SetClusterSetting(t, tc, "kv.rangefeed.enabled", true)
 	serverutils.SetClusterSetting(t, tc, "kv.closed_timestamp.target_duration", 10*time.Millisecond)
 	serverutils.SetClusterSetting(t, tc, "changefeed.experimental_poll_interval", 10*time.Millisecond)


### PR DESCRIPTION
In #102717, we introduced a mechanism to reduce message duplicates by re-loading job progress upon resuming. However, this pr forgot to account initial scans. During initial scans, we rely on an important prerequisite (resolved timestamps of all spans are required to be empty by keeping initial highwater as zero). The pr forwarded spans with resolved timestamps to its most up to date status in `reconcileJobStateWithLocalState`. This resulted in dropping events since we now sometimes make a new frontier with all spans forwarded to initialResolved https://github.com/cockroachdb/cockroach/blob/df196391c576f3a26e57ad6d694ee7e793c1af81/pkg/ccl/changefeedccl/changefeed_processors.go#L535. We should add more test coverage and re-think through the logic here though. 

This patch disables this feature by default.

Fixes: #123371
Release note: Disabled a changefeed optimization on reducing duplicates during
aggregator restarts due to its bad performance.