### PR TITLE
roachprod: pass same set of keys with session

### DIFF
--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -137,8 +137,11 @@ func IsLocalClusterName(clusterName string) bool {
 
 var localClusterRegex = regexp.MustCompile(`^local(|-[a-zA-Z0-9\-]+)$`)
 
+// DefaultPubKeyNames is the list of default public key names that `roachprod`
+// will look for in the SSH directory. The keys will also be passed when
+// establishing a remote session.
 // See https://github.com/openssh/openssh-portable/blob/86bdd385/ssh_config.5#L1123-L1130
-var defaultPubKeyNames = []string{
+var DefaultPubKeyNames = []string{
 	"id_rsa",
 	"id_ecdsa",
 	"id_ecdsa_sk",
@@ -155,7 +158,7 @@ func SSHPublicKeyPath() (string, error) {
 		return "", errors.Wrap(err, "failed to read SSH directory")
 	}
 
-	for _, name := range defaultPubKeyNames {
+	for _, name := range DefaultPubKeyNames {
 		idx := slices.IndexFunc(dirEnts, func(entry fs.DirEntry) bool {
 			return name == entry.Name()
 		})

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -331,10 +331,9 @@ var sshAuthArgsOnce sync.Once
 
 func sshAuthArgs() []string {
 	sshAuthArgsOnce.Do(func() {
-		paths := []string{
-			filepath.Join(config.OSUser.HomeDir, ".ssh", "id_ed25519"),
-			filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
-			filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
+		paths := make([]string, len(config.DefaultPubKeyNames))
+		for idx, name := range config.DefaultPubKeyNames {
+			paths[idx] = filepath.Join(config.SSHDirectory, ".ssh", name)
 		}
 		for _, p := range paths {
 			if _, err := os.Stat(p); err == nil {


### PR DESCRIPTION
Previously, the public key list used by session diverged from the list specified in the config `defaultPubKeyNames`. This change makes the list public and reuses it for remote sessions as well.

Release Note: None
Epic: None