### PR TITLE
storage: fix setting of compression algorithm

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1080,8 +1080,8 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	cfg.opts.FS = cfg.env
 	cfg.opts.Lock = cfg.env.DirectoryLock
 	cfg.opts.ErrorIfNotExists = cfg.mustExist
-	for _, l := range cfg.opts.Levels {
-		l.Compression = func() sstable.Compression {
+	for i := range cfg.opts.Levels {
+		cfg.opts.Levels[i].Compression = func() sstable.Compression {
 			return getCompressionAlgorithm(ctx, cfg.settings)
 		}
 	}


### PR DESCRIPTION
Fix an issue where the compression cluster setting is being set on a copy of the per-level configuration, rather than the configuration that is ultimately passed to Pebble.

Touches #123953.

Release note: None.

Epic: CRDB-37583