### PR TITLE
roachprod: opt-in fluent-servers logging configuration

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -376,6 +376,9 @@ func initFlags() {
 			"limit the number of files that can be created by the cockroach process")
 		cmd.Flags().IntVar(&startOpts.SQLPort,
 			"sql-port", startOpts.SQLPort, "port on which to listen for SQL clients")
+		cmd.Flags().BoolVar(&startOpts.EnableFluentSink,
+			"enable-fluent-sink", startOpts.EnableFluentSink,
+			"whether to enable the fluent-servers attribute in the CockroachDB logging configuration")
 	}
 
 	for _, cmd := range []*cobra.Command{

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -30,15 +30,15 @@ case $1 in
     if [[ "$*" != *"--restart"* ]]; then
       # implied for long-lived DRT clusters; avoid on init w/ --restart=false.
       shift
-      set -- start "--restart" "$@"
+      set -- start "--enable-fluent-sink" "--restart" "$@"
     fi
     if [[ "$*" != *"--secure"* ]]; then
       shift
-      set -- start "--secure" "$@"
+      set -- start "--enable-fluent-sink" "--secure" "$@"
     fi
     if [[ "$*" != *"--sql-port 26257"* ]]; then
       shift
-      set -- start "--sql-port" "26257" "$@"
+      set -- start "--enable-fluent-sink" "--sql-port" "26257" "$@"
     fi
     ;;
   "sql")


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/123227 we added the
ability for clusters created by `roachprod` to send their logs to an
external system using the `fluent-servers` attribute in the CockroachDB
logging configuration. However, the `fluent-servers` attribute was
enabled unconditionally which caused clusters to to log an error if the
requisite Fluent Bit server was not there to receive the logs.

```
E240503 20:21:50.574780 55 1@util/log/buffered_sink.go:353 ⋮ [-] 229  logging error from *log.fluentSink: dial tcp ‹127.0.0.1:5170›: connect: connection refused
```

This patch adds a `--enable-fluent-sink` option to the `roachprod start`
command to conditionally allow clusters to use the `fluent-servers`
logging configuration. It also updates `scripts/drtprod` to use this
option so they can continue to log to external systems.

Epic: none

Release note: none
