### PR TITLE
roachtest: expand and cloudify cdc/initial-scan-rolling-restart

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -274,6 +274,7 @@ go_library(
         "//pkg/util/uuid",
         "//pkg/util/version",
         "//pkg/workload",
+        "//pkg/workload/debug",
         "//pkg/workload/histogram",
         "//pkg/workload/querybench",
         "//pkg/workload/tpcc",

--- a/pkg/workload/debug/webhook_server.go
+++ b/pkg/workload/debug/webhook_server.go
@@ -37,7 +37,7 @@ var webhookServerCmd = &cobra.Command{
 }
 
 const (
-	port = 9707
+	WebhookServerPort = 9707
 )
 
 func webhookServer(cmd *cobra.Command, args []string) error {
@@ -124,11 +124,11 @@ func webhookServer(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("starting server on port %d", port)
+	log.Printf("starting server on port %d", WebhookServerPort)
 	return (&http.Server{
 		TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
 		Handler:   mux,
-		Addr:      fmt.Sprintf(":%d", port),
+		Addr:      fmt.Sprintf(":%d", WebhookServerPort),
 	}).ListenAndServeTLS("", "")
 }
 


### PR DESCRIPTION
This patch expands the `cdc/initial-scan-rolling-restart` test to also
test normal checkpoints (in addition to shutdown checkpoints). It also
updates the test to work on GCE so that it can run during nightly CI.

Informs #123371

Release note: None