### PR TITLE
release-23.2: catalog: repair descriptors with incorrect self references in FK

### DIFF
--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -136,4 +136,8 @@ const (
 	// GrantExecuteOnFunctionToPublicRole indicates that EXECUTE was granted
 	// to the public role for a function.
 	GrantExecuteOnFunctionToPublicRole
+
+	// FixedIncorrectForeignKeyOrigins indicates that foreign key origin /
+	// reference IDs that should point to the current descriptor were fixed.
+	FixedIncorrectForeignKeyOrigins
 )

--- a/pkg/sql/catalog/tabledesc/table_desc_test.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_test.go
@@ -81,8 +81,9 @@ func TestStripDanglingBackReferences(t *testing.T) {
 					},
 				},
 				InboundFKs: []descpb.ForeignKeyConstraint{
-					{OriginTableID: 12345},
-					{OriginTableID: 105},
+					{OriginTableID: 12345, ReferencedTableID: 104},
+					{OriginTableID: 12345, ReferencedTableID: 12345},
+					{OriginTableID: 105, ReferencedTableID: 104},
 				},
 				ReplacementOf: descpb.TableDescriptor_Replacement{ID: 12345},
 			},
@@ -144,6 +145,55 @@ func TestStripDanglingBackReferences(t *testing.T) {
 			}))
 			desc := b.BuildCreatedMutableTable()
 			require.True(t, desc.GetPostDeserializationChanges().Contains(catalog.StrippedDanglingBackReferences))
+			require.Equal(t, out.BuildCreatedMutableTable().TableDesc(), desc.TableDesc())
+		})
+	}
+}
+
+func TestFixIncorrectFKOriginTableID(t *testing.T) {
+	type testCase struct {
+		name                  string
+		input, expectedOutput descpb.TableDescriptor
+	}
+	testData := []testCase{
+		{
+			name: "incorrect FK Origin Table ID",
+			input: descpb.TableDescriptor{
+				Name: "foo",
+				ID:   104,
+				InboundFKs: []descpb.ForeignKeyConstraint{
+					{OriginTableID: 32, ReferencedTableID: 1},
+					{OriginTableID: 64, ReferencedTableID: 2},
+				},
+				OutboundFKs: []descpb.ForeignKeyConstraint{
+					{OriginTableID: 1, ReferencedTableID: 32},
+					{OriginTableID: 2, ReferencedTableID: 64},
+				},
+			},
+			expectedOutput: descpb.TableDescriptor{
+				Name: "foo",
+				ID:   104,
+				InboundFKs: []descpb.ForeignKeyConstraint{
+					{OriginTableID: 32, ReferencedTableID: 104},
+					{OriginTableID: 64, ReferencedTableID: 104},
+				},
+				OutboundFKs: []descpb.ForeignKeyConstraint{
+					{OriginTableID: 104, ReferencedTableID: 32},
+					{OriginTableID: 104, ReferencedTableID: 64},
+				},
+			},
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			b := NewBuilder(&test.input)
+			require.NoError(t, b.RunPostDeserializationChanges())
+			out := NewBuilder(&test.expectedOutput)
+			require.NoError(t, out.RunPostDeserializationChanges())
+			desc := b.BuildCreatedMutableTable()
+			require.True(t, desc.GetPostDeserializationChanges().Contains(catalog.FixedIncorrectForeignKeyOrigins))
+			require.False(t, out.BuildCreatedMutableTable().GetPostDeserializationChanges().Contains(catalog.FixedIncorrectForeignKeyOrigins))
 			require.Equal(t, out.BuildCreatedMutableTable().TableDesc(), desc.TableDesc())
 		})
 	}


### PR DESCRIPTION
Backport 1/1 commits from #123587.

/cc @cockroachdb/release

---

Previously, we had a corruption bug that could lead to descriptors with self references that pointed to incorrect descriptor IDs. This could lead to validation errors that make tables inaccessible. To address this, this patch will add an automatic post deserialization repair to fix these values to the current descriptor ID.

Fixes: #123555
Fixes: #123493

Release note (bug fix): automatically repair tables which see the following error "invalid inbound foreign key ... origin table ID should be" or "invalid outbound foreign key ... reference table ID should be".''

Release justification: a low risk fix to automatically repair a corruption that can make tables unreadable.
