### PR TITLE
rangefeed: deflake TestDBClientScan

### DIFF
--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -12,6 +12,7 @@ package rangefeed_test
 
 import (
 	"context"
+	"slices"
 	"sync/atomic"
 	"testing"
 
@@ -61,7 +62,7 @@ func TestDBClientScan(t *testing.T) {
 
 	beforeAny := db.Clock().Now()
 
-	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	scratchKey := slices.Clip(append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...))
 	_, _, err := srv.StorageLayer().SplitRange(scratchKey)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes #124002.

Avoids a data race due to slice aliasing.

Release note: None