### PR TITLE
loqrecovery: use latest cluster version for tests

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -327,7 +327,8 @@ func TestStageBadVersions(t *testing.T) {
 	})
 	require.Error(t, err, "shouldn't stage plan with old version")
 
-	plan.Version.Major += 2
+	plan.Version = clusterversion.Latest.Version()
+	plan.Version.Major += 1
 	_, err = adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{
 		Plan:           &plan,
 		AllNodes:       true,


### PR DESCRIPTION
Previously, we reused the cluster version in multiple test cases. This may not work as expected, when the versions are shuffled around, for example, when we mint the version.

This PR uses the latest version explicitly, instead of incrementing an existing version.

Epic: none
Release note: None