### PR TITLE
schemachanger: consider "dropping" columns during alter primary key

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3857,3 +3857,14 @@ statement error pgcode 42703 pq: column "i" does not exist
 ALTER TABLE foo DROP COLUMN i, DROP COLUMN i;
 
 subtest end
+
+subtest alter_primary_key_using_dropped_column
+
+statement ok
+CREATE TABLE foo_bar (i int unique not null, j int);
+
+skipif config local-legacy-schema-changer
+statement error pgcode 55000 pq: column "i" is being dropped
+ALTER TABLE foo_bar DROP COLUMN i, ALTER PRIMARY KEY USING COLUMNS (i);
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -287,7 +287,8 @@ func alterPKInPrimaryIndexAndItsTemp(
 //  3. no inaccessible columns;
 //  4. no nullable columns;
 //  5. no virtual columns (starting from v22.1);
-//  6. add more here
+//  6. No columns that are scheduled to be dropped (target status set to `ABSENT`);
+//  7. add more here
 //
 // Panic if any precondition is found unmet.
 func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
@@ -329,7 +330,7 @@ func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
 			panic(errors.AssertionFailedf("programming error: resolving column %v does not give a "+
 				"Column element.", col.Column))
 		}
-		if colCurrentStatus == scpb.Status_DROPPED || colCurrentStatus == scpb.Status_ABSENT {
+		if colCurrentStatus == scpb.Status_DROPPED || colCurrentStatus == scpb.Status_ABSENT || colTargetStatus == scpb.ToAbsent {
 			if colTargetStatus == scpb.ToPublic {
 				panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 					"column %q is being added", col.Column))


### PR DESCRIPTION
Previously, using the "comma syntax" for dropping a col and altering the primary key with the same name
(`alter table t drop column i, alter primary key using columns(i);`) led to an internal error. This commit makes it so that the error will instead be a proper external error by ensuring that resolving columns in the DSC considers the "dropping" state.

Fixes: #122917

Epic: CRDB-37763

Release note: None