### PR TITLE
roachprod: reintroduce --secure flag

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -48,6 +48,8 @@ var (
 	listJSON              bool
 	listMine              bool
 	listPattern           string
+	isSecure              bool   // Set based on the values passed to --secure and --insecure
+	secure                = true // DEPRECATED
 	insecure              = false
 	virtualClusterName    string
 	sqlInstance           int
@@ -413,6 +415,10 @@ func initFlags() {
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
 	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
+		// TODO(renato): remove --secure once the default of secure
+		// clusters has existed in roachprod long enough.
+		cmd.Flags().BoolVar(&secure,
+			"secure", secure, "use a secure cluster (DEPRECATED: clusters are secure by default; use --insecure to create insecure clusters.)")
 		cmd.Flags().BoolVar(&insecure,
 			"insecure", insecure, "use an insecure cluster")
 	}


### PR DESCRIPTION
In #123593, we changed roachprod's default when starting clusters: it will now start secure clusters unless the `--insecure` flag is passed (mirroring cockroach's behaviour and flag name).

However, this leads to problems when running roachprod commands in commits before and after this change. In this commit, we temporarily reintroduce the `--secure` flag to roachprod to reduce disruptions. Once the new default has existed for a while, we can revert this commit.

Epic: none

Release note: None