### PR TITLE
release-24.1: scplan: Fix deprule to drop constraint.

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -347,6 +347,13 @@ func TestBackupRollbacks_base_drop_column_with_index(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_drop_column_with_partial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -757,6 +764,13 @@ func TestBackupRollbacksMixedVersion_base_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1173,6 +1187,13 @@ func TestBackupSuccess_base_drop_column_with_index(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_drop_column_with_partial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1583,6 +1604,13 @@ func TestBackupSuccessMixedVersion_base_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region/drop_database_multiregion_primary_region.explain
@@ -75,8 +75,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
  │              ├── RemoveObjectParent {"ObjectID":108,"ParentSchemaID":105}
  │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":108}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":108}
@@ -97,7 +95,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":108}
@@ -110,7 +107,8 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_crdb_internal_r...","SchemaID":105}}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"table_regional_b...","SchemaID":105}}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":108}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
@@ -119,6 +117,8 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"root"}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":108}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}
@@ -246,8 +246,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
  │              ├── RemoveObjectParent {"ObjectID":108,"ParentSchemaID":105}
  │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":108}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":108}
@@ -268,7 +266,6 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":108}
@@ -282,7 +279,8 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":107,"Name":"_crdb_internal_r...","SchemaID":105}}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":108,"Name":"table_regional_b...","SchemaID":105}}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":108}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
@@ -291,6 +289,8 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"public"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"root"}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":108}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion/drop_table_multiregion.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion/drop_table_multiregion.explain
@@ -44,14 +44,8 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
  │              ├── RemoveObjectParent {"ObjectID":108,"ParentSchemaID":105}
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.TablePartit..."}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":108}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":108}
- │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":108}
- │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967294,"TableID":108}
@@ -63,20 +57,26 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":108}
- │              ├── RemoveDroppedColumnType {"ColumnID":2,"TableID":108}
- │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── RemoveColumnNotNull {"ColumnID":2,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":108}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
+ │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":108}
+ │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":108}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":108}
+ │              ├── RemoveDroppedColumnType {"ColumnID":2,"TableID":108}
+ │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"TableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Ordinal":1,"TableID":108}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":108}
  ├── PreCommitPhase
@@ -148,14 +148,8 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
  │              ├── RemoveObjectParent {"ObjectID":108,"ParentSchemaID":105}
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.TablePartit..."}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":108}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":108}
- │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":108}
- │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967294,"TableID":108}
@@ -167,20 +161,26 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":108}
- │              ├── RemoveDroppedColumnType {"ColumnID":2,"TableID":108}
- │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── RemoveColumnNotNull {"ColumnID":2,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":108}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
+ │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":108}
+ │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":108}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":108}
+ │              ├── RemoveDroppedColumnType {"ColumnID":2,"TableID":108}
+ │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"TableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Ordinal":1,"TableID":108}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region/drop_table_multiregion_primary_region.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region/drop_table_multiregion_primary_region.explain
@@ -36,8 +36,6 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
  │              ├── RemoveObjectParent {"ObjectID":108,"ParentSchemaID":105}
  │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":108}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":108}
@@ -49,14 +47,16 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":108}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":108}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":108}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}
@@ -113,8 +113,6 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── MarkDescriptorAsDropped {"DescriptorID":108}
  │              ├── RemoveObjectParent {"ObjectID":108,"ParentSchemaID":105}
  │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":108}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":108}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":108}
@@ -126,14 +124,16 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │              ├── NotImplementedForPublicObjects {"DescID":108,"ElementType":"scpb.Owner"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":108,"User":"root"}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":108}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":108}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":108}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":108}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":108}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":108}

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1164,9 +1164,12 @@ func (desc *wrapper) validateColumns() error {
 			return errors.Newf("both generated identity and computed expression specified for column %q", column.GetName())
 		}
 
-		// If the column is not in DELETE_ONLY and it's generated as identity, then
-		// the column has to have an enforced NOT NULL constraint.
-		if !column.DeleteOnly() && column.IsGeneratedAsIdentity() {
+		// If the column is public and it's generated as identity, then
+		// the column has to have an enforced NOT NULL constraint. In a mutation
+		// stage, the column is only accessible for non-user facing writes/deletes and its
+		// fine to not enforce the null constraint for identity columns until column
+		// moves to public.
+		if column.Public() && column.IsGeneratedAsIdentity() {
 			// A column's NOT NULL constraint is enforced when either the column
 			// descriptor is NOT NULL, or there is an enforced, functionally equivalent
 			// CHECK constraint, (col_name IS NOT NULL), in `desc`, which can happen

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3332,7 +3332,8 @@ INSERT INTO t_99035 VALUES (0,0);
 
 skipif config local-legacy-schema-changer
 skipif config local-mixed-23.1
-statement error validation of CHECK "j > 0:::INT8" failed on row: j=0, k=[0-9]+, p=30
+skipif config local-mixed-23.2
+statement error validation of CHECK "j > 0:::INT8" failed on row: i=NULL, j=0, k=[0-9]+, p=30
 ALTER TABLE t_99035 ADD COLUMN k INT DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (j), DROP COLUMN i, ADD COLUMN p INT DEFAULT 30, ADD CHECK (j>0);
 
 query II

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2769,8 +2769,10 @@ SELECT statistics_name, column_names, row_count, histogram_id IS NOT NULL AS has
 FROM [SHOW STATISTICS FOR TABLE t118537]
 ORDER BY statistics_name, column_names::STRING
 ----
-statistics_name  column_names  row_count  has_histogram
-mutation         {a}           10         true
+statistics_name  column_names                 row_count  has_histogram
+mutation         {a,crdb_internal_a_shard_3}  10         false
+mutation         {a}                          10         true
+mutation         {crdb_internal_a_shard_3}    10         true
 
 statement ok
 SET CLUSTER SETTING jobs.debug.pausepoints = ''

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
@@ -21,6 +21,8 @@ import (
 // DEFAULT expression, etc. disappear once the column reaches a suitable state.
 func init() {
 
+	// N.B. This rules is superseded by the "column constraint removed right before
+	// column reaches write only" rule below for the not null column check.
 	registerDepRuleForDrop(
 		"column no longer public before dependents",
 		scgraph.Precedence,
@@ -29,7 +31,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
-				to.TypeFilter(rulesVersionKey, isColumnDependent),
+				to.TypeFilter(rulesVersionKey, isColumnDependent, Not(isColumnNotNull)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 			}
 		},
@@ -112,22 +114,22 @@ func init() {
 	)
 
 	// Column constraint disappears in the same stage as the column
-	// becomes non-writable.
+	// becomes WRITE_ONLY.
 	//
-	// Column constraint cannot disappear while the column is still writable
+	// Column constraint cannot disappear while the column is still publicly writable
 	// because we then allow incorrect writes that would violate the constraint.
 	//
 	// Column constraint cannot still be enforced when the column becomes
-	// non-writable because an enforced constraint means writes will see and
+	// non-public because an enforced constraint means writes will see and
 	// attempt to uphold it but the column is no longer visible to them.
 	//
 	// N.B. This rule supersedes the above "dependents removed before column" rule.
 	// N.B. SameStage is enough; which transition happens first won't matter.
 	registerDepRuleForDrop(
-		"column constraint removed right before column reaches delete only",
-		scgraph.SameStagePrecedence,
+		"column constraint removed right before column reaches write only",
+		scgraph.Precedence,
 		"column-constraint", "column",
-		scpb.Status_ABSENT, scpb.Status_DELETE_ONLY,
+		scpb.Status_ABSENT, scpb.Status_WRITE_ONLY,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint, isSubjectTo2VersionInvariant),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
@@ -211,6 +211,13 @@ func isColumnDependent(e scpb.Element) bool {
 	return isColumnTypeDependent(e)
 }
 
+func isColumnNotNull(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ColumnNotNull:
+		return true
+	}
+	return false
+}
 func isColumnTypeDependent(e scpb.Element) bool {
 	switch e.(type) {
 	case *scpb.SequenceOwner, *scpb.ColumnDefaultExpression, *scpb.ColumnOnUpdateExpression:

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -2135,9 +2135,9 @@ deprules
     - $parent-descriptor-Node[CurrentStatus] = DROPPED
     - joinTargetNode($back-reference-in-parent-descriptor, $back-reference-in-parent-descriptor-Target, $back-reference-in-parent-descriptor-Node)
     - joinTargetNode($parent-descriptor, $parent-descriptor-Target, $parent-descriptor-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -2145,12 +2145,12 @@ deprules
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
     - $column-constraint-Node[CurrentStatus] = ABSENT
-    - $column-Node[CurrentStatus] = DELETE_ONLY
+    - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -2158,12 +2158,12 @@ deprules
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
     - $column-constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -2172,12 +2172,12 @@ deprules
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Target[TargetStatus] = ABSENT
-    - $column-Node[CurrentStatus] = DELETE_ONLY
+    - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -2186,7 +2186,7 @@ deprules
     - $column-constraint-Target[TargetStatus] = ABSENT
     - $column-constraint-Node[CurrentStatus] = ABSENT
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $column-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
 - name: column dependents exist before column becomes public
@@ -2276,7 +2276,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - toAbsent($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -2289,7 +2289,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - transient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -2302,7 +2302,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -2316,7 +2316,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -6218,9 +6218,9 @@ deprules
     - $parent-descriptor-Node[CurrentStatus] = DROPPED
     - joinTargetNode($back-reference-in-parent-descriptor, $back-reference-in-parent-descriptor-Target, $back-reference-in-parent-descriptor-Node)
     - joinTargetNode($parent-descriptor, $parent-descriptor-Target, $parent-descriptor-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -6228,12 +6228,12 @@ deprules
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
     - $column-constraint-Node[CurrentStatus] = ABSENT
-    - $column-Node[CurrentStatus] = DELETE_ONLY
+    - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -6241,12 +6241,12 @@ deprules
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
     - $column-constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -6255,12 +6255,12 @@ deprules
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-constraint-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Target[TargetStatus] = ABSENT
-    - $column-Node[CurrentStatus] = DELETE_ONLY
+    - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: column constraint removed right before column reaches delete only
+- name: column constraint removed right before column reaches write only
   from: column-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: column-Node
   query:
     - $column-constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnNotNull', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
@@ -6269,7 +6269,7 @@ deprules
     - $column-constraint-Target[TargetStatus] = ABSENT
     - $column-constraint-Node[CurrentStatus] = ABSENT
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $column-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($column-constraint, $column-constraint-Target, $column-constraint-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
 - name: column dependents exist before column becomes public
@@ -6359,7 +6359,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - toAbsent($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = WRITE_ONLY
@@ -6372,7 +6372,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - transient($column-Target, $dependent-Target)
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -6385,7 +6385,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
@@ -6399,7 +6399,7 @@ deprules
   to: dependent-Node
   query:
     - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
+    - $dependent[Type] IN ['*scpb.ColumnComment', '*scpb.ColumnDefaultExpression', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.IndexColumn', '*scpb.SequenceOwner']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -5,10 +5,8 @@ CREATE TABLE t (k INT NOT NULL, v STRING);
 ops
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
 ----
-StatementPhase stage 1 of 1 with 14 MutationType ops
+StatementPhase stage 1 of 1 with 12 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> BACKFILL_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
@@ -89,17 +87,8 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
       IndexID: 4
       Kind: 2
       TableID: 104
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 3
-      TableID: 104
-    *scop.SetColumnName
-      ColumnID: 3
-      Name: crdb_internal_column_3_name_placeholder
-      TableID: 104
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Column:{DescID: 104, ColumnID: 3}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], BACKFILL_ONLY] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT], PUBLIC] -> ABSENT
@@ -117,10 +106,8 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 19 MutationType ops
+PreCommitPhase stage 2 of 2 with 17 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> BACKFILL_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
@@ -209,13 +196,6 @@ PreCommitPhase stage 2 of 2 with 19 MutationType ops
       ColumnID: 2
       IndexID: 4
       Kind: 2
-      TableID: 104
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 3
-      TableID: 104
-    *scop.SetColumnName
-      ColumnID: 3
-      Name: crdb_internal_column_3_name_placeholder
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -423,9 +403,10 @@ PostCommitPhase stage 15 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 4
       TableID: 104
-PostCommitNonRevertiblePhase stage 1 of 4 with 15 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 4 with 16 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+    [[Column:{DescID: 104, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, ABSENT], VALIDATED] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -443,11 +424,6 @@ PostCommitNonRevertiblePhase stage 1 of 4 with 15 MutationType ops
       ColumnID: 3
       TableID: 104
     *scop.RemoveColumnFromIndex
-      ColumnID: 3
-      IndexID: 3
-      Kind: 2
-      TableID: 104
-    *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 3
       TableID: 104
@@ -466,14 +442,20 @@ PostCommitNonRevertiblePhase stage 1 of 4 with 15 MutationType ops
       IndexID: 5
       Kind: 2
       TableID: 104
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 3
+      TableID: 104
+    *scop.SetColumnName
+      ColumnID: 3
+      Name: crdb_internal_column_3_name_placeholder
       TableID: 104
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 104
-    *scop.MakeIndexAbsent
+    *scop.RemoveColumnFromIndex
+      ColumnID: 3
       IndexID: 3
+      Kind: 2
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 5
@@ -492,20 +474,27 @@ PostCommitNonRevertiblePhase stage 1 of 4 with 15 MutationType ops
       IndexID: 1
       Kind: 2
       Ordinal: 1
+      TableID: 104
+    *scop.MakeIndexAbsent
+      IndexID: 3
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 4 with 7 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 4 with 8 MutationType ops
   transitions:
+    [[Column:{DescID: 104, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_VALIDATED
     [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
   ops:
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 3
+      TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 1
       TableID: 104
@@ -631,10 +620,6 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 104, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 104, ColumnID: 3}, WRITE_ONLY]
   to:   [ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
@@ -667,9 +652,9 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 104, ColumnID: 3}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 104, ColumnID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, PUBLIC]
   to:   [ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}, VALIDATED]
   kind: PreviousTransactionPrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -1348,10 +1348,8 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
 ops
 ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
 ----
-StatementPhase stage 1 of 1 with 42 MutationType ops
+StatementPhase stage 1 of 1 with 40 MutationType ops
   transitions:
-    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 107, Name: v2, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
@@ -1492,13 +1490,6 @@ StatementPhase stage 1 of 1 with 42 MutationType ops
       Kind: 2
       Ordinal: 1
       TableID: 107
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 3
-      TableID: 107
-    *scop.SetColumnName
-      ColumnID: 3
-      Name: crdb_internal_column_3_name_placeholder
-      TableID: 107
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -1546,8 +1537,6 @@ StatementPhase stage 1 of 1 with 42 MutationType ops
       TableID: 108
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 107, Name: v2, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[Namespace:{DescID: 108, Name: fooview, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
@@ -1583,10 +1572,8 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 20 MutationType ops
+PreCommitPhase stage 2 of 2 with 18 MutationType ops
   transitions:
-    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 107, Name: v2, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
@@ -1655,13 +1642,6 @@ PreCommitPhase stage 2 of 2 with 20 MutationType ops
       IndexID: 4
       Kind: 2
       Ordinal: 1
-      TableID: 107
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 3
-      TableID: 107
-    *scop.SetColumnName
-      ColumnID: 3
-      Name: crdb_internal_column_3_name_placeholder
       TableID: 107
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -1798,9 +1778,10 @@ PostCommitPhase stage 7 of 7 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 3
       TableID: 107
-PostCommitNonRevertiblePhase stage 1 of 3 with 51 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 52 MutationType ops
   transitions:
-    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: v2, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT], VALIDATED] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
     [[IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -1922,8 +1903,12 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 51 MutationType ops
       Kind: 2
       Ordinal: 1
       TableID: 107
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 3
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 3
+      Name: crdb_internal_column_3_name_placeholder
       TableID: 107
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 2
@@ -2010,8 +1995,9 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 51 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 3 with 12 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 3 with 13 MutationType ops
   transitions:
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -2020,6 +2006,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 12 MutationType ops
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1, RecreateSourceIndexID: 0}, ABSENT], DELETE_ONLY] -> ABSENT
     [[View:{DescID: 108}, ABSENT], DROPPED] -> ABSENT
   ops:
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 3
+      TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 2
       TableID: 107
@@ -2143,10 +2132,6 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
   to:   [ColumnName:{DescID: 107, Name: v2, ColumnID: 3}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
@@ -2278,9 +2263,9 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 107, ColumnID: 3}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, PUBLIC]
   to:   [ColumnNotNull:{DescID: 107, ColumnID: 3, IndexID: 0}, VALIDATED]
   kind: PreviousTransactionPrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -230,13 +230,6 @@ StatementPhase stage 1 of 1 with 241 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 110
       ParentSchemaID: 105
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 110
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 110
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 110
@@ -294,13 +287,6 @@ StatementPhase stage 1 of 1 with 241 MutationType ops
       ObjectID: 109
       ParentSchemaID: 106
     *scop.RemoveTableComment
-      TableID: 109
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 109
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
       TableID: 109
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
@@ -808,10 +794,12 @@ StatementPhase stage 1 of 1 with 241 MutationType ops
         DescriptorID: 110
         Name: t1
         SchemaID: 105
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 110
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 110
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 110
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -834,10 +822,12 @@ StatementPhase stage 1 of 1 with 241 MutationType ops
         DescriptorID: 109
         Name: t1
         SchemaID: 106
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 109
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 109
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -966,6 +956,11 @@ StatementPhase stage 1 of 1 with 241 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 110
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 110
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -984,6 +979,11 @@ StatementPhase stage 1 of 1 with 241 MutationType ops
     *scop.MakeIndexAbsent
       IndexID: 1
       TableID: 110
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 109
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -1434,13 +1434,6 @@ PreCommitPhase stage 2 of 2 with 257 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 110
       ParentSchemaID: 105
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 110
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 110
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 110
@@ -1498,13 +1491,6 @@ PreCommitPhase stage 2 of 2 with 257 MutationType ops
       ObjectID: 109
       ParentSchemaID: 106
     *scop.RemoveTableComment
-      TableID: 109
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 109
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
       TableID: 109
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
@@ -2014,10 +2000,12 @@ PreCommitPhase stage 2 of 2 with 257 MutationType ops
         DescriptorID: 110
         Name: t1
         SchemaID: 105
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 110
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 110
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 110
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -2040,10 +2028,12 @@ PreCommitPhase stage 2 of 2 with 257 MutationType ops
         DescriptorID: 109
         Name: t1
         SchemaID: 106
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 109
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 109
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -2172,6 +2162,11 @@ PreCommitPhase stage 2 of 2 with 257 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 110
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 110
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -2190,6 +2185,11 @@ PreCommitPhase stage 2 of 2 with 257 MutationType ops
     *scop.MakeIndexAbsent
       IndexID: 1
       TableID: 110
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 109
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -2473,10 +2473,6 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 109, ColumnID: 1, IndexID: 0}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
   to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
@@ -2550,10 +2546,6 @@ DROP DATABASE db1 CASCADE
   rule: non-data dependents removed before descriptor
 - from: [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
   to:   [ColumnName:{DescID: 110, Name: id, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 110, ColumnID: 1, IndexID: 0}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
@@ -3141,9 +3133,9 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 109, ColumnID: 1, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 109, ColumnID: 1}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 109, ColumnID: 1, IndexID: 0}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
@@ -3153,9 +3145,9 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 110, ColumnID: 1, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 110, ColumnID: 1}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 110, ColumnID: 1, IndexID: 0}, ABSENT]
   to:   [Table:{DescID: 110}, ABSENT]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -368,10 +368,8 @@ DROP INDEX idx2 CASCADE
 ops
 DROP INDEX idx3 CASCADE
 ----
-StatementPhase stage 1 of 1 with 6 MutationType ops
+StatementPhase stage 1 of 1 with 4 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, RecreateSourceIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedColumnIDs: [5]}, ABSENT], PUBLIC] -> VALIDATED
@@ -390,17 +388,8 @@ StatementPhase stage 1 of 1 with 6 MutationType ops
       ConstraintID: 2
       Name: crdb_internal_constraint_2_name_placeholder
       TableID: 104
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 5
-      TableID: 104
-    *scop.SetColumnName
-      ColumnID: 5
-      Name: crdb_internal_column_5_name_placeholder
-      TableID: 104
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, RecreateSourceIndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedColumnIDs: [5]}, ABSENT], VALIDATED] -> PUBLIC
@@ -408,10 +397,8 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 8 MutationType ops
+PreCommitPhase stage 2 of 2 with 6 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, RecreateSourceIndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedColumnIDs: [5]}, ABSENT], PUBLIC] -> VALIDATED
@@ -429,13 +416,6 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
     *scop.SetConstraintName
       ConstraintID: 2
       Name: crdb_internal_constraint_2_name_placeholder
-      TableID: 104
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 5
-      TableID: 104
-    *scop.SetColumnName
-      ColumnID: 5
-      Name: crdb_internal_column_5_name_placeholder
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -448,14 +428,15 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
       - 104
       JobID: 1
       NonCancelable: true
-      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 8 MutationType ops pending
+      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 3 with 9 MutationType ops pending
       Statements:
       - statement: DROP INDEX idx3 CASCADE
         redactedstatement: DROP INDEX ‹defaultdb›.public.‹t1›@‹idx3› CASCADE
         statementtag: DROP INDEX
-PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 11 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], VALIDATED] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 5, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
@@ -470,8 +451,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
     *scop.RemoveCheckConstraint
       ConstraintID: 2
       TableID: 104
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 5
+      TableID: 104
+    *scop.SetColumnName
+      ColumnID: 5
+      Name: crdb_internal_column_5_name_placeholder
       TableID: 104
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 6
@@ -499,13 +484,15 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
   transitions:
-    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, RecreateSourceIndexID: 0}, ABSENT], DELETE_ONLY] -> ABSENT
     [[IndexData:{DescID: 104, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
   ops:
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 5
+      TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 6
       TableID: 104
@@ -514,6 +501,16 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
       StatementForDropJob:
         Statement: DROP INDEX defaultdb.public.t1@idx3 CASCADE
       TableID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 3 of 3 with 3 MutationType ops
+  transitions:
+    [[Column:{DescID: 104, ColumnID: 5}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
+  ops:
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 5
       TableID: 104
@@ -558,10 +555,6 @@ DROP INDEX idx3 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 104, ColumnID: 5}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 104, ColumnID: 5}, WRITE_ONLY]
   to:   [ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 5}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
@@ -578,9 +571,9 @@ DROP INDEX idx3 CASCADE
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 104, ColumnID: 5}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 104, ColumnID: 5}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, PUBLIC]
   to:   [ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, VALIDATED]
   kind: PreviousTransactionPrecedence
@@ -1203,17 +1196,7 @@ StatementPhase stage 1 of 1 with 34 MutationType ops
       ColumnID: 1
       Name: crdb_internal_column_1_name_placeholder
       TableID: 107
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 2
-      TableID: 107
-    *scop.SetColumnName
-      ColumnID: 2
-      Name: crdb_internal_column_2_name_placeholder
-      TableID: 107
     *scop.MakePublicColumnNotNullValidated
-      ColumnID: 2
-      TableID: 107
-    *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 107
     *scop.MakePublicColumnWriteOnly
@@ -1267,9 +1250,14 @@ StatementPhase stage 1 of 1 with 34 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 107
-    *scop.AssertColumnFamilyIsRemoved
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 2
       TableID: 107
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.SetColumnName
+      ColumnID: 2
+      Name: crdb_internal_column_2_name_placeholder
+      TableID: 107
+    *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
@@ -1280,6 +1268,9 @@ StatementPhase stage 1 of 1 with 34 MutationType ops
       TableID: 107
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
+      TableID: 107
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 2
       TableID: 107
     *scop.RemoveColumnFromIndex
       ColumnID: 2
@@ -1292,6 +1283,8 @@ StatementPhase stage 1 of 1 with 34 MutationType ops
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 1
+      TableID: 107
+    *scop.AssertColumnFamilyIsRemoved
       TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
@@ -1375,17 +1368,7 @@ PreCommitPhase stage 2 of 2 with 37 MutationType ops
       ColumnID: 1
       Name: crdb_internal_column_1_name_placeholder
       TableID: 107
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 2
-      TableID: 107
-    *scop.SetColumnName
-      ColumnID: 2
-      Name: crdb_internal_column_2_name_placeholder
-      TableID: 107
     *scop.MakePublicColumnNotNullValidated
-      ColumnID: 2
-      TableID: 107
-    *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 107
     *scop.MakePublicColumnWriteOnly
@@ -1439,9 +1422,14 @@ PreCommitPhase stage 2 of 2 with 37 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 107
-    *scop.AssertColumnFamilyIsRemoved
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 2
       TableID: 107
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.SetColumnName
+      ColumnID: 2
+      Name: crdb_internal_column_2_name_placeholder
+      TableID: 107
+    *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
@@ -1452,6 +1440,9 @@ PreCommitPhase stage 2 of 2 with 37 MutationType ops
       TableID: 107
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
+      TableID: 107
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 2
       TableID: 107
     *scop.RemoveColumnFromIndex
       ColumnID: 2
@@ -1464,6 +1455,8 @@ PreCommitPhase stage 2 of 2 with 37 MutationType ops
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 1
+      TableID: 107
+    *scop.AssertColumnFamilyIsRemoved
       TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -162,13 +162,6 @@ StatementPhase stage 1 of 1 with 154 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 109
       ParentSchemaID: 101
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 109
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 109
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 109
@@ -225,13 +218,6 @@ StatementPhase stage 1 of 1 with 154 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 108
       ParentSchemaID: 105
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 108
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 108
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 108
@@ -560,10 +546,12 @@ StatementPhase stage 1 of 1 with 154 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 105
       User: root
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 109
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 109
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -574,10 +562,12 @@ StatementPhase stage 1 of 1 with 154 MutationType ops
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 109
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 108
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 108
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 108
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -609,6 +599,11 @@ StatementPhase stage 1 of 1 with 154 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967294
       TableID: 113
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 109
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -627,6 +622,11 @@ StatementPhase stage 1 of 1 with 154 MutationType ops
     *scop.MakeIndexAbsent
       IndexID: 1
       TableID: 109
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 108
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 108
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -939,13 +939,6 @@ PreCommitPhase stage 2 of 2 with 166 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 109
       ParentSchemaID: 101
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 109
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 109
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 109
@@ -1002,13 +995,6 @@ PreCommitPhase stage 2 of 2 with 166 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 108
       ParentSchemaID: 105
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 108
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 108
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 108
@@ -1337,10 +1323,12 @@ PreCommitPhase stage 2 of 2 with 166 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 105
       User: root
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 109
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 109
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -1351,10 +1339,12 @@ PreCommitPhase stage 2 of 2 with 166 MutationType ops
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
       TableID: 109
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 108
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 108
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 108
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -1386,6 +1376,11 @@ PreCommitPhase stage 2 of 2 with 166 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967294
       TableID: 113
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 109
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -1404,6 +1399,11 @@ PreCommitPhase stage 2 of 2 with 166 MutationType ops
     *scop.MakeIndexAbsent
       IndexID: 1
       TableID: 109
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 108
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 108
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -52,10 +52,6 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 106, ColumnID: 1, IndexID: 0}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
   to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
@@ -584,9 +580,9 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 106, ColumnID: 1, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 1}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 106, ColumnID: 1, IndexID: 0}, ABSENT]
   to:   [Table:{DescID: 106}, ABSENT]
   kind: Precedence
@@ -1882,13 +1878,6 @@ StatementPhase stage 1 of 1 with 183 MutationType ops
       ParentSchemaID: 104
     *scop.RemoveTableComment
       TableID: 106
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 106
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 106
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 106
@@ -2377,10 +2366,12 @@ StatementPhase stage 1 of 1 with 183 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 106
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 106
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -2451,6 +2442,11 @@ StatementPhase stage 1 of 1 with 183 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967294
       TableID: 113
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 106
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 106
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1
@@ -2794,13 +2790,6 @@ PreCommitPhase stage 2 of 2 with 195 MutationType ops
       ParentSchemaID: 104
     *scop.RemoveTableComment
       TableID: 106
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 106
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 106
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 106
@@ -3289,10 +3278,12 @@ PreCommitPhase stage 2 of 2 with 195 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 106
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 106
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -3363,6 +3354,11 @@ PreCommitPhase stage 2 of 2 with 195 MutationType ops
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967294
       TableID: 113
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 106
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
+      TableID: 106
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -263,22 +263,8 @@ StatementPhase stage 1 of 1 with 117 MutationType ops
       ParentSchemaID: 101
     *scop.RemoveTableComment
       TableID: 109
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 109
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 109
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
-      TableID: 109
-    *scop.RemoveColumnDefaultExpression
-      ColumnID: 1
-      TableID: 109
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      PgAttributeNum: 1
       TableID: 109
     *scop.MakePublicColumnWriteOnly
       ColumnID: 2
@@ -430,10 +416,19 @@ StatementPhase stage 1 of 1 with 117 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 109
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 109
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 109
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
+      TableID: 109
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 1
+      TableID: 109
+    *scop.RemoveColumnComment
+      ColumnID: 1
+      PgAttributeNum: 1
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -458,6 +453,9 @@ StatementPhase stage 1 of 1 with 117 MutationType ops
     *scop.SetIndexName
       IndexID: 2
       Name: crdb_internal_index_2_name_placeholder
+      TableID: 109
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
       TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -511,6 +509,8 @@ StatementPhase stage 1 of 1 with 117 MutationType ops
       TableID: 109
     *scop.MakeIndexAbsent
       IndexID: 2
+      TableID: 109
+    *scop.AssertColumnFamilyIsRemoved
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
@@ -848,22 +848,8 @@ PreCommitPhase stage 2 of 2 with 127 MutationType ops
       ParentSchemaID: 101
     *scop.RemoveTableComment
       TableID: 109
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 109
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 109
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
-      TableID: 109
-    *scop.RemoveColumnDefaultExpression
-      ColumnID: 1
-      TableID: 109
-    *scop.RemoveColumnComment
-      ColumnID: 1
-      PgAttributeNum: 1
       TableID: 109
     *scop.MakePublicColumnWriteOnly
       ColumnID: 2
@@ -1015,10 +1001,19 @@ PreCommitPhase stage 2 of 2 with 127 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 109
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 109
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 109
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
+      TableID: 109
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 1
+      TableID: 109
+    *scop.RemoveColumnComment
+      ColumnID: 1
+      PgAttributeNum: 1
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -1043,6 +1038,9 @@ PreCommitPhase stage 2 of 2 with 127 MutationType ops
     *scop.SetIndexName
       IndexID: 2
       Name: crdb_internal_index_2_name_placeholder
+      TableID: 109
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
       TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -1096,6 +1094,8 @@ PreCommitPhase stage 2 of 2 with 127 MutationType ops
       TableID: 109
     *scop.MakeIndexAbsent
       IndexID: 2
+      TableID: 109
+    *scop.AssertColumnFamilyIsRemoved
       TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
@@ -1257,10 +1257,6 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
   to:   [ColumnName:{DescID: 109, Name: tracking_number, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 109, ColumnID: 1, IndexID: 0}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
@@ -1596,9 +1592,9 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 109, ColumnID: 1, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 109, ColumnID: 1}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 109, ColumnID: 1, IndexID: 0}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
   kind: Precedence
@@ -2545,13 +2541,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 47 MutationType ops
     *scop.RemoveObjectParent
       ObjectID: 104
       ParentSchemaID: 101
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 1
-      TableID: 104
-    *scop.SetColumnName
-      ColumnID: 1
-      Name: crdb_internal_column_1_name_placeholder
-      TableID: 104
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 1
       TableID: 104
@@ -2601,8 +2590,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 47 MutationType ops
     *scop.RemoveUserPrivileges
       DescriptorID: 104
       User: root
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 104
     *scop.RemoveColumnNotNull
       ColumnID: 1
       TableID: 104
@@ -2615,8 +2602,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 47 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 104
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 1
+      TableID: 104
+    *scop.SetColumnName
+      ColumnID: 1
+      Name: crdb_internal_column_1_name_placeholder
       TableID: 104
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -2633,6 +2624,11 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 47 MutationType ops
     *scop.SetIndexName
       IndexID: 2
       Name: crdb_internal_index_2_name_placeholder
+      TableID: 104
+    *scop.AssertColumnFamilyIsRemoved
+      TableID: 104
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 1
       TableID: 104
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -2721,10 +2717,6 @@ DROP TABLE defaultdb.customers CASCADE;
   rule: non-data dependents removed before descriptor
 - from: [Column:{DescID: 104, ColumnID: 1}, WRITE_ONLY]
   to:   [ColumnName:{DescID: 104, Name: id, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 104, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnNotNull:{DescID: 104, ColumnID: 1, IndexID: 0}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 104, ColumnID: 1}, WRITE_ONLY]
@@ -2824,9 +2816,9 @@ DROP TABLE defaultdb.customers CASCADE;
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnNotNull:{DescID: 104, ColumnID: 1, IndexID: 0}, ABSENT]
-  to:   [Column:{DescID: 104, ColumnID: 1}, DELETE_ONLY]
-  kind: SameStagePrecedence
-  rule: column constraint removed right before column reaches delete only
+  to:   [Column:{DescID: 104, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: column constraint removed right before column reaches write only
 - from: [ColumnNotNull:{DescID: 104, ColumnID: 1, IndexID: 0}, ABSENT]
   to:   [Table:{DescID: 104}, ABSENT]
   kind: Precedence
@@ -3260,35 +3252,10 @@ StatementPhase stage 1 of 1 with 55 MutationType ops
       TypeIDs:
       - 113
       - 114
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 2
-      TableID: 115
-    *scop.SetColumnName
-      ColumnID: 2
-      Name: crdb_internal_column_2_name_placeholder
-      TableID: 115
-    *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 115
-    *scop.UpdateTableBackReferencesInTypes
-      BackReferencedTableID: 115
-      TypeIDs:
-      - 113
-      - 114
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 2
       TableID: 115
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 3
-      TableID: 115
-    *scop.SetColumnName
-      ColumnID: 3
-      Name: crdb_internal_column_3_name_placeholder
-      TableID: 115
     *scop.MakePublicColumnNotNullValidated
-      ColumnID: 3
-      TableID: 115
-    *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 115
     *scop.MakePublicColumnWriteOnly
@@ -3345,12 +3312,29 @@ StatementPhase stage 1 of 1 with 55 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 115
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 115
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 2
       TableID: 115
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.SetColumnName
+      ColumnID: 2
+      Name: crdb_internal_column_2_name_placeholder
+      TableID: 115
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 115
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 115
+      TypeIDs:
+      - 113
+      - 114
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 3
+      TableID: 115
+    *scop.SetColumnName
+      ColumnID: 3
+      Name: crdb_internal_column_3_name_placeholder
+      TableID: 115
+    *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 115
     *scop.MakeDeleteOnlyColumnAbsent
@@ -3376,6 +3360,12 @@ StatementPhase stage 1 of 1 with 55 MutationType ops
     *scop.SetIndexName
       IndexID: 2
       Name: crdb_internal_index_2_name_placeholder
+      TableID: 115
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 2
+      TableID: 115
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 3
       TableID: 115
     *scop.RemoveColumnFromIndex
       ColumnID: 3
@@ -3406,6 +3396,8 @@ StatementPhase stage 1 of 1 with 55 MutationType ops
       TableID: 115
     *scop.MakeIndexAbsent
       IndexID: 2
+      TableID: 115
+    *scop.AssertColumnFamilyIsRemoved
       TableID: 115
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
@@ -3533,35 +3525,10 @@ PreCommitPhase stage 2 of 2 with 59 MutationType ops
       TypeIDs:
       - 113
       - 114
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 2
-      TableID: 115
-    *scop.SetColumnName
-      ColumnID: 2
-      Name: crdb_internal_column_2_name_placeholder
-      TableID: 115
-    *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 115
-    *scop.UpdateTableBackReferencesInTypes
-      BackReferencedTableID: 115
-      TypeIDs:
-      - 113
-      - 114
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 2
       TableID: 115
-    *scop.MakePublicColumnWriteOnly
-      ColumnID: 3
-      TableID: 115
-    *scop.SetColumnName
-      ColumnID: 3
-      Name: crdb_internal_column_3_name_placeholder
-      TableID: 115
     *scop.MakePublicColumnNotNullValidated
-      ColumnID: 3
-      TableID: 115
-    *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 115
     *scop.MakePublicColumnWriteOnly
@@ -3618,12 +3585,29 @@ PreCommitPhase stage 2 of 2 with 59 MutationType ops
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 4294967294
       TableID: 115
-    *scop.AssertColumnFamilyIsRemoved
-      TableID: 115
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.MakePublicColumnWriteOnly
       ColumnID: 2
       TableID: 115
-    *scop.MakeWriteOnlyColumnDeleteOnly
+    *scop.SetColumnName
+      ColumnID: 2
+      Name: crdb_internal_column_2_name_placeholder
+      TableID: 115
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 115
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 115
+      TypeIDs:
+      - 113
+      - 114
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 3
+      TableID: 115
+    *scop.SetColumnName
+      ColumnID: 3
+      Name: crdb_internal_column_3_name_placeholder
+      TableID: 115
+    *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 115
     *scop.MakeDeleteOnlyColumnAbsent
@@ -3649,6 +3633,12 @@ PreCommitPhase stage 2 of 2 with 59 MutationType ops
     *scop.SetIndexName
       IndexID: 2
       Name: crdb_internal_index_2_name_placeholder
+      TableID: 115
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 2
+      TableID: 115
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 3
       TableID: 115
     *scop.RemoveColumnFromIndex
       ColumnID: 3
@@ -3679,6 +3669,8 @@ PreCommitPhase stage 2 of 2 with 59 MutationType ops
       TableID: 115
     *scop.MakeIndexAbsent
       IndexID: 2
+      TableID: 115
+    *scop.AssertColumnFamilyIsRemoved
       TableID: 115
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -349,6 +349,13 @@ func TestEndToEndSideEffects_drop_column_with_index(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_drop_column_with_partial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -759,6 +766,13 @@ func TestExecuteWithDMLInjection_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1175,6 +1189,13 @@ func TestGenerateSchemaChangeCorpus_drop_column_with_index(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_drop_column_with_partial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1585,6 +1606,13 @@ func TestPause_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2001,6 +2029,13 @@ func TestPauseMixedVersion_drop_column_with_index(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_drop_column_with_partial_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2411,6 +2446,13 @@ func TestRollback_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_drop_column_with_null_constraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_2_of_7.explain
@@ -26,6 +26,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -36,7 +37,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_3_of_7.explain
@@ -26,6 +26,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -36,7 +37,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_4_of_7.explain
@@ -26,6 +26,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -36,7 +37,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_5_of_7.explain
@@ -26,6 +26,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -36,7 +37,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_6_of_7.explain
@@ -26,6 +26,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -36,7 +37,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column/add_column__rollback_7_of_7.explain
@@ -26,6 +26,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
@@ -36,7 +37,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_2_of_7.explain
@@ -21,6 +21,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 2 (tbl_pkey-)}
       │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
@@ -29,7 +30,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_3_of_7.explain
@@ -21,6 +21,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 2 (tbl_pkey-)}
       │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
@@ -29,7 +30,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_4_of_7.explain
@@ -21,6 +21,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 3}
       │    │    └── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 2 (tbl_pkey-)}
       │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
@@ -29,7 +30,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_5_of_7.explain
@@ -21,6 +21,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 2 (tbl_pkey-)}
       │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -29,7 +30,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_6_of_7.explain
@@ -21,6 +21,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 2 (tbl_pkey-)}
       │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -29,7 +30,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq/add_column_default_seq__rollback_7_of_7.explain
@@ -21,6 +21,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 3}
       │    │    └── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (l-), IndexID: 2 (tbl_pkey-)}
       │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
@@ -29,7 +30,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_2_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_2_of_8.explain
@@ -22,6 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -32,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_3_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_3_of_8.explain
@@ -22,6 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -32,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_4_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_4_of_8.explain
@@ -22,6 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -32,7 +33,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_5_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_5_of_8.explain
@@ -8,8 +8,9 @@ EXPLAIN (DDL) rollback at post-commit stage 5 of 8;
 ----
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
       │    │    ├── PUBLIC      → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
@@ -20,7 +21,8 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
@@ -33,26 +35,19 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
-      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
-      │    └── 7 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
-           └── 3 Mutation operations
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 7 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_6_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_6_of_8.explain
@@ -8,8 +8,9 @@ EXPLAIN (DDL) rollback at post-commit stage 6 of 8;
 ----
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
       │    │    ├── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
@@ -20,7 +21,8 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
@@ -33,28 +35,21 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
-      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
-           └── 3 Mutation operations
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 8 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_7_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_7_of_8.explain
@@ -8,8 +8,9 @@ EXPLAIN (DDL) rollback at post-commit stage 7 of 8;
 ----
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
       │    │    ├── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
@@ -20,7 +21,8 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
@@ -33,28 +35,21 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
-      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
-           └── 3 Mutation operations
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 8 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_8_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_8_of_8.explain
@@ -8,8 +8,9 @@ EXPLAIN (DDL) rollback at post-commit stage 8 of 8;
 ----
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 10 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
@@ -20,7 +21,8 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
@@ -33,26 +35,19 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
-      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
-      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
-      │    └── 7 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
-           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
-           └── 3 Mutation operations
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 7 Mutation operations
+                ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null__rollback_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null__rollback_2_of_2.explain
@@ -15,9 +15,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 3 (j-)}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 1 (tbl_pkey)}
       │    └── 5 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_2_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_3_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_4_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_5_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_6_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored/add_column_with_stored__rollback_7_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_2_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_3_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_4_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_5_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_6_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_with_stored_family/add_column_with_stored_family__rollback_7_of_7.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 3}
       │    │    └── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 2 (tbl_pkey-)}
       │    └── 13 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid.explain
@@ -19,11 +19,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
- │         ├── 3 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
+ │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
- │         └── 11 Mutation operations
+ │         └── 9 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
@@ -32,9 +30,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":2,"TableID":104,"TemporaryIndexID":5}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
- │              └── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 3 elements transitioning toward PUBLIC
@@ -49,9 +45,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 3}
  │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
- │    │    ├── 3 elements transitioning toward ABSENT
- │    │    │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
- │    │    │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
+ │    │    ├── 1 element transitioning toward ABSENT
  │    │    │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
@@ -68,11 +62,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
- │         ├── 3 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
+ │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
- │         └── 16 Mutation operations
+ │         └── 14 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
@@ -85,8 +77,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":2,"TableID":104,"TemporaryIndexID":5}}
  │              ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -210,23 +200,25 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey~)}
       │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY      Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → WRITE_ONLY       Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
+      │    │    ├── PUBLIC                → ABSENT           ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
       │    │    ├── VALIDATED             → ABSENT           ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
       │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
@@ -236,9 +228,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey~), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
       │    │    └── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 2 (t_pkey~)}
-      │    ├── 1 element transitioning toward ABSENT
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY         Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
       │    │    └── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 7 Mutation operations
+      │    └── 8 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid.side_effects
@@ -20,38 +20,24 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 11 MutationType ops
+## StatementPhase stage 1 of 1 with 9 MutationType ops
 upsert descriptor #104
    table:
   +  checks:
   +  - columnIds:
   +    - 2
-  +    expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +    expr: rowid IS NOT NULL
   +    isNonNullConstraint: true
   +    name: rowid_auto_not_null
   +    validity: Dropping
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
-  -  - defaultExpr: unique_rowid()
-  -    hidden: true
-  -    id: 2
-  -    name: rowid
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
-  ...
-       columnNames:
-       - a
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 1
-       name: primary
+       id: 2
+       name: rowid
+  +    nullable: true
+       type:
+         family: IntFamily
   ...
      id: 104
      modificationTime: {}
@@ -60,7 +46,7 @@ upsert descriptor #104
   +      check:
   +        columnIds:
   +        - 2
-  +        expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +        expr: rowid IS NOT NULL
   +        isNonNullConstraint: true
   +        name: rowid_auto_not_null
   +        validity: Dropping
@@ -93,7 +79,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      version: 4
   +    mutationId: 1
@@ -119,7 +105,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      useDeletePreservingEncoding: true
   +      version: 4
@@ -148,19 +134,6 @@ upsert descriptor #104
   +      version: 4
   +    mutationId: 1
   +    state: BACKFILLING
-  +  - column:
-  +      defaultExpr: unique_rowid()
-  +      hidden: true
-  +      id: 2
-  +      name: crdb_internal_column_2_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   -  nextConstraintId: 2
@@ -171,13 +144,6 @@ upsert descriptor #104
      nextMutationId: 1
      parentId: 100
   ...
-       - 2
-       keyColumnNames:
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       name: t_pkey
-       partitioning: {}
-  ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "1"
@@ -187,29 +153,25 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 16 MutationType ops
+## PreCommitPhase stage 2 of 2 with 14 MutationType ops
 upsert descriptor #104
    table:
   +  checks:
   +  - columnIds:
   +    - 2
-  +    expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +    expr: rowid IS NOT NULL
   +    isNonNullConstraint: true
   +    name: rowid_auto_not_null
   +    validity: Dropping
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
-  -  - defaultExpr: unique_rowid()
-  -    hidden: true
-  -    id: 2
-  -    name: rowid
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
+       id: 2
+       name: rowid
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
      createAsOfTime:
        wallTime: "1640995200000000000"
   +  declarativeSchemaChangerState:
@@ -239,13 +201,6 @@ upsert descriptor #104
      families:
      - columnIds:
   ...
-       columnNames:
-       - a
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 1
-       name: primary
-  ...
      id: 104
      modificationTime: {}
   +  mutations:
@@ -253,7 +208,7 @@ upsert descriptor #104
   +      check:
   +        columnIds:
   +        - 2
-  +        expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +        expr: rowid IS NOT NULL
   +        isNonNullConstraint: true
   +        name: rowid_auto_not_null
   +        validity: Dropping
@@ -286,7 +241,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      version: 4
   +    mutationId: 1
@@ -312,7 +267,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      useDeletePreservingEncoding: true
   +      version: 4
@@ -341,19 +296,6 @@ upsert descriptor #104
   +      version: 4
   +    mutationId: 1
   +    state: BACKFILLING
-  +  - column:
-  +      defaultExpr: unique_rowid()
-  +      hidden: true
-  +      id: 2
-  +      name: crdb_internal_column_2_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   -  nextConstraintId: 2
@@ -363,13 +305,6 @@ upsert descriptor #104
   +  nextIndexId: 5
      nextMutationId: 1
      parentId: 100
-  ...
-       - 2
-       keyColumnNames:
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       name: t_pkey
-       partitioning: {}
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -484,36 +419,59 @@ upsert descriptor #104
        mutationId: 1
        state: WRITE_ONLY
   -  - direction: ADD
-  -    index:
-  -      constraintId: 2
-  -      createdExplicitly: true
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - a
-  -      name: crdb_internal_index_2_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnIds:
-  -      - 2
-  -      storeColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
-  -      unique: true
-  -      version: 4
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-     - direction: DROP
+  +  - direction: DROP
        index:
+  -      constraintId: 2
+  +      constraintId: 3
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 2
+  +      id: 3
+         interleave: {}
+         keyColumnDirections:
   ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_2_name_placeholder
+  +      name: crdb_internal_index_3_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - rowid
+         unique: true
+  +      useDeletePreservingEncoding: true
+         version: 4
        mutationId: 1
-       state: WRITE_ONLY
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+       index:
+  -      constraintId: 3
+  +      constraintId: 4
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 3
+  +      id: 4
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_3_name_placeholder
+  +      name: crdb_internal_index_4_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnIds:
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
   +  - direction: DROP
   +    index:
   +      constraintId: 1
@@ -526,9 +484,10 @@ upsert descriptor #104
   +      keyColumnDirections:
   +      - ASC
   +      keyColumnIds:
-  +      - 2
+         - 2
+  -      storeColumnNames:
   +      keyColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+         - rowid
   +      name: crdb_internal_index_1_name_placeholder
   +      partitioning: {}
   +      sharded: {}
@@ -536,33 +495,37 @@ upsert descriptor #104
   +      - 1
   +      storeColumnNames:
   +      - a
-  +      unique: true
-  +      version: 4
-  +    mutationId: 1
+         unique: true
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-  +  - direction: ADD
-  +    index:
+     - direction: ADD
+       index:
+  -      constraintId: 4
   +      constraintId: 5
-  +      createdExplicitly: true
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 4
   +      id: 5
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - a
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_4_name_placeholder
   +      name: crdb_internal_index_5_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnNames: []
-  +      unique: true
+         partitioning: {}
+         sharded: {}
+         storeColumnNames: []
+         unique: true
   +      useDeletePreservingEncoding: true
-  +      version: 4
-  +    mutationId: 1
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
   +    state: DELETE_ONLY
      name: t
      nextColumnId: 3
@@ -590,7 +553,7 @@ upsert descriptor #104
   -    - 2
   +    - 1
        keyColumnNames:
-  -    - crdb_internal_column_2_name_placeholder
+  -    - rowid
   +    - a
        name: t_pkey
        partitioning: {}
@@ -600,7 +563,7 @@ upsert descriptor #104
   +    - 2
        storeColumnNames:
   -    - a
-  +    - crdb_internal_column_2_name_placeholder
+  +    - rowid
        unique: true
        version: 4
   ...
@@ -641,8 +604,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: BACKFILLING
   +    state: DELETE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
+     - direction: DROP
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -659,8 +622,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: MERGING
-     - column:
-         defaultExpr: unique_rowid()
+     - direction: DROP
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -681,8 +644,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: MERGING
   +    state: WRITE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
+     - direction: DROP
+       index:
   ...
        mutationId: 1
        state: WRITE_ONLY
@@ -710,13 +673,13 @@ begin transaction #17
 validate forward indexes [4] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 4 with 12 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 4 with 13 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
   -  - columnIds:
   -    - 2
-  -    expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  -    expr: rowid IS NOT NULL
   -    isNonNullConstraint: true
   -    name: rowid_auto_not_null
   -    validity: Dropping
@@ -724,11 +687,32 @@ upsert descriptor #104
      columns:
      - id: 1
   ...
+         oid: 20
+         width: 64
+  -  - defaultExpr: unique_rowid()
+  -    hidden: true
+  -    id: 2
+  -    name: rowid
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
            statement: ALTER TABLE t ADD PRIMARY KEY (a)
            statementTag: ALTER TABLE
   -    revertible: true
        targetRanks: <redacted>
        targets: <redacted>
+  ...
+       columnNames:
+       - a
+  -    - rowid
+  +    - crdb_internal_column_2_name_placeholder
+       defaultColumnId: 1
+       name: primary
   ...
      modificationTime: {}
      mutations:
@@ -736,7 +720,7 @@ upsert descriptor #104
   -      check:
   -        columnIds:
   -        - 2
-  -        expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  -        expr: rowid IS NOT NULL
   -        isNonNullConstraint: true
   -        name: rowid_auto_not_null
   -        validity: Dropping
@@ -769,7 +753,7 @@ upsert descriptor #104
   -      storeColumnIds:
   -      - 2
   -      storeColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
+  -      - rowid
   -      unique: true
   -      useDeletePreservingEncoding: true
   -      version: 4
@@ -778,12 +762,12 @@ upsert descriptor #104
      - direction: ADD
        index:
   ...
-       direction: DROP
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
+         - 2
+         keyColumnNames:
+  -      - rowid
+  +      - crdb_internal_column_2_name_placeholder
+         name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
   ...
          version: 4
        mutationId: 1
@@ -812,72 +796,99 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
        state: DELETE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      hidden: true
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: t
+     nextColumnId: 3
+  ...
+       - 2
+       storeColumnNames:
+  -    - rowid
+  +    - crdb_internal_column_2_name_placeholder
+       unique: true
+       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "11"
   +  version: "12"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 5 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 6 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #18
 begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 4 with 7 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 4 with 8 MutationType ops
 upsert descriptor #104
   ...
      modificationTime: {}
      mutations:
   -  - direction: ADD
-  -    index:
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      hidden: true
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
   -      constraintId: 4
-  -      createdExplicitly: true
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
+  +      constraintId: 2
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
   -      id: 4
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - a
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
   -      name: crdb_internal_index_4_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         sharded: {}
   -      storeColumnNames: []
   -      unique: true
   -      version: 4
   -    mutationId: 1
   -    state: WRITE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
-  ...
-     - direction: DROP
-       index:
+  -  - direction: DROP
+  -    index:
   -      constraintId: 1
   -      createdAtNanos: "1640995200000000000"
-  +      constraintId: 2
-  +      createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
   -      id: 1
-  +      id: 2
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
   -      - 2
-  +      - 1
-         keyColumnNames:
+  -      keyColumnNames:
   -      - crdb_internal_column_2_name_placeholder
   -      name: crdb_internal_index_1_name_placeholder
-  +      - a
-  +      name: crdb_internal_index_2_name_placeholder
-         partitioning: {}
-         sharded: {}
+  -      partitioning: {}
+  -      sharded: {}
          storeColumnIds:
   -      - 1
   +      - 2
@@ -888,9 +899,20 @@ upsert descriptor #104
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      hidden: true
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+       state: WRITE_ONLY
      name: t
-     nextColumnId: 3
   ...
      parentId: 100
      primaryIndex:

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_10_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_11_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_12_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_13_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -34,8 +31,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_14_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -34,8 +31,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_15_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_1_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+           ├── 1 element transitioning toward PUBLIC
            │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
            ├── 10 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -23,16 +21,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
            │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           └── 16 Mutation operations
-                ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+           └── 13 Mutation operations
                 ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-                ├── RefreshStats {"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_2_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_3_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_4_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_5_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,15 +19,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_6_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,15 +19,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_7_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_8_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid__rollback_9_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC    Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC    ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC    ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -34,8 +31,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
@@ -259,15 +259,17 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
       │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → WRITE_ONLY       Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
       │    │    ├── PUBLIC                → ABSENT           ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 3 (rowid-)}
+      │    │    ├── VALIDATED             → ABSENT           ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 1 (t_pkey-)}
       │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    └── PUBLIC                → VALIDATED        SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
-      │    └── 22 Mutation operations
+      │    └── 23 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
@@ -297,21 +299,19 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
       │    │    └── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY         Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
-      │    │    ├── VALIDATED   → ABSENT              ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
       │    │    ├── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    ├── PUBLIC      → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 2 (idx_b-)}
       │    │    ├── PUBLIC      → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (idx_b-)}
       │    │    ├── VALIDATED   → DELETE_ONLY         SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
       │    │    └── PUBLIC      → ABSENT              IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 2 (idx_b-)}
-      │    └── 13 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │    └── 12 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"t_pkey","TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
@@ -781,15 +781,19 @@ validate forward indexes [8] in table #104
 validate forward indexes [4] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 4 with 22 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 4 with 23 MutationType ops
 upsert descriptor #104
-  ...
-     - columnIds:
-       - 3
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
   -    expr: rowid IS NOT NULL
-  +    expr: crdb_internal_column_3_name_placeholder IS NOT NULL
-       isNonNullConstraint: true
-       name: rowid_auto_not_null
+  -    isNonNullConstraint: true
+  -    name: rowid_auto_not_null
+  -    validity: Dropping
+  +  checks: []
+     columns:
+     - id: 1
   ...
          oid: 20
          width: 64
@@ -840,16 +844,23 @@ upsert descriptor #104
   +    storeColumnNames: []
        version: 4
      modificationTime: {}
-  ...
-           columnIds:
-           - 3
+     mutations:
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
   -        expr: rowid IS NOT NULL
-  +        expr: crdb_internal_column_3_name_placeholder IS NOT NULL
-           isNonNullConstraint: true
-           name: rowid_auto_not_null
-  ...
-       mutationId: 1
-       state: WRITE_ONLY
+  -        isNonNullConstraint: true
+  -        name: rowid_auto_not_null
+  -        validity: Dropping
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: rowid_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 5
@@ -1000,42 +1011,15 @@ upsert descriptor #104
   +  version: "18"
 persist all catalog changes to storage
 adding table for stats refresh: 104
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 11 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 10 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #18
 begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 4 with 13 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
 upsert descriptor #104
-   table:
-  -  checks:
-  -  - columnIds:
-  -    - 3
-  -    expr: crdb_internal_column_3_name_placeholder IS NOT NULL
-  -    isNonNullConstraint: true
-  -    name: rowid_auto_not_null
-  -    validity: Dropping
-  +  checks: []
-     columns:
-     - id: 1
   ...
      modificationTime: {}
      mutations:
-  -  - constraint:
-  -      check:
-  -        columnIds:
-  -        - 3
-  -        expr: crdb_internal_column_3_name_placeholder IS NOT NULL
-  -        isNonNullConstraint: true
-  -        name: rowid_auto_not_null
-  -        validity: Dropping
-  -      constraintType: NOT_NULL
-  -      foreignKey: {}
-  -      name: rowid_auto_not_null
-  -      notNullColumn: 3
-  -      uniqueWithoutIndexConstraint: {}
-  -    direction: DROP
-  -    mutationId: 1
-  -    state: WRITE_ONLY
   -  - direction: ADD
   +  - direction: DROP
        index:

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.explain
@@ -19,11 +19,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
- │         ├── 3 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
+ │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
- │         └── 11 Mutation operations
+ │         └── 9 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
@@ -32,9 +30,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":2,"TableID":104,"TemporaryIndexID":5}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
- │              └── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 3 elements transitioning toward PUBLIC
@@ -49,9 +45,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 3}
  │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
- │    │    ├── 3 elements transitioning toward ABSENT
- │    │    │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
- │    │    │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
+ │    │    ├── 1 element transitioning toward ABSENT
  │    │    │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
@@ -68,11 +62,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
- │         ├── 3 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
+ │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
- │         └── 16 Mutation operations
+ │         └── 14 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
@@ -85,8 +77,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":2,"TableID":104,"TemporaryIndexID":5}}
  │              ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -210,23 +200,25 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey~)}
       │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY      Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → WRITE_ONLY       Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
+      │    │    ├── PUBLIC                → ABSENT           ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid-)}
       │    │    ├── VALIDATED             → ABSENT           ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 0}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (rowid-), IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
       │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
@@ -236,9 +228,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey~), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
       │    │    └── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 2 (t_pkey~)}
-      │    ├── 1 element transitioning toward ABSENT
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY         Column:{DescID: 104 (t), ColumnID: 2 (rowid-)}
       │    │    └── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 7 Mutation operations
+      │    └── 8 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.side_effects
@@ -20,38 +20,24 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 11 MutationType ops
+## StatementPhase stage 1 of 1 with 9 MutationType ops
 upsert descriptor #104
    table:
   +  checks:
   +  - columnIds:
   +    - 2
-  +    expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +    expr: rowid IS NOT NULL
   +    isNonNullConstraint: true
   +    name: rowid_auto_not_null
   +    validity: Dropping
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
-  -  - defaultExpr: unique_rowid()
-  -    hidden: true
-  -    id: 2
-  -    name: rowid
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
-  ...
-       columnNames:
-       - a
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 1
-       name: primary
+       id: 2
+       name: rowid
+  +    nullable: true
+       type:
+         family: IntFamily
   ...
      id: 104
      modificationTime: {}
@@ -60,7 +46,7 @@ upsert descriptor #104
   +      check:
   +        columnIds:
   +        - 2
-  +        expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +        expr: rowid IS NOT NULL
   +        isNonNullConstraint: true
   +        name: rowid_auto_not_null
   +        validity: Dropping
@@ -93,7 +79,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      version: 4
   +    mutationId: 1
@@ -119,7 +105,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      useDeletePreservingEncoding: true
   +      version: 4
@@ -148,19 +134,6 @@ upsert descriptor #104
   +      version: 4
   +    mutationId: 1
   +    state: BACKFILLING
-  +  - column:
-  +      defaultExpr: unique_rowid()
-  +      hidden: true
-  +      id: 2
-  +      name: crdb_internal_column_2_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   -  nextConstraintId: 2
@@ -171,13 +144,6 @@ upsert descriptor #104
      nextMutationId: 1
      parentId: 100
   ...
-       - 2
-       keyColumnNames:
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       name: t_pkey
-       partitioning: {}
-  ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "1"
@@ -187,29 +153,25 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 16 MutationType ops
+## PreCommitPhase stage 2 of 2 with 14 MutationType ops
 upsert descriptor #104
    table:
   +  checks:
   +  - columnIds:
   +    - 2
-  +    expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +    expr: rowid IS NOT NULL
   +    isNonNullConstraint: true
   +    name: rowid_auto_not_null
   +    validity: Dropping
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
-  -  - defaultExpr: unique_rowid()
-  -    hidden: true
-  -    id: 2
-  -    name: rowid
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
+       id: 2
+       name: rowid
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
      createAsOfTime:
        wallTime: "1640995200000000000"
   +  declarativeSchemaChangerState:
@@ -239,13 +201,6 @@ upsert descriptor #104
      families:
      - columnIds:
   ...
-       columnNames:
-       - a
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 1
-       name: primary
-  ...
      id: 104
      modificationTime: {}
   +  mutations:
@@ -253,7 +208,7 @@ upsert descriptor #104
   +      check:
   +        columnIds:
   +        - 2
-  +        expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  +        expr: rowid IS NOT NULL
   +        isNonNullConstraint: true
   +        name: rowid_auto_not_null
   +        validity: Dropping
@@ -286,7 +241,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      version: 4
   +    mutationId: 1
@@ -312,7 +267,7 @@ upsert descriptor #104
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+  +      - rowid
   +      unique: true
   +      useDeletePreservingEncoding: true
   +      version: 4
@@ -341,19 +296,6 @@ upsert descriptor #104
   +      version: 4
   +    mutationId: 1
   +    state: BACKFILLING
-  +  - column:
-  +      defaultExpr: unique_rowid()
-  +      hidden: true
-  +      id: 2
-  +      name: crdb_internal_column_2_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   -  nextConstraintId: 2
@@ -363,13 +305,6 @@ upsert descriptor #104
   +  nextIndexId: 5
      nextMutationId: 1
      parentId: 100
-  ...
-       - 2
-       keyColumnNames:
-  -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       name: t_pkey
-       partitioning: {}
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -484,36 +419,59 @@ upsert descriptor #104
        mutationId: 1
        state: WRITE_ONLY
   -  - direction: ADD
-  -    index:
-  -      constraintId: 2
-  -      createdExplicitly: true
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - a
-  -      name: crdb_internal_index_2_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnIds:
-  -      - 2
-  -      storeColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
-  -      unique: true
-  -      version: 4
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-     - direction: DROP
+  +  - direction: DROP
        index:
+  -      constraintId: 2
+  +      constraintId: 3
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 2
+  +      id: 3
+         interleave: {}
+         keyColumnDirections:
   ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_2_name_placeholder
+  +      name: crdb_internal_index_3_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - rowid
+         unique: true
+  +      useDeletePreservingEncoding: true
+         version: 4
        mutationId: 1
-       state: WRITE_ONLY
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+       index:
+  -      constraintId: 3
+  +      constraintId: 4
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 3
+  +      id: 4
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_3_name_placeholder
+  +      name: crdb_internal_index_4_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnIds:
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
   +  - direction: DROP
   +    index:
   +      constraintId: 1
@@ -526,9 +484,10 @@ upsert descriptor #104
   +      keyColumnDirections:
   +      - ASC
   +      keyColumnIds:
-  +      - 2
+         - 2
+  -      storeColumnNames:
   +      keyColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
+         - rowid
   +      name: crdb_internal_index_1_name_placeholder
   +      partitioning: {}
   +      sharded: {}
@@ -536,33 +495,37 @@ upsert descriptor #104
   +      - 1
   +      storeColumnNames:
   +      - a
-  +      unique: true
-  +      version: 4
-  +    mutationId: 1
+         unique: true
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-  +  - direction: ADD
-  +    index:
+     - direction: ADD
+       index:
+  -      constraintId: 4
   +      constraintId: 5
-  +      createdExplicitly: true
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 4
   +      id: 5
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - a
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_4_name_placeholder
   +      name: crdb_internal_index_5_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnNames: []
-  +      unique: true
+         partitioning: {}
+         sharded: {}
+         storeColumnNames: []
+         unique: true
   +      useDeletePreservingEncoding: true
-  +      version: 4
-  +    mutationId: 1
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
   +    state: DELETE_ONLY
      name: t
      nextColumnId: 3
@@ -590,7 +553,7 @@ upsert descriptor #104
   -    - 2
   +    - 1
        keyColumnNames:
-  -    - crdb_internal_column_2_name_placeholder
+  -    - rowid
   +    - a
        name: t_pkey
        partitioning: {}
@@ -600,7 +563,7 @@ upsert descriptor #104
   +    - 2
        storeColumnNames:
   -    - a
-  +    - crdb_internal_column_2_name_placeholder
+  +    - rowid
        unique: true
        version: 4
   ...
@@ -641,8 +604,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: BACKFILLING
   +    state: DELETE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
+     - direction: DROP
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -659,8 +622,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: MERGING
-     - column:
-         defaultExpr: unique_rowid()
+     - direction: DROP
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -681,8 +644,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: MERGING
   +    state: WRITE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
+     - direction: DROP
+       index:
   ...
        mutationId: 1
        state: WRITE_ONLY
@@ -710,13 +673,13 @@ begin transaction #17
 validate forward indexes [4] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 4 with 12 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 4 with 13 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
   -  - columnIds:
   -    - 2
-  -    expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  -    expr: rowid IS NOT NULL
   -    isNonNullConstraint: true
   -    name: rowid_auto_not_null
   -    validity: Dropping
@@ -724,11 +687,32 @@ upsert descriptor #104
      columns:
      - id: 1
   ...
+         oid: 20
+         width: 64
+  -  - defaultExpr: unique_rowid()
+  -    hidden: true
+  -    id: 2
+  -    name: rowid
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
            statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a)
            statementTag: ALTER TABLE
   -    revertible: true
        targetRanks: <redacted>
        targets: <redacted>
+  ...
+       columnNames:
+       - a
+  -    - rowid
+  +    - crdb_internal_column_2_name_placeholder
+       defaultColumnId: 1
+       name: primary
   ...
      modificationTime: {}
      mutations:
@@ -736,7 +720,7 @@ upsert descriptor #104
   -      check:
   -        columnIds:
   -        - 2
-  -        expr: crdb_internal_column_2_name_placeholder IS NOT NULL
+  -        expr: rowid IS NOT NULL
   -        isNonNullConstraint: true
   -        name: rowid_auto_not_null
   -        validity: Dropping
@@ -769,7 +753,7 @@ upsert descriptor #104
   -      storeColumnIds:
   -      - 2
   -      storeColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
+  -      - rowid
   -      unique: true
   -      useDeletePreservingEncoding: true
   -      version: 4
@@ -778,12 +762,12 @@ upsert descriptor #104
      - direction: ADD
        index:
   ...
-       direction: DROP
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
+         - 2
+         keyColumnNames:
+  -      - rowid
+  +      - crdb_internal_column_2_name_placeholder
+         name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
   ...
          version: 4
        mutationId: 1
@@ -812,72 +796,99 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
        state: DELETE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      hidden: true
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: t
+     nextColumnId: 3
+  ...
+       - 2
+       storeColumnNames:
+  -    - rowid
+  +    - crdb_internal_column_2_name_placeholder
+       unique: true
+       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "11"
   +  version: "12"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 5 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 6 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #18
 begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 4 with 7 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 4 with 8 MutationType ops
 upsert descriptor #104
   ...
      modificationTime: {}
      mutations:
   -  - direction: ADD
-  -    index:
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      hidden: true
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
   -      constraintId: 4
-  -      createdExplicitly: true
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
+  +      constraintId: 2
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
   -      id: 4
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - a
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
   -      name: crdb_internal_index_4_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         sharded: {}
   -      storeColumnNames: []
   -      unique: true
   -      version: 4
   -    mutationId: 1
   -    state: WRITE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
-  ...
-     - direction: DROP
-       index:
+  -  - direction: DROP
+  -    index:
   -      constraintId: 1
   -      createdAtNanos: "1640995200000000000"
-  +      constraintId: 2
-  +      createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
   -      id: 1
-  +      id: 2
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
   -      - 2
-  +      - 1
-         keyColumnNames:
+  -      keyColumnNames:
   -      - crdb_internal_column_2_name_placeholder
   -      name: crdb_internal_index_1_name_placeholder
-  +      - a
-  +      name: crdb_internal_index_2_name_placeholder
-         partitioning: {}
-         sharded: {}
+  -      partitioning: {}
+  -      sharded: {}
          storeColumnIds:
   -      - 1
   +      - 2
@@ -888,9 +899,20 @@ upsert descriptor #104
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      hidden: true
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+       state: WRITE_ONLY
      name: t
-     nextColumnId: 3
   ...
      parentId: 100
      primaryIndex:

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_10_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_11_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_12_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_13_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -34,8 +31,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_14_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -34,8 +31,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_15_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -35,8 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_1_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+           ├── 1 element transitioning toward PUBLIC
            │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
            ├── 10 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -23,16 +21,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
            │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           └── 16 Mutation operations
-                ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+           └── 13 Mutation operations
                 ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-                ├── RefreshStats {"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_2_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_3_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_4_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_5_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,15 +19,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_6_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,15 +19,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_7_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_8_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 1 element transitioning toward PUBLIC
       │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
@@ -21,8 +19,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 3}
       │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 11 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
@@ -30,8 +27,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid__rollback_9_of_15.explain
@@ -8,9 +8,7 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC    Column:{DescID: 104 (t), ColumnID: 2 (rowid+)}
-      │    │    ├── ABSENT                → PUBLIC    ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC    ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (rowid+), IndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
@@ -24,8 +22,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_pkey-)}
       │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    └── 17 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    └── 14 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -34,8 +31,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,21 +54,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 9 Mutation operations
+      │    └── 8 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,21 +54,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 9 Mutation operations
+      │    └── 8 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,21 +54,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 9 Mutation operations
+      │    └── 8 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,23 +54,21 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
+      │    ├── 7 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    └── 9 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,23 +54,21 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
+      │    ├── 7 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 10 Mutation operations
+      │    └── 9 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,21 +54,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    └── 9 Mutation operations
+      │    └── 8 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
@@ -11,12 +11,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
       │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
@@ -29,12 +30,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,21 +54,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    └── 9 Mutation operations
+      │    └── 8 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_2_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_2_of_16.explain
@@ -26,12 +26,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_3_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_3_of_16.explain
@@ -26,12 +26,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_4_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_4_of_16.explain
@@ -26,12 +26,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_5_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_5_of_16.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
@@ -31,7 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_6_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_6_of_16.explain
@@ -24,6 +24,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
@@ -31,7 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_7_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_7_of_16.explain
@@ -26,12 +26,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_8_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_8_of_16.explain
@@ -26,12 +26,12 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
@@ -9,32 +9,34 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 17 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT    ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
-      │    │    ├── PUBLIC                → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
-      │    │    ├── BACKFILL_ONLY         → ABSENT    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 21 Mutation operations
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 18 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 2 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
+      │    └── 22 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
@@ -52,19 +54,17 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED  → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
-      │    │    ├── VALIDATED  → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    └── 8 Mutation operations
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
+      │    │    ├── VALIDATED → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    └── 7 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
@@ -36,6 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 31 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
@@ -58,7 +59,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
@@ -23,6 +23,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 16 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
@@ -23,6 +23,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 16 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
@@ -23,6 +23,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 16 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
@@ -23,6 +23,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 16 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
@@ -23,6 +23,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 16 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
@@ -23,6 +23,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
       │    └── 16 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -34,7 +35,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── RemoveColumnNotNull {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence__statement_2_of_2.explain
@@ -26,9 +26,7 @@ Schema change plan for DROP SEQUENCE ‹defaultdb›.‹public›.‹sq1›; fol
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.SequenceOpt..."}
  │              ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":104}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":104}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":104}
  │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sq1","SchemaID":101}}
@@ -36,11 +34,13 @@ Schema change plan for DROP SEQUENCE ‹defaultdb›.‹public›.‹sq1›; fol
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"admin"}
  │              ├── RemoveUserPrivileges {"DescriptorID":104,"User":"root"}
  │              ├── RemoveColumnNotNull {"ColumnID":1,"TableID":104}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":104}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":104}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":104}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
- │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":104}
- │              └── MakeIndexAbsent {"IndexID":1,"TableID":104}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":104}
+ │              ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
+ │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":104}
  └── PreCommitPhase
       └── Stage 1 of 1 in PreCommitPhase
            ├── 2 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.definition
@@ -1,0 +1,25 @@
+setup
+create table t (i int primary key, j int not null);
+----
+
+# The column j is public with the constraint enforced through
+# the PostCommit stage, so we cannot insert null values
+# for j
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t (i) VALUES($stageKey);
+----
+pq: failed to satisfy CHECK constraint (j IS NOT NULL)
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=1
+INSERT INTO t (i) VALUES($stageKey);
+----
+pq: failed to satisfy CHECK constraint (j IS NOT NULL)
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=2:
+INSERT INTO t (i) VALUES($stageKey);
+INSERT INTO t (i) VALUES($stageKey + 1);
+
+test
+alter table t drop column j;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.explain
@@ -1,0 +1,159 @@
+/* setup */
+create table t (i int primary key, j int not null);
+
+/* test */
+EXPLAIN (DDL) alter table t drop column j;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 0}
+ │         └── 5 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_pkey+)}
+ │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 0}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 0}
+ │         └── 9 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 3}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":104}
+ │    ├── Stage 3 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 4 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
+ │    ├── Stage 6 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 7 of 7 in PostCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         └── 1 Validation operation
+ │              └── ValidateIndex {"IndexID":2,"TableID":104}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    └── ABSENT                → PUBLIC           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 2 (t_pkey+)}
+      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → WRITE_ONLY       Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC                → ABSENT           ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── VALIDATED             → ABSENT           ColumnNotNull:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 0}
+      │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+      │    └── 11 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 1 (t_pkey-)}
+      │    │    └── VALIDATED  → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    └── 6 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_ABSENT
+           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT           Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT           ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
+           └── 6 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.explain_shape
@@ -1,0 +1,16 @@
+/* setup */
+create table t (i int primary key, j int not null);
+
+/* test */
+EXPLAIN (DDL, SHAPE) alter table t drop column j;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›;
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index t_pkey- in relation t
+ │    └── into t_pkey+ (i)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation t
+ │    └── from t@[3] into t_pkey+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
+ └── execute 3 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_null_constraint/drop_column_with_null_constraint.side_effects
@@ -1,0 +1,637 @@
+/* setup */
+create table t (i int primary key, j int not null);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+alter table t drop column j;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.drop_column
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 5 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 2
+  +    expr: j IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: j_auto_not_null
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+     - id: 2
+       name: j
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        expr: j IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: j_auto_not_null
+  +        validity: Dropping
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: j_auto_not_null
+  +      notNullColumn: 2
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      name: crdb_internal_index_2_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 9 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 2
+  +    expr: j IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: j_auto_not_null
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+     - id: 2
+       name: j
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "2": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›
+  +        statement: ALTER TABLE t DROP COLUMN j
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        expr: j IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: j_auto_not_null
+  +        validity: Dropping
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: j_auto_not_null
+  +      notNullColumn: 2
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      name: crdb_internal_index_2_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t DROP COLUMN j"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 7 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 7 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 7 with 1 BackfillType op
+backfill indexes [2] from index #1 in table #104
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 7 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 4 of 7 with 1 MutationType op pending"
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 7 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 7 with 1 BackfillType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 7 with 1 BackfillType op
+merge temporary indexes [3] into backfilled indexes [2] in table #104
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 7 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 7 of 7 with 1 ValidationType op pending"
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 7 with 1 ValidationType op
+validate forward indexes [2] in table #104
+commit transaction #9
+begin transaction #10
+## PostCommitNonRevertiblePhase stage 1 of 3 with 11 MutationType ops
+upsert descriptor #104
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 2
+  -    expr: j IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: j_auto_not_null
+  -    validity: Dropping
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  -  - id: 2
+  -    name: j
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+           statement: ALTER TABLE t DROP COLUMN j
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+       columnNames:
+       - i
+  -    - j
+  +    - crdb_internal_column_2_name_placeholder
+       defaultColumnId: 2
+       name: primary
+  ...
+     modificationTime: {}
+     mutations:
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 2
+  -        expr: j IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: j_auto_not_null
+  -        validity: Dropping
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: j_auto_not_null
+  -      notNullColumn: 2
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 2
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 2
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - i
+  -      name: crdb_internal_index_2_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 2
+  +      storeColumnNames:
+  +      - crdb_internal_column_2_name_placeholder
+         unique: true
+         version: 4
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 3
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      name: crdb_internal_index_3_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 2
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 2
+       interleave: {}
+       keyColumnDirections:
+  ...
+       partitioning: {}
+       sharded: {}
+  -    storeColumnIds:
+  -    - 2
+  -    storeColumnNames:
+  -    - j
+  +    storeColumnNames: []
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #10
+begin transaction #11
+## PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         id: 2
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops pending"
+commit transaction #11
+begin transaction #12
+## PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "2": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›
+  -        statement: ALTER TABLE t DROP COLUMN j
+  -        statementTag: ALTER TABLE
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+  -    - 2
+       columnNames:
+       - i
+  -    - crdb_internal_column_2_name_placeholder
+       defaultColumnId: 2
+       name: primary
+  ...
+     id: 104
+     modificationTime: {}
+  -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - crdb_internal_column_2_name_placeholder
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j"
+  descriptor IDs: [104]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #12
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.explain
@@ -11,63 +11,55 @@ EXPLAIN (DDL) DROP INDEX idx CASCADE;
 Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
- │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_16", ColumnID: 3 (crdb_internal_j_shard_16-)}
- │         │    ├── PUBLIC → VALIDATED  ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
- │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
- │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
- │         │    └── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_j_shard_16", ConstraintID: 2 (check_crdb_internal_j_shard_16-)}
+ │         ├── 4 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_j_shard_16", ConstraintID: 2 (check_crdb_internal_j_shard_16-)}
+ │         └── 4 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              └── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 4 elements transitioning toward ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
+ │    │    │    ├── VALIDATED → PUBLIC SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
+ │    │    │    ├── VALIDATED → PUBLIC CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
+ │    │    │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_j_shard_16", ConstraintID: 2 (check_crdb_internal_j_shard_16-)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 4 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
+ │         │    ├── PUBLIC → VALIDATED CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_j_shard_16", ConstraintID: 2 (check_crdb_internal_j_shard_16-)}
  │         └── 6 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
  │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
  │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
- │              └── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
- ├── PreCommitPhase
- │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 6 elements transitioning toward ABSENT
- │    │    │    ├── WRITE_ONLY → PUBLIC Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
- │    │    │    ├── ABSENT     → PUBLIC ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_16", ColumnID: 3 (crdb_internal_j_shard_16-)}
- │    │    │    ├── VALIDATED  → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
- │    │    │    ├── VALIDATED  → PUBLIC SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
- │    │    │    ├── VALIDATED  → PUBLIC CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
- │    │    │    └── ABSENT     → PUBLIC ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_j_shard_16", ConstraintID: 2 (check_crdb_internal_j_shard_16-)}
- │    │    └── 1 Mutation operation
- │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
- │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
- │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_16", ColumnID: 3 (crdb_internal_j_shard_16-)}
- │         │    ├── PUBLIC → VALIDATED  ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
- │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
- │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
- │         │    └── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_j_shard_16", ConstraintID: 2 (check_crdb_internal_j_shard_16-)}
- │         └── 8 Mutation operations
- │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
- │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
- │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
- │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
- │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
-      │    │    ├── VALIDATED  → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 2 (idx-)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (idx-)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (idx-)}
-      │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
-      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 2 (idx-)}
-      │    │    └── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
-      │    └── 10 Mutation operations
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC    → WRITE_ONLY  Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
+      │    │    ├── PUBLIC    → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_16", ColumnID: 3 (crdb_internal_j_shard_16-)}
+      │    │    ├── VALIDATED → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 0}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-), IndexID: 2 (idx-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (idx-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (idx-)}
+      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 2 (idx-)}
+      │    │    └── VALIDATED → ABSENT      CheckConstraint:{DescID: 104 (t), IndexID: 0, ConstraintID: 2 (check_crdb_internal_j_shard_16-), ReferencedColumnIDs: [3]}
+      │    └── 11 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
@@ -75,15 +67,22 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx›
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
+      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 104 (t), IndexID: 2 (idx-)}
+      │    └── 5 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_16-)}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_16-)}
-           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx-), RecreateSourceIndexID: 0}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (idx-)}
-           └── 5 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_16-)}
+           └── 3 Mutation operations
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.explain_shape
@@ -9,4 +9,4 @@ INSERT INTO t VALUES(-3);
 EXPLAIN (DDL, SHAPE) DROP INDEX idx CASCADE;
 ----
 Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE;
- └── execute 3 system table mutations transactions
+ └── execute 4 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.side_effects
@@ -25,39 +25,28 @@ write *eventpb.DropIndex to event log:
     tag: DROP INDEX
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 6 MutationType ops
+## StatementPhase stage 1 of 1 with 4 MutationType ops
 upsert descriptor #104
   ...
-       - 3
-       constraintId: 2
-  -    expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
-  +    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+       expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
        fromHashShardedColumn: true
   -    name: check_crdb_internal_j_shard_16
   +    name: crdb_internal_constraint_2_name_placeholder
   +    validity: Dropping
   +  - columnIds:
   +    - 3
-  +    expr: crdb_internal_column_3_name_placeholder IS NOT NULL
+  +    expr: crdb_internal_j_shard_16 IS NOT NULL
   +    isNonNullConstraint: true
   +    name: crdb_internal_j_shard_16_auto_not_null
   +    validity: Dropping
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
-  -  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
-  -    hidden: true
-  -    id: 3
-  -    name: crdb_internal_j_shard_16
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-  -    virtual: true
-     createAsOfTime:
-       wallTime: "1640995200000000000"
+       id: 3
+       name: crdb_internal_j_shard_16
+  +    nullable: true
+       type:
+         family: IntFamily
   ...
      formatVersion: 3
      id: 104
@@ -95,7 +84,7 @@ upsert descriptor #104
   +      check:
   +        columnIds:
   +        - 3
-  +        expr: crdb_internal_column_3_name_placeholder IS NOT NULL
+  +        expr: crdb_internal_j_shard_16 IS NOT NULL
   +        isNonNullConstraint: true
   +        name: crdb_internal_j_shard_16_auto_not_null
   +        validity: Dropping
@@ -122,7 +111,7 @@ upsert descriptor #104
   +      - 3
   +      - 2
   +      keyColumnNames:
-  +      - crdb_internal_column_3_name_placeholder
+  +      - crdb_internal_j_shard_16
   +      - j
   +      keySuffixColumnIds:
   +      - 1
@@ -142,27 +131,13 @@ upsert descriptor #104
   +        columnIds:
   +        - 3
   +        constraintId: 2
-  +        expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  +        expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
   +        fromHashShardedColumn: true
   +        name: check_crdb_internal_j_shard_16
   +        validity: Dropping
   +      foreignKey: {}
   +      name: check_crdb_internal_j_shard_16
   +      uniqueWithoutIndexConstraint: {}
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - column:
-  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
-  +      hidden: true
-  +      id: 3
-  +      name: crdb_internal_column_3_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +      virtual: true
   +    direction: DROP
   +    mutationId: 1
   +    state: WRITE_ONLY
@@ -178,37 +153,29 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 8 MutationType ops
+## PreCommitPhase stage 2 of 2 with 6 MutationType ops
 upsert descriptor #104
   ...
-       - 3
-       constraintId: 2
-  -    expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
-  +    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+       expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
        fromHashShardedColumn: true
   -    name: check_crdb_internal_j_shard_16
   +    name: crdb_internal_constraint_2_name_placeholder
   +    validity: Dropping
   +  - columnIds:
   +    - 3
-  +    expr: crdb_internal_column_3_name_placeholder IS NOT NULL
+  +    expr: crdb_internal_j_shard_16 IS NOT NULL
   +    isNonNullConstraint: true
   +    name: crdb_internal_j_shard_16_auto_not_null
   +    validity: Dropping
      columns:
      - id: 1
   ...
-         oid: 20
-         width: 64
-  -  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
-  -    hidden: true
-  -    id: 3
-  -    name: crdb_internal_j_shard_16
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-  -    virtual: true
+       id: 3
+       name: crdb_internal_j_shard_16
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
      createAsOfTime:
        wallTime: "1640995200000000000"
   +  declarativeSchemaChangerState:
@@ -274,7 +241,7 @@ upsert descriptor #104
   +      check:
   +        columnIds:
   +        - 3
-  +        expr: crdb_internal_column_3_name_placeholder IS NOT NULL
+  +        expr: crdb_internal_j_shard_16 IS NOT NULL
   +        isNonNullConstraint: true
   +        name: crdb_internal_j_shard_16_auto_not_null
   +        validity: Dropping
@@ -301,7 +268,7 @@ upsert descriptor #104
   +      - 3
   +      - 2
   +      keyColumnNames:
-  +      - crdb_internal_column_3_name_placeholder
+  +      - crdb_internal_j_shard_16
   +      - j
   +      keySuffixColumnIds:
   +      - 1
@@ -321,27 +288,13 @@ upsert descriptor #104
   +        columnIds:
   +        - 3
   +        constraintId: 2
-  +        expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  +        expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
   +        fromHashShardedColumn: true
   +        name: check_crdb_internal_j_shard_16
   +        validity: Dropping
   +      foreignKey: {}
   +      name: check_crdb_internal_j_shard_16
   +      uniqueWithoutIndexConstraint: {}
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - column:
-  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
-  +      hidden: true
-  +      id: 3
-  +      name: crdb_internal_column_3_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +      virtual: true
   +    direction: DROP
   +    mutationId: 1
   +    state: WRITE_ONLY
@@ -362,20 +315,20 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 11 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
   -  - columnIds:
   -    - 3
   -    constraintId: 2
-  -    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  -    expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
   -    fromHashShardedColumn: true
   -    name: crdb_internal_constraint_2_name_placeholder
   -    validity: Dropping
   -  - columnIds:
   -    - 3
-  -    expr: crdb_internal_column_3_name_placeholder IS NOT NULL
+  -    expr: crdb_internal_j_shard_16 IS NOT NULL
   -    isNonNullConstraint: true
   -    name: crdb_internal_j_shard_16_auto_not_null
   -    validity: Dropping
@@ -383,13 +336,28 @@ upsert descriptor #104
      columns:
      - id: 1
   ...
+         oid: 20
+         width: 64
+  -  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
+  -    hidden: true
+  -    id: 3
+  -    name: crdb_internal_j_shard_16
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+  -    virtual: true
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
      modificationTime: {}
      mutations:
   -  - constraint:
   -      check:
   -        columnIds:
   -        - 3
-  -        expr: crdb_internal_column_3_name_placeholder IS NOT NULL
+  -        expr: crdb_internal_j_shard_16 IS NOT NULL
   -        isNonNullConstraint: true
   -        name: crdb_internal_j_shard_16_auto_not_null
   -        validity: Dropping
@@ -404,6 +372,11 @@ upsert descriptor #104
      - direction: DROP
        index:
   ...
+         - 2
+         keyColumnNames:
+  -      - crdb_internal_j_shard_16
+  +      - crdb_internal_column_3_name_placeholder
+         - j
          keySuffixColumnIds:
          - 1
   -      name: idx
@@ -419,17 +392,71 @@ upsert descriptor #104
   -        columnIds:
   -        - 3
   -        constraintId: 2
-  -        expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+  -        expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
   -        fromHashShardedColumn: true
   -        name: check_crdb_internal_j_shard_16
   -        validity: Dropping
   -      foreignKey: {}
   -      name: check_crdb_internal_j_shard_16
   -      uniqueWithoutIndexConstraint: {}
-  -    direction: DROP
-  -    mutationId: 1
-  -    state: WRITE_ONLY
   +    state: DELETE_ONLY
+  +  - column:
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
+  +      hidden: true
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+       direction: DROP
+       mutationId: 1
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "10"
+  +  version: "11"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops pending"
+commit transaction #3
+begin transaction #4
+## PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
+upsert descriptor #104
+  ...
+     modificationTime: {}
+     mutations:
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 2
+  -      keyColumnNames:
+  -      - crdb_internal_column_3_name_placeholder
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded:
+  -        columnNames:
+  -        - j
+  -        isSharded: true
+  -        name: crdb_internal_j_shard_16
+  -        shardBuckets: 16
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
      - column:
          computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
   ...
@@ -442,13 +469,16 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "10"
-  +  version: "11"
+  -  version: "11"
+  +  version: "12"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 3 MutationType ops pending"
-commit transaction #3
-begin transaction #4
-## PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
+create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
+  descriptor IDs: [104]
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 1 MutationType op pending"
+commit transaction #4
+notified job registry to adopt jobs: [2]
+begin transaction #5
+## PostCommitNonRevertiblePhase stage 3 of 3 with 3 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -483,36 +513,6 @@ upsert descriptor #104
      indexes: []
      modificationTime: {}
   -  mutations:
-  -  - direction: DROP
-  -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      - ASC
-  -      keyColumnIds:
-  -      - 3
-  -      - 2
-  -      keyColumnNames:
-  -      - crdb_internal_column_3_name_placeholder
-  -      - j
-  -      keySuffixColumnIds:
-  -      - 1
-  -      name: crdb_internal_index_2_name_placeholder
-  -      partitioning: {}
-  -      sharded:
-  -        columnNames:
-  -        - j
-  -        isSharded: true
-  -        name: crdb_internal_j_shard_16
-  -        shardBuckets: 16
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
   -  - column:
   -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(j))), 16:::INT8)
   -      hidden: true
@@ -533,17 +533,14 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "11"
-  +  version: "12"
+  -  version: "12"
+  +  version: "13"
 persist all catalog changes to storage
-create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
-  descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable
 updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 104
-commit transaction #4
-notified job registry to adopt jobs: [2]
+commit transaction #5
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep/drop_index_with_materialized_view_dep.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep/drop_index_with_materialized_view_dep.explain
@@ -43,10 +43,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │              ├── RemoveObjectParent {"ObjectID":106,"ParentSchemaID":101}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":106}
  │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":106}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":106}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
- │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":106}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":106}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967294,"TableID":106}
@@ -62,14 +59,17 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │              ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":106}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":106}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":106}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+ │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":106}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"TableID":106}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":106}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":106}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":106}
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
  ├── PreCommitPhase
@@ -137,10 +137,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │              ├── RemoveObjectParent {"ObjectID":106,"ParentSchemaID":101}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":106}
  │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":106}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":106}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
- │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":106}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":106}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967294,"TableID":106}
@@ -156,14 +153,17 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
  │              ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":106}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":106}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":106}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+ │              ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":106}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"TableID":106}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":106}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":106}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":106}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table/drop_table.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table/drop_table.explain
@@ -50,10 +50,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":107}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":107}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":107}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":107}
- │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":107}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":107}
- │              ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":107}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":107}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":107}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967294,"TableID":107}
@@ -69,15 +66,18 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  │              ├── RemoveColumnNotNull {"ColumnID":3,"TableID":107}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":107}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":107}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":107}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":107}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":107}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":107}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":107}
  │              ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":107}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":107}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":107}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":107}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":107}
  │              └── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":107}
@@ -156,10 +156,7 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":107}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":107}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":107}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":107}
- │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":107}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":107}
- │              ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":107}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967295,"TableID":107}
  │              ├── SetColumnName {"ColumnID":4294967295,"Name":"crdb_internal_co...","TableID":107}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":4294967294,"TableID":107}
@@ -175,15 +172,18 @@ Schema change plan for DROP TABLE ‹db›.‹sc›.‹t›;
  │              ├── RemoveColumnNotNull {"ColumnID":3,"TableID":107}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":107}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":107}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":107}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":107}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":107}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":107}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":107}
  │              ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":107}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":107}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":107}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":107}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":107}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":107}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default/drop_table_udf_default.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table_udf_default/drop_table_udf_default.explain
@@ -37,8 +37,6 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │         └── 33 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":105}
  │              ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":105}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":105}
@@ -58,11 +56,13 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":105}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":105}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":105}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":105}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":105}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":105}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":105}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":105}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
@@ -128,8 +128,6 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │         └── 36 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":105}
  │              ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
- │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
- │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":105}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":105}
@@ -149,11 +147,13 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":105}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967295,"TableID":105}
  │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4294967294,"TableID":105}
- │              ├── AssertColumnFamilyIsRemoved {"TableID":105}
- │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":105}
  │              ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":105}
  │              ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
+ │              ├── AssertColumnFamilyIsRemoved {"TableID":105}
+ │              ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
  │              ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
  │              ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":105}
  │              ├── MakeIndexAbsent {"IndexID":1,"TableID":105}


### PR DESCRIPTION
Backport 1/1 commits from #120792.

/cc @cockroachdb/release

---

This PR fixes the new schema changer deprule to
drop a constraint in the same stage a column moves to WRITE_ONLY. Once a column moves to WRITE_ONLY, it is inaccessible for user writes. The constraint can only be accurately enforced when a column is public for access by the optimizer. Without this, we get column inaccessible errors while attempting to write to the table when the column is in a dropping stage. This is because the column has moved to WRITE_ONLY and is no longer readable by the optimizer to enforce the constraint which is in the WRITE_ONLY stage as well.

Dropping of the dependent column once a constraint on it is dropped takes place within the PostCommitNonRevertible stage now ensuring the column is dropped as soon as the constraint is dropped preventing any schema inconsistencies.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/118314
Release note: None
Release justification: Fixes a high priority bug that prevents users from writing to the table when a column with dependent constraints is being dropped.