### PR TITLE
release-23.2: rowexec: fix zero oid handling in hash joiner

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -733,3 +733,22 @@ SELECT t2.col_1
 statement ok
 RESET testing_optimizer_random_seed;
 RESET testing_optimizer_disable_rule_probability;
+
+# Regression test for using the correct type when decoding EncDatum of Oid type
+# when probing the row-by-row hash table (#123548).
+statement ok
+CREATE TABLE t123548_1 (col1 REGCLASS, INDEX (col1));
+CREATE TABLE t123548_2 (col2 OID, UNIQUE (col2));
+INSERT INTO t123548_1 VALUES (0);
+INSERT INTO t123548_2 VALUES (0);
+SET testing_optimizer_random_seed = 5928357781746163642;
+SET testing_optimizer_disable_rule_probability = 1.000000;
+
+query T
+SELECT col1 FROM t123548_1 JOIN t123548_2 ON col1 = col2;
+----
+-
+
+statement ok
+RESET testing_optimizer_random_seed;
+RESET testing_optimizer_disable_rule_probability;

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -356,7 +356,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	const numCols = 2
 	rows := randgen.MakeRepeatedIntRows(numRowsInBucket, numRows, numCols)
 	storedEqColumns := columns{0}
-	types := []*types.T{types.Int, types.Int}
+	typs := []*types.T{types.Int, types.Int}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
 	getRowContainer := func() *HashDiskBackedRowContainer {
@@ -364,7 +364,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 		err = rc.Init(
 			ctx,
 			true, /* shouldMark */
-			types,
+			typs,
 			storedEqColumns,
 			true, /*encodeNull */
 		)
@@ -456,7 +456,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			t.Fatal(err)
 		}
 		func() {
-			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns)
+			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns, types.OneIntCol)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -479,7 +479,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			t.Fatal("unexpectedly using memory")
 		}
 		func() {
-			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns)
+			i, err := rc.NewBucketIterator(ctx, rows[0], storedEqColumns, types.OneIntCol)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #123646.

/cc @cockroachdb/release

---

This commit is similar to the fix in 3095ec7b86f7edcab46e468b6c5e0d0384fb1230 but it applies to hash joiner. Namely, previously it was possible that we'd modify the "probe" (i.e. left) row's EncDatums to decode them using the "build" (i.e. right) row's types, so we could store the incorrect type annotation, e.g. for zero oid datums. This is now fixed by specifying which type schema to use when decoding.

Fixes: #123548.

Release note: None

Release justification: bug fix.