### PR TITLE
jobs: avoid CTEs in crdb_internal.system_jobs query

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -66,6 +66,7 @@ exp,benchmark
 3,Jobs/jobs_page_default
 3,Jobs/jobs_page_latest_50
 3,Jobs/jobs_page_type_filtered
+1,Jobs/jobs_page_type_filtered_no_matches
 3,Jobs/jobs_page_type_filtered_no_matches
 8,Jobs/pause_job
 6,Jobs/resume_job

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -969,16 +969,8 @@ DISTINCT(id), status, created, payload.value AS payload, progress.value AS progr
 created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
 FROM
 system.jobs AS j
-LEFT JOIN (
-		SELECT job_id, value FROM system.job_info
-		WHERE info_key = 'legacy_progress'
-		ORDER BY written DESC
-) AS progress ON j.id = progress.job_id
-INNER JOIN (
-		SELECT job_id, value FROM system.job_info
-		WHERE info_key = 'legacy_payload'
-		ORDER BY written DESC
-) AS payload ON j.id = payload.job_id
+LEFT JOIN system.job_info AS progress ON j.id = progress.job_id AND progress.info_key = 'legacy_progress'
+INNER JOIN system.job_info AS payload ON j.id = payload.job_id AND payload.info_key = 'legacy_payload'
 `
 	systemJobsIDPredicate     = ` WHERE id = $1`
 	systemJobsTypePredicate   = ` WHERE job_type = $1`

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -964,32 +964,22 @@ const (
 	// so we perform a LEFT JOIN to get a NULL value when no progress row is
 	// found.
 	systemJobsAndJobInfoBaseQuery = `
-WITH
-	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload' ORDER BY written DESC),
-	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' ORDER BY written DESC)
-	SELECT
-		DISTINCT(id), status, created, payload.value AS payload, progress.value AS progress,
-		created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
-	FROM system.jobs AS j
-	INNER JOIN latestpayload AS payload ON j.id = payload.job_id
-	LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
+SELECT
+DISTINCT(id), status, created, payload.value AS payload, progress.value AS progress,
+created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
+FROM
+system.jobs AS j
+LEFT JOIN (
+		SELECT job_id, value FROM system.job_info
+		WHERE info_key = 'legacy_progress'
+		ORDER BY written DESC
+) AS progress ON j.id = progress.job_id
+INNER JOIN (
+		SELECT job_id, value FROM system.job_info
+		WHERE info_key = 'legacy_payload'
+		ORDER BY written DESC
+) AS payload ON j.id = payload.job_id
 `
-
-	// systemJobsAndJobInfoBaseQueryWithIDPredicate is the same as
-	// systemJobsAndJobInfoBaseQuery but with a predicate on `job_id` in the CTE
-	// queries.
-	systemJobsAndJobInfoBaseQueryWithIDPredicate = `
-WITH
-	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload' AND job_id = $1 ORDER BY written DESC LIMIT 1),
-	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' AND job_id = $1 ORDER BY written DESC LIMIT 1)
-	SELECT
-		id, status, created, payload.value AS payload, progress.value AS progress,
-		created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
-	FROM system.jobs AS j
-	INNER JOIN latestpayload AS payload ON j.id = payload.job_id
-	LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
-`
-
 	systemJobsIDPredicate     = ` WHERE id = $1`
 	systemJobsTypePredicate   = ` WHERE job_type = $1`
 	systemJobsStatusPredicate = ` WHERE status = $1`
@@ -1009,7 +999,7 @@ func getInternalSystemJobsQuery(predicate systemJobsPredicate) string {
 	case noPredicate:
 		return systemJobsAndJobInfoBaseQuery
 	case jobID:
-		return systemJobsAndJobInfoBaseQueryWithIDPredicate + systemJobsIDPredicate
+		return systemJobsAndJobInfoBaseQuery + systemJobsIDPredicate
 	case jobType:
 		return systemJobsAndJobInfoBaseQuery + systemJobsTypePredicate
 	case jobStatus:


### PR DESCRIPTION
The CTE in the query used for crdb_internal.system_jobs can prevent a
number of useful query optimizations.

Informs #122687

Release note (performance improvement): Further improves the
performance of job-system related queries.