### PR TITLE
goschedstats: make runtime_go1.20.go constraint more strict

### DIFF
--- a/pkg/util/goschedstats/BUILD.bazel
+++ b/pkg/util/goschedstats/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = [
         "runnable.go",
         "runtime_go1.19.go",
-        "runtime_go1.20.go",
+        "runtime_go1.20_21_22.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/goschedstats",
     visibility = ["//visibility:public"],

--- a/pkg/util/goschedstats/runtime_go1.20_21_22.go
+++ b/pkg/util/goschedstats/runtime_go1.20_21_22.go
@@ -8,12 +8,12 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-// The structure definitions in this file have been cross-checked against go1.20
-// and go1.21. Before allowing newer versions, please check that the structures
-// still match with those in go/src/runtime.
+// The structure definitions in this file have been cross-checked against
+// go1.20, go1.21, and go1.22. Before allowing newer versions, please check
+// that the structures still match with those in go/src/runtime.
 
-//go:build gc && go1.20
-// +build gc,go1.20
+//go:build gc && go1.20 && !go1.23
+// +build gc,go1.20,!go1.23
 
 package goschedstats
 


### PR DESCRIPTION
In 8c96097cd8cf79d99a14419a0a54707c18cf4384, the constraint was changed to allow all versions of go from go1.20 forwards. Instead, we should keep the constraint that forces us to verify that this file still works for the next version of golang.

Epic: None
Release note: None