### PR TITLE
lease: remove outdated NightlyStress call

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1762,7 +1762,7 @@ func TestModificationTimeTxnOrdering(testingT *testing.T) {
 
 	// Decide how long we should run this.
 	maxTime := time.Duration(20) * time.Second
-	if skip.NightlyStress() {
+	if skip.Duress() {
 		maxTime = time.Duration(2) * time.Minute
 	}
 


### PR DESCRIPTION
This test config is not used anymore.

fixes https://github.com/cockroachdb/cockroach/issues/123907
Release note: None