### PR TITLE
sql/randgen: limit the geometry and geography datum sizes

### DIFF
--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",
+        "@com_github_twpayne_go_geom//:go-geom",
     ],
 )
 


### PR DESCRIPTION
Previously, RandDatumWithNullChance could end up generating fairly large datums for geography / geoemtry datums because we allowed multiple geometry collections that were embedded which could have exponential sizes. This could lead to datums which are fairly large leading to errors. To address this, this patch will add logic to limit the size of generated geoemetry / geoegraphy datums.

Fixes: #123497

Release note: None