### PR TITLE
builtins: fix st_geojson when max_decimal_digits is specified

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -6294,3 +6294,11 @@ statement error pgcode 22023 pq: st_tileenvelope\(\): Unable to compute bbox
 SELECT st_tileenvelope(0, 0, 0, '010500000000000000');
 
 subtest end
+
+# Regression test for not respecting max_decimal_digits argument of the
+# st_geojson builtin function (#124368).
+query T
+SELECT st_asgeojson(tbl.*, 'g', 4)::JSONB->'geometry'->'coordinates'
+  FROM (VALUES ('SRID=4326;POINT (-123.45678901234 12.3456789012)'::GEOMETRY)) tbl(g);
+----
+[-123.4568, 12.3457]

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7777,7 +7777,7 @@ This variant will cast all geometry_str arguments into Geometry types.
 // stAsGeoJSONFromTuple returns a *tree.DString representing JSON output
 // for ST_AsGeoJSON.
 func stAsGeoJSONFromTuple(
-	evalCtx *eval.Context, tuple *tree.DTuple, geoColumn string, numDecimalDigits int, pretty bool,
+	evalCtx *eval.Context, tuple *tree.DTuple, geoColumn string, maxDecimalDigits int, pretty bool,
 ) (*tree.DString, error) {
 	typ := tuple.ResolvedType()
 	labels := typ.TupleLabels()
@@ -7805,7 +7805,7 @@ func stAsGeoJSONFromTuple(
 			if g, ok := d.(*tree.DGeometry); ok {
 				foundGeoColumn = true
 				var err error
-				geometry, err = g.ToJSON()
+				geometry, err = g.ToJSON(maxDecimalDigits)
 				if err != nil {
 					return nil, err
 				}
@@ -7814,7 +7814,7 @@ func stAsGeoJSONFromTuple(
 			if g, ok := d.(*tree.DGeography); ok {
 				foundGeoColumn = true
 				var err error
-				geometry, err = g.ToJSON()
+				geometry, err = g.ToJSON(maxDecimalDigits)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3553,8 +3553,8 @@ func (d *DGeography) Size() uintptr {
 }
 
 // ToJSON converts the DGeography to JSON.
-func (d *DGeography) ToJSON() (json.JSON, error) {
-	return spatialObjectToJSON(d.Geography.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)
+func (d *DGeography) ToJSON(maxDecimalDigits int) (json.JSON, error) {
+	return spatialObjectToJSON(d.Geography.SpatialObject(), maxDecimalDigits)
 }
 
 // DGeometry is the Geometry Datum.
@@ -3680,8 +3680,8 @@ func (d *DGeometry) Size() uintptr {
 }
 
 // ToJSON converts the DGeometry to JSON.
-func (d *DGeometry) ToJSON() (json.JSON, error) {
-	return spatialObjectToJSON(d.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)
+func (d *DGeometry) ToJSON(maxDecimalDigits int) (json.JSON, error) {
+	return spatialObjectToJSON(d.Geometry.SpatialObject(), maxDecimalDigits)
 }
 
 type DPGLSN struct {
@@ -4100,9 +4100,9 @@ func AsJSON(
 			AsStringWithFlags(t, FmtBareStrings, FmtDataConversionConfig(dcc), FmtLocation(loc)),
 		), nil
 	case *DGeometry:
-		return t.ToJSON()
+		return t.ToJSON(geo.DefaultGeoJSONDecimalDigits)
 	case *DGeography:
-		return t.ToJSON()
+		return t.ToJSON(geo.DefaultGeoJSONDecimalDigits)
 	case *DVoid:
 		return json.FromString(AsStringWithFlags(t, fmtRawStrings)), nil
 	default:
@@ -4114,8 +4114,8 @@ func AsJSON(
 	}
 }
 
-func spatialObjectToJSON(so geopb.SpatialObject, numDecimalDigits int) (json.JSON, error) {
-	j, err := geo.SpatialObjectToGeoJSON(so, numDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
+func spatialObjectToJSON(so geopb.SpatialObject, maxDecimalDigits int) (json.JSON, error) {
+	j, err := geo.SpatialObjectToGeoJSON(so, maxDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit fixes a regression in `st_geojson` builtin when `max_decimal_digits` argument is specified which was introduced in 600914174272f76a4eb111a9062dcf367f81f348 (during 24.1 cycle). In particular, this overload specifies the precision (rather than using the default number of digits), and that commit made it so that we ignore the precision argument. This is now fixed.

Fixes: #124368.

Release note (bug fix): CockroachDB previously would ignore `max_decimal_digits` argument of `st_geojson` builtin function and would use the default instead. The bug is only present in 24.1.0 releases.