### PR TITLE
roachtest: emit datadog events in runOperation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.6.1
 	github.com/Azure/go-autorest/autorest/adal v0.9.15
 	github.com/BurntSushi/toml v1.2.1
+	github.com/DataDog/datadog-go v3.2.0+incompatible
 	github.com/IBM/sarama v1.42.1
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_datadog_datadog_go//statsd",
         "@com_github_lib_pq//:pq",
         "@com_github_petermattis_goid//:goid",
         "@com_github_prometheus_client_golang//prometheus",

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -295,6 +295,12 @@ var (
 		Usage: `The port on which to serve the HTTP interface`,
 	})
 
+	DogstatsdAddr string = ""
+	_                    = registerRunOpsFlag(&DogstatsdAddr, FlagInfo{
+		Name:  "dogstatsd-addr",
+		Usage: `The address to which to connect to dogstatsd, to send Datadog events.`,
+	})
+
 	PreferLocalSSD bool = true
 	_                   = registerRunFlag(&PreferLocalSSD, FlagInfo{
 		Name:  "local-ssd",

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/operations"
@@ -50,6 +51,15 @@ const (
 	testResultFailure testResult = iota
 	testResultSuccess
 	testResultSkip
+)
+
+type ddEventType int
+
+const (
+	eventOpStarted ddEventType = iota
+	eventOpRan
+	eventOpFinishedCleanup
+	eventOpError
 )
 
 type testReportForGitHub struct {
@@ -439,6 +449,47 @@ func maybeDumpSummaryMarkdown(r *testRunner) error {
 	return nil
 }
 
+// maybeEmitDatadogEvent emits a datadog event if a non-nil statsd client is passed in.
+func maybeEmitDatadogEvent(
+	client *statsd.Client,
+	opSpec *registry.OperationSpec,
+	clusterName string,
+	eventType ddEventType,
+	operationID uint64,
+) {
+	if client == nil {
+		return
+	}
+	status := "started"
+
+	switch eventType {
+	case eventOpStarted:
+		status = "started"
+	case eventOpRan:
+		status = "finished running; waiting for cleanup"
+	case eventOpFinishedCleanup:
+		status = "cleaned up its state"
+	case eventOpError:
+		status = "ran with an error"
+	}
+	details := fmt.Sprintf("cluster: %s\n", clusterName)
+	ev := statsd.NewEvent(fmt.Sprintf("op %s %s", opSpec.Name, status), details)
+
+	ev.AggregationKey = fmt.Sprintf("operation-%d", operationID)
+	switch eventType {
+	case eventOpStarted:
+		ev.AlertType = statsd.Info
+	case eventOpRan:
+		ev.AlertType = statsd.Success
+	case eventOpFinishedCleanup:
+		ev.AlertType = statsd.Info
+	case eventOpError:
+		ev.AlertType = statsd.Error
+	}
+
+	_ = client.Event(ev)
+}
+
 // runOperation sequentially runs one operation matched by the passed-in filter.
 func runOperation(register func(registry.Registry), filter string, clusterName string) error {
 	//lint:ignore SA1019 deprecated
@@ -456,6 +507,15 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 
 	register(&r)
 	ctx := context.Background()
+
+	var statsdClient *statsd.Client
+	if roachtestflags.DogstatsdAddr != "" {
+		var err error
+		statsdClient, err = statsd.New(roachtestflags.DogstatsdAddr)
+		if err != nil {
+			return errors.Wrap(err, "failed to create statsd client")
+		}
+	}
 
 	// TODO(bilal): This is excessive for just getting the number of nodes in the
 	// cluster. We should expose a roachprod.Nodes method or so.
@@ -515,6 +575,10 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 		return nil
 	}
 
+	// operationRunID is used for datadog event aggregation and logging.
+	operationRunID := rand.Uint64()
+	maybeEmitDatadogEvent(statsdClient, opSpec, clusterName, eventOpStarted, operationRunID)
+	op.Status(fmt.Sprintf("running operation %s with run id %d", opSpec.Name, operationRunID))
 	var cleanup registry.OperationCleanup
 	func() {
 		ctx, cancel := context.WithTimeout(ctx, opSpec.Timeout)
@@ -524,9 +588,11 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 	}()
 	if op.Failed() {
 		op.Status("operation failed")
+		maybeEmitDatadogEvent(statsdClient, opSpec, clusterName, eventOpError, operationRunID)
 		return op.mu.failures[0]
 	}
 
+	maybeEmitDatadogEvent(statsdClient, opSpec, clusterName, eventOpRan, operationRunID)
 	if cleanup == nil {
 		op.Status("operation ran successfully")
 		return nil
@@ -549,8 +615,10 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 
 	if op.Failed() {
 		op.Status("operation cleanup failed")
+		maybeEmitDatadogEvent(statsdClient, opSpec, clusterName, eventOpError, operationRunID)
 		return op.mu.failures[0]
 	}
+	maybeEmitDatadogEvent(statsdClient, opSpec, clusterName, eventOpFinishedCleanup, operationRunID)
 
 	return nil
 }


### PR DESCRIPTION
This change adds a new command line arg to run-operation, namely `--dogstatsd-addr`, which if specified emits datadog events for operations to the appropriate dogstatsd instance.

Epic: none

Release note: None