### PR TITLE
catalog: repair descriptors with incorrect self references in FK

### DIFF
--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -136,4 +136,8 @@ const (
 	// StrippedNonExistentRoles indicates that at least one role identified did
 	// not exist.
 	StrippedNonExistentRoles
+
+	// FixedIncorrectForeignKeyOrigins indicates that foreign key origin /
+	// reference IDs that should point to the current descriptor were fixed.
+	FixedIncorrectForeignKeyOrigins
 )

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -423,6 +423,7 @@ func maybeFillInDescriptor(
 	set(catalog.RemovedDuplicateIDsInRefs, maybeRemoveDuplicateIDsInRefs(desc))
 	set(catalog.StrippedDanglingSelfBackReferences, maybeStripDanglingSelfBackReferences(desc))
 	set(catalog.FixSecondaryIndexEncodingType, maybeFixSecondaryIndexEncodingType(desc))
+	set(catalog.FixedIncorrectForeignKeyOrigins, maybeFixForeignKeySelfReferences(desc))
 	return changes, nil
 }
 
@@ -1196,4 +1197,24 @@ func resolveTableNamesForIDs(
 	}
 
 	return result, nil
+}
+
+// maybeFixForeignKeySelfReferences fixes references that should point to the
+// current descriptor inside OutboundFKs and InboundFKs.
+func maybeFixForeignKeySelfReferences(tableDesc *descpb.TableDescriptor) (wasRepaired bool) {
+	for idx := range tableDesc.OutboundFKs {
+		fk := &tableDesc.OutboundFKs[idx]
+		if fk.OriginTableID != tableDesc.ID {
+			fk.OriginTableID = tableDesc.ID
+			wasRepaired = true
+		}
+	}
+	for idx := range tableDesc.InboundFKs {
+		fk := &tableDesc.InboundFKs[idx]
+		if fk.ReferencedTableID != tableDesc.ID {
+			fk.ReferencedTableID = tableDesc.ID
+			wasRepaired = true
+		}
+	}
+	return wasRepaired
 }


### PR DESCRIPTION
Previously, we had a corruption bug that could lead to descriptors with self references that pointed to incorrect descriptor IDs. This could lead to validation errors that make tables inaccessible. To address this, this patch will add an automatic post deserialization repair to fix these values to the current descriptor ID.

Fixes: #123555
Fixes: #123493

Release note (bug fix): automatically repair tables which see the following error "invalid inbound foreign key ... origin table ID should be" or "invalid outbound foreign key ... reference table ID should be".