### PR TITLE
roachtest: update dsc job compat to mixed version v241-v242

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -31,7 +31,7 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 	// This test requires us to come back and change the stmts in executeSupportedDDLs to be those
 	// supported in the "previous" major release.
 	r.Add(registry.TestSpec{
-		Name:             "declarative_schema_changer/job-compatibility-mixed-version-V232-V241",
+		Name:             "declarative_schema_changer/job-compatibility-mixed-version-V241-V242",
 		Owner:            registry.OwnerSQLFoundations,
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.AllExceptAWS,
@@ -123,6 +123,16 @@ func executeSupportedDDLs(
 		`ALTER TABLE testdb.testsc.t3 VALIDATE CONSTRAINT check_positive_not_valid`,
 	}
 
+	// DDLs supported in V24_1.
+	v241DDLs := []string{
+		`ALTER TABLE testdb.testsc.t ADD COLUMN k int, ADD COLUMN l int, DROP COLUMN l`,
+		`ALTER TABLE testdb.testsc.t ALTER COLUMN k SET DEFAULT 42`,
+		`ALTER TABLE testdb.testsc.t ALTER COLUMN k DROP DEFAULT`,
+		`CREATE DATABASE testdb2`,
+		`CREATE SCHEMA testdb2.testsc`,
+		`CREATE SEQUENCE testdb2.testsc.s`,
+	}
+
 	// Used to clean up our CREATE-d elements after we are done with them.
 	cleanup := []string{
 		`DROP INDEX testdb.testsc.t@idx`,
@@ -136,9 +146,12 @@ func executeSupportedDDLs(
 		`DROP DATABASE testdb CASCADE`,
 		`DROP OWNED BY foo`,
 		`DROP FUNCTION fn`,
+		`DROP SEQUENCE testdb2.testsc.s`,
+		`DROP SCHEMA testdb2.testsc`,
+		`DROP DATABASE testdb2 CASCADE`,
 	}
 
-	ddls := append(v232DDLs, cleanup...)
+	ddls := append(v232DDLs, append(v241DDLs, cleanup...)...)
 
 	for _, ddl := range ddls {
 		if err := helper.ExecWithGateway(r, nodes, ddl); err != nil {


### PR DESCRIPTION
This patch updates the dsc job compat roachtest to `declarative_schema_changer/job-compatibility-mixed-version-V241-V242`.

Epic: CRDB-35306
Informs: #116395

Release note: None