### PR TITLE
packer: move `add-apt-repository` call to after `sleep`

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -28,11 +28,11 @@ echo 'deb https://packages.cloud.google.com/apt cloud-sdk main' > /etc/apt/sourc
 curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | apt-key add -
 echo "deb https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
 
-add-apt-repository ppa:git-core/ppa
-
 # Some images come with apt autoupgrade job running at start, let's give it a few minutes to finish to avoid races.
 echo "Sleeping for 3 minutes to allow apt daily cronjob to finish..."
 sleep 3m
+
+add-apt-repository ppa:git-core/ppa
 apt-get update
 
 # Installing gnome-keyring prevents the error described in


### PR DESCRIPTION
Updates are still going on on the VM while this is happening.

Epic: none
Release note: None