### PR TITLE
roachtest: skip multi-store-remove while debugging

### DIFF
--- a/pkg/cmd/roachtest/tests/multi_store_remove.go
+++ b/pkg/cmd/roachtest/tests/multi_store_remove.go
@@ -33,6 +33,7 @@ const (
 func registerMultiStoreRemove(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "multi-store-remove",
+		Skip:              "#123989",
 		Owner:             registry.OwnerStorage,
 		Cluster:           r.MakeClusterSpec(multiStoreNodes, spec.SSD(multiStoreStoresPerNode)),
 		CompatibleClouds:  registry.OnlyGCE,


### PR DESCRIPTION
This roachtest has failed consistently for the past few days, since being enabled in #123694. Skip while we debug, to avoid noise.

Touches: #123989.

Release note: None.

Epic: None.