### PR TITLE
tla-plus: add .cfg file for ParallelCommits spec

### DIFF
--- a/docs/tla-plus/.gitignore
+++ b/docs/tla-plus/.gitignore
@@ -13,4 +13,5 @@
 **/*.toolbox/**/MC.cfg
 **/*.pdf
 **/*.old
+**/states
 **/*~

--- a/docs/tla-plus/ParallelCommits/ParallelCommits.cfg
+++ b/docs/tla-plus/ParallelCommits/ParallelCommits.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION
+  Spec
+
+CONSTANTS
+  KEYS         = {k1, k2}
+  PREVENTERS   = {p1, p2}
+  MAX_ATTEMPTS = 3
+
+INVARIANTS
+  TypeInvariants
+  AckImpliesCommit
+
+PROPERTIES
+  TemporalTxnRecordProperties
+  TemporalIntentProperties
+  TemporalTSCacheProperties
+  ImplicitCommitLeadsToExplicitCommit
+  AckLeadsToExplicitCommit


### PR DESCRIPTION
NOTE: this is just extracting the first commit from https://github.com/cockroachdb/cockroach/pull/123189 out into a separate PR so that we can get it merged.

This commit updates the ParallelCommit spec with a .cfg config file which mirrors its Toolbox .launch file. This allows the spec to be checked with the command-line version of the TLC model checker. As a result, this allows the spec to play well with the VSCode TLA+ extension, which is more popular and easier to use than the original eclipse-based TLA+ Toolbox.

Epic: None
Relase note: None