### PR TITLE
log: fix race in TestLogEntryPropagation

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -749,8 +749,8 @@ func TestLogEntryPropagation(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = f.Close() }()
-	defer func(prevStderr *os.File) { OrigStderr = prevStderr }(OrigStderr)
-	OrigStderr = f
+	require.NoError(t, hijackStderr(f))
+	defer func() { require.NoError(t, hijackStderr(OrigStderr)) }()
 
 	const specialMessage = `CAPTAIN KIRK`
 


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/122791

TestLogEntryPropagation was unsafely reassigning `OrigStderr` in the log
package which was tripping the race detector.

This patch makes use of the existing `redirectStderr` function which
allows us to safely reassign stderr.

Release note: none