### PR TITLE
drtprod: set max-rate on ua tpcc

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -224,8 +224,14 @@ EOF"
         roachprod ssh workload-ua:1 -- 'cat - > tpcc << EOF 
 #!/usr/bin/env bash
 
-exec ./cockroach workload run tpcc \
-  --warehouses=150000 --workers=100 --wait=false --tolerate-errors --display-every 60s \$(cat /home/ubuntu/pgurls.txt)
+exec ./cockroach workload run tpcc \\
+  --warehouses=150000 \\
+  --max-rate=1200 \\
+  --workers=100 \\
+  --wait=false \\
+  --tolerate-errors \\
+  --display-every 60s \\
+  \$(cat /home/ubuntu/pgurls.txt)
 EOF'
         roachprod ssh workload-ua:1 -- "chmod +x ./tpcc;
 sudo tee /etc/systemd/system/tpcc.service > /dev/null << EOF


### PR DESCRIPTION
Uncapped was using too much CPU; max-rate 1200 uses around 60%.

Release note: none.
Epic: none.