### PR TITLE
roachprod: make clusters secure by default

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -96,6 +96,16 @@ var (
 		"user-cert":     install.AuthUserCert,
 	}
 
+	defaultAuthMode = func() string {
+		for modeStr, mode := range pgAuthModes {
+			if mode == install.DefaultAuthMode {
+				return modeStr
+			}
+		}
+
+		panic(fmt.Errorf("could not find string for default auth mode"))
+	}()
+
 	sshKeyUser string
 
 	fluentBitConfig fluentbit.Config
@@ -186,8 +196,12 @@ func initFlags() {
 		"external", false, "return pgurls for external connections")
 	pgurlCmd.Flags().StringVar(&pgurlCertsDir,
 		"certs-dir", install.CockroachNodeCertsDir, "cert dir to use for secure connections")
-	pgurlCmd.Flags().StringVar(&authMode,
-		"auth-mode", "root", fmt.Sprintf("form of authentication to use, valid auth-modes: %v", maps.Keys(pgAuthModes)))
+
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd} {
+		cmd.Flags().StringVar(&authMode,
+			"auth-mode", defaultAuthMode, fmt.Sprintf("form of authentication to use, valid auth-modes: %v", maps.Keys(pgAuthModes)))
+	}
+
 	pprofCmd.Flags().DurationVar(&pprofOpts.Duration,
 		"duration", 30*time.Second, "Duration of profile to capture")
 	pprofCmd.Flags().BoolVar(&pprofOpts.Heap,

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -48,7 +48,7 @@ var (
 	listJSON              bool
 	listMine              bool
 	listPattern           string
-	secure                = false
+	insecure              = false
 	virtualClusterName    string
 	sqlInstance           int
 	extraSSHOptions       = ""
@@ -396,8 +396,8 @@ func initFlags() {
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
 	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
-		cmd.Flags().BoolVar(&secure,
-			"secure", false, "use a secure cluster")
+		cmd.Flags().BoolVar(&insecure,
+			"insecure", insecure, "use an insecure cluster")
 	}
 	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, loadBalanceCmd, jaegerStartCmd} {
 		cmd.Flags().StringVar(&virtualClusterName,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -486,7 +486,7 @@ These resources will automatically be destroyed when the cluster is destroyed.
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		return roachprod.CreateLoadBalancer(context.Background(), config.Logger,
-			args[0], secure, virtualClusterName, sqlInstance,
+			args[0], !insecure, virtualClusterName, sqlInstance,
 		)
 	}),
 }
@@ -505,10 +505,11 @@ var startCmd = &cobra.Command{
 	Short: "start nodes on a cluster",
 	Long: `Start nodes on a cluster.
 
-The --secure flag can be used to start nodes in secure mode (i.e. using
-certs). When specified, there is a one time initialization for the cluster to
-create and distribute the certs. Note that running some modes in secure mode
-and others in insecure mode is not a supported Cockroach configuration.
+Nodes are started in secure mode by default and there is a one time
+initialization for the cluster to create and distribute the certs.
+Note that running some modes in secure mode and others in insecure
+mode is not a supported Cockroach configuration. To start nodes in
+insecure mode, use the --insecure flag.
 
 As a debugging aid, the --sequential flag starts the nodes sequentially so node
 IDs match hostnames. Otherwise nodes are started in parallel.
@@ -534,7 +535,7 @@ cluster setting will be set to its value.
 		clusterSettingsOpts := []install.ClusterSettingOption{
 			install.TagOption(tag),
 			install.PGUrlCertsDirOption(pgurlCertsDir),
-			install.SecureOption(secure),
+			install.SecureOption(!insecure),
 			install.UseTreeDistOption(useTreeDist),
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
@@ -590,10 +591,11 @@ default. To start an external process instance, pass the
 --external-cluster flag indicating where the SQL server processes
 should be started.
 
-The --secure flag can be used to start nodes in secure mode (i.e. using
-certs). When specified, there is a one time initialization for the cluster to
-create and distribute the certs. Note that running some modes in secure mode
-and others in insecure mode is not a supported Cockroach configuration.
+Nodes are started in secure mode by default and there is a one time
+initialization for the cluster to create and distribute the certs.
+Note that running some modes in secure mode and others in insecure
+mode is not a supported Cockroach configuration. To start nodes in
+insecure mode, use the --insecure flag.
 
 As a debugging aid, the --sequential flag starts the services
 sequentially; otherwise services are started in parallel.
@@ -612,7 +614,7 @@ environment variables to the cockroach process.
 		clusterSettingsOpts := []install.ClusterSettingOption{
 			install.TagOption(tag),
 			install.PGUrlCertsDirOption(pgurlCertsDir),
-			install.SecureOption(secure),
+			install.SecureOption(!insecure),
 			install.UseTreeDistOption(useTreeDist),
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
@@ -664,7 +666,7 @@ non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 			SQLInstance:        sqlInstance,
 		}
 		clusterName := args[0]
-		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, secure, stopOpts)
+		return roachprod.StopServiceForVirtualCluster(context.Background(), config.Logger, clusterName, !insecure, stopOpts)
 	}),
 }
 
@@ -841,7 +843,7 @@ var runCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
 		return roachprod.Run(context.Background(), config.Logger, args[0], extraSSHOptions, tag,
-			secure, os.Stdout, os.Stderr, args[1:], install.RunOptions{FailOption: install.FailSlow})
+			!insecure, os.Stdout, os.Stderr, args[1:], install.RunOptions{FailOption: install.FailSlow})
 	}),
 }
 
@@ -1005,7 +1007,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(context.Background(), config.Logger, args[0], secure, virtualClusterName, sqlInstance, args[1:])
+		return roachprod.SQL(context.Background(), config.Logger, args[0], !insecure, virtualClusterName, sqlInstance, args[1:])
 	}),
 }
 
@@ -1014,7 +1016,7 @@ var pgurlCmd = &cobra.Command{
 	Short: "generate pgurls for the nodes in a cluster",
 	Long: `Generate pgurls for the nodes in a cluster.
 
---auth-mode specifies the method of authentication if --secure is passed.
+--auth-mode specifies the method of authentication unless --insecure is passed.
 Defaults to root if not passed. Available auth-modes are:
 
 	root: authenticates with the root user and root certificates
@@ -1033,7 +1035,7 @@ Defaults to root if not passed. Available auth-modes are:
 
 		urls, err := roachprod.PgURL(context.Background(), config.Logger, args[0], pgurlCertsDir, roachprod.PGURLOptions{
 			External:           external,
-			Secure:             secure,
+			Secure:             !insecure,
 			VirtualClusterName: virtualClusterName,
 			SQLInstance:        sqlInstance,
 			Auth:               auth,
@@ -1081,7 +1083,7 @@ var adminurlCmd = &cobra.Command{
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		urls, err := roachprod.AdminURL(
-			context.Background(), config.Logger, args[0], virtualClusterName, sqlInstance, adminurlPath, adminurlIPs, urlOpen, secure,
+			context.Background(), config.Logger, args[0], virtualClusterName, sqlInstance, adminurlPath, adminurlIPs, urlOpen, !insecure,
 		)
 		if err != nil {
 			return err
@@ -1208,13 +1210,14 @@ var grafanaURLCmd = &cobra.Command{
 }
 
 var grafanaAnnotationCmd = &cobra.Command{
-	Use:   `grafana-annotation <host> <text> --secure --tags [<tag1>, ...] --dashboard-uid <dashboard-uid> --time-range [<start-time>, <end-time>]`,
+	Use:   `grafana-annotation <host> <text> --tags [<tag1>, ...] --dashboard-uid <dashboard-uid> --time-range [<start-time>, <end-time>]`,
 	Short: `adds an annotation to the specified grafana instance`,
 	Long: fmt.Sprintf(`Adds an annotation to the specified grafana instance
 
---secure indicates if the grafana instance needs an authentication token to connect
-to. If set, a service account json and audience will be read in from the environment
-variables %s and %s to attempt authentication through google IDP.
+By default, we assume the grafana instance needs an authentication token to connect
+to. A service account json and audience will be read in from the environment
+variables %s and %s to attempt authentication through google IDP. Use the --insecure
+option when a token is not necessary.
 
 --tags specifies the tags the annotation should have.
 
@@ -1228,7 +1231,7 @@ creates an annotation over time range.
 
 Example:
 # Create an annotation over time range 1-100 on the centralized grafana instance, which needs authentication.
-roachprod grafana-annotation grafana.testeng.crdb.io example-annotation-event --secure --tags my-cluster --tags test-run-1 --dashboard-uid overview --time-range 1,100
+roachprod grafana-annotation grafana.testeng.crdb.io example-annotation-event --tags my-cluster --tags test-run-1 --dashboard-uid overview --time-range 1,100
 `, grafana.ServiceAccountJson, grafana.ServiceAccountAudience),
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
@@ -1251,7 +1254,7 @@ roachprod grafana-annotation grafana.testeng.crdb.io example-annotation-event --
 			return errors.Newf("Too many arguments for --time-range, expected 1 or 2, got: %d", len(grafanaTimeRange))
 		}
 
-		return roachprod.AddGrafanaAnnotation(context.Background(), args[0] /* host */, secure, req)
+		return roachprod.AddGrafanaAnnotation(context.Background(), args[0] /* host */, !insecure, req)
 	}),
 }
 
@@ -1261,7 +1264,7 @@ var jaegerStartCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		return roachprod.StartJaeger(context.Background(), config.Logger, args[0],
-			virtualClusterName, secure, jaegerConfigNodes)
+			virtualClusterName, !insecure, jaegerConfigNodes)
 	}),
 }
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1007,7 +1007,12 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(context.Background(), config.Logger, args[0], !insecure, virtualClusterName, sqlInstance, args[1:])
+		auth, ok := pgAuthModes[authMode]
+		if !ok {
+			return errors.Newf("unsupported auth-mode %s, valid auth-modes: %v", authMode, maps.Keys(pgAuthModes))
+		}
+
+		return roachprod.SQL(context.Background(), config.Logger, args[0], !insecure, virtualClusterName, sqlInstance, auth, args[1:])
 	}),
 }
 
@@ -1027,7 +1032,6 @@ Defaults to root if not passed. Available auth-modes are:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-
 		auth, ok := pgAuthModes[authMode]
 		if !ok {
 			return errors.Newf("unsupported auth-mode %s, valid auth-modes: %v", authMode, maps.Keys(pgAuthModes))

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -444,7 +444,7 @@ func (c *SyncedCluster) Stop(
 		}
 		return c.kill(ctx, l, "stop", display, sig, wait, maxWait, virtualClusterLabel)
 	} else {
-		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, []string{
+		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, DefaultAuthMode, []string{
 			"-e", fmt.Sprintf("ALTER TENANT '%s' STOP SERVICE", virtualClusterName),
 		})
 		if err != nil || res[0].Err != nil {

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -160,7 +160,7 @@ func (e *expander) maybeExpandPgURL(
 	}
 	switch m[1] {
 	case ":L":
-		url, err := c.loadBalancerURL(ctx, l, virtualClusterName, sqlInstance, AuthUserCert)
+		url, err := c.loadBalancerURL(ctx, l, virtualClusterName, sqlInstance, DefaultAuthMode)
 		return url, url != "", err
 	default:
 		if e.pgURLs[virtualClusterName] == nil {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -441,6 +441,7 @@ func SQL(
 	secure bool,
 	tenantName string,
 	tenantInstance int,
+	authMode install.PGAuthMode,
 	cmdArray []string,
 ) error {
 	c, err := getClusterFromCache(l, clusterName, install.SecureOption(secure))
@@ -448,10 +449,10 @@ func SQL(
 		return err
 	}
 	if len(c.Nodes) == 1 {
-		return c.ExecOrInteractiveSQL(ctx, l, tenantName, tenantInstance, cmdArray)
+		return c.ExecOrInteractiveSQL(ctx, l, tenantName, tenantInstance, authMode, cmdArray)
 	}
 
-	results, err := c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, cmdArray)
+	results, err := c.ExecSQL(ctx, l, c.Nodes, tenantName, tenantInstance, authMode, cmdArray)
 	if err != nil {
 		return err
 	}
@@ -2087,7 +2088,9 @@ func StartJaeger(
 		if err != nil {
 			return err
 		}
-		_, err = c.ExecSQL(ctx, l, nodes, virtualClusterName, 0, []string{"-e", setupStmt})
+		_, err = c.ExecSQL(
+			ctx, l, nodes, virtualClusterName, 0, install.DefaultAuthMode, []string{"-e", setupStmt},
+		)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**roachprod: make clusters secure by default**
Roachtest has been creating secure clusters in tests for a while
now. It makes sense for roachprod to use the same, better default when
setting up clusters.

If necessary, users can still create insecure clusters by passing the
`--insecure` flag to `roachprod start` and other commands.

Fixes: #38539

Release note: None

**roachprod: use non-root user by default in roachprod sql**
This brings roachprod's and roachtest's defaults closer. Now that we
create secure roachprod clusters by default (which includes creating
an admin user), we are able to change the default authentication mode
used when starting a SQL shell.

Like with `pgurl`, the authentication mode can be changed with the
`--auth-mode` command line flag.
