### PR TITLE
roachtest: add a new cdc/kafka-chaos-single-row test

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1573,6 +1573,78 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
+		Name:             "cdc/kafka-chaos-single-row",
+		Owner:            `cdc`,
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.AllExceptAWS,
+		// TODO(#122372): Add this to the nightly test suite after we fix the Kafka restart bug.
+		Suites:          registry.ManualOnly,
+		RequiresLicense: true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			ct := newCDCTester(ctx, t, c)
+			defer ct.Close()
+
+			_, err := ct.DB().ExecContext(ctx, `CREATE TABLE t (id INT PRIMARY KEY, x INT);`)
+			if err != nil {
+				t.Fatal("failed to create table")
+			}
+			_, err = ct.DB().ExecContext(ctx, `INSERT INTO t VALUES (1, -1);`)
+			if err != nil {
+				t.Fatal("failed to insert row into table")
+			}
+
+			feed := ct.newChangefeed(feedArgs{
+				sinkType: kafkaSink,
+				targets:  []string{"t"},
+				kafkaArgs: kafkaFeedArgs{
+					kafkaChaos:    true,
+					validateOrder: true,
+				},
+				opts: map[string]string{
+					"updated":                       "",
+					"initial_scan":                  "'no'",
+					"min_checkpoint_frequency":      "'3s'",
+					"protect_data_from_gc_on_pause": "",
+					"on_error":                      "pause",
+					"kafka_sink_config":             `'{"Flush": {"MaxMessages": 100, "Frequency": "1s","Messages": 100 }, "Version": "2.7.2", "RequiredAcks": "ALL","Compression": "GZIP"}'`,
+				},
+			})
+			ct.runFeedLatencyVerifier(feed, latencyTargets{
+				steadyLatency: 5 * time.Minute,
+			})
+
+			conn1, err := ct.DB().Conn(ctx)
+			if err != nil {
+				t.Fatalf("failed to create a conn: %s", err)
+			}
+			defer func() {
+				_ = conn1.Close()
+			}()
+			conn2, err := ct.DB().Conn(ctx)
+			if err != nil {
+				t.Fatalf("failed to create a conn: %s", err)
+			}
+			defer func() {
+				_ = conn2.Close()
+			}()
+
+			// Repeatedly update a single row in a table in order to create a large
+			// number of events with the same key that will span multiple batches.
+			for i := 0; i < 1000000; i++ {
+				stmt := fmt.Sprintf(`UPDATE t SET x = %d WHERE id = 1;`, i)
+				if i%2 == 0 {
+					_, err = conn1.ExecContext(ctx, stmt)
+				} else {
+					_, err = conn2.ExecContext(ctx, stmt)
+				}
+				if err != nil {
+					t.Fatalf("failed to execute stmt %q: %s", stmt, err)
+				}
+			}
+		},
+	})
+	r.Add(registry.TestSpec{
 		Name:             "cdc/crdb-chaos",
 		Owner:            `cdc`,
 		Benchmark:        true,


### PR DESCRIPTION
This patch adds a new `cdc/kafka-chaos-single-row` roachtest, which
will serve as a regression test for the Kafka restarts bug. It is
currently configured to only be able to run manually since we have not
yet fixed the bug.

Informs #122372

Release note: None