### PR TITLE
streamclient: plumb WithFiltering into streamclient

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -87,6 +87,7 @@ func (sc testStreamClient) Subscribe(
 	_ SubscriptionToken,
 	_ hlc.Timestamp,
 	_ span.Frontier,
+	_ ...SubscribeOption,
 ) (Subscription, error) {
 	sampleKV := roachpb.KeyValue{
 		Key: []byte("key_1"),

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -507,6 +507,7 @@ func (m *RandomStreamClient) Subscribe(
 	spec SubscriptionToken,
 	initialScanTime hlc.Timestamp,
 	_ span.Frontier,
+	_ ...SubscribeOption,
 ) (Subscription, error) {
 	partitionURL, err := url.Parse(string(spec))
 	if err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -124,6 +124,7 @@ func (m *mockStreamClient) Subscribe(
 	token streamclient.SubscriptionToken,
 	initialScanTime hlc.Timestamp,
 	_ span.Frontier,
+	_ ...streamclient.SubscribeOption,
 ) (streamclient.Subscription, error) {
 	var events []streamingccl.Event
 	var ok bool
@@ -180,6 +181,7 @@ func (m *errorStreamClient) Subscribe(
 	_ streamclient.SubscriptionToken,
 	_ hlc.Timestamp,
 	_ span.Frontier,
+	_ ...streamclient.SubscribeOption,
 ) (streamclient.Subscription, error) {
 	return nil, errors.New("this client always returns an error")
 }

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -143,6 +143,7 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 		rangefeed.WithOnDeleteRange(s.onDeleteRange),
 		rangefeed.WithFrontierQuantized(quantize.Get(&s.execCfg.Settings.SV)),
 		rangefeed.WithOnValues(s.onValues),
+		rangefeed.WithFiltering(s.spec.WithFiltering),
 	}
 	if emitMetadata.Get(&s.execCfg.Settings.SV) {
 		opts = append(opts, rangefeed.WithOnMetadata(s.onMetadata))

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -100,7 +100,7 @@ message StreamPartitionSpec {
   // of the stream.  If unspecified, reasonable defaults will be set.
   message ExecutionConfig {
     reserved 1;
-    
+
     // Controls how often checkpoint records are published.
     google.protobuf.Duration min_checkpoint_frequency = 2
        [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
@@ -117,6 +117,11 @@ message StreamPartitionSpec {
   repeated cockroach.sql.jobs.jobspb.ResolvedSpan progress = 6  [(gogoproto.nullable) = false];
 
   bool compressed = 7;
+
+  // WithFiltering controls whether the rangefeed started for this
+  // partition should filter datums where OmitInRangefeeds should be
+  // set.
+  bool with_filtering = 8;
 }
 
 // SpanConfigEventStreamSpec is the span config event stream specification.


### PR DESCRIPTION
This adds the concept of SubscribeOptions to the the streamclient Subscribe method. The first option added here is the WithFiltering option that controls whether the rangefeed is started WithFiltering or not.

We plan to use WithFiltering for basic data-loop prevention in a row-based ingestion prototype. While future versions of the the row-based ingestion will likely require more advanced filtering semantics, this will get us started and I think the SubscribeOptions will be useful in the future.

This option has no caller yet.

Epic: none
Release note: None