### PR TITLE
sqlstats: set default value of sql.stats.flush.minimum_interval to 10m

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -564,6 +564,12 @@ func testResetSQLStatsRPCForTenant(
 	controlCluster.TenantConn(0 /* idx */).
 		Exec(t, "SET CLUSTER SETTING sql.stats.flush.interval = '24h'")
 
+	// Set min flush to 0.
+	testCluster.TenantConn(0 /* idx */).
+		Exec(t, "SET CLUSTER SETTING sql.stats.flush.minimum_interval = '0s'")
+	controlCluster.TenantConn(0 /* idx */).
+		Exec(t, "SET CLUSTER SETTING sql.stats.flush.minimum_interval = '0s'")
+
 	defer func() {
 		// Cleanup
 		testCluster.TenantConn(0 /* idx */).

--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -338,6 +338,8 @@ func TestClusterResetSQLStats(t *testing.T) {
 			})
 			defer testCluster.Stopper().Stop(ctx)
 
+			persistedsqlstats.MinimumInterval.Override(ctx, &testCluster.ApplicationLayer().ClusterSettings().SV, 0)
+
 			gateway := testCluster.Server(1 /* idx */).ApplicationLayer()
 			status := gateway.StatusServer().(serverpb.SQLStatusServer)
 

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -260,6 +260,8 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	defer sqlDB.Close()
 	ts := srv.ApplicationLayer()
 
+	persistedsqlstats.MinimumInterval.Override(ctx, &ts.ClusterSettings().SV, 0)
+
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 
@@ -566,6 +568,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	defer sqlDB.Close()
 	ts := s.ApplicationLayer()
+	persistedsqlstats.MinimumInterval.Override(ctx, &ts.ClusterSettings().SV, 0)
 
 	execCfg := ts.ExecutorConfig().(ExecutorConfig)
 	st := cluster.MakeTestingClusterSettings()
@@ -784,6 +787,8 @@ func TestFlushToActivityWithDifferentAggTs(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	defer sqlDB.Close()
 	ts := srv.ApplicationLayer()
+
+	persistedsqlstats.MinimumInterval.Override(ctx, &ts.ClusterSettings().SV, 0)
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -349,6 +349,8 @@ func BenchmarkSqlStatsPersisted(b *testing.B) {
 					b.ReportAllocs()
 					// Run flush benchmark first to initialize stats tables
 					b.Run("BenchmarkPersistedSqlStatsFlush", func(b *testing.B) {
+						persistedsqlstats.MinimumInterval.Override(context.Background(),
+							&tc.ApplicationLayer(0).ClusterSettings().SV, 0)
 						runBenchmarkPersistedSqlStatsFlush(b, tc, sqlRunner, ctx)
 					})
 
@@ -387,6 +389,7 @@ func BenchmarkSqlStatsMaxFlushTime(b *testing.B) {
 		},
 	})
 	defer s.Stopper().Stop(ctx)
+	persistedsqlstats.MinimumInterval.Override(ctx, &s.ClusterSettings().SV, 0)
 	sqlConn := sqlutils.MakeSQLRunner(conn)
 
 	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -40,7 +40,7 @@ var MinimumInterval = settings.RegisterDurationSetting(
 	"the minimum interval that SQL stats can be flushes to disk. If a "+
 		"flush operation starts within less than the minimum interval, the flush "+
 		"operation will be aborted",
-	0,
+	time.Minute*10,
 	settings.NonNegativeDuration,
 )
 

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -152,6 +152,7 @@ func TestSQLStatsCompactor(t *testing.T) {
 			defer srv.Stopper().Stop(ctx)
 			server := srv.ApplicationLayer()
 
+			persistedsqlstats.MinimumInterval.Override(ctx, &server.ClusterSettings().SV, 0)
 			sqlConn := sqlutils.MakeSQLRunner(conn)
 			internalExecutor := server.InternalExecutor().(isql.Executor)
 

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -88,6 +88,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 	})
 	defer cluster.Stopper().Stop(ctx)
 
+	persistedsqlstats.MinimumInterval.Override(ctx, &cluster.ApplicationLayer(0).ClusterSettings().SV, 0)
 	server := cluster.Server(0 /* idx */).ApplicationLayer()
 	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
 

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -61,8 +61,6 @@ func (s *PersistedSQLStats) MaybeFlush(ctx context.Context, stopper *stop.Stoppe
 	}
 
 	if flushingTooSoon {
-		log.Infof(ctx, "flush aborted due to high flush frequency. "+
-			"The minimum interval between flushes is %s", minimumFlushInterval.String())
 		return false
 	}
 


### PR DESCRIPTION
This commit sets the minimum flush interval for sql stats to be
equivalent to the default flush interval, 10m. This ensures that
the flush will not be allowed to trigger consecutively when there
is constant memory pressure (ex. due to hitting in-memory fingerprint
limit) on the sql stats system. We want to prevent the flush from
constantly running in the BG since it can use up resources.

Fixes: #123091
Epic: CRDB-37544

Release note: None