### PR TITLE
sql: grant/revoke on a large number of objects can create a lot of jobs

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -56,9 +56,9 @@ exp,benchmark
 5,GenerateObjects/generate_10_tables
 16,GenerateObjects/generate_10x10_schemas_and_tables_in_existing_db
 5,GenerateObjects/generate_50000_tables
-15,Grant/grant_all_on_1_table
-19,Grant/grant_all_on_2_tables
-23,Grant/grant_all_on_3_tables
+10,Grant/grant_all_on_1_table
+10,Grant/grant_all_on_2_tables
+10,Grant/grant_all_on_3_tables
 19,GrantRole/grant_1_role
 25,GrantRole/grant_2_roles
 6,Jobs/cancel_job
@@ -104,9 +104,9 @@ exp,benchmark
 4,ORMQueries/pg_type
 133,ORMQueries/prisma_column_descriptions
 3,ORMQueries/prisma_column_descriptions_updated
-15,Revoke/revoke_all_on_1_table
-19,Revoke/revoke_all_on_2_tables
-23,Revoke/revoke_all_on_3_tables
+10,Revoke/revoke_all_on_1_table
+10,Revoke/revoke_all_on_2_tables
+10,Revoke/revoke_all_on_3_tables
 17,RevokeRole/revoke_1_role
 21,RevokeRole/revoke_2_roles
 14,ShowGrants/grant_2_roles

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -197,3 +197,26 @@ test           sc102962     root     ALL             true
 
 statement error pgcode 2BP01 pq: cannot drop role/user r102962: grants still exist on test.sc102962
 DROP ROLE r102962
+
+statement ok
+CREATE USER ROACH;
+CREATE SCHEMA ROACHHOUSE;
+CREATE SCHEMA ROACHLAYER;
+CREATE SCHEMA ROACHSTATION;
+BEGIN;
+GRANT ALL ON SCHEMA ROACHHOUSE TO ROACH;
+GRANT ALL ON SCHEMA ROACHLAYER TO ROACH;
+GRANT ALL ON SCHEMA ROACHSTATION TO ROACH;
+COMMIT;
+
+query T
+SELECT description FROM [SHOW JOBS] WHERE description LIKE  '%updating privileges for schema%';
+----
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS FOR roach
+----
+database_name  schema_name   object_name  object_type  grantee  privilege_type  is_grantable
+test           roachhouse    NULL         schema       roach    ALL             false
+test           roachlayer    NULL         schema       roach    ALL             false
+test           roachstation  NULL         schema       roach    ALL             false

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -2973,3 +2973,23 @@ GRANT SELECT ON TABLE t, crdb_internal.tables TO testuser;
 
 statement error pgcode 0A000 cannot mix grants between virtual and non-virtual tables
 GRANT SELECT ON TABLE crdb_internal.tables, t TO testuser;
+
+statement ok
+CREATE USER ROACH;
+CREATE TABLE table1 (count INT);
+CREATE TABLE table2 (count INT);
+BEGIN;
+GRANT ALL ON table1 TO ROACH;
+GRANT ALL ON table2 TO ROACH;
+COMMIT;
+
+query T rowsort
+select description from [show jobs] where description LIKE '%updating privileges for table%';
+----
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS FOR roach
+----
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+db             public       table1       table        roach    ALL             false
+db             public       table2       table        roach    ALL             false

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -126,3 +126,26 @@ test           public       owner_grant_option  other_owner               ALL   
 test           public       owner_grant_option  owner_grant_option_child  USAGE           false
 test           public       owner_grant_option  public                    USAGE           false
 test           public       owner_grant_option  root                      ALL             true
+
+statement ok
+CREATE USER roach;
+CREATE TYPE custom_type1 AS ENUM ('roach1', 'roach2', 'roach3');
+CREATE TYPE custom_type2 AS ENUM ('roachA', 'roachB', 'roachC');
+CREATE TYPE custom_type3 AS ENUM ('roachI', 'roachII', 'roachIII');
+BEGIN;
+GRANT ALL ON TYPE custom_type1 TO roach;
+GRANT ALL ON TYPE custom_type2 TO roach;
+GRANT ALL ON TYPE custom_type3 TO roach;
+COMMIT
+
+query T
+select description from [show jobs] where description LIKE '%type%'
+----
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS FOR roach
+----
+database_name  schema_name  object_name   object_type  grantee  privilege_type  is_grantable
+test           public       custom_type1  type         roach    ALL             false
+test           public       custom_type2  type         roach    ALL             false
+test           public       custom_type3  type         roach    ALL             false

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6445,12 +6445,6 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 			jobRegex:   `^ALTER SCHEMA db_rename_schema.sc RENAME TO new_name$`,
 		},
 		{
-			name:       "grant on schema",
-			setupStmts: `CREATE DATABASE db_grant_on_schema; CREATE SCHEMA db_grant_on_schema.sc;`,
-			scStmt:     `GRANT ALL ON SCHEMA db_grant_on_schema.sc TO PUBLIC`,
-			jobRegex:   `updating privileges for schema`,
-		},
-		{
 			name:       "rename database",
 			setupStmts: `CREATE DATABASE db_rename;`,
 			scStmt:     `ALTER DATABASE db_rename RENAME TO db_new_name`,
@@ -7820,4 +7814,54 @@ func TestMemoryMonitorErrorsDuringBackfillAreRetried(t *testing.T) {
 		tdb.Exec(t, `ALTER TABLE foo ADD COLUMN j INT NOT NULL DEFAULT 42`)
 		require.Equalf(t, shouldFail.Load(), int64(2), "not all failure conditions were hit %d", shouldFail.Load())
 	})
+}
+
+// TestLeaseTimeoutWithConcurrentTransactions tests two concurrent transactions
+// on tables, we verify that the second transaction waits for the first
+// transaction to commit or for the lease to expire.
+func TestLeaseTimeoutWithConcurrentTransactions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "slow test")
+	ctx := context.Background()
+
+	settings := cluster.MakeTestingClusterSettings()
+	lease.LeaseDuration.Override(ctx, &settings.SV, 15*time.Second)
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{Settings: settings})
+	defer s.Stopper().Stop(ctx)
+
+	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+
+	sqlRunner.Exec(t, `CREATE USER ROACHMIN;`)
+	sqlRunner.Exec(t, `GRANT ADMIN TO ROACHMIN;`)
+	sqlRunner.Exec(t, `CREATE TABLE PROMO_CODES (my_int INT);`)
+	sqlRunner.Exec(t, `CREATE TABLE RIDES (my_int INT);`)
+
+	txn1 := sqlRunner.Begin(t)
+	txn1.Exec(`SELECT * FROM PROMO_CODES;`)
+
+	txn2 := sqlRunner.Begin(t)
+	txn2.Exec(`GRANT ALL ON TABLE PROMO_CODES TO ROACHMIN;`)
+	txn2.Exec(`GRANT ALL ON TABLE RIDES TO ROACHMIN;`)
+
+	blocker := make(chan struct{})
+	group := ctxgroup.WithContext(ctx)
+
+	group.GoCtx(func(ctx context.Context) error {
+		err := txn2.Commit()
+		close(blocker)
+		return err
+	})
+
+	<-blocker
+	_, err := txn1.Exec("INSERT INTO promo_codes values (1)")
+	require.NoError(t, err)
+
+	// txn1.commit() completes with an error due to lease timeout on txn2.commit().
+	err = txn1.Commit()
+	require.ErrorContains(t, err, "RETRY_COMMIT_DEADLINE_EXCEEDED")
+
+	err = group.Wait()
+	require.NoError(t, err)
 }

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -165,6 +165,14 @@ func (p *planner) writeTypeDesc(ctx context.Context, typeDesc *typedesc.Mutable)
 	return p.txn.Run(ctx, b)
 }
 
+func (p *planner) writeDescToBatch(
+	ctx context.Context, typeDesc catalog.MutableDescriptor, b *kv.Batch,
+) error {
+	return p.Descriptors().WriteDescToBatch(
+		ctx, p.extendedEvalCtx.Tracing.KVTracingEnabled(), typeDesc, b,
+	)
+}
+
 // typeSchemaChanger is the struct that actually runs the type schema change.
 type typeSchemaChanger struct {
 	typeID descpb.ID


### PR DESCRIPTION
Previously we would create multiple jobs for granting on multiple tables and types within one transaction.  This caused a performance slowdown, these code changes skip the making of multiple jobs and just execute the grants in a batch.

Fixes:#117643
Release note(performance improvement): multiple grants on tables and types within one transaction now run faster.