### PR TITLE
release-23.1: colexecerror: avoid debug.Stack in CatchVectorizedRuntimeError

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3135,6 +3135,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.force_panic"></a><code>crdb_internal.force_panic(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td><td>Volatile</td></tr>
+<tr><td><a name="crdb_internal.force_panic"></a><code>crdb_internal.force_panic(msg: <a href="string.html">string</a>, mode: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.force_retry"></a><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.generate_test_objects"></a><code>crdb_internal.generate_test_objects(names: <a href="string.html">string</a>, counts: <a href="int.html">int</a>[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Generates a number of objects whose name follow the provided pattern.</p>

--- a/pkg/sql/colexec/colexecwindow/min_max_queue.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_queue.go
@@ -63,7 +63,6 @@ func (q *minMaxQueue) get(pos int) uint32 {
 }
 
 // getFirst returns the element at the start of the minMaxQueue.
-// gcassert:inline
 func (q *minMaxQueue) getFirst() uint32 {
 	if q.empty {
 		colexecerror.InternalError(errors.AssertionFailedf("getting first from empty minMaxQueue"))

--- a/pkg/sql/colexecerror/BUILD.bazel
+++ b/pkg/sql/colexecerror/BUILD.bazel
@@ -15,12 +15,25 @@ go_library(
 
 go_test(
     name = "colexecerror_test",
-    srcs = ["error_test.go"],
+    srcs = [
+        "error_test.go",
+        "main_test.go",
+    ],
     args = ["-test.timeout=295s"],
     deps = [
         ":colexecerror",
+        "//pkg/base",
+        "//pkg/security/securityassets",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -106,6 +106,9 @@ const (
 	sqlColPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/col"
 	sqlRowPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/row"
 	sqlSemPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/sem"
+	// When running BenchmarkCatchVectorizedRuntimeError under bazel, the
+	// repository prefix is missing.
+	testSqlColPackagesPrefix = "pkg/sql/col"
 )
 
 // shouldCatchPanic checks whether the panic that was emitted from
@@ -135,7 +138,8 @@ func shouldCatchPanic(panicEmittedFrom string) bool {
 		strings.HasPrefix(panicEmittedFrom, execinfraPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlColPackagesPrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlRowPackagesPrefix) ||
-		strings.HasPrefix(panicEmittedFrom, sqlSemPackagesPrefix)
+		strings.HasPrefix(panicEmittedFrom, sqlSemPackagesPrefix) ||
+		strings.HasPrefix(panicEmittedFrom, testSqlColPackagesPrefix)
 }
 
 // StorageError is an error that was created by a component below the sql

--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -42,17 +42,42 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 			// StorageError was caused by something below SQL, and represents an error
 			// that we'd simply like to propagate along.
 			var se *StorageError
-			// notInternalError is an error that will be returned to the client
-			// without a stacktrace, sentry report, or "internal error" designation.
+			// notInternalError is an error from the vectorized engine that we'd
+			// simply like to propagate along.
 			var nie *notInternalError
-			if errors.As(err, &se) || errors.As(err, &nie) {
+			// internalError is an error from the vectorized engine that might need to
+			// be returned to the client with a stacktrace, sentry report, and
+			// "internal error" designation.
+			var ie *internalError
+			passthrough := errors.As(err, &se) || errors.As(err, &nie)
+			if errors.As(err, &ie) {
+				// Unwrap so that internalError doesn't show up in sentry reports.
+				retErr = ie.Unwrap()
+				// If the internal error doesn't already have an error code, mark it as
+				// an assertion error so that we generate a sentry report. (We don't do
+				// this for StorageError, notInternalError, or context.Canceled to avoid
+				// creating unnecessary sentry reports.)
+				if !passthrough && !errors.Is(retErr, context.Canceled) {
+					if code := pgerror.GetPGCode(retErr); code == pgcode.Uncategorized {
+						retErr = errors.NewAssertionErrorWithWrappedErrf(
+							retErr, "unexpected error from the vectorized engine",
+						)
+					}
+				}
+				return
+			}
+			if passthrough {
 				retErr = err
 				return
 			}
 		}
 
-		// Find where the panic came from and only proceed if it is related to the
-		// vectorized engine.
+		// For other types of errors, we need to check where the panic came from. We
+		// only want to recover from panics that originated within the vectorized
+		// engine. We treat a panic from lower in the stack as unrecoverable.
+
+		// Find where the panic came from and only proceed if it
+		// is related to the vectorized engine.
 		stackTrace := string(debug.Stack())
 		scanner := bufio.NewScanner(strings.NewReader(stackTrace))
 		panicLineFound := false
@@ -193,16 +218,41 @@ func decodeNotInternalError(
 	return newNotInternalError(cause)
 }
 
-func init() {
-	errors.RegisterWrapperDecoder(errors.GetTypeKey((*notInternalError)(nil)), decodeNotInternalError)
+// internalError is an error that occurs because the vectorized engine is in an
+// unexpected state. Usually it wraps an assertion error.
+type internalError struct {
+	cause error
 }
 
-// InternalError simply panics with the provided object. It will always be
-// caught and returned as internal error to the client with the corresponding
+func newInternalError(err error) *internalError {
+	return &internalError{cause: err}
+}
+
+var (
+	_ errors.Wrapper = &internalError{}
+)
+
+func (e *internalError) Error() string { return e.cause.Error() }
+func (e *internalError) Cause() error  { return e.cause }
+func (e *internalError) Unwrap() error { return e.Cause() }
+
+func decodeInternalError(
+	_ context.Context, cause error, _ string, _ []string, _ proto.Message,
+) error {
+	return newInternalError(cause)
+}
+
+func init() {
+	errors.RegisterWrapperDecoder(errors.GetTypeKey((*notInternalError)(nil)), decodeNotInternalError)
+	errors.RegisterWrapperDecoder(errors.GetTypeKey((*internalError)(nil)), decodeInternalError)
+}
+
+// InternalError panics with the error wrapped by internalError. It will always
+// be caught and returned as internal error to the client with the corresponding
 // stack trace. This method should be called to propagate errors that resulted
 // in the vectorized engine being in an *unexpected* state.
 func InternalError(err error) {
-	panic(err)
+	panic(newInternalError(err))
 }
 
 // ExpectedError panics with the error that is wrapped by

--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -11,9 +11,8 @@
 package colexecerror
 
 import (
-	"bufio"
 	"context"
-	"runtime/debug"
+	"runtime"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -72,29 +71,42 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 			}
 		}
 
-		// For other types of errors, we need to check where the panic came from. We
-		// only want to recover from panics that originated within the vectorized
-		// engine. We treat a panic from lower in the stack as unrecoverable.
-
-		// Find where the panic came from and only proceed if it
-		// is related to the vectorized engine.
-		stackTrace := string(debug.Stack())
-		scanner := bufio.NewScanner(strings.NewReader(stackTrace))
-		panicLineFound := false
-		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), panicLineSubstring) {
-				panicLineFound = true
-				break
+		// For other types of errors, we need to check whence the panic originated
+		// to know what to do. If the panic originated in the vectorized engine, we
+		// can safely return it as a normal error knowing that any illegal state
+		// will be cleaned up when the statement finishes. If the panic originated
+		// lower in the stack, however, we must treat it as unrecoverable because it
+		// could indicate an illegal state that might persist even after this
+		// statement finishes.
+		//
+		// To check whence the panic originated, we find the frame just before the
+		// panic frame.
+		var panicLineFound bool
+		var panicEmittedFrom string
+		// We should be able to find it within 3 program counters, starting with the
+		// caller of this deferred function (2 above the runtime.Callers frame).
+		pc := make([]uintptr, 3)
+		n := runtime.Callers(2, pc)
+		if n >= 1 {
+			frames := runtime.CallersFrames(pc[:n])
+			// A fixed number of program counters can expand to any number of frames.
+			for {
+				frame, more := frames.Next()
+				if strings.Contains(frame.File, panicLineSubstring) {
+					panicLineFound = true
+				} else if panicLineFound {
+					panicEmittedFrom = frame.Function
+					break
+				}
+				if !more {
+					break
+				}
 			}
 		}
-		if !panicLineFound {
-			panic(errors.AssertionFailedf("panic line %q not found in the stack trace\n%s", panicLineSubstring, stackTrace))
-		}
-		if !scanner.Scan() {
-			panic(errors.AssertionFailedf("unexpectedly there is no line below the panic line in the stack trace\n%s", stackTrace))
-		}
-		panicEmittedFrom := strings.TrimSpace(scanner.Text())
 		if !shouldCatchPanic(panicEmittedFrom) {
+			// The panic is from outside the vectorized engine (or we didn't find it
+			// in the stack). We treat it as unrecoverable because it could indicate
+			// an illegal state that might persist even after this statement finishes.
 			panic(panicObj)
 		}
 

--- a/pkg/sql/colexecerror/error_test.go
+++ b/pkg/sql/colexecerror/error_test.go
@@ -11,13 +11,22 @@
 package colexecerror_test
 
 import (
-	"errors"
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -73,4 +82,170 @@ func TestNonCatchablePanicIsNotCaught(t *testing.T) {
 			colexecerror.NonCatchablePanic("should panic")
 		}))
 	})
+}
+
+// BenchmarkCatchVectorizedRuntimeError measures the time for
+// CatchVectorizedRuntimeError to catch and process an error.
+func BenchmarkCatchVectorizedRuntimeError(b *testing.B) {
+	err := errors.New("oops")
+	storageErr := colexecerror.NewStorageError(err)
+	pgErr := pgerror.WithCandidateCode(err, pgcode.Warning)
+
+	cases := []struct {
+		name    string
+		thrower func()
+	}{
+		{
+			"noError",
+			func() {},
+		},
+		{
+			"expected",
+			func() {
+				colexecerror.ExpectedError(err)
+			},
+		},
+		{
+			"storage",
+			func() {
+				colexecerror.InternalError(storageErr)
+			},
+		},
+		{
+			"contextCanceled",
+			func() {
+				colexecerror.InternalError(context.Canceled)
+			},
+		},
+		{
+			"internalWithCode",
+			func() {
+				colexecerror.InternalError(pgErr)
+			},
+		},
+		{
+			"internal",
+			func() {
+				colexecerror.InternalError(err)
+			},
+		},
+		{
+			"runtime",
+			func() {
+				arr := []int{0, 1, 2}
+				_ = arr[3]
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_ = colexecerror.CatchVectorizedRuntimeError(tc.thrower)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkSQLCatchVectorizedRuntimeError measures the time for
+// CatchVectorizedRuntimeError to catch and process an error with a deeper stack
+// than in BenchmarkCatchVectorizedRuntimeError.
+func BenchmarkSQLCatchVectorizedRuntimeError(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	cases := []struct {
+		name    string
+		builtin string
+	}{
+		{
+			"noError",
+			"crdb_internal.void_func()",
+		},
+		{
+			"expectedWithCode",
+			"crdb_internal.force_error('01000', 'oops')",
+		},
+		{
+			"expectedAssertion",
+			"crdb_internal.force_assertion_error('oops')",
+		},
+		{
+			"internalAssertion",
+			"crdb_internal.force_panic('oops', 'internalAssertion')",
+		},
+		{
+			"internalIndexOutOfRange",
+			"crdb_internal.force_panic('oops', 'indexOutOfRange')",
+		},
+		{
+			"internalDivideByZero",
+			"crdb_internal.force_panic('oops', 'divideByZero')",
+		},
+		{
+			"contextCanceled",
+			"crdb_internal.force_panic('oops', 'contextCanceled')",
+		},
+	}
+
+	// We execute this SELECT statement with various error-producing
+	// builtins. Ordering the projection this way creates a moderately deep stack
+	// with several nested calls to CatchVectorizedRuntimeError.
+	sqlFmt := `SELECT count(%s) OVER (),
+  0,
+  '',
+  0.0,
+  NULL,
+  '2000-01-01 00:00:00'::timestamptz,
+  b'00000000',
+  i + 0,
+  i * 1.5,
+  i / 100
+  FROM generate_series(0, 0) AS s(i)
+`
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(b, base.TestServerArgs{SQLMemoryPoolSize: 10 << 30})
+	defer s.Stopper().Stop(ctx)
+
+	for _, parallelism := range []int{1, 20, 50} {
+		numConns := runtime.GOMAXPROCS(0) * parallelism
+		b.Run(fmt.Sprintf("conns=%d", numConns), func(b *testing.B) {
+			for _, tc := range cases {
+				stmt := fmt.Sprintf(sqlFmt, tc.builtin)
+				b.Run(tc.name, func(b *testing.B) {
+					// Create as many warm connections as we will need for the benchmark.
+					conns := make(chan *gosql.DB, numConns)
+					for i := 0; i < numConns; i++ {
+						conn := serverutils.OpenDBConn(
+							b, s.ServingSQLAddr(), "" /* useDatabase */, false /* insecure */, s.Stopper(),
+						)
+						// Make sure we're using local, vectorized execution.
+						sqlDB := sqlutils.MakeSQLRunner(conn)
+						sqlDB.Exec(b, "SET distsql = off")
+						sqlDB.Exec(b, "SET vectorize = on")
+						// Warm up the connection by executing the statement once. We should
+						// always go through the query plan cache after this.
+						_, _ = conn.Exec(stmt)
+						conns <- conn
+					}
+					b.SetParallelism(parallelism)
+					b.ResetTimer()
+					b.RunParallel(func(pb *testing.PB) {
+						var conn *gosql.DB
+						select {
+						case conn = <-conns:
+						default:
+							b.Fatal("not enough warm connections")
+						}
+						for pb.Next() {
+							_, _ = conn.Exec(stmt)
+						}
+					})
+				})
+			}
+		})
+	}
 }

--- a/pkg/sql/colexecerror/main_test.go
+++ b/pkg/sql/colexecerror/main_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colexecerror_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	securityassets.SetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+
+	os.Exit(m.Run())
+}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -28,6 +28,7 @@ import (
 	"math/rand"
 	"net"
 	"regexp/syntax"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -5524,6 +5525,50 @@ SELECT
 				// Golang's 'panic' and would convert it into an internal
 				// error).
 				colexecerror.NonCatchablePanic(msg)
+				// This code is unreachable.
+				panic(msg)
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: volatility.Volatile,
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "msg", Typ: types.String}, {Name: "mode", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if !isAdmin {
+					return nil, errInsufficientPriv
+				}
+				s, ok := tree.AsDString(args[0])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[0])
+				}
+				msg := string(s)
+				mode, ok := tree.AsDString(args[1])
+				if !ok {
+					return nil, errors.Newf("expected string value, got %T", args[1])
+				}
+				switch string(mode) {
+				case "internalAssertion":
+					err := errors.AssertionFailedf("%s", msg)
+					// Panic instead of returning the error. The vectorized panic-catcher
+					// will catch the panic and convert it into an internal error.
+					colexecerror.InternalError(err)
+				case "indexOutOfRange":
+					msg += string(msg[math.MaxInt])
+				case "divideByZero":
+					var foo []int
+					msg += strconv.Itoa(len(msg) / len(foo))
+				case "contextCanceled":
+					panic(context.Canceled)
+				default:
+					return nil, errors.Newf(
+						"expected mode to be one of: internalAssertion, indexOutOfRange, divideByZero, contextCanceled",
+					)
+				}
 				// This code is unreachable.
 				panic(msg)
 			},

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2420,6 +2420,7 @@ var builtinOidsArray = []string{
 	2512: `merge_statement_stats(arg1: jsonb) -> jsonb`,
 	2513: `merge_transaction_stats(arg1: jsonb) -> jsonb`,
 	2517: `jsonb_array_to_string_array(input: jsonb) -> string[]`,
+	2608: `crdb_internal.force_panic(msg: string, mode: string) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1838,7 +1838,7 @@ func TestLint(t *testing.T) {
 			// engine, don't forget to "register" the newly added package in
 			// sql/colexecerror/error.go file.
 			"sql/col*",
-			":!sql/colexecerror/error.go",
+			":!sql/colexecerror/error*.go",
 			// This exception is because execgen itself uses panics during code
 			// generation - not at execution time. The (glob,exclude) directive
 			// (see git help gitglossary) makes * behave like a normal, single dir


### PR DESCRIPTION
Backport 4/4 commits from #123277 on behalf of @michae2.

/cc @cockroachdb/release

----

See individual commits for details.

Benchmarks before and after the change:

```
                                                                    │ /tmp/tmp.PrzUglo6GH/bench.catch~3 │    /tmp/tmp.PrzUglo6GH/bench.catch     │
                                                                    │              sec/op               │    sec/op      vs base                 │
CatchVectorizedRuntimeError/noError-12                                                    0.4033n ± ∞ ¹   0.4224n ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/expected-12                                                 40831.00n ± ∞ ¹    98.55n ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/storage-12                                                  41302.00n ± ∞ ¹    99.54n ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/contextCanceled-12                                          40947.00n ± ∞ ¹    99.78n ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/internalWithCode-12                                          41088.0n ± ∞ ¹    474.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/internal-12                                                  41032.0n ± ∞ ¹    943.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/runtime-12                                                    37.094µ ± ∞ ¹    1.091µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/noError-12                                         43.83µ ± ∞ ¹    43.63µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/expectedWithCode-12                              1234.24µ ± ∞ ¹    48.27µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/expectedAssertion-12                             1182.11µ ± ∞ ¹    88.12µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/internalAssertion-12                             1211.83µ ± ∞ ¹    77.58µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/internalIndexOutOfRange-12                       1227.76µ ± ∞ ¹    82.40µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/internalDivideByZero-12                          1224.45µ ± ∞ ¹    81.01µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/contextCanceled-12                               1265.30µ ± ∞ ¹    44.83µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/noError-12                                        43.78µ ± ∞ ¹    42.83µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/expectedWithCode-12                             1210.98µ ± ∞ ¹    48.41µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/expectedAssertion-12                            1187.21µ ± ∞ ¹    84.70µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/internalAssertion-12                            1224.62µ ± ∞ ¹    73.85µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/internalIndexOutOfRange-12                      1224.56µ ± ∞ ¹    81.39µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/internalDivideByZero-12                         1259.05µ ± ∞ ¹    80.63µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/contextCanceled-12                              1262.44µ ± ∞ ¹    47.13µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/noError-12                                        44.98µ ± ∞ ¹    43.53µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/expectedWithCode-12                             1231.37µ ± ∞ ¹    48.65µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/expectedAssertion-12                            1201.74µ ± ∞ ¹    97.23µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/internalAssertion-12                            1249.63µ ± ∞ ¹    80.46µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/internalIndexOutOfRange-12                      1257.86µ ± ∞ ¹    77.83µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/internalDivideByZero-12                         1251.79µ ± ∞ ¹    82.22µ ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=600/contextCanceled-12                              1271.82µ ± ∞ ¹    51.19µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                                                    243.2µ          13.09µ        -94.62%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                                    │ /tmp/tmp.PrzUglo6GH/bench.catch~3 │    /tmp/tmp.PrzUglo6GH/bench.catch     │
                                                                    │               B/op                │     B/op       vs base                 │
CatchVectorizedRuntimeError/noError-12                                                      0.000 ± ∞ ¹     0.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/expected-12                                                   9834.00 ± ∞ ¹     32.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/storage-12                                                    8880.00 ± ∞ ¹     32.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/contextCanceled-12                                            8840.00 ± ∞ ¹     40.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/internalWithCode-12                                           9.586Ki ± ∞ ¹   1.511Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/internal-12                                                  10.479Ki ± ∞ ¹   2.961Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/runtime-12                                                   10.964Ki ± ∞ ¹   2.656Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/noError-12                                        81.75Ki ± ∞ ¹   81.71Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/expectedWithCode-12                              143.04Ki ± ∞ ¹   85.28Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/expectedAssertion-12                              362.7Ki ± ∞ ¹   304.5Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/internalAssertion-12                              304.2Ki ± ∞ ¹   245.3Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/internalIndexOutOfRange-12                        313.0Ki ± ∞ ¹   267.2Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/internalDivideByZero-12                           308.3Ki ± ∞ ¹   260.7Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/contextCanceled-12                               128.96Ki ± ∞ ¹   80.60Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/noError-12                                       81.21Ki ± ∞ ¹   81.25Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/expectedWithCode-12                             136.02Ki ± ∞ ¹   84.99Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/expectedAssertion-12                             362.0Ki ± ∞ ¹   302.9Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/internalAssertion-12                             291.4Ki ± ∞ ¹   244.5Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/internalIndexOutOfRange-12                       317.1Ki ± ∞ ¹   267.0Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/internalDivideByZero-12                          308.4Ki ± ∞ ¹   260.4Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/contextCanceled-12                              145.34Ki ± ∞ ¹   81.73Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/noError-12                                       81.33Ki ± ∞ ¹   81.24Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/expectedWithCode-12                             137.49Ki ± ∞ ¹   85.05Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/expectedAssertion-12                             364.7Ki ± ∞ ¹   305.8Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/internalAssertion-12                             318.4Ki ± ∞ ¹   244.5Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/internalIndexOutOfRange-12                       315.8Ki ± ∞ ¹   265.4Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/internalDivideByZero-12                          310.9Ki ± ∞ ¹   260.2Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/contextCanceled-12                              133.20Ki ± ∞ ¹   80.53Ki ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                                                                                               ⁴                  -61.19%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
⁴ summaries must be >0 to compute geomean

                                                                    │ /tmp/tmp.PrzUglo6GH/bench.catch~3 │    /tmp/tmp.PrzUglo6GH/bench.catch    │
                                                                    │             allocs/op             │  allocs/op    vs base                 │
CatchVectorizedRuntimeError/noError-12                                                      0.000 ± ∞ ¹    0.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
CatchVectorizedRuntimeError/expected-12                                                    36.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/storage-12                                                     11.000 ± ∞ ¹    3.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/contextCanceled-12                                             11.000 ± ∞ ¹    4.000 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/internalWithCode-12                                             35.00 ± ∞ ¹    37.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/internal-12                                                     46.00 ± ∞ ¹    59.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
CatchVectorizedRuntimeError/runtime-12                                                      58.00 ± ∞ ¹    51.00 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/noError-12                                          838.0 ± ∞ ¹    838.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=12/expectedWithCode-12                                1110.0 ± ∞ ¹    950.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/expectedAssertion-12                               1.736k ± ∞ ¹   1.581k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/internalAssertion-12                               1.285k ± ∞ ¹   1.228k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/internalIndexOutOfRange-12                         1.418k ± ∞ ¹   1.425k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/internalDivideByZero-12                            1.413k ± ∞ ¹   1.411k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=12/contextCanceled-12                                  880.0 ± ∞ ¹    865.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/noError-12                                         836.0 ± ∞ ¹    836.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
SQLCatchVectorizedRuntimeError/conns=240/expectedWithCode-12                               1012.0 ± ∞ ¹    949.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/expectedAssertion-12                              1.744k ± ∞ ¹   1.572k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/internalAssertion-12                              1.201k ± ∞ ¹   1.228k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/internalIndexOutOfRange-12                        1.518k ± ∞ ¹   1.424k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/internalDivideByZero-12                           1.429k ± ∞ ¹   1.411k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=240/contextCanceled-12                                 993.0 ± ∞ ¹    865.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/noError-12                                         838.0 ± ∞ ¹    837.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/expectedWithCode-12                               1038.0 ± ∞ ¹    951.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/expectedAssertion-12                              1.782k ± ∞ ¹   1.594k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/internalAssertion-12                              1.471k ± ∞ ¹   1.231k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/internalIndexOutOfRange-12                        1.476k ± ∞ ¹   1.417k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/internalDivideByZero-12                           1.471k ± ∞ ¹   1.411k ± ∞ ¹        ~ (p=1.000 n=1) ³
SQLCatchVectorizedRuntimeError/conns=600/contextCanceled-12                                 960.0 ± ∞ ¹    867.0 ± ∞ ¹        ~ (p=1.000 n=1) ³
geomean                                                                                               ⁴                 -18.86%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
⁴ summaries must be >0 to compute geomean
```

Fixes: #123235

Release note (performance improvement): Make error handling in the vectorized execution engine much cheaper. This should help avoid bad metastable regimes perpetuated by statement timeout handling consuming all CPU time, leading to more statement timeouts.

Co-authored-by: Drew Kimball <drewk@cockroachlabs.com>

----

Release justification: fix for serious performance issue.