### PR TITLE
roachtest: prefix all logs with worker tags

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -60,7 +60,6 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_datadog_datadog_go//statsd",
         "@com_github_lib_pq//:pq",
         "@com_github_petermattis_goid//:goid",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1927,7 +1927,7 @@ func (c *clusterImpl) Get(
 	return errors.Wrap(roachprod.Get(ctx, l, c.MakeNodes(opts...), src, dest), "cluster.Get")
 }
 
-// Put a string into the specified file on the remote(s).
+// PutString into the specified file on the remote(s).
 func (c *clusterImpl) PutString(
 	ctx context.Context, content, dest string, mode os.FileMode, nodes ...option.Option,
 ) error {


### PR DESCRIPTION
Previously, many of the runner logs didn't have the worker tags. This was inadequate because we couldn't break up the logs by `wX` tags to see what each worker was doing.
This PR prefixes worker tags to the logs that were missing them.

Epic: none
Fixes: #114045
Release note: None