### PR TITLE
backupccl: test that we actually downloaded all data during online restore

### DIFF
--- a/pkg/testutils/jobutils/BUILD.bazel
+++ b/pkg/testutils/jobutils/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "jobutils",
-    srcs = ["jobs_verification.go"],
+    srcs = [
+        "backup_restore.go",
+        "jobs_verification.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/jobutils",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/testutils/jobutils/backup_restore.go
+++ b/pkg/testutils/jobutils/backup_restore.go
@@ -1,0 +1,23 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobutils
+
+// getExternalBytesForConnectedTenant returns the count of external bytes of the
+// tenant that ran the query.
+const GetExternalBytesForConnectedTenant = `SELECT
+COALESCE(stats->>'external_file_bytes','0') FROM
+crdb_internal.tenant_span_stats( ARRAY(SELECT(crdb_internal.tenant_span()[1], crdb_internal.tenant_span()[2])))`
+
+// getExternalBytesUserKeySpace returns the count of external bytes over all
+// user key space [TenantTableDataMin, TenantTableDataMax). This can only get
+// run from the system tenant.
+const GetExternalBytesTenantKeySpace = `SELECT COALESCE(stats->>'external_file_bytes','0') FROM crdb_internal.tenant_span_stats(
+		ARRAY(SELECT('\x89'::BYTES,'\xffff'::BYTES)))`


### PR DESCRIPTION

Release note: none

Epic: none