### PR TITLE
sql/lexbase: remove map access overhead when encoding SQL strings

### DIFF
--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -112,7 +112,12 @@ func EncodeEscapedSQLIdent(buf *bytes.Buffer, s string) {
 	buf.WriteByte('"')
 }
 
-var mustQuoteMap = map[byte]bool{
+const (
+	minPrintableChar = 0x20 // ' '
+	maxPrintableChar = 0x7E // '~'
+)
+
+var mustQuoteMap = [maxPrintableChar + 1]bool{
 	' ': true,
 	',': true,
 	'{': true,
@@ -151,7 +156,7 @@ func EncodeSQLStringWithFlags(buf *bytes.Buffer, in string, flags EncodeFlags) {
 			continue
 		}
 		ch := byte(r)
-		if r >= 0x20 && r < 0x7F {
+		if r >= minPrintableChar && r <= maxPrintableChar {
 			if mustQuoteMap[ch] {
 				// We have to quote this string - ignore bareStrings setting
 				bareStrings = false

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -213,6 +213,14 @@ var schemas = []string{
 	)
 	`,
 	`
+	CREATE TABLE json_table
+	(
+		k INT PRIMARY KEY,
+		i INT,
+		j JSON
+	)
+	`,
+	`
 		CREATE TABLE single_col_histogram (k TEXT PRIMARY KEY);
 	`,
 	`
@@ -445,6 +453,11 @@ var queries = [...]benchQuery{
 		name:  "single-col-histogram-range",
 		query: "SELECT * FROM single_col_histogram WHERE k >= $1",
 		args:  []interface{}{"'abc'"},
+	},
+	{
+		name:  "json-insert",
+		query: "INSERT INTO json_table(k, i, j) VALUES ($1, $2, $3)",
+		args:  []interface{}{1, 10, `'{"a": "foo", "b": "bar", "c": [2, 3, "baz", true, false, null]}'`},
 	},
 	{
 		name: "batch-insert-one",


### PR DESCRIPTION
#### opt: add benchmark for simple INSERT with JSON column

Release note: None

#### sql/lexbase: remove map access overhead when encoding SQL strings

Map accesses have been replaced with more efficient array accesses for
determining characters to quote in `EncodeSQLStringWithFlags`. In a CPU
profile from a recent POC these map access accounted for a significant
portion of CPU time spent in query optimization because the optimizer's
interner converts `tree.DJSON` objects to strings using this encoding
function when hashing and checking equality of JSON constants.

Epic: None

Release note: None
