### PR TITLE
release-24.1: skip: remove `skip.UnderStressRace{,WithIssue}`

### DIFF
--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -208,7 +208,7 @@ func TestTenantBackupMultiRegionDatabases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "test is too heavy to run under stress")
+	skip.UnderRace(t, "test is too heavy to run under stress")
 
 	tc, db, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		t, 3 /*numServers*/, base.TestingKnobs{},

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -534,7 +534,7 @@ func TestBackupRestoreExecLocality(t *testing.T) {
 func TestBackupManifestFileCount(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "multinode cluster setup times out under stressrace, likely due to resource starvation.")
+	skip.UnderRace(t, "multinode cluster setup times out under race, likely due to resource starvation.")
 
 	const numAccounts = 1000
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
@@ -729,7 +729,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "this test is heavyweight and is not expected to reveal any direct bugs under stress race")
+	skip.UnderRace(t, "this test is heavyweight and is not expected to reveal any direct bugs under stress race")
 
 	const numAccounts = 1
 	_, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
@@ -913,7 +913,7 @@ func TestBackupRestoreEmpty(t *testing.T) {
 func TestBackupRestoreNegativePrimaryKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "test is too slow to run under race, presumably because of the multiple splits")
+	skip.UnderRace(t, "test is too slow to run under race, presumably because of the multiple splits")
 
 	const numAccounts = 1000
 
@@ -6413,7 +6413,7 @@ func TestRestoreErrorPropagates(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "multinode cluster setup times out under stressrace, likely due to resource starvation.")
+	skip.UnderRace(t, "multinode cluster setup times out under race, likely due to resource starvation.")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -9013,7 +9013,7 @@ func TestBackupWorkerFailure(t *testing.T) {
 
 	skip.WithIssue(t, 113125)
 
-	skip.UnderStressRace(t, "test is too slow to run under race")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
@@ -9643,7 +9643,7 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "test is too slow to run under race")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
 	localExternalDir, cleanup := testutils.TempDir(t)
@@ -9746,7 +9746,7 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "test is too slow under stressrace, it fails in the upsert loop")
+	skip.UnderRace(t, "test is too slow under race, it fails in the upsert loop")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -10106,7 +10106,7 @@ func TestBackupRestoreOldIncrementalDefault(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "multinode cluster setup times out under stressrace, likely due to resource starvation.")
+	skip.UnderRace(t, "multinode cluster setup times out under race, likely due to resource starvation.")
 
 	const numAccounts = 1
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
@@ -10216,7 +10216,7 @@ func TestBackupRestoreSeparateExplicitIsDefault(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "multinode cluster setup times out under stressrace, likely due to resource starvation.")
+	skip.UnderRace(t, "multinode cluster setup times out under race, likely due to resource starvation.")
 
 	const numAccounts = 1
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -623,7 +623,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "too slow under stress race")
+	skip.UnderRace(t, "too slow under stress race")
 	params := base.TestServerArgs{}
 	// Disable GC job so that the final check of crdb_internal.tables is
 	// guaranteed to not be cleaned up. Although this was never observed by a

--- a/pkg/ccl/backupccl/restore_multiregion_rbr_test.go
+++ b/pkg/ccl/backupccl/restore_multiregion_rbr_test.go
@@ -34,7 +34,7 @@ func TestMultiRegionRegionlessRestoreNoLicense(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "test is too heavy to run under stress")
+	skip.UnderRace(t, "test is too heavy to run under stress")
 
 	ctx := context.Background()
 

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -755,7 +755,7 @@ func TestShowBackupCheckFiles(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const numAccounts = 11
-	skip.UnderStressRace(t, "multinode cluster setup times out under stressrace, likely due to resource starvation.")
+	skip.UnderRace(t, "multinode cluster setup times out under race, likely due to resource starvation.")
 
 	_, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts,
 		InitManualReplication)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -450,7 +450,7 @@ func startTestFullServer(
 // need to be applied to each of the servers in the test cluster
 // returned from this function.
 func startTestCluster(t testing.TB) (serverutils.TestClusterInterface, *gosql.DB, func()) {
-	skip.UnderStressRace(t, "multinode setup doesn't work under testrace")
+	skip.UnderRace(t, "multinode setup doesn't work under testrace")
 	ctx := context.Background()
 	knobs := base.TestingKnobs{
 		DistSQL:          &execinfra.TestingKnobs{Changefeed: &TestingKnobs{}},

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -40,7 +40,7 @@ import (
 func TestTenantAutoUpgradeRespectsAutoUpgradeEnabledSetting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	v0 := clusterversion.MinSupported
 	ctx := context.Background()
@@ -138,7 +138,7 @@ func TestTenantAutoUpgradeRespectsAutoUpgradeEnabledSetting(t *testing.T) {
 func TestTenantAutoUpgrade(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	v0 := clusterversion.MinSupported
 	ctx := context.Background()
@@ -253,7 +253,7 @@ func TestTenantAutoUpgrade(t *testing.T) {
 func TestTenantUpgrade(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 	ctx := context.Background()
 
 	v1 := clusterversion.MinSupported.Version()

--- a/pkg/ccl/multiregionccl/roundtrips_test.go
+++ b/pkg/ccl/multiregionccl/roundtrips_test.go
@@ -35,7 +35,7 @@ import (
 func TestEnsureLocalReadsOnGlobalTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "https://github.com/cockroachdb/cockroach/issues/102798#issuecomment-1543852311")
+	skip.UnderRace(t, "https://github.com/cockroachdb/cockroach/issues/102798#issuecomment-1543852311")
 
 	// ensureOnlyLocalReads looks at a trace to ensure that reads were served
 	// locally. It returns true if the read was served as a follower read.

--- a/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
+++ b/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
@@ -32,7 +32,7 @@ func TestTenantAdminAPI(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// The liveness session might expire before the stress race can finish.
-	skip.UnderStressRace(t, "expensive tests")
+	skip.UnderRace(t, "expensive tests")
 
 	ctx := context.Background()
 

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -55,7 +55,7 @@ func TestTenantStatusAPI(t *testing.T) {
 	defer s.SetupSingleFileLogging()()
 
 	// The liveness session might expire before the stress race can finish.
-	skip.UnderStressRace(t, "expensive tests")
+	skip.UnderRace(t, "expensive tests")
 
 	ctx := context.Background()
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -87,7 +87,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	skip.UnderStressRace(t, "test takes ~5 minutes under stressrace")
+	skip.UnderRace(t, "test takes ~5 minutes under race")
 
 	serverA, aDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -609,7 +609,7 @@ func TestStreamDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "disabled under stress and race")
+	skip.UnderRace(t, "disabled under race")
 
 	h, cleanup := replicationtestutils.NewReplicationHelper(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -275,7 +275,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	// This test depends on an intricate sequencing of events that can take
 	// several seconds, and requires maintaining expected leases.
 	skip.UnderShort(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	succeedsSoonDuration := testutils.DefaultSucceedsSoonDuration
 	if util.RaceEnabled {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4682,7 +4682,7 @@ func TestRefreshFailureIncludesConflictingTxn(t *testing.T) {
 func TestPartialPartition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "times out with 5 nodes")
+	skip.UnderRace(t, "times out with 5 nodes")
 	ctx := context.Background()
 
 	testCases := []struct {

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -960,7 +960,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 	skip.UnderShort(t)
 	// The test has 5 nodes. Its possible in stress-race for nodes to be starved
 	// out heartbeating their liveness.
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	stickyRegistry := fs.NewStickyRegistry()
 	ctx := context.Background()

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5958,9 +5958,9 @@ func TestRaftCampaignPreVoteCheckQuorum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive, so skip under deadlock detector and stressrace.
+	// Timing-sensitive, so skip under deadlock detector and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 
@@ -6037,9 +6037,9 @@ func TestRaftForceCampaignPreVoteCheckQuorum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive, so skip under deadlock detector and stressrace.
+	// Timing-sensitive, so skip under deadlock detector and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 
@@ -6134,9 +6134,9 @@ func TestRaftPreVote(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive, so skip it under deadlock detector and stressrace.
+	// Timing-sensitive, so skip it under deadlock detector and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	testutils.RunTrueAndFalse(t, "partial", func(t *testing.T, partial bool) {
 		testutils.RunTrueAndFalse(t, "quiesce", func(t *testing.T, quiesce bool) {
@@ -6377,9 +6377,9 @@ func TestRaftCheckQuorum(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// This test is timing-sensitive, so skip it under deadlock detector and
-	// stressrace.
+	// race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	testutils.RunTrueAndFalse(t, "symmetric", func(t *testing.T, symmetric bool) {
 		testutils.RunTrueAndFalse(t, "quiesce", func(t *testing.T, quiesce bool) {
@@ -6646,9 +6646,9 @@ func TestRaftUnquiesceLeaderNoProposal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive, so skip under deadlock detector and stressrace.
+	// Timing-sensitive, so skip under deadlock detector and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -6766,9 +6766,9 @@ func TestRaftPreVoteUnquiesceDeadLeader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive, so skip under deadlock detector and stressrace.
+	// Timing-sensitive, so skip under deadlock detector and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	manualClock := hlc.NewHybridManualClock()

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2612,9 +2612,9 @@ func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Timing-sensitive test, disable under deadlock and stressrace.
+	// Timing-sensitive test, disable under deadlock and race.
 	skip.UnderDeadlock(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // time out early
 	defer cancel()
@@ -4149,9 +4149,8 @@ func TestLBSplitUnsafeKeys(t *testing.T) {
 	ctx := context.Background()
 	const indexID = 1
 
-	// The test is expensive and prone to timing out under race.
+	// The test is expensive and prone to timing out under race or deadlock.
 	skip.UnderRace(t)
-	skip.UnderStressRace(t)
 	skip.UnderDeadlock(t)
 
 	makeTestKey := func(tableID uint32, suffix []byte) roachpb.Key {

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -722,7 +722,7 @@ func TestRejectBadVersionApplication(t *testing.T) {
 func prepTestCluster(
 	t *testing.T, nodes int,
 ) (*testcluster.TestCluster, fs.StickyRegistry, map[int]loqrecovery.PlanStore) {
-	skip.UnderStressRace(t, "cluster frequently fails to start under stress race")
+	skip.UnderRace(t, "cluster frequently fails to start under stress race")
 
 	reg := fs.NewStickyRegistry()
 

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -52,7 +52,7 @@ import (
 )
 
 func TestStorage(t *testing.T) {
-	skip.UnderStressRace(t, "very large test which is slow under stressrace")
+	skip.UnderRace(t, "very large test which is slow under race")
 	for _, withDeprecatedSpans := range []bool{true, false} {
 		for _, withMetaTable := range []bool{true, false} {
 			for _, test := range testCases {

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -34,9 +34,9 @@ func TestLeaseRenewer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// stressrace and deadlock make the test too slow, resulting in an inability
+	// race and deadlock make the test too slow, resulting in an inability
 	// to maintain leases and Raft leadership.
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 	skip.UnderDeadlock(t)
 
 	// We test with kv.expiration_leases_only.enabled both enabled and disabled,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1586,7 +1586,7 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 
 	// The zone config change leads to snapshot timeouts under stress race which
 	// make the test take 300+s.
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	serverArgs := make(map[int]base.TestServerArgs)

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -41,9 +41,8 @@ func TestConstraintConformanceReportIntegration(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	// This test takes seconds because of replication vagaries.
 	skip.UnderShort(t)
-	// Under stressrace, replication changes seem to hit 1m deadline errors and
+	// Under race, replication changes seem to hit 1m deadline errors and
 	// don't make progress.
-	skip.UnderStressRace(t)
 	skip.UnderRace(t, "takes >1min under race")
 	// Similarly, skip the test under deadlock builds.
 	skip.UnderDeadlock(t, "takes >1min under deadlock")

--- a/pkg/kv/kvserver/split/load_based_splitter_test.go
+++ b/pkg/kv/kvserver/split/load_based_splitter_test.go
@@ -766,7 +766,7 @@ func makeMultiRequestConfigs(
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderShort(t, "takes 20s")
-	skip.UnderStressRace(t, "takes 20s")
+	skip.UnderRace(t, "takes 20s")
 
 	parseGeneratorType := func(dist string) int {
 		switch dist {

--- a/pkg/server/application_api/sessions_test.go
+++ b/pkg/server/application_api/sessions_test.go
@@ -113,7 +113,7 @@ func TestListSessionsPrivileges(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Skip under stress race as the sleep query might finish before the stress race can finish.
-	skip.UnderStressRace(t, "list sessions privileges")
+	skip.UnderRace(t, "list sessions privileges")
 
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
@@ -322,7 +322,7 @@ func TestListClosedSessions(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// The active sessions might close before the stress race can finish.
-	skip.UnderStressRace(t, "active sessions")
+	skip.UnderRace(t, "active sessions")
 
 	ctx := context.Background()
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -199,7 +199,7 @@ func TestStatusAPITransactions(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderDeadlock(t, "test is very slow under deadlock")
-	skip.UnderStressRace(t, "test is too slow to run under stressrace")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	ctx := context.Background()
@@ -679,7 +679,7 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	if skip.Duress() {
 		additionalTimeout = additionalTimeoutUnderDuress
 	}
-	skip.UnderStressRace(t, "test is too slow to run under stressrace")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
@@ -852,7 +852,7 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Resource-intensive test, times out under stress.
-	skip.UnderStressRace(t, "expensive tests")
+	skip.UnderRace(t, "expensive tests")
 
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
@@ -1025,7 +1025,7 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	// The liveness session might expire before the stress race can finish.
-	skip.UnderStressRace(t, "expensive tests")
+	skip.UnderRace(t, "expensive tests")
 
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3647,7 +3647,7 @@ func TestAmbiguousResultIsRetried(t *testing.T) {
 func TestLeaseTableWriteFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	type filter = kvserverbase.ReplicaResponseFilter
 	var f atomic.Value

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -4539,7 +4539,7 @@ func TestImportDefaultNextVal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer setImportReaderParallelism(1)()
-	skip.UnderStressRace(t, "test hits a timeout before a successful run")
+	skip.UnderRace(t, "test hits a timeout before a successful run")
 
 	const nodes = 3
 	numFiles := 1
@@ -5322,7 +5322,7 @@ func TestImportWorkerFailure(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderDeadlock(t, "test is flaky under deadlock")
-	skip.UnderStressRace(t, "test is flaky under stressrace")
+	skip.UnderRace(t, "test is flaky under race")
 
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}
@@ -5420,7 +5420,7 @@ func TestImportMysql(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	const (
 		nodes = 3

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -403,7 +403,7 @@ import (
 //    Skips this entire logic test using skip.IgnoreLint(). Should be near top
 //    of test file. Note that this is different from `skipif`.
 //
-//  - skip under <deadlock/race/stress/stressrace/metamorphic/duress> [ISSUE] [args...]
+//  - skip under <deadlock/race/stress/metamorphic/duress> [ISSUE] [args...]
 //    Skips this entire logic test using skip.UnderDeadlock(), skip.UnderRace(),
 //    etc. Should be near top of test file. Note that this is different from
 //    `skipif`.
@@ -3109,12 +3109,6 @@ func (t *logicTest) processSubtest(
 						skip.UnderStress(t.t(), args...)
 					} else {
 						skip.UnderStressWithIssue(t.t(), githubIssueID, args...)
-					}
-				case "stressrace":
-					if githubIssueID, args := parse(fields[3:]); githubIssueID < 0 {
-						skip.UnderStressRace(t.t(), args...)
-					} else {
-						skip.UnderStressRaceWithIssue(t.t(), githubIssueID, args...)
 					}
 				case "metamorphic":
 					if githubIssueID, args := parse(fields[3:]); githubIssueID < 0 {

--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -62,8 +62,7 @@ func TestIndexBackfillMergeRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "TODO(ssd) test times outs under race")
-	skip.UnderRace(t, "TODO(ssd) test times outs under race")
+	skip.UnderRace(t, "TODO(ssd) test times out under race")
 
 	params, _ := createTestServerParams()
 

--- a/pkg/sql/scatter_test.go
+++ b/pkg/sql/scatter_test.go
@@ -33,7 +33,7 @@ func TestScatterRandomizeLeases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "uses too many resources for stressrace")
+	skip.UnderRace(t, "uses too many resources for race")
 	skip.UnderShort(t, "takes 25s")
 
 	const numHosts = 3

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -853,7 +853,7 @@ func isPQErrWithCode(err error, codes ...pgcode.Code) bool {
 func TestCompareLegacyAndDeclarative(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "too slow under stress race")
+	skip.UnderRace(t, "too slow under stress race")
 
 	ss := &staticSQLStmtLineProvider{
 		stmts: []string{

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -35,8 +35,8 @@ func TestShowTraceReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t) // too slow
-	skip.UnderDeadlock(t)   // too slow
+	skip.UnderRace(t)     // too slow
+	skip.UnderDeadlock(t) // too slow
 
 	const numNodes = 4
 

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -238,7 +238,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.WithIssue(t, 120626)
-	skip.UnderStressRace(t, "test is too slow to run under race")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	stubTime := timeutil.Now().Truncate(time.Hour)
 	sqlStatsKnobs := sqlstats.CreateTestingKnobs()

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -891,7 +891,7 @@ func TestInsightsIndexRecommendationIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "expensive tests")
+	skip.UnderRace(t, "expensive tests")
 
 	ctx := context.Background()
 	srv, sqlConn, _ := serverutils.StartServer(t, base.TestServerArgs{})

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -70,7 +70,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	stubTime := &stubTime{}
 	injector := newRuntimeKnobsInjector()

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -74,7 +74,7 @@ func TestSQLStatsFlush(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	fakeTime := stubTime{
 		aggInterval: time.Hour,

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -185,7 +185,7 @@ func TestSQLStatsWithMultipleIdxRec(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "expensive tests")
+	skip.UnderRace(t, "expensive tests")
 
 	fakeTime := stubTime{
 		aggInterval: time.Hour,

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -173,7 +173,7 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 func TestSQLStatsScheduleOperations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t, "test is too slow to run under race")
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
 	helper, helperCleanup := newTestHelper(t, &sqlstats.TestingKnobs{JobMonitorUpdateCheckInterval: time.Second})

--- a/pkg/sql/telemetry_datadriven_test.go
+++ b/pkg/sql/telemetry_datadriven_test.go
@@ -58,7 +58,7 @@ import (
 func TestTelemetryLoggingDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Some queries may be retried under stress.
-	skip.UnderStressRace(t, "results inconsistent under stress")
+	skip.UnderRace(t, "results inconsistent under stress")
 
 	sc := log.ScopeWithoutShowLogs(t)
 	defer sc.Close(t)

--- a/pkg/sql/ttl/ttljob/ttljob_processor_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor_test.go
@@ -226,7 +226,7 @@ func TestSpanToQueryBoundsCompositeKeys(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderStress(t)
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 
 	testCases := []struct {
 		desc string

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -137,25 +137,6 @@ func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{
 	}
 }
 
-// UnderStressRace skips this test during stressrace runs, which are tests run
-// under stress with the -race flag.
-func UnderStressRace(t SkippableTest, args ...interface{}) {
-	t.Helper()
-	if Stress() && util.RaceEnabled {
-		maybeSkip(t, "disabled under stressrace", args...)
-	}
-}
-
-// UnderStressRaceWithIssue skips this test during stressrace runs, which are
-// tests run under stress with the -race flag, logging the given issue ID as the
-// reason.
-func UnderStressRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
-	t.Helper()
-	if Stress() && util.RaceEnabled {
-		maybeSkip(t, withIssue("disabled under stressrace", githubIssueID), args...)
-	}
-}
-
 // UnderMetamorphic skips this test during metamorphic runs, which are tests
 // run with the metamorphic build tag.
 func UnderMetamorphic(t SkippableTest, args ...interface{}) {

--- a/pkg/upgrade/upgrades/permanent_sql_stats_ttl_test.go
+++ b/pkg/upgrade/upgrades/permanent_sql_stats_ttl_test.go
@@ -28,8 +28,8 @@ import (
 // we still need to test that the upgrade happens as expected when creating a
 // new cluster.
 func TestSQLStatsTTLChange(t *testing.T) {
-	skip.UnderStressRace(t)
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})

--- a/pkg/upgrade/upgrades/permanent_system_activity_update_job_test.go
+++ b/pkg/upgrade/upgrades/permanent_system_activity_update_job_test.go
@@ -26,8 +26,8 @@ import (
 // versions this old, but we still need to test that the upgrade happens as
 // expected when creating a new cluster.
 func TestCreateActivityUpdateJobMigration(t *testing.T) {
-	skip.UnderStressRace(t)
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t)
 	ctx := context.Background()
 
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})

--- a/pkg/upgrade/upgrades/v23_2_create_region_liveness_test.go
+++ b/pkg/upgrade/upgrades/v23_2_create_region_liveness_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestRegionLivenessTableMigration(t *testing.T) {
-	skip.UnderStressRace(t)
+	skip.UnderRace(t)
 	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 23, 2)
 
 	defer leaktest.AfterTest(t)()

--- a/pkg/util/startup/startup_test.go
+++ b/pkg/util/startup/startup_test.go
@@ -94,9 +94,9 @@ func TestStartupFailureRandomRange(t *testing.T) {
 	// of CI at all, and we also don't want to stress it in nightlies as part of
 	// a big package (where it will take a lot of time that could be spent running
 	// "faster" tests). In this package, it is the only test and so it's fine to
-	// run it under nightly (skipping nightly stressrace because race builds with
-	// many nodes are very resource intensive and tend to collapse).
-	skip.UnderStressRace(t, "6 nodes with replication is too slow for stress race")
+	// run it under nightly (skipping race builds because with many nodes they are
+	// very resource intensive and tend to collapse).
+	skip.UnderRace(t, "6 nodes with replication is too slow for race")
 	if !skip.NightlyStress() {
 		skip.IgnoreLint(t, "test takes 30s to run due to circuit breakers and timeouts")
 	}


### PR DESCRIPTION
Backport 1/1 commits from #123910.

/cc @cockroachdb/release

---

... and replace with `UnderRace`.

We are eliminating our use of https://github.com/cockroachdb/stress in `cockroachdb/cockroach` CI. In our nightlies on `master` and `release-24.1`, we are already not using `stress` (in favor of remote execution). It's still used in some nightlies (like the Pebble nightly) and Bazel Extended CI, though these uses will presumably be reduced as well.

Meanwhile, the difference between these two functions is not clear and it's not always obvious which you should pick. Prior to the remote execution-based "stress" nightly, *either* would work. With remote execution, only `skip.UnderRace` works (as this is not "stress" as far as `skip` is concerned). This is confusing.

Even before we were using remote execution, we were running the nightly `stressrace` with only one concurrent test run, so this was not any more "stressful" than not using `stress`, further confusing which `skip` function was appropriate to use.

We migrate instead to simply having one function: `skip.UnderRace`.

Epic: none

Release note: None

Release justification: Test-only code changes