### PR TITLE
sql: stop propagating DistSQL version via gossip

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1124,12 +1124,6 @@ func parseGossipValues(gossipInfo *gossip.InfoStatus) (string, error) {
 				return "", errors.Wrapf(err, "failed to parse value for key %q", key)
 			}
 			output = append(output, fmt.Sprintf("%q: %+v", key, healthAlert))
-		} else if strings.HasPrefix(key, gossip.KeyDistSQLNodeVersionKeyPrefix) {
-			var version execinfrapb.DistSQLVersionGossipInfo
-			if err := protoutil.Unmarshal(bytes, &version); err != nil {
-				return "", errors.Wrapf(err, "failed to parse value for key %q", key)
-			}
-			output = append(output, fmt.Sprintf("%q: %+v", key, version))
 		} else if strings.HasPrefix(key, gossip.KeyDistSQLDrainingPrefix) {
 			var drainingInfo execinfrapb.DistSQLDrainingInfo
 			if err := protoutil.Unmarshal(bytes, &drainingInfo); err != nil {

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -76,10 +76,6 @@ const (
 	// release, delete this key.
 	KeyDeprecatedSystemConfig = "system-db"
 
-	// KeyDistSQLNodeVersionKeyPrefix is key prefix for each node's DistSQL
-	// version.
-	KeyDistSQLNodeVersionKeyPrefix = "distsql-version"
-
 	// KeyDistSQLDrainingPrefix is the key prefix for each node's DistSQL
 	// draining state.
 	KeyDistSQLDrainingPrefix = "distsql-draining"
@@ -154,11 +150,6 @@ func DecodeStoreDescKey(storeKey string) (roachpb.StoreID, error) {
 		return 0, errors.Wrapf(err, "failed parsing StoreID from key %q", storeKey)
 	}
 	return roachpb.StoreID(storeID), nil
-}
-
-// MakeDistSQLNodeVersionKey returns the gossip key for the given store.
-func MakeDistSQLNodeVersionKey(instanceID base.SQLInstanceID) string {
-	return MakeKey(KeyDistSQLNodeVersionKeyPrefix, instanceID.String())
 }
 
 // MakeDistSQLDrainingKey returns the gossip key for the given node's distsql

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -108,23 +108,6 @@ func NewServer(
 // initialized. For example, the initialization of the flow runner has to
 // happen in NewServer.
 func (ds *ServerImpl) Start() {
-	// Gossip the version info so that other nodes don't plan incompatible flows
-	// for us.
-	if g, ok := ds.ServerConfig.Gossip.Optional(MultiTenancyIssueNo); ok {
-		if nodeID, ok := ds.ServerConfig.NodeID.OptionalNodeID(); ok {
-			if err := g.AddInfoProto(
-				gossip.MakeDistSQLNodeVersionKey(base.SQLInstanceID(nodeID)),
-				&execinfrapb.DistSQLVersionGossipInfo{
-					Version:            execinfra.Version,
-					MinAcceptedVersion: execinfra.MinAcceptedVersion,
-				},
-				0, // ttl - no expiration
-			); err != nil {
-				panic(err)
-			}
-		}
-	}
-
 	if err := ds.setDraining(false); err != nil {
 		panic(err)
 	}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -1306,11 +1306,8 @@ func TestPartitionSpans(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := mockGossip.AddInfoProto(
-			gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
-			&execinfrapb.DistSQLVersionGossipInfo{
-				MinAcceptedVersion: execinfra.MinAcceptedVersion,
-				Version:            execinfra.Version,
-			},
+			gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+			&execinfrapb.DistSQLDrainingInfo{Draining: false},
 			0, // ttl - no expiration
 		); err != nil {
 			t.Fatal(err)
@@ -1688,15 +1685,15 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		// All the nodes advertise their DistSQL versions. This is to simulate the
-		// "node overridden by another node at the same address" case mentioned in
-		// the test comment - for such a node, the descriptor would be taken out of
-		// the gossip data, but other datums it advertised are left in place.
+		// All the nodes advertise that they are not draining. This is to
+		// simulate the "node overridden by another node at the same address"
+		// case mentioned in the test comment - for such a node, the descriptor
+		// would be taken out of the gossip data, but other datums it advertised
+		// are left in place.
 		if err := mockGossip.AddInfoProto(
-			gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
-			&execinfrapb.DistSQLVersionGossipInfo{
-				MinAcceptedVersion: execinfra.MinAcceptedVersion,
-				Version:            execinfra.Version,
+			gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+			&execinfrapb.DistSQLDrainingInfo{
+				Draining: false,
 			},
 			0, // ttl - no expiration
 		); err != nil {
@@ -1780,11 +1777,8 @@ func TestCheckNodeHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := mockGossip.AddInfoProto(
-		gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
-		&execinfrapb.DistSQLVersionGossipInfo{
-			MinAcceptedVersion: execinfra.MinAcceptedVersion,
-			Version:            execinfra.Version,
-		},
+		gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+		&execinfrapb.DistSQLDrainingInfo{Draining: false},
 		0, // ttl - no expiration
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -359,22 +359,6 @@ message RemoteProducerMetadata {
   // NEXT ID: 13
 }
 
-// DistSQLVersionGossipInfo represents the DistSQL server version information
-// that gets gossiped for each node. This is used by planners to avoid planning
-// on nodes with incompatible version during rolling cluster updates.
-//
-// For the meaning of the fields, see the corresponding constants in
-// distsqlrun/server.go.
-// TODO(yuzefovich): propagating version information is no longer needed once
-// compatibility with 23.2 is unnecessary.
-message DistSQLVersionGossipInfo {
-  optional uint32 version = 1 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "DistSQLVersion"];
-
-  optional uint32 min_accepted_version = 2 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "DistSQLVersion"];
-}
-
 // DistSQLDrainingInfo represents the DistSQL draining state that gets gossiped
 // for each node. This is used by planners to avoid planning on nodes that are
 // known to be draining.

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
-        "//pkg/gossip",
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -136,27 +135,6 @@ func TestServer(t *testing.T) {
 			})
 		}
 	})
-}
-
-// Test that a node gossips its DistSQL version information.
-func TestDistSQLServerGossipsVersion(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
-
-	var v execinfrapb.DistSQLVersionGossipInfo
-	if err := s.GossipI().(*gossip.Gossip).GetInfoProto(
-		gossip.MakeDistSQLNodeVersionKey(base.SQLInstanceID(s.NodeID())), &v,
-	); err != nil {
-		t.Fatal(err)
-	}
-
-	if v.Version != execinfra.Version || v.MinAcceptedVersion != execinfra.MinAcceptedVersion {
-		t.Fatalf("node is gossipping the wrong version. Expected: [%d-%d], got [%d-%d",
-			execinfra.Version, execinfra.MinAcceptedVersion, v.Version, v.MinAcceptedVersion)
-	}
 }
 
 // runLocalFlow takes in a SetupFlowRequest to setup a local sync flow that is


### PR DESCRIPTION
In de5a89350f1d5edc14bb56537e837c4238812c50 we made it so that we no longer check the DistSQL version of all nodes that we obtain via gossip for physical planning decisions (under the assumption that we will no longer bump the version in backwards-incompatible way, so all nodes are compatible). This check is only present in 23.2 and prior versions, and given that we're in 24.3 time frame, the compatibility with 23.2 is no longer need, it is now safe to remove propagating this information.

Informs: #98550
Epic: None

Release note: None