### PR TITLE
streamingest: prevent starting duplicate replication

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
@@ -325,6 +325,14 @@ func alterTenantRestartReplication(
 		)
 	}
 
+	if tenInfo.DataState != mtinfopb.DataStateReady {
+		return errors.Newf("cannot start replication for tenant %q (%s) in state %s (is replication or a restore already running?)",
+			tenInfo.Name,
+			dstTenantID,
+			tenInfo.DataState,
+		)
+	}
+
 	if alterTenantStmt.Options.ExpirationWindowSet() {
 		return CannotSetExpirationWindowErr
 	}

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -105,6 +105,10 @@ func TestAlterTenantCompleteToLatest(t *testing.T) {
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 START REPLICATION OF $2 ON $3`,
 		args.DestTenantName, args.SrcTenantName, c.SrcURL.String())
 
+	c.DestSysSQL.ExpectErr(c.T, `is replication or a restore already running`,
+		`ALTER TENANT $1 START REPLICATION OF $2 ON $3`,
+		args.DestTenantName, args.SrcTenantName, c.SrcURL.String())
+
 	// Wait for the resumed replication to advance.
 	_, ingestionJobID = replicationtestutils.GetStreamJobIds(t, ctx, c.DestSysSQL, args.DestTenantName)
 	targetReplicatedTime = c.SrcCluster.Server(0).Clock().Now()


### PR DESCRIPTION
If a tenant is in data set add or drop, another job is already actively writing (or removing) its content, such as another replication job or a restore. In such cases we should not allow another replication job to be started writing to the same tenant.

Release note: none.
Epic: none.