### PR TITLE
ui: fix replication lag metric for multinode clusters and cutover

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
@@ -58,7 +58,7 @@ export default function (props: GraphDashboardProps) {
       <Axis units={AxisUnits.Duration} label="duration">
         <Metric
           downsampler={TimeSeriesQueryAggregator.MIN}
-          aggregator={TimeSeriesQueryAggregator.AVG}
+          aggregator={TimeSeriesQueryAggregator.MAX}
           name="cr.node.physical_replication.replicated_time_seconds"
           title="Replication Lag"
           transform={datapoints =>


### PR DESCRIPTION
Replication lag metric would report absurdly high lag for multinode clusters as it would take the average of the reported timestamps, and as some nodes may report 0, this would cause extremely low replicated times. To resolve this, the metric should pick the maximum time reported by all of the nodes. Additionally, on cutover or job fail/cancellation, stop reporting replicated time to avoid falsely reporting high replication lag.

Informs https://github.com/cockroachdb/cockroach/issues/120652

Release note (ui change): fix replication lag metric reporting for multinode clusters and cutover