### PR TITLE
workflows: set timeouts for GitHub Actions Essential CI jobs

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -53,6 +53,7 @@ concurrency:
 jobs:
   acceptance:
     runs-on: [self-hosted, basic_big_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -78,6 +79,7 @@ jobs:
         if: always()
   check_generated_code:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -92,6 +94,7 @@ jobs:
         if: always()
   docker_image_amd64:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,6 +115,7 @@ jobs:
         if: always()
   examples_orms:
     runs-on: [self-hosted, basic_big_runner_group]
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,6 +136,7 @@ jobs:
         if: always()
   lint:
     runs-on: [self-hosted, basic_big_runner_group]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -155,6 +160,7 @@ jobs:
         if: always()
   local_roachtest:
     runs-on: [self-hosted, basic_big_runner_group]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -175,6 +181,7 @@ jobs:
         if: always()
   local_roachtest_fips:
     runs-on: [self-hosted, basic_runner_group_fips]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,6 +202,7 @@ jobs:
         if: always()
   linux_amd64_build:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -215,6 +223,7 @@ jobs:
         if: always()
   linux_amd64_fips_build:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -235,6 +244,7 @@ jobs:
         if: always()
   linux_arm64_build:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -255,6 +265,7 @@ jobs:
         if: always()
   macos_amd64_build:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -275,6 +286,7 @@ jobs:
         if: always()
   macos_arm64_build:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -295,6 +307,7 @@ jobs:
         if: always()
   unit_tests:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -317,6 +330,7 @@ jobs:
         if: always()
   windows_build:
     runs-on: [self-hosted, basic_runner_group]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I've selected the timeouts according to how long each job seems to run in practice, with a big buffer to allow for load on the remote execution cluster, etc. The longest-running jobs I've given 60 minutes, with less time for the shorter jobs.

Epic: CRDB-8308
Release note: None