### PR TITLE
roachtest: skip opr_sanity.sql in pg_regress

### DIFF
--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -223,7 +223,8 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"expressions " +
 		"mvcc " +
 		"regex " +
-		"opr_sanity " +
+		// TODO(#123651): re-enable when pg_catalog.pg_proc is fixed up.
+		// "opr_sanity " +
 		"copyselect " +
 		"copydml " +
 		"copy " +


### PR DESCRIPTION
We currently have incomplete `pg_catalog.pg_proc` contents, so `opr_sanity.sql` subtest results in invalid entries that need to be updated every time when a new builtin function is introduced, which is an unnecessary toil. Let's skip this subtest for now.

Informs: #123401.
Informs: #123651.
Epic: None

Release note: None