### PR TITLE
sql,sqlstats: lift out fields required for logging from `dispatchToExecutionEngine`

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2885,7 +2885,6 @@ func (ex *connExecutor) execCopyOut(
 			ex.implicitTxn(),
 			ex.planner.CurrentDatabase(),
 		)
-		var stats topLevelQueryStats
 		ex.planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
@@ -2899,7 +2898,6 @@ func (ex *connExecutor) execCopyOut(
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
-			&stats,
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()
@@ -3150,7 +3148,6 @@ func (ex *connExecutor) execCopyIn(
 			ex.implicitTxn(),
 			ex.planner.CurrentDatabase(),
 		)
-		var stats topLevelQueryStats
 		ex.planner.maybeLogStatement(ctx, ex.executorType,
 			int(ex.state.mu.autoRetryCounter), int(ex.extraTxnState.txnCounter.Load()),
 			numInsertedRows, ex.state.mu.stmtCount,
@@ -3160,7 +3157,6 @@ func (ex *connExecutor) execCopyIn(
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
-			&stats,
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2876,15 +2876,6 @@ func (ex *connExecutor) execCopyOut(
 		}
 
 		// Log the query for sampling.
-		// These fields are not available in COPY, so use the empty value.
-		flags := tree.FmtFlags(queryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV))
-		f := tree.NewFmtCtx(flags)
-		f.FormatNode(cmd.Stmt)
-		stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
-			f.CloseAndGetString(),
-			ex.implicitTxn(),
-			ex.planner.CurrentDatabase(),
-		)
 		ex.planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
@@ -2897,7 +2888,7 @@ func (ex *connExecutor) execCopyOut(
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
-			stmtFingerprintID,
+			ex.implicitTxn(),
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()
@@ -3139,15 +3130,6 @@ func (ex *connExecutor) execCopyIn(
 			numInsertedRows = cm.numInsertedRows()
 			res.SetRowsAffected(ctx, numInsertedRows)
 		}
-		// These fields are not available in COPY, so use the empty value.
-		flags := tree.FmtHideConstants | tree.FmtFlags(queryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV))
-		f := tree.NewFmtCtx(flags)
-		f.FormatNode(cmd.Stmt)
-		stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
-			f.CloseAndGetString(),
-			ex.implicitTxn(),
-			ex.planner.CurrentDatabase(),
-		)
 		ex.planner.maybeLogStatement(ctx, ex.executorType,
 			int(ex.state.mu.autoRetryCounter), int(ex.extraTxnState.txnCounter.Load()),
 			numInsertedRows, ex.state.mu.stmtCount,
@@ -3156,7 +3138,7 @@ func (ex *connExecutor) execCopyIn(
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
-			stmtFingerprintID,
+			ex.implicitTxn(),
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -853,7 +853,6 @@ func (ex *connExecutor) execStmtInOpenState(
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
-			&topLevelQueryStats{},
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()
@@ -1868,7 +1867,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 						&ex.extraTxnState.hasAdminRoleCache,
 						ex.server.TelemetryLoggingMetrics,
 						ppInfo.dispatchToExecutionEngine.stmtFingerprintID,
-						ppInfo.dispatchToExecutionEngine.queryStats,
 						ex.statsCollector,
 						ex.extraTxnState.shouldLogToTelemetry)
 				},
@@ -1895,7 +1893,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 				&ex.extraTxnState.hasAdminRoleCache,
 				ex.server.TelemetryLoggingMetrics,
 				stmtFingerprintID,
-				&stats,
 				ex.statsCollector,
 				ex.extraTxnState.shouldLogToTelemetry)
 		}
@@ -2095,9 +2092,10 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 }
 
 // populateQueryLevelStats collects query-level execution statistics
-// and populates it in the instrumentationHelper's queryLevelStatsWithErr field.
-// Query-level execution statistics are collected using the statement's trace
-// and the plan's flow metadata.
+// and populates it in the instrumentationHelper's fields:
+//   - topLevelStats contains the top-level execution statistics.
+//   - queryLevelStatsWithErr contains query-level execution statistics are
+//     collected using the statement's trace and the plan's flow metadata.
 func populateQueryLevelStats(
 	ctx context.Context,
 	p *planner,
@@ -2106,6 +2104,8 @@ func populateQueryLevelStats(
 	cpuStats *multitenantcpu.CPUUsageHelper,
 ) {
 	ih := &p.instrumentation
+	ih.topLevelStats = *topLevelStats
+
 	if _, ok := ih.Tracing(); !ok {
 		return
 	}
@@ -2560,7 +2560,6 @@ func (ex *connExecutor) execStmtInNoTxnState(
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
-			&topLevelQueryStats{},
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -392,7 +392,6 @@ func (ex *connExecutor) execStmtInOpenState(
 	} else {
 		stmt = makeStatement(parserStmt, queryID, stmtFingerprintFmtMask)
 	}
-	stmtFingerprint := stmt.StmtNoConstants
 
 	var queryTimeoutTicker *time.Timer
 	var txnTimeoutTicker *time.Timer
@@ -619,12 +618,6 @@ func (ex *connExecutor) execStmtInOpenState(
 		// TODO(radu): should we trim the "EXPLAIN ANALYZE (DEBUG)" part from
 		// stmt.SQL?
 
-		// Recompute statement fingerprint since the AST has changed.
-		flags := tree.FmtHideConstants | stmtFingerprintFmtMask
-		f := tree.NewFmtCtx(flags)
-		f.FormatNode(ast)
-		stmtFingerprint = f.CloseAndGetString()
-
 		// Clear any ExpectedTypes we set if we prepared this statement (they
 		// reflect the column types of the EXPLAIN itself and not those of the inner
 		// statement).
@@ -656,7 +649,6 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.ExpectedTypes = ps.Columns
 		stmt.StmtNoConstants = ps.StatementNoConstants
 		stmt.StmtSummary = ps.StatementSummary
-		stmtFingerprint = stmt.StmtNoConstants
 		res.ResetStmtType(ps.AST)
 
 		if e.DiscardRows {
@@ -834,11 +826,6 @@ func (ex *connExecutor) execStmtInOpenState(
 		if p, ok := retPayload.(payloadWithError); ok {
 			execErr = p.errorCause()
 		}
-		stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
-			stmtFingerprint,
-			ex.implicitTxn(),
-			p.CurrentDatabase(),
-		)
 
 		p.maybeLogStatement(
 			ctx,
@@ -852,7 +839,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
-			stmtFingerprintID,
+			ex.implicitTxn(),
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()
@@ -1839,7 +1826,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		res.DisableBuffering()
 	}
 
-	var stmtFingerprintID appstatspb.StmtFingerprintID
 	var stats topLevelQueryStats
 	defer func() {
 		var bulkJobId uint64
@@ -1866,7 +1852,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 						ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 						&ex.extraTxnState.hasAdminRoleCache,
 						ex.server.TelemetryLoggingMetrics,
-						ppInfo.dispatchToExecutionEngine.stmtFingerprintID,
+						ex.implicitTxn(),
 						ex.statsCollector,
 						ex.extraTxnState.shouldLogToTelemetry)
 				},
@@ -1892,7 +1878,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 				ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 				&ex.extraTxnState.hasAdminRoleCache,
 				ex.server.TelemetryLoggingMetrics,
-				stmtFingerprintID,
+				ex.implicitTxn(),
 				ex.statsCollector,
 				ex.extraTxnState.shouldLogToTelemetry)
 		}
@@ -2044,7 +2030,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		})
 	} else {
 		populateQueryLevelStats(ctx, planner, ex.server.cfg, &stats, &ex.cpuStatsCollector)
-		stmtFingerprintID = ex.recordStatementSummary(
+		ex.recordStatementSummary(
 			ctx, planner,
 			int(ex.state.mu.autoRetryCounter), res.RowsAffected(), res.Err(), stats,
 		)
@@ -2541,12 +2527,6 @@ func (ex *connExecutor) execStmtInNoTxnState(
 			execErr = p.errorCause()
 		}
 
-		stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
-			stmt.StmtNoConstants,
-			ex.implicitTxn(),
-			p.CurrentDatabase(),
-		)
-
 		p.maybeLogStatement(
 			ctx,
 			ex.executorType,
@@ -2559,7 +2539,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 			ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
-			stmtFingerprintID,
+			ex.implicitTxn(),
 			ex.statsCollector,
 			ex.extraTxnState.shouldLogToTelemetry)
 	}()

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -143,14 +143,13 @@ func (p *planner) maybeLogStatement(
 	hasAdminRoleCache *HasAdminRoleCache,
 	telemetryLoggingMetrics *telemetryLoggingMetrics,
 	stmtFingerprintID appstatspb.StmtFingerprintID,
-	queryStats *topLevelQueryStats,
 	statsCollector *sslocal.StatsCollector,
 	shouldLogToTelemetry bool,
 ) {
 	p.maybeAuditRoleBasedAuditEvent(ctx, execType)
 	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter,
 		rows, stmtCount, bulkJobId, err, queryReceived, hasAdminRoleCache,
-		telemetryLoggingMetrics, stmtFingerprintID, queryStats, statsCollector,
+		telemetryLoggingMetrics, stmtFingerprintID, statsCollector,
 		shouldLogToTelemetry)
 }
 
@@ -164,7 +163,6 @@ func (p *planner) maybeLogStatementInternal(
 	hasAdminRoleCache *HasAdminRoleCache,
 	telemetryMetrics *telemetryLoggingMetrics,
 	stmtFingerprintID appstatspb.StmtFingerprintID,
-	topLevelQueryStats *topLevelQueryStats,
 	statsCollector *sslocal.StatsCollector,
 	shouldLogToTelemetry bool,
 ) {
@@ -375,9 +373,9 @@ func (p *planner) maybeLogStatementInternal(
 			OutputRowsEstimate:                    p.curPlan.instrumentation.outputRows,
 			StatsAvailable:                        p.curPlan.instrumentation.statsAvailable,
 			NanosSinceStatsCollected:              int64(p.curPlan.instrumentation.nanosSinceStatsCollected),
-			BytesRead:                             topLevelQueryStats.bytesRead,
-			RowsRead:                              topLevelQueryStats.rowsRead,
-			RowsWritten:                           topLevelQueryStats.rowsWritten,
+			BytesRead:                             p.curPlan.instrumentation.topLevelStats.bytesRead,
+			RowsRead:                              p.curPlan.instrumentation.topLevelStats.rowsRead,
+			RowsWritten:                           p.curPlan.instrumentation.topLevelStats.rowsWritten,
 			InnerJoinCount:                        int64(p.curPlan.instrumentation.joinTypeCounts[descpb.InnerJoin]),
 			LeftOuterJoinCount:                    int64(p.curPlan.instrumentation.joinTypeCounts[descpb.LeftOuterJoin]),
 			FullOuterJoinCount:                    int64(p.curPlan.instrumentation.joinTypeCounts[descpb.FullOuterJoin]),

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -222,6 +222,10 @@ func (ex *connExecutor) recordStatementSummary(
 	stmtFingerprintID, err :=
 		ex.statsCollector.RecordStatement(ctx, recordedStmtStatsKey, recordedStmtStats)
 
+	// TODO(xinhaoz): This can be set directly within statsCollector once
+	// https://github.com/cockroachdb/cockroach/pull/123698 is merged.
+	ex.statsCollector.SetStatementFingerprintID(stmtFingerprintID)
+
 	if err != nil {
 		if log.V(1) {
 			log.Warningf(ctx, "failed to record statement: %s", err)
@@ -300,6 +304,7 @@ func (ex *connExecutor) recordStatementSummary(
 			sessionAge,
 		)
 	}
+
 	return stmtFingerprintID
 }
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -146,6 +146,9 @@ type instrumentationHelper struct {
 
 	inFlightTraceCollector
 
+	// topLevelStats are the statistics collected for every query execution.
+	topLevelStats topLevelQueryStats
+
 	queryLevelStatsWithErr *execstats.QueryLevelStatsWithErr
 
 	// If savePlanForStats is true and the explainPlan was collected, the
@@ -424,6 +427,7 @@ func (ih *instrumentationHelper) Setup(
 	ih.evalCtx = p.EvalContext()
 	ih.isTenant = execinfra.IncludeRUEstimateInExplainAnalyze.Get(cfg.SV()) && cfg.DistSQLSrv != nil &&
 		cfg.DistSQLSrv.TenantCostController != nil
+	ih.topLevelStats = topLevelQueryStats{}
 
 	switch ih.outputMode {
 	case explainAnalyzeDebugOutput:


### PR DESCRIPTION
**sql: record topLevelQueryStats in instrumentationhelper**

Previously topLevelQueryStats were being passed directly into
the logging function after execution in dispatchToExecutionEngine.
This commit persists the top level stats of the query execution
into the planner's instrumentation helper, similar to what we do
with sampled query exec stats.  This allows us to move the logging
operation in dispatchToExecutionEngine to `execStmtInOpenState`.

Part of: https://github.com/cockroachdb/cockroach/issues/122722


Release note: None

**sql, sqlstats: construct statement fingerprint id on demand when logging**

Currently we construct the stmt fingerprint id at various places to
pass to the logging function. We only need the statement fingerprint
id for telemetry logging, so this construction is wasteful in other
scenarios. This commit moves the stmt fingerprint id generation to
the logging function.

Summary:
- Record the current stmt fingerprint id in the stats collector when
  writing sql stats. This value is reset at the start of stmt exec.
- Construct stmt fingerprint at the time of logging based on the AST
  in the planner if it was not available in the stats collector.

This change is motivated by the desire to move logging from
`disatpchToExecutionEngine` to `execStmtInOpenState`. See issue
for details.

Part of: https://github.com/cockroachdb/cockroach/issues/122722
Release note: None