### PR TITLE
kvcoord: finish request span of proxied trace

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -240,6 +240,9 @@ func (gt *grpcTransport) sendBatch(
 				"trying to ingest remote spans but there is no recording span set up")
 		}
 		span.ImportRemoteRecording(reply.CollectedSpans)
+		// The field is cleared by the sender because if the spans are re-imported
+		// by accident, duplicate spans may occur.
+		reply.CollectedSpans = nil
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "ba: %s RPC error", ba.String())
@@ -376,6 +379,9 @@ func (s *senderTransport) SendNext(
 			panic("trying to ingest remote spans but there is no recording span set up")
 		}
 		span.ImportRemoteRecording(br.CollectedSpans)
+		// The field is cleared by the sender because if the spans are re-imported
+		// by accident, duplicate spans may occur.
+		br.CollectedSpans = nil
 	}
 
 	return br, nil


### PR DESCRIPTION
The local evaluation and dist-sender spans were previously omitted from the traces of proxied requests. Finish the proxied request trace span to include these spans in tracing.

Resolves: #120841
Release note: None