### PR TITLE
restore: fix bugs in ID rewriting

### DIFF
--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -236,7 +236,7 @@ func sendAddRemoteSSTWorker(
 			// key to split on. Note that it only is safe with
 			// https://github.com/cockroachdb/cockroach/pull/114464
 			log.Infof(ctx, "flushing %s batch of %d SSTs at end of restore span entry %s", sz(batchSize), len(toAdd), entry.Span)
-			rewrittenFlushKey, ok, err := kr.RewriteKey(entry.Span.EndKey, 0)
+			rewrittenFlushKey, ok, err := kr.RewriteKey(entry.Span.EndKey.Clone(), 0)
 			if !ok || err != nil {
 				return errors.Newf("flush key %s could not be rewritten", entry.Span.EndKey)
 			}
@@ -508,11 +508,10 @@ func (r *restoreResumer) maybeWriteDownloadJob(
 	if err != nil {
 		return errors.Wrap(err, "creating key rewriter from rekeys")
 	}
-
 	downloadSpans := mainRestoreData.getSpans()
 	for i := range downloadSpans {
 		var err error
-		downloadSpans[i], err = rewriteSpan(kr, downloadSpans[i], execinfrapb.ElidePrefix_None)
+		downloadSpans[i], err = rewriteSpan(kr, downloadSpans[i].Clone(), execinfrapb.ElidePrefix_None)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -504,11 +504,6 @@ func (r *restoreResumer) maybeWriteDownloadJob(
 	}
 
 	downloadSpans := mainRestoreData.getSpans()
-	if !preRestoreData.isEmpty() {
-		// Order the pre restore data first so they are downloaded first.
-		downloadSpans = preRestoreData.getSpans()
-		downloadSpans = append(downloadSpans, mainRestoreData.getSpans()...)
-	}
 
 	log.Infof(ctx, "creating job to track downloads in %d spans", len(downloadSpans))
 	downloadJobRecord := jobs.Record{

--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -202,6 +202,9 @@ func TestOnlineRestoreWaitForDownload(t *testing.T) {
 	var downloadJobID jobspb.JobID
 	sqlDB.QueryRow(t, `SELECT job_id FROM [SHOW JOBS] WHERE description LIKE '%Background Data Download%'`).Scan(&downloadJobID)
 	jobutils.WaitForJobToSucceed(t, sqlDB, downloadJobID)
+	sqlDB.CheckQueryResults(t, `SELECT * FROM crdb_internal.tenant_span_stats(
+		ARRAY(SELECT(crdb_internal.table_span('data2.bank'::regclass::oid::int)[1], crdb_internal.table_span('data2.bank'::regclass::oid::int)[2]))
+	) WHERE (stats->>'external_file_bytes')::int > 0`, [][]string{})
 }
 
 // TestOnlineRestoreTenant runs an online restore of a tenant and ensures the


### PR DESCRIPTION
Fixes the failure to rewrite the download spans -- meaning we'd download the wrong span, leaving the restored span u-un-downloaded -- and the corruption of span keys due to rewriting that altered the covering's internal keys, subsequent download keys, etc.

Release note: none.
Epic: none.