### PR TITLE
kvserver: return process error on scatter

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4142,12 +4142,13 @@ func (r *Replica) adminScatter(
 	}
 
 	// Loop until we hit an error or until we hit `maxAttempts` for the range.
+	var err error
 	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
 		if currentAttempt == maxAttempts {
 			break
 		}
 		desc, conf := r.DescAndSpanConfig()
-		_, err := rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
+		_, err = rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
 		if err != nil {
 			// The replica can not be processed, so skip it.
 			break


### PR DESCRIPTION
Prior to c9cf06893bf827a1752213aa3aebee2aaea35f13, a replica would return any errors processing the range with scatter options via the replicate queue, to the caller. Reinstall this behavior, which informs the caller about any relevant errors.

Fixes: #124510
Release note (bug fix): ADMIN SCATTER would not return any processing errors to the client in v24.1.0. ADMIN SCATTER will now return errors encountered during processing, as was the case prior to v24.1.0.