### PR TITLE
2024 05 09 raft cleanup

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -99,7 +99,6 @@
             "pkg/kv/kvserver/rangefeed/scheduler.go": "flagged by linter, should be evaluated",
             "pkg/kv/kvserver/replica.go": "flagged by linter, should be evaluated",
             "pkg/kv/kvserver/replica_app_batch.go": "flagged by linter, should be evaluated",
-            "pkg/kv/kvserver/replica_raft.go": "flagged by linter, should be evaluated",
             "pkg/kv/kvserver/replica_raft_quiesce.go": "flagged by linter, should be evaluated",
             "pkg/kv/kvserver/replica_raftstorage.go": "flagged by linter, should be evaluated",
             "pkg/kv/kvserver/replica_rangefeed.go": "flagged by linter, should be evaluated",

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1588,9 +1588,11 @@ func (r *Replica) maybeCoalesceHeartbeat(
 	switch msg.Type {
 	case raftpb.MsgHeartbeat:
 		r.store.coalescedMu.Lock()
+		defer r.store.coalescedMu.Unlock()
 		hbMap = r.store.coalescedMu.heartbeats
 	case raftpb.MsgHeartbeatResp:
 		r.store.coalescedMu.Lock()
+		defer r.store.coalescedMu.Unlock()
 		hbMap = r.store.coalescedMu.heartbeatResponses
 	default:
 		return false
@@ -1613,7 +1615,6 @@ func (r *Replica) maybeCoalesceHeartbeat(
 		NodeID:  toReplica.NodeID,
 	}
 	hbMap[toStore] = append(hbMap[toStore], beat)
-	r.store.coalescedMu.Unlock()
 	return true
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1869,11 +1869,11 @@ func (r *Replica) lookupLatestDescriptors(
 // as unreachable on the next tick.
 func (r *Replica) addUnreachableRemoteReplica(remoteReplica roachpb.ReplicaID) {
 	r.unreachablesMu.Lock()
+	defer r.unreachablesMu.Unlock()
 	if r.unreachablesMu.remotes == nil {
 		r.unreachablesMu.remotes = make(map[roachpb.ReplicaID]struct{})
 	}
 	r.unreachablesMu.remotes[remoteReplica] = struct{}{}
-	r.unreachablesMu.Unlock()
 }
 
 // sendRaftMessageRequest sends a raft message, returning false if the message

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -744,15 +744,6 @@ var noSnap IncomingSnapshot
 func (r *Replica) handleRaftReady(
 	ctx context.Context, inSnap IncomingSnapshot,
 ) (handleRaftReadyStats, error) {
-
-	// Don't process anything if this fn returns false.
-	if fn := r.store.cfg.TestingKnobs.DisableProcessRaft; fn != nil && fn(r.store.StoreID()) {
-		return handleRaftReadyStats{
-			tBegin: timeutil.Now(),
-			tEnd:   timeutil.Now(),
-		}, nil
-	}
-
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	return r.handleRaftReadyRaftMuLocked(ctx, inSnap)
@@ -779,6 +770,14 @@ func (r *Replica) detachRaftEntriesMonitorRaftMuLocked() {
 func (r *Replica) handleRaftReadyRaftMuLocked(
 	ctx context.Context, inSnap IncomingSnapshot,
 ) (stats handleRaftReadyStats, _ error) {
+	// Don't process anything if this fn returns false.
+	if fn := r.store.cfg.TestingKnobs.DisableProcessRaft; fn != nil && fn(r.store.StoreID()) {
+		return handleRaftReadyStats{
+			tBegin: timeutil.Now(),
+			tEnd:   timeutil.Now(),
+		}, nil
+	}
+
 	// handleRaftReadyRaftMuLocked is not prepared to handle context cancellation,
 	// so assert that it's given a non-cancellable context.
 	if ctx.Done() != nil {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1821,9 +1821,7 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 		RangeStartKey: startKey, // usually nil
 	}
 	if !r.sendRaftMessageRequest(ctx, req) {
-		r.mu.Lock()
-		r.mu.droppedMessages++
-		r.mu.Unlock()
+		r.droppedMessages.Add(1)
 		r.addUnreachableRemoteReplica(toReplica.ReplicaID)
 	}
 }

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2508,12 +2508,12 @@ func (r *Replica) maybeAcquireSnapshotMergeLock(
 	// left-hand neighbor has no pending merges to apply. And that RHS replica
 	// could not have been further split or merged, as it never processes another
 	// command after the merge commits.
-	endKey := r.Desc().EndKey
-	if endKey == nil {
+	if !r.IsInitialized() {
 		// The existing replica is unitialized, in which case we've already
 		// installed a placeholder for snapshot's keyspace. No merge lock needed.
 		return nil, func() {}
 	}
+	endKey := r.Desc().EndKey
 	unlocks := []func(){}
 	for endKey.Less(inSnap.Desc.EndKey) {
 		sRepl := r.store.LookupReplica(endKey)


### PR DESCRIPTION
This set of commits are minor refactoring of replica_raft.go. The bulk of the changes are to remove all the uses of non-deferred `Unlock`. There should not be any functional changes in these commits.

Release Note: None

Part of: https://github.com/cockroachdb/cockroach/issues/105366