### PR TITLE
roachprod: add env var for secure default

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/gce",
+        "//pkg/util/envutil",
         "//pkg/util/flagutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
@@ -50,7 +51,7 @@ var (
 	listPattern           string
 	isSecure              bool   // Set based on the values passed to --secure and --insecure
 	secure                = true // DEPRECATED
-	insecure              = false
+	insecure              = envutil.EnvOrDefaultBool("COCKROACH_ROACHPROD_INSECURE", false)
 	virtualClusterName    string
 	sqlInstance           int
 	extraSSHOptions       = ""


### PR DESCRIPTION
When constantly interacting with intentionally insecure clusters, constantly needing to re-specify `--insecure` is tedious and adds significant friction for no utility. Instead, one can now export an env var in their session in such cases to change the default back.

Release note: none.
Epic: none.