### PR TITLE
opt: normalize sequential % in regexes to single %

### DIFF
--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -160,19 +160,23 @@ func (c *CustomFuncs) MakeIntersectionFunction(args memo.ScalarListExpr) opt.Sca
 	)
 }
 
-func (c *CustomFuncs) CollapseRepeatedChar(input opt.ScalarExpr) opt.ScalarExpr {
-	pattern, ok := memo.ExtractConstDatum(input).(*tree.DString)
-	if !ok {
-		panic(errors.AssertionFailedf("expected string constant"))
-	}
-	collapsed := util.CollapseRepeatedChar(string(*pattern), '%')
-	return c.f.ConstructConstVal(tree.NewDString(collapsed), input.DataType())
-}
-
-func (c *CustomFuncs) CanCollapseRepeatedChar(input opt.ScalarExpr) bool {
+// CanCollapseRepeatedLikeWildcards returns true if the input pattern contains
+// repeated '%' characters.
+func (c *CustomFuncs) CanCollapseRepeatedLikeWildcards(input opt.ScalarExpr) bool {
 	pattern, ok := memo.ExtractConstDatum(input).(*tree.DString)
 	if !ok {
 		panic(errors.AssertionFailedf("expected string constant"))
 	}
 	return strings.Contains(string(*pattern), "%%")
+}
+
+// CollapseRepeatedLikeWildcards collapses repeated '%' characters in the input
+// pattern.
+func (c *CustomFuncs) CollapseRepeatedLikeWildcards(input opt.ScalarExpr) opt.ScalarExpr {
+	pattern, ok := memo.ExtractConstDatum(input).(*tree.DString)
+	if !ok {
+		panic(errors.AssertionFailedf("expected string constant"))
+	}
+	collapsed := util.CollapseRepeatedRune(string(*pattern), '%')
+	return c.f.ConstructConstVal(tree.NewDString(collapsed), input.DataType())
 }

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -283,10 +283,10 @@ $left
 $left
 
 # Normalize patterns used in LIKE clause by removing redundant '%' characters
-[NormalizeLikePattern, Normalize]
+[CollapseRepeatedLikeWildcards, Normalize]
 (Like | NotLike | ILike | NotILike | SimilarTo | NotSimilarTo
     $left:*
-    $right:(ConstValue) & (CanCollapseRepeatedChar $right)
+    $right:(ConstValue) & (CanCollapseRepeatedLikeWildcards $right)
 )
 =>
-((OpName) $left (CollapseRepeatedChar $right))
+((OpName) $left (CollapseRepeatedLikeWildcards $right))

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -281,3 +281,12 @@ $left
 (Ne $left:* (False))
 =>
 $left
+
+# Normalize patterns used in LIKE clause by removing redundant '%' characters
+[NormalizeLikePattern, Normalize]
+(Like | NotLike | ILike | NotILike | SimilarTo | NotSimilarTo
+    $left:*
+    $right:(ConstValue) & (CanCollapseRepeatedChar $right)
+)
+=>
+((OpName) $left (CollapseRepeatedChar $right))

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1087,3 +1087,73 @@ project
  │    └── columns: b:2
  └── projections
       └── b:2 [as="?column?":5, outer=(2)]
+
+norm expect=NormalizeLikePattern
+SELECT s FROM a WHERE s LIKE '%%abc%%%%dddd'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 LIKE '%abc%dddd' [outer=(4), constraints=(/4: (/NULL - ])]
+
+norm expect=NormalizeLikePattern
+SELECT s FROM a WHERE s LIKE '%%abc%%%%dddd'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 LIKE '%abc%dddd' [outer=(4), constraints=(/4: (/NULL - ])]
+
+norm expect=NormalizeLikePattern
+SELECT s NOT LIKE 'a%%bcd%%' FROM a
+----
+project
+ ├── columns: "?column?":12
+ ├── scan a
+ │    └── columns: s:4
+ └── projections
+      └── s:4 NOT LIKE 'a%bcd%' [as="?column?":12, outer=(4)]
+
+norm expect=NormalizeLikePattern
+SELECT s FROM a WHERE s ILIKE '%%abc%%%%dddd'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 ILIKE '%abc%dddd' [outer=(4), constraints=(/4: (/NULL - ])]
+
+norm expect=NormalizeLikePattern
+SELECT s FROM a WHERE s NOT ILIKE 'abcd%%%'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 NOT ILIKE 'abcd%' [outer=(4), constraints=(/4: (/NULL - ])]
+
+norm expect=NormalizeLikePattern
+SELECT s FROM a WHERE s SIMILAR TO '%a%b%%c%%d'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 SIMILAR TO '%a%b%c%d' [outer=(4), constraints=(/4: [/'' - ])]
+
+norm expect=NormalizeLikePattern
+SELECT s FROM a WHERE s NOT SIMILAR TO '%%%%'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 NOT SIMILAR TO '%' [outer=(4), constraints=(/4: (/NULL - ])]

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -1088,7 +1088,11 @@ project
  └── projections
       └── b:2 [as="?column?":5, outer=(2)]
 
-norm expect=NormalizeLikePattern
+# --------------------------------------------------
+# CollapseRepeatedLikeWildcards
+# --------------------------------------------------
+
+norm expect=CollapseRepeatedLikeWildcards
 SELECT s FROM a WHERE s LIKE '%%abc%%%%dddd'
 ----
 select
@@ -1098,17 +1102,31 @@ select
  └── filters
       └── s:4 LIKE '%abc%dddd' [outer=(4), constraints=(/4: (/NULL - ])]
 
-norm expect=NormalizeLikePattern
-SELECT s FROM a WHERE s LIKE '%%abc%%%%dddd'
+norm expect=CollapseRepeatedLikeWildcards
+SELECT s FROM a WHERE s LIKE '%%%%∀%%∀%%%∀%∀%%%%'
 ----
 select
  ├── columns: s:4!null
  ├── scan a
  │    └── columns: s:4
  └── filters
-      └── s:4 LIKE '%abc%dddd' [outer=(4), constraints=(/4: (/NULL - ])]
+      └── s:4 LIKE e'%\U00002200%\U00002200%\U00002200%\U00002200%' [outer=(4), constraints=(/4: (/NULL - ])]
 
-norm expect=NormalizeLikePattern
+# TODO: This case shows an incorrect transformation. The escaped "%" characters
+# are not wildcards, therefore the string has no repeated wildcards that can be
+# collapsed.
+norm
+SELECT s FROM a WHERE s LIKE '\%%a\%%bc\%%'
+----
+select
+ ├── columns: s:4!null
+ ├── fd: ()-->(4)
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 LIKE e'\\%a\\%bc\\%' [outer=(4), constraints=(/4: [/'%a%bc%' - /'%a%bc%']; tight), fd=()-->(4)]
+
+norm expect=CollapseRepeatedLikeWildcards
 SELECT s NOT LIKE 'a%%bcd%%' FROM a
 ----
 project
@@ -1118,7 +1136,7 @@ project
  └── projections
       └── s:4 NOT LIKE 'a%bcd%' [as="?column?":12, outer=(4)]
 
-norm expect=NormalizeLikePattern
+norm expect=CollapseRepeatedLikeWildcards
 SELECT s FROM a WHERE s ILIKE '%%abc%%%%dddd'
 ----
 select
@@ -1128,7 +1146,7 @@ select
  └── filters
       └── s:4 ILIKE '%abc%dddd' [outer=(4), constraints=(/4: (/NULL - ])]
 
-norm expect=NormalizeLikePattern
+norm expect=CollapseRepeatedLikeWildcards
 SELECT s FROM a WHERE s NOT ILIKE 'abcd%%%'
 ----
 select
@@ -1138,7 +1156,7 @@ select
  └── filters
       └── s:4 NOT ILIKE 'abcd%' [outer=(4), constraints=(/4: (/NULL - ])]
 
-norm expect=NormalizeLikePattern
+norm expect=CollapseRepeatedLikeWildcards
 SELECT s FROM a WHERE s SIMILAR TO '%a%b%%c%%d'
 ----
 select
@@ -1148,7 +1166,7 @@ select
  └── filters
       └── s:4 SIMILAR TO '%a%b%c%d' [outer=(4), constraints=(/4: [/'' - ])]
 
-norm expect=NormalizeLikePattern
+norm expect=CollapseRepeatedLikeWildcards
 SELECT s FROM a WHERE s NOT SIMILAR TO '%%%%'
 ----
 select
@@ -1157,3 +1175,13 @@ select
  │    └── columns: s:4
  └── filters
       └── s:4 NOT SIMILAR TO '%' [outer=(4), constraints=(/4: (/NULL - ])]
+
+norm expect-not=CollapseRepeatedLikeWildcards
+SELECT s FROM a WHERE s LIKE '%abc%'
+----
+select
+ ├── columns: s:4!null
+ ├── scan a
+ │    └── columns: s:4
+ └── filters
+      └── s:4 LIKE '%abc%' [outer=(4), constraints=(/4: (/NULL - ])]

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -142,7 +142,7 @@ func TestStringListBuilder(t *testing.T) {
 	expect("[one, two]")
 }
 
-func TestCollapseRepeatedChar(t *testing.T) {
+func TestCollapseRepeatedRune(t *testing.T) {
 	type testCase struct {
 		input    string
 		target   rune
@@ -172,13 +172,13 @@ func TestCollapseRepeatedChar(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if result := CollapseRepeatedChar(test.input, test.target); result != test.expected {
+		if result := CollapseRepeatedRune(test.input, test.target); result != test.expected {
 			t.Errorf("%q: expected %q but got %q", test.input, test.expected, result)
 		}
 	}
 }
 
-func BenchmarkCollapseRepeatedChar(b *testing.B) {
+func BenchmarkCollapseRepeatedRune(b *testing.B) {
 	type testCase struct {
 		name  string
 		input string
@@ -193,7 +193,7 @@ func BenchmarkCollapseRepeatedChar(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				_ = CollapseRepeatedChar(tc.input, '%')
+				_ = CollapseRepeatedRune(tc.input, '%')
 			}
 		})
 	}


### PR DESCRIPTION
Cloned #80432, and called the created function inside scalar_funcs.go. Have added tests in testdata/rules/scalar. I don't know 
how the test output is supposed to be written. Please help.
Epic: None
Issue:https://github.com/cockroachdb/cockroach/issues/80192