### PR TITLE
release-23.1: stats: add a testing knob to disable initial table collection

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -57,4 +57,5 @@ type TestingKnobs struct {
 	KeyVisualizer                  ModuleTestingKnobs
 	TenantCapabilitiesTestingKnobs ModuleTestingKnobs
 	AutoConfig                     ModuleTestingKnobs
+	TableStatsKnobs                ModuleTestingKnobs
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -1114,6 +1114,9 @@ func TestScheduledJobsConsumption(t *testing.T) {
 					RetryMaxDelay:     &zeroDuration,
 				},
 			},
+			TableStatsKnobs: &stats.TableStatsTestingKnobs{
+				DisableInitialTableCollection: true,
+			},
 		},
 	})
 
@@ -1133,10 +1136,9 @@ func TestScheduledJobsConsumption(t *testing.T) {
 	after.Sub(&before)
 	require.Zero(t, after.WriteBatches)
 	require.Zero(t, after.WriteBytes)
-	// Expect up to 3 batches for initial auto-stats query, schema catalog fill,
-	// and anything else that happens once during server startup but might not be
-	// done by this point.
-	require.LessOrEqual(t, after.ReadBatches, uint64(3))
+	// Expect up to 2 batches for schema catalog fill and anything else that
+	// happens once during server startup but might not be done by this point.
+	require.LessOrEqual(t, after.ReadBatches, uint64(2))
 
 	// Make sure that at least 100 writes (deletes) are reported. The TTL job
 	// should not be exempt from cost control.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1132,12 +1132,17 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		}
 	}
 
+	var tableStatsTestingKnobs *stats.TableStatsTestingKnobs
+	if tableStatsKnobs := cfg.TestingKnobs.TableStatsKnobs; tableStatsKnobs != nil {
+		tableStatsTestingKnobs = tableStatsKnobs.(*stats.TableStatsTestingKnobs)
+	}
 	statsRefresher := stats.MakeRefresher(
 		cfg.AmbientCtx,
 		cfg.Settings,
 		cfg.circularInternalExecutor,
 		execCfg.TableStatsCache,
 		stats.DefaultAsOfTime,
+		tableStatsTestingKnobs,
 	)
 	execCfg.StatsRefresher = statsRefresher
 

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -236,6 +237,7 @@ type Refresher struct {
 	ex      isql.Executor
 	cache   *TableStatisticsCache
 	randGen autoStatsRand
+	knobs   *TableStatsTestingKnobs
 
 	// mutations is the buffered channel used to pass messages containing
 	// metadata about SQL mutations to the background Refresher thread.
@@ -294,6 +296,17 @@ type settingOverride struct {
 	settings catpb.AutoStatsSettings
 }
 
+// TableStatsTestingKnobs contains testing knobs for table statistics.
+type TableStatsTestingKnobs struct {
+	// DisableInitialTableCollection, if set, indicates that the "initial table
+	// collection" performed by the Refresher should be skipped.
+	DisableInitialTableCollection bool
+}
+
+var _ base.ModuleTestingKnobs = &TableStatsTestingKnobs{}
+
+func (k *TableStatsTestingKnobs) ModuleTestingKnobs() {}
+
 // MakeRefresher creates a new Refresher.
 func MakeRefresher(
 	ambientCtx log.AmbientContext,
@@ -301,6 +314,7 @@ func MakeRefresher(
 	ex isql.Executor,
 	cache *TableStatisticsCache,
 	asOfTime time.Duration,
+	knobs *TableStatsTestingKnobs,
 ) *Refresher {
 	randSource := rand.NewSource(rand.Int63())
 
@@ -310,6 +324,7 @@ func MakeRefresher(
 		ex:               ex,
 		cache:            cache,
 		randGen:          makeAutoStatsRand(randSource),
+		knobs:            knobs,
 		mutations:        make(chan mutation, refreshChanBufferLen),
 		settings:         make(chan settingOverride, refreshChanBufferLen),
 		asOfTime:         asOfTime,
@@ -444,6 +459,9 @@ func (r *Refresher) Start(
 		for {
 			select {
 			case <-initialTableCollection:
+				if r.knobs != nil && r.knobs.DisableInitialTableCollection {
+					continue
+				}
 				r.ensureAllTables(ctx, &r.st.SV, initialTableCollectionDelay)
 				if len(r.mutationCounts) > 0 {
 					ensuringAllTables = true

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -74,7 +74,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 		s.InternalDB().(descs.DB),
 	)
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
-	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 	// There should not be any stats yet.
 	if err := checkStatsCount(ctx, cache, descA, 0 /* expected */); err != nil {
@@ -199,7 +199,7 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 		s.InternalDB().(descs.DB),
 	)
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
-	r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+	r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 	// Exclude the 3 system tables which don't use autostats.
 	systemTablesWithStats := bootstrap.NumSystemTablesForSystemTenant - 3
@@ -300,7 +300,7 @@ func BenchmarkEnsureAllTables(b *testing.B) {
 				s.InternalDB().(descs.DB),
 			)
 			require.NoError(b, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
-			r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+			r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -377,7 +377,7 @@ func TestAverageRefreshTime(t *testing.T) {
 		s.InternalDB().(descs.DB),
 	)
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
-	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 	// curTime is used as the current time throughout the test to ensure that the
 	// calculated average refresh time is consistent even if there are delays due
@@ -624,7 +624,7 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 		s.InternalDB().(descs.DB),
 	)
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
-	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 	AutomaticStatisticsClusterMode.Override(ctx, &st.SV, true)
 
@@ -679,7 +679,7 @@ func TestAutoStatsOnStartupClusterSettingOff(t *testing.T) {
 		s.InternalDB().(descs.DB),
 	)
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
-	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+	refresher := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 	// Refresher start should trigger stats collection on t.a.
 	if err := refresher.Start(
@@ -725,7 +725,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 		s.InternalDB().(descs.DB),
 	)
 	require.NoError(t, cache.Start(ctx, keys.SystemSQLCodec, s.RangeFeedFactory().(*rangefeed.Factory)))
-	r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */)
+	r := MakeRefresher(s.AmbientCtx(), st, executor, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
 	// Try to refresh stats on a table that doesn't exist.
 	r.maybeRefreshStats(


### PR DESCRIPTION
Backport 1/1 commits from #123233.

/cc @cockroachdb/release

---

This is needed to stabilize `TestScheduledJobsConsumption` on 24.1 and earlier branches. This test became flaky due to the partial backport of #121861 to all branches.

Fixes: #122336.

Release note: None

Release justification: test-only change.