### PR TITLE
changefeedccl: skip flaky pulsar tests

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -881,7 +881,7 @@ func randomSinkTypeWithOptions(options feedTestOptions) string {
 		"pubsub":       1,
 		"sinkless":     2,
 		"cloudstorage": 0,
-		"pulsar":       1,
+		"pulsar":       0,
 	}
 	if options.externalIODir != "" {
 		sinkWeights["cloudstorage"] = 3


### PR DESCRIPTION
This patch skips flaky tests for pulsar sinks. We will add them back when pulsar
is fully supported.

Release note: none
Fixes: #123718
Fixes: #123719
Fixes: #123720
Fixes: #123721