### PR TITLE
roachprod: fetch secrets from cloud store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/secretmanager v1.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
 cloud.google.com/go/pubsub v1.28.0 h1:XzabfdPx/+eNrsVVGLFgeUnQQKPGkMb8klRCeYK52is=
 cloud.google.com/go/pubsub v1.28.0/go.mod h1:vuXFpwaVoIPQMGXqRyUQigu/AX1S3IWugR9xznmcXX8=
-cloud.google.com/go/secretmanager v1.10.0 h1:pu03bha7ukxF8otyPKTFdDz+rr9sE3YauS5PliDXK60=
-cloud.google.com/go/secretmanager v1.10.0/go.mod h1:MfnrdvKMPNra9aZtQFvBcvRU54hbPD8/HayQdlUgJpU=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -559,9 +559,6 @@ var updateTargetsCmd = &cobra.Command{
 The "start" command updates the prometheus target configuration every time. But, in case of any  
 failure, this command can be used to update the configurations. 
 
-The --args and --env flags can be used to pass arbitrary command line flags and
-environment variables to the cockroach process.
-` + tagHelp + `
 The default prometheus url is https://grafana.testeng.crdb.io/. This can be overwritten by using the
 environment variable COCKROACH_PROM_HOST_URL
 
@@ -570,9 +567,7 @@ Note that if the cluster is started in insecure mode, set the insecure mode here
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		clusterSettingsOpts := []install.ClusterSettingOption{
-			install.TagOption(tag),
 			install.SecureOption(isSecure),
-			install.EnvOption(nodeEnv),
 		}
 		return roachprod.UpdateTargets(context.Background(), config.Logger, args[0], clusterSettingsOpts...)
 	}),

--- a/pkg/roachprod/promhelperclient/BUILD.bazel
+++ b/pkg/roachprod/promhelperclient/BUILD.bazel
@@ -12,9 +12,9 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/util/httputil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_google_cloud_go_secretmanager//apiv1",
-        "@com_google_cloud_go_secretmanager//apiv1/secretmanagerpb",
+        "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//idtoken",
+        "@org_golang_google_api//option",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )
@@ -25,7 +25,6 @@ go_test(
     embed = [":promhelperclient"],
     deps = [
         "//pkg/roachprod/logger",
-        "//pkg/util/httputil",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_api//idtoken",
         "@org_golang_x_oauth2//:oauth2",

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/idtoken"
@@ -40,7 +39,7 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 	promUrl := "http://prom_url.com"
 	c := NewPromClient()
 	t.Run("UpdatePrometheusTargets fails with 400", func(t *testing.T) {
-		c.httpPut = func(ctx context.Context, reqUrl string, h *httputil.RequestHeaders, body io.Reader) (
+		c.httpPut = func(ctx context.Context, reqUrl string, h *http.Header, body io.Reader) (
 			resp *http.Response, err error) {
 			require.Equal(t, getUrl(promUrl, "c1"), reqUrl)
 			return &http.Response{
@@ -48,12 +47,12 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("failed")),
 			}, nil
 		}
-		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, []string{"n1"}, true, l)
+		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, map[int]string{1: "n1"}, true, l)
 		require.NotNil(t, err)
 		require.Equal(t, "request failed with status 400 and error failed", err.Error())
 	})
 	t.Run("UpdatePrometheusTargets succeeds", func(t *testing.T) {
-		c.httpPut = func(ctx context.Context, url string, h *httputil.RequestHeaders, body io.Reader) (
+		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (
 			resp *http.Response, err error) {
 			require.Equal(t, getUrl(promUrl, "c1"), url)
 			ir, err := getInstanceConfigRequest(io.NopCloser(body))
@@ -76,7 +75,7 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 				StatusCode: 200,
 			}, nil
 		}
-		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, []string{"n1", "", "n3"}, true, l)
+		err := c.UpdatePrometheusTargets(ctx, promUrl, "c1", false, map[int]string{1: "n1", 3: "n3"}, true, l)
 		require.Nil(t, err)
 	})
 }
@@ -93,7 +92,7 @@ func TestDeleteClusterConfig(t *testing.T) {
 	promUrl := "http://prom_url.com"
 	c := NewPromClient()
 	t.Run("DeleteClusterConfig fails with 400", func(t *testing.T) {
-		c.httpDelete = func(ctx context.Context, url string, h *httputil.RequestHeaders) (
+		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
 			resp *http.Response, err error) {
 			require.Equal(t, getUrl(promUrl, "c1"), url)
 			return &http.Response{
@@ -106,7 +105,7 @@ func TestDeleteClusterConfig(t *testing.T) {
 		require.Equal(t, "request failed with status 400 and error failed", err.Error())
 	})
 	t.Run("DeleteClusterConfig succeeds", func(t *testing.T) {
-		c.httpDelete = func(ctx context.Context, url string, h *httputil.RequestHeaders) (
+		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
 			resp *http.Response, err error) {
 			require.Equal(t, getUrl(promUrl, "c1"), url)
 			return &http.Response{

--- a/pkg/util/httputil/client.go
+++ b/pkg/util/httputil/client.go
@@ -26,12 +26,6 @@ var DefaultClient = NewClientWithTimeout(StandardHTTPTimeout)
 // StandardHTTPTimeout is the default timeout to use for HTTP connections.
 const StandardHTTPTimeout time.Duration = 3 * time.Second
 
-// RequestHeaders are the headers to be part of the request
-type RequestHeaders struct {
-	ContentType   string
-	Authorization string
-}
-
 // NewClientWithTimeout defines a http.Client with the given timeout.
 func NewClientWithTimeout(timeout time.Duration) *Client {
 	return NewClientWithTimeouts(timeout, timeout)
@@ -90,14 +84,14 @@ func Post(
 // Put is like http.Put but uses the provided context and obeys its cancellation.
 // It also uses the default client with a default 3 second timeout.
 func Put(
-	ctx context.Context, url string, h *RequestHeaders, body io.Reader,
+	ctx context.Context, url string, h *http.Header, body io.Reader,
 ) (resp *http.Response, err error) {
 	return DefaultClient.Put(ctx, url, h, body)
 }
 
 // Delete is like http.Delete but uses the provided context and obeys its cancellation.
 // It also uses the default client with a default 3 second timeout.
-func Delete(ctx context.Context, url string, h *RequestHeaders) (resp *http.Response, err error) {
+func Delete(ctx context.Context, url string, h *http.Header) (resp *http.Response, err error) {
 	return DefaultClient.Delete(ctx, url, h)
 }
 
@@ -115,33 +109,28 @@ func (c *Client) Get(ctx context.Context, url string) (resp *http.Response, err 
 // 1. ContentType
 // 2. Authorization
 func (c *Client) Put(
-	ctx context.Context, url string, h *RequestHeaders, body io.Reader,
+	ctx context.Context, url string, h *http.Header, body io.Reader,
 ) (resp *http.Response, err error) {
 	req, err := http.NewRequestWithContext(ctx, "PUT", url, body)
 	if err != nil {
 		return nil, err
 	}
 	if h != nil {
-		if h.ContentType != "" {
-			req.Header.Set("Content-Type", h.ContentType)
-		}
-		if h.Authorization != "" {
-			req.Header.Set("Authorization", h.Authorization)
-		}
+		req.Header = *h
 	}
 	return c.Do(req)
 }
 
 // Delete is like http.Client.Delete but uses the provided context and obeys its cancellation.
 func (c *Client) Delete(
-	ctx context.Context, url string, h *RequestHeaders,
+	ctx context.Context, url string, h *http.Header,
 ) (resp *http.Response, err error) {
 	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	if h != nil && h.Authorization != "" {
-		req.Header.Set("Authorization", h.Authorization)
+	if h != nil {
+		req.Header = *h
 	}
 	return c.Do(req)
 }


### PR DESCRIPTION
Due to the complexity of fetching the secrets from the secrets manager, the secrets are now maintained in cloud storage.

Fixes: #117125
Epic: none