### PR TITLE
raft: remove RawNode.TickQuiesced

### DIFF
--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -68,20 +68,6 @@ func (rn *RawNode) Tick() {
 	rn.raft.tick()
 }
 
-// TickQuiesced advances the internal logical clock by a single tick without
-// performing any other state machine processing. It allows the caller to avoid
-// periodic heartbeats and elections when all of the peers in a Raft group are
-// known to be at the same state. Expected usage is to periodically invoke Tick
-// or TickQuiesced depending on whether the group is "active" or "quiesced".
-//
-// WARNING: Be very careful about using this method as it subverts the Raft
-// state machine. You should probably be using Tick instead.
-//
-// DEPRECATED: This method will be removed in a future release.
-func (rn *RawNode) TickQuiesced() {
-	rn.raft.electionElapsed++
-}
-
 // Campaign causes this RawNode to transition to candidate state.
 func (rn *RawNode) Campaign() error {
 	return rn.raft.Step(pb.Message{


### PR DESCRIPTION
This commit removes the `(*RawNode).TickQuiesced` method. The method was deprecated back in https://github.com/etcd-io/raft/pull/62 and has not been in use since 2018.

Epic: None
Release note: None