### PR TITLE
kv: use request's PrevLease during batch eval, stop using applied lease

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -144,7 +144,6 @@ func TestLeaseTransferForwardsStartTime(t *testing.T) {
 				StoreID:            1,
 				Desc:               &desc,
 				Clock:              clock,
-				Lease:              prevLease,
 				CurrentReadSummary: currentReadSummary,
 			}
 			cArgs := CommandArgs{


### PR DESCRIPTION
Informs #123498.

This commit changes the above-raft batch evaluation for `RequestLease` and `TransferLease` requests to stop using `cArgs.EvalCtx.GetLease()` as the previous lease and to instead use the request's supplied `PrevLease`.

This was an unintentional source of complexity which dates back to at least 08334a3 (before proposer-eval kv). It was later justified post-hoc through some revisionist history in the comment discussing a desire to "detect lease requests that will inevitably fail early", but that never actually made sense because the applied lease should be equal to the request's `PrevLease` if the locking in `pendingLeaseRequest` is handled correctly.

By using the request's `PrevLease` instead of the applied lease, we avoid questions about whether these can ever differ.

Release note: None