### PR TITLE
ci/roachtest: fix ssh key gen in private roachtest nightly

### DIFF
--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
@@ -5,6 +5,9 @@ set -exuo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 
 source "$dir/teamcity-support.sh"
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "private-roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+fi
 
 $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh amd64
 


### PR DESCRIPTION
Public roachtest nightlies have been generating
an ssh keypair on startup, for some time [1].
It was a soft requirement until [2]. In [2],
we streamlined the management and distribution
of ssh keypairs, thus making it a hard requirement.

This change synchronizes the above aspect of the CI config. with that of the public roachtest nightly.

[1] https://github.com/cockroachdb/cockroach/blob/d146ecff6f687e438706cf63591cafca60cc116d/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh#L9-L10
[2] https://github.com/cockroachdb/cockroach/pull/119106

Epic: none
Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/107776