### PR TITLE
roachprod: remove logging from updatePrometheusTargets

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -790,7 +790,6 @@ func updatePrometheusTargets(ctx context.Context, l *logger.Logger, c *install.S
 					return
 				}
 				nodeInfo := fmt.Sprintf("%s:%d", v.PublicIP, desc.Port)
-				l.Printf("node information obtained for node index %d: %s", index, nodeInfo)
 				nodeIPPorts[index] = nodeInfo
 			}(int(node), c.VMs[node-1])
 		}


### PR DESCRIPTION
It's hard to tell what the logging is about when it happens in the context of a roachtest. It's also verbose as it prints one log line for each VM whenever a test starts cockroach.

Epic: none

Release note: None