### PR TITLE
release-23.1: backupccl: don't attempt to set GC TTL on NonPhysical table

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2551,11 +2551,11 @@ func (r *restoreResumer) dropDescriptors(
 		// configuration for every table that we are going to drop with a small GC TTL.
 		//
 		// NB: We can't set GC TTLs for non-system tenants currently.
-		if codec.ForSystemTenant() {
+		if codec.ForSystemTenant() && tableToDrop.IsPhysicalTable() {
 			if err := setGCTTLForDroppingTable(
 				ctx, txn, descsCol, tableToDrop,
 			); err != nil {
-				return errors.Wrapf(err, "setting low GC TTL for table %q", tableToDrop.GetName())
+				log.Warningf(ctx, "setting low GC TTL for table %q failed: %s", tableToDrop.GetName(), err.Error())
 			}
 		}
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
@@ -7,6 +7,7 @@ exec-sql
 CREATE DATABASE restore;
 CREATE SCHEMA restore.myschema;
 CREATE TABLE foobar (pk int primary key);
+CREATE VIEW foobar_v AS SELECT pk FROM foobar;
 CREATE TABLE restore.myschema.table1 (pk int primary key);
 INSERT INTO restore.myschema.table1 VALUES (1);
 CREATE TYPE data.myenum AS ENUM ('hello');


### PR DESCRIPTION
Backport 1/1 commits from #123202.

/cc @cockroachdb/release

---

In #88342, we introduced code to reduce the GC TTL of tables to facilitate
faster cleanup in the case of a failed restore. This introduced a bug
in which the revert could fail because we are not able to set the
GC.TTL on non-physical tables.

Here, we exclude non-physical tables when lowering gc.ttlseconds and
also make this a warning instead of an error.

For releases where we've both moved to only inspecting the namespace
table for RESTORE collisions and where the default TTL is low, we
should consider removing this code completely.

Epic: none
Fixes https://github.com/cockroachdb/cockroach/issues/122168

Release note (bug fix): Fix a bug where a failed RESTORE could leave
the system in a state where re-attempting the restore was not possible
without manual intervention.

Release justification: Bug fix for a bug that causes descriptors to be permanently offline without manual intervention.
