### PR TITLE
roachtest: use correct systemd unit name

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -308,7 +309,9 @@ sudo systemd-run --property=Type=exec \
 		//   └─md0         9:0    0 872.3G  0 raid0 /mnt/data1
 		//
 		// and so the actual write throttle is about 2x what was set.
-		c.Run(ctx, option.WithNodes(c.Node(3)), "sudo", "systemctl", "set-property", "cockroach", "'IOWriteBandwidthMax={store-dir} 20971520'")
+		c.Run(ctx, option.WithNodes(c.Node(3)), "sudo", "systemctl", "set-property",
+			roachtestutil.SystemInterfaceSystemdUnitName(),
+			"'IOWriteBandwidthMax={store-dir} 20971520'")
 		t.L().Printf("installed write throughput limit on n3")
 	}
 

--- a/pkg/cmd/roachtest/tests/limit_capacity.go
+++ b/pkg/cmd/roachtest/tests/limit_capacity.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -112,7 +113,8 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 	t.Status(fmt.Sprintf("initial (single node) qps: %.0f", qpsInitial))
 
 	if cfg.writeCapBytes >= 0 {
-		c.Run(ctx, option.WithNodes(limitedNode), "sudo", "systemctl", "set-property", "cockroach-system",
+		c.Run(ctx, option.WithNodes(limitedNode), "sudo", "systemctl", "set-property",
+			roachtestutil.SystemInterfaceSystemdUnitName(),
 			fmt.Sprintf("'IOWriteBandwidthMax=/mnt/data1 %d'", cfg.writeCapBytes))
 	}
 


### PR DESCRIPTION
Fix a couple roachtests that hardcoded an incorrect systemd unit name.

Fixes #123353.
Epic: none
Release note: none