### PR TITLE
opt: add optimizer_push_offset_into_index_join

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3790,6 +3790,10 @@ func (m *sessionDataMutator) SetOptimizerProveImplicationWithVirtualComputedColu
 	m.data.OptimizerProveImplicationWithVirtualComputedColumns = val
 }
 
+func (m *sessionDataMutator) SetOptimizerPushOffsetIntoIndexJoin(val bool) {
+	m.data.OptimizerPushOffsetIntoIndexJoin = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6163,6 +6163,7 @@ optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_prove_implication_with_virtual_computed_columns  on
+optimizer_push_offset_into_index_join                      on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2889,6 +2889,7 @@ optimizer_always_use_histograms                            on                  N
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns  on                  NULL      NULL        NULL        string
+optimizer_push_offset_into_index_join                      on                  NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL      NULL        NULL        string
@@ -3073,6 +3074,7 @@ optimizer_always_use_histograms                            on                  N
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
 optimizer_prove_implication_with_virtual_computed_columns  on                  NULL  user     NULL      on                  on
+optimizer_push_offset_into_index_join                      on                  NULL  user     NULL      on                  on
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL  user     NULL      on                  on
@@ -3256,6 +3258,7 @@ optimizer_always_use_histograms                            NULL    NULL     NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
+optimizer_push_offset_into_index_join                      NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -126,6 +126,7 @@ optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_prove_implication_with_virtual_computed_columns  on
+optimizer_push_offset_into_index_join                      on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -738,6 +738,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 	h.evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = true
 	h.evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
 	h.evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = true
+	h.evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin = true
 
 	// Set up the test catalog.
 	h.testCat = testcat.New()

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -197,6 +197,7 @@ type Memo struct {
 	useImprovedZigzagJoinCosting               bool
 	useImprovedMultiColumnSelectivityEstimate  bool
 	proveImplicationWithVirtualComputedCols    bool
+	pushOffsetIntoIndexJoin                    bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -280,6 +281,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useImprovedZigzagJoinCosting:               evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting,
 		useImprovedMultiColumnSelectivityEstimate:  evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate,
 		proveImplicationWithVirtualComputedCols:    evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns,
+		pushOffsetIntoIndexJoin:                    evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -441,6 +443,7 @@ func (m *Memo) IsStale(
 		m.useImprovedZigzagJoinCosting != evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting ||
 		m.useImprovedMultiColumnSelectivityEstimate != evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate ||
 		m.proveImplicationWithVirtualComputedCols != evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns ||
+		m.pushOffsetIntoIndexJoin != evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -489,6 +489,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = false
 	notStale()
 
+	// Stale optimizer_push_offset_into_index_join.
+	evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin = true
+	stale()
+	evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -320,6 +320,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = true
 	ot.evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
 	ot.evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns = true
+	ot.evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin = true
 
 	return ot
 }

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -420,3 +420,9 @@ func (c *CustomFuncs) GeneratePartialOrderTopK(
 		grp.Memo().AddTopKToGroup(&memo.TopKExpr{Input: input, TopKPrivate: newPrivate}, grp)
 	}
 }
+
+// CanPushOffsetIntoIndexJoin returns true if the session setting
+// optimizer_push_offset_into_index_join is enabled.
+func (c *CustomFuncs) CanPushOffsetIntoIndexJoin() bool {
+	return c.e.evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin
+}

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -59,6 +59,7 @@
 [PushOffsetIntoIndexJoin, Explore]
 (Offset
     (IndexJoin $input:* $indexJoinPrivate:*) &
+        (CanPushOffsetIntoIndexJoin) &
         (IndexJoinPreservesRows $indexJoinPrivate)
     $offsetExpr:(Const $offset:* & (IsPositiveInt $offset))
     $ordering:* &

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -873,6 +873,27 @@ index-join kuv
       │         └── fd: (4)-->(1,2)
       └── 5
 
+# The offset is not pushed into the index join if
+# optimizer_push_offset_into_index_join is false.
+opt expect-not=PushOffsetIntoIndexJoin set=(optimizer_push_offset_into_index_join=off)
+SELECT * FROM kuv WHERE k = 1 OR k = 2 ORDER BY u OFFSET 5
+----
+offset
+ ├── columns: k:1!null u:2 v:3
+ ├── internal-ordering: +2
+ ├── ordering: +2
+ ├── sort
+ │    ├── columns: k:1!null u:2 v:3
+ │    ├── ordering: +2
+ │    └── index-join kuv
+ │         ├── columns: k:1!null u:2 v:3
+ │         └── scan kuv@kuv_k_u_idx
+ │              ├── columns: k:1!null u:2 rowid:4!null
+ │              ├── constraint: /1/2/4: [/1 - /2]
+ │              ├── key: (4)
+ │              └── fd: (4)-->(1,2)
+ └── 5
+
 # Ensure that the offset is not pushed down when the ordering requires columns
 # produced by the IndexJoin.
 opt expect-not=PushOffsetIntoIndexJoin

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -517,6 +517,9 @@ message LocalOnlySessionData {
   // index implication.
   bool optimizer_prove_implication_with_virtual_computed_columns = 130;
   reserved 131;
+  // OptimizerPushOffsetIntoIndexJoin, when true, indicates that the optimizer
+  // should push offset expressions into index joins.
+  bool optimizer_push_offset_into_index_join = 132;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3360,6 +3360,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_push_offset_into_index_join`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_push_offset_into_index_join`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_push_offset_into_index_join", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerPushOffsetIntoIndexJoin(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
The `optimizer_push_offset_into_index_join` session setting has been
added. If enabled, the `PushOffsetIntoIndexJoin` rule is enabled which
attempts to push offset expressions into index joins to reduce the
number of lookup rows. It is enabled by default, but will be disabled in
some backports by default to avoid query plan changes.

Release note (sql change): The `optimizer_push_offset_into_index_join`
session setting has been added. When enabled, the optimizer will attempt
to push offset expressions into index join expressions to produce more
efficient query plans. It is enabled by default on 24.1+ and disabled on
23.2.
