### PR TITLE
release-23.1: schemachange/mixed-versions-compat disable 22.2 corpus

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -143,6 +143,9 @@ func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c 
 
 	// Test definitions which indicates which version of the corpus to fetch,
 	// and the binary to validate against.
+	// Note: Testing against 22.2 corpus files has been removed since we no longer
+	// run nighties on that branch. We will validate the mixed version state works
+	// correctly on 23.1.
 	compatTests := []struct {
 		testName               string
 		binaryVersion          *clusterupgrade.Version
@@ -154,11 +157,6 @@ func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c 
 			binaryVersion:          predecessorVersion,
 			corpusVersion:          fmt.Sprintf("mixed-release-%s", releaseSeries(currentVersion)),
 			alternateCorpusVersion: "mixed-master",
-		},
-		{
-			testName:      "forwards compatibility",
-			binaryVersion: currentVersion,
-			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(predecessorVersion)),
 		},
 		{
 			testName:      "same version",


### PR DESCRIPTION
Previously, we would run logictest on the 22.2 branch which would generate the coprus files which would be used for backwards compatibility. We stopped running the nighties on that branch so new files were no longer generated and the old ones from the google cloud storage bucket for this test will eventually expire. Since, we are no longer making major changes on this branch (or 22.2), we no longer have need to validate compatibility any further against 22.2. To address this, this patch drops the backwards compatibility test from this roachtest.

Fixes: #123638
Release note: None
Release justification: test only change to disable backwards compatibility tests now change 22.2 can no longer change.