### PR TITLE
githubpost: assign backupccl test failures to disaster-recovery

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -690,8 +690,20 @@ func getOwner(ctx context.Context, packageName, testName string) (_teams []team.
 		if testEng.Name() == "" {
 			log.Fatalf("test-eng team could not be found in TEAMS.yaml")
 		}
-		log.Printf("assigning %s.%s to 'test-eng' as catch-all", packageName, testName)
-		match = []team.Team{testEng}
+
+		// Workaround for #107885.
+		if strings.Contains(packageName, "backupccl") {
+			dr := co.GetTeamForAlias("cockroachdb/disaster-recovery")
+			if dr.Name() == "" {
+				log.Fatalf("disaster-recovery team could not be found in TEAMS.yaml")
+			}
+
+			log.Printf("assigning %s.%s to 'disaster-recovery' due to #107885", packageName, testName)
+			match = []team.Team{dr}
+		} else {
+			log.Printf("assigning %s.%s to 'test-eng' as catch-all", packageName, testName)
+			match = []team.Team{testEng}
+		}
 	}
 	return match
 }


### PR DESCRIPTION
Temporary workaround for `backupccl` failures, by far the most common occurrence of #107885.

Informs: #107885

Release note: None