### PR TITLE
roachpb: remove Lease.DeprecatedStartStasis

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -77,13 +77,7 @@ func RequestLease(
 		return newFailedLeaseTrigger(false /* isTransfer */), rErr
 	}
 
-	// MIGRATION(tschottdorf): needed to apply Raft commands which got proposed
-	// before the StartStasis field was introduced.
 	newLease := args.Lease
-	if newLease.DeprecatedStartStasis == nil {
-		newLease.DeprecatedStartStasis = newLease.Expiration
-	}
-
 	isExtension := prevLease.Replica.StoreID == newLease.Replica.StoreID
 	effectiveStart := newLease.Start
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1925,7 +1925,6 @@ func (l Lease) Speculative() bool {
 func (l Lease) Equivalent(newL Lease, expToEpochEquiv bool) bool {
 	// Ignore proposed timestamp & deprecated start stasis.
 	l.ProposedTS, newL.ProposedTS = nil, nil
-	l.DeprecatedStartStasis, newL.DeprecatedStartStasis = nil, nil
 	// Ignore sequence numbers, they are simply a reflection of
 	// the equivalency of other fields.
 	l.Sequence, newL.Sequence = 0, 0

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -679,19 +679,7 @@ message Lease {
 
   // The address of the would-be lease holder.
   ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
-
-  // The start of the lease stasis period. This field is deprecated.
-  //
-  // TODO(erikgrinaker): remove this. Migration:
-  //
-  // - 2016: the field was deprecated (#10305).
-  //
-  // - 24.1: stop reading the field. 23.2 nodes compare the field below Raft in
-  //   Lease.Equal(), so we must populate the field for backwards compatibility.
-  //
-  // - 24.2 or later: remove the field when backwards compatibility with 23.2
-  //   is no longer needed.
-  util.hlc.Timestamp deprecated_start_stasis = 4;
+  reserved 4;
 
   // The current timestamp when this lease has been proposed. Used after a
   // transfer and after a node restart to enforce that a node only uses leases


### PR DESCRIPTION
This commit completes the migration that was started in b468d1a9. That commit stopped v24.1 nodes from reading the field. This one stops v24.2 nodes from writing it. This in turn allows v24.2 code to be compiled with the field removed.

Epic: None
Release note: None