### PR TITLE
roachtest: add tpcc OR roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -356,7 +356,7 @@ func registerBackupFixtures(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
 			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{
 				backupSpecs: backupSpecs{
-					workload:           tpccRestore{opts: tpccRestoreOptions{warehouses: 500}},
+					workload:           tpccRestore{opts: tpccRestoreOptions{warehouses: 5000}},
 					nonRevisionHistory: true,
 				},
 			}),

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -550,6 +550,13 @@ func runRestore(
 			if _, err := db.Exec("SET CLUSTER SETTING admission.sql_kv_response.enabled=false"); err != nil {
 				return err
 			}
+			if _, err := db.Exec("SET CLUSTER SETTING kv.consistency_queue.enabled=false"); err != nil {
+				return err
+			}
+			if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.skip_external_bytes.enabled=true"); err != nil {
+				return err
+			}
+
 		}
 		opts := ""
 		if runOnline {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/errors"
@@ -965,13 +966,18 @@ type restoreDriver struct {
 	// gets computed during test execution, it is stored in the restoreDriver
 	// rather than the restoreSpecs.
 	aost string
+
+	rng *rand.Rand
 }
 
 func makeRestoreDriver(t test.Test, c cluster.Cluster, sp restoreSpecs) restoreDriver {
+	rng, seed := randutil.NewPseudoRand()
+	t.L().Printf(`Random Seed is %d`, seed)
 	return restoreDriver{
-		t:  t,
-		c:  c,
-		sp: sp,
+		t:   t,
+		c:   c,
+		sp:  sp,
+		rng: rng,
 	}
 }
 


### PR DESCRIPTION
This patch adds a 400 GB and 8.5 TB Online Restore TPCC roachtest.

Epic: none

Release note: none