### PR TITLE
release-23.2: sql/opt: add error handling during query plan cache invalidation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -795,3 +795,29 @@ CREATE FUNCTION f113186() RETURNS RECORD AS $$ SELECT 1.99; $$ LANGUAGE SQL;
 # Until #113186 is resolved, the internal error is expected.
 statement error pgcode XX000 internal error: invalid datum type given: DECIMAL, expected INT8
 SELECT * FROM f113186() AS foo(x INT);
+
+statement ok
+CREATE FUNCTION f(x ANYELEMENT) RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+
+statement ok
+SELECT f(0);
+
+statement ok
+SELECT f(0);
+
+statement ok
+DROP FUNCTION f(ANYELEMENT);
+CREATE FUNCTION f(x INT) RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+
+statement ok
+SELECT f('0');
+
+statement ok
+DROP FUNCTION f(INT);
+CREATE FUNCTION f(x TEXT) RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+
+statement ok
+SELECT f('0');
+
+statement ok
+DROP FUNCTION f(TEXT);

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -446,7 +446,7 @@ func (md *Metadata) CheckDependencies(
 					tree.UDFRoutine|tree.BuiltinRoutine|tree.ProcedureRoutine,
 				)
 				if err != nil || toCheck.Oid != overload.Oid || toCheck.Version != overload.Version {
-					return false, err
+					return false, maybeSwallowMetadataResolveErr(err)
 				}
 			}
 		} else {


### PR DESCRIPTION
Backport 1/1 commits from #123457.

/cc @cockroachdb/release

---

This commit adds some missing error-handling to the metadata staleness check. This is necessary because object resolution error during staleness checking must be swallowed so that the query can be replanned.

Fixes #123456

Release note (bug fix): Fixed a bug that could cause calling a routine to return an unexpected `function ... does not exist` error. The bug is triggered when the routine is called twice using the exact same SQL query, and either: (a) the routine has polymorphic arguments, or:
(b) in between the two calls, the routine is replaced by a routine with the
    same name and different parameters.
This bug has existed since alpha versions of 23.1.

---

Release justification: bug fix