### PR TITLE
roachtest: bump timeout of failover/chaos tests

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -80,7 +80,7 @@ func registerFailover(r registry.Registry) {
 				Name:                "failover/chaos" + suffix,
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
-				Timeout:             60 * time.Minute,
+				Timeout:             90 * time.Minute,
 				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.DisableLocalSSD(), spec.ReuseNone()), // uses disk stalls
 				CompatibleClouds:    registry.OnlyGCE,                                                             // dmsetup only configured for gce
 				Suites:              registry.Suites(registry.Nightly),
@@ -290,6 +290,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 		defer cancelWorkload()
 
 		for i := 0; i < 20; i++ {
+			t.L().Printf("chaos iteration %d", i)
 			sleepFor(ctx, t, time.Minute)
 
 			// Ranges may occasionally escape their constraints. Move them to where


### PR DESCRIPTION
Fixes #124030.

The test runs 20 iterations of failures, each of which include 3 sleeps, two of which take 1 minute. This is not quite enough time so the test occasionally times out when it is otherwise making progress.

Release note: None