### PR TITLE
invertedidx: right-size pre-allocation for trigram rule

### DIFF
--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -276,8 +276,8 @@ func TryFilterInvertedIndexBySimilarity(
 			// Create a key for the trigram. The trigram is encoded so that it
 			// can be correctly compared to histogram upper bounds, which are
 			// also encoded. The byte slice is pre-sized to hold the trigram
-			// plus two extra bytes for the prefix and terminator.
-			k := make([]byte, 0, len(trgms[j])+2)
+			// plus three extra bytes for the prefix, escape, and terminator.
+			k := make([]byte, 0, len(trgms[j])+3)
 			k = encoding.EncodeStringAscending(k, trgms[j])
 			key := constraint.MakeKey(tree.NewDEncodedKey(tree.DEncodedKey(k)))
 
@@ -428,7 +428,7 @@ func similarityTrigramsToScan(s string, similarityThreshold float64) []string {
 			i++
 		}
 
-		// If there are still trigrams to remove, remove trigrams as the end of
+		// If there are still trigrams to remove, remove trigrams at the end of
 		// the slice.
 		if toRemove > 0 {
 			trgms = trgms[:len(trgms)-toRemove]

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -942,7 +942,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 
 // GenerateTrigramSimilarityInvertedIndexScans generates scans on inverted
 // trigram indexes that are constrained by similarity filters (e.g.,
-// `s & % 'foo'`). It is similar conceptually to GenerateInvertedIndexScans, but
+// `s % 'foo'`). It is similar conceptually to GenerateInvertedIndexScans, but
 // it produces expression trees optimized specially for similarity filters. The
 // resulting expressions:
 //

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1119,9 +1119,9 @@ func encodeTrigramInvertedIndexTableKeys(
 	for i := range trigrams {
 		// Make sure to copy inKey into a new byte slice to avoid aliasing.
 		inKeyLen := len(inKey)
-		// Pre-size the outkey - we know we're going to encode the trigram plus 2
-		// extra bytes for the prefix and terminator.
-		outKey := make([]byte, inKeyLen, inKeyLen+len(trigrams[i])+2)
+		// Pre-size the outkey - we know we're going to encode the trigram plus
+		// three extra bytes for the prefix, escape, and terminator.
+		outKey := make([]byte, inKeyLen, inKeyLen+len(trigrams[i])+3)
 		copy(outKey, inKey)
 		newKey := encoding.EncodeStringAscending(outKey, trigrams[i])
 		outKeys[i] = newKey


### PR DESCRIPTION
When encoding each string, I think we always need to add at least three
extra bytes:
- prefix `bytesMarker`
- escape
- terminator.

(We need to add more escapes if the string itself has the escape character.)

Previously, we would pre-allocate extra capacity only for two bytes, so we'd always have to reallocate. This is now fixed.

The same problem is also fixed when encoding inverted index keys for trigrams. Additionally, this commit fixes a couple of typos in the comments.

Epic: None
Informs: #112675.

Release note: None