### PR TITLE
streamingccl: mark cutback retention jobs as successful

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -185,7 +185,7 @@ func startPostCutoverRetentionJob(
 		req := streampb.ReplicationProducerRequest{
 			ReplicationStartTime: cutoverTime,
 		}
-		_, err = streamproducer.StartReplicationProducerJob(ctx, evalCtx, txn, info.Name, req)
+		_, err = streamproducer.StartReplicationProducerJob(ctx, evalCtx, txn, info.Name, req, true)
 		return err
 	})
 }

--- a/pkg/ccl/streamingccl/streamproducer/producer_job.go
+++ b/pkg/ccl/streamingccl/streamproducer/producer_job.go
@@ -53,11 +53,16 @@ func makeProducerJobRecord(
 	expirationWindow time.Duration,
 	user username.SQLUsername,
 	ptsID uuid.UUID,
+	assumeSucceeded bool,
 ) jobs.Record {
 	tenantID := tenantInfo.ID
 	tenantName := tenantInfo.Name
 	currentTime := timeutil.Now()
 	expiration := currentTime.Add(expirationWindow)
+	status := jobspb.StreamReplicationProgress_NOT_FINISHED
+	if assumeSucceeded {
+		status = jobspb.StreamReplicationProgress_FINISHED_SUCCESSFULLY
+	}
 	return jobs.Record{
 		JobID:       registry.MakeJobID(),
 		Description: fmt.Sprintf("History Retention for Physical Replication of %s", tenantName),
@@ -69,7 +74,8 @@ func makeProducerJobRecord(
 			ExpirationWindow:           expirationWindow,
 		},
 		Progress: jobspb.StreamReplicationProgress{
-			Expiration: expiration,
+			Expiration:            expiration,
+			StreamIngestionStatus: status,
 		},
 	}
 }

--- a/pkg/ccl/streamingccl/streamproducer/producer_job_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/producer_job_test.go
@@ -93,7 +93,7 @@ func TestStreamReplicationProducerJob(t *testing.T) {
 		ti := &mtinfopb.TenantInfo{
 			SQLInfo: mtinfopb.SQLInfo{ID: 10},
 		}
-		jr := makeProducerJobRecord(registry, ti, time.Millisecond, usr, ptsID)
+		jr := makeProducerJobRecord(registry, ti, time.Millisecond, usr, ptsID, false)
 
 		require.NoError(t, runJobWithProtectedTimestamp(ptsID, ts, jr))
 
@@ -121,7 +121,7 @@ func TestStreamReplicationProducerJob(t *testing.T) {
 		ts := hlc.Timestamp{WallTime: ptsTime.UnixNano()}
 		ptsID := uuid.MakeV4()
 		expirationWindow := time.Hour
-		jr := makeProducerJobRecord(registry, ti, expirationWindow, usr, ptsID)
+		jr := makeProducerJobRecord(registry, ti, expirationWindow, usr, ptsID, false)
 
 		require.NoError(t, runJobWithProtectedTimestamp(ptsID, ts, jr))
 

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -38,7 +38,7 @@ func (r *replicationStreamManagerImpl) StartReplicationStream(
 	if err := r.checkLicense(); err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}
-	return StartReplicationProducerJob(ctx, r.evalCtx, r.txn, tenantName, req)
+	return StartReplicationProducerJob(ctx, r.evalCtx, r.txn, tenantName, req, false)
 }
 
 // HeartbeatReplicationStream implements streaming.ReplicationStreamManager interface.

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -71,6 +71,7 @@ func StartReplicationProducerJob(
 	txn isql.Txn,
 	tenantName roachpb.TenantName,
 	req streampb.ReplicationProducerRequest,
+	assumeSucceeded bool,
 ) (streampb.ReplicationProducerSpec, error) {
 	execConfig := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 
@@ -116,7 +117,7 @@ func StartReplicationProducerJob(
 	registry := execConfig.JobRegistry
 	ptsID := uuid.MakeV4()
 
-	jr := makeProducerJobRecord(registry, tenantRecord, defaultExpirationWindow, evalCtx.SessionData().User(), ptsID)
+	jr := makeProducerJobRecord(registry, tenantRecord, defaultExpirationWindow, evalCtx.SessionData().User(), ptsID, assumeSucceeded)
 	if _, err := registry.CreateAdoptableJobWithTxn(ctx, jr, jr.JobID, txn); err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}


### PR DESCRIPTION
Previously we started creating a stream producer job in the destination cluster when we completed replication cutover, to preserve the history as of that cutover time in case the another cluster would subsequently want to start replicating as of that time, e.g. reversing the direction of replication, or in case the promoted cluster would want to revert to the cutover time as part of a demotion back to a standby.

However, this placeholder job is, by design, never actually used by replication -- it exists only to keep the option open for some other replication job to be started -- and thus is never heartbeated or marked as no longer needed due to successful completion of replication, causing it to be marked as FAILED when it expires.

This changes the initial status so that it is created already indicating that replication succeeded. Thus when it expires, it is marked as successful instead of failed, avoiding the spurious 'failures' that one observes in the job system surfaces.

Release note (enterprise change): History Retention jobs created at the completion of cluster replication no longer erroneously indicate they failed when the expire.

Epic: none.