### PR TITLE
roachtest: add missing backslash in nightly script

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -62,7 +62,7 @@ build/teamcity-roachtest-invoke.sh \
   --select-probability="${select_probability}" \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
-  --clear-cluster-cache="${CLEAR_CLUSTER_CACHE:-true}"
+  --clear-cluster-cache="${CLEAR_CLUSTER_CACHE:-true}" \
   --parallelism="${PARALLELISM}" \
   --cpu-quota="${CPUQUOTA}" \
   --cluster-id="${TC_BUILD_ID}" \


### PR DESCRIPTION
This causes all subsequent flags to be dropped.

Fixes: #123348
Release note: none
Epic: none