### PR TITLE
roachtestutil: dynamically determine block device to stall

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
-        "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/kv/kvpb",
         "//pkg/roachprod/config",

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -448,10 +448,12 @@ type dmsetupDiskStaller struct {
 
 var _ diskStaller = (*dmsetupDiskStaller)(nil)
 
-func (s *dmsetupDiskStaller) device() string { return roachtestutil.GetDiskDevice(s.t, s.c) }
+func (s *dmsetupDiskStaller) device(nodes option.NodeListOption) string {
+	return roachtestutil.GetDiskDevice(s.t, s.c, nodes)
+}
 
 func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
-	dev := s.device()
+	dev := s.device(s.c.All())
 	// snapd will run "snapd auto-import /dev/dm-0" via udev triggers when
 	// /dev/dm-0 is created. This possibly interferes with the dmsetup create
 	// reload, so uninstall snapd.


### PR DESCRIPTION
Previously, we hardcoded the block device on which to run the disk-stalled* roachtests and the disk-stall operation. This was a flaky approach as sometimes we'd use a local ssd as a block device which had very different numbers than a Google persistent disk.

This change updates the cgroup disk staller to programmatically determine the major/minor device numbers for the block device to stall (the one mounted at /mnt/data1). It also updates the dmsetup disk staller to dynamically determine the block device name mounted at /mnt/data1.

Fixes #123080, #123054.

Epic: none

Release note: None