### PR TITLE
pkg/cli: debugzip - decode some system tables before dumping them

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -861,8 +860,8 @@ func TestToHex(t *testing.T) {
 	// fields is not always precise as there can be spaces in the fields but the
 	// hex fields are always in the end of the row and they don't contain spaces.
 	hexFiles := map[string][]hexField{
-		"debug/system.descriptor.txt": {
-			{idx: 1, msg: &descpb.Descriptor{}},
+		"debug/system.scheduled_jobs.txt": {
+			{idx: -3, msg: &jobspb.ScheduleDetails{}},
 		},
 	}
 


### PR DESCRIPTION
Previously, the `system.descriptor` and `system.span_configurations` tables were dumped as it is to the `debug.zip`. The columns in these tables are in hex format. This then needed to be decoded using the command `cockroach debug decode-proto`.

This commit changes that by taking care of decoding the columns in the SELECT statement itself. This way, the user directly gets human-readable `system.descriptor.txt` and `system.span_configurations.txt`.

Part of: CRDB-35172
Epic: CRDB-32134
Fixes: #117428
Release note: None