### PR TITLE
roachtest: use first transient error when checking for flakes

### DIFF
--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -348,7 +348,22 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 13. Verify hostError failure are routed to test-eng and marked as infra-flake, when the
+		// 13. When a transient error happens as a result of *another*
+		// transient error, the corresponding issue uses the first
+		// transient error in the chain.
+		{
+			failures: []failure{
+				createFailure(rperrors.TransientFailure(
+					rperrors.NewSSHError(errors.New("oops")), "some_problem",
+				)),
+			},
+			expectedPost:          true,
+			expectedTeam:          "@cockroachdb/test-eng",
+			expectedName:          "ssh_problem",
+			expectedMessagePrefix: testName + " failed",
+			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
+		},
+		// 14. Verify hostError failure are routed to test-eng and marked as infra-flake, when the
 		// first failure is a non-handled error.
 		{
 			nonReleaseBlocker:     true,
@@ -359,7 +374,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 14. Verify hostError failure are routed to test-eng and marked as infra-flake, when the only error is
+		// 15. Verify hostError failure are routed to test-eng and marked as infra-flake, when the only error is
 		// hostError failure
 		{
 			nonReleaseBlocker: true,

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_15.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_15.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -90,6 +90,10 @@ func (te TransientError) Is(other error) bool {
 	return errors.Is(te.Err, other)
 }
 
+func (te TransientError) Unwrap() error {
+	return te.Err
+}
+
 func (te TransientError) ExitCode() int {
 	return transientExitCode
 }


### PR DESCRIPTION
Previously, roachtest would only look at the outermost error in a chain that matched a `TransientError` (or `ErrorWithOwnership`) when checking for flakes. However, that is in most cases *not* what we want: if a transient error wraps another transient error, the actual reason for the failure is the original (wrapped) error.

Informs: #123887

Release note: None