### PR TITLE
cdcevent: minor refactor to allow reuse

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -457,6 +457,13 @@ func NewEventDecoder(
 		return nil, err
 	}
 
+	return NewEventDecoderWithCache(ctx, rfCache, includeVirtual, keyOnly), nil
+}
+
+// NewEventDecoderWithCache returns key value decoder.
+func NewEventDecoderWithCache(
+	ctx context.Context, rfCache *rowFetcherCache, includeVirtual bool, keyOnly bool,
+) Decoder {
 	eventDescriptorCache := cache.NewUnorderedCache(DefaultCacheConfig)
 	getEventDescriptor := func(
 		desc catalog.TableDescriptor,
@@ -469,7 +476,7 @@ func NewEventDecoder(
 	return &eventDecoder{
 		getEventDescriptor: getEventDescriptor,
 		rfCache:            rfCache,
-	}, nil
+	}
 }
 
 // RowType is the type of the row being decoded.


### PR DESCRIPTION
This makes it possible to construct a cdcevent decoder with a fixed set of descriptors. The fixed implementation is not used in this PR but will be used in a follow up.

Epic: none
Release note: None