### PR TITLE
pgwire: fix error messages when reading from client buffer

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -1064,9 +1064,9 @@ func (s *Server) serveImpl(
 					}
 				}
 
-				// Write out the error over pgwire.
+				// Notify connExecutor of the error so it can send it to the client.
 				if err := c.stmtBuf.Push(ctx, sql.SendError{Err: err}); err != nil {
-					return false, isSimpleQuery, errors.New("pgwire: error writing too big error message to the client")
+					return false, isSimpleQuery, errors.New("pgwire: error writing error message to the client")
 				}
 
 				// If this is a simple query, we have to send the sync message back as
@@ -1077,7 +1077,7 @@ func (s *Server) serveImpl(
 						// protocol.
 						ExplicitFromClient: false,
 					}); err != nil {
-						return false, isSimpleQuery, errors.New("pgwire: error writing sync to the client whilst message is too big")
+						return false, isSimpleQuery, errors.New("pgwire: error writing sync to the client while handling error")
 					}
 				}
 
@@ -1208,7 +1208,8 @@ func (s *Server) serveImpl(
 			default:
 				return false, isSimpleQuery, c.stmtBuf.Push(
 					ctx,
-					sql.SendError{Err: pgwirebase.NewUnrecognizedMsgTypeErr(typ)})
+					sql.SendError{Err: pgwirebase.NewUnrecognizedMsgTypeErr(typ)},
+				)
 			}
 		}()
 		if err != nil {


### PR DESCRIPTION
In 9b93b72adbb7051fca9b5bf9c36692c419b8e1ba, I changed the error
handling logic in the pgwire connection loop, but left the old wording
that was specific to one type of error.

This fixes the error message and improves the comments.

Epic: None
Release note: None