### PR TITLE
sql/schema_changer_test.go not checking err, fix for linting issue

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7839,11 +7839,14 @@ func TestLeaseTimeoutWithConcurrentTransactions(t *testing.T) {
 	sqlRunner.Exec(t, `CREATE TABLE RIDES (my_int INT);`)
 
 	txn1 := sqlRunner.Begin(t)
-	txn1.Exec(`SELECT * FROM PROMO_CODES;`)
+	_, err := txn1.Exec(`SELECT * FROM PROMO_CODES;`)
+	require.NoError(t, err)
 
 	txn2 := sqlRunner.Begin(t)
-	txn2.Exec(`GRANT ALL ON TABLE PROMO_CODES TO ROACHMIN;`)
-	txn2.Exec(`GRANT ALL ON TABLE RIDES TO ROACHMIN;`)
+	_, err = txn2.Exec(`GRANT ALL ON TABLE PROMO_CODES TO ROACHMIN;`)
+	require.NoError(t, err)
+	_, err = txn2.Exec(`GRANT ALL ON TABLE RIDES TO ROACHMIN;`)
+	require.NoError(t, err)
 
 	blocker := make(chan struct{})
 	group := ctxgroup.WithContext(ctx)
@@ -7855,7 +7858,7 @@ func TestLeaseTimeoutWithConcurrentTransactions(t *testing.T) {
 	})
 
 	<-blocker
-	_, err := txn1.Exec("INSERT INTO promo_codes values (1)")
+	_, err = txn1.Exec("INSERT INTO promo_codes values (1)")
 	require.NoError(t, err)
 
 	// txn1.commit() completes with an error due to lease timeout on txn2.commit().


### PR DESCRIPTION
Methods that returned an err were not checked in PR #123414 which is causing a failure with our lint test, this PR contains those err checks.

Informs: #123414

Release note: None