### PR TITLE
release-24.1: cluster-ui: bump cluster-ui npm version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.1.0-prerelease.0",
+  "version": "24.1.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
bumps the cluster-ui version from `24.1.0-prerelease.0` to `24.1.0`

Epic: none
Release note: None