### PR TITLE
rowexec: fix zero oid handling in hash joiner

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -733,3 +733,22 @@ SELECT t2.col_1
 statement ok
 RESET testing_optimizer_random_seed;
 RESET testing_optimizer_disable_rule_probability;
+
+# Regression test for using the correct type when decoding EncDatum of Oid type
+# when probing the row-by-row hash table (#123548).
+statement ok
+CREATE TABLE t123548_1 (col1 REGCLASS, INDEX (col1));
+CREATE TABLE t123548_2 (col2 OID, UNIQUE (col2));
+INSERT INTO t123548_1 VALUES (0);
+INSERT INTO t123548_2 VALUES (0);
+SET testing_optimizer_random_seed = 5928357781746163642;
+SET testing_optimizer_disable_rule_probability = 1.000000;
+
+query T
+SELECT col1 FROM t123548_1 JOIN t123548_2 ON col1 = col2;
+----
+-
+
+statement ok
+RESET testing_optimizer_random_seed;
+RESET testing_optimizer_disable_rule_probability;

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -79,8 +79,9 @@ type HashRowContainer interface {
 	// did not match.
 	// 	- probeEqCols are the equality columns of the given row that are used to
 	// 	  get the bucket of matching rows.
+	//  - probeEqColTypes are the types of the equality columns.
 	NewBucketIterator(
-		ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
+		ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns, probeEqColTypes []*types.T,
 	) (RowMarkerIterator, error)
 
 	// NewUnmarkedIterator returns a RowIterator that iterates over unmarked
@@ -157,10 +158,10 @@ func encodeColumnsOfRow(
 // row. The returned byte slice is only valid until the next call to
 // encodeEqualityColumns().
 func (e *columnEncoder) encodeEqualityCols(
-	ctx context.Context, row rowenc.EncDatumRow, eqCols columns,
+	ctx context.Context, row rowenc.EncDatumRow, eqCols columns, eqColTypes []*types.T,
 ) ([]byte, error) {
 	encoded, hasNull, err := encodeColumnsOfRow(
-		ctx, &e.datumAlloc, e.scratch, row, eqCols, e.keyTypes, e.encodeNull,
+		ctx, &e.datumAlloc, e.scratch, row, eqCols, eqColTypes, e.encodeNull,
 	)
 	if err != nil {
 		return nil, err
@@ -284,7 +285,7 @@ func (h *HashMemRowContainer) Close(ctx context.Context) {
 func (h *HashMemRowContainer) addRowToBucket(
 	ctx context.Context, row rowenc.EncDatumRow, rowIdx int,
 ) error {
-	encoded, err := h.encodeEqualityCols(ctx, row, h.storedEqCols)
+	encoded, err := h.encodeEqualityCols(ctx, row, h.storedEqCols, h.keyTypes)
 	if err != nil {
 		return err
 	}
@@ -321,9 +322,10 @@ func (h *HashMemRowContainer) ReserveMarkMemoryMaybe(ctx context.Context) error 
 
 // hashMemRowBucketIterator iterates over the rows in a bucket.
 type hashMemRowBucketIterator struct {
-	container     *HashMemRowContainer
-	scratchEncRow rowenc.EncDatumRow
-	probeEqCols   columns
+	container       *HashMemRowContainer
+	scratchEncRow   rowenc.EncDatumRow
+	probeEqCols     columns
+	probeEqColTypes []*types.T
 	// rowIdxs are the indices of rows in the bucket.
 	rowIdxs []int
 	curIdx  int
@@ -333,12 +335,13 @@ var _ RowMarkerIterator = &hashMemRowBucketIterator{}
 
 // NewBucketIterator implements the HashRowContainer interface.
 func (h *HashMemRowContainer) NewBucketIterator(
-	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
+	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns, probeEqColTypes []*types.T,
 ) (RowMarkerIterator, error) {
 	ret := &hashMemRowBucketIterator{
-		container:     h,
-		scratchEncRow: make(rowenc.EncDatumRow, len(h.types)),
-		probeEqCols:   probeEqCols,
+		container:       h,
+		scratchEncRow:   make(rowenc.EncDatumRow, len(h.types)),
+		probeEqCols:     probeEqCols,
+		probeEqColTypes: probeEqColTypes,
 	}
 
 	if err := ret.Reset(ctx, row); err != nil {
@@ -402,7 +405,7 @@ func (i *hashMemRowBucketIterator) Mark(ctx context.Context) error {
 }
 
 func (i *hashMemRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDatumRow) error {
-	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols)
+	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols, i.probeEqColTypes)
 	if err != nil {
 		return err
 	}
@@ -592,8 +595,9 @@ func (h *HashDiskRowContainer) IsEmpty() bool {
 // hashDiskRowBucketIterator iterates over the rows in a bucket.
 type hashDiskRowBucketIterator struct {
 	*diskRowIterator
-	container   *HashDiskRowContainer
-	probeEqCols columns
+	container       *HashDiskRowContainer
+	probeEqCols     columns
+	probeEqColTypes []*types.T
 	// haveMarkedRows returns true if we've marked rows since the last time we
 	// recreated our underlying diskRowIterator.
 	haveMarkedRows bool
@@ -608,11 +612,12 @@ var _ RowMarkerIterator = &hashDiskRowBucketIterator{}
 
 // NewBucketIterator implements the HashRowContainer interface.
 func (h *HashDiskRowContainer) NewBucketIterator(
-	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
+	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns, probeEqColTypes []*types.T,
 ) (RowMarkerIterator, error) {
 	ret := &hashDiskRowBucketIterator{
 		container:       h,
 		probeEqCols:     probeEqCols,
+		probeEqColTypes: probeEqColTypes,
 		diskRowIterator: h.NewIterator(ctx).(*diskRowIterator),
 	}
 	if err := ret.Reset(ctx, row); err != nil {
@@ -667,7 +672,7 @@ func (i *hashDiskRowBucketIterator) Row() (tree.Datums, error) {
 }
 
 func (i *hashDiskRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDatumRow) error {
-	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols)
+	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols, i.probeEqColTypes)
 	if err != nil {
 		return err
 	}
@@ -1003,9 +1008,9 @@ func (h *HashDiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 
 // NewBucketIterator implements the hashRowContainer interface.
 func (h *HashDiskBackedRowContainer) NewBucketIterator(
-	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
+	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns, probeEqColTypes []*types.T,
 ) (RowMarkerIterator, error) {
-	return h.src.NewBucketIterator(ctx, row, probeEqCols)
+	return h.src.NewBucketIterator(ctx, row, probeEqCols, probeEqColTypes)
 }
 
 // NewUnmarkedIterator implements the hashRowContainer interface.

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -324,7 +324,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	const numCols = 2
 	rows := randgen.MakeRepeatedIntRows(numRowsInBucket, numRows, numCols)
 	storedEqColumns := columns{0}
-	types := []*types.T{types.Int, types.Int}
+	typs := []*types.T{types.Int, types.Int}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
 	getRowContainer := func() *HashDiskBackedRowContainer {
@@ -332,7 +332,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 		err = rc.Init(
 			ctx,
 			true, /* shouldMark */
-			types,
+			typs,
 			storedEqColumns,
 			true, /*encodeNull */
 		)
@@ -424,7 +424,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			t.Fatal(err)
 		}
 		func() {
-			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns)
+			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns, types.OneIntCol)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -447,7 +447,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			t.Fatal("unexpectedly using memory")
 		}
 		func() {
-			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns)
+			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns, types.OneIntCol)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This commit is similar to the fix in 3095ec7b86f7edcab46e468b6c5e0d0384fb1230 but it applies to hash joiner. Namely, previously it was possible that we'd modify the "probe" (i.e. left) row's EncDatums to decode them using the "build" (i.e. right) row's types, so we could store the incorrect type annotation, e.g. for zero oid datums. This is now fixed by specifying which type schema to use when decoding.

Fixes: #123548.

Release note: None