### PR TITLE
[CC-28198] sqlproxy: fix ProxyProtocolListenAddr using wrong ACL.

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -321,13 +321,15 @@ func newProxyHandler(
 
 // handle is called by the proxy server to handle a single incoming client
 // connection.
-func (handler *proxyHandler) handle(ctx context.Context, incomingConn net.Conn) error {
+func (handler *proxyHandler) handle(
+	ctx context.Context, incomingConn net.Conn, requireProxyProtocol bool,
+) error {
 	connReceivedTime := timeutil.Now()
 
 	// Parse headers before admitting the connection since the connection may
 	// be upgraded to TLS.
 	var endpointID string
-	if handler.RequireProxyProtocol {
+	if requireProxyProtocol {
 		var err error
 		endpointID, err = acl.FindPrivateEndpointID(incomingConn)
 		if err != nil {

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1205,12 +1205,16 @@ func TestProxyHandler_handle(t *testing.T) {
 	defer stopper.Stop(ctx)
 	proxy, _ := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{})
 
-	p1, p2 := net.Pipe()
-	require.NoError(t, p1.Close())
-
 	// Check that handle does not return any error if the incoming connection
 	// has no data packets.
-	require.Nil(t, proxy.handler.handle(ctx, p2))
+	p1, p2 := net.Pipe()
+	require.NoError(t, p1.Close())
+	require.Nil(t, proxy.handler.handle(ctx, p2, false /* requireProxyProtocol */))
+
+	p1, p2 = net.Pipe()
+	require.NoError(t, p1.Close())
+	p2 = proxyproto.NewConn(p2)
+	require.Nil(t, proxy.handler.handle(ctx, p2, true /* requireProxyProtocol */))
 }
 
 func TestDenylistUpdate(t *testing.T) {


### PR DESCRIPTION
Previously in SQLProxy, the ProxyProtocolListenAddr port required proxy protocol, but did not inspect the proxy protocol for the endpoint ID. Instead, it accidentally relied on the IP allowlist ACL. This commit fixes that behavior.

Epic: None

Release note: None