### PR TITLE
backupccl: deflake TestDataDriven_external_connections_privileges

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-privileges
@@ -53,26 +53,12 @@ BACKUP TABLE foo INTO 'external://root'
 ----
 pq: user testuser does not have USAGE privilege on external_connection root
 
-query-sql
-SELECT * FROM system.privileges
-----
-root /externalconn/root {ALL} {} 1
-testuser /externalconn/testuser-ec {ALL} {} 100
-testuser /global/ {EXTERNALCONNECTION} {} 100
-
 # Revoke the USAGE privilege. Note testuser had ALL privileges since they
 # created the External Connection, but revoking USAGE means that they will now
 # only have DROP privileges. Thus, they shouldn't be able to restore.
 exec-sql
 REVOKE USAGE ON EXTERNAL CONNECTION "testuser-ec" FROM testuser;
 ----
-
-query-sql
-SELECT * FROM system.privileges
-----
-root /externalconn/root {ALL} {} 1
-testuser /externalconn/testuser-ec {DROP} {} 100
-testuser /global/ {EXTERNALCONNECTION} {} 100
 
 exec-sql user=testuser
 RESTORE TABLE foo FROM LATEST IN 'external://testuser-ec'


### PR DESCRIPTION
This test already tests the permissions end-to-end by asserting that the user can or cannot complete the expected actions. No need to print the system database as well.

Fixes #123379
Release note: None