### PR TITLE
sql: fix crash when planning stats collection on virtual col with UDT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2877,3 +2877,72 @@ vectorized: true
           estimated row count: 10 (1.0% of the table; stats collected <hidden> ago)
           table: mno@mno_o_idx
           spans: [/11 - /11]
+
+# Regression for not setting the TypeResolver on the SemaContext when dealing
+# with stats on virtual computed columns (#122312).
+statement ok
+CREATE TABLE t122312 (s STRING, g greeting AS (s::greeting) VIRTUAL)
+
+statement ok
+ANALYZE t122312
+
+# Regression for not setting the txn of the schemaResolver when type checking
+# stats on virtual computed columns.
+statement ok
+CREATE TYPE order_status AS ENUM ('pending', 'paid', 'dispatched', 'delivered')
+
+statement ok
+CREATE TABLE orders (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "customer_id" UUID NOT NULL,
+  "total" DECIMAL NOT NULL,
+  "balance" DECIMAL NOT NULL,
+  "order_ts" TIMESTAMPTZ(0) NOT NULL DEFAULT now(),
+  "dispatch_ts" TIMESTAMPTZ(0),
+  "delivery_ts" TIMESTAMPTZ(0),
+  "status" order_status AS (
+    CASE
+      WHEN "delivery_ts" IS NOT NULL THEN 'delivered'
+      WHEN "dispatch_ts" IS NOT NULL THEN 'dispatched'
+      WHEN "balance" = 0 THEN 'paid'
+      ELSE 'pending'
+    END) VIRTUAL,
+  INDEX ("status")
+)
+
+statement ok
+INSERT INTO orders ("customer_id", "total", "balance", "dispatch_ts", "delivery_ts") VALUES
+  ('bdeb232e-12e9-4a33-9dd5-7bb9b694291a', 100, 100, NULL, NULL),
+  ('0dc59725-d20b-4370-a05d-11db025a0064', 200, 0, NULL, NULL),
+  ('d53d4021-9390-4b3a-9e5a-4bf1ff3e5a4c', 300, 0, now(), NULL),
+  ('d53d4021-9390-4b3a-9e5a-4bf1ff3e5a4c', 400, 0, now(), now())
+
+statement ok
+ANALYZE orders
+
+query TIIIIB colnames
+SELECT column_names, row_count, null_count, distinct_count, avg_size, histogram_id IS NOT NULL AS has_histogram
+FROM [SHOW STATISTICS FOR TABLE orders]
+ORDER BY column_names::STRING
+----
+column_names   row_count  null_count  distinct_count  avg_size  has_histogram
+{balance}      4          0           2               32        true
+{customer_id}  4          0           3               16        true
+{delivery_ts}  4          3           2               6         true
+{dispatch_ts}  4          2           2               12        true
+{id}           4          0           4               16        true
+{order_ts}     4          0           1               24        true
+{status}       4          0           4               48        true
+{total}        4          0           4               32        true
+
+let $hist_status
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE orders] WHERE column_names = ARRAY['status']
+
+query TIRI colnames,nosort
+SHOW HISTOGRAM $hist_status
+----
+upper_bound   range_rows  distinct_range_rows  equal_rows
+'pending'     0           0                    1
+'paid'        0           0                    1
+'dispatched'  0           0                    1
+'delivered'   0           0                    1


### PR DESCRIPTION
CREATE STATISTICS executes in multiple layers: the "outer" layer is a normal execution of the CREATE STATISTICS statement. During this execution, we create, start, and await a CreateStats job. The CreateStats job in turn starts an "inner" layer which uses a separate internal transaction to plan and execute distributed statistics collection.

Within the inner layer, we were using the job's planner (JobExecContext) to plan distributed stats collection. This planner has no associated transaction. If it weren't for user-defined types, this would be fine, but user-defined types must be resolved using a transaction.

We had a hack in place to set the evalCtx.Txn to the internal transaction in order to execute collection on normal columns with user-defined type. But this hack did not work for virtual computed columns with user-defined type, because type-checking their expressions uses more facilites of the planner than just the evalCtx. (Specifically the schemaResolver.)

So, instead of setting the evalCtx.Txn, we create a new "inner" planner that is associated with the internal transaction of the inner layer. This works for all columns with user-defined type.

Fixes: #123821

Release note (bug fix): Fix a crash introduced in v23.2.5 and v24.1.0-beta.2 that could occur when planning statistics collection on a table with a virtual computed column using a user-defined type when the newly-introduced cluster setting `sql.stats.virtual_computed_columns.enabled` is set to true. (The setting was introduced in v23.2.4 and v24.1.0-alpha.1.)