### PR TITLE
kvclient: remove unnecessary retry from test

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4894,13 +4894,8 @@ func TestProxyTracing(t *testing.T) {
 
 	p.EnablePartition(true)
 
-	// TODO(kvoli,andrewbaptist): Currently this may return an error on first
-	// attempt with 'pq: partitioned from 127.0.0.1:XXXXX, n3'. Remove the retry
-	// loop below once this is resolved.
-	testutils.SucceedsSoon(t, func() error {
-		_, err = conn.Exec("SET TRACING = on; SELECT FROM t where i = 987654321; SET TRACING = off")
-		return err
-	})
+	_, err = conn.Exec("SET TRACING = on; SELECT FROM t where i = 987654321; SET TRACING = off")
+	require.NoError(t, err)
 
 	// Expect the "proxy request complete" message to be in the trace and that it
 	// comes from the proxy node n2.

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -192,7 +192,7 @@ func (p *Partitioner) RegisterTestingKnobs(
 			panic("address not mapped, call RegisterNodeAddr before enabling the partition" + addr)
 		}
 		if partitionedServers[id.(roachpb.NodeID)] {
-			return errors.Newf("partitioned from %s, n%d", addr, id)
+			return errors.Newf("rpc error: partitioned from %s, n%d", addr, id)
 		}
 		return nil
 	}


### PR DESCRIPTION
DistSQL will retry if the error string contains "rpc error" in
`IsDistSQLRetryableError`. This commit changes the error message for the
`Partitioner` to always include "rpc error" in the error and therfore
allows removing the extra looping in the test.

Fixes: https://github.com/cockroachdb/cockroach/issues/124246

Release note: None