### PR TITLE
kvclient: add WithFiltering option to rangefeed client

### DIFF
--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -40,6 +40,7 @@ type config struct {
 	useRowTimestampInInitialScan bool
 
 	withDiff             bool
+	withFiltering        bool
 	onUnrecoverableError OnUnrecoverableError
 	onCheckpoint         OnCheckpoint
 	frontierQuantize     time.Duration
@@ -143,6 +144,14 @@ func WithOnInternalError(f OnUnrecoverableError) Option {
 func WithDiff(withDiff bool) Option {
 	return optionFunc(func(c *config) {
 		c.withDiff = withDiff
+	})
+}
+
+// WithFiltering makes an option to set whether to filter out rangefeeds events
+// where the user has set omit_from_changefeeds in their session.
+func WithFiltering(withFiltering bool) Option {
+	return optionFunc(func(c *config) {
+		c.withFiltering = withFiltering
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -321,6 +321,9 @@ func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier) {
 	if f.withDiff {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithDiff())
 	}
+	if f.withFiltering {
+		rangefeedOpts = append(rangefeedOpts, kvcoord.WithFiltering())
+	}
 	if f.onMetadata != nil {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithMetadata())
 	}


### PR DESCRIPTION
This adds a WithFiltering option to the rangefeed client that passes through the option to the underlying rangefeed.

Epic: none
Release note: None