### PR TITLE
internal/sqlsmith: fix recent regression with non-determinism

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -770,7 +770,10 @@ func makeScalarSubquery(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr,
 	if s.disableNondeterministicLimits {
 		// The ORDER BY clause must be fully specified with all select list columns
 		// in order to make a LIMIT clause deterministic.
-		selectStmt.OrderBy = s.makeOrderByWithAllCols(selectRefs)
+		selectStmt.OrderBy, ok = s.makeOrderByWithAllCols(selectRefs)
+		if !ok {
+			return nil, false
+		}
 	}
 
 	subq := &tree.Subquery{


### PR DESCRIPTION
We recently merged ce8ec9e775d384a4b2fd36057975352da361b9c6 which made it so that we no longer attempt to order by TSVector and TSQuery types (which isn't supported so previously would always result in an error). However, that introduced a regression when "non-deterministic limits are disabled" making the output non-deterministic. Namely, it now became possible for `makeOrderByWithAllCols` to produce such an ORDER BY clause that doesn't include all columns. The fix is to stop generating the statement if it requires all columns in the ORDER BY, yet some columns are not orderable.

Fixes: #124477.

Release note: None