### PR TITLE
tree,parser: fix round-tripping of StorageParameter

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	gojson "encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -2230,7 +2231,7 @@ func isSetOrResetSchemaLocked(n *tree.AlterTable) bool {
 				return true
 			}
 		case *tree.AlterTableResetStorageParams:
-			if cmd.Params.Contains("schema_locked") {
+			if slices.Contains(cmd.Params, "schema_locked") {
 				return true
 			}
 		}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -402,8 +402,8 @@ func (u *sqlSymUnion) storageParams() []tree.StorageParam {
     }
     return nil
 }
-func (u *sqlSymUnion) storageParamKeys() []tree.Name {
-    if params, ok := u.val.([]tree.Name); ok {
+func (u *sqlSymUnion) storageParamKeys() []string {
+    if params, ok := u.val.([]string); ok {
         return params
     }
     return nil
@@ -1365,7 +1365,7 @@ func (u *sqlSymUnion) showFingerprintOptions() *tree.ShowFingerprintOptions {
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list copy_generic_options copy_generic_options_list
 %type <str> import_format
 %type <str> storage_parameter_key
-%type <tree.NameList> storage_parameter_key_list
+%type <[]string> storage_parameter_key_list
 %type <tree.StorageParam> storage_parameter
 %type <[]tree.StorageParam> storage_parameter_list opt_table_with opt_with_storage_parameter_list
 
@@ -9882,17 +9882,17 @@ storage_parameter_key:
 storage_parameter_key_list:
   storage_parameter_key
   {
-    $$.val = []tree.Name{tree.Name($1)}
+    $$.val = []string{$1}
   }
 | storage_parameter_key_list ',' storage_parameter_key
   {
-    $$.val = append($1.storageParamKeys(), tree.Name($3))
+    $$.val = append($1.storageParamKeys(), $3)
   }
 
 storage_parameter:
   storage_parameter_key '=' var_value
   {
-    $$.val = tree.StorageParam{Key: tree.Name($1), Value: $3.expr()}
+    $$.val = tree.StorageParam{Key: $1, Value: $3.expr()}
   }
 
 storage_parameter_list:

--- a/pkg/sql/parser/testdata/alter_table
+++ b/pkg/sql/parser/testdata/alter_table
@@ -1135,42 +1135,50 @@ ALTER TABLE _ EXPERIMENTAL_AUDIT SET OFF -- identifiers removed
 parse
 ALTER TABLE t SET (fillfactor = 100, autovacuum_enabled = false)
 ----
-ALTER TABLE t SET (fillfactor = 100, autovacuum_enabled = false)
-ALTER TABLE t SET (fillfactor = (100), autovacuum_enabled = (false)) -- fully parenthesized
-ALTER TABLE t SET (fillfactor = _, autovacuum_enabled = _) -- literals removed
-ALTER TABLE _ SET (_ = 100, _ = false) -- identifiers removed
+ALTER TABLE t SET ('fillfactor' = 100, 'autovacuum_enabled' = false) -- normalized!
+ALTER TABLE t SET ('fillfactor' = (100), 'autovacuum_enabled' = (false)) -- fully parenthesized
+ALTER TABLE t SET ('fillfactor' = _, 'autovacuum_enabled' = _) -- literals removed
+ALTER TABLE _ SET ('fillfactor' = 100, 'autovacuum_enabled' = false) -- identifiers removed
 
 parse
 ALTER TABLE t RESET (fillfactor)
 ----
-ALTER TABLE t RESET (fillfactor)
-ALTER TABLE t RESET (fillfactor) -- fully parenthesized
-ALTER TABLE t RESET (fillfactor) -- literals removed
-ALTER TABLE _ RESET (_) -- identifiers removed
+ALTER TABLE t RESET ('fillfactor') -- normalized!
+ALTER TABLE t RESET ('fillfactor') -- fully parenthesized
+ALTER TABLE t RESET ('fillfactor') -- literals removed
+ALTER TABLE _ RESET ('fillfactor') -- identifiers removed
 
 parse
 ALTER TABLE t RESET (fillfactor, autovacuum_enabled)
 ----
-ALTER TABLE t RESET (fillfactor, autovacuum_enabled)
-ALTER TABLE t RESET (fillfactor, autovacuum_enabled) -- fully parenthesized
-ALTER TABLE t RESET (fillfactor, autovacuum_enabled) -- literals removed
-ALTER TABLE _ RESET (_, _) -- identifiers removed
+ALTER TABLE t RESET ('fillfactor', 'autovacuum_enabled') -- normalized!
+ALTER TABLE t RESET ('fillfactor', 'autovacuum_enabled') -- fully parenthesized
+ALTER TABLE t RESET ('fillfactor', 'autovacuum_enabled') -- literals removed
+ALTER TABLE _ RESET ('fillfactor', 'autovacuum_enabled') -- identifiers removed
+
+parse
+ALTER TABLE t RESET (fillfactor, autovacuum_enabled, 'string')
+----
+ALTER TABLE t RESET ('fillfactor', 'autovacuum_enabled', 'string') -- normalized!
+ALTER TABLE t RESET ('fillfactor', 'autovacuum_enabled', 'string') -- fully parenthesized
+ALTER TABLE t RESET ('fillfactor', 'autovacuum_enabled', 'string') -- literals removed
+ALTER TABLE _ RESET ('fillfactor', 'autovacuum_enabled', 'string') -- identifiers removed
 
 parse
 ALTER TABLE t SET (exclude_data_from_backup = true)
 ----
-ALTER TABLE t SET (exclude_data_from_backup = true)
-ALTER TABLE t SET (exclude_data_from_backup = (true)) -- fully parenthesized
-ALTER TABLE t SET (exclude_data_from_backup = _) -- literals removed
-ALTER TABLE _ SET (_ = true) -- identifiers removed
+ALTER TABLE t SET ('exclude_data_from_backup' = true) -- normalized!
+ALTER TABLE t SET ('exclude_data_from_backup' = (true)) -- fully parenthesized
+ALTER TABLE t SET ('exclude_data_from_backup' = _) -- literals removed
+ALTER TABLE _ SET ('exclude_data_from_backup' = true) -- identifiers removed
 
 parse
 ALTER TABLE t RESET (exclude_data_from_backup)
 ----
-ALTER TABLE t RESET (exclude_data_from_backup)
-ALTER TABLE t RESET (exclude_data_from_backup) -- fully parenthesized
-ALTER TABLE t RESET (exclude_data_from_backup) -- literals removed
-ALTER TABLE _ RESET (_) -- identifiers removed
+ALTER TABLE t RESET ('exclude_data_from_backup') -- normalized!
+ALTER TABLE t RESET ('exclude_data_from_backup') -- fully parenthesized
+ALTER TABLE t RESET ('exclude_data_from_backup') -- literals removed
+ALTER TABLE _ RESET ('exclude_data_from_backup') -- identifiers removed
 
 error
 ALTER PARTITION p OF TABLE tbl@idx CONFIGURE ZONE USING num_replicas = 1

--- a/pkg/sql/parser/testdata/create_index
+++ b/pkg/sql/parser/testdata/create_index
@@ -207,10 +207,10 @@ CREATE UNIQUE INVERTED INDEX _ ON _ (_) -- identifiers removed
 parse
 CREATE INDEX a ON b (c) WITH (fillfactor = 100, y_bounds = 50)
 ----
-CREATE INDEX a ON b (c) WITH (fillfactor = 100, y_bounds = 50)
-CREATE INDEX a ON b (c) WITH (fillfactor = (100), y_bounds = (50)) -- fully parenthesized
-CREATE INDEX a ON b (c) WITH (fillfactor = _, y_bounds = _) -- literals removed
-CREATE INDEX _ ON _ (_) WITH (_ = 100, _ = 50) -- identifiers removed
+CREATE INDEX a ON b (c) WITH ('fillfactor' = 100, 'y_bounds' = 50) -- normalized!
+CREATE INDEX a ON b (c) WITH ('fillfactor' = (100), 'y_bounds' = (50)) -- fully parenthesized
+CREATE INDEX a ON b (c) WITH ('fillfactor' = _, 'y_bounds' = _) -- literals removed
+CREATE INDEX _ ON _ (_) WITH ('fillfactor' = 100, 'y_bounds' = 50) -- identifiers removed
 
 parse
 CREATE INDEX ON a ((a + b))
@@ -416,10 +416,10 @@ CREATE INDEX ON _ ((ARRAY[_, _])) STORING (_, _) NOT VISIBLE -- identifiers remo
 parse
 CREATE INDEX a ON b (c) WITH (fillfactor = 100, y_bounds = 50) NOT VISIBLE
 ----
-CREATE INDEX a ON b (c) WITH (fillfactor = 100, y_bounds = 50) NOT VISIBLE
-CREATE INDEX a ON b (c) WITH (fillfactor = (100), y_bounds = (50)) NOT VISIBLE -- fully parenthesized
-CREATE INDEX a ON b (c) WITH (fillfactor = _, y_bounds = _) NOT VISIBLE -- literals removed
-CREATE INDEX _ ON _ (_) WITH (_ = 100, _ = 50) NOT VISIBLE -- identifiers removed
+CREATE INDEX a ON b (c) WITH ('fillfactor' = 100, 'y_bounds' = 50) NOT VISIBLE -- normalized!
+CREATE INDEX a ON b (c) WITH ('fillfactor' = (100), 'y_bounds' = (50)) NOT VISIBLE -- fully parenthesized
+CREATE INDEX a ON b (c) WITH ('fillfactor' = _, 'y_bounds' = _) NOT VISIBLE -- literals removed
+CREATE INDEX _ ON _ (_) WITH ('fillfactor' = 100, 'y_bounds' = 50) NOT VISIBLE -- identifiers removed
 
 parse
 CREATE UNIQUE INDEX idx ON a (((lower(a) || ' ') || lower(b))) NOT VISIBLE
@@ -440,10 +440,10 @@ CREATE INVERTED INDEX IF NOT EXISTS _ ON _ (_) WHERE _ > 3 -- identifiers remove
 parse
 CREATE INDEX geom_idx_2 ON some_spatial_table USING GIST(geom) WITH (s2_max_cells = 20, s2_max_level = 12, s2_level_mod = 3) NOT VISIBLE
 ----
-CREATE INVERTED INDEX geom_idx_2 ON some_spatial_table (geom) WITH (s2_max_cells = 20, s2_max_level = 12, s2_level_mod = 3) NOT VISIBLE -- normalized!
-CREATE INVERTED INDEX geom_idx_2 ON some_spatial_table (geom) WITH (s2_max_cells = (20), s2_max_level = (12), s2_level_mod = (3)) NOT VISIBLE -- fully parenthesized
-CREATE INVERTED INDEX geom_idx_2 ON some_spatial_table (geom) WITH (s2_max_cells = _, s2_max_level = _, s2_level_mod = _) NOT VISIBLE -- literals removed
-CREATE INVERTED INDEX _ ON _ (_) WITH (_ = 20, _ = 12, _ = 3) NOT VISIBLE -- identifiers removed
+CREATE INVERTED INDEX geom_idx_2 ON some_spatial_table (geom) WITH ('s2_max_cells' = 20, 's2_max_level' = 12, 's2_level_mod' = 3) NOT VISIBLE -- normalized!
+CREATE INVERTED INDEX geom_idx_2 ON some_spatial_table (geom) WITH ('s2_max_cells' = (20), 's2_max_level' = (12), 's2_level_mod' = (3)) NOT VISIBLE -- fully parenthesized
+CREATE INVERTED INDEX geom_idx_2 ON some_spatial_table (geom) WITH ('s2_max_cells' = _, 's2_max_level' = _, 's2_level_mod' = _) NOT VISIBLE -- literals removed
+CREATE INVERTED INDEX _ ON _ (_) WITH ('s2_max_cells' = 20, 's2_max_level' = 12, 's2_level_mod' = 3) NOT VISIBLE -- identifiers removed
 
 parse
 CREATE UNIQUE INDEX IF NOT EXISTS a ON b (c) WHERE d > 3 NOT VISIBLE

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -2065,10 +2065,18 @@ CREATE TABLE IF NOT EXISTS _ (_, _ FAMILY _) AS SELECT * FROM _ -- identifiers r
 parse
 CREATE TABLE a WITH (fillfactor=100) AS SELECT * FROM b
 ----
-CREATE TABLE a WITH (fillfactor = 100) AS SELECT * FROM b -- normalized!
-CREATE TABLE a WITH (fillfactor = (100)) AS SELECT (*) FROM b -- fully parenthesized
-CREATE TABLE a WITH (fillfactor = _) AS SELECT * FROM b -- literals removed
-CREATE TABLE _ WITH (_ = 100) AS SELECT * FROM _ -- identifiers removed
+CREATE TABLE a WITH ('fillfactor' = 100) AS SELECT * FROM b -- normalized!
+CREATE TABLE a WITH ('fillfactor' = (100)) AS SELECT (*) FROM b -- fully parenthesized
+CREATE TABLE a WITH ('fillfactor' = _) AS SELECT * FROM b -- literals removed
+CREATE TABLE _ WITH ('fillfactor' = 100) AS SELECT * FROM _ -- identifiers removed
+
+parse
+CREATE TABLE tbl (a INT) WITH ( 'string' = 'val' )
+----
+CREATE TABLE tbl (a INT8) WITH ('string' = 'val') -- normalized!
+CREATE TABLE tbl (a INT8) WITH ('string' = ('val')) -- fully parenthesized
+CREATE TABLE tbl (a INT8) WITH ('string' = '_') -- literals removed
+CREATE TABLE _ (_ INT8) WITH ('string' = 'val') -- identifiers removed
 
 error
 CREATE TABLE test (
@@ -2215,10 +2223,10 @@ CREATE TABLE _ (_ INT4) LOCALITY REGIONAL BY ROW AS _ -- identifiers removed
 parse
 CREATE TABLE a (b INT) WITH (fillfactor=100)
 ----
-CREATE TABLE a (b INT8) WITH (fillfactor = 100) -- normalized!
-CREATE TABLE a (b INT8) WITH (fillfactor = (100)) -- fully parenthesized
-CREATE TABLE a (b INT8) WITH (fillfactor = _) -- literals removed
-CREATE TABLE _ (_ INT8) WITH (_ = 100) -- identifiers removed
+CREATE TABLE a (b INT8) WITH ('fillfactor' = 100) -- normalized!
+CREATE TABLE a (b INT8) WITH ('fillfactor' = (100)) -- fully parenthesized
+CREATE TABLE a (b INT8) WITH ('fillfactor' = _) -- literals removed
+CREATE TABLE _ (_ INT8) WITH ('fillfactor' = 100) -- identifiers removed
 
 parse
 CREATE TABLE arr_t (i STRING DEFAULT (('{' || 'a' || '}')::STRING[])[1]::STRING)

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
@@ -4,7 +4,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 /* test */
 EXPLAIN (DDL) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 ----
-Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 9 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain_shape
@@ -4,7 +4,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 /* test */
 EXPLAIN (DDL, SHAPE) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 ----
-Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey- in relation t
  │    └── into t_pkey+ (j, crdb_internal_j_shard_3+; i)

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
@@ -16,7 +16,7 @@ write *eventpb.AlterTable to event log:
   mutationId: 1
   sql:
     descriptorId: 104
-    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›)
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›)
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
@@ -157,8 +157,8 @@ upsert descriptor #104
   +      name: t
   +    relevantStatements:
   +    - statement:
-  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›)
-  +        statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count = 3)
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›)
+  +        statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = 3)
   +        statementTag: ALTER TABLE
   +    revertible: true
   +    targetRanks: <redacted>
@@ -268,7 +268,7 @@ upsert descriptor #104
   -  version: "1"
   +  version: "2"
 persist all catalog changes to storage
-create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count = 3)"
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = 3)"
   descriptor IDs: [104]
 # end PreCommitPhase
 commit transaction #1
@@ -711,7 +711,7 @@ begin transaction #18
 ## PostCommitPhase stage 16 of 16 with 4 MutationType ops
 upsert descriptor #104
   ...
-           statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count = 3)
+           statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = 3)
            statementTag: ALTER TABLE
   -    revertible: true
        targetRanks: <redacted>
@@ -963,8 +963,8 @@ upsert descriptor #104
   -      name: t
   -    relevantStatements:
   -    - statement:
-  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›)
-  -        statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count = 3)
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›)
+  -        statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = 3)
   -        statementTag: ALTER TABLE
   -    targetRanks: <redacted>
   -    targets: <redacted>
@@ -1023,7 +1023,7 @@ upsert descriptor #104
   -  version: "13"
   +  version: "14"
 persist all catalog changes to storage
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count = 3)"
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = 3)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 10 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 11 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 12 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 13 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 14 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 15 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 16 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_1_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_1_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 1 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
            ├── 12 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_2_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_2_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 2 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_3_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_3_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 3 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_4_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_4_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 4 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_5_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_5_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 5 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_6_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_6_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 6 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_7_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_7_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 7 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_8_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_8_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 8 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH (bucket_count=3);
 EXPLAIN (DDL) rollback at post-commit stage 9 of 16;
 ----
-Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH (‹bucket_count› = ‹3›);
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 )
 
 // AlterTable represents an ALTER TABLE statement.
@@ -637,7 +638,7 @@ func (node *AlterTableSetStorageParams) Format(ctx *FmtCtx) {
 
 // AlterTableResetStorageParams represents a ALTER TABLE RESET command.
 type AlterTableResetStorageParams struct {
-	Params NameList
+	Params []string
 }
 
 // TelemetryName implements the AlterTableCmd interface.
@@ -647,8 +648,14 @@ func (node *AlterTableResetStorageParams) TelemetryName() string {
 
 // Format implements the NodeFormatter interface.
 func (node *AlterTableResetStorageParams) Format(ctx *FmtCtx) {
+	buf, f := &ctx.Buffer, ctx.flags
 	ctx.WriteString(" RESET (")
-	ctx.FormatNode(&node.Params)
+	for i, param := range node.Params {
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		lexbase.EncodeSQLStringWithFlags(buf, param, f.EncodeFlags())
+	}
 	ctx.WriteString(")")
 }
 

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1441,7 +1441,7 @@ func (node *RangePartition) Format(ctx *FmtCtx) {
 
 // StorageParam is a key-value parameter for table storage.
 type StorageParam struct {
-	Key   Name
+	Key   string
 	Value Expr
 }
 
@@ -1450,14 +1450,13 @@ type StorageParams []StorageParam
 
 // Format implements the NodeFormatter interface.
 func (o *StorageParams) Format(ctx *FmtCtx) {
+	buf, f := &ctx.Buffer, ctx.flags
 	for i := range *o {
 		n := &(*o)[i]
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		// TODO(knz): the key may need to be formatted differently
-		// if we want to de-anonymize it.
-		ctx.FormatNode(&n.Key)
+		lexbase.EncodeSQLStringWithFlags(buf, n.Key, f.EncodeFlags())
 		if n.Value != nil {
 			ctx.WriteString(` = `)
 			ctx.FormatNode(n.Value)
@@ -1468,9 +1467,8 @@ func (o *StorageParams) Format(ctx *FmtCtx) {
 // GetVal returns corresponding value if a key exists, otherwise nil is
 // returned.
 func (o *StorageParams) GetVal(key string) Expr {
-	k := Name(key)
 	for _, param := range *o {
-		if param.Key == k {
+		if param.Key == key {
 			return param.Value
 		}
 	}

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -54,7 +54,7 @@ func Set(
 		return err
 	}
 	for _, sp := range params {
-		key := string(sp.Key)
+		key := sp.Key
 		if sp.Value == nil {
 			return pgerror.Newf(pgcode.InvalidParameterValue, "storage parameter %q requires a value", key)
 		}
@@ -92,14 +92,14 @@ func Set(
 // Reset sets the given storage parameters using the
 // given observer.
 func Reset(
-	ctx context.Context, evalCtx *eval.Context, params tree.NameList, paramObserver Setter,
+	ctx context.Context, evalCtx *eval.Context, params []string, paramObserver Setter,
 ) error {
 	if err := storageParamPreChecks(ctx, evalCtx, nil /* setParam */, params); err != nil {
 		return err
 	}
 	for _, p := range params {
-		telemetry.Inc(sqltelemetry.ResetTableStorageParameter(string(p)))
-		if err := paramObserver.Reset(ctx, evalCtx, string(p)); err != nil {
+		telemetry.Inc(sqltelemetry.ResetTableStorageParameter(p))
+		if err := paramObserver.Reset(ctx, evalCtx, p); err != nil {
 			return err
 		}
 	}
@@ -128,10 +128,7 @@ func SetFillFactor(ctx context.Context, evalCtx *eval.Context, key string, datum
 // storageParamPreChecks is where we specify pre-conditions for setting/resetting
 // storage parameters `param`.
 func storageParamPreChecks(
-	ctx context.Context,
-	evalCtx *eval.Context,
-	setParams tree.StorageParams,
-	resetParams tree.NameList,
+	ctx context.Context, evalCtx *eval.Context, setParams tree.StorageParams, resetParams []string,
 ) error {
 	if setParams != nil && resetParams != nil {
 		return errors.AssertionFailedf("only one of setParams and resetParams should be non-nil.")
@@ -139,11 +136,9 @@ func storageParamPreChecks(
 
 	var keys []string
 	for _, param := range setParams {
-		keys = append(keys, string(param.Key))
+		keys = append(keys, param.Key)
 	}
-	for _, param := range resetParams {
-		keys = append(keys, string(param))
-	}
+	keys = append(keys, resetParams...)
 
 	for _, key := range keys {
 		if key == `schema_locked` {


### PR DESCRIPTION
Previously, storage parameters could not round trip the parse-format-parse steps if the parameter key was a reserved keyword.

This was because the Name type was used for keys, which ends up double-quoting the name. For storage parameters, we want single quotes, as they are just string literals, so we can use a normal string type.

fixes https://github.com/cockroachdb/cockroach/issues/124380
Release note: None