### PR TITLE
roachtest: implement `As` for `ErrorWithOwnership`

### DIFF
--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 go_test(
     name = "registry_test",
     srcs = [
+        "errors_test.go",
         "filter_test.go",
         "test_spec_test.go",
     ],
@@ -36,7 +37,9 @@ go_test(
     deps = [
         "//pkg/cmd/roachtest/spec",
         "//pkg/internal/team",
+        "//pkg/roachprod/errors",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/roachtest/registry/errors.go
+++ b/pkg/cmd/roachtest/registry/errors.go
@@ -10,7 +10,10 @@
 
 package registry
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type (
 	ErrorWithOwnership struct {
@@ -30,6 +33,14 @@ type (
 
 func (ewo ErrorWithOwnership) Error() string {
 	return fmt.Sprintf("%s [owner=%s]", ewo.Err.Error(), ewo.Owner)
+}
+
+func (ewo ErrorWithOwnership) Is(target error) bool {
+	return errors.Is(ewo.Err, target)
+}
+
+func (ewo ErrorWithOwnership) As(reference interface{}) bool {
+	return errors.As(ewo.Err, reference)
 }
 
 func WithTitleOverride(title string) errorOption {

--- a/pkg/cmd/roachtest/registry/errors_test.go
+++ b/pkg/cmd/roachtest/registry/errors_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package registry
+
+import (
+	"io/fs"
+	"testing"
+
+	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorWithOwner(t *testing.T) {
+	originalErr := fs.ErrExist
+	newErr := ErrorWithOwner(OwnerTestEng, originalErr)
+	require.True(t, errors.Is(newErr, fs.ErrExist))
+
+	originalErr = rperrors.NewSSHError(errors.New("oops"))
+	newErr = ErrorWithOwner(OwnerTestEng, originalErr)
+
+	// Make sure that we are still able to detect transient errors when
+	// the error is assigned an ownership later.
+	var transient rperrors.TransientError
+	require.True(t, errors.As(newErr, &transient))
+	require.True(t, rperrors.IsTransient(newErr))
+}

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -97,7 +97,8 @@ func (te TransientError) ExitCode() int {
 // IsTransient allows callers to check if a given error is a roachprod
 // transient error.
 func IsTransient(err error) bool {
-	return errors.Is(err, TransientError{})
+	var ref TransientError
+	return errors.As(err, &ref)
 }
 
 // NewSSHError returns a transient error for SSH-related issues.


### PR DESCRIPTION
Previously, the `ErrorWithOwnership` type would wrap the original error but callers would not be able to use `errors.As` to find out if the error was of a specific type (notably, roachprod transient errors).

In this commit, we introduce an appropriate implementation of `As` for the `ErrorWithOwnerhsip` type, allowing us to properly identify transient failures even when the ownership is changed.

Fixes: #123979

Release note: None