### PR TITLE
sqlstats: fix sampling logic for first recording of a statement

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1147,6 +1147,7 @@ func (s *Server) newConnExecutor(
 		applicationStats,
 		ex.server.insights.Writer(ex.sessionData().Internal),
 		ex.phaseTimes,
+		s.sqlStats.GetCounters(),
 		s.cfg.SQLStatsTestingKnobs,
 	)
 	ex.dataMutatorIterator.onApplicationNameChange = func(newName string) {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3344,12 +3344,6 @@ func (ex *connExecutor) recordTransactionFinish(
 	txnTime := txnEnd.Sub(txnStart)
 	ex.totalActiveTimeStopWatch.Stop()
 
-	if ex.server.cfg.TestingKnobs.OnRecordTxnFinish != nil {
-		ex.server.cfg.TestingKnobs.OnRecordTxnFinish(
-			ex.executorType == executorTypeInternal, ex.phaseTimes, ex.planner.stmt.SQL,
-		)
-	}
-
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.
 	if contentionDuration := ex.extraTxnState.accumulatedStats.ContentionTime.Nanoseconds(); contentionDuration > 0 {
@@ -3403,6 +3397,12 @@ func (ex *connExecutor) recordTransactionFinish(
 		// TODO(107318): add readonly
 		SessionData: ex.sessionData(),
 		TxnErr:      txnErr,
+	}
+
+	if ex.server.cfg.TestingKnobs.OnRecordTxnFinish != nil {
+		ex.server.cfg.TestingKnobs.OnRecordTxnFinish(
+			ex.executorType == executorTypeInternal, ex.phaseTimes, ex.planner.stmt.SQL, recordedTxnStats,
+		)
 	}
 
 	ex.maybeRecordRetrySerializableContention(ev.txnID, transactionFingerprintID, txnErr)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3300,7 +3300,8 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.extraTxnState.rowsReadLogged = false
 
 	txnExecStatsSampleRate := collectTxnStatsSampleRate.Get(&ex.server.GetExecutorConfig().Settings.SV)
-	ex.extraTxnState.shouldCollectTxnExecutionStats = txnExecStatsSampleRate > ex.rng.internal.Float64()
+	ex.extraTxnState.shouldCollectTxnExecutionStats = !ex.server.cfg.TestingKnobs.DisableProbabilisticSampling &&
+		txnExecStatsSampleRate > ex.rng.internal.Float64()
 
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3291,7 +3291,6 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.extraTxnState.transactionStatementsHash = util.MakeFNV64()
 	ex.extraTxnState.transactionStatementFingerprintIDs = nil
 	ex.extraTxnState.numRows = 0
-	ex.extraTxnState.shouldCollectTxnExecutionStats = false
 	ex.extraTxnState.accumulatedStats = execstats.QueryLevelStats{}
 	ex.extraTxnState.idleLatency = 0
 	ex.extraTxnState.rowsRead = 0
@@ -3299,9 +3298,9 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.extraTxnState.rowsWritten = 0
 	ex.extraTxnState.rowsWrittenLogged = false
 	ex.extraTxnState.rowsReadLogged = false
-	if txnExecStatsSampleRate := collectTxnStatsSampleRate.Get(&ex.server.GetExecutorConfig().Settings.SV); txnExecStatsSampleRate > 0 {
-		ex.extraTxnState.shouldCollectTxnExecutionStats = txnExecStatsSampleRate > ex.rng.internal.Float64()
-	}
+
+	txnExecStatsSampleRate := collectTxnStatsSampleRate.Get(&ex.server.GetExecutorConfig().Settings.SV)
+	ex.extraTxnState.shouldCollectTxnExecutionStats = txnExecStatsSampleRate > ex.rng.internal.Float64()
 
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1640,7 +1640,7 @@ type ExecutorTestingKnobs struct {
 
 	// OnRecordTxnFinish, if set, will be called as we record a transaction
 	// finishing.
-	OnRecordTxnFinish func(isInternal bool, phaseTimes *sessionphase.Times, stmt string)
+	OnRecordTxnFinish func(isInternal bool, phaseTimes *sessionphase.Times, stmt string, txnStats sqlstats.RecordedTxnStats)
 
 	// UseTransactionDescIDGenerator is used to force descriptor ID generation
 	// to use a transaction, and, in doing so, more deterministically allocate

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1662,6 +1662,13 @@ type ExecutorTestingKnobs struct {
 	// ForceSQLLivenessSession will force the use of a sqlliveness session for
 	// transaction deadlines even in the system tenant.
 	ForceSQLLivenessSession bool
+
+	// DisableProbabilisticSampling, if set to true, will disable
+	// probabilistic transaction sampling. This is important for tests that
+	// want to deterministically test cases where we turn on transaction sampling
+	// due to some other condition. We can't set the probability to 0 since
+	// that would disable the feature entirely.
+	DisableProbabilisticSampling bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -470,19 +470,23 @@ func (ih *instrumentationHelper) Setup(
 		}
 	}
 
-	ih.collectExecStats = collectTxnExecStats
+	shouldSampleFirstEncounter := func() bool {
+		// If this is the first time we see this statement in the current stats
+		// container, we'll collect its execution stats anyway (unless the user
+		// disabled txn or stmt stats collection entirely).
+		// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
+		if collectTxnStatsSampleRate.Get(&cfg.Settings.SV) == 0 ||
+			!sqlstats.StmtStatsEnable.Get(&cfg.Settings.SV) {
+			return false
+		}
 
-	// Don't collect it if Stats Collection is disabled. If it is disabled the
-	// stats are not stored, so it always returns false for previouslySampled.
-	// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
-	if !collectTxnExecStats && (!previouslySampled && sqlstats.StmtStatsEnable.Get(&cfg.Settings.SV)) {
-		// We don't collect the execution stats for statements in this txn, but
-		// this is the first time we see this statement ever, so we'll collect
-		// its execution stats anyway (unless the user disabled txn stats
-		// collection entirely).
-		statsCollectionDisabled := collectTxnStatsSampleRate.Get(&cfg.Settings.SV) == 0
-		ih.collectExecStats = !statsCollectionDisabled
+		// We don't want to collect the stats if the stats container is full,
+		// since previouslySampled will always return false for statements
+		// not already in the container.
+		return !previouslySampled && !statsCollector.StatementsContainerFull()
 	}
+
+	ih.collectExecStats = collectTxnExecStats || shouldSampleFirstEncounter()
 
 	if !ih.collectBundle && ih.withStatementTrace == nil && ih.outputMode == unmodifiedOutput {
 		if ih.collectExecStats {

--- a/pkg/sql/instrumentation_test.go
+++ b/pkg/sql/instrumentation_test.go
@@ -13,11 +13,15 @@ package sql
 import (
 	"context"
 	gosql "database/sql"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -199,4 +203,94 @@ func TestSampledStatsCollection(t *testing.T) {
 		// stats are collected. Should we make DEALLOCATE similar to that, or
 		// should we change PREPARE so that stats are collected?
 	})
+}
+
+// TestSampledStatsCollectionOnNewFingerprint tests that we sample
+// a fingerprint if it's the first time the current sql stats
+// container has seen it, unless the container is full.
+func TestSampledStatsCollectionOnNewFingerprint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testApp := `sampling-test`
+	ctx := context.Background()
+	var collectedTxnStats []sqlstats.RecordedTxnStats
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &ExecutorTestingKnobs{
+				DisableProbabilisticSampling: true,
+				OnRecordTxnFinish: func(isInternal bool, _ *sessionphase.Times, stmt string, txnStats sqlstats.RecordedTxnStats) {
+					// We won't run into a race here because we'll only observe
+					// txns from a single connection.
+					if txnStats.SessionData.ApplicationName == testApp {
+						if strings.Contains(stmt, `SET application_name`) {
+							return
+						}
+						collectedTxnStats = append(collectedTxnStats, txnStats)
+					}
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+	ts := s.ApplicationLayer()
+	st := &ts.ClusterSettings().SV
+	conn := sqlutils.MakeSQLRunner(ts.SQLConn(t))
+	conn.Exec(t, "SET application_name = $1", testApp)
+
+	t.Run("do-sampling-when-container-not-full", func(t *testing.T) {
+		// All of these statements should be sampled because they are new
+		// fingerprints.
+		queries := []string{
+			"SELECT 1",
+			"SELECT 1, 2, 3",
+			"CREATE TABLE IF NOT EXISTS foo (x INT)",
+			"SELECT * FROM foo",
+			// An explicit txn results in the queries inside being recorded as 'new' statements.
+			"BEGIN; SELECT 1; COMMIT;",
+		}
+
+		for _, q := range queries {
+			conn.Exec(t, q)
+		}
+
+		require.Equal(t, len(queries), len(collectedTxnStats))
+
+		// We should have collected stats for each of the queries.
+		for i := range collectedTxnStats {
+			require.True(t, collectedTxnStats[i].CollectedExecStats)
+		}
+	})
+
+	collectedTxnStats = nil
+
+	t.Run("skip-sampling-when-container-full", func(t *testing.T) {
+		// We'll set the in-memory container cap to 1 statement. The container
+		// will be full after the first statement is recorded, and thus each
+		// subsequent statement will be new to the container.
+		persistedsqlstats.MinimumInterval.Override(ctx, st, 10*time.Minute)
+		sqlstats.MaxMemSQLStatsStmtFingerprints.Override(ctx, st, 1)
+		// Use a new conn to ensure we hit the cap (the limit is node-wide).
+		conn2 := sqlutils.MakeSQLRunner(ts.SQLConn(t))
+		conn2.Exec(t, "SELECT 1")
+
+		queries := []string{
+			"SELECT 'aaaaaa'",
+			"CREATE TABLE IF NOT EXISTS bar (x INT)",
+			"SELECT * FROM bar",
+			"BEGIN; SELECT 1; SELECT 1, 2; COMMIT;",
+		}
+
+		// Back to our observed connection.
+		for _, q := range queries {
+			conn.Exec(t, q)
+		}
+		require.Equal(t, len(queries), len(collectedTxnStats))
+
+		// Verify we did not collect execution stats for any of the queries.
+		for i := range collectedTxnStats {
+			require.False(t, collectedTxnStats[i].CollectedExecStats)
+		}
+	})
+
 }

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -104,6 +104,10 @@ func (s *SQLStats) GetTotalFingerprintBytes() int64 {
 	return s.mu.mon.AllocBytes()
 }
 
+func (s *SQLStats) GetCounters() *ssmemstorage.SQLStatsAtomicCounters {
+	return s.atomic
+}
+
 func (s *SQLStats) getStatsForApplication(appName string) *ssmemstorage.Container {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -463,6 +463,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		appStats,
 		insightsProvider.Writer(false /* internal */),
 		sessionphase.NewTimes(),
+		sqlStats.GetCounters(),
 		nil, /* knobs */
 	)
 
@@ -589,6 +590,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			appStats,
 			insightsProvider.Writer(false /* internal */),
 			sessionphase.NewTimes(),
+			sqlStats.GetCounters(),
 			nil, /* knobs */
 		)
 

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -739,7 +739,7 @@ func TestTransactionServiceLatencyOnExtendedProtocol(t *testing.T) {
 				finishedExecute.Set(true)
 			}
 		},
-		OnRecordTxnFinish: func(isInternal bool, phaseTimes *sessionphase.Times, stmt string) {
+		OnRecordTxnFinish: func(isInternal bool, phaseTimes *sessionphase.Times, stmt string, _ sqlstats.RecordedTxnStats) {
 			tc.Lock()
 			defer tc.Unlock()
 			if !isInternal && tc.query == stmt && finishedExecute.Get() {

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/redact"
 )
 
@@ -47,8 +48,11 @@ type StatsCollector struct {
 	sendInsights bool
 
 	flushTarget sqlstats.ApplicationStats
-	st          *cluster.Settings
-	knobs       *sqlstats.TestingKnobs
+
+	uniqueServerCounts *ssmemstorage.SQLStatsAtomicCounters
+
+	st    *cluster.Settings
+	knobs *sqlstats.TestingKnobs
 }
 
 var _ sqlstats.ApplicationStats = &StatsCollector{}
@@ -59,14 +63,16 @@ func NewStatsCollector(
 	appStats sqlstats.ApplicationStats,
 	insights insights.Writer,
 	phaseTime *sessionphase.Times,
+	uniqueServerCounts *ssmemstorage.SQLStatsAtomicCounters,
 	knobs *sqlstats.TestingKnobs,
 ) *StatsCollector {
 	return &StatsCollector{
-		ApplicationStats: appStats,
-		insightsWriter:   insights,
-		phaseTimes:       phaseTime.Clone(),
-		st:               st,
-		knobs:            knobs,
+		ApplicationStats:   appStats,
+		insightsWriter:     insights,
+		phaseTimes:         phaseTime.Clone(),
+		uniqueServerCounts: uniqueServerCounts,
+		st:                 st,
+		knobs:              knobs,
 	}
 }
 
@@ -295,4 +301,10 @@ func (s *StatsCollector) ObserveTransaction(
 	} else {
 		s.insightsWriter.ObserveTransaction(value.SessionID, &insight)
 	}
+}
+
+// StatementsContainerFull returns true if the current statement
+// container is at capacity.
+func (s *StatsCollector) StatementsContainerFull() bool {
+	return s.uniqueServerCounts.GetStatementCount() >= s.uniqueServerCounts.UniqueStmtFingerprintLimit.Get(&s.st.SV)
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_counter.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_counter.go
@@ -175,3 +175,9 @@ func (s *SQLStatsAtomicCounters) freeByCnt(
 func (s *SQLStatsAtomicCounters) GetTotalFingerprintCount() int64 {
 	return atomic.LoadInt64(&s.uniqueStmtFingerprintCount) + atomic.LoadInt64(&s.uniqueTxnFingerprintCount)
 }
+
+// GetStatementCount returns the number of unique statement fingerprints stored
+// in the current SQLStats.
+func (s *SQLStatsAtomicCounters) GetStatementCount() int64 {
+	return atomic.LoadInt64(&s.uniqueStmtFingerprintCount)
+}


### PR DESCRIPTION
By default we sample execution stats for 1% of statements,
(`sql.txn_stats.sample_rate`). We also turn on sampling if
this is the first time we're recording this fingerprint in the
application container. This 'sample on first encounter' logic did
not factor in the scenario where we may be unable to write new
fingerprints due to reaching max container capacities. Previously,
this meant that once the containers were full we'd begin to trace
every fingerprint that did not already get recorded.

This commit ensures that we also check the capacity when deciding
to sample a fingerprint we haven't recorded yet, skipping the sampling
if it is full.  Note that although the container may reach capacity
during the statement's execution, it's more important that we stop sampling
once we are sure the fingerprint cannot be written to the container.

Fixes: https://github.com/cockroachdb/cockroach/issues/123690

Release note: None