### PR TITLE
execinfra: add a sanity check that DistSQL version is not bumped

### DIFF
--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
     srcs = [
         "base_test.go",
         "main_test.go",
+        "version_test.go",
     ],
     embed = [":execinfra"],
     deps = [
@@ -104,6 +105,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/execinfra/version_test.go
+++ b/pkg/sql/execinfra/version_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execinfra
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionNotBumped is a sanity check that we won't ever bump DistSQL
+// version in backwards-incompatible way.
+func TestVersionNotBumped(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	require.Equal(t, 71, int(Version))            // DO NOT ADJUST
+	require.Equal(t, 71, int(MinAcceptedVersion)) // DO NOT ADJUST
+}


### PR DESCRIPTION
The last bump was in 23.1, and we won't ever bump DistSQL version in backwards-incompatible going forward.

Epic: None

Release note: None