### PR TITLE
sql: skip TestExplainRedact under race

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -38,6 +38,7 @@ func TestExplainRedactDDL(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderDeadlock(t, "the test is too slow")
+	skip.UnderRace(t, "the test is too slow")
 
 	const numStatements = 10
 

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -509,6 +509,7 @@ func TestExplainRedact(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderDeadlock(t, "the test is too slow")
+	skip.UnderRace(t, "the test is too slow")
 
 	const numStatements = 10
 


### PR DESCRIPTION
We just saw a failure under race with a timeout with no clear signs of anything being wrong, so let's just skip a couple of tests under race.

Fixes: #123987.

Release note: None