### PR TITLE
logictest: deflake synthetic_privileges test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -388,7 +388,8 @@ GRANT SYSTEM ALL TO testuser
 statement ok
 CANCEL SESSION (SELECT session_id FROM [SHOW SESSIONS] WHERE user_name = 'testuser')
 
-user testuser
+# Force a new session to be created, causing a connection attempt.
+user testuser nodeIdx=0 newsession
 
 statement ok
 SELECT 1


### PR DESCRIPTION
The test was relying on behavior from before
a65fea782a5fc3803289b05827e4c8f12980c3c6, where the connection would not be closed for up to 1 second after being cancelled with CANCEL SESSION.

After that commit, the connection is closed nearly immediately, so the test was much more likely to hit an error when trying to reuse the connection.

I confirmed this was the bug by reverting
a65fea782a5fc3803289b05827e4c8f12980c3c6, then adding a sleep in the test before switching to the testuser connection. That made the test hit the same error.

fixes https://github.com/cockroachdb/cockroach/issues/124449
Release note: None