### PR TITLE
spanconfigsplitterccl: deflake looking up dropped table

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/tables
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/tables
@@ -36,6 +36,6 @@ DROP TABLE db.t2;
 ----
 
 # Dropped tables should not observe any splits.
-splits id=107
+splits last_seen_id
 ----
 = 0


### PR DESCRIPTION
The ID of the dropped table is not always the same between test runs, so instead, we capture the ID and use it, rather than hardcoding it.

fixes https://github.com/cockroachdb/cockroach/issues/123496
Release note: None