### PR TITLE
roachprod: don't overwrite tenant in `pgurl` expansion

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -622,12 +622,10 @@ func (c *SyncedCluster) NodeURL(
 	} else {
 		v.Add("sslmode", "disable")
 	}
-	// Add the virtual cluster name option explicitly for shared-process
-	// tenants or for the system tenant. This is to make sure we connect
-	// to the system tenant in case we have previously changed the
-	// default virtual cluster.
-	if (serviceMode == ServiceModeShared && virtualClusterName != "") ||
-		virtualClusterName == SystemInterfaceName {
+
+	// Add the cluster connection parameter explicitly for
+	// shared-process virtual clusters when a cluster name was passed.
+	if serviceMode == ServiceModeShared && virtualClusterName != "" {
 		v.Add("options", fmt.Sprintf("-ccluster=%s", virtualClusterName))
 	}
 	u.RawQuery = v.Encode()

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -117,8 +117,8 @@ func (e *expander) maybeExpandMap(
 // instance is provided, the first instance is assumed.
 func extractVirtualClusterInfo(matches []string) (string, int, error) {
 	// Defaults if the passed in group match is empty.
-	virtualClusterName := SystemInterfaceName
-	sqlInstance := 0
+	var virtualClusterName string
+	var sqlInstance int
 
 	// Extract the cluster name and instance matches.
 	trim := func(s string) string {


### PR DESCRIPTION
Previously, the `{pgurl}` expansion would force the `cluster` connection parameter to `system`. This means that if the caller previously configured a different default virtual cluster, `pgurl` would ignore that and continue connecting to `system`, which is quite surprising.

In this commit, we only set an explicit `cluster` connection parameter if the user passed one; this should allow `pgurl` users to connect to the default tenant by default.

Epic: none

Release note: None