### PR TITLE
nogo: adjust include/exclude rules

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -1,35 +1,30 @@
 {
+    "_base": {
+	"description": "Base config that all subsequent analyzers, even unspecified will inherit.",
+	"exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/shirou/gopsutil": "third-party code"
+	}
+    },
     "assign": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
         }
     },
-    "composites": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
-    "copylocks": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
     "deepequalerrors": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        },
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "_test\\.go$": "tests"
         }
     },
     "deferunlockcheck": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/shirou/gopsutil": "third-party code",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
@@ -187,785 +182,580 @@
             "pkg/workload/schemachange/deck.go": "flagged by linter, should be evaluated",
             "pkg/workload/schemachange/schemachange.go": "flagged by linter, should be evaluated",
             "pkg/workload/tpcc/generate.go": "flagged by linter, should be evaluated"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "errcheck": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/elastic/gosigar": "third-party",
+            "github.com/shirou/gopsutil": "third-party",
+            "bazel-out/.*/testmain\\.go$": "generated test main file by rules_go",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
-            "cockroach/bazel-out/.*/testmain\\.go$": "generated test main file by rules_go",
-            "cockroach/pkg/raft/.*": "imported third-party package"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            "pkg/raft/.*": "imported third-party package"
         }
     },
     "errcmp": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/elastic/gosigar": "third-party",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
-            "cockroach/bazel-out/.*/testmain\\.go$": "generated test main file by rules_go",
-            "cockroach/pkg/cmd/github-pull-request-make/main.go": "invalid direct cast on error object",
-            "cockroach/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/kv/kvpb/batch_generated-gen\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/kv/kvpb/errors\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/raft/.*": "imported third-party package",
-            "cockroach/pkg/sql/pgwire/pgerror/constraint_name\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/sql/pgwire/pgerror/pgcode\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/testutils/lint/lint_test\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/util/timeutil/timeout_error\\.go$": "invalid direct cast on error object",
-            "cockroach/pkg/util/sysutil/sysutil_.*": "type can change by system",
-            "cockroach/pkg/cloud/gcp/gcs_retry\\.go$": "invalid direct cast on error object"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            "bazel-out/.*/testmain\\.go$": "generated test main file by rules_go",
+            "pkg/cmd/github-pull-request-make/main.go": "invalid direct cast on error object",
+            "pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error\\.go$": "invalid direct cast on error object",
+            "pkg/kv/kvpb/batch_generated-gen\\.go$": "invalid direct cast on error object",
+            "pkg/kv/kvpb/errors\\.go$": "invalid direct cast on error object",
+            "pkg/raft/.*": "imported third-party package",
+            "pkg/sql/pgwire/pgerror/constraint_name\\.go$": "invalid direct cast on error object",
+            "pkg/sql/pgwire/pgerror/pgcode\\.go$": "invalid direct cast on error object",
+            "pkg/testutils/lint/lint_test\\.go$": "invalid direct cast on error object",
+            "pkg/util/timeutil/timeout_error\\.go$": "invalid direct cast on error object",
+            "pkg/util/sysutil/sysutil_.*": "type can change by system",
+            "pkg/cloud/gcp/gcs_retry\\.go$": "invalid direct cast on error object"
         }
     },
     "errwrap": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             ".*\\.pb\\.go$": "generated code",
-            ".*\\.pb\\.gw\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            ".*\\.pb\\.gw\\.go$": "generated code",
+            "external/": "exclude all third-party code for all analyzers"
         }
     },
     "fmtsafe": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
-            "cockroach/pkg/raft/.*": "imported third-party package",
-            "cockroach/pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
-            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression",
+            "pkg/raft/.*": "imported third-party package",
+            "pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
+            "pkg/util/log/channels\\.go$": "format argument is not a constant expression",
             "pkg/util/log/log_channels_generated\\.go$": "format argument is not a constant expression"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "grpcconnclose": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
-    "hash": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
-    "loopvarcapture": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-           "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-       }
-    },
-    "lostcancel": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "nilness": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/shirou/gopsutil": "third-party code",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
             "/_cgo_gotypes.go$": "cgo generated code",
             "_test\\.go$": "tests"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "printf": {
         "analyzer_flags": {
             "funcs": "ErrEvent,ErrEventf,Error,Errorf,ErrorfDepth,Event,Eventf,Fatal,Fatalf,FatalfDepth,Info,Infof,InfofDepth,AssertionFailedf,AssertionFailedWithDepthf,NewAssertionErrorWithWrappedErrf,DangerousStatementf,pgerror.New,pgerror.NewWithDepthf,pgerror.Newf,SetDetailf,SetHintf,Unimplemented,Unimplementedf,UnimplementedWithDepthf,UnimplementedWithIssueDetailf,UnimplementedWithIssuef,VEvent,VEventf,Warning,Warningf,WarningfDepth,Wrapf,WrapWithDepthf,redact.Fprint,redact.Fprintf,redact.Sprint,redact.Sprintf"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "returncheck": {
         "exclude_files": {
-            "cockroach/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go": "existing failure",
-            "cockroach/pkg/kv/txn_external_test.go": "existing failure"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
-    "returnerrcheck": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            "external/": "exclude all third-party code for all analyzers",
+            "pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go": "existing failure",
+            "pkg/kv/txn_external_test.go": "existing failure"
         }
     },
     "S1000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1002": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1004": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1006": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1007": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1008": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1009": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1010": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1011": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
             "pkg/sql/sem/builtins/aggregate_builtins_test\\.go": "false positive, apparently"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1012": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1016": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1017": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1018": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1019": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
             "pkg/raft/.*": "imported third-party package"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1020": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1021": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1023": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1024": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1025": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1028": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1029": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1030": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1031": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1032": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1033": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1034": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1035": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1036": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1037": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1038": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1039": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "S1040": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1002": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1004": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1006": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1007": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1008": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1010": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1011": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1012": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1013": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1014": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1015": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1016": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1017": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1018": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1019": {
         "exclude_files": {
-            "cockroach/pkg/kv/kvpb/api_test.go$": "same package that grpc-go imports",
-            "cockroach/pkg/rpc/codec.go$": "rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).",
-            "cockroach/pkg/rpc/stats_handler.go$": "Using deprecated WireLength call",
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/shirou/gopsutil": "third-party code",
+            "pkg/kv/kvpb/api_test.go$": "same package that grpc-go imports",
+            "pkg/rpc/codec.go$": "rpc/codec.go imports the same proto package that grpc-go imports (as of crdb@dd87d1145 and grpc-go@7b167fd6).",
+            "pkg/rpc/stats_handler.go$": "Using deprecated WireLength call",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
@@ -989,1128 +779,842 @@
             "pkg/util/bulk/tracing_aggregator.go$":"temporary exclusion until #100438 is resolved",
             "pkg/util/log/file_api.go$": "excluded until all uses of io/ioutil are replaced",
             "pkg/build/bazel/bazel\\.go$": "Runfile function deprecated"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1020": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1021": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1023": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1024": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1025": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1026": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1027": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1028": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1029": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA1030": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2002": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA2003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA3000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA3001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
-            "cockroach/pkg/raft/.*": "imported third-party package"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            "pkg/raft/.*": "imported third-party package"
         }
     },
     "SA4000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4004": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4006": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/shirou/gopsutil": "third-party code",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4008": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4009": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4010": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4011": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4012": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4013": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4014": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4015": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4016": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4017": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4018": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4019": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4020": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4021": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4022": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4023": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4024": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4025": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4026": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4027": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4028": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4029": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4030": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA4031": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5002": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5004": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5007": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5008": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5009": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5010": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5011": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "_test\\.go$": "tests",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA5012": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6000": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6002": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA6005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9002": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9003": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9004": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9006": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9007": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "SA9008": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1000": {
         "exclude_files": {
-            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            ".*": "skipped in default staticcheck config",
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
             "pkg/raft/.*": "imported third-party package",
             "pkg/sql/roleoption": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1001": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code",
-            "cockroach/pkg/sql/schemachanger/scplan/internal/rules/.*/.*.go$":  "schema changer rules"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            "pkg/sql/schemachanger/scplan/internal/rules/.*/.*.go$":  "schema changer rules"
         }
     },
     "ST1003": {
         "exclude_files": {
-            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            ".*": "skipped in default staticcheck config",
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1005": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1006": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/elastic/gosigar": "third-party",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1008": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1011": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1011": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1012": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1013": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1015": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1016": {
         "exclude_files": {
-            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            ".*": "skipped in default staticcheck config",
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1017": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1018": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1019": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1020": {
         "exclude_files": {
-            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            ".*": "skipped in default staticcheck config",
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1021": {
         "exclude_files": {
-            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            ".*": "skipped in default staticcheck config",
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1022": {
         "exclude_files": {
-            "cockroach/pkg/.*$": "skipped in default staticcheck config",
+            ".*": "skipped in default staticcheck config",
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "ST1023": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "shadow": {
-       "exclude_files": {
+	"exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             "pkg/.*\\.og\\.go$": "generated code",
             "pkg/raft/.*": "imported third-party package"
-       },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
-    "stdmethods": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
-    },
-    "stringintconv": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        }
+	}
     },
     "structtag": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
@@ -2118,48 +1622,32 @@
         }
     },
     "testinggoroutine": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        },
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "_test\\.go$": "tests"
         }
     },
     "unconvert": {
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
+            "github.com/elastic/gosigar": "third-party",
+            "github.com/shirou/gopsutil": "third-party code",
             "pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "U1000": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
-        },
         "exclude_files": {
+            "external/": "exclude all third-party code for all analyzers",
             "pkg/util/goschedstats/runtime_go.*.go$": "patch code"
-        }
-    },
-    "unreachable": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
     "unsafeptr": {
         "exclude_files": {
-            "cockroach/pkg/sql/colexec/colexechash/hash\\.go$": "re-implements runtime.noescape for efficient hashing"
-        },
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code",
-            "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+            "external/": "exclude all third-party code for all analyzers",
+            "pkg/sql/colexec/colexechash/hash\\.go$": "re-implements runtime.noescape for efficient hashing"
         }
     }
 }


### PR DESCRIPTION
As of #79929, we have been using `only_files` using the pattern `cockroach/pkg` in order to only run lints against first-party code. While this has worked locally, this doesn't work in remote execution where the structure of the staging directory for the code differs. Instead of trying to allow-list first-party code, we instead deny-list third-party code using the name "external". This works for most third-party dependencies except for the cgo code, which need some special handling.

Separately, it is unfortunate that it's difficult to match exclusively against first-party code (see #124154). I will look into whether we can submit a change upstream to address this.

To avoid future packages accidentally skipping lints due to this change, I added a separate lint check to make sure no Go package names end in the string `external`.

Epic: CRDB-8308
Release note: None