### PR TITLE
roachtest: replace control characters with spaces

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -452,13 +452,13 @@ func (h *queryComparisonHelper) runQuery(stmt string) ([][]string, error) {
 	// such a scenario, since the stmt didn't execute successfully, it won't get
 	// logged by the caller).
 	h.logStmt(fmt.Sprintf("-- %s: %s", timeutil.Now(),
-		// Remove all control characters, including newline symbols, to log this
-		// stmt as a single line. This way this auxiliary logging takes up less
-		// space (if the stmt executes successfully, it'll still get logged with
-		// the nice formatting).
+		// Replace all control characters, including newline symbols, with a
+		// single space to log this stmt as a single line. This way this
+		// auxiliary logging takes up less space (if the stmt executes
+		// successfully, it'll still get logged with the nice formatting).
 		strings.Map(func(r rune) rune {
 			if unicode.IsControl(r) {
-				return -1
+				return ' '
 			}
 			return r
 		}, stmt),


### PR DESCRIPTION
In 51318d56e3ee1ef31764e84cd10bb2754c129669 we completely removed control characters when logging stmts in the auxiliary logging in order to ensure that the stmt fits within a single line (the only one that is commented out). However, this makes the query in the commented out line not be parsable, so this commit switches to replacing all control characters with a single space instead.

Informs: #123141
Epic: None

Release note: None