### PR TITLE
status: fix possible index out of bounds in cpu sampling

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -815,7 +815,10 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(ctx context.Context, cs *CGoMem
 	if err != nil {
 		log.Ops.Errorf(ctx, "unable to get system CPU usage: %v", err)
 	}
-	cpuUsage := cpuUsageStats[0]
+	var cpuUsage cpu.TimesStat
+	if len(cpuUsageStats) > 0 {
+		cpuUsage = cpuUsageStats[0]
+	}
 	numHostCPUs, err := cpu.Counts(true /* logical */)
 	if err != nil {
 		log.Ops.Errorf(ctx, "unable to get system CPU details: %v", err)


### PR DESCRIPTION
This commit fixes a possible index out of bounds crash that could previously occur when `cpu.Times` returned an error when sampling runtime stats. The bug was introduced in 4b9a337c0be581d1317d9d1172c6f1fb8e1a7a1f.

Fixes: #120129.

Release note: None