### PR TITLE
roachtest: teach multitenant-upgrade test about 24.2

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -80,6 +80,8 @@ func runMultiTenantUpgrade(
 	versionToMinSupportedVersion := map[string]string{
 		"23.2": "23.1",
 		"24.1": "23.2",
+		// TODO: test out version skipping, since it is available internally.
+		"24.2": "24.1",
 	}
 	curBinaryMajorAndMinorVersion := getMajorAndMinorVersionOnly(v)
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]


### PR DESCRIPTION
As a follow up, this test should set the min binary version for 24.2 to 23.2,
but that requires further test fixups. This patch merely deflakes the test.

Fixes https://github.com/cockroachdb/cockroach/issues/123930

Release note: none