### PR TITLE
scripts/drtprod: set required environment variable

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -93,7 +93,7 @@ case $1 in
 
     # Single quotes around the shell expansion cause it to be processed on the
     # remote host instead of the local host.
-    roachprod ssh ${cluster} -- DD_INSTALL_ONLY=true bash -c '"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"'
+    roachprod ssh ${cluster} -- DD_INSTALL_ONLY=true DD_API_KEY=${dd_api_key} bash -c '"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"'
 
     roachprod ssh ${cluster} -- "sudo tee /etc/datadog-agent/datadog.yaml > /dev/null << EOF
 ---


### PR DESCRIPTION
Unfortunately the Datadog installation script requires that you pass the `DD_API_KEY` environment variable even if you're only doing an installation and no configuration.

This patch passes the `DD_API_KEY` environment variable to satisfy this requirement.

Epic: none

Release note: none