### PR TITLE
roachtest: address ORM test issues after enabling READ COMMITTED

### DIFF
--- a/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
@@ -37,7 +37,6 @@ var jasyncSqlBlocklist = blocklist{
 	`com.github.aysnc.sql.db.integration.PreparedStatementSpec.prepared statements should support handling JSON type`:                                               "unknown",
 	`com.github.aysnc.sql.db.integration.TransactionSpec.transactions should commit simple inserts`:                                                                 "unknown",
 	`com.github.aysnc.sql.db.integration.TransactionSpec.transactions should commit simple inserts, prepared statements`:                                            "unknown",
-	`com.github.aysnc.sql.db.integration.TransactionSpec.transactions should rollback explicitly`:                                                                   "unknown",
 	`com.github.aysnc.sql.db.integration.TransactionSpec.transactions should rollback to savepoint`:                                                                 "unknown",
 	`com.github.aysnc.sql.db.integration.pool.ActorAsyncObjectPoolSpec.pool should enqueue an action if the pool is full`:                                           "unknown",
 	`com.github.aysnc.sql.db.integration.pool.ActorAsyncObjectPoolSpec.pool should give me a valid object when I ask for one`:                                       "unknown",

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -268,7 +268,7 @@ func registerRubyPG(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(1),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly, registry.Driver),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRubyPGTest(ctx, t, c)


### PR DESCRIPTION
The ruby-pg test is not fully supported in Azure, since it gets a message like:
```
this spec depends on out-of-memory condition in put_copy_data, which is not reliable on all platforms
```
for some tests.

Also, with READ COMMITTED enabled, a jasync test started passing.

fixes https://github.com/cockroachdb/cockroach/issues/123804
fixes https://github.com/cockroachdb/cockroach/issues/123801
Release note: None