### PR TITLE
release-23.2: ci: autokill roachtest nightlies when failure rate exceeds threshold

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -62,6 +62,7 @@ build/teamcity-roachtest-invoke.sh \
   --select-probability="${select_probability}" \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
+  --auto-kill-threshold="${AUTO_KILL_THRESHOLD:-0.05}" \
   --parallelism="${PARALLELISM}" \
   --cpu-quota="${CPUQUOTA}" \
   --cluster-id="${TC_BUILD_ID}" \

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -304,6 +304,12 @@ var (
 			run at least one test per prefix.`,
 	})
 
+	AutoKillThreshold float64 = 1.0
+	_                         = registerRunFlag(&AutoKillThreshold, FlagInfo{
+		Name:  "auto-kill-threshold",
+		Usage: `Percentage of failed tests before all remaining tests are automatically terminated.`,
+	})
+
 	GlobalSeed int64 = randutil.NewPseudoSeed()
 	_                = registerRunFlag(&GlobalSeed, FlagInfo{
 		Name:  "global-seed",

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -332,6 +332,7 @@ func (r *testRunner) Run(
 				lopt,
 				topt,
 				l,
+				n*count,
 			)
 
 			if err != nil {
@@ -513,6 +514,7 @@ func (r *testRunner) runWorker(
 	lopt loggingOpt,
 	topt testOpts,
 	l *logger.Logger,
+	maxTotalFailures int,
 ) error {
 	stdout := lopt.stdout
 
@@ -569,6 +571,14 @@ func (r *testRunner) runWorker(
 				// The context has been canceled. No need to continue.
 				return errors.Wrap(ctx.Err(), "worker ctx done")
 			}
+		}
+
+		// stop the tests if the failure rate has been exceeded
+		r.status.Lock()
+		failureRate := float64(len(r.status.fail)) / float64(maxTotalFailures)
+		r.status.Unlock()
+		if failureRate > roachtestflags.AutoKillThreshold {
+			return errors.Errorf("failure rate %.2f exceeds limit %.2f", failureRate, roachtestflags.AutoKillThreshold)
 		}
 
 		wStatus.SetTest(nil /* test */, testToRunRes{})
@@ -1063,7 +1073,10 @@ func (r *testRunner) runTest(
 		// Only include tests with a Run function in the summary output.
 		if s.Run != nil {
 			if t.Failed() {
-				r.status.fail[t] = struct{}{}
+				errWithOwner := failuresAsErrorWithOwnership(t.failures())
+				if errWithOwner == nil || !errWithOwner.InfraFlake {
+					r.status.fail[t] = struct{}{}
+				}
 			} else if s.Skip != "" {
 				r.status.skip[t] = struct{}{}
 			} else {


### PR DESCRIPTION
Backport 1/1 commits from #122783.

/cc @cockroachdb/release

---

Nightly roachtests are fairly stable, exhibiting failure rates < 5%, on average. Occasionally, a regression, typically merged the day of the nightly run, or a infrastructure change/transient issue, can result in a cascade of failures. Since a high failure rate is likely indicative of an issue which may impact a large subset of the roachtests, the preference is to kill the CI job on the grounds of having reached a point of diminished returns.

This PR introduces a roachtest CLI argument, `auto-kill-threshold`, which when exceeded would auto-kill the nightlies.

Epic: none
Fixes: #120160 
Release note: None

---

Release justification: This backport ensures that we autokill the nightly suite in case it crosses the default threshold.