### PR TITLE
roachprod: fix `start.sh` profile check

### DIFF
--- a/pkg/roachprod/install/scripts/start.sh
+++ b/pkg/roachprod/install/scripts/start.sh
@@ -77,7 +77,7 @@ sudo systemctl reset-failed "${VIRTUAL_CLUSTER_LABEL}" 2>/dev/null || true
 
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
-if [ ! -e "${HOME}/.profile-cockroach" ]; then
+if [ ! -e "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" ]; then
   cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<EOQ
 echo ""
 if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then

--- a/pkg/roachprod/install/testdata/start/start.txt
+++ b/pkg/roachprod/install/testdata/start/start.txt
@@ -81,7 +81,7 @@ sudo systemctl reset-failed "${VIRTUAL_CLUSTER_LABEL}" 2>/dev/null || true
 
 # The first time we run, install a small script that shows some helpful
 # information when we ssh in.
-if [ ! -e "${HOME}/.profile-cockroach" ]; then
+if [ ! -e "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" ]; then
   cat > "${HOME}/.profile-${VIRTUAL_CLUSTER_LABEL}" <<EOQ
 echo ""
 if systemctl is-active -q ${VIRTUAL_CLUSTER_LABEL}; then


### PR DESCRIPTION
Previously, multiple entries would be created in "${HOME}/.profile" since the check for "${HOME}/.profile-cockroach" would always fail. This updates the check to look for the correct file based on the virtual cluster label.

Fixes: #121267

Epic: None
Release Note: None