### PR TITLE
uuid: use cryptographically random ChaCha8 algorithm from math/rand/v2

### DIFF
--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -597,7 +597,7 @@ func (r *randomBackupNemesis) runNemesis(ctx context.Context) error {
 }
 
 func (r *randomBackupNemesis) makeRandomBankTable(prefix string) (string, error) {
-	tableName := fmt.Sprintf("%s_%s", prefix, uuid.FastMakeV4().String())
+	tableName := fmt.Sprintf("%s_%s", prefix, uuid.MakeV4().String())
 	if _, err := r.tenantDB.Exec(fmt.Sprintf(`CREATE TABLE "%s" (id INT PRIMARY KEY, n INT, s STRING)`, tableName)); err != nil {
 		return "", err
 	}

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -380,7 +380,7 @@ func TestStageVersionCheck(t *testing.T) {
 	// To avoid crafting real replicas we use StaleLeaseholderNodeIDs to force
 	// node to stage plan for verification.
 	p := loqrecoverypb.ReplicaUpdatePlan{
-		PlanID:                  uuid.FastMakeV4(),
+		PlanID:                  uuid.MakeV4(),
 		Version:                 v,
 		ClusterID:               tc.Server(0).StorageClusterID().String(),
 		DecommissionedNodeIDs:   []roachpb.NodeID{4},

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -628,7 +628,7 @@ func sendBatchRequest(
 	if err != nil {
 		return kvpb.BatchResponse{}, err
 	}
-	requestFileName := "request-" + uuid.FastMakeV4().String() + ".json"
+	requestFileName := "request-" + uuid.MakeV4().String() + ".json"
 	if err := c.PutString(ctx, reqArg, requestFileName, 0755, c.Node(node)); err != nil {
 		return kvpb.BatchResponse{}, err
 	}

--- a/pkg/jobs/jobsprofiler/profiler_test.go
+++ b/pkg/jobs/jobsprofiler/profiler_test.go
@@ -125,7 +125,7 @@ func TestStorePerNodeProcessorProgressFraction(t *testing.T) {
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 
-	randID := uuid.FastMakeV4()
+	randID := uuid.MakeV4()
 	componentID := execinfrapb.ComponentID{
 		FlowID: execinfrapb.FlowID{UUID: randID},
 		Type:   execinfrapb.ComponentID_PROCESSOR,

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -75,7 +75,7 @@ func TestErrPriority(t *testing.T) {
 	require.Equal(t, ErrorScoreTxnAbort, ErrPriority(unhandledAbort))
 	require.Equal(t, ErrorScoreTxnRestart, ErrPriority(unhandledRetry))
 	{
-		id1 := uuid.Must(uuid.NewV4())
+		id1 := uuid.NewV4()
 		require.Equal(t, ErrorScoreTxnRestart, ErrPriority(&TransactionRetryWithProtoRefreshError{
 			PrevTxnID:       id1,
 			NextTransaction: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: id1}},

--- a/pkg/kv/kvserver/batcheval/declare_test.go
+++ b/pkg/kv/kvserver/batcheval/declare_test.go
@@ -65,7 +65,7 @@ func TestRequestsSerializeWithAllKeys(t *testing.T) {
 			}
 			testTxn := &roachpb.Transaction{
 				TxnMeta: enginepb.TxnMeta{
-					ID:             uuid.FastMakeV4(),
+					ID:             uuid.MakeV4(),
 					Key:            startKey,
 					WriteTimestamp: hlc.Timestamp{WallTime: 1},
 				},

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -338,7 +338,7 @@ type testIntent struct {
 func generateScattered(total int, txns int, maxKeySize int, random *rand.Rand) []testIntent {
 	var txnIds []uuid.UUID
 	for len(txnIds) < txns {
-		txnIds = append(txnIds, uuid.FastMakeV4())
+		txnIds = append(txnIds, uuid.MakeV4())
 	}
 	var intents []testIntent
 	for len(intents) < total {
@@ -367,7 +367,7 @@ func generateSequential(total int, maxTxnSize int, maxKeySize int, random *rand.
 	for ; len(intents) < total; leftForTransaction-- {
 		if leftForTransaction == 0 {
 			leftForTransaction = intnFrom1(random, maxTxnSize)
-			txnUUID = uuid.FastMakeV4()
+			txnUUID = uuid.MakeV4()
 		}
 		intents = append(intents,
 			testIntent{
@@ -425,7 +425,7 @@ func TestGCIntentBatcherErrorHandling(t *testing.T) {
 
 	key1 := []byte("key1")
 	key2 := []byte("key2")
-	txn1 := enginepb.MVCCMetadata{Txn: &enginepb.TxnMeta{ID: uuid.FastMakeV4()}}
+	txn1 := enginepb.MVCCMetadata{Txn: &enginepb.TxnMeta{ID: uuid.MakeV4()}}
 
 	// Verify intent cleanup error is propagated to caller.
 	info := Info{}

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -45,7 +45,7 @@ func newEnv(t *testing.T) *env {
 	// all of it with the datadriven harness!
 	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
 	require.NoError(t, InitEngine(ctx, eng, roachpb.StoreIdent{
-		ClusterID: uuid.FastMakeV4(),
+		ClusterID: uuid.MakeV4(),
 		NodeID:    1,
 		StoreID:   1,
 	}))

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery_test.go
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery_test.go
@@ -97,7 +97,7 @@ func TestClusterInfoMergeChecksDescriptor(t *testing.T) {
 }
 
 func TestClusterInfoMergeSameClusterID(t *testing.T) {
-	uuid1 := uuid.FastMakeV4()
+	uuid1 := uuid.MakeV4()
 	info1 := ClusterReplicaInfo{
 		ClusterID:   uuid1.String(),
 		Descriptors: []roachpb.RangeDescriptor{{RangeID: 1}},
@@ -125,8 +125,8 @@ func TestClusterInfoMergeSameClusterID(t *testing.T) {
 }
 
 func TestClusterInfoMergeRejectDifferentMetadata(t *testing.T) {
-	uuid1 := uuid.FastMakeV4()
-	uuid2 := uuid.FastMakeV4()
+	uuid1 := uuid.MakeV4()
+	uuid2 := uuid.MakeV4()
 	info1 := ClusterReplicaInfo{
 		ClusterID:   uuid1.String(),
 		Descriptors: []roachpb.RangeDescriptor{{RangeID: 1}},
@@ -167,7 +167,7 @@ func TestClusterInfoMergeRejectDifferentMetadata(t *testing.T) {
 }
 
 func TestClusterInfoInitializeByMerge(t *testing.T) {
-	uuid1 := uuid.FastMakeV4().String()
+	uuid1 := uuid.MakeV4().String()
 	version1 := roachpb.Version{Major: 22, Minor: 2}
 	info := ClusterReplicaInfo{
 		ClusterID:   uuid1,

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -134,10 +134,7 @@ func PlanReplicas(
 	deadNodeIDs []roachpb.NodeID,
 	uuidGen uuid.Generator,
 ) (loqrecoverypb.ReplicaUpdatePlan, PlanningReport, error) {
-	planID, err := uuidGen.NewV4()
-	if err != nil {
-		return loqrecoverypb.ReplicaUpdatePlan{}, PlanningReport{}, err
-	}
+	planID := uuidGen.NewV4()
 	var replicas []loqrecoverypb.ReplicaInfo
 	for _, node := range clusterInfo.LocalInfo {
 		replicas = append(replicas, node.Replicas...)

--- a/pkg/kv/kvserver/loqrecovery/plan_test.go
+++ b/pkg/kv/kvserver/loqrecovery/plan_test.go
@@ -39,7 +39,7 @@ func TestVersionIsPreserved(t *testing.T) {
 // infoWithVersion creates a skeleton info that passes all checks beside version.
 func infoWithVersion(v roachpb.Version) loqrecoverypb.ClusterReplicaInfo {
 	return loqrecoverypb.ClusterReplicaInfo{
-		ClusterID: uuid.FastMakeV4().String(),
+		ClusterID: uuid.MakeV4().String(),
 		Version:   v,
 	}
 }

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -218,10 +218,10 @@ func (*seqUUIDGen) NewV3(uuid.UUID, string) uuid.UUID {
 	panic("not implemented")
 }
 
-func (g *seqUUIDGen) NewV4() (uuid.UUID, error) {
+func (g *seqUUIDGen) NewV4() uuid.UUID {
 	nextV4 := g.next()
 	nextV4.SetVersion(uuid.V4)
-	return nextV4, nil
+	return nextV4
 }
 
 func (*seqUUIDGen) NewV5(uuid.UUID, string) uuid.UUID {

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -506,7 +506,7 @@ func TestStageRecoveryPlansToWrongCluster(t *testing.T) {
 
 	sk := tc.ScratchRange(t)
 
-	fakeClusterID, _ := uuid.NewV4()
+	fakeClusterID := uuid.NewV4()
 	// Stage plan with id of different cluster and see if error is raised.
 	plan := makeTestRecoveryPlan(ctx, t, adm)
 	plan.ClusterID = fakeClusterID.String()

--- a/pkg/kv/kvserver/loqrecovery/store_test.go
+++ b/pkg/kv/kvserver/loqrecovery/store_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func createSomePlan(rangeID int) loqrecoverypb.ReplicaUpdatePlan {
-	planID := uuid.FastMakeV4()
+	planID := uuid.MakeV4()
 	return loqrecoverypb.ReplicaUpdatePlan{
 		PlanID: planID,
 		Updates: []loqrecoverypb.ReplicaUpdate{

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -51,7 +51,7 @@ func TestReplicaChecksumVersion(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "matchingVersion", func(t *testing.T, matchingVersion bool) {
 		cc := kvserverpb.ComputeChecksum{
-			ChecksumID: uuid.FastMakeV4(),
+			ChecksumID: uuid.MakeV4(),
 			Mode:       kvpb.ChecksumMode_CHECK_FULL,
 		}
 		if matchingVersion {
@@ -190,7 +190,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	}
 
 	// Checksum computation failed to start.
-	id := uuid.FastMakeV4()
+	id := uuid.MakeV4()
 	c, _ := tc.repl.trackReplicaChecksum(id)
 	close(c.started)
 	rc, err := tc.repl.getChecksum(ctx, id)
@@ -198,7 +198,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	require.Nil(t, rc.Checksum)
 
 	// Checksum computation started, but failed.
-	id = uuid.FastMakeV4()
+	id = uuid.MakeV4()
 	c, _ = tc.repl.trackReplicaChecksum(id)
 	var g errgroup.Group
 	g.Go(func() error {
@@ -213,13 +213,13 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	require.NoError(t, g.Wait())
 
 	// The initial wait for the task start expires. This will take 10ms.
-	id = uuid.FastMakeV4()
+	id = uuid.MakeV4()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "checksum computation did not start")
 	require.Nil(t, rc.Checksum)
 
 	// The computation has started, but the request context timed out.
-	id = uuid.FastMakeV4()
+	id = uuid.MakeV4()
 	c, _ = tc.repl.trackReplicaChecksum(id)
 	g.Go(func() error {
 		c.started <- func() {}
@@ -232,7 +232,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	require.NoError(t, g.Wait())
 
 	// Context is canceled during the initial waiting.
-	id = uuid.FastMakeV4()
+	id = uuid.MakeV4()
 	ctx, cancel = context.WithCancel(context.Background())
 	cancel()
 	rc, err = tc.repl.getChecksum(ctx, id)
@@ -241,7 +241,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 
 	// The task failed to start because the checksum collection request did not
 	// join. Later, when it joins, it doesn't find any trace and times out.
-	id = uuid.FastMakeV4()
+	id = uuid.MakeV4()
 	c, _ = tc.repl.trackReplicaChecksum(id)
 	require.NoError(t, startChecksumTask(context.Background(), id))
 	// TODO(pavelkalinnikov): Avoid this long wait in the test.

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1733,10 +1733,7 @@ func SendEmptySnapshot(
 		return err
 	}
 
-	snapUUID, err := uuid.NewV4()
-	if err != nil {
-		return err
-	}
+	snapUUID := uuid.NewV4()
 
 	// The snapshot must use a Pebble snapshot, since it requires consistent
 	// iterators.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -988,7 +988,7 @@ func MakeTransaction(
 	admissionPriority admissionpb.WorkPriority,
 	omitInRangefeeds bool,
 ) Transaction {
-	u := uuid.FastMakeV4()
+	u := uuid.MakeV4()
 	gul := now.Add(maxOffsetNs, 0)
 
 	return Transaction{

--- a/pkg/rpc/down_node_test.go
+++ b/pkg/rpc/down_node_test.go
@@ -42,7 +42,7 @@ func TestConnectingToDownNode(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "refused", func(t *testing.T, refused bool) {
 		ctx := context.Background()
 
-		rpcCtx := newTestContext(uuid.FastMakeV4(), &timeutil.DefaultTimeSource{}, time.Second, stop.NewStopper())
+		rpcCtx := newTestContext(uuid.MakeV4(), &timeutil.DefaultTimeSource{}, time.Second, stop.NewStopper())
 		defer rpcCtx.Stopper.Stop(ctx)
 		rpcCtx.NodeID.Set(context.Background(), 1)
 

--- a/pkg/server/distsql_flows_test.go
+++ b/pkg/server/distsql_flows_test.go
@@ -31,7 +31,7 @@ func TestMergeDistSQLRemoteFlows(t *testing.T) {
 
 	flowIDs := make([]execinfrapb.FlowID, 4)
 	for i := range flowIDs {
-		flowIDs[i].UUID = uuid.FastMakeV4()
+		flowIDs[i].UUID = uuid.MakeV4()
 	}
 	sort.Slice(flowIDs, func(i, j int) bool {
 		return bytes.Compare(flowIDs[i].GetBytes(), flowIDs[j].GetBytes()) < 0

--- a/pkg/server/node_tombstone_storage_test.go
+++ b/pkg/server/node_tombstone_storage_test.go
@@ -37,8 +37,7 @@ func TestNodeTombstoneStorage(t *testing.T) {
 
 	// The tombstone storage only writes to initialized engines.
 	// We'll test uninited engines at the end of the test.
-	id, err := uuid.NewV4()
-	require.NoError(t, err)
+	id := uuid.NewV4()
 	for i := range engs {
 		require.NoError(t, kvstorage.WriteClusterVersion(ctx, engs[i], clusterversion.TestingClusterVersion))
 		require.NoError(t, kvstorage.InitEngine(ctx, engs[i], roachpb.StoreIdent{

--- a/pkg/sql/catalog/schematelemetry/schema_telemetry_job.go
+++ b/pkg/sql/catalog/schematelemetry/schema_telemetry_job.go
@@ -88,7 +88,7 @@ func (t schemaTelemetryResumer) Resume(ctx context.Context, execCtx interface{})
 		return err
 	}
 
-	events, err := CollectClusterSchemaForTelemetry(ctx, p.ExecCfg(), asOf, uuid.FastMakeV4(), maxRecords)
+	events, err := CollectClusterSchemaForTelemetry(ctx, p.ExecCfg(), asOf, uuid.MakeV4(), maxRecords)
 	if err != nil || len(events) == 0 {
 		return err
 	}

--- a/pkg/sql/catalog/systemschema_test/systemschema_test.go
+++ b/pkg/sql/catalog/systemschema_test/systemschema_test.go
@@ -85,7 +85,7 @@ func runTest(t *testing.T, path string, db *gosql.DB, execCfg *sql.ExecutorConfi
 			return sb.String()
 
 		case "schema_telemetry":
-			snapshotID := uuid.FastMakeV4()
+			snapshotID := uuid.MakeV4()
 			maxRecords := 100000
 			// By default, collect the entirety of the system schema.
 			// In that case, the snapshot ID won't matter.

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -400,7 +400,7 @@ func newDiskQueue(
 		return nil, err
 	}
 	d := &diskQueue{
-		dirName:          uuid.FastMakeV4().String(),
+		dirName:          uuid.MakeV4().String(),
 		typs:             typs,
 		cfg:              cfg,
 		files:            make([]file, 0, 4),

--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -367,17 +367,11 @@ func BenchmarkSortUUID(b *testing.B) {
 						// all abbreviated values are the same, then comparing
 						// them is unnecessary work because we must always fall
 						// back to full comparisons.
-						id, err := uuid.NewV4()
-						if err != nil {
-							b.Fatalf("unexpected error: %s", err)
-						}
+						id := uuid.NewV4()
 						constPrefix := id[:8]
 
 						for j := 0; j < coldata.BatchSize(); j++ {
-							id, err := uuid.NewV4()
-							if err != nil {
-								b.Fatalf("unexpected error: %s", err)
-							}
+							id := uuid.NewV4()
 							idBytes := id[:16]
 							// Make the abbreviated bytes constant constAbbrPct% of
 							// the time.

--- a/pkg/sql/contention/contentionutils/concurrent_buffer_guard_test.go
+++ b/pkg/sql/contention/contentionutils/concurrent_buffer_guard_test.go
@@ -186,7 +186,7 @@ func randomGeneratedInput() (input []pair, expected map[uuid.UUID]int) {
 
 	p := pair{}
 	for i := 0; i < inputSize; i++ {
-		p.k = uuid.FastMakeV4()
+		p.k = uuid.MakeV4()
 		p.v = rand.Int()
 		input = append(input, p)
 		expected[p.k] = p.v

--- a/pkg/sql/contention/event_store_test.go
+++ b/pkg/sql/contention/event_store_test.go
@@ -148,7 +148,7 @@ func TestCollectionThreshold(t *testing.T) {
 		{
 			BlockingEvent: kvpb.ContentionEvent{
 				TxnMeta: enginepb.TxnMeta{
-					ID: uuid.FastMakeV4(),
+					ID: uuid.MakeV4(),
 				},
 				Duration: 10 * time.Millisecond,
 			},
@@ -156,7 +156,7 @@ func TestCollectionThreshold(t *testing.T) {
 		{
 			BlockingEvent: kvpb.ContentionEvent{
 				TxnMeta: enginepb.TxnMeta{
-					ID: uuid.FastMakeV4(),
+					ID: uuid.MakeV4(),
 				},
 				Duration: 2 * time.Second,
 			},
@@ -206,7 +206,7 @@ func BenchmarkEventStoreIntake(b *testing.B) {
 		input := make([]contentionpb.ExtendedContentionEvent, 0, b.N)
 		for i := 0; i < b.N; i++ {
 			event := contentionpb.ExtendedContentionEvent{}
-			event.BlockingEvent.TxnMeta.ID = uuid.FastMakeV4()
+			event.BlockingEvent.TxnMeta.ID = uuid.MakeV4()
 			input = append(input, event)
 		}
 		starter := make(chan struct{})
@@ -271,11 +271,11 @@ func randomlyGenerateTestData(testSize int, numOfCoordinator int) []testData {
 	for i := 0; i < testSize; i++ {
 		tcs = append(tcs, testData{
 			blockingTxn: contentionpb.ResolvedTxnID{
-				TxnID:            uuid.FastMakeV4(),
+				TxnID:            uuid.MakeV4(),
 				TxnFingerprintID: appstatspb.TransactionFingerprintID(math.MaxUint64 - uint64(i)),
 			},
 			waitingTxn: contentionpb.ResolvedTxnID{
-				TxnID:            uuid.FastMakeV4(),
+				TxnID:            uuid.MakeV4(),
 				TxnFingerprintID: appstatspb.TransactionFingerprintID(math.MaxUint64/2 - uint64(i)),
 			},
 			coordinatorNodeID: strconv.Itoa(rand.Intn(numOfCoordinator)),

--- a/pkg/sql/contention/resolver_test.go
+++ b/pkg/sql/contention/resolver_test.go
@@ -41,66 +41,66 @@ func TestResolver(t *testing.T) {
 		tcs := []testData{
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 100,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 900,
 				},
 				coordinatorNodeID: "1",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 101,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 901,
 				},
 				coordinatorNodeID: "1",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 102,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 903,
 				},
 				coordinatorNodeID: "1",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 200,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 904,
 				},
 				coordinatorNodeID: "2",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 201,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 905,
 				},
 				coordinatorNodeID: "2",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 300,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 906,
 				},
 				coordinatorNodeID: "3",
@@ -130,55 +130,55 @@ func TestResolver(t *testing.T) {
 		tcs := []testData{
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 101,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 901,
 				},
 				coordinatorNodeID: "3",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: appstatspb.InvalidTransactionFingerprintID,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 902,
 				},
 				coordinatorNodeID: "1",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 102,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 903,
 				},
 				coordinatorNodeID: "1",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 201,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: appstatspb.InvalidTransactionFingerprintID,
 				},
 				coordinatorNodeID: "2",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: appstatspb.InvalidTransactionFingerprintID,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: appstatspb.InvalidTransactionFingerprintID,
 				},
 				coordinatorNodeID: "2",
@@ -213,11 +213,11 @@ func TestResolver(t *testing.T) {
 		newData := []testData{
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 2000,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 904,
 				},
 				coordinatorNodeID: "2",
@@ -311,26 +311,26 @@ func TestResolver(t *testing.T) {
 
 	t.Run("retry_after_missing_value", func(t *testing.T) {
 		statusServer.clear()
-		missingTxnID := uuid.FastMakeV4()
+		missingTxnID := uuid.MakeV4()
 		tcs := []testData{
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 101,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 901,
 				},
 				coordinatorNodeID: "3",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 102,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 902,
 				},
 				coordinatorNodeID: "1",
@@ -341,7 +341,7 @@ func TestResolver(t *testing.T) {
 					TxnFingerprintID: 1000,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 903,
 				},
 				coordinatorNodeID: "1",
@@ -385,16 +385,16 @@ func TestResolver(t *testing.T) {
 	})
 
 	t.Run("handle_transient_rpc_failure", func(t *testing.T) {
-		missingTxnID1 := uuid.FastMakeV4()
+		missingTxnID1 := uuid.MakeV4()
 		statusServer.clear()
 		tcs := []testData{
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 201,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 901,
 				},
 				coordinatorNodeID: "2",
@@ -405,29 +405,29 @@ func TestResolver(t *testing.T) {
 					TxnFingerprintID: 301,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 902,
 				},
 				coordinatorNodeID: "3",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 100,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 903,
 				},
 				coordinatorNodeID: "1",
 			},
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 101,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 904,
 				},
 				coordinatorNodeID: "1",
@@ -473,7 +473,7 @@ func TestResolver(t *testing.T) {
 
 		// Throw in a second unresolved contention event where the RPC failure
 		// is happening.
-		missingTxnID2 := uuid.FastMakeV4()
+		missingTxnID2 := uuid.MakeV4()
 		tcs = []testData{
 			{
 				blockingTxn: contentionpb.ResolvedTxnID{
@@ -481,7 +481,7 @@ func TestResolver(t *testing.T) {
 					TxnFingerprintID: 202,
 				},
 				waitingTxn: contentionpb.ResolvedTxnID{
-					TxnID:            uuid.FastMakeV4(),
+					TxnID:            uuid.MakeV4(),
 					TxnFingerprintID: 905,
 				},
 				coordinatorNodeID: "2",

--- a/pkg/sql/contention/txnidcache/fifo_cache_test.go
+++ b/pkg/sql/contention/txnidcache/fifo_cache_test.go
@@ -141,7 +141,7 @@ func generateInputBlock(
 	expected = make(map[uuid.UUID]appstatspb.TransactionFingerprintID)
 
 	for i := 0; i < size; i++ {
-		input[i].TxnID = uuid.FastMakeV4()
+		input[i].TxnID = uuid.MakeV4()
 		input[i].TxnFingerprintID =
 			appstatspb.TransactionFingerprintID(rand.Uint64())
 

--- a/pkg/sql/contention/txnidcache/txn_id_cache_test.go
+++ b/pkg/sql/contention/txnidcache/txn_id_cache_test.go
@@ -263,11 +263,11 @@ func TestInvalidTxnID(t *testing.T) {
 
 	inputData := []contentionpb.ResolvedTxnID{
 		{
-			TxnID:            uuid.FastMakeV4(),
+			TxnID:            uuid.MakeV4(),
 			TxnFingerprintID: appstatspb.TransactionFingerprintID(1),
 		},
 		{
-			TxnID:            uuid.FastMakeV4(),
+			TxnID:            uuid.MakeV4(),
 			TxnFingerprintID: appstatspb.TransactionFingerprintID(2),
 		},
 	}

--- a/pkg/sql/contention/txnidcache/writer_test.go
+++ b/pkg/sql/contention/txnidcache/writer_test.go
@@ -177,7 +177,7 @@ func TestTxnIDCacheCanBeDisabledViaClusterSetting(t *testing.T) {
 	sink := &counterSink{}
 	w := newWriter(st, sink)
 	w.Record(contentionpb.ResolvedTxnID{
-		TxnID: uuid.FastMakeV4(),
+		TxnID: uuid.MakeV4(),
 	})
 
 	w.DrainWriteBuffer()
@@ -187,7 +187,7 @@ func TestTxnIDCacheCanBeDisabledViaClusterSetting(t *testing.T) {
 	MaxSize.Override(ctx, &st.SV, 0)
 
 	w.Record(contentionpb.ResolvedTxnID{
-		TxnID: uuid.FastMakeV4(),
+		TxnID: uuid.MakeV4(),
 	})
 	w.DrainWriteBuffer()
 	require.Equal(t, 1, sink.numOfRecord)
@@ -196,7 +196,7 @@ func TestTxnIDCacheCanBeDisabledViaClusterSetting(t *testing.T) {
 	MaxSize.Override(ctx, &st.SV, 1<<10)
 
 	w.Record(contentionpb.ResolvedTxnID{
-		TxnID: uuid.FastMakeV4(),
+		TxnID: uuid.MakeV4(),
 	})
 	w.DrainWriteBuffer()
 	require.Equal(t, 2, sink.numOfRecord)

--- a/pkg/sql/contentionpb/contention_test.go
+++ b/pkg/sql/contentionpb/contention_test.go
@@ -22,17 +22,17 @@ import (
 
 func TestExtendedContentionEventHash(t *testing.T) {
 	event1 := ExtendedContentionEvent{}
-	event1.BlockingEvent.TxnMeta.ID = uuid.FastMakeV4()
-	event1.WaitingTxnID = uuid.FastMakeV4()
+	event1.BlockingEvent.TxnMeta.ID = uuid.MakeV4()
+	event1.WaitingTxnID = uuid.MakeV4()
 	event1.WaitingStmtID = clusterunique.ID{Uint128: uint128.Uint128{Lo: 12, Hi: 987}}
 
 	eventWithDifferentBlockingTxnID := event1
-	eventWithDifferentBlockingTxnID.BlockingEvent.TxnMeta.ID = uuid.FastMakeV4()
+	eventWithDifferentBlockingTxnID.BlockingEvent.TxnMeta.ID = uuid.MakeV4()
 
 	require.NotEqual(t, eventWithDifferentBlockingTxnID.Hash(), event1.Hash())
 
 	eventWithDifferentWaitingTxnID := event1
-	eventWithDifferentWaitingTxnID.WaitingTxnID = uuid.FastMakeV4()
+	eventWithDifferentWaitingTxnID.WaitingTxnID = uuid.MakeV4()
 	require.NotEqual(t, eventWithDifferentWaitingTxnID.Hash(), event1.Hash())
 
 	eventWithDifferentStmtId := event1

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -928,13 +928,13 @@ func TestTxnContentionEventsTableWithRangeDescriptor(t *testing.T) {
 			Key: roachpb.Key(rangeKey),
 			TxnMeta: enginepb.TxnMeta{
 				Key: roachpb.Key(rangeKey),
-				ID:  uuid.FastMakeV4(),
+				ID:  uuid.MakeV4(),
 			},
 
 			Duration: 1 * time.Minute,
 		},
 		BlockingTxnFingerprintID: 9001,
-		WaitingTxnID:             uuid.FastMakeV4(),
+		WaitingTxnID:             uuid.MakeV4(),
 		WaitingTxnFingerprintID:  9002,
 		WaitingStmtID:            clusterunique.ID{Uint128: uint128.Uint128{Lo: 9003, Hi: 1004}},
 		WaitingStmtFingerprintID: 9004,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4878,7 +4878,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	localityFiler roachpb.Locality,
 ) *PlanningCtx {
 	distribute := distributionType == FullDistribution
-	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID)
+	infra := physicalplan.NewPhysicalInfrastructure(uuid.MakeV4(), dsp.gatewaySQLInstanceID)
 	planCtx := &PlanningCtx{
 		ExtendedEvalCtx: evalCtx,
 		localityFilter:  localityFiler,

--- a/pkg/sql/distsql_plan_set_op_test.go
+++ b/pkg/sql/distsql_plan_set_op_test.go
@@ -60,7 +60,7 @@ func TestMergeResultTypesForSetOp(t *testing.T) {
 			}
 		}
 	}
-	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
+	infra := physicalplan.NewPhysicalInfrastructure(uuid.MakeV4(), base.SQLInstanceID(1))
 	var leftPlan, rightPlan PhysicalPlan
 	leftPlan.PhysicalInfrastructure = infra
 	rightPlan.PhysicalInfrastructure = infra

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -721,7 +721,7 @@ func TestCancelFlowsCoordinator(t *testing.T) {
 	// has 67% probability of participating in the plan.
 	makeFlowsToCancel := func(rng *rand.Rand) map[base.SQLInstanceID]*execinfrapb.FlowSpec {
 		res := make(map[base.SQLInstanceID]*execinfrapb.FlowSpec)
-		flowID := execinfrapb.FlowID{UUID: uuid.FastMakeV4()}
+		flowID := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 		for id := 1; id <= numNodes; id++ {
 			if rng.Float64() < 0.33 {
 				// This node wasn't a part of the current plan.

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -675,7 +675,7 @@ func TestFlowCancelPartiallyBlocked(t *testing.T) {
 	// RegisterFlow with an immediate timeout.
 	flow := &FlowBase{
 		FlowCtx: execinfra.FlowCtx{
-			ID: execinfrapb.FlowID{UUID: uuid.FastMakeV4()},
+			ID: execinfrapb.FlowID{UUID: uuid.MakeV4()},
 		},
 		inboundStreams: inboundStreams,
 		flowRegistry:   fr,

--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -132,7 +132,7 @@ func TestShowJobsWithExecutionDetails(t *testing.T) {
 		return fakeExecResumer{
 			OnResume: func(ctx context.Context) error {
 				p := sql.PhysicalPlan{}
-				infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
+				infra := physicalplan.NewPhysicalInfrastructure(uuid.MakeV4(), base.SQLInstanceID(1))
 				p.PhysicalInfrastructure = infra
 				jobsprofiler.StorePlanDiagram(ctx, s.Stopper(), &p, s.InternalDB().(isql.DB), j.ID())
 				checkForPlanDiagrams(ctx, t, s.InternalDB().(isql.DB), j.ID(), 1)
@@ -183,7 +183,7 @@ func TestReadWriteProfilerExecutionDetails(t *testing.T) {
 			return fakeExecResumer{
 				OnResume: func(ctx context.Context) error {
 					p := sql.PhysicalPlan{}
-					infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
+					infra := physicalplan.NewPhysicalInfrastructure(uuid.MakeV4(), base.SQLInstanceID(1))
 					p.PhysicalInfrastructure = infra
 					jobsprofiler.StorePlanDiagram(ctx, s.Stopper(), &p, s.InternalDB().(isql.DB), j.ID())
 					checkForPlanDiagrams(ctx, t, s.InternalDB().(isql.DB), j.ID(), 1)
@@ -346,7 +346,7 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 		return fakeExecResumer{
 			OnResume: func(ctx context.Context) error {
 				p := sql.PhysicalPlan{}
-				infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
+				infra := physicalplan.NewPhysicalInfrastructure(uuid.MakeV4(), base.SQLInstanceID(1))
 				p.PhysicalInfrastructure = infra
 				jobsprofiler.StorePlanDiagram(ctx, s.Stopper(), &p, s.InternalDB().(isql.DB), j.ID())
 				checkForPlanDiagrams(ctx, t, s.InternalDB().(isql.DB), j.ID(), expectedDiagrams)

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -75,7 +75,7 @@ func runTestFlow(
 		Version:           execinfra.Version,
 		LeafTxnInputState: leafInputState,
 		Flow: execinfrapb.FlowSpec{
-			FlowID:     execinfrapb.FlowID{UUID: uuid.FastMakeV4()},
+			FlowID:     execinfrapb.FlowID{UUID: uuid.MakeV4()},
 			Processors: procs,
 		},
 	}

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -184,7 +184,7 @@ func RandDatumWithNullChance(
 			sign*rng.Int63n(1000),
 		)}
 	case types.UuidFamily:
-		gen := uuid.NewGenWithReader(rng)
+		gen := uuid.NewGenWithRand(rng.Uint64)
 		return tree.NewDUuid(tree.DUuid{UUID: uuid.Must(gen.NewV4())})
 	case types.INetFamily:
 		ipAddr := ipaddr.RandIPAddr(rng)

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -185,7 +185,7 @@ func RandDatumWithNullChance(
 		)}
 	case types.UuidFamily:
 		gen := uuid.NewGenWithRand(rng.Uint64)
-		return tree.NewDUuid(tree.DUuid{UUID: uuid.Must(gen.NewV4())})
+		return tree.NewDUuid(tree.DUuid{UUID: gen.NewV4()})
 	case types.INetFamily:
 		ipAddr := ipaddr.RandIPAddr(rng)
 		return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipAddr})

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9038,10 +9038,7 @@ func generateRandomUUID4Impl() builtinDefinition {
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
 			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				uv, err := uuid.NewV4()
-				if err != nil {
-					return nil, err
-				}
+				uv := uuid.NewV4()
 				return tree.NewDUuid(tree.DUuid{UUID: uv}), nil
 			},
 			Info:       "Generates a random version 4 UUID, and returns it as a value of UUID type.",

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -642,7 +642,7 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	db := sqlutils.MakeSQLRunner(sqlDB)
 	db.Exec(t, `SET CLUSTER SETTING sql.stats.activity.flush.enabled = true;`)
 	// Generate a random app name each time to avoid conflicts
-	appName := "test_status_api" + uuid.FastMakeV4().String()
+	appName := "test_status_api" + uuid.MakeV4().String()
 	db.Exec(t, "SET SESSION application_name = $1", appName)
 
 	// Generate some sql stats data.

--- a/pkg/sql/sqlliveness/slstorage/sessionid_test.go
+++ b/pkg/sql/sqlliveness/slstorage/sessionid_test.go
@@ -27,9 +27,9 @@ func FuzzSessionIDEncoding(f *testing.F) {
 	defer log.Scope(f).Close(f)
 
 	f.Add(string(""))
-	f.Add(string(uuid.FastMakeV4().GetBytes()))
+	f.Add(string(uuid.MakeV4().GetBytes()))
 
-	session, err := slstorage.MakeSessionID(enum.One, uuid.FastMakeV4())
+	session, err := slstorage.MakeSessionID(enum.One, uuid.MakeV4())
 	require.NoError(f, err)
 	f.Add(string(session))
 

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -46,7 +46,7 @@ func TestRegistry(t *testing.T) {
 	session := Session{ID: clusterunique.IDFromBytes([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))}
 
 	t.Run("slow detection", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -83,7 +83,7 @@ func TestRegistry(t *testing.T) {
 	t.Run("failure detection", func(t *testing.T) {
 		// Verify that statement error info gets bubbled up to the transaction
 		// when the transaction does not have this information.
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		statement := &Statement{
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
 			FingerprintID:    appstatspb.StmtFingerprintID(100),
@@ -128,7 +128,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -153,7 +153,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("too fast", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		st := cluster.MakeTestingClusterSettings()
 		LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
 		statement2 := &Statement{
@@ -177,7 +177,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("buffering statements per session", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -185,7 +185,7 @@ func TestRegistry(t *testing.T) {
 			LatencyInSeconds: 2,
 		}
 		otherSession := Session{ID: clusterunique.IDFromBytes([]byte("cccccccccccccccccccccccccccccccc"))}
-		otherTransaction := &Transaction{ID: uuid.FastMakeV4()}
+		otherTransaction := &Transaction{ID: uuid.MakeV4()}
 		otherStatement := &Statement{
 			ID:               clusterunique.IDFromBytes([]byte("dddddddddddddddddddddddddddddddd")),
 			FingerprintID:    appstatspb.StmtFingerprintID(101),
@@ -231,7 +231,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("sibling statements without problems", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		statement := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
@@ -274,14 +274,14 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("txn with no stmts", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		st := cluster.MakeTestingClusterSettings()
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, newStore(st))
 		require.NotPanics(t, func() { registry.ObserveTransaction(session.ID, transaction) })
 	})
 
 	t.Run("txn with high accumulated contention without high single stmt contention", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		st := cluster.MakeTestingClusterSettings()
 		store := newStore(st)
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, store)
@@ -292,7 +292,7 @@ func TestRegistry(t *testing.T) {
 			FingerprintID:    appstatspb.StmtFingerprintID(100),
 			LatencyInSeconds: 0.00001,
 		}
-		txnHighContention := &Transaction{ID: uuid.FastMakeV4(), Contention: &contentionDuration}
+		txnHighContention := &Transaction{ID: uuid.MakeV4(), Contention: &contentionDuration}
 
 		registry.ObserveStatement(session.ID, statement)
 		registry.ObserveTransaction(session.ID, txnHighContention)
@@ -325,7 +325,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("statement that is slow but should be ignored", func(t *testing.T) {
-		transaction := &Transaction{ID: uuid.FastMakeV4()}
+		transaction := &Transaction{ID: uuid.MakeV4()}
 		statementNotIgnored := &Statement{
 			Status:           Statement_Completed,
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),

--- a/pkg/sql/sqlstats/insights/store_test.go
+++ b/pkg/sql/sqlstats/insights/store_test.go
@@ -43,7 +43,7 @@ func TestStore(t *testing.T) {
 func addInsight(store *lockingStore, idBase uint64) {
 	store.AddInsight(&Insight{
 		Transaction: &Transaction{
-			ID: uuid.FastMakeV4(),
+			ID: uuid.MakeV4(),
 		},
 		Statements: []*Statement{{ID: clusterunique.ID{Uint128: uint128.FromInts(0, idBase)}}},
 	})

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -779,7 +779,7 @@ func TestSQLStatsPlanSampling(t *testing.T) {
 
 	dbName := "defaultdb"
 
-	appName := fmt.Sprintf("TestSQLStatsPlanSampling_%s", uuid.FastMakeV4().String())
+	appName := fmt.Sprintf("TestSQLStatsPlanSampling_%s", uuid.MakeV4().String())
 	sqlRun.Exec(t, "SET application_name = $1", appName)
 
 	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)

--- a/pkg/util/uuid/benchmark_fast_test.go
+++ b/pkg/util/uuid/benchmark_fast_test.go
@@ -16,24 +16,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-func BenchmarkFastMakeV4(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		uuid.FastMakeV4()
-	}
-}
-
 func BenchmarkMakeV4(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		uuid.MakeV4()
 	}
-}
-
-func BenchmarkConcurrentFastMakeV4(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			uuid.FastMakeV4()
-		}
-	})
 }
 
 func BenchmarkConcurrentMakeV4(b *testing.B) {

--- a/pkg/util/uuid/benchmark_fast_test.go
+++ b/pkg/util/uuid/benchmark_fast_test.go
@@ -27,3 +27,19 @@ func BenchmarkMakeV4(b *testing.B) {
 		uuid.MakeV4()
 	}
 }
+
+func BenchmarkConcurrentFastMakeV4(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			uuid.FastMakeV4()
+		}
+	})
+}
+
+func BenchmarkConcurrentMakeV4(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			uuid.MakeV4()
+		}
+	})
+}

--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"io"
 	math_rand "math/rand/v2"
 	"net"
 	"sync"
@@ -92,7 +91,9 @@ type Gen struct {
 	hardwareAddrOnce  sync.Once
 	storageMutex      syncutil.Mutex
 
-	rand io.Reader
+	// randUint64 is the function used to generate random uint64 values. The
+	// function is stored directly to avoid the overhead of interface dispatch.
+	randUint64 func() uint64
 
 	epochFunc     epochFunc
 	hwAddrFunc    HWAddrFunc
@@ -111,11 +112,11 @@ func NewGen() *Gen {
 	return NewGenWithHWAF(defaultHWAddrFunc)
 }
 
-// NewGenWithReader returns a new instance of gen which uses r as its source of
-// randomness.
-func NewGenWithReader(r io.Reader) *Gen {
+// NewGenWithRand returns a new instance of gen which uses randUint64 as its
+// source of randomness.
+func NewGenWithRand(randUint64 func() uint64) *Gen {
 	g := NewGen()
-	g.rand = r
+	g.randUint64 = randUint64
 	return g
 }
 
@@ -134,7 +135,10 @@ func NewGenWithHWAF(hwaf HWAddrFunc) *Gen {
 	return &Gen{
 		epochFunc:  time.Now,
 		hwAddrFunc: hwaf,
-		rand:       mathRandReader{},
+		// "math/rand".Uint64 is safe for concurrent use. As of go1.22, the
+		// math/rand (and math/rand/v2) package uses a cryptographically secure RNG.
+		// See https://go.dev/blog/randv2 and https://go.dev/blog/chacha8rand.
+		randUint64: math_rand.Uint64,
 	}
 }
 
@@ -142,10 +146,7 @@ func NewGenWithHWAF(hwaf HWAddrFunc) *Gen {
 func (g *Gen) NewV1() (UUID, error) {
 	u := UUID{}
 
-	timeNow, clockSeq, err := g.getClockSequence()
-	if err != nil {
-		return Nil, err
-	}
+	timeNow, clockSeq := g.getClockSequence()
 	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
 	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
 	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
@@ -175,16 +176,8 @@ func (g *Gen) NewV3(ns UUID, name string) UUID {
 // NewV4 returns a randomly generated UUID.
 func (g *Gen) NewV4() (UUID, error) {
 	u := UUID{}
-	if r, ok := g.rand.(mathRandReader); ok {
-		binary.BigEndian.PutUint64(u[:Size/2], r.Uint64())
-		binary.BigEndian.PutUint64(u[Size/2:], r.Uint64())
-	} else {
-		willEscape := UUID{}
-		if _, err := io.ReadFull(g.rand, willEscape[:]); err != nil {
-			return Nil, err
-		}
-		u = willEscape
-	}
+	binary.BigEndian.PutUint64(u[:Size/2], g.randUint64())
+	binary.BigEndian.PutUint64(u[Size/2:], g.randUint64())
 	u.SetVersion(V4)
 	u.SetVariant(VariantRFC4122)
 
@@ -201,18 +194,12 @@ func (g *Gen) NewV5(ns UUID, name string) UUID {
 }
 
 // Returns the epoch and clock sequence.
-func (g *Gen) getClockSequence() (uint64, uint16, error) {
-	var err error
+func (g *Gen) getClockSequence() (uint64, uint16) {
 	g.clockSequenceOnce.Do(func() {
-		buf := make([]byte, 2)
-		if _, err = io.ReadFull(g.rand, buf); err != nil {
-			return
-		}
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf[:], g.randUint64())
 		g.clockSequence = binary.BigEndian.Uint16(buf)
 	})
-	if err != nil {
-		return 0, 0, err
-	}
 
 	g.storageMutex.Lock()
 	defer g.storageMutex.Unlock()
@@ -225,7 +212,7 @@ func (g *Gen) getClockSequence() (uint64, uint16, error) {
 	}
 	g.lastTime = timeNow
 
-	return timeNow, g.clockSequence, nil
+	return timeNow, g.clockSequence
 }
 
 // Returns the hardware address.
@@ -238,11 +225,13 @@ func (g *Gen) getHardwareAddr() ([]byte, error) {
 			return
 		}
 
-		// Initialize hardwareAddr randomly in case
-		// of real network interfaces absence.
-		if _, err = io.ReadFull(g.rand, g.hardwareAddr[:]); err != nil {
-			return
+		// Initialize hardwareAddr randomly in case of real network interfaces
+		// absence.
+		hwAddr, err = RandomHardwareAddrFunc()
+		if err != nil {
+			panic("RandomHardwareAddrFunc does not return an error")
 		}
+		copy(g.hardwareAddr[:], hwAddr)
 		// Set multicast bit as recommended by RFC-4122
 		g.hardwareAddr[0] |= 0x01
 	})
@@ -287,7 +276,8 @@ func defaultHWAddrFunc() (net.HardwareAddr, error) {
 }
 
 // RandomHardwareAddrFunc returns a random hardware address, with the multicast
-// and local-admin bits set as per the IEEE802 spec.
+// and local-admin bits set as per the IEEE802 spec. This function never
+// returns an error, but the signature has to match the HWAddrFunc type.
 func RandomHardwareAddrFunc() (net.HardwareAddr, error) {
 	var hardwareAddr = make([]byte, 8)
 	binary.BigEndian.PutUint64(hardwareAddr, math_rand.Uint64())

--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	math_rand "math/rand/v2"
 	"net"
 	"sync"
 	"time"
@@ -175,11 +176,8 @@ func (g *Gen) NewV3(ns UUID, name string) UUID {
 func (g *Gen) NewV4() (UUID, error) {
 	u := UUID{}
 	if r, ok := g.rand.(mathRandReader); ok {
-		if n, err := r.Read(u[:]); n != len(u) {
-			panic("math/rand.Read always returns len(p)")
-		} else if err != nil {
-			panic("math/rand.Read always returns a nil error")
-		}
+		binary.BigEndian.PutUint64(u[:Size/2], r.Uint64())
+		binary.BigEndian.PutUint64(u[Size/2:], r.Uint64())
 	} else {
 		willEscape := UUID{}
 		if _, err := io.ReadFull(g.rand, willEscape[:]); err != nil {
@@ -291,12 +289,10 @@ func defaultHWAddrFunc() (net.HardwareAddr, error) {
 // RandomHardwareAddrFunc returns a random hardware address, with the multicast
 // and local-admin bits set as per the IEEE802 spec.
 func RandomHardwareAddrFunc() (net.HardwareAddr, error) {
-	var err error
-	var hardwareAddr = make(net.HardwareAddr, 6)
-	if _, err = io.ReadFull(mathRandReader{}, hardwareAddr[:]); err != nil {
-		return []byte{}, err
-	}
+	var hardwareAddr = make([]byte, 8)
+	binary.BigEndian.PutUint64(hardwareAddr, math_rand.Uint64())
 	// Set multicast bit and local-admin bit to match Postgres.
 	hardwareAddr[0] |= 0x03
-	return hardwareAddr, nil
+	// Discard the last 2 bytes.
+	return hardwareAddr[:6], nil
 }

--- a/pkg/util/uuid/generator.go
+++ b/pkg/util/uuid/generator.go
@@ -57,7 +57,7 @@ func NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns a randomly generated UUID.
-func NewV4() (UUID, error) {
+func NewV4() UUID {
 	return DefaultGenerator.NewV4()
 }
 
@@ -71,7 +71,7 @@ type Generator interface {
 	NewV1() (UUID, error)
 	// NewV2(domain byte) (UUID, error) // CRL: Removed support for V2.
 	NewV3(ns UUID, name string) UUID
-	NewV4() (UUID, error)
+	NewV4() UUID
 	NewV5(ns UUID, name string) UUID
 }
 
@@ -174,14 +174,14 @@ func (g *Gen) NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns a randomly generated UUID.
-func (g *Gen) NewV4() (UUID, error) {
+func (g *Gen) NewV4() UUID {
 	u := UUID{}
 	binary.BigEndian.PutUint64(u[:Size/2], g.randUint64())
 	binary.BigEndian.PutUint64(u[Size/2:], g.randUint64())
 	u.SetVersion(V4)
 	u.SetVariant(VariantRFC4122)
 
-	return u, nil
+	return u
 }
 
 // NewV5 returns a UUID based on SHA-1 hash of the namespace UUID and name.

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -360,12 +360,7 @@ func BenchmarkGenerator(b *testing.B) {
 	})
 	b.Run("V4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			Must(NewV4())
-		}
-	})
-	b.Run("FastV4", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			FastMakeV4()
+			MakeV4()
 		}
 	})
 	b.Run("V5", func(b *testing.B) {

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -213,10 +213,7 @@ func testNewV4(t *testing.T) {
 }
 
 func testNewV4Basic(t *testing.T) {
-	u, err := NewV4()
-	if err != nil {
-		t.Fatal(err)
-	}
+	u := NewV4()
 	if got, want := u.Version(), V4; got != want {
 		t.Errorf("got version %d, want %d", got, want)
 	}
@@ -226,14 +223,8 @@ func testNewV4Basic(t *testing.T) {
 }
 
 func testNewV4DifferentAcrossCalls(t *testing.T) {
-	u1, err := NewV4()
-	if err != nil {
-		t.Fatal(err)
-	}
-	u2, err := NewV4()
-	if err != nil {
-		t.Fatal(err)
-	}
+	u1 := NewV4()
+	u2 := NewV4()
 	if u1 == u2 {
 		t.Errorf("generated identical UUIDs across calls: %v", u1)
 	}

--- a/pkg/util/uuid/generator_test.go
+++ b/pkg/util/uuid/generator_test.go
@@ -18,8 +18,8 @@ package uuid
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
+	math_rand "math/rand/v2"
 	"net"
 	"testing"
 	"time"
@@ -38,9 +38,7 @@ func testNewV1(t *testing.T) {
 	t.Run("Basic", testNewV1Basic)
 	t.Run("DifferentAcrossCalls", testNewV1DifferentAcrossCalls)
 	t.Run("StaleEpoch", testNewV1StaleEpoch)
-	t.Run("FaultyRand", testNewV1FaultyRand)
 	t.Run("MissingNetwork", testNewV1MissingNetwork)
-	t.Run("MissingNetworkFaultyRand", testNewV1MissingNetworkFaultyRand)
 }
 
 func TestNewGenWithHWAF(t *testing.T) {
@@ -131,7 +129,7 @@ func testNewV1StaleEpoch(t *testing.T) {
 			return timeutil.Unix(0, 0)
 		},
 		hwAddrFunc: defaultHWAddrFunc,
-		rand:       rand.Reader,
+		randUint64: math_rand.Uint64,
 	}
 	u1, err := g.NewV1()
 	if err != nil {
@@ -146,50 +144,17 @@ func testNewV1StaleEpoch(t *testing.T) {
 	}
 }
 
-func testNewV1FaultyRand(t *testing.T) {
-	g := &Gen{
-		epochFunc:  time.Now,
-		hwAddrFunc: defaultHWAddrFunc,
-		rand: &faultyReader{
-			readToFail: 0, // fail immediately
-		},
-	}
-	u, err := g.NewV1()
-	if err == nil {
-		t.Fatalf("got %v, want error", u)
-	}
-	if u != Nil {
-		t.Fatalf("got %v on error, want Nil", u)
-	}
-}
-
 func testNewV1MissingNetwork(t *testing.T) {
 	g := &Gen{
 		epochFunc: time.Now,
 		hwAddrFunc: func() (net.HardwareAddr, error) {
 			return []byte{}, fmt.Errorf("uuid: no hw address found")
 		},
-		rand: rand.Reader,
+		randUint64: math_rand.Uint64,
 	}
 	_, err := g.NewV1()
 	if err != nil {
 		t.Errorf("did not handle missing network interfaces: %v", err)
-	}
-}
-
-func testNewV1MissingNetworkFaultyRand(t *testing.T) {
-	g := &Gen{
-		epochFunc: time.Now,
-		hwAddrFunc: func() (net.HardwareAddr, error) {
-			return []byte{}, fmt.Errorf("uuid: no hw address found")
-		},
-		rand: &faultyReader{
-			readToFail: 1,
-		},
-	}
-	u, err := g.NewV1()
-	if err == nil {
-		t.Errorf("did not error on faulty reader and missing network, got %v", u)
 	}
 }
 
@@ -245,8 +210,6 @@ func testNewV3DifferentNamespaces(t *testing.T) {
 func testNewV4(t *testing.T) {
 	t.Run("Basic", testNewV4Basic)
 	t.Run("DifferentAcrossCalls", testNewV4DifferentAcrossCalls)
-	t.Run("FaultyRand", testNewV4FaultyRand)
-	t.Run("ShortRandomRead", testNewV4ShortRandomRead)
 }
 
 func testNewV4Basic(t *testing.T) {
@@ -273,34 +236,6 @@ func testNewV4DifferentAcrossCalls(t *testing.T) {
 	}
 	if u1 == u2 {
 		t.Errorf("generated identical UUIDs across calls: %v", u1)
-	}
-}
-
-func testNewV4FaultyRand(t *testing.T) {
-	g := &Gen{
-		epochFunc:  time.Now,
-		hwAddrFunc: defaultHWAddrFunc,
-		rand: &faultyReader{
-			readToFail: 0, // fail immediately
-		},
-	}
-	u, err := g.NewV4()
-	if err == nil {
-		t.Errorf("got %v, nil error", u)
-	}
-}
-
-func testNewV4ShortRandomRead(t *testing.T) {
-	g := &Gen{
-		epochFunc: time.Now,
-		hwAddrFunc: func() (net.HardwareAddr, error) {
-			return []byte{}, fmt.Errorf("uuid: no hw address found")
-		},
-		rand: bytes.NewReader([]byte{42}),
-	}
-	u, err := g.NewV4()
-	if err == nil {
-		t.Errorf("got %v, nil error", u)
 	}
 }
 
@@ -368,17 +303,4 @@ func BenchmarkGenerator(b *testing.B) {
 			NewV5(NamespaceDNS, "www.example.com")
 		}
 	})
-}
-
-type faultyReader struct {
-	callsNum   int
-	readToFail int // Read call number to fail
-}
-
-func (r *faultyReader) Read(dest []byte) (int, error) {
-	r.callsNum++
-	if (r.callsNum - 1) == r.readToFail {
-		return 0, fmt.Errorf("io: reader is faulty")
-	}
-	return rand.Read(dest)
 }

--- a/pkg/util/uuid/uuid_test.go
+++ b/pkg/util/uuid/uuid_test.go
@@ -165,7 +165,7 @@ func TestTimestampFromV1(t *testing.T) {
 		want    Timestamp
 		wanterr bool
 	}{
-		{u: Must(NewV4()), wanterr: true},
+		{u: NewV4(), wanterr: true},
 		{u: Must(FromString("00000000-0000-1000-0000-000000000000")), want: 0},
 		{u: Must(FromString("424f137e-a2aa-11e8-98d0-529269fb1459")), want: 137538640775418750},
 		{u: Must(FromString("ffffffff-ffff-1fff-ffff-ffffffffffff")), want: Timestamp(1<<60 - 1)},

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -93,9 +93,9 @@ func (u *UUID) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-// MakeV4 calls Must(NewV4)
+// MakeV4 calls NewV4.
 func MakeV4() UUID {
-	return Must(NewV4())
+	return NewV4()
 }
 
 // NewPopulatedUUID returns a populated UUID.

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -99,16 +99,6 @@ func MakeV4() UUID {
 	return Must(NewV4())
 }
 
-// FastMakeV4 generates a UUID using a fast but not cryptographically secure
-// source of randomness.
-func FastMakeV4() UUID {
-	u, err := fastGen.NewV4()
-	if err != nil {
-		panic(errors.Wrap(err, "should never happen with math/rand.Rand"))
-	}
-	return u
-}
-
 // mathRandReader is an io.Reader that calls through to "math/rand".Read
 // which is safe for concurrent use.
 type mathRandReader struct{}
@@ -119,9 +109,6 @@ func (r mathRandReader) Read(p []byte) (n int, err error) {
 	//lint:ignore SA1019 deprecated
 	return math_rand.Read(p)
 }
-
-// fastGen is a non-cryptographically secure Generator.
-var fastGen = NewGenWithReader(mathRandReader{})
 
 // NewPopulatedUUID returns a populated UUID.
 func NewPopulatedUUID(r interface {

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -14,7 +14,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	math_rand "math/rand"
+	math_rand "math/rand/v2"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
@@ -104,10 +104,11 @@ func MakeV4() UUID {
 type mathRandReader struct{}
 
 func (r mathRandReader) Read(p []byte) (n int, err error) {
-	// https://github.com/cockroachdb/cockroach/issues/110597 tracks this
-	// deprecated usage.
-	//lint:ignore SA1019 deprecated
-	return math_rand.Read(p)
+	panic("unimplemented")
+}
+
+func (r mathRandReader) Uint64() uint64 {
+	return math_rand.Uint64()
 }
 
 // NewPopulatedUUID returns a populated UUID.

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -14,7 +14,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	math_rand "math/rand/v2"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
@@ -97,18 +96,6 @@ func (u *UUID) UnmarshalJSON(data []byte) error {
 // MakeV4 calls Must(NewV4)
 func MakeV4() UUID {
 	return Must(NewV4())
-}
-
-// mathRandReader is an io.Reader that calls through to "math/rand".Read
-// which is safe for concurrent use.
-type mathRandReader struct{}
-
-func (r mathRandReader) Read(p []byte) (n int, err error) {
-	panic("unimplemented")
-}
-
-func (r mathRandReader) Uint64() uint64 {
-	return math_rand.Uint64()
 }
 
 // NewPopulatedUUID returns a populated UUID.

--- a/pkg/workload/movr/workload.go
+++ b/pkg/workload/movr/workload.go
@@ -37,10 +37,7 @@ type movrWorker struct {
 }
 
 func (m *movrWorker) getRandomUser(city string) (string, error) {
-	id, err := uuid.NewV4()
-	if err != nil {
-		return "", err
-	}
+	id := uuid.NewV4()
 	var user string
 	q := `
 		SELECT
@@ -53,15 +50,12 @@ func (m *movrWorker) getRandomUser(city string) (string, error) {
 					(SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT 1) AS b
 			);
 		`
-	err = m.db.QueryRow(q, city, id.String()).Scan(&user)
+	err := m.db.QueryRow(q, city, id.String()).Scan(&user)
 	return user, err
 }
 
 func (m *movrWorker) getRandomPromoCode() (string, error) {
-	id, err := uuid.NewV4()
-	if err != nil {
-		return "", err
-	}
+	id := uuid.NewV4()
 	q := `
 		SELECT
 			IFNULL(a, b)
@@ -74,15 +68,12 @@ func (m *movrWorker) getRandomPromoCode() (string, error) {
 			);
 		`
 	var code string
-	err = m.db.QueryRow(q, id.String()).Scan(&code)
+	err := m.db.QueryRow(q, id.String()).Scan(&code)
 	return code, err
 }
 
 func (m *movrWorker) getRandomVehicle(city string) (string, error) {
-	id, err := uuid.NewV4()
-	if err != nil {
-		return "", err
-	}
+	id := uuid.NewV4()
 	q := `
 		SELECT
 			IFNULL(a, b)
@@ -95,7 +86,7 @@ func (m *movrWorker) getRandomVehicle(city string) (string, error) {
 			);
 		`
 	var vehicle string
-	err = m.db.QueryRow(q, city, id.String()).Scan(&vehicle)
+	err := m.db.QueryRow(q, city, id.String()).Scan(&vehicle)
 	return vehicle, err
 }
 
@@ -263,10 +254,7 @@ func (m *movrWorker) generateWorkSimulation() func(context.Context) error {
 
 	return func(ctx context.Context) error {
 		activeCity := randCity(m.rng)
-		id, err := uuid.NewV4()
-		if err != nil {
-			return err
-		}
+		id := uuid.NewV4()
 		// Our workload is as follows: with 95% chance, do a simple read operation.
 		// Else, update all active vehicle locations, then pick a random "write" operation
 		// weighted by the weights in movrWorkloadFns.
@@ -275,7 +263,7 @@ func (m *movrWorker) generateWorkSimulation() func(context.Context) error {
 				return m.readVehicles(activeCity)
 			})
 		}
-		err = runAndRecord("updateActiveRides", func() error {
+		err := runAndRecord("updateActiveRides", func() error {
 			return m.updateActiveRides()
 		})
 		if err != nil {

--- a/pkg/workload/workloadsql/workloadsql_test.go
+++ b/pkg/workload/workloadsql/workloadsql_test.go
@@ -122,10 +122,7 @@ func TestSplits(t *testing.T) {
 				Name:   `uuids`,
 				Schema: `(a UUID PRIMARY KEY)`,
 				Splits: workload.Tuples(ranges-1, func(i int) []interface{} {
-					u, err := uuid.NewV4()
-					if err != nil {
-						panic(err)
-					}
+					u := uuid.NewV4()
 					return []interface{}{u.String()}
 				}),
 			},

--- a/scripts/bench
+++ b/scripts/bench
@@ -52,7 +52,7 @@ for (( i=0; i<${#shas[@]}; i+=1 )); do
   sha=${shas[i]}
   echo "Switching to $name"
   git checkout -q "$sha"
-  (set -x; ./dev bench ${PKG} --timeout=${BENCHTIMEOUT:-5m} --filter=${BENCHES} --count=${N:-10} $benchtime --bench-mem -v --stream-output --ignore-cache | tee "${dest}/bench.${name}" 2> "${dest}/log.txt")
+  (set -x; ./dev bench ${PKG} --timeout=${BENCHTIMEOUT:-5m} --filter=${BENCHES} --count=${N:-10} $benchtime --bench-mem -v --stream-output --ignore-cache --test-args='-test.cpu 8' | tee "${dest}/bench.${name}" 2> "${dest}/log.txt")
 done
 
 benchstat "${dest}/bench.$OLDNAME" "${dest}/bench.$NEWNAME"


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/109397

###  uuid: add parallel benchmark

This lets us test the effect of sharing a global random source
between multiple threads.

### uuid: use mathRandReader instead of crypto/rand

go1.22 uses a new random number generator called ChaCha8, and it is
cryptographically random. We can use this instead of the slower
crypto/rand random source to ensure UUID uniqueness.

https://go.dev/blog/chacha8rand

### *: rename FastMakeV4 to MakeV4

There's no need for a separate FastMakeV4 function now; it's the same as
MakeV4.

###  uuid: use math/rand/v2

This new rand package is an improvement since it makes it impossible to
accidentally set a global seed for the shared RNG, which would make
UUIDs become entirely predictable and collision-prone.

It also appears to be faster. I think it's because now the global RNG
does not need to be guarded by a mutex.

```
Removing the top-level Seed also let us hard-code the use of scalable,
per-thread generators by the top-level methods, avoiding a GODEBUG check
at each use.
```

See:
- https://go.dev/blog/randv2
- golang/go@0b9974d

### uuid: remove impossible error cases; reduce branching

This consolidates some conditional branches so that the Uint64()
function is always used to generate random numbers rather than using
(io.Reader).Read(). This change makes it so some functions can no longer
return errors, so some tests were removed.

---

### Diff between `crypto/rand` and `math/rand/v1`
```
goos: darwin
goarch: arm64
                       │ bench-crypto-rand.txt │    bench-math-rand-v1-trial1.txt    │
                       │        sec/op         │   sec/op     vs base                │
FastMakeV4-8                       29.49n ± 1%   29.68n ± 1%   +0.63% (p=0.011 n=10)
MakeV4-8                          519.50n ± 0%   29.52n ± 0%  -94.32% (p=0.000 n=10)
ConcurrentFastMakeV4-8             133.2n ± 0%   133.0n ± 0%   -0.19% (p=0.048 n=10)
ConcurrentMakeV4-8                 464.6n ± 1%   133.0n ± 0%  -71.36% (p=0.000 n=10)
geomean                            175.5n        62.75n       -64.24%

                       │ bench-crypto-rand.txt │      bench-math-rand-v1-trial1.txt      │
                       │         B/op          │    B/op     vs base                     │
FastMakeV4-8                      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
MakeV4-8                          16.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
ConcurrentFastMakeV4-8            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ConcurrentMakeV4-8                16.00 ± 0%      0.00 ± 0%  -100.00% (p=0.000 n=10)
geomean                                      ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                       │ bench-crypto-rand.txt │      bench-math-rand-v1-trial1.txt      │
                       │       allocs/op       │ allocs/op   vs base                     │
FastMakeV4-8                      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
MakeV4-8                          1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
ConcurrentFastMakeV4-8            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ConcurrentMakeV4-8                1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                                      ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

### Diff between `math/rand/v1` and `math/rand/v2`
```
goos: darwin
goarch: arm64
                   │ bench-math-rand-v1-trial2.txt │       bench-math-rand-v2.txt        │
                   │            sec/op             │   sec/op     vs base                │
MakeV4-8                               29.44n ± 1%   12.18n ± 1%  -58.61% (p=0.000 n=10)
ConcurrentMakeV4-8                   133.100n ± 0%   1.642n ± 2%  -98.77% (p=0.000 n=10)
geomean                                62.60n        4.472n       -92.86%

                   │ bench-math-rand-v1-trial2.txt │       bench-math-rand-v2.txt        │
                   │             B/op              │    B/op     vs base                 │
MakeV4-8                              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentMakeV4-8                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                   │ bench-math-rand-v1-trial2.txt │       bench-math-rand-v2.txt        │
                   │           allocs/op           │ allocs/op   vs base                 │
MakeV4-8                              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentMakeV4-8                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

### Overall improvement from this PR
```
goos: darwin
goarch: arm64
                       │ bench-crypto-rand.txt │        bench-math-rand-v2.txt         │
                       │        sec/op         │   sec/op     vs base                  │
FastMakeV4-8                       29.49n ± 1%
MakeV4-8                          519.50n ± 0%   12.18n ± 1%  -97.65% (p=0.000 n=10)
ConcurrentFastMakeV4-8             133.2n ± 0%
ConcurrentMakeV4-8               464.600n ± 1%   1.642n ± 2%  -99.65% (p=0.000 n=10)
geomean                            175.5n        4.472n       -99.09%                ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                       │ bench-crypto-rand.txt │          bench-math-rand-v2.txt          │
                       │         B/op          │   B/op     vs base                       │
FastMakeV4-8                      0.000 ± 0%
MakeV4-8                          16.00 ± 0%     0.00 ± 0%  -100.00% (p=0.000 n=10)
ConcurrentFastMakeV4-8            0.000 ± 0%
ConcurrentMakeV4-8                16.00 ± 0%     0.00 ± 0%  -100.00% (p=0.000 n=10)
geomean                                      ¹              ?                       ² ¹ ³
¹ summaries must be >0 to compute geomean
² benchmark set differs from baseline; geomeans may not be comparable
³ ratios must be >0 to compute geomean

                       │ bench-crypto-rand.txt │          bench-math-rand-v2.txt           │
                       │       allocs/op       │ allocs/op   vs base                       │
FastMakeV4-8                      0.000 ± 0%
MakeV4-8                          1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
ConcurrentFastMakeV4-8            0.000 ± 0%
ConcurrentMakeV4-8                1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                                      ¹               ?                       ² ¹ ³
¹ summaries must be >0 to compute geomean
² benchmark set differs from baseline; geomeans may not be comparable
³ ratios must be >0 to compute geomean
```