### PR TITLE
jwtauthccl: add http client to jwt authenticator conf

### DIFF
--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/httputil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/ccl/jwtauthccl/authentication_jwt_test.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -802,6 +803,10 @@ func TestJWTAuthCanUseHTTPProxy(t *testing.T) {
 		})()
 
 	authenticator := jwtAuthenticator{}
+	authenticator.mu.Lock()
+	defer authenticator.mu.Unlock()
+	authenticator.mu.conf.httpClient = httputil.NewClientWithTimeout(httputil.StandardHTTPTimeout)
+
 	res, err := getHttpResponse(ctx, "http://my-server/.well-known/openid-configuration", &authenticator)
 	require.NoError(t, err)
 	require.EqualValues(t, "proxied-http://my-server/.well-known/openid-configuration", string(res))

--- a/pkg/util/httputil/client.go
+++ b/pkg/util/httputil/client.go
@@ -12,7 +12,6 @@ package httputil
 
 import (
 	"context"
-	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -33,7 +32,6 @@ func NewClientWithTimeout(timeout time.Duration) *Client {
 
 // NewClientWithTimeouts defines a http.Client with the given dialer and client timeouts.
 func NewClientWithTimeouts(dialerTimeout, clientTimeout time.Duration) *Client {
-	var tlsConf *tls.Config
 	t := http.DefaultTransport.(*http.Transport)
 	return &Client{&http.Client{
 		Timeout: clientTimeout,
@@ -48,9 +46,6 @@ func NewClientWithTimeouts(dialerTimeout, clientTimeout time.Duration) *Client {
 			IdleConnTimeout:       t.IdleConnTimeout,
 			TLSHandshakeTimeout:   t.TLSHandshakeTimeout,
 			ExpectContinueTimeout: t.ExpectContinueTimeout,
-
-			// Add our custom CA.
-			TLSClientConfig: tlsConf,
 		},
 	}}
 }


### PR DESCRIPTION
Currently, we create a new http client every time we fetch the jwks URL or fetch jwk set from jwks URL. We can simply reuse the http client by adding it to authenticator conf struct.

fixes CRDB-38629
Epic None

Release note: None