### PR TITLE
release-23.1: roachtest: disable or fix failing azure tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_azure.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_azure.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_TENANT_ID -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e SELECT_PROBABILITY -e COCKROACH_RANDOM_SEED -e ROACHTEST_ASSERTIONS_ENABLED_SEED -e ROACHTEST_FORCE_RUN_INVALID_RELEASE_BRANCH -e CLEAR_CLUSTER_CACHE" \
+			       run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -62,6 +62,7 @@ build/teamcity-roachtest-invoke.sh \
   --select-probability="${select_probability}" \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
+  --clear-cluster-cache="${CLEAR_CLUSTER_CACHE:-true}"
   --parallelism="${PARALLELISM}" \
   --cpu-quota="${CPUQUOTA}" \
   --cluster-id="${TC_BUILD_ID}" \

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -62,7 +62,7 @@ build/teamcity-roachtest-invoke.sh \
   --select-probability="${select_probability}" \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
-  --clear-cluster-cache="${CLEAR_CLUSTER_CACHE:-true}"
+  --clear-cluster-cache="${CLEAR_CLUSTER_CACHE:-true}" \
   --parallelism="${PARALLELISM}" \
   --cpu-quota="${CPUQUOTA}" \
   --cluster-id="${TC_BUILD_ID}" \

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -916,13 +916,25 @@ func (f *clusterFactory) newCluster(
 	}
 	// loop assumes maxAttempts is atleast (1).
 	for i := 1; ; i++ {
+		// NB: this intentionally avoids re-using the name across iterations in
+		// the loop. See:
+		//
+		// https://github.com/cockroachdb/cockroach/issues/67906#issuecomment-887477675
+		genName := f.genName(cfg)
+		// Logs for creating a new cluster go to a dedicated log file.
+		var retryStr string
+		if i > 1 {
+			retryStr = "-retry" + strconv.Itoa(i-1)
+		}
+		logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", genName+retryStr+".log")
+		l, err := logger.RootLogger(logPath, teeOpt)
+		if err != nil {
+			log.Fatalf(ctx, "%v", err)
+		}
+
 		c := &clusterImpl{
-			cloud: cloud,
-			// NB: this intentionally avoids re-using the name across iterations in
-			// the loop. See:
-			//
-			// https://github.com/cockroachdb/cockroach/issues/67906#issuecomment-887477675
-			name:       f.genName(cfg),
+			cloud:      cloud,
+			name:       genName,
 			spec:       cfg.spec,
 			expiration: cfg.spec.Expiration(),
 			r:          f.r,
@@ -931,19 +943,9 @@ func (f *clusterFactory) newCluster(
 			destroyState: destroyState{
 				owned: true,
 			},
+			l: l,
 		}
 		c.status("creating cluster")
-
-		// Logs for creating a new cluster go to a dedicated log file.
-		var retryStr string
-		if i > 1 {
-			retryStr = "-retry" + strconv.Itoa(i-1)
-		}
-		logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", c.name+retryStr+".log")
-		l, err := logger.RootLogger(logPath, teeOpt)
-		if err != nil {
-			log.Fatalf(ctx, "%v", err)
-		}
 
 		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
 		createVMOpts.ClusterName = c.name

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -208,6 +208,9 @@ var OnlyAzure = Clouds(spec.Azure)
 // OnlyLocal contains only the Local cloud.
 var OnlyLocal = Clouds(spec.Local)
 
+// CloudsWithServiceRegistration contains clouds that support service registration.
+var CloudsWithServiceRegistration = Clouds(spec.Local, spec.GCE)
+
 // Clouds creates a CloudSet for the given clouds. Cloud names must be one of:
 // spec.Local, spec.GCE, spec.AWS, spec.Azure.
 func Clouds(clouds ...string) CloudSet {
@@ -228,6 +231,17 @@ func (cs CloudSet) NoAWS() CloudSet {
 // NoAzure removes the Azure cloud and returns the new set.
 func (cs CloudSet) NoAzure() CloudSet {
 	return CloudSet{m: removeFromSet(cs.m, spec.Azure)}
+}
+
+// Remove removes all clouds passed in and returns the new set.
+func (cs CloudSet) Remove(clouds ...string) CloudSet {
+	assertValidValues(allClouds, clouds...)
+	copyCs := CloudSet{m: cs.m}
+	for _, c := range clouds {
+		copyCs.m = removeFromSet(copyCs.m, c)
+	}
+
+	return copyCs
 }
 
 // Contains returns true if the set contains the given cloud.

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -193,13 +193,19 @@ var AllExceptLocal = AllClouds.NoLocal()
 // AllExceptAWS contains all clouds except AWS.
 var AllExceptAWS = AllClouds.NoAWS()
 
+// AllExceptAzure contains all clouds except Azure.
+var AllExceptAzure = AllClouds.NoAzure()
+
 // OnlyAWS contains only the AWS cloud.
 var OnlyAWS = Clouds(spec.AWS)
 
 // OnlyGCE contains only the GCE cloud.
 var OnlyGCE = Clouds(spec.GCE)
 
-// OnlyLocal contains only the GCE cloud.
+// OnlyAzure contains only the Azure cloud.
+var OnlyAzure = Clouds(spec.Azure)
+
+// OnlyLocal contains only the Local cloud.
 var OnlyLocal = Clouds(spec.Local)
 
 // Clouds creates a CloudSet for the given clouds. Cloud names must be one of:

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -309,6 +309,15 @@ var (
 		Name:  "global-seed",
 		Usage: `The global random seed used for all tests.`,
 	})
+
+	ClearClusterCache bool = true
+	_                      = registerRunFlag(&ClearClusterCache, FlagInfo{
+		Name: "clear-cluster-cache",
+		Usage: `
+						Clear the local cluster cache of missing clusters when syncing resources with
+						providers. Set this to false when running many concurrent Azure tests. Azure
+						can return stale VM information when many PUT calls are made in succession.`,
+	})
 )
 
 // The flags below override the final cluster configuration. They have no

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -113,6 +114,8 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	if literalArtifactsDir == "" {
 		literalArtifactsDir = artifactsDir
 	}
+
+	roachprod.ClearClusterCache = roachtestflags.ClearClusterCache
 
 	setLogConfig(artifactsDir)
 	runnerDir := filepath.Join(artifactsDir, runnerLogsDir)

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -322,6 +322,8 @@ func (s *ClusterSpec) RoachprodOpts(
 		return vm.CreateOpts{}, nil, "", errors.Errorf("unsupported cloud %v", cloud)
 	}
 	if cloud != GCE {
+		// TODO(DarrylWong): support specifying SSD count on other providers, see: #123777.
+		// Once done, revisit all tests that set SSD count to see if they can run on non GCE.
 		if s.SSDs != 0 {
 			return vm.CreateOpts{}, nil, "", errors.Errorf("specifying SSD count is not yet supported on %s", cloud)
 		}

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -21,13 +21,14 @@ import (
 
 func registerAcceptance(r registry.Registry) {
 	testCases := map[registry.Owner][]struct {
-		name              string
-		fn                func(ctx context.Context, t test.Test, c cluster.Cluster)
-		skip              string
-		numNodes          int
-		timeout           time.Duration
-		encryptionSupport registry.EncryptionSupport
-		defaultLeases     bool
+		name               string
+		fn                 func(ctx context.Context, t test.Test, c cluster.Cluster)
+		skip               string
+		numNodes           int
+		timeout            time.Duration
+		encryptionSupport  registry.EncryptionSupport
+		defaultLeases      bool
+		incompatibleClouds []string // Already assumes AWS is incompatible.
 	}{
 		registry.OwnerKV: {
 			{name: "decommission-self", fn: runDecommissionSelf},
@@ -107,7 +108,7 @@ func registerAcceptance(r registry.Registry) {
 				Skip:              tc.skip,
 				EncryptionSupport: tc.encryptionSupport,
 				Timeout:           10 * time.Minute,
-				CompatibleClouds:  registry.AllExceptAWS,
+				CompatibleClouds:  registry.AllExceptAWS.Remove(tc.incompatibleClouds...),
 				Suites:            registry.Suites(registry.Nightly, registry.Quick),
 			}
 

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -251,7 +251,7 @@ func registerActiveRecord(r registry.Registry) {
 		Timeout:          5 * time.Hour,
 		Cluster:          r.MakeClusterSpec(1),
 		NativeLibs:       registry.LibGEOS,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Run:              runActiveRecord,
 		Leases:           registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -92,7 +92,7 @@ func registerMultiTenantFairness(r registry.Registry) {
 			Owner:             registry.OwnerAdmissionControl,
 			Benchmark:         true,
 			Leases:            registry.MetamorphicLeases,
-			CompatibleClouds:  registry.AllExceptAWS,
+			CompatibleClouds:  registry.CloudsWithServiceRegistration,
 			Suites:            registry.Suites(registry.Nightly),
 			NonReleaseBlocker: false,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -305,14 +305,17 @@ func initBulkJobPerfArtifacts(testName string, timeout time.Duration) (func(), *
 }
 
 func registerBackup(r registry.Registry) {
-
 	backup2TBSpec := r.MakeClusterSpec(10)
 	r.Add(registry.TestSpec{
-		Name:              fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
-		Owner:             registry.OwnerDisasterRecovery,
-		Benchmark:         true,
-		Cluster:           backup2TBSpec,
-		CompatibleClouds:  registry.AllExceptAWS,
+		Name:      fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
+		Owner:     registry.OwnerDisasterRecovery,
+		Benchmark: true,
+		Cluster:   backup2TBSpec,
+		// The default storage on Azure Standard_D4ds_v5 is only 150 GiB compared
+		// to 400 on GCE, which is not enough for this test. We could request a
+		// larger volume size and set spec.LocalSSDDisable if we wanted to run
+		// this on Azure.
+		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -948,12 +948,15 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "cdc/initial-scan-only",
-		Owner:            registry.OwnerCDC,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
-		RequiresLicense:  true,
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:            "cdc/initial-scan-only",
+		Owner:           registry.OwnerCDC,
+		Benchmark:       true,
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),
+		RequiresLicense: true,
+		// This test uses google cloudStorageSink because it is the fastest,
+		// but it is not a requirement for this test. The sink could be
+		// chosen on a per cloud basis if we want to run this on other clouds.
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1154,7 +1157,7 @@ func registerCDC(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),
 		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1183,7 +1186,7 @@ func registerCDC(r registry.Registry) {
 		Owner:            `cdc`,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		RequiresLicense:  true,
@@ -1286,7 +1289,7 @@ func registerCDC(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),
 		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1328,7 +1331,7 @@ func registerCDC(r registry.Registry) {
 		Owner:            `cdc`,
 		Cluster:          r.MakeClusterSpec(1),
 		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -283,6 +283,9 @@ func (bo replicateBulkOps) sourceRunCmd(tenantName string, nodes option.NodeList
 func (bo replicateBulkOps) runDriver(
 	workloadCtx context.Context, c cluster.Cluster, t test.Test, setup *c2cSetup,
 ) error {
+	if c.Cloud() != spec.GCE && !c.IsLocal() {
+		t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
+	}
 	runBackupMVCCRangeTombstones(workloadCtx, t, c, mvccRangeTombstoneConfig{
 		skipBackupRestore: true,
 		skipClusterSetup:  true,

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -58,7 +58,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 			// See: https://github.com/cockroachdb/cockroach/issues/112111.
 			// Once this issue is fixed we should remove this Ubuntu Version override.
 			Cluster:             r.MakeClusterSpec(4, spec.ReuseNone(), spec.DisableLocalSSD(), spec.UbuntuVersion(vm.FocalFossa)),
-			CompatibleClouds:    registry.AllExceptAWS,
+			CompatibleClouds:    registry.OnlyGCE,
 			Suites:              registry.Suites(registry.Nightly),
 			Timeout:             30 * time.Minute,
 			SkipPostValidations: registry.PostValidationNoDeadNodes,

--- a/pkg/cmd/roachtest/tests/fixtures.go
+++ b/pkg/cmd/roachtest/tests/fixtures.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 )
 
@@ -62,14 +63,14 @@ func registerFixtures(r registry.Registry) {
 		fixtureVersion := strings.TrimPrefix(t.BuildVersion().String(), "v")
 		makeVersionFixtureAndFatal(ctx, t, c, fixtureVersion)
 	}
-	spec := registry.TestSpec{
+
+	r.Add(registry.TestSpec{
 		Name:             "generate-fixtures",
 		Timeout:          30 * time.Minute,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Fixtures),
 		Owner:            registry.OwnerTestEng,
 		Cluster:          r.MakeClusterSpec(4),
 		Run:              runFixtures,
-	}
-	r.Add(spec)
+	})
 }

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -40,7 +40,7 @@ func registerMultiTenantDistSQL(r registry.Registry) {
 				Name:             fmt.Sprintf("multitenant/distsql/instances=%d/bundle=%s/timeout=%d", numInstances, b, to),
 				Owner:            registry.OwnerSQLQueries,
 				Cluster:          r.MakeClusterSpec(4),
-				CompatibleClouds: registry.AllExceptAWS,
+				CompatibleClouds: registry.CloudsWithServiceRegistration,
 				Suites:           registry.Suites(registry.Nightly),
 				Leases:           registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -133,7 +133,7 @@ func registerMultiTenantTPCH(r registry.Registry) {
 		Owner:            registry.OwnerSQLQueries,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(1 /* nodeCount */),
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.CloudsWithServiceRegistration,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -98,11 +98,13 @@ func registerPop(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "pop",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "pop",
+		Owner:   registry.OwnerSQLFoundations,
+		Cluster: r.MakeClusterSpec(1),
+		Leases:  registry.MetamorphicLeases,
+		// This test requires custom ports but service registration is
+		// currently only supported on GCE.
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Run:              runPop,
 	})

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -157,11 +157,13 @@ func registerRustPostgres(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "rust-postgres",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1, spec.CPU(16)),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "rust-postgres",
+		Owner:   registry.OwnerSQLFoundations,
+		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
+		Leases:  registry.MetamorphicLeases,
+		// This test requires custom ports but service registration is
+		// currently only supported on GCE.
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRustPostgres(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -306,17 +306,22 @@ var tpccSupportedWarehouses = []struct {
 	v          *version.Version
 	warehouses int
 }{
+	// TODO(darrylwong): these numbers are old, with azure and n5 cluster values being copied
+	// from other configs. We should take another pass to figure out more current numbers.
+
 	// We append "-0" to the version so that we capture all prereleases of the
 	// specified version. Otherwise, "v2.1.0" would compare greater than
 	// "v2.1.0-alpha.x".
 	{hardware: "gce-n4cpu16", v: version.MustParse(`v2.1.0-0`), warehouses: 1300},
 	{hardware: "gce-n4cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 1250},
 	{hardware: "aws-n4cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 2100},
+	{hardware: "azure-n4cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 1300},
 
 	// TODO(tbg): this number is copied from gce-n4cpu16. The real number should be a
 	// little higher, find out what it is.
 	{hardware: "gce-n5cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 1300},
 	{hardware: "aws-n5cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 2100},
+	{hardware: "azure-n5cpu16", v: version.MustParse(`v19.1.0-0`), warehouses: 1300},
 	// Ditto.
 	{hardware: "gce-n5cpu16", v: version.MustParse(`v2.1.0-0`), warehouses: 1300},
 }
@@ -788,35 +793,41 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  4,
 
-		LoadWarehousesGCE: 1000,
-		LoadWarehousesAWS: 1000,
-		EstimatedMaxGCE:   750,
-		EstimatedMaxAWS:   900,
+		LoadWarehousesGCE:   1000,
+		LoadWarehousesAWS:   1000,
+		LoadWarehousesAzure: 1000,
+		EstimatedMaxGCE:     750,
+		EstimatedMaxAWS:     900,
+		EstimatedMaxAzure:   900,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehousesGCE: 3500,
-		LoadWarehousesAWS: 3900,
-		EstimatedMaxGCE:   3100,
-		EstimatedMaxAWS:   3600,
-		Clouds:            registry.AllClouds,
-		Suites:            registry.Suites(registry.Nightly),
+		LoadWarehousesGCE:   3500,
+		LoadWarehousesAWS:   3900,
+		LoadWarehousesAzure: 3900,
+		EstimatedMaxGCE:     3100,
+		EstimatedMaxAWS:     3600,
+		EstimatedMaxAzure:   3600,
+		Clouds:              registry.AllClouds,
+		Suites:              registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
 		CPUs:  16,
 
-		LoadWarehousesGCE: 11500,
-		LoadWarehousesAWS: 11500,
-		EstimatedMaxGCE:   10000,
-		EstimatedMaxAWS:   10000,
+		LoadWarehousesGCE:   11500,
+		LoadWarehousesAWS:   11500,
+		LoadWarehousesAzure: 11500,
+		EstimatedMaxGCE:     10000,
+		EstimatedMaxAWS:     10000,
+		EstimatedMaxAzure:   10000,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Weekly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
@@ -824,10 +835,12 @@ func registerTPCC(r registry.Registry) {
 		CPUs:         16,
 		Distribution: multiZone,
 
-		LoadWarehousesGCE: 6500,
-		LoadWarehousesAWS: 6500,
-		EstimatedMaxGCE:   6300,
-		EstimatedMaxAWS:   6300,
+		LoadWarehousesGCE:   6500,
+		LoadWarehousesAWS:   6500,
+		LoadWarehousesAzure: 6500,
+		EstimatedMaxGCE:     6300,
+		EstimatedMaxAWS:     6300,
+		EstimatedMaxAzure:   6300,
 
 		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
@@ -839,10 +852,12 @@ func registerTPCC(r registry.Registry) {
 		Distribution: multiRegion,
 		LoadConfig:   multiLoadgen,
 
-		LoadWarehousesGCE: 3000,
-		LoadWarehousesAWS: 3000,
-		EstimatedMaxGCE:   2500,
-		EstimatedMaxAWS:   2500,
+		LoadWarehousesGCE:   3000,
+		LoadWarehousesAWS:   3000,
+		LoadWarehousesAzure: 3000,
+		EstimatedMaxGCE:     2500,
+		EstimatedMaxAWS:     2500,
+		EstimatedMaxAzure:   2500,
 
 		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
@@ -853,12 +868,14 @@ func registerTPCC(r registry.Registry) {
 		Chaos:      true,
 		LoadConfig: singlePartitionedLoadgen,
 
-		LoadWarehousesGCE: 2000,
-		LoadWarehousesAWS: 2000,
-		EstimatedMaxGCE:   1700,
-		EstimatedMaxAWS:   1700,
+		LoadWarehousesGCE:   2000,
+		LoadWarehousesAWS:   2000,
+		LoadWarehousesAzure: 2000,
+		EstimatedMaxGCE:     1700,
+		EstimatedMaxAWS:     1700,
+		EstimatedMaxAzure:   1700,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
 	})
 
@@ -868,38 +885,44 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  4,
 
-		LoadWarehousesGCE: 1000,
-		LoadWarehousesAWS: 1000,
-		EstimatedMaxGCE:   750,
-		EstimatedMaxAWS:   900,
-		EncryptionEnabled: true,
+		LoadWarehousesGCE:   1000,
+		LoadWarehousesAWS:   1000,
+		LoadWarehousesAzure: 1000,
+		EstimatedMaxGCE:     750,
+		EstimatedMaxAWS:     900,
+		EstimatedMaxAzure:   900,
+		EncryptionEnabled:   true,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehousesGCE: 3500,
-		LoadWarehousesAWS: 3900,
-		EstimatedMaxGCE:   3100,
-		EstimatedMaxAWS:   3600,
-		EncryptionEnabled: true,
-		Clouds:            registry.AllClouds,
-		Suites:            registry.Suites(registry.Nightly),
+		LoadWarehousesGCE:   3500,
+		LoadWarehousesAWS:   3900,
+		LoadWarehousesAzure: 3900,
+		EstimatedMaxGCE:     3100,
+		EstimatedMaxAWS:     3600,
+		EstimatedMaxAzure:   3600,
+		EncryptionEnabled:   true,
+		Clouds:              registry.AllClouds,
+		Suites:              registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
 		CPUs:  16,
 
-		LoadWarehousesGCE: 11500,
-		LoadWarehousesAWS: 11500,
-		EstimatedMaxGCE:   10000,
-		EstimatedMaxAWS:   10000,
-		EncryptionEnabled: true,
+		LoadWarehousesGCE:   11500,
+		LoadWarehousesAWS:   11500,
+		LoadWarehousesAzure: 11500,
+		EstimatedMaxGCE:     10000,
+		EstimatedMaxAWS:     10000,
+		EstimatedMaxAzure:   10000,
+		EncryptionEnabled:   true,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Weekly),
 	})
 
@@ -908,48 +931,56 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 3,
 		CPUs:  4,
 
-		LoadWarehousesGCE: 1000,
-		LoadWarehousesAWS: 1000,
-		EstimatedMaxGCE:   750,
-		EstimatedMaxAWS:   900,
-		ExpirationLeases:  true,
+		LoadWarehousesGCE:   1000,
+		LoadWarehousesAWS:   1000,
+		LoadWarehousesAzure: 1000,
+		EstimatedMaxGCE:     750,
+		EstimatedMaxAWS:     900,
+		EstimatedMaxAzure:   900,
+		ExpirationLeases:    true,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 3,
 		CPUs:  16,
 
-		LoadWarehousesGCE: 3500,
-		LoadWarehousesAWS: 3900,
-		EstimatedMaxGCE:   3100,
-		EstimatedMaxAWS:   3600,
-		ExpirationLeases:  true,
-		Clouds:            registry.AllClouds,
-		Suites:            registry.Suites(registry.Nightly),
+		LoadWarehousesGCE:   3500,
+		LoadWarehousesAWS:   3900,
+		LoadWarehousesAzure: 3900,
+		EstimatedMaxGCE:     3100,
+		EstimatedMaxAWS:     3600,
+		EstimatedMaxAzure:   3600,
+		ExpirationLeases:    true,
+		Clouds:              registry.AllClouds,
+		Suites:              registry.Suites(registry.Nightly),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
 		CPUs:  16,
 
-		LoadWarehousesGCE: 11500,
-		LoadWarehousesAWS: 11500,
-		EstimatedMaxGCE:   10000,
-		EstimatedMaxAWS:   10000,
-		ExpirationLeases:  true,
+		LoadWarehousesGCE:   11500,
+		LoadWarehousesAWS:   11500,
+		LoadWarehousesAzure: 11500,
+		EstimatedMaxGCE:     10000,
+		EstimatedMaxAWS:     10000,
+		EstimatedMaxAzure:   10000,
+		ExpirationLeases:    true,
 
-		Clouds: registry.AllExceptAWS,
+		Clouds: registry.OnlyGCE,
 		Suites: registry.Suites(registry.Weekly),
 	})
 }
 
-func gceOrAws(cloud string, gce, aws int) int {
+func valueForCloud(cloud string, gce, aws, azure int) int {
 	switch cloud {
 	case spec.AWS:
 		return aws
 	case spec.GCE:
 		return gce
+	case spec.Azure:
+		return azure
 	default:
 		panic(fmt.Sprintf("unknown cloud %s", cloud))
 	}
@@ -1023,15 +1054,17 @@ type tpccBenchSpec struct {
 	// The number of warehouses to load into the cluster before beginning
 	// benchmarking. Should be larger than EstimatedMax and should be a
 	// value that is unlikely to be achievable.
-	LoadWarehousesGCE int
-	LoadWarehousesAWS int
+	LoadWarehousesGCE   int
+	LoadWarehousesAWS   int
+	LoadWarehousesAzure int
 	// An estimate of the maximum number of warehouses achievable in the
 	// cluster config. The closer this is to the actual max achievable
 	// warehouse count, the faster the benchmark will be in producing a
 	// result. This can be adjusted over time as performance characteristics
 	// change (i.e. CockroachDB gets faster!).
-	EstimatedMaxGCE int
-	EstimatedMaxAWS int
+	EstimatedMaxGCE   int
+	EstimatedMaxAWS   int
+	EstimatedMaxAzure int
 
 	// MinVersion to pass to testRegistryImpl.Add.
 	MinVersion string
@@ -1046,11 +1079,11 @@ type tpccBenchSpec struct {
 }
 
 func (s tpccBenchSpec) EstimatedMax(cloud string) int {
-	return gceOrAws(cloud, s.EstimatedMaxGCE, s.EstimatedMaxAWS)
+	return valueForCloud(cloud, s.EstimatedMaxGCE, s.EstimatedMaxAWS, s.EstimatedMaxAzure)
 }
 
 func (s tpccBenchSpec) LoadWarehouses(cloud string) int {
-	return gceOrAws(cloud, s.LoadWarehousesGCE, s.LoadWarehousesAWS)
+	return valueForCloud(cloud, s.LoadWarehousesGCE, s.LoadWarehousesAWS, s.LoadWarehousesAzure)
 }
 
 // partitions returns the number of partitions specified to the load generator.

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -113,7 +113,7 @@ func registerTPCE(r registry.Registry) {
 		Owner:            registry.OwnerTestEng,
 		Timeout:          4 * time.Hour,
 		Cluster:          r.MakeClusterSpec(smallNightly.nodes+1, spec.CPU(smallNightly.cpus), spec.SSD(smallNightly.ssds)),
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		// Never run with runtime assertions as this makes this test take
 		// too long to complete.
@@ -134,7 +134,7 @@ func registerTPCE(r registry.Registry) {
 		Name:             fmt.Sprintf("tpce/c=%d/nodes=%d", largeWeekly.customers, largeWeekly.nodes),
 		Owner:            registry.OwnerTestEng,
 		Benchmark:        true,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Timeout:          36 * time.Hour,
 		Cluster:          r.MakeClusterSpec(largeWeekly.nodes+1, spec.CPU(largeWeekly.cpus), spec.SSD(largeWeekly.ssds)),

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -121,7 +121,7 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 					},
-					CompatibleClouds: registry.AllExceptAWS,
+					CompatibleClouds: registry.OnlyGCE,
 					Suites:           registry.Suites(registry.Nightly),
 				})
 			}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -225,6 +225,13 @@ func CachedClusters(l *logger.Logger, fn func(clusterName string, numVMs int)) {
 	}
 }
 
+// ClearClusterCache indicates if we should ever clear the local cluster
+// cache of clusters. This flag is set to false during Azure nightly runs,
+// as the large amount of concurrent resources created will cause Azure.List
+// to return stale VM information with no error. Similar to when there is an
+// error, we do not want to remove any clusters from the cache.
+var ClearClusterCache = true
+
 // Sync grabs an exclusive lock on the roachprod state and then proceeds to
 // read the current state from the cloud and write it out to disk. The locking
 // protects both the reading and the writing in order to prevent the hazard
@@ -246,7 +253,7 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 	// Instead, we tell syncClustersCache not to remove any clusters as we
 	// can't tell if a cluster was deleted or not found due to the error.
 	// The next successful ListCloud call will clean it up.
-	overwriteMissingClusters := err == nil
+	overwriteMissingClusters := err == nil && ClearClusterCache
 	if err := syncClustersCache(l, cld, overwriteMissingClusters); err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1323,6 +1323,8 @@ func Create(
 
 	if createVMOpts.SSDOpts.FileSystem == vm.Zfs {
 		for _, provider := range createVMOpts.VMProviders {
+			// TODO(DarrylWong): support zfs on other providers, see: #123775.
+			// Once done, revisit all tests that set zfs to see if they can run on non GCE.
 			if provider != gce.ProviderName {
 				return fmt.Errorf(
 					"creating a node with --filesystem=zfs is currently only supported on gce",


### PR DESCRIPTION
Backport 7/7 commits from #121709.

/cc @cockroachdb/release

---

In the near future we will start running nightly roachtests on Azure. This PR attempts to disable or fix most roachtests that fail on Azure.

The vast majority of failures are due to some sort of cloud incompatibility, i.e. trying to write to a gcs bucket or using google pub/sub changefeeds. In these cases, the test was disabled for Azure. A few tests however, failed due to a lack of setup and were fixed instead.

We also make a change to when the local cluster cache can delete clusters. Instead, we now attempt to clear the cache of deleted clusters at the start of a roachtest run, but do not allow deletion after that. This is due to Azure returning stale information about which VMs we have running. With the original cache behavior, this would see us removing all Azure VMs after `azure.List` returned no VMs.

Release note: none
Fixes: none
Epic: none

Release Justification: test-only change
