### PR TITLE
sql: fix error with DROP VALUE and DROP SCHEMA in same txn

### DIFF
--- a/pkg/sql/jobs_collection.go
+++ b/pkg/sql/jobs_collection.go
@@ -38,7 +38,7 @@ type txnJobsCollection struct {
 	// job for a relation in one transaction. These jobs will be created and
 	// queued at commit time.
 	uniqueToCreate map[descpb.ID]*jobs.Record
-	// uniqueToCreate contains job records that are not unique to a descriptor
+	// nonUniqueToCreate contains job records that are not unique to a descriptor
 	// IDs. These jobs will be created and queued at commit time.
 	nonUniqueToCreate []*jobs.Record
 }

--- a/pkg/sql/logictest/testdata/logic_test/drop_schema
+++ b/pkg/sql/logictest/testdata/logic_test/drop_schema
@@ -6,3 +6,18 @@ CREATE DATABASE test2
 
 statement error pq: cannot drop schema "public"
 DROP SCHEMA test2.public
+
+# Regression test for ALTER TYPE ... DROP VALUE followed by DROP SCHEMA CASCADE.
+# The type schema change should never be executed, since the DROP SCHEMA would
+# have already removed the type.
+statement ok
+CREATE SCHEMA schema_123539;
+
+statement ok
+CREATE TYPE schema_123539.enum_123539 AS ENUM ('s', 't');
+
+statement ok
+BEGIN;
+ALTER TYPE schema_123539.enum_123539 DROP VALUE 's';
+DROP SCHEMA schema_123539 CASCADE;
+COMMIT;


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/123539
fixes https://github.com/cockroachdb/cockroach/issues/123488
fixes https://github.com/cockroachdb/cockroach/issues/121828
fixes https://github.com/cockroachdb/cockroach/issues/122785

Release note (bug fix): Fixed a bug that would occur when `ALTER TYPE ... DROP VALUE` is followed by `DROP SCHEMA CASCADE ...` in the same transaction. Previously, the `ALTER TYPE` schema change would get queued up to run at commit time, but by that point, the type may have already been removed, so the commit could fail. This is fixed now.