### PR TITLE
streamclient: allow running on remote execution

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -57,7 +57,6 @@ go_test(
         "span_config_stream_client_test.go",
     ],
     embed = [":streamclient"],
-    tags = ["no-remote-exec"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
I don't know how long this has worked, but it works now.

Epic: CRDB-8308
Release note: None