### PR TITLE
backupccl: download pre restore data in cluster restore

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2338,12 +2338,12 @@ func (bc *backupCollection) verifyOnlineRestore(
 	}
 	conn := d.testUtils.cluster.Conn(ctx, l, d.roachNodes[0])
 	defer conn.Close()
-	var externalBytes int
+	var externalBytes uint64
 	if err := conn.QueryRowContext(ctx, jobutils.GetExternalBytesForConnectedTenant).Scan(&externalBytes); err != nil {
 		return nil, fmt.Errorf("could not get external bytes: %w", err)
 	}
 	if externalBytes != 0 {
-		return nil, fmt.Errorf("download job %d did not download all data", downloadJobID)
+		return nil, fmt.Errorf("download job %d did not download all data. Cluster has %d external bytes", downloadJobID, externalBytes)
 	}
 	return restoredContents, nil
 }


### PR DESCRIPTION
This patch adds the pre restore data spans to the list of spans to download.
While these pre restore spans map to data in the temporary system table
database that are then rewwritten to the actual system table, the download job
ought to download all external data linked into the cluster out of principle.

Fixes #124330

Release note: none