### PR TITLE
*: remove all version checks against 23.2

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1229,11 +1229,6 @@ func restorePlanHook(
 		return nil, nil, nil, false, err
 	}
 
-	if restoreStmt.Options.RemoveRegions && !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V23_2) {
-		return nil, nil, nil, false,
-			errors.Newf("to set the remove_regions option, cluster version must be >= %s", clusterversion.V23_2.String())
-	}
-
 	if !restoreStmt.Options.SchemaOnly && restoreStmt.Options.VerifyData {
 		return nil, nil, nil, false,
 			errors.New("to set the verify_backup_table_data option, the schema_only option must be set")

--- a/pkg/clusterversion/README.md
+++ b/pkg/clusterversion/README.md
@@ -147,13 +147,19 @@ avoid large changes on `master` which might cause merge conflicts for backports.
 
 - [ ] File issue(s) to remove `TODO_Delete_` uses and simplify related code; assign
   to relevant teams (depending on which top-level packages use such gates).
+  Version checks against what is now the minimum version (e.g. `V23_2`) should
+  also be removed, as this version will always be active.
   <details><summary>For the overachiever</summary>
   Historically, these cleanup issues have not received much attention and the code
   was carried over for a long time. Feel free to ping individuals or do some of
-  the cleanup directly (in separate PRs). The cleanup comes down to simplifying the
-  code based on the knowledge that `IsActive()` will always return `true` for
-  obsolete gates. If simplifying the code becomes non-trivial, error on the side
-  of just removing `IsActive()` calls and leaving TODOs for further cleanup.
+  the cleanup directly (in separate PRs).
+  
+  The cleanup comes down to simplifying the code based on the knowledge that
+  `IsActive()` will always return `true` for obsolete gates. If simplifying the
+  code becomes non-trivial, error on the side of just removing `IsActive()` calls
+  and leaving TODOs for further cleanup.
+  
+  Example PRs: #124013, #124286
   </details>
   
 - [ ] Regenerate expected test data results as needed; file issues for any

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -17,7 +17,6 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -645,9 +644,6 @@ func (c *muxStream) close() (toRestart []*activeMuxRangeFeed) {
 func NewCloseStreamRequest(
 	ctx context.Context, st *cluster.Settings, streamID int64,
 ) (*kvpb.RangeFeedRequest, error) {
-	if !st.Version.IsActive(ctx, clusterversion.V23_2) {
-		return nil, errors.Newf("CloseStream request requires cluster version 23.2 or above, found %s", st.Version)
-	}
 	return &kvpb.RangeFeedRequest{
 		StreamID:    streamID,
 		CloseStream: true,

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -22,21 +21,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
-)
-
-// enableStickyGCHint controls whether the sticky GCHint is enabled.
-var enableStickyGCHint = settings.RegisterBoolSetting(
-	settings.SystemOnly,
-	"kv.gc.sticky_hint.enabled",
-	"enable writing sticky GC hints which expedite garbage collection after schema changes"+
-		" (ignored and assumed 'true' in 23.2)",
-	false,
 )
 
 func init() {
@@ -152,14 +141,7 @@ func DeleteRange(
 				return err
 			}
 
-			updated := false
-			// TODO(pavelkalinnikov): deprecate the cluster setting and call
-			// ScheduleGCFor unconditionally when min supported version is 23.2.
-			if cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_2) ||
-				enableStickyGCHint.Get(&cArgs.EvalCtx.ClusterSettings().SV) {
-				// Add the timestamp to GCHint to guarantee that GC eventually clears it.
-				updated = hint.ScheduleGCFor(h.Timestamp)
-			}
+			updated := hint.ScheduleGCFor(h.Timestamp)
 			// If the range tombstone covers the whole Range key span, update the
 			// corresponding timestamp in GCHint to enable ClearRange optimization.
 			if args.Key.Equal(desc.StartKey.AsRawKey()) && args.EndKey.Equal(desc.EndKey.AsRawKey()) {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
@@ -2728,14 +2727,7 @@ func shouldCampaignAfterConfChange(
 			return false
 		}
 	}
-	// Prior to 23.2, the first voter in the descriptor campaigned, so we do
-	// the same in mixed-version clusters to avoid ties.
-	if !st.Version.IsActive(ctx, clusterversion.V23_2) {
-		if storeID != desc.Replicas().VoterDescriptors()[0].StoreID {
-			// We're not the designated campaigner.
-			return false
-		}
-	} else if !leaseStatus.OwnedBy(storeID) || !leaseStatus.IsValid() {
+	if !leaseStatus.OwnedBy(storeID) || !leaseStatus.IsValid() {
 		// We're not the leaseholder.
 		return false
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -378,19 +378,11 @@ func newRaftConfig(
 		Storage:                     strg,
 		Logger:                      logger,
 
-		// StepDownOnRemoval requires 23.2. Otherwise, in a mixed-version cluster, a
-		// 23.2 leader may step down when it demotes itself to learner, but a
-		// designated follower (first in the range) running 23.1 will only campaign
-		// once the leader is entirely removed from the range descriptor (see
-		// shouldCampaignOnConfChange). This would leave the range without a leader,
-		// having to wait out an election timeout.
-		//
 		// We only set this on replica initialization, so replicas without
 		// StepDownOnRemoval may remain on 23.2 nodes until they restart. That's
 		// totally fine, we just can't rely on this behavior until 24.1, but
 		// we currently don't either.
-		StepDownOnRemoval: storeCfg.Settings.Version.IsActive(ctx, clusterversion.V23_2) &&
-			raftStepDownOnRemoval,
+		StepDownOnRemoval: raftStepDownOnRemoval,
 
 		PreVote:     true,
 		CheckQuorum: storeCfg.RaftEnableCheckQuorum,

--- a/pkg/server/job_profiler.go
+++ b/pkg/server/job_profiler.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -29,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/zipper"
-	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -67,10 +65,6 @@ func (s *statusServer) RequestJobProfilerExecutionDetails(
 	// profiler details.
 	if local {
 		jobID := jobspb.JobID(req.JobId)
-		if !execCfg.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
-			return nil, errors.Newf("execution details can only be requested on a cluster with version >= %s",
-				clusterversion.V23_2.String())
-		}
 		e := makeJobProfilerExecutionDetailsBuilder(execCfg.SQLStatusServer, execCfg.InternalDB, jobID, execCfg.JobRegistry)
 
 		// TODO(adityamaru): When we start collecting more information we can consider

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2047,9 +2047,6 @@ func (n *Node) MuxRangeFeed(stream kvpb.Internal_MuxRangeFeedServer) error {
 
 			if err == nil {
 				cause := kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED
-				if !n.storeCfg.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
-					cause = kvpb.RangeFeedRetryError_REASON_REPLICA_REMOVED
-				}
 				err = kvpb.NewRangeFeedRetryError(cause)
 			}
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -243,6 +243,7 @@ var retiredSettings = map[InternalKey]struct{}{
 
 	// removed as of 24.2
 	"storage.value_blocks.enabled": {},
+	"kv.gc.sticky_hint.enabled":    {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/sql/alter_index_visible.go
+++ b/pkg/sql/alter_index_visible.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -21,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -84,12 +82,6 @@ func (n *alterIndexVisibleNode) ReadingOwnWrites() {}
 func (n *alterIndexVisibleNode) startExec(params runParams) error {
 	if n.n.Invisibility.Value != 0.0 && n.index.Primary() {
 		return pgerror.Newf(pgcode.FeatureNotSupported, "primary index cannot be invisible")
-	}
-
-	activeVersion := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
-	if !activeVersion.IsActive(clusterversion.V23_2) &&
-		n.n.Invisibility.Value > 0.0 && n.n.Invisibility.Value < 1.0 {
-		return unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
 	}
 
 	// Warn if this invisible index may still be used to enforce constraint check

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -295,11 +294,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 					}
 				}
 
-				activeVersion := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
-				if !activeVersion.IsActive(clusterversion.V23_2) &&
-					d.Invisibility.Value > 0.0 && d.Invisibility.Value < 1.0 {
-					return unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported")
-				}
 				idx := descpb.IndexDescriptor{
 					Name:             string(d.Name),
 					Unique:           true,

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -108,7 +108,7 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 		types.INetFamily, types.IntervalFamily, types.JsonFamily, types.OidFamily, types.TimeFamily,
 		types.TimestampFamily, types.TimestampTZFamily, types.UuidFamily, types.TimeTZFamily,
 		types.GeographyFamily, types.GeometryFamily, types.EnumFamily, types.Box2DFamily,
-		types.TSQueryFamily, types.TSVectorFamily:
+		types.TSQueryFamily, types.TSVectorFamily, types.PGLSNFamily, types.RefCursorFamily:
 	// These types are OK.
 
 	case types.TupleFamily:
@@ -117,22 +117,6 @@ func ValidateColumnDefType(ctx context.Context, version clusterversion.Handle, t
 		}
 		if t.TypeMeta.ImplicitRecordType {
 			return unimplemented.NewWithIssue(70099, "cannot use table record type as table column")
-		}
-
-	case types.PGLSNFamily:
-		if !version.IsActive(ctx, clusterversion.V23_2) {
-			return pgerror.Newf(
-				pgcode.FeatureNotSupported,
-				"pg_lsn not supported until version 23.2",
-			)
-		}
-
-	case types.RefCursorFamily:
-		if !version.IsActive(ctx, clusterversion.V23_2) {
-			return pgerror.Newf(
-				pgcode.FeatureNotSupported,
-				"refcursor not supported until version 23.2",
-			)
 		}
 
 	default:

--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -14,13 +14,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 	"github.com/robfig/cron/v3"
 )
@@ -103,7 +101,7 @@ func ValidateTTLExpirationExpr(desc catalog.TableDescriptor) error {
 // ValidateTTLExpirationColumn validates that the ttl_expire_after setting, if
 // any, is in a valid state. It requires that the TTLDefaultExpirationColumn
 // exists and has DEFAULT/ON UPDATE clauses.
-func ValidateTTLExpirationColumn(desc catalog.TableDescriptor, allowDescPK bool) error {
+func ValidateTTLExpirationColumn(desc catalog.TableDescriptor) error {
 	if !desc.HasRowLevelTTL() {
 		return nil
 	}
@@ -131,20 +129,6 @@ func ValidateTTLExpirationColumn(desc catalog.TableDescriptor, allowDescPK bool)
 			catpb.TTLDefaultExpirationColumnName,
 			expectedStr,
 		)
-	}
-
-	// For row-level TTL, only ascending PKs are permitted.
-	if !allowDescPK {
-		pk := desc.GetPrimaryIndex()
-		for i := 0; i < pk.NumKeyColumns(); i++ {
-			dir := pk.GetKeyColumnDirection(i)
-			if dir != catenumpb.IndexColumn_ASC {
-				return unimplemented.NewWithIssuef(
-					76912,
-					`non-ascending ordering on PRIMARY KEYs are not supported with row-level TTL`,
-				)
-			}
-		}
 	}
 
 	return nil

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -977,7 +977,7 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	// ValidateRowLevelTTL is also used before the table descriptor is fully
 	// initialized to validate the storage parameters.
 	vea.Report(ValidateTTLExpirationExpr(desc))
-	vea.Report(ValidateTTLExpirationColumn(desc, vea.IsActive(clusterversion.V23_2)))
+	vea.Report(ValidateTTLExpirationColumn(desc))
 
 	// Validate that there are no column with both a foreign key ON UPDATE and an
 	// ON UPDATE expression. This check is made to ensure that we know which ON

--- a/pkg/sql/jobs_profiler_execution_details.go
+++ b/pkg/sql/jobs_profiler_execution_details.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler/profilerconstants"
@@ -172,11 +171,6 @@ func constructBackupExecutionDetails(
 // RequestExecutionDetailFiles implements the JobProfiler interface.
 func (p *planner) RequestExecutionDetailFiles(ctx context.Context, jobID jobspb.JobID) error {
 	execCfg := p.ExecCfg()
-	if !execCfg.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
-		return errors.Newf("execution details can only be requested on a cluster with version >= %s",
-			clusterversion.V23_2.String())
-	}
-
 	_, err := execCfg.SQLStatusServer.RequestJobProfilerExecutionDetails(ctx,
 		&serverpb.RequestJobProfilerExecutionDetailsRequest{
 			JobId: int64(jobID),

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -341,10 +341,6 @@ func (b *Builder) buildStmt(
 		switch stmt := stmt.(type) {
 		case *tree.Select, tree.SelectStatement:
 		case *tree.Insert, *tree.Update, *tree.Delete:
-			activeVersion := b.evalCtx.Settings.Version.ActiveVersion(b.ctx)
-			if !activeVersion.IsActive(clusterversion.V23_2) {
-				panic(unimplemented.Newf("user-defined functions", "%s usage inside a function definition is not supported until version 23.2", stmt.StatementTag()))
-			}
 		case *tree.Call:
 			activeVersion := b.evalCtx.Settings.Version.ActiveVersion(b.ctx)
 			if !activeVersion.IsActive(clusterversion.V24_1) {

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -40,11 +39,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		if string(cf.Name.CatalogName) != b.evalCtx.SessionData().Database {
 			panic(unimplemented.New("CREATE FUNCTION", "cross-db references not supported"))
 		}
-	}
-
-	activeVersion := b.evalCtx.Settings.Version.ActiveVersion(b.ctx)
-	if cf.IsProcedure && !activeVersion.IsActive(clusterversion.V23_2) {
-		panic(unimplemented.New("procedures", "procedures are not yet supported"))
 	}
 
 	sch, resName := b.resolveSchemaForCreateFunction(&cf.Name)
@@ -122,9 +116,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		panic(pgerror.New(pgcode.InvalidFunctionDefinition, "no language specified"))
 	}
 	if language == tree.RoutineLangPLpgSQL {
-		if !activeVersion.IsActive(clusterversion.V23_2) {
-			panic(unimplemented.New("PLpgSQL", "PLpgSQL is not supported until version 23.2"))
-		}
 		if err := plpgsql.CheckClusterSupportsPLpgSQL(b.evalCtx.Settings); err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -11,7 +11,6 @@
 package optbuilder
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -364,17 +363,15 @@ func (item *lockingItem) validate() {
 // guaranteed-durable locking for SELECT FOR UPDATE, SELECT FOR SHARE, or
 // constraint checks.
 func (b *Builder) shouldUseGuaranteedDurability() bool {
-	return b.evalCtx.Settings.Version.IsActive(b.ctx, clusterversion.V23_2) &&
-		(b.evalCtx.TxnIsoLevel != isolation.Serializable ||
-			b.evalCtx.SessionData().DurableLockingForSerializable)
+	return b.evalCtx.TxnIsoLevel != isolation.Serializable ||
+		b.evalCtx.SessionData().DurableLockingForSerializable
 }
 
 // shouldBuildLockOp returns whether we should use the Lock operator for SELECT
 // FOR UPDATE or SELECT FOR SHARE.
 func (b *Builder) shouldBuildLockOp() bool {
-	return b.evalCtx.Settings.Version.IsActive(b.ctx, clusterversion.V23_2) &&
-		(b.evalCtx.TxnIsoLevel != isolation.Serializable ||
-			b.evalCtx.SessionData().OptimizerUseLockOpForSerializable)
+	return b.evalCtx.TxnIsoLevel != isolation.Serializable ||
+		b.evalCtx.SessionData().OptimizerUseLockOpForSerializable
 }
 
 // buildLocking constructs one Lock operator for each data source that this

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -155,11 +155,9 @@ func makeState(
 	// certain transitions and fences like the two version invariant.
 	// This only applies for cluster at or beyond version 23.2.
 	var descriptorIDsInSchemaChange catalog.DescriptorIDSet
-	if version.IsActive(clusterversion.V23_2) {
-		for _, e := range bs.output {
-			if isElementAllowedInVersion(e.element) && e.metadata.IsLinkedToSchemaChange() {
-				descriptorIDsInSchemaChange.Add(screl.GetDescID(e.element))
-			}
+	for _, e := range bs.output {
+		if isElementAllowedInVersion(e.element) && e.metadata.IsLinkedToSchemaChange() {
+			descriptorIDsInSchemaChange.Add(screl.GetDescID(e.element))
 		}
 	}
 	for _, e := range bs.output {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -36,9 +36,6 @@ func alterTableDropColumn(
 	fallBackIfRegionalByRowTable(b, n, tbl.TableID)
 	checkSafeUpdatesForDropColumn(b)
 	checkRegionalByRowColumnConflict(b, tbl, n)
-	// Version gates functionally that is implemented after the statement is
-	// publicly published.
-	fallbackIfAddColDropColAlterPKInOneAlterTableStmtBeforeV232(b, tbl.TableID, n)
 
 	col, elts, done := resolveColumnForDropColumn(b, tn, tbl, n)
 	if done {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -421,11 +421,6 @@ func notFilter(
 	}
 }
 
-func isColumnFilter(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) bool {
-	_, isColumn := e.(*scpb.Column)
-	return isColumn
-}
-
 func publicTargetFilter(_ scpb.Status, target scpb.TargetStatus, _ scpb.Element) bool {
 	return target == scpb.ToPublic
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -64,7 +64,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.DropIndex)(nil)):           {fn: DropIndex, statementTags: []string{tree.DropIndexTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.DropRoutine)(nil)):         {fn: DropFunction, statementTags: []string{tree.DropFunctionTag, tree.DropProcedureTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateRoutine)(nil)):       {fn: CreateFunction, statementTags: []string{tree.CreateFunctionTag, tree.CreateProcedureTag}, on: true, checks: nil},
-	reflect.TypeOf((*tree.CreateSchema)(nil)):        {fn: CreateSchema, statementTags: []string{tree.CreateSchemaTag}, on: true, checks: isV232Active},
+	reflect.TypeOf((*tree.CreateSchema)(nil)):        {fn: CreateSchema, statementTags: []string{tree.CreateSchemaTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateSequence)(nil)):      {fn: CreateSequence, statementTags: []string{tree.CreateSequenceTag}, on: true, checks: isV241Active},
 	reflect.TypeOf((*tree.CreateDatabase)(nil)):      {fn: CreateDatabase, statementTags: []string{tree.CreateDatabaseTag}, on: true, checks: isV241Active},
 }
@@ -204,10 +204,6 @@ func getDeclarativeSchemaChangerModeForStmt(
 		ret = sessiondatapb.UseNewSchemaChangerUnsafe
 	}
 	return ret
-}
-
-var isV232Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {
-	return activeVersion.IsActive(clusterversion.V23_2)
 }
 
 var isV241Active = func(_ tree.NodeFormatter, _ sessiondatapb.NewSchemaChangerMode, activeVersion clusterversion.ClusterVersion) bool {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
@@ -174,10 +174,6 @@ func checkOpFunc(el scpb.Element, fn interface{}) (opType scop.Type, _ error) {
 // a descriptor is an added state, and has no data. This can allow us to
 // skip certain operations like backfills / validation.
 func checkIfDescriptorIsWithoutData(id descpb.ID, md *opGenContext) bool {
-	// Older versions did not emit the data element.
-	if !md.ActiveVersion.IsActive(clusterversion.V23_2) {
-		return false
-	}
 	doesDescriptorHaveData := false
 	for idx, t := range md.Targets {
 		// Validate this is the descriptor ID we are

--- a/pkg/sql/schemachanger/screl/scalars.go
+++ b/pkg/sql/schemachanger/screl/scalars.go
@@ -124,7 +124,7 @@ func VersionSupportsElementUse(el scpb.Element, version clusterversion.ClusterVe
 		// These elements need v23.1 so they can be used without checking any version gates.
 		return true
 	case *scpb.SequenceOption:
-		return version.IsActive(clusterversion.V23_2)
+		return true
 	default:
 		panic(errors.AssertionFailedf("unknown element %T", el))
 	}

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -593,11 +592,6 @@ func performCastWithoutPrecisionTruncation(
 		}
 
 	case types.PGLSNFamily:
-		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
-			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-				"version %v must be finalized to use pg_lsn",
-				clusterversion.V23_2.Version())
-		}
 		switch d := d.(type) {
 		case *tree.DString:
 			return tree.ParseDPGLSN(string(*d))
@@ -608,11 +602,6 @@ func performCastWithoutPrecisionTruncation(
 		}
 
 	case types.RefCursorFamily:
-		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
-			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-				"version %v must be finalized to use refcursor",
-				clusterversion.V23_2.Version())
-		}
 		switch d := d.(type) {
 		case *tree.DString:
 			return tree.NewDRefCursor(string(*d)), nil

--- a/pkg/sql/sem/eval/unsupported_types.go
+++ b/pkg/sql/sem/eval/unsupported_types.go
@@ -14,8 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -34,17 +32,5 @@ var _ tree.UnsupportedTypeChecker = &unsupportedTypeChecker{}
 
 // CheckType implements the tree.UnsupportedTypeChecker interface.
 func (tc *unsupportedTypeChecker) CheckType(ctx context.Context, typ *types.T) error {
-	var errorTypeString string
-	switch typ.Family() {
-	case types.PGLSNFamily:
-		errorTypeString = "pg_lsn"
-	case types.RefCursorFamily:
-		errorTypeString = "refcursor"
-	}
-	if errorTypeString != "" && !tc.version.IsActive(ctx, clusterversion.V23_2) {
-		return pgerror.Newf(pgcode.FeatureNotSupported,
-			"%s not supported until version 23.2", errorTypeString,
-		)
-	}
 	return nil
 }

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -314,7 +314,7 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	alterTypeDropValue:                clusterversion.MinSupported,
 	commentOn:                         clusterversion.MinSupported,
 	createIndex:                       clusterversion.MinSupported,
-	createSchema:                      clusterversion.V23_2,
+	createSchema:                      clusterversion.MinSupported,
 	createSequence:                    clusterversion.MinSupported,
 	dropIndex:                         clusterversion.MinSupported,
 	dropSchema:                        clusterversion.MinSupported,


### PR DESCRIPTION
Now that `MinSupported` is `V23_2`, we no longer need to check if 23.2
is active. This change removes all these checks.

Epic: none
Release note: None