### PR TITLE
geo: allow arbitrary precision when encoding to json

### DIFF
--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -32,8 +32,10 @@ import (
 	"github.com/twpayne/go-geom/encoding/wkt"
 )
 
-// DefaultGeoJSONDecimalDigits is the default number of digits coordinates in GeoJSON.
-const DefaultGeoJSONDecimalDigits = 9
+// FullPrecisionGeoJSON, when used in place of max decimal digits in
+// GeoJSON functions, indicates to GeoJSON that it should use full
+// precision when encoding JSON.
+const FullPrecisionGeoJSON = -1
 
 // SpatialObjectToWKT transforms a given SpatialObject to WKT.
 func SpatialObjectToWKT(so geopb.SpatialObject, maxDecimalDigits int) (geopb.WKT, error) {

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -258,6 +258,37 @@ true  true
 true  true
 true  true
 
+# Regression test for #124175. Allow full precision for encoding JSON instead of the old default limit of 9.
+query FFT nosort
+SELECT
+  st_x(g), st_y(g), to_json(g)
+FROM ( VALUES
+  ('SRID=4326;POINT (-123.45 12.3456)'::GEOMETRY),
+  ('SRID=4326;POINT (-123.45678901234 12.3456789012)'::GEOMETRY),
+  ('SRID=4326;POINT (-123.4567890123456789 12.34567890123456789)'::GEOMETRY)
+) tbl(g)
+----
+-123.45 12.3456 {"coordinates": [-123.45, 12.3456], "type": "Point"}
+-123.45678901234 12.3456789012 {"coordinates": [-123.45678901234, 12.3456789012], "type": "Point"}
+-123.45678901234568 12.345678901234567 {"coordinates": [-123.45678901234568, 12.345678901234567], "type": "Point"}
+
+# st_asgeojson uses a default of 9 decimal digit precision.
+query TTTT nosort
+SELECT
+  st_asgeojson(tbl.*)::JSONB->'geometry'->'coordinates',
+  st_asgeojson(g)::JSONB->'coordinates',
+  st_asgeojson(tbl.*, 'g')::JSONB->'geometry'->'coordinates',
+  st_asgeojson(tbl.*, 'g', 4)::JSONB->'geometry'->'coordinates'
+FROM ( VALUES
+  ('SRID=4326;POINT (-123.45 12.3456)'::GEOMETRY),
+  ('SRID=4326;POINT (-123.45678901234 12.3456789012)'::GEOMETRY),
+  ('SRID=4326;POINT (-123.4567890123456789 12.34567890123456789)'::GEOMETRY)
+) tbl(g)
+----
+[-123.45, 12.3456]              [-123.45, 12.3456]              [-123.45, 12.3456]              [-123.45, 12.3456]
+[-123.456789012, 12.345678901]  [-123.456789012, 12.345678901]  [-123.456789012, 12.345678901]  [-123.4568, 12.3457]
+[-123.456789012, 12.345678901]  [-123.456789012, 12.345678901]  [-123.456789012, 12.345678901]  [-123.4568, 12.3457]
+
 subtest cast_test
 
 query T nosort

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -67,6 +67,8 @@ const spheroidDistanceMessage = "\n\nWhen operating on a spheroid, this function
 
 const (
 	defaultWKTDecimalDigits = 15
+	// defaultGeoJSONDecimalDigits is the default number of digits coordinates for builtins in GeoJSON.
+	defaultGeoJSONDecimalDigits = 9
 )
 
 // infoBuilder is used to build a detailed info string that is consistent between
@@ -1778,14 +1780,14 @@ var geoBuiltins = map[string]builtinDefinition{
 					evalCtx,
 					tuple,
 					"", /* geoColumn */
-					geo.DefaultGeoJSONDecimalDigits,
+					defaultGeoJSONDecimalDigits,
 					false, /* pretty */
 				)
 			},
 			Info: infoBuilder{
 				info: fmt.Sprintf(
 					"Returns the GeoJSON representation of a given Geometry. Coordinates have a maximum of %d decimal digits.",
-					geo.DefaultGeoJSONDecimalDigits,
+					defaultGeoJSONDecimalDigits,
 				),
 			}.String(),
 			Volatility: volatility.Immutable,
@@ -1799,14 +1801,14 @@ var geoBuiltins = map[string]builtinDefinition{
 					evalCtx,
 					tuple,
 					string(tree.MustBeDString(args[1])),
-					geo.DefaultGeoJSONDecimalDigits,
+					defaultGeoJSONDecimalDigits,
 					false, /* pretty */
 				)
 			},
 			Info: infoBuilder{
 				info: fmt.Sprintf(
 					"Returns the GeoJSON representation of a given Geometry, using geo_column as the geometry for the given Feature. Coordinates have a maximum of %d decimal digits.",
-					geo.DefaultGeoJSONDecimalDigits,
+					defaultGeoJSONDecimalDigits,
 				),
 			}.String(),
 			Volatility: volatility.Stable,
@@ -1864,14 +1866,14 @@ var geoBuiltins = map[string]builtinDefinition{
 		},
 		geometryOverload1(
 			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
-				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), defaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
 				return tree.NewDString(string(geojson)), err
 			},
 			types.String,
 			infoBuilder{
 				info: fmt.Sprintf(
 					"Returns the GeoJSON representation of a given Geometry. Coordinates have a maximum of %d decimal digits.",
-					geo.DefaultGeoJSONDecimalDigits,
+					defaultGeoJSONDecimalDigits,
 				),
 			},
 			volatility.Immutable,
@@ -1921,14 +1923,14 @@ Options is a flag that can be bitmasked. The options are:
 		},
 		geographyOverload1(
 			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
-				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
+				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), defaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
 				return tree.NewDString(string(geojson)), err
 			},
 			types.String,
 			infoBuilder{
 				info: fmt.Sprintf(
 					"Returns the GeoJSON representation of a given Geography. Coordinates have a maximum of %d decimal digits.",
-					geo.DefaultGeoJSONDecimalDigits,
+					defaultGeoJSONDecimalDigits,
 				),
 			},
 			volatility.Immutable,

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -881,13 +881,13 @@ func performCastWithoutPrecisionTruncation(
 		case *tree.DJSON:
 			return v, nil
 		case *tree.DGeography:
-			j, err := geo.SpatialObjectToGeoJSON(v.Geography.SpatialObject(), -1, geo.SpatialObjectToGeoJSONFlagZero)
+			j, err := geo.SpatialObjectToGeoJSON(v.Geography.SpatialObject(), geo.FullPrecisionGeoJSON, geo.SpatialObjectToGeoJSONFlagZero)
 			if err != nil {
 				return nil, err
 			}
 			return tree.ParseDJSON(string(j))
 		case *tree.DGeometry:
-			j, err := geo.SpatialObjectToGeoJSON(v.Geometry.SpatialObject(), -1, geo.SpatialObjectToGeoJSONFlagZero)
+			j, err := geo.SpatialObjectToGeoJSON(v.Geometry.SpatialObject(), geo.FullPrecisionGeoJSON, geo.SpatialObjectToGeoJSONFlagZero)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4100,9 +4100,9 @@ func AsJSON(
 			AsStringWithFlags(t, FmtBareStrings, FmtDataConversionConfig(dcc), FmtLocation(loc)),
 		), nil
 	case *DGeometry:
-		return t.ToJSON(geo.DefaultGeoJSONDecimalDigits)
+		return t.ToJSON(geo.FullPrecisionGeoJSON)
 	case *DGeography:
-		return t.ToJSON(geo.DefaultGeoJSONDecimalDigits)
+		return t.ToJSON(geo.FullPrecisionGeoJSON)
 	case *DVoid:
 		return json.FromString(AsStringWithFlags(t, fmtRawStrings)), nil
 	default:


### PR DESCRIPTION
We used to set a default limit of 9 digit precision when converting geo datums to json. However, some users expect higher precision in json. This PR changes the default precision to -1, which allows arbitrary precision with our geo library. Because of truncation when the data enters the database, there is a limit to the precision, but now the json output matches the database data.

Epic: none
Fixes: #124175

Release note: Do not limit precision when encoding geo data types to JSON.