### PR TITLE
raft/tracker: pause after empty probes too

### DIFF
--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by Cockroach Labs, Inc.
+// All modifications are Copyright 2024 Cockroach Labs, Inc.
+//
 // Copyright 2019 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -173,12 +176,7 @@ func (pr *Progress) SentEntries(entries int, bytes uint64) {
 		// consider this message being a probe, so that the flow is paused.
 		pr.MsgAppFlowPaused = pr.Inflights.Full()
 	case StateProbe:
-		// TODO(pavelkalinnikov): this condition captures the previous behaviour,
-		// but we should set MsgAppFlowPaused unconditionally for simplicity, because any
-		// MsgApp in StateProbe is a probe, not only non-empty ones.
-		if entries > 0 {
-			pr.MsgAppFlowPaused = true
-		}
+		pr.MsgAppFlowPaused = true
 	default:
 		panic(fmt.Sprintf("sending append in unhandled state %s", pr.State))
 	}


### PR DESCRIPTION
This commit removes an unnecessary condition for setting `MsgAppFlowPaused` in `StateProbe`. Any append message in `StateProbe` should be considered a probe, and cause the flow to pause.

Release note: none
Epic: none