### PR TITLE
pgwire: deflake TestPipelineMetric

### DIFF
--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -244,7 +244,7 @@ func TestPipelineMetric(t *testing.T) {
 
 	// Run the conn's loop in the background - it will push commands to the
 	// buffer. serveImpl also performs the server handshake.
-	serveCtx, stopServe := context.WithCancel(ctx)
+	serveCtx, stopServe := context.WithCancel(context.Background())
 	defer stopServe()
 	serveGroup := ctxgroup.WithContext(serveCtx)
 	serveGroup.GoCtx(func(ctx context.Context) error {


### PR DESCRIPTION
The wrong context was used for the server, which meant that it could get cancelled too early.

fixes https://github.com/cockroachdb/cockroach/issues/124270
Release note: None