### PR TITLE
release-23.2: roachtest/cdc: ensure hydra endpoint is up

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -66,6 +66,9 @@ import (
 // seen with a 1-5% probability
 var kafkaCreateTopicRetryDuration = 1 * time.Minute
 
+// hydraRetryDuration is the length of time we retry hydra oauth setup.
+var hydraRetryDuration = 1 * time.Minute
+
 type sinkType string
 
 const (
@@ -2075,12 +2078,20 @@ func (k kafkaManager) configureHydraOauth(ctx context.Context) (string, string) 
 		err := k.c.RunE(ctx, k.nodes, `/home/ubuntu/hydra-serve.sh`)
 		return errors.Wrap(err, "hydra failed")
 	})
-	result, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), k.nodes, "/home/ubuntu/hydra create oauth2-client",
-		"-e", "http://localhost:4445",
-		"--grant-type", "client_credentials",
-		"--token-endpoint-auth-method", "client_secret_basic",
-		"--name", `"Test Client"`,
-	)
+
+	var result install.RunResultDetails
+	// The admin server may not be up immediately, so retry the create command
+	// until it succeeds or times out.
+
+	err = retry.ForDuration(hydraRetryDuration, func() error {
+		result, err = k.c.RunWithDetailsSingleNode(ctx, k.t.L(), k.c.Node(k.c.Spec().NodeCount), "/home/ubuntu/hydra create oauth2-client",
+			"-e", "http://localhost:4445",
+			"--grant-type", "client_credentials",
+			"--token-endpoint-auth-method", "client_secret_basic",
+			"--name", `"Test Client"`,
+		)
+		return err
+	})
 	if err != nil {
 		k.t.Fatal(err)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #123345.

/cc @cockroachdb/release

---

When we start hydra to enable oauth during roachtest testing, the admin endpoint may not have started before the create oauth client command is called, resulting in a test failure. This PR puts the create command in a retry loop with a timeout so that the command has a chance to succeed.

Fixes: #122456
Epic: None

Release note: None

Release Justification: Test-only change to deflake CDC roachtests by waiting until hydra endpoint is up to start oauth.