### PR TITLE
release-24.1: import: mark import.constraint_validation cluster setting unsafe

### DIFF
--- a/pkg/ccl/importerccl/BUILD.bazel
+++ b/pkg/ccl/importerccl/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -107,11 +107,12 @@ var processorsPerNode = settings.RegisterIntSetting(
 
 var performConstraintValidation = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
-	"bulkio.import.constraint_validation.enabled",
+	"bulkio.import.constraint_validation.unsafe.enabled",
 	"should import perform constraint validation after data load. "+
 		"NOTE: this setting should not be used on production clusters, as it could result in "+
 		"incorrect query results if the imported data set violates constraints (i.e. contains duplicates).",
 	true,
+	settings.WithUnsafe,
 )
 
 type preparedSchemaMetadata struct {


### PR DESCRIPTION
Backport 1/1 commits from #122052.

/cc @cockroachdb/release

---

Mark the bulkio.import.constraint_validation.enabled cluster setting unsafe, since it could result in inconsistent data, and as such, should never be used on production clusters.

Release note: None
Epic: none
Release justification: Small change to guard against user misuse.
