### PR TITLE
roachtest: add c2c/import/kv0 roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1257,6 +1257,9 @@ func registerClusterToCluster(r registry.Registry) {
 			// replanning and distributed catch up scans fix the poor initial plan. If
 			// max accepted latency doubles, then there's likely a regression.
 			maxAcceptedLatency: 1 * time.Hour,
+			// Skipping node distribution check because there is little data on the
+			// source when the replication stream begins.
+			skipNodeDistributionCheck: true,
 			clouds:             registry.AllExceptAWS,
 			suites:             registry.Suites(registry.Nightly),
 		},

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1200,10 +1200,10 @@ func registerClusterToCluster(r registry.Registry) {
 			// With the machine type and size we use, this is the smallest disk that
 			// gives us max write BW of 800MB/s.
 			pdSize: 1667,
-			// Write ~150GB data to disk.
+			// Write ~375GB data to disk.
 			workload: replicateImportKV{
 				replicateSplits: true,
-				replicateKV:     replicateKV{readPercent: 0, initRows: 100000000, maxBlockBytes: 1024}},
+				replicateKV:     replicateKV{readPercent: 0, initRows: 200000000, maxBlockBytes: 1024}},
 			timeout:            1 * time.Hour,
 			maxAcceptedLatency: 1 * time.Hour,
 			// Cutover to one second after the import completes.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -777,8 +777,8 @@ func UpdateTargets(
 func updatePrometheusTargets(ctx context.Context, l *logger.Logger, c *install.SyncedCluster) {
 	nodeIPPorts := make([]string, len(c.Nodes))
 	var wg sync.WaitGroup
-	for i, node := range c.VMs {
-		if node.Provider == gce.ProviderName {
+	for i, node := range c.Nodes {
+		if c.VMs[node].Provider == gce.ProviderName {
 			wg.Add(1)
 			go func(index int, v vm.VM) {
 				defer wg.Done()
@@ -791,7 +791,7 @@ func updatePrometheusTargets(ctx context.Context, l *logger.Logger, c *install.S
 				nodeInfo := fmt.Sprintf("%s:%d", v.PublicIP, desc.Port)
 				l.Printf("node information obtained for node index %d: %s", index, nodeInfo)
 				nodeIPPorts[index] = nodeInfo
-			}(i, node)
+			}(i, c.VMs[node])
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
This patch adds a c2c roachtest which runs a kv import after the replication
stream has started, inducing catchup scans during the kv import.

Informs #122846

Release note: none