### PR TITLE
raft: add match index safety check on followers

### DIFF
--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -380,8 +380,8 @@ func TestLeaderStartReplication(t *testing.T) {
 	sort.Sort(messageSlice(msgs))
 	wents := []pb.Entry{{Index: li + 1, Term: 1, Data: []byte("some data")}}
 	assert.Equal(t, []pb.Message{
-		{From: 1, To: 2, Term: 1, Type: pb.MsgApp, Index: li, LogTerm: 1, Entries: wents, Commit: li},
-		{From: 1, To: 3, Term: 1, Type: pb.MsgApp, Index: li, LogTerm: 1, Entries: wents, Commit: li},
+		{From: 1, To: 2, Term: 1, Type: pb.MsgApp, Index: li, LogTerm: 1, Entries: wents, Commit: li, Match: li},
+		{From: 1, To: 3, Term: 1, Type: pb.MsgApp, Index: li, LogTerm: 1, Entries: wents, Commit: li, Match: li},
 	}, msgs)
 	assert.Equal(t, []pb.Entry{
 		{Index: li + 1, Term: 1, Data: []byte("some data")},

--- a/pkg/raft/raftpb/raft.proto
+++ b/pkg/raft/raftpb/raft.proto
@@ -106,6 +106,21 @@ message Message {
 	// to respond and who to respond to when the work associated with a message
 	// is complete. Populated for MsgStorageAppend and MsgStorageApply messages.
 	repeated Message     responses   = 14 [(gogoproto.nullable) = false];
+
+  // match is the log index up to which the follower's log must persistently
+  // match the leader's. If the follower's persistent log is shorter, it means
+  // the follower has broken its promise and violated safety of Raft. Typically
+  // this means the environment (Storage) hasn't provided the required
+  // durability guarantees.
+  //
+  // If a follower sees a match index exceeding its log's last index, it must
+  // cease its membership (stop voting and acking appends) in the raft group, in
+  // order to limit the damage. Today it simply panics.
+  //
+  // match is only populated by the leader when sending messages to a voting
+  // follower. This can be 0 if the leader hasn't yet established the follower's
+  // match index, or for backward compatibility.
+  optional uint64 match = 15 [(gogoproto.nullable) = false];
 }
 
 message HardState {

--- a/pkg/raft/raftpb/raft_test.go
+++ b/pkg/raft/raftpb/raft_test.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by Cockroach Labs, Inc.
+// All modifications are Copyright 2024 Cockroach Labs, Inc.
+//
 // Copyright 2021 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/raft/raftpb/raft_test.go
+++ b/pkg/raft/raftpb/raft_test.go
@@ -45,7 +45,7 @@ func TestProtoMemorySizes(t *testing.T) {
 	assert(unsafe.Sizeof(s), if64Bit(144, 80), "Snapshot")
 
 	var m Message
-	assert(unsafe.Sizeof(m), if64Bit(160, 112), "Message")
+	assert(unsafe.Sizeof(m), if64Bit(168, 112), "Message")
 
 	var hs HardState
 	assert(unsafe.Sizeof(hs), 24, "HardState")


### PR DESCRIPTION
This PR adds a safety check which ensures that a follower's log state does not contradict to the leader's `Match` index.

If the leader has a non-zero `Match` for the follower, it believes that the follower's log a) is consistent with this leader, and b) has all entries up to the `Match` index persisted. If the follower's `Term <= leader.Term` and (b) turns out to not be the case, this means the follower has lost part of the durable state (for example, fsync didn't work properly in the system, and the node got restarted). This is a safety violation, so this follower panics to avoid spreading the harm.

In the future, it would be better to "quarantine" this follower, and surface this information to the operator without crashing the node.

Touches #122690
Epic: none
Release note: none