### PR TITLE
kv: remove Tracer field from RaftTransport

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2472,7 +2472,6 @@ func TestStoreReplicaGCAfterMerge(t *testing.T) {
 	transport := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
-		tc.Servers[0].AmbientCtx().Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(),
 			gossip.AddressResolver(tc.Servers[0].GossipI().(*gossip.Gossip))),
 		nil, /* grpcServer */

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3403,7 +3403,6 @@ func TestReplicaGCRace(t *testing.T) {
 	fromTransport := kvserver.NewRaftTransport(
 		ambient,
 		cluster.MakeTestingClusterSettings(),
-		ambient.Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(), gossip.AddressResolver(fromStore.Gossip())),
 		nil, /* grpcServer */
 		tc.Servers[0].Stopper(),
@@ -3795,7 +3794,6 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	transport0 := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
-		tc.Servers[0].AmbientCtx().Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(),
 			gossip.AddressResolver(tc.GetFirstStoreFromServer(t, 0).Gossip())),
 		nil, /* grpcServer */
@@ -6904,7 +6902,7 @@ func TestStoreMetricsOnIncomingOutgoingMsg(t *testing.T) {
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
-	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 	store := kvserver.NewStore(ctx, cfg, eng, &node)
 	store.Ident = &roachpb.StoreIdent{
 		ClusterID: uuid.Nil,

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -175,11 +175,9 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 ) (*kvserver.RaftTransport, net.Addr) {
 	grpcServer, err := rpc.NewServer(context.Background(), rttc.nodeRPCContext)
 	require.NoError(rttc.t, err)
-	ctwWithTracer := log.MakeTestingAmbientCtxWithNewTracer()
 	transport := kvserver.NewRaftTransport(
-		ctwWithTracer,
+		log.MakeTestingAmbientCtxWithNewTracer(),
 		rttc.st,
-		ctwWithTracer.Tracer,
 		nodedialer.New(rttc.nodeRPCContext, gossip.AddressResolver(rttc.gossip)),
 		grpcServer,
 		rttc.stopper,

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -67,11 +67,9 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		return addr, nil
 	}
 
-	ctxWithTracer := log.MakeTestingAmbientCtxWithNewTracer()
 	tp := NewRaftTransport(
-		ctxWithTracer,
+		log.MakeTestingAmbientCtxWithNewTracer(),
 		cluster.MakeTestingClusterSettings(),
-		ctxWithTracer.Tracer,
 		nodedialer.New(rpcC, resolver),
 		grpcServer,
 		stopper,

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -247,7 +247,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 
-	cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 	store := NewStore(ctx, cfg, eng, &node)
 	// Fake an ident because this test doesn't want to start the store
 	// but without an Ident there will be NPEs.

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -156,7 +156,7 @@ func TestRaftCrossLocalityMetrics(t *testing.T) {
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
-	cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 	store := NewStore(ctx, cfg, eng, &node)
 	store.Ident = &roachpb.StoreIdent{
 		ClusterID: uuid.Nil,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -236,7 +236,6 @@ func createTestStoreWithoutStart(
 	cfg.Transport = NewRaftTransport(
 		cfg.AmbientCtx,
 		cfg.Settings,
-		cfg.Tracer(),
 		cfg.NodeDialer,
 		server,
 		stopper,
@@ -546,7 +545,7 @@ func TestInitializeEngineErrors(t *testing.T) {
 	require.NoError(t, eng.PutUnversioned(roachpb.Key("foo"), []byte("bar")))
 
 	cfg := TestStoreConfig(nil)
-	cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 	store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -138,7 +138,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 		stopper.AddCloser(memEngine)
 
 		cfg := TestStoreConfig(clock)
-		cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+		cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 
 		store := NewStore(ctx, cfg, memEngine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Fake-set an ident. This is usually read from the engine on store.Start()
@@ -231,7 +231,7 @@ func createStores(count int) (*timeutil.ManualTime, []*Store, *Stores, *stop.Sto
 	// Create two stores with ranges we care about.
 	stores := []*Store{}
 	for i := 0; i < count; i++ {
-		cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+		cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 		eng := storage.NewDefaultInMemForTesting()
 		stopper.AddCloser(eng)
 		s := NewStore(context.Background(), cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -630,7 +630,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	raftTransport := kvserver.NewRaftTransport(
 		cfg.AmbientCtx,
 		st,
-		cfg.AmbientCtx.Tracer,
 		kvNodeDialer,
 		grpcServer.Server,
 		stopper,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -182,7 +182,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		Stopper:      ltc.stopper,
 	}
 	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.dbContext)
-	transport := kvserver.NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+	transport := kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
 	// By default, disable the replica scanner and split queue, which
 	// confuse tests using LocalTestCluster.
 	if ltc.StoreTestingKnobs == nil {


### PR DESCRIPTION
Simple refactor. This commit removes the `Tracer` field from the `RaftTransport` struct and its constructors. This field was not needed, as the same `Tracer` instance is already available in the `RaftTransport`'s `AmbientContext`.

Epic: None
Release note: None