### PR TITLE
roachtest: increase timeout for sql-stats/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -46,7 +46,7 @@ func registerSqlStatsMixedVersion(r registry.Registry) {
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.Suites(registry.Nightly),
 		Run:              runSQLStatsMixedVersion,
-		Timeout:          15 * time.Minute,
+		Timeout:          1 * time.Hour,
 	})
 }
 


### PR DESCRIPTION
The timeout was previously set to 15m. We set it to a more generous value of 1h, since the mvt framework applies some waits so that we don't start upgrades immediately.

Epic: none
Fixes: #123541