### PR TITLE
roachtest: disable azure tests that use zfs or specify ssd counts

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -331,6 +331,8 @@ func (s *ClusterSpec) RoachprodOpts(
 		return vm.CreateOpts{}, nil, "", errors.Errorf("unsupported cloud %v", cloud)
 	}
 	if cloud != GCE {
+		// TODO(DarrylWong): support specifying SSD count on other providers, see: #123777.
+		// Once done, revisit all tests that set SSD count to see if they can run on non GCE.
 		if s.SSDs != 0 {
 			return vm.CreateOpts{}, nil, "", errors.Errorf("specifying SSD count is not yet supported on %s", cloud)
 		}

--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -52,7 +52,7 @@ func registerClearRange(r registry.Registry) {
 		// to <3:30h but it varies.
 		Timeout:           5*time.Hour + 120*time.Minute,
 		Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
-		CompatibleClouds:  registry.AllExceptAWS,
+		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Leases:            registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -282,7 +282,7 @@ func registerTPCE(r registry.Registry) {
 		Owner:            registry.OwnerTestEng,
 		Timeout:          4 * time.Hour,
 		Cluster:          r.MakeClusterSpec(smallNightly.nodes+1, spec.CPU(smallNightly.cpus), spec.SSD(smallNightly.ssds)),
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		// Never run with runtime assertions as this makes this test take
 		// too long to complete.
@@ -303,7 +303,7 @@ func registerTPCE(r registry.Registry) {
 		Name:             fmt.Sprintf("tpce/c=%d/nodes=%d", largeWeekly.customers, largeWeekly.nodes),
 		Owner:            registry.OwnerTestEng,
 		Benchmark:        true,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Timeout:          36 * time.Hour,
 		Cluster:          r.MakeClusterSpec(largeWeekly.nodes+1, spec.CPU(largeWeekly.cpus), spec.SSD(largeWeekly.ssds)),

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -140,7 +140,7 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{})
 					},
-					CompatibleClouds: registry.AllExceptAWS,
+					CompatibleClouds: registry.OnlyGCE,
 					Suites:           registry.Suites(registry.Nightly),
 				})
 			}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1512,6 +1512,8 @@ func Create(
 
 	if createVMOpts.SSDOpts.FileSystem == vm.Zfs {
 		for _, provider := range createVMOpts.VMProviders {
+			// TODO(DarrylWong): support zfs on other providers, see: #123775.
+			// Once done, revisit all tests that set zfs to see if they can run on non GCE.
 			if provider != gce.ProviderName {
 				return fmt.Errorf(
 					"creating a node with --filesystem=zfs is currently only supported on gce",


### PR DESCRIPTION
Both these options are not supported for roachprod azure yet, resulting in cluster_creation errors.

Informs: #120621
Fixes: none
Epic: none
Release note: none