### PR TITLE
workload/tpcc: add the IDs in errors about missing rows

### DIFF
--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -278,7 +278,7 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, error) {
 							n.config.auditor.newOrderRollbacks.Add(1)
 							return errSimulated
 						}
-						return errors.New("missing item row")
+						return errors.Newf("missing item row(s): %s", iIDs)
 					}
 
 					if err := rows.Scan(&item.iPrice, &item.iName, iData); err != nil {

--- a/pkg/workload/tpcc/order_status.go
+++ b/pkg/workload/tpcc/order_status.go
@@ -143,7 +143,7 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 				if err := o.selectByCustID.QueryRowTx(
 					ctx, tx, wID, d.dID, d.cID,
 				).Scan(&d.cBalance, &d.cFirst, &d.cMiddle, &d.cLast); err != nil {
-					return errors.Wrap(err, "select customer by id failed")
+					return errors.Wrapf(err, "select customer by id failed w_id %d d_id %d c_id %d", wID, d.dID, d.cID)
 				}
 			} else {
 				// Case 2: Pick the middle row, rounded up, from the selection by last name.
@@ -164,10 +164,10 @@ func (o *orderStatus) run(ctx context.Context, wID int) (interface{}, error) {
 					}
 					return rows.Err()
 				}(); err != nil {
-					return errors.Wrap(err, "select customer by last name failed")
+					return errors.Wrapf(err, "select customer by last name failed w_id %d d_id %d c_id %d", wID, d.dID, d.cID)
 				}
 				if len(customers) == 0 {
-					return errors.New("found no customers matching query orderStatus.selectByLastName")
+					return errors.Newf("found no customers matching query orderStatus.selectByLastName w_id %d d_id %d c_id %d", wID, d.dID, d.cID)
 				}
 				cIdx := (len(customers) - 1) / 2
 				c := customers[cIdx]

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -243,7 +243,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, error) {
 				&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
 				&d.cCreditLim, &d.cDiscount, &d.cBalance, &d.cData,
 			); err != nil {
-				return errors.Wrap(err, "update customer failed")
+				return errors.Wrapf(err, "update customer failed %d %d %d", d.cWID, d.cDID, d.cID)
 			}
 
 			hData := fmt.Sprintf("%s    %s", wName, dName)


### PR DESCRIPTION
Release note: none.
Epic: none.