### PR TITLE
roachtest: surface cloud cluster spec info in artifacts

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -981,7 +981,7 @@ func getGoCoverArtifacts(ctx context.Context, c *clusterImpl, t test.Test) {
 // this returns. This happens when the test doesn't respond to cancellation.
 //
 // Args:
-// c: The cluster on which the test will run. runTest() does not wipe or destroy  the cluster.
+// c: The cluster on which the test will run. runTest() does not wipe or destroy the cluster.
 func (r *testRunner) runTest(
 	ctx context.Context,
 	t *testImpl,
@@ -1476,7 +1476,7 @@ func (r *testRunner) teardownTest(
 func (r *testRunner) collectArtifacts(
 	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool, timeout time.Duration,
 ) error {
-	// Collecting artifacts may hang so we run it in a goroutine which is abandoned
+	// Collecting artifacts may hang, so we run it in a goroutine which is abandoned
 	// after a timeout.
 	artifactsCollectedCh := make(chan struct{})
 	_ = r.stopper.RunAsyncTask(ctx, "collect-artifacts", func(ctx context.Context) {
@@ -1561,6 +1561,9 @@ func (r *testRunner) collectArtifacts(
 		}
 		if err := c.FetchDebugZip(ctx, t.L(), "debug.zip"); err != nil {
 			t.L().Printf("failed to collect zip: %s", err)
+		}
+		if err := c.FetchVMSpecs(ctx, t.L()); err != nil {
+			t.L().Errorf("failed to collect VM specs: %s", err)
 		}
 	})
 

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -278,6 +278,10 @@ func (p *Provider) GetHostErrorVMs(
 	return nil, nil
 }
 
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 const (
 	defaultSSDMachineType = "m6id.xlarge"
 	defaultMachineType    = "m6i.xlarge"

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -113,6 +113,10 @@ func (p *Provider) GetHostErrorVMs(
 	return nil, nil
 }
 
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -48,6 +48,10 @@ func (p *provider) GetHostErrorVMs(
 	return nil, nil
 }
 
+func (p *provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (p *provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -400,6 +400,29 @@ func (p *Provider) GetHostErrorVMs(
 	return hostErrorVMs, nil
 }
 
+// GetVMSpecs returns a json list of VM specs, provided by GCE
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	if p.GetProject() == "" {
+		return nil, errors.New("project name cannot be empty")
+	}
+	if vms == nil {
+		return nil, errors.New("vms cannot be nil")
+	}
+	// Extract the spec of all VMs.
+	var vmSpecs []map[string]interface{}
+	for _, vmInstance := range vms {
+		var vmSpec map[string]interface{}
+		vmFullResourceName := "projects/" + p.GetProject() + "/zones/" + vmInstance.Zone + "/instances/" + vmInstance.Name
+		args := []string{"compute", "instances", "describe", vmFullResourceName, "--format=json"}
+
+		if err := runJSONCommand(args, &vmSpec); err != nil {
+			return nil, errors.Wrapf(err, "error describing instance %s in zone %s", vmInstance.Name, vmInstance.Zone)
+		}
+		vmSpecs = append(vmSpecs, vmSpec)
+	}
+	return vmSpecs, nil
+}
+
 func buildFilterCliArgs(
 	vms vm.List, projectName string, since time.Time, filter string,
 ) ([]string, error) {

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -141,6 +141,10 @@ func (p *Provider) GetHostErrorVMs(
 	return nil, nil
 }
 
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -508,8 +508,10 @@ type Provider interface {
 	// GetPreemptedSpotVMs returns a list of Spot VMs that were preempted since the time specified.
 	// Returns nil, nil when SupportsSpotVMs() is false.
 	GetPreemptedSpotVMs(l *logger.Logger, vms List, since time.Time) ([]PreemptedVM, error)
-	// GetHostErrorVMs returns a list of Spot VMs that had host error since the time specified.
+	// GetHostErrorVMs returns a list of VMs that had host error since the time specified.
 	GetHostErrorVMs(l *logger.Logger, vms List, since time.Time) ([]string, error)
+	// GetVMSpecs returns a json list of VM specs, according to a specific cloud provider.
+	GetVMSpecs(vms List) ([]map[string]interface{}, error)
 
 	// CreateLoadBalancer creates a load balancer, for a specific port, that
 	// delegates to the given cluster.


### PR DESCRIPTION
Previously, getting the spec of the VMs on which a roachtest ran was tricky to derive.
This was inadequate because it's often necessary to understand the particulars of a roachtest run's environment.
To address this, this patch creates a json file per VM describing its spec. These files are stored under `artifacts/vm_spec`.

Epic: none
Fixes: #112707
Release note: None