### PR TITLE
roachprod: secure clusters in dynamic admin url port

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -415,7 +415,7 @@ func initFlags() {
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd, updateTargetsCmd} {
 		// TODO(renato): remove --secure once the default of secure
 		// clusters has existed in roachprod long enough.
 		cmd.Flags().BoolVar(&secure,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -564,11 +564,14 @@ environment variables to the cockroach process.
 ` + tagHelp + `
 The default prometheus url is https://grafana.testeng.crdb.io/. This can be overwritten by using the
 environment variable COCKROACH_PROM_HOST_URL
+
+Note that if the cluster is started in insecure mode, set the insecure mode here as well by using the --insecure flag.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		clusterSettingsOpts := []install.ClusterSettingOption{
 			install.TagOption(tag),
+			install.SecureOption(isSecure),
 			install.EnvOption(nodeEnv),
 		}
 		return roachprod.UpdateTargets(context.Background(), config.Logger, args[0], clusterSettingsOpts...)

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -48,7 +48,7 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("failed")),
 			}, nil
 		}
-		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, []string{"n1"}, l)
+		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, []string{"n1"}, true, l)
 		require.NotNil(t, err)
 		require.Equal(t, "request failed with status 400 and error failed", err.Error())
 	})
@@ -76,7 +76,7 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 				StatusCode: 200,
 			}, nil
 		}
-		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, []string{"n1", "", "n3"}, l)
+		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, []string{"n1", "", "n3"}, true, l)
 		require.Nil(t, err)
 	})
 }

--- a/pkg/roachprod/promhelperclient/promhelper_utils.go
+++ b/pkg/roachprod/promhelperclient/promhelper_utils.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
@@ -22,8 +23,9 @@ import (
 )
 
 var (
+	userHome, _ = os.UserHomeDir()
 	// promCredFile is where the prom helper credentials are stored
-	promCredFile = os.TempDir() + "promhelpers-secrets"
+	promCredFile = filepath.Join(userHome, ".roachprod", "promhelper-secrets")
 )
 
 // FetchedFrom indicates where the credentials have been fetched from.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -798,7 +798,7 @@ func updatePrometheusTargets(ctx context.Context, l *logger.Logger, c *install.S
 	if len(nodeIPPorts) > 0 {
 		if err := promhelperclient.NewPromClient().UpdatePrometheusTargets(ctx,
 			envutil.EnvOrDefaultString(prometheusHostUrlEnv, defaultPrometheusHostUrl),
-			c.Name, false, nodeIPPorts, l); err != nil {
+			c.Name, false, nodeIPPorts, !c.Secure, l); err != nil {
 			l.Errorf("creating cluster config failed for the ip:ports %v: %v", nodeIPPorts, err)
 		}
 	}


### PR DESCRIPTION
A recent change to support dynamic cluster port was introduced. But, that was not considering secured clusters
This change supports secure cluster

Fixes: #117125
Epic: none