### PR TITLE
kvpb: remove deprecated fields from BulkOpSummary

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2149,8 +2149,6 @@ func BulkOpSummaryID(tableID, indexID uint64) uint64 {
 func (b *BulkOpSummary) Add(other BulkOpSummary) {
 	b.DataSize += other.DataSize
 	b.SSTDataSize += other.SSTDataSize
-	b.DeprecatedRows += other.DeprecatedRows
-	b.DeprecatedIndexEntries += other.DeprecatedIndexEntries
 
 	if other.EntryCounts != nil && b.EntryCounts == nil {
 		b.EntryCounts = make(map[uint64]int64, len(other.EntryCounts))

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1870,19 +1870,7 @@ message BulkOpSummary {
   int64 data_size = 1;
   // SSTDataSize is the size of the SST, post compression, sent to KV.
   int64 sst_data_size = 6 [(gogoproto.customname) = "SSTDataSize"];
-  // DeprecatedRows contained the row count when "rows" were always defined as
-  // entries in the index with ID 1, however since 20.1 and the introduction of
-  // PK changes, the low-level counters that produce BulkOpSummaries are unable
-  // to assume which index is primary and thus cannot distinguish "rows" vs
-  // "index entries". Callers wishing to get a "row count" from a BulkOpSummary
-  // should use EntryCounts instead, fetching the count for the table/index that
-  // corresponds to the PK.
-  int64 deprecated_rows = 2;
-  // DeprecatedIndexEntries contained the index entry count prior to 20.1. See
-  // the comment on DeprecatedRows for details.
-  int64 deprecated_index_entries = 3;
-
-  reserved 4;
+  reserved 2, 3, 4;
   // EntryCounts contains the number of keys processed for each tableID/indexID
   // pair, stored under the key (tableID << 32) | indexID. This EntryCount key
   // generation logic is also available in the BulkOpSummaryID helper. It does

--- a/pkg/storage/row_counter.go
+++ b/pkg/storage/row_counter.go
@@ -66,11 +66,5 @@ func (r *RowCounter) Count(key roachpb.Key) error {
 	}
 	r.EntryCounts[kvpb.BulkOpSummaryID(uint64(tableID), uint64(indexID))]++
 
-	if indexID == 1 {
-		r.DeprecatedRows++
-	} else {
-		r.DeprecatedIndexEntries++
-	}
-
 	return nil
 }

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint_tenant
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint_tenant
@@ -30,21 +30,21 @@ data: /Tenant/11/Table/1/1/"d"/0/2.000000000,0 -> /BYTES/d
 run ok
 export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=10
 ----
-export: data_size:78 deprecated_rows:4 entry_counts:<key:4294967297 value:4 >  fingerprint=true
+export: data_size:78 entry_counts:<key:4294967297 value:4 >  fingerprint=true
 fingerprint: 9925016972726554372
 
 # Fingerprint tenant 11
 run ok
 export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=11
 ----
-export: data_size:78 deprecated_rows:4 entry_counts:<key:4294967297 value:4 >  fingerprint=true
+export: data_size:78 entry_counts:<key:4294967297 value:4 >  fingerprint=true
 fingerprint: 11108963465360970374
 
 # Fingerprint tenant 10 with tenant prefix stripped
 run ok
 export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=10 stripTenantPrefix stripValueChecksum
 ----
-export: data_size:78 deprecated_rows:4 entry_counts:<key:4294967297 value:4 >  fingerprint=true
+export: data_size:78 entry_counts:<key:4294967297 value:4 >  fingerprint=true
 fingerprint: 18366154626077700017
 
 # Fingerprint tenant 11 with tenant prefix stripped
@@ -52,5 +52,5 @@ fingerprint: 18366154626077700017
 run ok
 export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=11 stripTenantPrefix stripValueChecksum
 ----
-export: data_size:78 deprecated_rows:4 entry_counts:<key:4294967297 value:4 >  fingerprint=true
+export: data_size:78 entry_counts:<key:4294967297 value:4 >  fingerprint=true
 fingerprint: 18366154626077700017


### PR DESCRIPTION
These fields aren't actually used and haven't been for several years now.

Epic: None

Release note: None