### PR TITLE
sql: fix two session variables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -912,3 +912,7 @@ SHOW application_name
 ·
 
 subtest end
+
+# Regression test for incorrectly marking this variable as boolean.
+statement ok
+SET copy_num_retries_per_batch = 5;

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2305,7 +2305,7 @@ var varGen = map[string]sessionVar{
 
 	// CockroachDB extension.
 	`copy_num_retries_per_batch`: {
-		GetStringVal: makePostgresBoolGetStringValFn(`copy_num_retries_per_batch`),
+		GetStringVal: makeIntGetStringValFn(`copy_num_retries_per_batch`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
 			b, err := strconv.ParseInt(s, 10, 64)
 			if err != nil {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2243,7 +2243,9 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().CostScansWithDefaultColSize), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(costScansWithDefaultColSize.Get(sv))
+		},
 	},
 
 	// CockroachDB extension.


### PR DESCRIPTION
**sql: fix the type of copy_num_retries_per_batch**

We were incorrectly using the boolean getter for this integer variable. The bug was introduced when this variable was added in 1c1d3133e754e08a2837f3dadf7e670ebf2242a7.

Release note: None

**sql: fix cost_scans_with_default_col_size**

This commit fixes an omission where `cost_scans_with_default_col_size` session variable didn't actually use the corresponding cluster setting for its default value. In other words, the cluster setting actually had no effect. The bug has been present since this variable was introduced in af32d9dc887e3a6771013dc49293ae83cbe07dd4.

Release note: None

Epic: None