### PR TITLE
dev: in `lint`, ignore cached test results

### DIFF
--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -59,7 +59,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 	args = append(args, additionalBazelArgs...)
-	args = append(args, "--test_arg", "-test.v")
+	args = append(args, "--nocache_test_results", "--test_arg", "-test.v")
 	if short {
 		args = append(args, "--test_arg", "-test.short")
 	}

--- a/pkg/cmd/dev/testdata/recorderdriven/lint
+++ b/pkg/cmd/dev/testdata/recorderdriven/lint
@@ -7,5 +7,5 @@ bazel run //pkg/gen:code
 bazel info workspace --color=no
 bazel run //pkg/cmd/generate-cgo:generate-cgo '--run_under=cd crdb-checkout && '
 which cc
-bazel test //pkg/testutils/lint:lint_test --test_arg -test.v --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_env=HOME=/home/user --sandbox_writable_path=/home/user --test_output streamed --test_env=GO_SDK=/path/to/go/sdk --test_env=CC=/usr/bin/cc --test_env=CXX=/usr/bin/cc
+bazel test //pkg/testutils/lint:lint_test --nocache_test_results --test_arg -test.v --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_env=HOME=/home/user --sandbox_writable_path=/home/user --test_output streamed --test_env=GO_SDK=/path/to/go/sdk --test_env=CC=/usr/bin/cc --test_env=CXX=/usr/bin/cc
 bazel build //pkg/cmd/cockroach-short //pkg/cmd/dev //pkg/obsservice/cmd/obsservice //pkg/cmd/roachprod //pkg/cmd/roachtest --//build/toolchains:nogo_flag

--- a/pkg/cmd/dev/testdata/recorderdriven/lint.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/lint.rec
@@ -16,7 +16,7 @@ which cc
 ----
 /usr/bin/cc
 
-bazel test //pkg/testutils/lint:lint_test --test_arg -test.v --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_env=HOME=/home/user --sandbox_writable_path=/home/user --test_output streamed --test_env=GO_SDK=/path/to/go/sdk --test_env=CC=/usr/bin/cc --test_env=CXX=/usr/bin/cc
+bazel test //pkg/testutils/lint:lint_test --nocache_test_results --test_arg -test.v --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_env=HOME=/home/user --sandbox_writable_path=/home/user --test_output streamed --test_env=GO_SDK=/path/to/go/sdk --test_env=CC=/usr/bin/cc --test_env=CXX=/usr/bin/cc
 ----
 
 bazel build //pkg/cmd/cockroach-short //pkg/cmd/dev //pkg/obsservice/cmd/obsservice //pkg/cmd/roachprod //pkg/cmd/roachtest --//build/toolchains:nogo_flag


### PR DESCRIPTION
Since lint checks look at the whole tree, but do not depend on the whole tree at the Bazel level, it can cache test results incorrectly when the tree content has actually changed. We ask `bazel` to never cache test results.

Closes #124152

Epic: CRDB-17171
Release note: None