### PR TITLE
sqlstats: turn off sql activity tables by default

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -37,7 +37,7 @@ var sqlStatsActivityFlushEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.stats.activity.flush.enabled",
 	"enable the flush to the system statement and transaction activity tables",
-	true)
+	false)
 
 // sqlStatsActivityTopCount is the cluster setting that controls the number of
 // rows selected to be inserted into the activity tables

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -75,6 +75,7 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	ts := srv.ApplicationLayer()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 
 	var count int
 	row := db.QueryRow(t, "SELECT count_rows() FROM system.public.transaction_activity")
@@ -145,6 +146,7 @@ func TestMergeFunctionLogic(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 
 	appName := "TestMergeFunctionLogic"
 	db.Exec(t, "SET SESSION application_name=$1", appName)
@@ -259,6 +261,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	ts := srv.ApplicationLayer()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 
 	// Give permission to write to sys tables.
 	db.Exec(t, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
@@ -503,7 +506,9 @@ func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	defer db.Close()
 
-	_, err := db.ExecContext(ctx, "SET CLUSTER SETTING sql.stats.flush.interval = '100ms'")
+	_, err := db.ExecContext(ctx, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "SET CLUSTER SETTING sql.stats.flush.interval = '100ms'")
 	require.NoError(t, err)
 	appName := "TestScheduledSQLStatsCompaction"
 	_, err = db.ExecContext(ctx, "SET SESSION application_name=$1", appName)
@@ -567,6 +572,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 	db.Exec(t, "SET SESSION application_name = 'test_txn_activity_table'")
 
 	// Generate some sql stats data.
@@ -634,6 +640,7 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 	// Generate a random app name each time to avoid conflicts
 	appName := "test_status_api" + uuid.FastMakeV4().String()
 	db.Exec(t, "SET SESSION application_name = $1", appName)
@@ -779,6 +786,7 @@ func TestFlushToActivityWithDifferentAggTs(t *testing.T) {
 	ts := srv.ApplicationLayer()
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 
 	// Start with empty activity tables.
 	execCfg := ts.ExecutorConfig().(ExecutorConfig)


### PR DESCRIPTION
This commit changes the default value for the cluster setting `sql.stats.activity.flush.enabled` from true to false. This effectively disables writing to the sql activity tables once sql stats are flushed. The sql activity tabls were introduced to decrease latency when requesitng stats from the admin UI by aggregating and caching  of the most recent hour(s) of sql stats.

In practice, the sql activity job proved to be too expensive and slow to run when needing to aggregate and write a high volume of data every flush. Due to the time required for the activity job to complete in high fingerprint workloads, the stats could also be stale by the time the job finishes, requiring another update immediately. In conclusion for high fingerprint cardinality workloads it's likely the sql activity table maintenance operations are doing more harm than good. We should disable this feature by default since in cases where fingerprint cardinality is not an issue,  the regular stats tables are likely sufficient.

Fixes: #123081
Epic: CRDB-37544