### PR TITLE
roachtest: fix full backup fingerprint time

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -70,7 +70,6 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			name:                 "backup-restore/online-restore",
 			metamorphicRangeSize: false,
 			onlineRestore:        true,
-			skip:                 "it fails consistently",
 		},
 		{
 			name: "backup-restore/mock",

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1976,6 +1976,11 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	}
 
 	fingerprintAOST := latestIncBackupEndTime
+	if fingerprintAOST == "" {
+		// If latestIncBackupEndTime is empty, we never took an incremental backup.
+		// Fingerprint on the full backup endtime instead.
+		fingerprintAOST = fullBackupEndTime
+	}
 	if collection.restoreAOST != "" {
 		fingerprintAOST = collection.restoreAOST
 	}


### PR DESCRIPTION
The backup-restore roachtest framework would previously choose an incorrect backup cluster fingerprint timestamp if no incremental backups were taken. This would cause the backup-restore/online-restore roachtest to fail with fingerprint mismatch errors. This patch fixes this bug.

Epic: none

Release note: none