### PR TITLE
ui: prevent /_status/nodes calls for secondary tenants

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsConnected.ts
@@ -25,7 +25,6 @@ import {
   DatabaseDetailsPage,
   DatabaseDetailsPageActions,
   DatabaseDetailsPageData,
-  ViewMode,
 } from "./databaseDetailsPage";
 import { actions as analyticsActions } from "../store/analytics";
 import { Filters } from "../queryFilter";
@@ -44,6 +43,7 @@ import {
   selectIndexRecommendationsEnabled,
 } from "../store/clusterSettings/clusterSettings.selectors";
 import { actions as nodesActions } from "../store/nodes/nodes.reducer";
+import { ViewMode } from "./types";
 
 const mapStateToProps = (
   state: AppState,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.spec.tsx
@@ -1,0 +1,70 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { expect } from "chai";
+import { defaultFilters } from "../queryFilter";
+import { indexUnusedDuration } from "../util";
+import * as H from "history";
+import { shallow } from "enzyme";
+import {
+  DatabaseDetailsPage,
+  DatabaseDetailsPageProps,
+} from "./databaseDetailsPage";
+import { ViewMode } from "./types";
+
+describe("DatabaseDetailsPage", () => {
+  const history = H.createHashHistory();
+  const props: DatabaseDetailsPageProps = {
+    loading: false,
+    loaded: false,
+    requestError: undefined,
+    queryError: undefined,
+    name: "things",
+    search: null,
+    filters: defaultFilters,
+    nodeRegions: {},
+    showNodeRegionsColumn: false,
+    viewMode: ViewMode.Tables,
+    sortSettingTables: { ascending: true, columnTitle: "name" },
+    sortSettingGrants: { ascending: true, columnTitle: "name" },
+    tables: [],
+    showIndexRecommendations: false,
+    csIndexUnusedDuration: indexUnusedDuration,
+    isTenant: false,
+    refreshTableDetails: () => {},
+    refreshNodes: () => {},
+    refreshDatabaseDetails: () => {},
+    history: history,
+    location: history.location,
+    match: {
+      url: "",
+      path: history.location.pathname,
+      isExact: false,
+      params: {},
+    },
+  };
+  it("should call refreshNodes if isTenant is false", () => {
+    const mockCallback = jest.fn(() => {});
+    shallow(<DatabaseDetailsPage {...props} refreshNodes={mockCallback} />);
+    expect(mockCallback.mock.calls).to.have.length(1);
+  });
+  it("should not call refreshNodes if isTenant is true", () => {
+    const mockCallback = jest.fn(() => {});
+    shallow(
+      <DatabaseDetailsPage
+        {...props}
+        refreshNodes={mockCallback}
+        isTenant={true}
+      />,
+    );
+    expect(mockCallback.mock.calls).to.have.length(0);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -22,13 +22,13 @@ import {
   DatabaseDetailsPage,
   DatabaseDetailsPageDataTable,
   DatabaseDetailsPageProps,
-  ViewMode,
 } from "./databaseDetailsPage";
 
 import * as H from "history";
 import moment from "moment-timezone";
 import { defaultFilters } from "src/queryFilter";
 import { indexUnusedDuration } from "src/util/constants";
+import { ViewMode } from "./types";
 const history = H.createHashHistory();
 
 const withLoadingIndicator: DatabaseDetailsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -261,7 +261,9 @@ export class DatabaseDetailsPage extends React.Component<
   }
 
   componentDidMount(): void {
-    this.props.refreshNodes();
+    if (!this.props.isTenant) {
+      this.props.refreshNodes();
+    }
     if (!this.props.loaded && !this.props.loading && !this.props.requestError) {
       this.props.refreshDatabaseDetails(
         this.props.name,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -61,6 +61,7 @@ import {
 } from "../api";
 import { checkInfoAvailable } from "../databases";
 import { InlineAlert } from "@cockroachlabs/ui-components";
+import { ViewMode } from "./types";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -176,11 +177,6 @@ export interface DatabaseDetailsPageActions {
 export type DatabaseDetailsPageProps = DatabaseDetailsPageData &
   DatabaseDetailsPageActions &
   RouteComponentProps<unknown>;
-
-export enum ViewMode {
-  Tables = "Tables",
-  Grants = "Grants",
-}
 
 interface DatabaseDetailsPageState {
   pagination: ISortedTablePagination;

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
@@ -22,7 +22,6 @@ import {
   DatabaseDetailsPageDataTable,
   DatabaseDetailsPageDataTableDetails,
   DatabaseDetailsPageProps,
-  ViewMode,
 } from "./databaseDetailsPage";
 import classNames from "classnames/bind";
 import styles from "./databaseDetailsPage.module.scss";
@@ -34,6 +33,7 @@ import { Breadcrumbs } from "../breadcrumbs";
 import { CaretRight } from "../icon/caretRight";
 import { CockroachCloudContext } from "../contexts";
 import { checkInfoAvailable, getNetworkErrorMessage } from "../databases";
+import { ViewMode } from "./types";
 
 const cx = classNames.bind(styles);
 

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/types.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2024 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./databaseDetailsPage";
-export * from "./databaseDetailsConnected";
-export * from "./types";
+export enum ViewMode {
+  Tables = "Tables",
+  Grants = "Grants",
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.spec.tsx
@@ -1,0 +1,84 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { expect } from "chai";
+import { indexUnusedDuration } from "../util";
+import * as H from "history";
+import { shallow } from "enzyme";
+import { DatabaseTablePage, DatabaseTablePageProps } from "./databaseTablePage";
+import { util } from "../index";
+
+describe("DatabaseTablePage", () => {
+  const history = H.createHashHistory();
+  const props: DatabaseTablePageProps = {
+    databaseName: "DATABASE",
+    name: "TABLE",
+    schemaName: "",
+    showNodeRegionsSection: false,
+    details: {
+      loading: false,
+      loaded: false,
+      requestError: undefined,
+      queryError: undefined,
+      createStatement: undefined,
+      replicaData: undefined,
+      spanStats: undefined,
+      indexData: undefined,
+      grants: {
+        all: [],
+        error: undefined,
+      },
+      statsLastUpdated: undefined,
+      nodesByRegionString: "",
+    },
+    automaticStatsCollectionEnabled: true,
+    indexUsageStatsEnabled: true,
+    showIndexRecommendations: true,
+    csIndexUnusedDuration: indexUnusedDuration,
+    hasAdminRole: false,
+    indexStats: {
+      loading: false,
+      loaded: false,
+      lastError: undefined,
+      stats: [],
+      lastReset: util.minDate,
+    },
+    refreshSettings: () => {},
+    refreshUserSQLRoles: () => {},
+    refreshTableDetails: () => {},
+    isTenant: false,
+    history: history,
+    location: history.location,
+    match: {
+      url: "",
+      path: history.location.pathname,
+      isExact: false,
+      params: {},
+    },
+  };
+  it("should call refreshNodes if isTenant is false", () => {
+    const mockCallback = jest.fn(() => {});
+    shallow(<DatabaseTablePage {...props} refreshNodes={mockCallback} />);
+    expect(mockCallback.mock.calls).to.have.length(1);
+  });
+  it("should not call refreshNodes if isTenant is true", () => {
+    const mockCallback = jest.fn(() => {});
+
+    shallow(
+      <DatabaseTablePage
+        {...props}
+        refreshNodes={mockCallback}
+        isTenant={true}
+      />,
+    );
+    expect(mockCallback.mock.calls).to.have.length(0);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -128,6 +128,7 @@ export interface DatabaseTablePageData {
   automaticStatsCollectionEnabled?: boolean;
   hasAdminRole?: UIConfigState["hasAdminRole"];
   csIndexUnusedDuration: string;
+  isTenant?: UIConfigState["isTenant"];
 }
 
 export interface DatabaseTablePageDataDetails {
@@ -281,7 +282,7 @@ export class DatabaseTablePage extends React.Component<
 
   private refresh() {
     this.props.refreshUserSQLRoles();
-    if (this.props.refreshNodes != null) {
+    if (this.props.refreshNodes != null && !this.props.isTenant) {
       this.props.refreshNodes();
     }
 

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePageConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePageConnected.ts
@@ -90,6 +90,7 @@ export const mapStateToProps = (
       stats: deriveIndexDetailsMemoized({ database, table, indexUsageStats }),
       lastReset,
     },
+    isTenant,
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.spec.tsx
@@ -1,0 +1,95 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { expect } from "chai";
+import { DatabasesPage, DatabasesPageProps } from "./databasesPage";
+import { defaultFilters } from "../queryFilter";
+import { indexUnusedDuration } from "../util";
+import * as H from "history";
+import { shallow } from "enzyme";
+
+describe("DatabasesPage", () => {
+  const history = H.createHashHistory();
+  const props: DatabasesPageProps = {
+    loading: false,
+    loaded: true,
+    requestError: null,
+    queryError: undefined,
+    databases: [
+      {
+        detailsLoading: false,
+        detailsLoaded: false,
+        spanStatsLoading: false,
+        spanStatsLoaded: false,
+        detailsRequestError: undefined,
+        spanStatsRequestError: undefined,
+        detailsQueryError: undefined,
+        spanStatsQueryError: undefined,
+        name: "system",
+        nodes: [],
+        spanStats: undefined,
+        tables: undefined,
+        nodesByRegionString: "",
+        numIndexRecommendations: 0,
+      },
+      {
+        detailsLoading: false,
+        detailsLoaded: false,
+        spanStatsLoading: false,
+        spanStatsLoaded: false,
+        detailsRequestError: undefined,
+        spanStatsRequestError: undefined,
+        detailsQueryError: undefined,
+        spanStatsQueryError: undefined,
+        name: "test",
+        nodes: [],
+        spanStats: undefined,
+        tables: undefined,
+        nodesByRegionString: "",
+        numIndexRecommendations: 0,
+      },
+    ],
+    search: null,
+    filters: defaultFilters,
+    nodeRegions: {},
+    isTenant: false,
+    sortSetting: { ascending: true, columnTitle: "name" },
+    showNodeRegionsColumn: false,
+    indexRecommendationsEnabled: true,
+    csIndexUnusedDuration: indexUnusedDuration,
+    automaticStatsCollectionEnabled: true,
+    refreshDatabases: () => {},
+    refreshDatabaseDetails: () => {},
+    refreshDatabaseSpanStats: () => {},
+    refreshSettings: () => {},
+    history: history,
+    location: history.location,
+    match: {
+      url: "",
+      path: history.location.pathname,
+      isExact: false,
+      params: {},
+    },
+  };
+  it("should call refreshNodes if isTenant is false", () => {
+    const mockCallback = jest.fn(() => {});
+    shallow(<DatabasesPage {...props} refreshNodes={mockCallback} />);
+    expect(mockCallback.mock.calls).to.have.length(1);
+  });
+  it("should not call refreshNodes if isTenant is true", () => {
+    const mockCallback = jest.fn(() => {});
+
+    shallow(
+      <DatabasesPage {...props} refreshNodes={mockCallback} isTenant={true} />,
+    );
+    expect(mockCallback.mock.calls).to.have.length(0);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -240,7 +240,7 @@ export class DatabasesPage extends React.Component<
   };
 
   componentDidMount(): void {
-    if (this.props.refreshNodes != null) {
+    if (this.props.refreshNodes != null && !this.props.isTenant) {
       this.props.refreshNodes();
     }
 

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDeailsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDeailsPage.spec.tsx
@@ -1,0 +1,66 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { expect } from "chai";
+import { shallow } from "enzyme";
+import { IndexDetailsPage, IndexDetailsPageProps, util } from "../index";
+import moment from "moment";
+
+describe("IndexDetailsPage", () => {
+  const props: IndexDetailsPageProps = {
+    databaseName: "DATABASE",
+    tableName: "TABLE",
+    indexName: "INDEX",
+    nodeRegions: {},
+    hasAdminRole: undefined,
+    hasViewActivityRedactedRole: undefined,
+    timeScale: {
+      key: "Past 10 Minutes",
+      windowSize: moment.duration(10, "minutes"),
+      windowValid: moment.duration(10, "seconds"),
+      sampleSize: moment.duration(10, "seconds"),
+      fixedWindowEnd: false,
+    },
+    details: {
+      loading: false,
+      loaded: false,
+      createStatement: "",
+      totalReads: 0,
+      indexRecommendations: [],
+      tableID: undefined,
+      indexID: undefined,
+      lastRead: util.minDate,
+      lastReset: util.minDate,
+    },
+    breadcrumbItems: null,
+    isTenant: false,
+    refreshUserSQLRoles: () => {},
+    onTimeScaleChange: () => {},
+    refreshIndexStats: () => {},
+  };
+  it("should call refreshNodes if isTenant is false", () => {
+    const mockCallback = jest.fn(() => {});
+    shallow(<IndexDetailsPage {...props} refreshNodes={mockCallback} />);
+    expect(mockCallback.mock.calls).to.have.length(1);
+  });
+  it("should not call refreshNodes if isTenant is true", () => {
+    const mockCallback = jest.fn(() => {});
+
+    shallow(
+      <IndexDetailsPage
+        {...props}
+        refreshNodes={mockCallback}
+        isTenant={true}
+      />,
+    );
+    expect(mockCallback.mock.calls).to.have.length(0);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -259,7 +259,7 @@ export class IndexDetailsPage extends React.Component<
 
   private refresh() {
     this.props.refreshUserSQLRoles();
-    if (this.props.refreshNodes != null) {
+    if (this.props.refreshNodes != null && !this.props.isTenant) {
       this.props.refreshNodes();
     }
     if (!this.props.details.loaded && !this.props.details.loading) {

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -17,7 +17,7 @@ import {
   SqlStatsSortType,
   DEFAULT_STATS_REQ_OPTIONS,
 } from "src/api/statementsApi";
-import { ViewMode } from "src/databaseDetailsPage/databaseDetailsPage";
+import { ViewMode } from "src/databaseDetailsPage/types";
 
 type SortSetting = {
   ascending: boolean;

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -216,6 +216,7 @@ describe("Database Table Page", function () {
         stats: [],
         lastReset: util.minDate,
       },
+      isTenant: false,
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -85,6 +85,7 @@ export const mapStateToProps = (
       stats: deriveIndexDetailsMemoized({ database, table, indexUsageStats }),
       lastReset: lastReset,
     },
+    isTenant,
   };
 };
 


### PR DESCRIPTION

/_status/nodes is not implemented for secondary tenants, resulting in 501
responses in cloud for serverless tenants. To fix, this api is now gated by
a tenant check and will no longer be called by serverless / secondary tenants.

Fixes: CC-26900
Epic: None
Release note: None