### PR TITLE
roachtest: fix indexes/2/nodes=6/multi-region on Azure

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -134,6 +134,11 @@ type ClusterSpec struct {
 		VolumeThroughput int
 		Zones            string
 	}
+
+	// Azure-specific arguments. These values apply only on clusters instantiated on Azure.
+	Azure struct {
+		Locations string
+	}
 }
 
 // MakeClusterSpec makes a ClusterSpec.
@@ -425,6 +430,10 @@ func (s *ClusterSpec) RoachprodOpts(
 	case GCE:
 		if s.GCE.Zones != "" {
 			zonesStr = s.GCE.Zones
+		}
+	case Azure:
+		if s.Azure.Locations != "" {
+			zonesStr = s.Azure.Locations
 		}
 	}
 	var zones []string

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -266,3 +266,14 @@ func AWSZones(zones string) Option {
 		spec.AWS.Zones = zones
 	}
 }
+
+// AzureLocations is a node option which requests Geo-distributed nodes; only
+// applies when the test runs on Azure.
+//
+// Note that this overrides the --locations flag and is useful for tests that
+// require running on specific zones.
+func AzureLocations(locations string) Option {
+	return func(spec *ClusterSpec) {
+		spec.Azure.Locations = locations
+	}
+}

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -30,6 +30,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 	const nodes = 6
 	gceGeoZones := []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
 	awsGeoZones := []string{"us-east-2b", "us-west-1a", "eu-west-1a"}
+	azureGeoZones := []string{"eastus", "westus2", "westeurope"}
 	r.Add(registry.TestSpec{
 		Name:      fmt.Sprintf("indexes/%d/nodes=%d/multi-region", secondaryIndexes, nodes),
 		Owner:     registry.OwnerKV,
@@ -40,15 +41,23 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 			spec.Geo(),
 			spec.GCEZones(strings.Join(gceGeoZones, ",")),
 			spec.AWSZones(strings.Join(awsGeoZones, ",")),
+			spec.AzureLocations(strings.Join(azureGeoZones, ",")),
 		),
 		// TODO(radu): enable this test on AWS.
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		// Uses CONFIGURE ZONE USING ... COPY FROM PARENT syntax.
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			firstAZ := gceGeoZones[0]
-			if c.Cloud() == spec.AWS {
+			var firstAZ string
+			switch c.Cloud() {
+			case spec.GCE:
+				firstAZ = gceGeoZones[0]
+			case spec.AWS:
 				firstAZ = awsGeoZones[0]
+			case spec.Azure:
+				firstAZ = azureGeoZones[0]
+			default:
+				t.Fatalf("unsupported cloud %s", c.Cloud())
 			}
 			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)


### PR DESCRIPTION
Fixes #123805.

This commit fixes the `indexes/2/nodes=6/multi-region` test on Azure. It does so by passing the equivalent Azure zones to cluster creation.

I don't feel strongly about where we call these "zones" vs. where we call them "locations". I'd prefer that everything stay uniform, but we have already adopted the term "location" in the Azure flags and ProviderOpts, so this commit mostly sticks with that.

Release note: None