### PR TITLE
roachtest: turn on DistSender circuit breakers for failover chaos tests

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -213,6 +213,11 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
+	// DistSender circuit breakers are useful for these chaos tests. Turn them on.
+	// TODO(arul): this can be removed if/when we turn on DistSender circuit
+	// breakers for all ranges by default.
+	settings.ClusterSettings["kv.dist_sender.circuit_breakers.mode"] = "all ranges"
+
 	m := c.NewMonitor(ctx, c.Range(1, 9))
 
 	failers := []Failer{}


### PR DESCRIPTION
Failover chaos tests create asymetric partitions where DistSender circuit breakers are useful. It prevents failure modes such as https://github.com/cockroachdb/cockroach/issues/123736#issuecomment-2100948030.

Fixes #123736

Release note: None