### PR TITLE
release-23.2: roachprod: bump max DNS results limit

### DIFF
--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -30,7 +30,7 @@ import (
 const (
 	dnsManagedZone           = "roachprod-managed"
 	dnsDomain                = "roachprod-managed.crdb.io"
-	dnsMaxResults            = 1000
+	dnsMaxResults            = 10000
 	dnsMaxConcurrentRequests = 4
 
 	// dnsProblemLabel is the label used when we see transient DNS


### PR DESCRIPTION
Backport 1/1 commits from #121047.

/cc @cockroachdb/release

---

The `gcloud` DNS commands filter after retrieving results, set by the limit, and not before, since the API call itself has no concept of a filter. This means the limit has to be higher to ensure the full list is retrieved, before the `gcloud` command filters. Currently, we are getting nearer to the 1000 limit, hence this change bumps it to 10000 to avoid possible future problems.

Epic: None
Release Note: None

Release justification: Test only change.