### PR TITLE
ttljob: don't block job completion on stats queries

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1738,6 +1738,9 @@ type TTLTestingKnobs struct {
 	// PreSelectStatement runs before the start of the TTL select-delete
 	// loop.
 	PreSelectStatement string
+	// ExtraStatsQuery is an additional query to run while gathering stats if
+	// the ttl_row_stats_poll_interval is set. It is always run first.
+	ExtraStatsQuery string
 }
 
 // ModuleTestingKnobs implements the base.ModuleTestingKnobs interface.

--- a/pkg/sql/ttl/ttljob/ttljob_metrics.go
+++ b/pkg/sql/ttl/ttljob/ttljob_metrics.go
@@ -197,24 +197,35 @@ func (m *rowLevelTTLMetrics) fetchStatistics(
 		return err
 	}
 
-	for _, c := range []struct {
+	type statsQuery struct {
 		opName string
 		query  string
 		args   []interface{}
 		gauge  *aggmetric.Gauge
-	}{
-		{
+	}
+	var statsQueries []statsQuery
+	if ttlKnobs := execCfg.TTLTestingKnobs; ttlKnobs != nil && ttlKnobs.ExtraStatsQuery != "" {
+		statsQueries = append(statsQueries, statsQuery{
+			opName: fmt.Sprintf("ttl extra stats query %s", relationName),
+			query:  ttlKnobs.ExtraStatsQuery,
+		},
+		)
+	}
+	statsQueries = append(statsQueries,
+		statsQuery{
 			opName: fmt.Sprintf("ttl num rows stats %s", relationName),
 			query:  `SELECT count(1) FROM [%d AS t] AS OF SYSTEM TIME %s`,
 			gauge:  m.TotalRows,
 		},
-		{
+		statsQuery{
 			opName: fmt.Sprintf("ttl num expired rows stats %s", relationName),
 			query:  `SELECT count(1) FROM [%d AS t] AS OF SYSTEM TIME %s WHERE (` + string(ttlExpr) + `) < $1`,
 			args:   []interface{}{details.Cutoff},
 			gauge:  m.TotalExpiredRows,
 		},
-	} {
+	)
+
+	for _, c := range statsQueries {
 		// User a super low quality of service (lower than TTL low), as we don't
 		// really care if statistics gets left behind and prefer the TTL job to
 		// have priority.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/124305

Release note (bug fix): Previously, if the ttl_row_stats_poll_interval
storage parameter was non-zero for a table with row level TTL enabled,
the queries issued to update row stats could block the job from
completing. Now, if the job completes, these stats queries are cancelled
instead. This means that the jobs.row_level_ttl.total_rows and
jobs.row_level_ttl.total_expired_rows metrics will report 0 if the job
finishes before the row stats queries complete.