### PR TITLE
ui: update job description capitalization

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -57,8 +57,8 @@
   }
 
   &__status,
-  &__running-status {
-    text-transform: capitalize;
+  &__running-status:first-letter {
+    text-transform: uppercase;
   }
   &__progress {
     display: flex;


### PR DESCRIPTION
Changed job description capitalization to only first letter.

Epic: none

Release note: none