### PR TITLE
rangefeed: fix sendMetadata deadlock

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -237,7 +237,9 @@ func (m *rangefeedMuxer) startSingleRangeFeed(
 	if m.cfg.withMetadata {
 		// Send metadata after the stream successfully registers to avoid sending
 		// metadata about a rangefeed that never starts.
-		sendMetadata(m.eventCh, span, parentRangefeedMetadata)
+		if err := sendMetadata(ctx, m.eventCh, span, parentRangefeedMetadata); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If the rangefeed client's context is cancelled before a metadata event is sent
on the event channel, the rangefeed could hang forever. This bug was introduced
in #123001.

Fixes #123355
Fixes #123397

Release note: none