### PR TITLE
drtprod: ingest kv workload metrics as a datadog distribution

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -131,6 +131,7 @@ instances:
   - openmetrics_endpoint: http://localhost:2114/metrics
     namespace: workload3
     raw_metric_prefix: workload_
+    histogram_buckets_as_distributions: true
     metrics:
     - tpcc_.*
     - kv_.*


### PR DESCRIPTION
Somewhat counterintuitively, Datadog's agent defaults to ingesting openmetrics histograms as counters only, losing all info about the different buckets. This change updates the datadog agent config to ingest kv workload metrics for the drt-chaos workload as a "distribution", which retains that info.

Epic: none

Release note: None