### PR TITLE
roachtest: move generate-fixtures roachtest to test-eng ownership

### DIFF
--- a/pkg/cmd/roachtest/tests/fixtures.go
+++ b/pkg/cmd/roachtest/tests/fixtures.go
@@ -67,7 +67,7 @@ func registerFixtures(r registry.Registry) {
 		Timeout:          30 * time.Minute,
 		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Fixtures),
-		Owner:            registry.OwnerDevInf,
+		Owner:            registry.OwnerTestEng,
 		Cluster:          r.MakeClusterSpec(4),
 		Run:              runFixtures,
 	})


### PR DESCRIPTION
Epic: none
Release note: None