### PR TITLE
release-23.1: sqlinstance: ensure that session expiration is up to date

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -492,8 +492,7 @@ func (r *refreshInstanceSessionListener) OnSessionDeleted(
 			}
 			if _, err := r.cfg.sqlInstanceStorage.CreateNodeInstance(
 				ctx,
-				s.ID(),
-				s.Expiration(),
+				s,
 				r.cfg.AdvertiseAddr,
 				r.cfg.SQLAdvertiseAddr,
 				r.cfg.Locality,
@@ -1504,8 +1503,7 @@ func (s *SQLServer) preStart(
 				// Write/acquire our instance row.
 				return s.sqlInstanceStorage.CreateNodeInstance(
 					ctx,
-					session.ID(),
-					session.Expiration(),
+					session,
 					s.cfg.AdvertiseAddr,
 					s.cfg.SQLAdvertiseAddr,
 					s.distSQLServer.Locality,
@@ -1515,8 +1513,7 @@ func (s *SQLServer) preStart(
 			}
 			return s.sqlInstanceStorage.CreateInstance(
 				ctx,
-				session.ID(),
-				session.Expiration(),
+				session,
 				s.cfg.AdvertiseAddr,
 				s.cfg.SQLAdvertiseAddr,
 				s.distSQLServer.Locality,

--- a/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slstorage",
+        "//pkg/sql/sqlliveness/sqllivenesstestutils",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
@@ -89,8 +89,7 @@ func TestRangeFeed(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		storage := newStorage(t, tenant.Codec())
-
-		require.NoError(t, storage.generateAvailableInstanceRows(ctx, [][]byte{enum.One}, tenant.Clock().Now().Add(int64(time.Minute), 0)))
+		require.NoError(t, storage.generateAvailableInstanceRows(ctx, [][]byte{enum.One}))
 
 		feed, err := storage.newInstanceCache(ctx, tenant.Stopper())
 		require.NoError(t, err)

--- a/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instancestorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/sqllivenesstestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -69,7 +70,7 @@ func TestReader(t *testing.T) {
 	})
 	t.Run("read-without-waiting", func(t *testing.T) {
 		storage, slStorage, clock, reader := setup(t)
-		sessionID := makeSession()
+		session := makeSession()
 		const rpcAddr = "rpcAddr"
 		const sqlAddr = "sqlAddr"
 		binaryVersion := roachpb.Version{Major: 23, Minor: 2}
@@ -77,10 +78,11 @@ func TestReader(t *testing.T) {
 		// Set a high enough expiration to ensure the session stays
 		// live through the test.
 		const expiration = 10 * time.Minute
-		sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
-		instance, err := storage.CreateInstance(ctx, sessionID, sessionExpiry, rpcAddr, sqlAddr, locality, binaryVersion)
+		session.StartTS = clock.Now()
+		session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
+		instance, err := storage.CreateInstance(ctx, session, rpcAddr, sqlAddr, locality, binaryVersion)
 		require.NoError(t, err)
-		err = slStorage.Insert(ctx, sessionID, sessionExpiry)
+		err = slStorage.Insert(ctx, session.ID(), session.Expiration())
 		require.NoError(t, err)
 		reader.Start(ctx, instance)
 
@@ -96,7 +98,7 @@ func TestReader(t *testing.T) {
 		storage, slStorage, clock, reader := setup(t)
 		reader.Start(ctx, sqlinstance.InstanceInfo{})
 		require.NoError(t, reader.WaitForStarted(ctx))
-		sessionID := makeSession()
+		session := makeSession()
 		const rpcAddr = "rpcAddr"
 		const sqlAddr = "sqlAddr"
 		binaryVersion := roachpb.Version{Major: 25, Minor: 3}
@@ -105,12 +107,13 @@ func TestReader(t *testing.T) {
 		// live through the test.
 		const expiration = 10 * time.Minute
 		{
-			sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
-			instance, err := storage.CreateInstance(ctx, sessionID, sessionExpiry, rpcAddr, sqlAddr, locality, binaryVersion)
+			session.StartTS = clock.Now()
+			session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
+			instance, err := storage.CreateInstance(ctx, session, rpcAddr, sqlAddr, locality, binaryVersion)
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = slStorage.Insert(ctx, sessionID, sessionExpiry)
+			err = slStorage.Insert(ctx, session.ID(), session.Expiration())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -147,7 +150,7 @@ func TestReader(t *testing.T) {
 		instanceIDs := []base.SQLInstanceID{1, 2, 3}
 		rpcAddresses := []string{"addr1", "addr2", "addr3"}
 		sqlAddresses := []string{"addr4", "addr5", "addr6"}
-		sessionIDs := []sqlliveness.SessionID{makeSession(), makeSession(), makeSession()}
+		sessions := []*sqllivenesstestutils.FakeSession{makeSession(), makeSession(), makeSession()}
 		localities := []roachpb.Locality{
 			{Tiers: []roachpb.Tier{{Key: "region", Value: "region1"}}},
 			{Tiers: []roachpb.Tier{{Key: "region", Value: "region2"}}},
@@ -226,11 +229,15 @@ func TestReader(t *testing.T) {
 		}
 
 		expectationsFromOffset := func(offset int) expectations {
+			sessionIDs := make([]sqlliveness.SessionID, 0, len(sessions[offset:]))
+			for _, session := range sessions[offset:] {
+				sessionIDs = append(sessionIDs, session.ID())
+			}
 			return expectations{
 				instanceIDs:    instanceIDs[offset:],
 				rpcAddresses:   rpcAddresses[offset:],
 				sqlAddresses:   sqlAddresses[offset:],
-				sessionIDs:     sessionIDs[offset:],
+				sessionIDs:     sessionIDs,
 				localities:     localities[offset:],
 				binaryVersions: binaryVersions[offset:],
 			}
@@ -239,12 +246,13 @@ func TestReader(t *testing.T) {
 		{
 			// Set up mock data within instance and session storage.
 			for index, rpcAddr := range rpcAddresses {
-				sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
-				_, err := storage.CreateInstance(ctx, sessionIDs[index], sessionExpiry, rpcAddr, sqlAddresses[index], localities[index], binaryVersions[index])
+				sessions[index].StartTS = clock.Now()
+				sessions[index].ExpTS = sessions[index].StartTS.Add(expiration.Nanoseconds(), 0)
+				_, err := storage.CreateInstance(ctx, sessions[index], rpcAddr, sqlAddresses[index], localities[index], binaryVersions[index])
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = slStorage.Insert(ctx, sessionIDs[index], sessionExpiry)
+				err = slStorage.Insert(ctx, sessions[index].SessionID, sessions[index].Expiration())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -257,7 +265,7 @@ func TestReader(t *testing.T) {
 
 		// Release an instance and verify only active instances are returned.
 		{
-			err := storage.ReleaseInstance(ctx, sessionIDs[0], instanceIDs[0])
+			err := storage.ReleaseInstance(ctx, sessions[0].ID(), instanceIDs[0])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -268,7 +276,7 @@ func TestReader(t *testing.T) {
 
 		// Verify instances with expired sessions are filtered out.
 		{
-			err := slStorage.Delete(ctx, sessionIDs[1])
+			err := slStorage.Delete(ctx, sessions[1].ID())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -281,14 +289,15 @@ func TestReader(t *testing.T) {
 		// the latest instance information is returned. This heuristic is used
 		// when instance information isn't released correctly prior to SQL instance shutdown.
 		{
-			sessionID := makeSession()
+			session := makeSession()
 			locality := roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "region4"}}}
-			sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
-			instance, err := storage.CreateInstance(ctx, sessionID, sessionExpiry, rpcAddresses[2], sqlAddresses[2], locality, binaryVersions[2])
+			session.StartTS = clock.Now()
+			session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
+			instance, err := storage.CreateInstance(ctx, session, rpcAddresses[2], sqlAddresses[2], locality, binaryVersions[2])
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = slStorage.Insert(ctx, sessionID, sessionExpiry)
+			err = slStorage.Insert(ctx, session.ID(), session.Expiration())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -297,7 +306,7 @@ func TestReader(t *testing.T) {
 					[]base.SQLInstanceID{instance.InstanceID}, /* instanceIDs */
 					[]string{rpcAddresses[2]},                 /* rpcAddresses */
 					[]string{sqlAddresses[2]},                 /* sqlAddresses */
-					[]sqlliveness.SessionID{sessionID},        /* sessionIDs */
+					[]sqlliveness.SessionID{session.ID()},     /* sessions */
 					[]roachpb.Locality{locality},              /* localities */
 					[]roachpb.Version{binaryVersions[2]},      /* binaryVersions */
 				})
@@ -315,7 +324,7 @@ func TestReader(t *testing.T) {
 		instanceIDs := [...]base.SQLInstanceID{1, 2, 3}
 		rpcAddresses := [...]string{"addr1", "addr2", "addr3"}
 		sqlAddresses := [...]string{"addr4", "addr5", "addr6"}
-		sessionIDs := [...]sqlliveness.SessionID{makeSession(), makeSession(), makeSession()}
+		sessions := [...]*sqllivenesstestutils.FakeSession{makeSession(), makeSession(), makeSession()}
 		localities := [...]roachpb.Locality{
 			{Tiers: []roachpb.Tier{{Key: "region", Value: "region1"}}},
 			{Tiers: []roachpb.Tier{{Key: "region", Value: "region2"}}},
@@ -327,12 +336,13 @@ func TestReader(t *testing.T) {
 		{
 			// Set up mock data within instance and session storage.
 			for index, rpcAddr := range rpcAddresses {
-				sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
-				_, err := storage.CreateInstance(ctx, sessionIDs[index], sessionExpiry, rpcAddr, sqlAddresses[index], localities[index], binaryVersions[index])
+				sessions[index].StartTS = clock.Now()
+				sessions[index].ExpTS = sessions[index].StartTS.Add(expiration.Nanoseconds(), 0)
+				_, err := storage.CreateInstance(ctx, sessions[index], rpcAddr, sqlAddresses[index], localities[index], binaryVersions[index])
 				if err != nil {
 					t.Fatal(err)
 				}
-				err = slStorage.Insert(ctx, sessionIDs[index], sessionExpiry)
+				err = slStorage.Insert(ctx, sessions[index].ID(), sessions[index].Expiration())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -364,7 +374,7 @@ func TestReader(t *testing.T) {
 
 		// Verify request for released instance data results in an error.
 		{
-			err := storage.ReleaseInstance(ctx, sessionIDs[0], instanceIDs[0])
+			err := storage.ReleaseInstance(ctx, sessions[0].ID(), instanceIDs[0])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -378,7 +388,7 @@ func TestReader(t *testing.T) {
 		}
 		// Verify request for instance with expired session results in an error.
 		{
-			err := slStorage.Delete(ctx, sessionIDs[1])
+			err := slStorage.Delete(ctx, sessions[1].ID())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -161,15 +161,14 @@ func NewStorage(
 // associates it with its SQL address and session information.
 func (s *Storage) CreateNodeInstance(
 	ctx context.Context,
-	sessionID sqlliveness.SessionID,
-	sessionExpiration hlc.Timestamp,
+	session sqlliveness.Session,
 	rpcAddr string,
 	sqlAddr string,
 	locality roachpb.Locality,
 	binaryVersion roachpb.Version,
 	nodeID roachpb.NodeID,
 ) (instance sqlinstance.InstanceInfo, _ error) {
-	return s.createInstanceRow(ctx, sessionID, sessionExpiration, rpcAddr, sqlAddr, locality, binaryVersion, nodeID)
+	return s.createInstanceRow(ctx, session, rpcAddr, sqlAddr, locality, binaryVersion, nodeID)
 }
 
 const noNodeID = 0
@@ -178,14 +177,13 @@ const noNodeID = 0
 // associates it with its SQL address and session information.
 func (s *Storage) CreateInstance(
 	ctx context.Context,
-	sessionID sqlliveness.SessionID,
-	sessionExpiration hlc.Timestamp,
+	session sqlliveness.Session,
 	rpcAddr string,
 	sqlAddr string,
 	locality roachpb.Locality,
 	binaryVersion roachpb.Version,
 ) (instance sqlinstance.InstanceInfo, _ error) {
-	return s.createInstanceRow(ctx, sessionID, sessionExpiration, rpcAddr, sqlAddr, locality, binaryVersion, noNodeID)
+	return s.createInstanceRow(ctx, session, rpcAddr, sqlAddr, locality, binaryVersion, noNodeID)
 }
 
 // ReleaseInstance deallocates the instance id iff it is currently owned by the
@@ -246,8 +244,7 @@ func (s *Storage) ReleaseInstance(
 
 func (s *Storage) createInstanceRow(
 	ctx context.Context,
-	sessionID sqlliveness.SessionID,
-	sessionExpiration hlc.Timestamp,
+	session sqlliveness.Session,
 	rpcAddr string,
 	sqlAddr string,
 	locality roachpb.Locality,
@@ -257,11 +254,11 @@ func (s *Storage) createInstanceRow(
 	if len(sqlAddr) == 0 || len(rpcAddr) == 0 {
 		return sqlinstance.InstanceInfo{}, errors.AssertionFailedf("missing sql or rpc address information for instance")
 	}
-	if len(sessionID) == 0 {
+	if len(session.ID()) == 0 {
 		return sqlinstance.InstanceInfo{}, errors.AssertionFailedf("no session information for instance")
 	}
 
-	region, _, err := slstorage.UnsafeDecodeSessionID(sessionID)
+	region, _, err := slstorage.UnsafeDecodeSessionID(session.ID())
 	if err != nil {
 		return sqlinstance.InstanceInfo{}, errors.Wrap(err, "unable to determine region for sql_instance")
 	}
@@ -286,7 +283,7 @@ func (s *Storage) createInstanceRow(
 
 			// Set the transaction deadline to the session expiration to ensure
 			// transaction commits before the session expires.
-			err = txn.UpdateDeadline(ctx, sessionExpiration)
+			err = txn.UpdateDeadline(ctx, session.Expiration())
 			if err != nil {
 				return err
 			}
@@ -311,14 +308,14 @@ func (s *Storage) createInstanceRow(
 			b := txn.NewBatch()
 
 			rowCodec := s.getReadCodec(&version)
-			value, err := rowCodec.encodeValue(rpcAddr, sqlAddr, sessionID, locality, binaryVersion)
+			value, err := rowCodec.encodeValue(rpcAddr, sqlAddr, session.ID(), locality, binaryVersion)
 			if err != nil {
 				return err
 			}
 			b.Put(rowCodec.encodeKey(region, availableID), value)
 
 			if dualCodec := s.getDualWriteCodec(&version); dualCodec != nil {
-				dualValue, err := dualCodec.encodeValue(rpcAddr, sqlAddr, sessionID, locality, binaryVersion)
+				dualValue, err := dualCodec.encodeValue(rpcAddr, sqlAddr, session.ID(), locality, binaryVersion)
 				if err != nil {
 					return err
 				}
@@ -348,7 +345,7 @@ func (s *Storage) createInstanceRow(
 				InstanceID:      instanceID,
 				InstanceRPCAddr: rpcAddr,
 				InstanceSQLAddr: sqlAddr,
-				SessionID:       sessionID,
+				SessionID:       session.ID(),
 				Locality:        locality,
 				BinaryVersion:   binaryVersion,
 			}, err
@@ -368,7 +365,7 @@ func (s *Storage) createInstanceRow(
 		// every region, then writing to the local region. Allocating globally
 		// would require one round trip for reading and one round trip for
 		// writes.
-		if err := s.generateAvailableInstanceRows(ctx, [][]byte{region}, sessionExpiration); err != nil {
+		if err := s.generateAvailableInstanceRows(ctx, [][]byte{region}); err != nil {
 			log.Warningf(ctx, "failed to generate available instance rows: %v", err)
 		}
 	}
@@ -638,7 +635,7 @@ func (s *Storage) RunInstanceIDReclaimLoop(
 				}
 
 				// Allocate new ids regions that do not have enough pre-allocated sql instances.
-				if err := s.generateAvailableInstanceRows(ctx, regions, sessionExpirationFn()); err != nil {
+				if err := s.generateAvailableInstanceRows(ctx, regions); err != nil {
 					log.Warningf(ctx, "failed to generate available instance rows: %v", err)
 				}
 			}
@@ -675,9 +672,7 @@ func (s *Storage) versionGuard(
 // generateAvailableInstanceRows allocates available instance IDs, and store
 // them in the sql_instances table. When instance IDs are pre-allocated, all
 // other fields in that row will be NULL.
-func (s *Storage) generateAvailableInstanceRows(
-	ctx context.Context, regions [][]byte, sessionExpiration hlc.Timestamp,
-) error {
+func (s *Storage) generateAvailableInstanceRows(ctx context.Context, regions [][]byte) error {
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
 	target := int(PreallocatedCount.Get(&s.settings.SV))
 	return s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instancestorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/sqllivenesstestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -47,12 +48,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeSession() sqlliveness.SessionID {
-	session, err := slstorage.MakeSessionID(enum.One, uuid.MakeV4())
+func makeSession() *sqllivenesstestutils.FakeSession {
+	sessionID, err := slstorage.MakeSessionID(enum.One, uuid.MakeV4())
 	if err != nil {
 		panic(err)
 	}
-	return session
+	return &sqllivenesstestutils.FakeSession{SessionID: sessionID}
 }
 
 // TestStorage verifies that instancestorage stores and retrieves SQL instance data correctly.
@@ -89,14 +90,16 @@ func TestStorage(t *testing.T) {
 		stopper, storage, _, clock := setup(t)
 		defer stopper.Stop(ctx)
 		const id = base.SQLInstanceID(1)
-		sessionID := makeSession()
+		session := makeSession()
 		const rpcAddr = "rpcAddr"
 		const sqlAddr = "sqlAddr"
 		locality := roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "test"}, {Key: "az", Value: "a"}}}
 		binaryVersion := roachpb.Version{Major: 28, Minor: 4}
 		const expiration = time.Minute
 		{
-			instance, err := storage.CreateInstance(ctx, sessionID, clock.Now().Add(expiration.Nanoseconds(), 0), rpcAddr, sqlAddr, locality, binaryVersion)
+			session.StartTS = clock.Now()
+			session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
+			instance, err := storage.CreateInstance(ctx, session, rpcAddr, sqlAddr, locality, binaryVersion)
 			require.NoError(t, err)
 			require.Equal(t, id, instance.InstanceID)
 		}
@@ -107,6 +110,7 @@ func TestStorage(t *testing.T) {
 		stopper, storage, slStorage, clock := setup(t)
 		defer stopper.Stop(ctx)
 
+		sessionStart := clock.Now()
 		sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
 
 		makeInstance := func(id int) sqlinstance.InstanceInfo {
@@ -115,7 +119,7 @@ func TestStorage(t *testing.T) {
 				InstanceID:      base.SQLInstanceID(id),
 				InstanceSQLAddr: fmt.Sprintf("sql-addr-%d", id),
 				InstanceRPCAddr: fmt.Sprintf("rpc-addr-%d", id),
-				SessionID:       makeSession(),
+				SessionID:       makeSession().ID(),
 				Locality:        roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: fmt.Sprintf("region-%d", id)}}},
 				BinaryVersion:   roachpb.Version{Major: 22, Minor: int32(id)},
 			}
@@ -130,7 +134,10 @@ func TestStorage(t *testing.T) {
 				require.NoError(t, slStorage.Insert(ctx, instance.SessionID, sessionExpiry))
 			}
 
-			created, err := storage.CreateInstance(ctx, instance.SessionID, sessionExpiry, instance.InstanceRPCAddr, instance.InstanceSQLAddr, instance.Locality, instance.BinaryVersion)
+			session := &sqllivenesstestutils.FakeSession{SessionID: instance.SessionID,
+				StartTS: sessionStart,
+				ExpTS:   sessionExpiry}
+			created, err := storage.CreateInstance(ctx, session, instance.InstanceRPCAddr, instance.InstanceSQLAddr, instance.Locality, instance.BinaryVersion)
 			require.NoError(t, err)
 
 			require.Equal(t, instance, created)
@@ -267,10 +274,12 @@ func TestSQLAccess(t *testing.T) {
 	var locality roachpb.Locality
 	var binaryVersion roachpb.Version
 	require.NoError(t, locality.Set(tierStr))
+	session := makeSession()
+	session.StartTS = clock.Now()
+	session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
 	instance, err := storage.CreateInstance(
 		ctx,
-		makeSession(),
-		clock.Now().Add(expiration.Nanoseconds(), 0),
+		session,
 		"rpcAddr",
 		"sqlAddr",
 		locality,
@@ -393,11 +402,12 @@ func TestConcurrentCreateAndRelease(t *testing.T) {
 		sqlAddr         = "sqlAddr"
 		expiration      = time.Minute
 	)
-	sessionID := makeSession()
+	session := makeSession()
+	session.StartTS = clock.Now()
+	session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
 	locality := roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "test-region"}}}
 	binaryVersion := roachpb.Version{Major: 23, Minor: 4}
-	sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
-	err := slStorage.Insert(ctx, sessionID, sessionExpiry)
+	err := slStorage.Insert(ctx, session.ID(), session.Expiration())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,12 +426,12 @@ func TestConcurrentCreateAndRelease(t *testing.T) {
 			t.Helper()
 			state.Lock()
 			defer state.Unlock()
-			sessionExpiry = clock.Now().Add(expiration.Nanoseconds(), 0)
-			_, err = slStorage.Update(ctx, sessionID, sessionExpiry)
+			session.ExpTS = clock.Now().Add(expiration.Nanoseconds(), 0)
+			_, err = slStorage.Update(ctx, session.ID(), session.Expiration())
 			if err != nil {
 				t.Fatal(err)
 			}
-			instance, err := storage.CreateInstance(ctx, sessionID, sessionExpiry, rpcAddr, sqlAddr, locality, binaryVersion)
+			instance, err := storage.CreateInstance(ctx, session, rpcAddr, sqlAddr, locality, binaryVersion)
 			require.NoError(t, err)
 			if len(state.freeInstances) > 0 {
 				_, free := state.freeInstances[instance.InstanceID]
@@ -445,7 +455,7 @@ func TestConcurrentCreateAndRelease(t *testing.T) {
 			if i == -1 {
 				return
 			}
-			require.NoError(t, storage.ReleaseInstance(ctx, sessionID, i))
+			require.NoError(t, storage.ReleaseInstance(ctx, session.ID(), i))
 			state.freeInstances[i] = struct{}{}
 			delete(state.liveInstances, i)
 		}
@@ -484,7 +494,7 @@ func TestConcurrentCreateAndRelease(t *testing.T) {
 			} else {
 				require.Equal(t, rpcAddr, instanceInfo.InstanceRPCAddr)
 				require.Equal(t, sqlAddr, instanceInfo.InstanceSQLAddr)
-				require.Equal(t, sessionID, instanceInfo.SessionID)
+				require.Equal(t, session.ID(), instanceInfo.SessionID)
 				require.Equal(t, locality, instanceInfo.Locality)
 				require.Equal(t, binaryVersion, instanceInfo.BinaryVersion)
 				_, live := state.liveInstances[i]
@@ -547,12 +557,12 @@ func TestReclaimLoop(t *testing.T) {
 
 	// Expiration < ReclaimLoopInterval.
 	const expiration = 5 * time.Hour
-	sessionExpiry := clock.Now().Add(expiration.Nanoseconds(), 0)
+	session := makeSession()
+	session.StartTS = clock.Now()
+	session.ExpTS = session.StartTS.Add(expiration.Nanoseconds(), 0)
 
 	db := s.InternalDB().(descs.DB)
-	err := storage.RunInstanceIDReclaimLoop(ctx, s.Stopper(), ts, db, func() hlc.Timestamp {
-		return sessionExpiry
-	})
+	err := storage.RunInstanceIDReclaimLoop(ctx, s.Stopper(), ts, db, session.Expiration)
 	require.NoError(t, err)
 
 	reclaimGroupInterval := instancestorage.ReclaimLoopInterval.Get(&s.ClusterSettings().SV)
@@ -599,7 +609,11 @@ func TestReclaimLoop(t *testing.T) {
 	instanceIDs := [...]base.SQLInstanceID{1, 2}
 	rpcAddresses := [...]string{"addr1", "addr2"}
 	sqlAddresses := [...]string{"addr3", "addr4"}
-	sessionIDs := [...]sqlliveness.SessionID{makeSession(), makeSession()}
+	sessionIDs := [...]*sqllivenesstestutils.FakeSession{makeSession(), makeSession()}
+	for _, id := range sessionIDs {
+		id.StartTS = session.StartTS
+		id.ExpTS = session.ExpTS
+	}
 	localities := [...]roachpb.Locality{
 		{Tiers: []roachpb.Tier{{Key: "region", Value: "region1"}}},
 		{Tiers: []roachpb.Tier{{Key: "region", Value: "region2"}}},
@@ -609,15 +623,15 @@ func TestReclaimLoop(t *testing.T) {
 	}
 
 	for i, id := range instanceIDs {
-		require.NoError(t, slStorage.Insert(ctx, sessionIDs[i], sessionExpiry))
+		require.NoError(t, slStorage.Insert(ctx, sessionIDs[i].ID(), session.Expiration()))
 		require.NoError(t, storage.CreateInstanceDataForTest(
 			ctx,
 			region,
 			id,
 			rpcAddresses[i],
 			sqlAddresses[i],
-			sessionIDs[i],
-			sessionExpiry,
+			sessionIDs[i].ID(),
+			session.Expiration(),
 			localities[i],
 			binaryVersions[i],
 		))
@@ -652,7 +666,7 @@ func TestReclaimLoop(t *testing.T) {
 		case 0, 1:
 			require.Equal(t, rpcAddresses[i], instance.InstanceRPCAddr)
 			require.Equal(t, sqlAddresses[i], instance.InstanceSQLAddr)
-			require.Equal(t, sessionIDs[i], instance.SessionID)
+			require.Equal(t, sessionIDs[i].ID(), instance.SessionID)
 			require.Equal(t, localities[i], instance.Locality)
 			require.Equal(t, binaryVersions[i], instance.BinaryVersion)
 		default:


### PR DESCRIPTION
Backport 1/1 commits from #120006.

/cc @cockroachdb/release

---

Previously, during some tests, sessions could expire while retrying transactions within the sqlinstance code for row generation. This resulted in intermittent failures in TestColdStartLatency, preventing transactions from writing due to stale deadlines. To address this, this patch now passes full sqlliveness.Session objects to ensure up-to-date expiry times.

Fixes: #120981
Fixes https://github.com/cockroachdb/cockroach/issues/123683

Release note: None
Release justification: low risk fix to address issues a scenario where node start up can fail with transient availability issues