### PR TITLE
streamingccl: enable snappy compression in transit

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -43,8 +43,10 @@ go_library(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_golang_snappy//:snappy",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgx_v4//:pgx",
+        "@com_github_pkg_errors//:errors",
     ],
 )
 

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -257,7 +257,8 @@ func getFirstDialer(
 }
 
 type options struct {
-	streamID streampb.StreamID
+	streamID   streampb.StreamID
+	compressed bool
 }
 
 func (o *options) appName() string {
@@ -277,6 +278,13 @@ type Option func(*options)
 func WithStreamID(id streampb.StreamID) Option {
 	return func(o *options) {
 		o.streamID = id
+	}
+}
+
+// WithCompression controls requesting a compressed stream from the producer.
+func WithCompression(enabled bool) Option {
+	return func(o *options) {
+		o.compressed = enabled
 	}
 }
 

--- a/pkg/ccl/streamingccl/streamclient/span_config_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/span_config_stream_client.go
@@ -177,7 +177,7 @@ func (p *spanConfigStreamSubscription) Subscribe(ctx context.Context) error {
 		rows.Close()
 	}()
 
-	p.err = subscribeInternal(ctx, rows, p.eventsChan, p.closeChan)
+	p.err = subscribeInternal(ctx, rows, p.eventsChan, p.closeChan, false)
 	return p.err
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -108,6 +108,13 @@ var ingestSplitEvent = settings.RegisterBoolSetting(
 	false,
 )
 
+var compress = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"physical_replication.consumer.stream_compression.enabled",
+	"enables requesting a compressed stream from the producer when resumed",
+	true,
+)
+
 var streamIngestionResultTypes = []*types.T{
 	types.Bytes, // jobspb.ResolvedSpans
 }
@@ -435,7 +442,8 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 			log.Infof(ctx, "using testing client")
 		} else {
 			streamClient, err = streamclient.NewStreamClient(ctx, streamingccl.StreamAddress(addr), db,
-				streamclient.WithStreamID(streampb.StreamID(sip.spec.StreamID)))
+				streamclient.WithStreamID(streampb.StreamID(sip.spec.StreamID)),
+				streamclient.WithCompression(compress.Get(&evalCtx.Settings.SV)))
 			if err != nil {
 
 				sip.MoveToDrainingAndLogError(errors.Wrapf(err, "creating client for partition spec %q from %q", token, redactedAddr))

--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_golang_snappy//:snappy",
     ],
 )
 

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/golang/snappy"
 )
 
 var activeStreams = struct {
@@ -370,6 +371,9 @@ func (s *eventStream) sendFlush(ctx context.Context, event *streampb.StreamEvent
 	data, err := protoutil.Marshal(event)
 	if err != nil {
 		return err
+	}
+	if s.spec.Compressed {
+		data = snappy.Encode(nil, data)
 	}
 	select {
 	case <-ctx.Done():

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -115,6 +115,8 @@ message StreamPartitionSpec {
 
   // Progress describes previous progress made towards replicating these spans.
   repeated cockroach.sql.jobs.jobspb.ResolvedSpan progress = 6  [(gogoproto.nullable) = false];
+
+  bool compressed = 7;
 }
 
 // SpanConfigEventStreamSpec is the span config event stream specification.


### PR DESCRIPTION
Release note: none.
Epic: none.