### PR TITLE
drtprod: move drt-chaos to local ssds

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -129,7 +129,7 @@ EOF"
     ;;
   "create")
     if [ "$#" -lt 2 ]; then
-      echo "usage: drtprod create {drt-main,drt-ua1,drt-ua2}"
+      echo "usage: drtprod create {drt-main,drt-chaos,drt-ua1,drt-ua2}"
       exit 1
     fi
     case "${2}" in
@@ -152,10 +152,13 @@ EOF"
           --gce-managed \
           --gce-zones "us-east1-d,us-east1-b,us-east1-c" \
           --nodes 6 \
-          --gce-machine-type n2-standard-8 \
-          --gce-pd-volume-size 3000 --local-ssd=false \
+          --gce-machine-type n2-standard-16 \
+          --gce-local-ssd-count="4" \
+          --gce-enable-multiple-stores \
+          --local-ssd=true \
           --username drt \
-          --lifetime 8760h
+          --lifetime="8760h" \
+          --gce-image "ubuntu-2204-jammy-v20240319"
         # setup dns
         $0 dns drt-chaos create
         ;;


### PR DESCRIPTION
Now that the local ssd bug is identified, we can move drt-chaos to local ssds as well and save some $.

Epic: none

Release note: None