### PR TITLE
roachprod: use yaml for creating the cluster config

### DIFF
--- a/pkg/roachprod/promhelperclient/BUILD.bazel
+++ b/pkg/roachprod/promhelperclient/BUILD.bazel
@@ -9,10 +9,12 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/promhelperclient",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/util/httputil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_google_cloud_go_storage//:storage",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_api//idtoken",
         "@org_golang_google_api//option",
         "@org_golang_x_oauth2//:oauth2",
@@ -26,6 +28,7 @@ go_test(
     deps = [
         "//pkg/roachprod/logger",
         "@com_github_stretchr_testify//require",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_api//idtoken",
         "@org_golang_x_oauth2//:oauth2",
     ],


### PR DESCRIPTION
currently a template is used to generate the yaml for the prometheus cluster config. this is error-prone and adding new parameters also becomes risky.
with this change, we are using go yaml to generate the yaml

Fixes: #124320
Epic: none