### PR TITLE
jobs: TestingRegisterConstructor needs to take global lock

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1488,6 +1488,9 @@ func TestingClearConstructors() func() {
 // TestingRegisterConstructor is like RegisterConstructor but returns a cleanup function
 // resets the registration for the given type.
 func TestingRegisterConstructor(typ jobspb.Type, fn Constructor, opts ...RegisterOption) func() {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
 	var cleanupFn func()
 	if origConstructorFn, found := globalMu.constructors[typ]; found {
 		origOpts := globalMu.options[typ]


### PR DESCRIPTION
Previously, the TestingRegisterConstructor didn't take the global lock resulting in a race with the jobs sytem during test.

Fixes: #123357
Epic: None

Release note: None