### PR TITLE
externalconn: support mixed-case for connection URI params.

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -968,7 +968,7 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 	}
 	for _, param := range requiredSASLParams {
 		if dialConfig.saslEnabled {
-			if len(u.q[param]) == 0 {
+			if !u.contains(param) {
 				errStr := fmt.Sprintf(`%s must be provided when SASL is enabled`, param)
 				if dialConfig.saslMechanism != sarama.SASLTypePlaintext {
 					errStr += fmt.Sprintf(` using mechanism %s`, dialConfig.saslMechanism)
@@ -976,7 +976,7 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 				return kafkaDialConfig{}, errors.Errorf("%s", errStr)
 			}
 		} else {
-			if len(u.q[param]) > 0 {
+			if u.contains(param) {
 				return kafkaDialConfig{}, errors.Errorf(`%s must be enabled if %s is provided`,
 					changefeedbase.SinkParamSASLEnabled, param)
 			}
@@ -988,7 +988,7 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 			changefeedbase.SinkParamSASLTokenURL, changefeedbase.SinkParamSASLGrantType,
 			changefeedbase.SinkParamSASLScopes}
 		for _, param := range oauthParams {
-			if len(u.q[param]) > 0 {
+			if u.contains(param) {
 				return kafkaDialConfig{}, errors.Errorf(`%s is only a valid parameter for %s=%s`, param,
 					changefeedbase.SinkParamSASLMechanism, sarama.SASLTypeOAuth)
 			}

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -115,7 +115,7 @@ func makeDeprecatedPubsubSink(
 	knobs *TestingKnobs,
 ) (Sink, error) {
 
-	pubsubURL := sinkURL{URL: u, q: u.Query()}
+	pubsubURL := sinkURL{URL: u}
 	pubsubTopicName := pubsubURL.consumeParam(changefeedbase.SinkParamTopicName)
 
 	var formatType changefeedbase.FormatType

--- a/pkg/ccl/changefeedccl/sink_pubsub_v2.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub_v2.go
@@ -105,7 +105,7 @@ func makePubsubSinkClient(
 			changefeedbase.OptEnvelope, encodingOpts.Envelope)
 	}
 
-	pubsubURL := sinkURL{URL: u, q: u.Query()}
+	pubsubURL := sinkURL{URL: u}
 
 	projectID := pubsubURL.Host
 	if projectID == "" {
@@ -374,7 +374,7 @@ func getGCPCredentials(ctx context.Context, u sinkURL) (option.ClientOption, err
 	case authDefault:
 		fallthrough
 	default:
-		if u.q.Get(credentialsParam) == "" {
+		if !u.contains(credentialsParam) {
 			return nil, errors.New("missing credentials parameter")
 		}
 		err := u.decodeBase64(credentialsParam, &credsJSON)
@@ -436,7 +436,7 @@ func makePubsubSink(
 		return nil, err
 	}
 
-	pubsubURL := sinkURL{URL: u, q: u.Query()}
+	pubsubURL := sinkURL{URL: u}
 	var includeTableNameAttribute bool
 	_, err = pubsubURL.consumeBool(changefeedbase.SinkParamTableNameAttribute, &includeTableNameAttribute)
 	if err != nil {

--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -133,6 +133,15 @@ exec-sql
 DROP EXTERNAL CONNECTION "foo-s3";
 ----
 
+# Create an external connection with params in a mix of upper and lower case.
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-s3" AS 's3://foo/bar?auth=implicit&AWS_access_key_id=123&AWS_secret_access_key=456&ASSUME_ROLE=ronaldo,rashford,bruno';
+----
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-s3"
+----
+
 inspect-system-table
 ----
 
@@ -161,6 +170,15 @@ pq: failed to construct External Connection details: invalid changefeed sink URI
 inspect-system-table
 ----
 foo-kafka STORAGE {"provider": "kafka", "simpleUri": {"uri": "kafka://broker.address.com:9092?topic_prefix=bar_&tls_enabled=true&ca_cert=Zm9vCg==&sasl_enabled=true&sasl_user={sasl user}&sasl_password={url-encoded password}&sasl_mechanism=SCRAM-SHA-256"}} root 1
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-kafka"
+----
+
+# Create an external connection with params in a mix of upper and lower case.
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-kafka" AS 'kafka://broker.address.com:9092?TOPIC_PREFIX=bar_&tls_enabled=true&CA_CERT=Zm9vCg==&SASL_enabled=true&SASL_user={sasl user}&SASL_password={url-encoded password}&SASL_mechanism=SCRAM-SHA-256'
+----
 
 exec-sql
 DROP EXTERNAL CONNECTION "foo-kafka"
@@ -283,6 +301,15 @@ exec-sql
 DROP EXTERNAL CONNECTION "baz-azure";
 ----
 
+# Create an external connection with params in a mix of upper and lower case.
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-azure" AS 'azure-storage://bucket/path?AZURE_account_name=foo&AZURE_account_key=Zm9vCg==&AZURE_environment=AzureUSGovernmentCloud'
+----
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-azure"
+----
+
 enable-check-external-storage
 ----
 
@@ -310,6 +337,15 @@ foo-kms KMS {"provider": "azure_kms", "simpleUri": {"uri": "azure-kms:///cmk/id?
 
 exec-sql
 DROP EXTERNAL CONNECTION "foo-kms";
+----
+
+# Create an external connection with params in a mix of upper and lower case.
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-kms" AS 'gcp-kms:///cmk?auth=specified&BEARER_token=c29tZXRoaW5nCg==';
+----
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-kms"
 ----
 
 inspect-system-table

--- a/pkg/cloud/azure/azure_kms.go
+++ b/pkg/cloud/azure/azure_kms.go
@@ -63,7 +63,7 @@ type kmsURIParams struct {
 // resolveKMSURIParams parses the `kmsURI` for all the supported KMS parameters.
 func resolveKMSURIParams(kmsURI *url.URL) (kmsURIParams, error) {
 	kmsConsumeURL := cloud.ConsumeURL{URL: kmsURI}
-	auth, err := azureAuthMethod(kmsURI, &kmsConsumeURL)
+	auth, err := azureAuthMethod(&kmsConsumeURL)
 	if err != nil {
 		return kmsURIParams{}, err
 	}

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -105,11 +105,11 @@ const (
 	deprecatedExternalConnectionScheme = "azure-storage"
 )
 
-func azureAuthMethod(uri *url.URL, consumeURI *cloud.ConsumeURL) (cloudpb.AzureAuth, error) {
+func azureAuthMethod(consumeURI *cloud.ConsumeURL) (cloudpb.AzureAuth, error) {
 	authParam := consumeURI.ConsumeParam(cloud.AuthParam)
 	switch authParam {
 	case "", cloud.AuthParamSpecified:
-		if uri.Query().Get(AzureAccountKeyParam) != "" {
+		if consumeURI.Contains(AzureAccountKeyParam) {
 			return cloudpb.AzureAuth_LEGACY, nil
 		}
 		return cloudpb.AzureAuth_EXPLICIT, nil
@@ -126,7 +126,7 @@ func parseAzureURL(uri *url.URL) (cloudpb.ExternalStorage, error) {
 	azureURL := cloud.ConsumeURL{URL: uri}
 	conf := cloudpb.ExternalStorage{}
 	conf.Provider = cloudpb.ExternalStorageProvider_azure
-	auth, err := azureAuthMethod(uri, &azureURL)
+	auth, err := azureAuthMethod(&azureURL)
 	if err != nil {
 		return conf, err
 	}


### PR DESCRIPTION
This change allows parameters in a connection URI to be in mixed case. This
means that `AZURE_CLIENT_ID`, `AZURE_account_key` and `azure_client_secret`
are all valid within the same connection string.

This improvement enhances user experience by providing more flexibility in
how connection URIs can be formatted.

Epic: [CRDB-28198](https://cockroachlabs.atlassian.net/browse/CRDB-28198)
Fixes: https://github.com/cockroachdb/cockroach/issues/103779
Release note: None