### PR TITLE
tree: don't redact PlaceholderIdx type in logs

### DIFF
--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -18,16 +18,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/redact"
 )
 
 // PlaceholderIdx is the 0-based index of a placeholder. Placeholder "$1"
 // has PlaceholderIdx=0.
 type PlaceholderIdx uint16
 
+var _ redact.SafeValue = PlaceholderIdx(0)
+
 // MaxPlaceholderIdx is the maximum allowed value of a PlaceholderIdx.
 // The pgwire protocol is limited to 2^16 placeholders, so we limit the IDs to
 // this range as well.
 const MaxPlaceholderIdx = math.MaxUint16
+
+// SafeValue implements the redact.SafeValue interface.
+func (idx PlaceholderIdx) SafeValue() {}
 
 // String returns the index as a placeholder string representation ($1, $2 etc).
 func (idx PlaceholderIdx) String() string {

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -197,6 +197,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/sem/tree": {
 						"IsolationLevel": {},
+						"PlaceholderIdx": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness": {
 						"SessionID": {},


### PR DESCRIPTION
This is just an integer constant, so it is not sensitive.

Epic: None
Release note: None