### PR TITLE
sqlstats: add fingerprint cardinality estimation metric

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -482,15 +482,16 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		DB: NewInternalDB(
 			s, MemoryMetrics{}, sqlStatsInternalExecutorMonitor,
 		),
-		ClusterID:               s.cfg.NodeInfo.LogicalClusterID,
-		SQLIDContainer:          cfg.NodeInfo.NodeID,
-		JobRegistry:             s.cfg.JobRegistry,
-		Knobs:                   cfg.SQLStatsTestingKnobs,
-		FlushesSuccessful:       serverMetrics.StatsMetrics.SQLStatsFlushesSuccessful,
-		FlushDoneSignalsIgnored: serverMetrics.StatsMetrics.SQLStatsFlushDoneSignalsIgnored,
-		FlushedFingerprintCount: serverMetrics.StatsMetrics.SQLStatsFlushFingerprintCount,
-		FlushesFailed:           serverMetrics.StatsMetrics.SQLStatsFlushesFailed,
-		FlushLatency:            serverMetrics.StatsMetrics.SQLStatsFlushLatency,
+		ClusterID:                             s.cfg.NodeInfo.LogicalClusterID,
+		SQLIDContainer:                        cfg.NodeInfo.NodeID,
+		JobRegistry:                           s.cfg.JobRegistry,
+		Knobs:                                 cfg.SQLStatsTestingKnobs,
+		FlushesSuccessful:                     serverMetrics.StatsMetrics.SQLStatsFlushesSuccessful,
+		FlushDoneSignalsIgnored:               serverMetrics.StatsMetrics.SQLStatsFlushDoneSignalsIgnored,
+		FlushedFingerprintCount:               serverMetrics.StatsMetrics.SQLStatsFlushFingerprintCount,
+		FlushedFingerprintCardinalityEstimate: serverMetrics.StatsMetrics.SQLStatsFlushFingerprintCardinalityEstimate,
+		FlushesFailed:                         serverMetrics.StatsMetrics.SQLStatsFlushesFailed,
+		FlushLatency:                          serverMetrics.StatsMetrics.SQLStatsFlushLatency,
 	}, memSQLStats)
 
 	s.sqlStats = persistedSQLStats
@@ -585,11 +586,12 @@ func makeServerMetrics(cfg *ExecutorConfig) ServerMetrics {
 				SigFigs:      3,
 				BucketConfig: metric.MemoryUsage64MBBuckets,
 			}),
-			ReportedSQLStatsMemoryCurBytesCount: metric.NewGauge(MetaReportedSQLStatsMemCurBytes),
-			DiscardedStatsCount:                 metric.NewCounter(MetaDiscardedSQLStats),
-			SQLStatsFlushesSuccessful:           metric.NewCounter(MetaSQLStatsFlushesSuccessful),
-			SQLStatsFlushDoneSignalsIgnored:     metric.NewCounter(MetaSQLStatsFlushDoneSignalsIgnored),
-			SQLStatsFlushFingerprintCount:       metric.NewCounter(MetaSQLStatsFlushFingerprintCount),
+			ReportedSQLStatsMemoryCurBytesCount:         metric.NewGauge(MetaReportedSQLStatsMemCurBytes),
+			DiscardedStatsCount:                         metric.NewCounter(MetaDiscardedSQLStats),
+			SQLStatsFlushesSuccessful:                   metric.NewCounter(MetaSQLStatsFlushesSuccessful),
+			SQLStatsFlushDoneSignalsIgnored:             metric.NewCounter(MetaSQLStatsFlushDoneSignalsIgnored),
+			SQLStatsFlushFingerprintCount:               metric.NewCounter(MetaSQLStatsFlushFingerprintCount),
+			SQLStatsFlushFingerprintCardinalityEstimate: metric.NewGauge(MetaSQLStatsFlushFingerprintCardinalityEstimate),
 
 			SQLStatsFlushesFailed: metric.NewCounter(MetaSQLStatsFlushesFailed),
 			SQLStatsFlushLatency: metric.NewHistogram(metric.HistogramOptions{

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1099,6 +1099,12 @@ var (
 		Measurement: "successful flushes",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaSQLStatsFlushFingerprintCardinalityEstimate = metric.Metadata{
+		Name:        "sql.stats.flush.fingerprint.cardinality_estimate",
+		Help:        "Estimated number of distinct fingerprints seen over last flush interval",
+		Measurement: "distinct fingerprints",
+		Unit:        metric.Unit_COUNT,
+	}
 	MetaSQLStatsFlushFingerprintCount = metric.Metadata{
 		Name:        "sql.stats.flush.fingerprint.count",
 		Help:        "The number of unique statement and transaction fingerprints included in the SQL Stats flush",

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -75,12 +75,13 @@ type StatsMetrics struct {
 
 	DiscardedStatsCount *metric.Counter
 
-	SQLStatsFlushesSuccessful       *metric.Counter
-	SQLStatsFlushDoneSignalsIgnored *metric.Counter
-	SQLStatsFlushFingerprintCount   *metric.Counter
-	SQLStatsFlushesFailed           *metric.Counter
-	SQLStatsFlushLatency            metric.IHistogram
-	SQLStatsRemovedRows             *metric.Counter
+	SQLStatsFlushesSuccessful                   *metric.Counter
+	SQLStatsFlushDoneSignalsIgnored             *metric.Counter
+	SQLStatsFlushFingerprintCount               *metric.Counter
+	SQLStatsFlushFingerprintCardinalityEstimate *metric.Gauge
+	SQLStatsFlushesFailed                       *metric.Counter
+	SQLStatsFlushLatency                        metric.IHistogram
+	SQLStatsRemovedRows                         *metric.Counter
 
 	SQLTxnStatsCollectionOverhead metric.IHistogram
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -68,6 +68,10 @@ func (s *PersistedSQLStats) MaybeFlush(ctx context.Context, stopper *stop.Stoppe
 
 	fingerprintCount := s.SQLStats.GetTotalFingerprintCount()
 	s.cfg.FlushedFingerprintCount.Inc(fingerprintCount)
+
+	cardinality := s.SQLStats.GetCardinality()
+	s.cfg.FlushedFingerprintCardinalityEstimate.Update(int64(cardinality))
+
 	if log.V(1) {
 		log.Infof(ctx, "flushing %d stmt/txn fingerprints (%d bytes) after %s",
 			fingerprintCount, s.SQLStats.GetTotalFingerprintBytes(), timeutil.Since(s.lastFlushStarted))

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -46,11 +46,12 @@ type Config struct {
 	JobRegistry             *jobs.Registry
 
 	// Metrics.
-	FlushesSuccessful       *metric.Counter
-	FlushLatency            metric.IHistogram
-	FlushDoneSignalsIgnored *metric.Counter
-	FlushesFailed           *metric.Counter
-	FlushedFingerprintCount *metric.Counter
+	FlushesSuccessful                     *metric.Counter
+	FlushLatency                          metric.IHistogram
+	FlushDoneSignalsIgnored               *metric.Counter
+	FlushesFailed                         *metric.Counter
+	FlushedFingerprintCount               *metric.Counter
+	FlushedFingerprintCardinalityEstimate *metric.Gauge
 
 	// Testing knobs.
 	Knobs *sqlstats.TestingKnobs

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -109,6 +109,7 @@ func (s *SQLStats) GetApplicationStats(appName string, internal bool) sqlstats.A
 	a := ssmemstorage.New(
 		s.st,
 		s.atomic,
+		s.cardinality,
 		s.mu.mon,
 		appName,
 		s.knobs,

--- a/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/util/mon",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_axiomhq_hyperloglog//:hyperloglog",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -45,6 +45,7 @@ func TestRecordStatement(t *testing.T) {
 		}
 		memContainer := New(settings,
 			nil, /* uniqueServerCount */
+			NewSQLCardinality(),
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			knobs,
@@ -80,6 +81,7 @@ func TestRecordTransaction(t *testing.T) {
 		}
 		memContainer := New(settings,
 			nil, /* uniqueServerCount */
+			NewSQLCardinality(),
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			knobs,


### PR DESCRIPTION
This commit adds a hyperloglog-based cardinality estimator for statement fingerprints that are flowing through sql stats.

The metric is attached to the SQLStats struct alongside the `atomic` counters to globally measure fingerprints across all apps.

TODO: how should estimates across all nodes be aggregated by DB Console? Do we just take the MAX? I think that would assume that all traffic is uniformly distributed across all nodes.

TODO: reset the cardinality on flush

TODO: add transaction cardinality tracking

Release note (ops change): A new metric is added
`sql.stats.flush.fingerprint.cardinality_estimate` which estimates the number of unique fingerprints flowing through the sql stats infrastructure. Customers can compare this metric to the `sql.stats.flush.fingerprint.count` to get a sense of whether the stats subsystem is measuring all the fingerprints they're generating. Customers can increase the values of `sql.metrics.max_mem_stmt_fingerprints` and `sql.metrics.max_mem_txn_fingerprints` cluster settings to capture more fingerprints if needed, although that will come with some performance hits.