### PR TITLE
bazel: remove `simplestamp` configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -113,12 +113,6 @@ build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/b
 build:macos --linkopt="-Xlinker"
 build:macos --linkopt="-no_warn_duplicate_libraries"
 
-# --config=simplestamp configures the build to stamp the build with inferred
-# information about the configuration.
-# All `dev` builds will use this configuration; all `cross` builds will use a
-# more precise --workspace_status_command option.
-build:simplestamp --stamp --workspace_status_command=./build/bazelutil/stamp.sh
-
 build:engflowbase --define=EXECUTOR=remote
 build:engflowbase --disk_cache=
 build:engflowbase --experimental_inmemory_dotd_files


### PR DESCRIPTION
This is no longer used.

Release note: None
Epic: CRDB-17171