### PR TITLE
release-23.2: sqlstats: put logging of sql stats flush signal behind vmodule

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -211,7 +211,9 @@ func (s *PersistedSQLStats) startSQLStatsFlushLoop(ctx context.Context, stopper 
 					// Don't block the flush loop if the sql activity update job is not
 					// ready to receive. We should at least continue to collect and flush
 					// stats for this node.
-					log.Warning(ctx, "sql-stats-worker: unable to signal flush completion")
+					if log.V(1) {
+						log.Warning(ctx, "sql-stats-worker: unable to signal flush completion")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Backport 1/2 commits from #121578.

Release justification: bug fix

/cc @cockroachdb/release

---

The sql stats flush worker may be unable to signal the sql activity update job to do work if it has not yet completed its previous run. Currently we emit a warning log if this occurs. Since the frequency of failing to signal may be high, we should put this behind vmodule.

Fixes: #121577

Release note: None