### PR TITLE
mixedversion: redirect failures to test-eng if user hooks never ran

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/cmd/roachprod/grafana",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
         "//pkg/cmd/roachtest/test",
@@ -49,6 +50,7 @@ go_test(
     embed = [":mixedversion"],
     deps = [
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/roachtestutil/clusterupgrade",
         "//pkg/roachpb",
@@ -59,6 +61,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/version",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -36,7 +36,7 @@ var (
 			Stdout: io.Discard,
 			Stderr: io.Discard,
 		}
-		l, err := cfg.NewLogger("/dev/null" /* path */)
+		l, err := cfg.NewLogger("" /* path */)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
If a mixed-version test fails before user-provided functions had a chance to run, then it means that *something* went wrong while setting up the cluster. In these cases, it doesn't make sense to create an issue with the team that owns the test as it adds noise (e.g., #123610).

With this commit, we now redirect these failures to test-eng, who will be better positioned to diagnose and fix any issues.

Epic: none

Release note: None