### PR TITLE
roachprod: changes in promhelper client for modify labels

### DIFF
--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -51,6 +51,8 @@ type PromClient struct {
 	// httpDelete is used for http DELETE operation.
 	httpDelete func(ctx context.Context, url string, h *http.Header) (
 		resp *http.Response, err error)
+	// httpGet is used for http GET operation.
+	httpGet func(ctx context.Context, url string, h *http.Header) (resp *http.Response, err error)
 	// newTokenSource is the token generator source.
 	newTokenSource func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (
 		oauth2.TokenSource, error)
@@ -61,12 +63,13 @@ func NewPromClient() *PromClient {
 	return &PromClient{
 		httpPut:        httputil.Put,
 		httpDelete:     httputil.Delete,
+		httpGet:        httputil.GetWithHeaders,
 		newTokenSource: idtoken.NewTokenSource,
 	}
 }
 
-// instanceConfigRequest is the HTTP request received for generating instance config
-type instanceConfigRequest struct {
+// instanceConfig is the HTTP request received for generating instance config
+type instanceConfig struct {
 	//Config is the content of the yaml file
 	Config   string `json:"config"`
 	Insecure bool   `json:"insecure"`
@@ -85,6 +88,20 @@ func (c *PromClient) UpdatePrometheusTargets(
 	if err != nil {
 		return err
 	}
+	return c.updatePromTargets(ctx, promUrl, clusterName, forceFetchCreds, insecure, req, l)
+}
+
+// updatePromTargets is an internal function to update the prometheus config
+// This takes the req as io.Reader.
+func (c *PromClient) updatePromTargets(
+	ctx context.Context,
+	promUrl string,
+	clusterName string,
+	forceFetchCreds bool,
+	insecure bool,
+	req io.Reader,
+	l *logger.Logger,
+) error {
 	token, err := c.getToken(ctx, promUrl, forceFetchCreds, l)
 	if err != nil {
 		return err
@@ -104,7 +121,7 @@ func (c *PromClient) UpdatePrometheusTargets(
 		defer func() { _ = response.Body.Close() }()
 		if response.StatusCode == http.StatusUnauthorized && !forceFetchCreds {
 			l.Printf("request failed - this may be due to a stale token. retrying with forceFetchCreds true ...")
-			return c.UpdatePrometheusTargets(ctx, promUrl, clusterName, true, nodes, insecure, l)
+			return c.updatePromTargets(ctx, promUrl, clusterName, true, insecure, req, l)
 		}
 		body, err := io.ReadAll(response.Body)
 		if err != nil {
@@ -147,6 +164,132 @@ func (c *PromClient) DeleteClusterConfig(
 	return nil
 }
 
+// AppendOrUpdateLabels appends or updates the labels in the cluster config. This reads the current
+// cluster config and modifies the labels and then, updates the config
+func (c *PromClient) AppendOrUpdateLabels(
+	ctx context.Context,
+	promUrl, clusterName string,
+	forceFetchCreds, insecure bool,
+	nodeLabels map[int]map[string]string,
+	l *logger.Logger,
+) error {
+	ccParams, err := c.getClusterConfig(ctx, promUrl, clusterName, forceFetchCreds, insecure, l)
+	if err != nil {
+		return err
+	}
+	updateNeeded := false
+	for i := range ccParams {
+		// extract the node ID
+		nodeID, err := strconv.Atoi(ccParams[i].Labels["node"])
+		if err != nil {
+			return err
+		}
+		// check if the node ID has and entry for add/update labels
+		if labels, ok := nodeLabels[nodeID]; ok {
+			for k, v := range labels {
+				// add/overwrite the label
+				ccParams[i].Labels[k] = v
+				updateNeeded = true
+			}
+		}
+	}
+	if !updateNeeded {
+		l.Printf("No update needed for cluster config")
+		return nil
+	}
+	req, err := marshalCreateRequest(ccParams, insecure)
+	if err != nil {
+		return err
+	}
+	return c.updatePromTargets(ctx, promUrl, clusterName, forceFetchCreds, insecure, req, l)
+}
+
+// RemoveLabels removes the labels in the cluster config. This reads the current
+// cluster config and delete the labels and then, updates the config
+func (c *PromClient) RemoveLabels(
+	ctx context.Context,
+	promUrl, clusterName string,
+	forceFetchCreds, insecure bool,
+	nodeLabelKeys map[int][]string,
+	l *logger.Logger,
+) error {
+	ccParams, err := c.getClusterConfig(ctx, promUrl, clusterName, forceFetchCreds, insecure, l)
+	if err != nil {
+		return err
+	}
+	updateNeeded := false
+	for i := range ccParams {
+		// extract the node ID
+		nodeID, err := strconv.Atoi(ccParams[i].Labels["node"])
+		if err != nil {
+			return err
+		}
+		// check if the node ID has and entry for add/update labels
+		if labels, ok := nodeLabelKeys[nodeID]; ok {
+			for _, k := range labels {
+				// add/overwrite the label
+				delete(ccParams[i].Labels, k)
+				updateNeeded = true
+			}
+		}
+	}
+	if !updateNeeded {
+		l.Printf("No delete needed for cluster config")
+		return nil
+	}
+	req, err := marshalCreateRequest(ccParams, insecure)
+	if err != nil {
+		return err
+	}
+	return c.updatePromTargets(ctx, promUrl, clusterName, forceFetchCreds, insecure, req, l)
+}
+
+// getClusterConfig gets the cluster config in the promUrl
+func (c *PromClient) getClusterConfig(
+	ctx context.Context,
+	promUrl, clusterName string,
+	forceFetchCreds, insecure bool,
+	l *logger.Logger,
+) ([]*CCParams, error) {
+	token, err := c.getToken(ctx, promUrl, forceFetchCreds, l)
+	if err != nil {
+		return nil, err
+	}
+	url := getUrl(promUrl, clusterName)
+	if insecure {
+		// add the query parameter as insecure
+		url = fmt.Sprintf("%s?insecure=true", url)
+	}
+	l.Printf("invoking GET for URL: %s", url)
+	h := &http.Header{}
+	h.Set("Authorization", token)
+	response, err := c.httpGet(ctx, url, h)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		defer func() { _ = response.Body.Close() }()
+		if response.StatusCode == http.StatusUnauthorized && !forceFetchCreds {
+			return c.getClusterConfig(ctx, promUrl, clusterName, true, insecure, l)
+		}
+		return nil, errors.Newf("request failed with status %d and error %s", response.StatusCode,
+			string(body))
+	}
+	res := &instanceConfig{}
+	if err = json.Unmarshal(body, res); err != nil {
+		return nil, err
+	}
+	configs := make([]*CCParams, 0)
+	if err = yaml.UnmarshalStrict([]byte(res.Config), &configs); err != nil {
+		return nil, err
+	}
+	return configs, nil
+}
+
 func getUrl(promUrl, clusterName string) string {
 	return fmt.Sprintf("%s/%s/%s/%s", promUrl, resourceVersion, resourceName, clusterName)
 }
@@ -182,11 +325,16 @@ func buildCreateRequest(nodes map[int]*NodeInfo, insecure bool) (io.Reader, erro
 		}
 		configs = append(configs, params)
 	}
+	return marshalCreateRequest(configs, insecure)
+}
+
+// marshalCreateRequest creates the request from list of CCParams
+func marshalCreateRequest(configs []*CCParams, insecure bool) (io.Reader, error) {
 	cb, err := yaml.Marshal(&configs)
 	if err != nil {
 		return nil, err
 	}
-	b, err := json.Marshal(&instanceConfigRequest{Config: string(cb), Insecure: insecure})
+	b, err := json.Marshal(&instanceConfig{Config: string(cb), Insecure: insecure})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -11,6 +11,7 @@
 package promhelperclient
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -87,6 +88,320 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 	})
 }
 
+func Test_getPrometheusTargets(t *testing.T) {
+	l := func() *logger.Logger {
+		l, err := logger.RootLogger("", logger.TeeToStdout)
+		if err != nil {
+			panic(err)
+		}
+		return l
+	}()
+	ctx := context.Background()
+	promUrl := "http://prom_url.com"
+	c := NewPromClient()
+	t.Run("getClusterConfig fails with 400", func(t *testing.T) {
+		c.httpGet = func(ctx context.Context, reqUrl string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1"), reqUrl)
+			return &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(strings.NewReader("failed")),
+			}, nil
+		}
+		configs, err := c.getClusterConfig(ctx, promUrl, "c1", false, false, l)
+		require.NotNil(t, err)
+		require.Equal(t, "request failed with status 400 and error failed", err.Error())
+		require.Nil(t, configs)
+	})
+	t.Run("getClusterConfig succeeds", func(t *testing.T) {
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+
+			config := &instanceConfig{
+				Config:   validConfig,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		configs, err := c.getClusterConfig(ctx, promUrl, "c1", false, true, l)
+		require.Equal(t, 2, len(configs))
+		require.Equal(t, "10.142.0.133:29001", configs[0].Targets[0])
+		require.Equal(t, "10.142.1.10:29001", configs[1].Targets[0])
+		require.Equal(t, "10.142.0.133", configs[0].Labels["host_ip"])
+		require.Equal(t, "1", configs[1].Labels["node"])
+		require.Nil(t, err)
+	})
+	t.Run("getClusterConfig fails in yaml unmarshalling", func(t *testing.T) {
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config:   `bad`,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		configs, err := c.getClusterConfig(ctx, promUrl, "c1", false, true, l)
+		require.Zero(t, len(configs))
+		require.Equal(t, "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `bad` into []*promhelperclient.CCParams", err.Error())
+	})
+	t.Run("getClusterConfig fails in json unmarshalling", func(t *testing.T) {
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString("bad")),
+			}, nil
+		}
+		configs, err := c.getClusterConfig(ctx, promUrl, "c1", false, true, l)
+		require.Zero(t, len(configs))
+		require.Equal(t, "invalid character 'b' looking for beginning of value", err.Error())
+	})
+}
+
+func TestAppendOrUpdateLabels(t *testing.T) {
+	l := func() *logger.Logger {
+		l, err := logger.RootLogger("", logger.TeeToStdout)
+		if err != nil {
+			panic(err)
+		}
+		return l
+	}()
+	ctx := context.Background()
+	promUrl := "http://prom_url.com"
+	t.Run("get cluster config fails", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString("bad")),
+			}, nil
+		}
+		err := c.AppendOrUpdateLabels(ctx, promUrl, "c1", false, true, nil, l)
+		require.Equal(t, "invalid character 'b' looking for beginning of value", err.Error())
+	})
+	t.Run("invalid node ID in get cluster config", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config: `- targets:
+  - 10.142.0.133:29001
+  labels:
+    job: cockroachdb
+    node: "invalid"`,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		err := c.AppendOrUpdateLabels(ctx, promUrl, "c1", false, true, nil, l)
+		require.Equal(t, "strconv.Atoi: parsing \"invalid\": invalid syntax", err.Error())
+	})
+	t.Run("successful update", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config:   validConfig,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		newLabels := map[int]map[string]string{
+			2: {"newLabel": "withValue"},
+			1: {"anotherLabel": "anotherValue", "host_ip": "new_ip"},
+		}
+		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1"), url)
+			ir, err := getInstanceConfigRequest(io.NopCloser(body))
+			require.Nil(t, err)
+			require.NotNil(t, ir.Config)
+			configs := make([]*CCParams, 0)
+			require.Nil(t, yaml.UnmarshalStrict([]byte(ir.Config), &configs))
+			require.Equal(t, 2, len(configs))
+			for _, c := range configs {
+				nodeID, err := strconv.Atoi(c.Labels["node"])
+				require.NoError(t, err)
+				for k, v := range newLabels[nodeID] {
+					require.Equal(t, v, c.Labels[k])
+				}
+			}
+			return &http.Response{
+				StatusCode: 200,
+			}, nil
+		}
+		err := c.AppendOrUpdateLabels(ctx, promUrl, "c1", false, true,
+			newLabels, l)
+		require.Nil(t, err)
+	})
+	t.Run("no value passed for update", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config:   validConfig,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (resp *http.Response, err error) {
+			return nil, fmt.Errorf("invalid invocation")
+		}
+		err := c.AppendOrUpdateLabels(ctx, promUrl, "c1", false, true,
+			make(map[int]map[string]string), l)
+		require.Nil(t, err)
+	})
+}
+
+func TestRemoveLabels(t *testing.T) {
+	l := func() *logger.Logger {
+		l, err := logger.RootLogger("", logger.TeeToStdout)
+		if err != nil {
+			panic(err)
+		}
+		return l
+	}()
+	ctx := context.Background()
+	promUrl := "http://prom_url.com"
+	t.Run("get cluster config fails", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString("bad")),
+			}, nil
+		}
+		err := c.RemoveLabels(ctx, promUrl, "c1", false, true, nil, l)
+		require.Equal(t, "invalid character 'b' looking for beginning of value", err.Error())
+	})
+	t.Run("invalid node ID in get cluster config", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config: `- targets:
+  - 10.142.0.133:29001
+  labels:
+    job: cockroachdb
+    node: "invalid"`,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		err := c.RemoveLabels(ctx, promUrl, "c1", false, true, nil, l)
+		require.Equal(t, "strconv.Atoi: parsing \"invalid\": invalid syntax", err.Error())
+	})
+	t.Run("successful delete", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config:   validConfig,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		newLabels := map[int][]string{
+			2: {"cluster", "project"},
+			1: {"instance"},
+		}
+		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1"), url)
+			ir, err := getInstanceConfigRequest(io.NopCloser(body))
+			require.Nil(t, err)
+			require.NotNil(t, ir.Config)
+			configs := make([]*CCParams, 0)
+			require.Nil(t, yaml.UnmarshalStrict([]byte(ir.Config), &configs))
+			require.Equal(t, 2, len(configs))
+			for _, c := range configs {
+				nodeID, err := strconv.Atoi(c.Labels["node"])
+				require.NoError(t, err)
+				for _, k := range newLabels[nodeID] {
+					require.Equal(t, "", c.Labels[k])
+				}
+			}
+			return &http.Response{
+				StatusCode: 200,
+			}, nil
+		}
+		err := c.RemoveLabels(ctx, promUrl, "c1", false, true,
+			newLabels, l)
+		require.Nil(t, err)
+	})
+	t.Run("no value passed for update", func(t *testing.T) {
+		c := NewPromClient()
+		c.httpGet = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, getUrl(promUrl, "c1?insecure=true"), url)
+			config := &instanceConfig{
+				Config:   validConfig,
+				Insecure: true,
+			}
+			b, err := json.Marshal(config)
+			require.Nil(t, err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (resp *http.Response, err error) {
+			return nil, fmt.Errorf("invalid invocation")
+		}
+		err := c.RemoveLabels(ctx, promUrl, "c1", false, true,
+			make(map[int][]string), l)
+		require.Nil(t, err)
+	})
+}
+
 func TestDeleteClusterConfig(t *testing.T) {
 	l := func() *logger.Logger {
 		l, err := logger.RootLogger(filepath.Join(t.TempDir(), "test.log"), logger.TeeToStdout)
@@ -125,8 +440,8 @@ func TestDeleteClusterConfig(t *testing.T) {
 }
 
 // getInstanceConfigRequest returns the instanceConfigRequest after parsing the request json
-func getInstanceConfigRequest(body io.ReadCloser) (*instanceConfigRequest, error) {
-	var insConfigReq instanceConfigRequest
+func getInstanceConfigRequest(body io.ReadCloser) (*instanceConfig, error) {
+	var insConfigReq instanceConfig
 	if err := json.NewDecoder(body).Decode(&insConfigReq); err != nil {
 		return nil, err
 	}
@@ -199,3 +514,28 @@ func (tk *mockToken) Token() (*oauth2.Token, error) {
 	}
 	return &oauth2.Token{AccessToken: tk.token}, nil
 }
+
+const validConfig = `- targets:
+  - 10.142.0.133:29001
+  labels:
+    cluster: bhaskarbora-test
+    host_ip: 10.142.0.133
+    instance: bhaskarbora-test-0002
+    job: cockroachdb
+    node: "2"
+    project: cockroach-ephemeral
+    region: us-east1
+    tenant: system
+    zone: us-east1-b
+- targets:
+  - 10.142.1.10:29001
+  labels:
+    cluster: bhaskarbora-test
+    host_ip: 10.142.1.10
+    instance: bhaskarbora-test-0001
+    job: cockroachdb
+    node: "1"
+    project: cockroach-ephemeral
+    region: us-east1
+    tenant: system
+    zone: us-east1-b`

--- a/pkg/util/httputil/client.go
+++ b/pkg/util/httputil/client.go
@@ -59,7 +59,16 @@ type Client struct {
 // Get does like http.Get but uses the provided context and obeys its cancellation.
 // It also uses the default client with a default 3 second timeout.
 func Get(ctx context.Context, url string) (resp *http.Response, err error) {
-	return DefaultClient.Get(ctx, url)
+	return GetWithHeaders(ctx, url, nil)
+}
+
+// GetWithHeaders does like http.Get but uses the provided context and obeys its cancellation.
+// It also uses the default client with a default 3 second timeout.
+// Also, it takes http headers as input.
+func GetWithHeaders(
+	ctx context.Context, url string, h *http.Header,
+) (resp *http.Response, err error) {
+	return DefaultClient.GetWithHeaders(ctx, url, h)
 }
 
 // Head does like http.Head but uses the provided context and obeys its cancellation.
@@ -90,11 +99,22 @@ func Delete(ctx context.Context, url string, h *http.Header) (resp *http.Respons
 	return DefaultClient.Delete(ctx, url, h)
 }
 
-// Get does like http.Client.Get but uses the provided context and obeys its cancellation.
+// Get is like http.Client.Get but uses the provided context and obeys its cancellation.
 func (c *Client) Get(ctx context.Context, url string) (resp *http.Response, err error) {
+	return c.GetWithHeaders(ctx, url, nil)
+}
+
+// GetWithHeaders is like http.Client.Get but uses the provided context and
+// obeys its cancellation along with http headers.
+func (c *Client) GetWithHeaders(
+	ctx context.Context, url string, h *http.Header,
+) (resp *http.Response, err error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
+	}
+	if h != nil {
+		req.Header = *h
 	}
 	return c.Do(req)
 }


### PR DESCRIPTION
When a test is run, a new label has to be added to prometheus. To do this, we need to first get the current config, add the new label and update the config. This change does that. Post this change, the label update will be integrated.

The change also needs a change in httputil client GET function to support headers being passed.

Fixes: #124319
Epic: none