### PR TITLE
jobs: exempt stats jobs from logs

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1585,7 +1585,11 @@ func (r *Registry) stepThroughStateMachine(
 			log.Errorf(ctx, "%s job %d: stepping through state %s with unexpected error: %+v", jobType, job.ID(), status, jobErr)
 		}
 	} else {
-		log.Infof(ctx, "%s job %d: stepping through state %s", jobType, job.ID(), status)
+		if jobType == jobspb.TypeAutoCreateStats {
+			log.VInfof(ctx, 1, "%s job %d: stepping through state %s", jobType, job.ID(), status)
+		} else {
+			log.Infof(ctx, "%s job %d: stepping through state %s", jobType, job.ID(), status)
+		}
 	}
 	jm := r.metrics.JobMetrics[jobType]
 	onExecutionFailed := func(cause error) error {


### PR DESCRIPTION
Unlike most jobs that represent some meaningful user/system action or event, where the time the event started and ended are rare and often significant, stats are continiously updated by the system as an automatic background process.

Unfortunately that process creates a distinct job each time it chooses to update a table, resulting in this constant background process appearing as constant stream of separate jobs, rather than one continuous one. To reduce the amount this stream of jobs adds noise to the logs about significant jobs, this patch moves log messages about job state transitions behind a verbose check for these jobs.

Release note: none.
Epic: none.