### PR TITLE
colexecerror: do not catch runtime panics in crdb_test builds

### DIFF
--- a/pkg/sql/colexecerror/BUILD.bazel
+++ b/pkg/sql/colexecerror/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util/buildutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
     ],

--- a/pkg/sql/colexecerror/error_test.go
+++ b/pkg/sql/colexecerror/error_test.go
@@ -38,6 +38,10 @@ func TestCatchVectorizedRuntimeError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Use the release-build panic-catching behavior instead of the
+	// crdb_test-build behavior.
+	defer colexecerror.ProductionBehaviorForTests()()
+
 	// Setup multiple levels of catchers to ensure that the panic-catcher
 	// doesn't fool itself into catching panics that the inner catcher emitted.
 	require.Panics(t, func() {
@@ -76,6 +80,10 @@ func TestCatchVectorizedRuntimeError(t *testing.T) {
 func TestNonCatchablePanicIsNotCaught(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// Use the release-build panic-catching behavior instead of the
+	// crdb_test-build behavior.
+	defer colexecerror.ProductionBehaviorForTests()()
 
 	require.Panics(t, func() {
 		require.NoError(t, colexecerror.CatchVectorizedRuntimeError(func() {
@@ -137,6 +145,10 @@ func BenchmarkCatchVectorizedRuntimeError(b *testing.B) {
 			},
 		},
 	}
+
+	// Use the release-build panic-catching behavior instead of the
+	// crdb_test-build behavior.
+	defer colexecerror.ProductionBehaviorForTests()()
 
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -209,6 +221,10 @@ func BenchmarkSQLCatchVectorizedRuntimeError(b *testing.B) {
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(b, base.TestServerArgs{SQLMemoryPoolSize: 10 << 30})
 	defer s.Stopper().Stop(ctx)
+
+	// Use the release-build panic-catching behavior instead of the
+	// crdb_test-build behavior.
+	defer colexecerror.ProductionBehaviorForTests()()
 
 	for _, parallelism := range []int{1, 20, 50} {
 		numConns := runtime.GOMAXPROCS(0) * parallelism

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -35,6 +35,10 @@ func TestOutboxCatchesPanics(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Use the release-build panic-catching behavior instead of the
+	// crdb_test-build behavior.
+	defer colexecerror.ProductionBehaviorForTests()()
+
 	var (
 		input    = colexecop.NewBatchBuffer()
 		typs     = []*types.T{types.Int}
@@ -142,6 +146,10 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 	// This is similar to TestOutboxCatchesPanics, but focuses on verifying that
 	// the Outbox drains its metadata sources even after an error.
 	t.Run("AfterOutboxError", func(t *testing.T) {
+		// Use the release-build panic-catching behavior instead of the
+		// crdb_test-build behavior.
+		defer colexecerror.ProductionBehaviorForTests()()
+
 		// This test, similar to TestOutboxCatchesPanics, relies on the fact that
 		// a BatchBuffer panics when there are no batches to return.
 		require.Panics(t, func() { input.Next() })


### PR DESCRIPTION
CatchVectorizedRuntimeError performs its stack-walking in order to catch *all* panics originating from within the vectorized execution engine, including runtime panics. The purpose of this is to limit the impact of a bug in vectorized execution to failure of a single execution rather than crashing the node.

During tests, however, we'd like to make these runtime panics louder, since we believe they represent bugs in vectorized execution. So let's not catch panics under crdb_test builds unless they're wrapped.

Epic: None

Release note: None