### PR TITLE
sqlstats: remove unnecessary StatementFingerprintID construction

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -71,7 +71,6 @@ func (s *StmtStatsIterator) Next() bool {
 
 	stmtKey := s.stmtKeys[s.idx]
 
-	stmtFingerprintID := constructStatementFingerprintIDFromStmtKey(stmtKey)
 	statementStats, _, _ :=
 		s.container.getStatsForStmtWithKey(stmtKey, invalidStmtFingerprintID, false /* createIfNonexistent */)
 
@@ -104,7 +103,7 @@ func (s *StmtStatsIterator) Next() bool {
 			PlanHash:                 stmtKey.planHash,
 			TransactionFingerprintID: stmtKey.transactionFingerprintID,
 		},
-		ID:    stmtFingerprintID,
+		ID:    statementStats.ID,
 		Stats: data,
 	}
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -640,7 +640,7 @@ func (s *Container) PopAllStats(
 				PlanHash:                 key.planHash,
 				TransactionFingerprintID: key.transactionFingerprintID,
 			},
-			ID:    constructStatementFingerprintIDFromStmtKey(key),
+			ID:    stmt.ID,
 			Stats: data,
 		})
 	}


### PR DESCRIPTION
Previously we were constructing the stmt fingerprint id unnecessarily
in 2 functions in sqlstats:
- The Next function for the StmtStatsIterator
- PopAllStats, which returns the sql stats collected thus far and
resets the in-memory sql stats containers.

The ID is available in the recorded statement in both of these cases-
there's no need to reconstruct this value and doing is needlessly
expensive.

Epic: none

Release note: None