### PR TITLE
sql: warn users away from updated at indexes

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -422,6 +422,25 @@ func (n *createTableNode) startExec(params runParams) error {
 		}
 	}
 
+	// Issue a warning to users who attempt to build indexes
+	// with a timestamp field as the first column of the index.
+	for _, def := range n.n.Defs {
+		if d, ok := def.(*tree.IndexTableDef); ok {
+			if len(d.Columns) == 0 {
+				continue
+			}
+			if columnHasDefaultTimestampExpression(desc, d.Columns[0].Column) {
+				params.p.BufferClientNotice(params.ctx,
+					errors.WithHintf(
+						pgnotice.Newf("it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots."),
+						"consider using hash-sharded index. See %s", docs.URL("hash-sharded-indexes.html"),
+					),
+				)
+				break
+			}
+		}
+	}
+
 	// Replace all UDF names with OIDs in check constraints and update back
 	// references in functions used.
 	for _, ck := range desc.CheckConstraints() {
@@ -2914,4 +2933,18 @@ func isImplicitlyCreatedBySystem(td *tabledesc.Mutable, c *descpb.ColumnDescript
 		return true, nil
 	}
 	return false, nil
+}
+
+func columnHasDefaultTimestampExpression(desc catalog.TableDescriptor, columnName tree.Name) bool {
+	column := catalog.FindColumnByTreeName(desc, columnName)
+	expr := column.GetDefaultExpr()
+	exprLen := len(expr)
+	return exprLen >= 19 && expr[:19] == "current_timestamp()" ||
+		exprLen >= 17 && expr[:17] == "clock_timestamp()" ||
+		exprLen >= 14 && expr[:14] == "current_date()" ||
+		exprLen >= 14 && expr[:14] == "current_time()" ||
+		exprLen >= 16 && expr[:16] == "localtimestamp()" ||
+		exprLen >= 5 && expr[:5] == "now()" ||
+		exprLen >= 21 && expr[:21] == "statement_timestamp()" ||
+		exprLen >= 23 && expr[:23] == "transaction_timestamp()"
 }

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -448,3 +448,89 @@ CREATE INDEX ON v (b);
 # schema changer.
 statement ok
 CREATE INDEX ON v ((b>0));
+
+statement ok
+CREATE TABLE test_updated_at (
+  temp1 TEXT,
+  temp2 TEXT,
+  updated_at_1 TIMESTAMPTZ DEFAULT current_timestamp(),
+  updated_at_2 TIMESTAMP DEFAULT clock_timestamp(),
+  updated_at_3 DATE DEFAULT current_date(),
+  updated_at_4 TIME DEFAULT current_time(),
+  updated_at_5 INT DEFAULT localtimestamp()::int,
+  updated_at_6 INTEGER DEFAULT now()::int,
+  updated_at_7 BIGINT DEFAULT statement_timestamp()::bigint,
+  updated_at_8 SMALLINT DEFAULT transaction_timestamp()::smallint
+);
+
+statement ok
+CREATE INDEX test_updated_at_index_1 ON test_updated_at(temp1, updated_at_1);
+
+statement ok
+CREATE INDEX test_updated_at_index_2 ON test_updated_at(temp1, updated_at_1, temp2);
+
+statement ok
+CREATE INDEX test_updated_at_index_3 ON test_updated_at(temp1, updated_at_4, updated_at_7);
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_4 ON test_updated_at(updated_at_1);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_5 ON test_updated_at(updated_at_2, temp1);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_6 ON test_updated_at(updated_at_2, temp1, temp2);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_7 ON test_updated_at(updated_at_3);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_8 ON test_updated_at(updated_at_4);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_9 ON test_updated_at(updated_at_5);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_10 ON test_updated_at(updated_at_6);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_11 ON test_updated_at(updated_at_7);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_12 ON test_updated_at(updated_at_8);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+query T noticetrace
+CREATE INDEX test_updated_at_index_13 ON test_updated_at(updated_at_1, updated_at_2);
+----
+NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.
+HINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+
+statement ok
+DROP TABLE test_updated_at;

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1068,3 +1068,39 @@ CREATE TABLE public.t_115352 (
 )
 
 subtest end
+
+statement ok
+CREATE TABLE test_updated_at1 (id UUID PRIMARY KEY, temp1 TEXT, updated_at TIMESTAMP DEFAULT current_timestamp(), INDEX temp1_updated_at_index (temp1, updated_at));
+
+statement ok
+CREATE TABLE test_updated_at2 (id UUID PRIMARY KEY, temp1 TEXT, temp2 TEXT, updated_at TIMESTAMPTZ DEFAULT now(), INDEX temp1_updated_at_temp2_index (temp1, updated_at, temp2));
+
+statement ok
+CREATE TABLE test_updated_at3 (id UUID PRIMARY KEY, updated_at TIMESTAMPTZ, INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at4 (id UUID PRIMARY KEY, updated_at TIMESTAMPTZ DEFAULT current_timestamp(), INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at5 (id UUID PRIMARY KEY, updated_at TIMESTAMP DEFAULT clock_timestamp(), INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at6 (id UUID PRIMARY KEY, updated_at DATE DEFAULT current_date(), INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at7 (id UUID PRIMARY KEY, updated_at TIME DEFAULT current_time(), INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at8 (id UUID PRIMARY KEY, updated_at INT DEFAULT localtimestamp()::int, INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at9 (id UUID PRIMARY KEY, updated_at INTEGER DEFAULT now()::int, INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at10 (id UUID PRIMARY KEY, updated_at BIGINT DEFAULT statement_timestamp()::bigint, INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at11 (id UUID PRIMARY KEY, updated_at SMALLINT DEFAULT transaction_timestamp()::smallint, INDEX updated_at_index (updated_at));
+
+statement notice NOTICE: it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots.\nHINT: consider using hash-sharded index. See https://www.cockroachlabs.com/docs/(v\d+\.\d+)|(dev)/hash-sharded-indexes.html
+CREATE TABLE test_updated_at12 (id UUID PRIMARY KEY, temp1 TEXT, updated_at TIMESTAMPTZ DEFAULT current_timestamp(), INDEX updated_at_index (updated_at, temp1));

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -247,6 +247,17 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			pgnotice.Newf("CONCURRENTLY is not required as all indexes are created concurrently"),
 		)
 	}
+
+	// Issue a warning to users who attempt to build indexes
+	// with a timestamp field as the first column of the index.
+	if len(idxSpec.columns) > 0 && columnHasDefaultTimestampExpression(b, idxSpec.secondary.TableID, idxSpec.columns[0].ColumnID) {
+		b.EvalCtx().ClientNoticeSender.BufferClientNotice(b,
+			errors.WithHintf(
+				pgnotice.Newf("it is not recommended to use a column with a default timestamp value as the first index column, as it may cause hotspots."),
+				"consider using hash-sharded index. See %s", docs.URL("hash-sharded-indexes.html"),
+			),
+		)
+	}
 }
 
 func nextRelationIndexID(b BuildCtx, relation scpb.Element) catid.IndexID {
@@ -777,6 +788,23 @@ func maybeCreateAndAddShardCol(
 	b.Add(shardCheckConstraintName)
 
 	return shardColName, shardColID
+}
+
+func columnHasDefaultTimestampExpression(
+	b BuildCtx, tableID catid.DescID, columnID tree.ColumnID,
+) bool {
+	if defExprEl := retrieveColumnDefaultExpressionElem(b, tableID, columnID); defExprEl != nil {
+		defExpr, exprLen := defExprEl.Expr, len(defExprEl.Expr)
+		return exprLen >= 19 && defExpr[:19] == "current_timestamp()" ||
+			exprLen >= 17 && defExpr[:17] == "clock_timestamp()" ||
+			exprLen >= 14 && defExpr[:14] == "current_date()" ||
+			exprLen >= 14 && defExpr[:14] == "current_time()" ||
+			exprLen >= 16 && defExpr[:16] == "localtimestamp()" ||
+			exprLen >= 5 && defExpr[:5] == "now()" ||
+			exprLen >= 21 && defExpr[:21] == "statement_timestamp()" ||
+			exprLen >= 23 && defExpr[:23] == "transaction_timestamp()"
+	}
+	return false
 }
 
 func maybeCreateVirtualColumnForIndex(


### PR DESCRIPTION
Not every user aware that using regular indexes on timestamp fields can cause hotspots.
This warning will provide a documentation link for hash-sharded indexes which is better solution
for indexing sequential values

Release note (sql change): warn user to use hash-sharded index when indexing timestamp fields

Fixes: #41058