### PR TITLE
roachpb: make Lease.ProposedTS non-nullable

### DIFF
--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -385,11 +385,12 @@ func TestNotLeaseholderError(t *testing.T) {
 		err *NotLeaseHolderError
 	}{
 		{
-			exp: `[NotLeaseHolderError] r1: replica not lease holder; current lease is repl=(n1,s1):1 seq=2 start=0.000000001,0 epo=1`,
+			exp: `[NotLeaseHolderError] r1: replica not lease holder; current lease is repl=(n1,s1):1 seq=2 start=0.000000002,0 epo=1 pro=0.000000001,0`,
 			err: &NotLeaseHolderError{
 				RangeID: 1,
 				Lease: &roachpb.Lease{
-					Start:           hlc.ClockTimestamp{WallTime: 1},
+					Start:           hlc.ClockTimestamp{WallTime: 2},
+					ProposedTS:      hlc.ClockTimestamp{WallTime: 1},
 					Replica:         *rd,
 					Epoch:           1,
 					Sequence:        2,

--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/errors"
 )
 
 func newFailedLeaseTrigger(isTransfer bool) result.Result {
@@ -62,10 +61,6 @@ func evalNewLease(
 ) (result.Result, error) {
 	// When returning an error from this method, must always return
 	// a newFailedLeaseTrigger() to satisfy stats.
-
-	if lease.ProposedTS == nil {
-		return newFailedLeaseTrigger(isTransfer), errors.AssertionFailedf("ProposedTS must be set")
-	}
 
 	// Ensure either an Epoch is set or Start < Expiration.
 	if (lease.Type() == roachpb.LeaseExpiration && lease.GetExpiration().LessEq(lease.Start.ToTimestamp())) ||
@@ -165,7 +160,7 @@ func evalNewLease(
 	pd.Replicated.State = &kvserverpb.ReplicaState{
 		Lease: &lease,
 	}
-	pd.Replicated.PrevLeaseProposal = prevLease.ProposedTS
+	pd.Replicated.PrevLeaseProposal = &prevLease.ProposedTS
 
 	// If we're setting a new prior read summary, store it to disk & in-memory.
 	if priorReadSum != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -77,7 +77,7 @@ func TestLeaseCommandLearnerReplica(t *testing.T) {
 	_, err = RequestLease(ctx, nil, cArgs, nil)
 
 	const expForLearner = `cannot replace lease <empty> ` +
-		`with repl=(n2,s2):2LEARNER seq=0 start=0,0 exp=<nil>: ` +
+		`with repl=(n2,s2):2LEARNER seq=0 start=0,0 exp=<nil> pro=0,0: ` +
 		`lease target replica cannot hold lease`
 	require.EqualError(t, err, expForLearner)
 }
@@ -112,8 +112,8 @@ func TestLeaseTransferForwardsStartTime(t *testing.T) {
 			}
 			now := clock.NowAsClockTimestamp()
 			nextLease := roachpb.Lease{
-				ProposedTS: &now,
 				Replica:    replicas[1],
+				ProposedTS: now,
 				Start:      now,
 			}
 			if epoch {

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2327,7 +2327,7 @@ func TestLeaseExtensionNotBlockedByRead(t *testing.T) {
 				Start:      now,
 				Expiration: now.ToTimestamp().Add(time.Second.Nanoseconds(), 0).Clone(),
 				Replica:    replDesc,
-				ProposedTS: &now,
+				ProposedTS: now,
 			},
 		}
 

--- a/pkg/kv/kvserver/kvserverbase/forced_error.go
+++ b/pkg/kv/kvserver/kvserverbase/forced_error.go
@@ -152,7 +152,6 @@ func CheckForcedErr(
 		// PrevLeaseProposal is always set. Its nullability dates back to the
 		// migration that introduced it.
 		if raftCmd.ReplicatedEvalResult.PrevLeaseProposal != nil &&
-			// NB: ProposedTS can be nil if the right-hand side is the Range's initial zero Lease.
 			(!raftCmd.ReplicatedEvalResult.PrevLeaseProposal.Equal(replicaState.Lease.ProposedTS)) {
 			leaseMismatch = true
 		}

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -403,7 +403,7 @@ func buildReplicaDescriptorFromTestData(
 		Start:           clock.Now().Add(5*time.Minute.Nanoseconds(), 0).UnsafeToClockTimestamp(),
 		Expiration:      nil,
 		Replica:         desc.InternalReplicas[lhIndex],
-		ProposedTS:      nil,
+		ProposedTS:      hlc.ClockTimestamp{},
 		Epoch:           0,
 		Sequence:        0,
 		AcquisitionType: 0,

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -603,10 +603,7 @@ func (r *Replica) maybeLogLeaseAcquisition(
 	}
 
 	const slowLeaseApplyWarnThreshold = time.Second
-	var newLeaseAppDelay time.Duration
-	if newLease.ProposedTS != nil { // non-nil in practice, but never migrated
-		newLeaseAppDelay = time.Duration(now.WallTime - newLease.ProposedTS.WallTime)
-	}
+	newLeaseAppDelay := time.Duration(now.WallTime - newLease.ProposedTS.WallTime)
 	if newLeaseAppDelay > slowLeaseApplyWarnThreshold {
 		// If we hold the lease now and the lease was proposed "earlier", there
 		// must have been replication lag, and possibly reads and/or writes were

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -330,9 +330,9 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		Key: startKey,
 	}
 	reqLease := roachpb.Lease{
-		Start:      status.Now,
 		Replica:    nextLeaseHolder,
-		ProposedTS: &status.Now,
+		Start:      status.Now,
+		ProposedTS: status.Now,
 	}
 
 	var reqLeaseLiveness livenesspb.Liveness
@@ -840,7 +840,7 @@ func (r *Replica) leaseStatus(
 	// may cause, see https://github.com/cockroachdb/cockroach/issues/100101.
 	if expiration.LessEq(now.ToTimestamp()) {
 		status.State = kvserverpb.LeaseState_EXPIRED
-	} else if ownedLocally && lease.ProposedTS != nil && lease.ProposedTS.Less(minProposedTS) {
+	} else if ownedLocally && lease.ProposedTS.Less(minProposedTS) {
 		// If the replica owns the lease, additional verify that the lease's
 		// proposed timestamp is not earlier than the min proposed timestamp.
 		status.State = kvserverpb.LeaseState_PROSCRIBED

--- a/pkg/kv/kvserver/replica_range_lease_test.go
+++ b/pkg/kv/kvserver/replica_range_lease_test.go
@@ -58,7 +58,7 @@ func TestReplicaLeaseStatus(t *testing.T) {
 		Replica:    r1,
 		Start:      ts[1],
 		Expiration: ts[4].ToTimestamp().Clone(),
-		ProposedTS: &hlc.ClockTimestamp{WallTime: ts[1].WallTime - 100},
+		ProposedTS: hlc.ClockTimestamp{WallTime: ts[1].WallTime - 100},
 	}
 	epoLease := roachpb.Lease{
 		Replica:    expLease.Replica,

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -603,7 +603,7 @@ func TestReplicaReadConsistency(t *testing.T) {
 	tc.manualClock.MustAdvanceTo(leaseExpiry(tc.repl))
 	start := tc.Clock().NowAsClockTimestamp()
 	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		ProposedTS: &start,
+		ProposedTS: start,
 		Start:      start,
 		Expiration: start.ToTimestamp().Add(10, 0).Clone(),
 		Replica:    secondReplica,
@@ -821,7 +821,7 @@ func TestApplyCmdLeaseError(t *testing.T) {
 	tc.manualClock.MustAdvanceTo(leaseExpiry(tc.repl))
 	start := tc.Clock().NowAsClockTimestamp()
 	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		ProposedTS: &start,
+		ProposedTS: start,
 		Start:      start,
 		Expiration: start.ToTimestamp().Add(10, 0).Clone(),
 		Replica:    secondReplica,
@@ -980,7 +980,7 @@ func TestReplicaLease(t *testing.T) {
 	tc.manualClock.MustAdvanceTo(leaseExpiry(tc.repl))
 	now := tc.Clock().NowAsClockTimestamp()
 	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		ProposedTS: &now,
+		ProposedTS: now,
 		Start:      now.ToTimestamp().Add(10, 0).UnsafeToClockTimestamp(),
 		Expiration: now.ToTimestamp().Add(20, 0).Clone(),
 		Replica:    secondReplica,
@@ -1036,7 +1036,7 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 	tc.manualClock.MustAdvanceTo(leaseExpiry(tc.repl))
 	now := tc.Clock().NowAsClockTimestamp()
 	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		ProposedTS: &now,
+		ProposedTS: now,
 		Start:      now,
 		Expiration: now.ToTimestamp().Add(10, 0).Clone(),
 		Replica:    secondReplica,
@@ -1133,7 +1133,7 @@ func TestReplicaLeaseCounters(t *testing.T) {
 
 	now := tc.Clock().NowAsClockTimestamp()
 	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		ProposedTS: &now,
+		ProposedTS: now,
 		Start:      now,
 		Expiration: now.ToTimestamp().Add(10, 0).Clone(),
 		Replica: roachpb.ReplicaDescriptor{
@@ -1164,7 +1164,7 @@ func TestReplicaLeaseCounters(t *testing.T) {
 
 	// Make lease request fail by requesting overlapping lease from bogus Replica.
 	if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-		ProposedTS: &now,
+		ProposedTS: now,
 		Start:      now,
 		Expiration: now.ToTimestamp().Add(10, 0).Clone(),
 		Replica: roachpb.ReplicaDescriptor{
@@ -1264,7 +1264,7 @@ func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 		propTS := test.start.UnsafeToClockTimestamp()
 		propTS.Logical = int32(i)
 		if err := sendLeaseRequest(tc.repl, &roachpb.Lease{
-			ProposedTS: &propTS,
+			ProposedTS: propTS,
 			Start:      test.start.UnsafeToClockTimestamp(),
 			Expiration: test.expiration.Clone(),
 			Replica: roachpb.ReplicaDescriptor{
@@ -7876,8 +7876,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 
 		lease := prevLease
 		lease.Sequence = 0
-		now := tc.Clock().Now().UnsafeToClockTimestamp()
-		lease.ProposedTS = &now
+		lease.ProposedTS = tc.Clock().Now().UnsafeToClockTimestamp()
 
 		ba.Add(&kvpb.RequestLeaseRequest{
 			RequestHeader: kvpb.RequestHeader{

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1852,14 +1852,13 @@ func (l Lease) SafeFormat(w redact.SafePrinter, _ rune) {
 		w.SafeString("<empty>")
 		return
 	}
+	w.Printf("repl=%s seq=%d start=%s", l.Replica, l.Sequence, l.Start)
 	if l.Type() == LeaseExpiration {
-		w.Printf("repl=%s seq=%d start=%s exp=%s", l.Replica, l.Sequence, l.Start, l.Expiration)
+		w.Printf(" exp=%s", l.Expiration)
 	} else {
-		w.Printf("repl=%s seq=%d start=%s epo=%d", l.Replica, l.Sequence, l.Start, l.Epoch)
+		w.Printf(" epo=%d", l.Epoch)
 	}
-	if l.ProposedTS != nil {
-		w.Printf(" pro=%s", l.ProposedTS)
-	}
+	w.Printf(" pro=%s", l.ProposedTS)
 }
 
 // Empty returns true for the Lease zero-value.
@@ -1924,7 +1923,7 @@ func (l Lease) Speculative() bool {
 // reverse is not true.
 func (l Lease) Equivalent(newL Lease, expToEpochEquiv bool) bool {
 	// Ignore proposed timestamp & deprecated start stasis.
-	l.ProposedTS, newL.ProposedTS = nil, nil
+	l.ProposedTS, newL.ProposedTS = hlc.ClockTimestamp{}, hlc.ClockTimestamp{}
 	l.DeprecatedStartStasis, newL.DeprecatedStartStasis = nil, nil
 	// Ignore sequence numbers, they are simply a reflection of
 	// the equivalency of other fields.

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -698,8 +698,8 @@ message Lease {
   // proposed after the time of the said transfer or restart. This is nullable
   // to help with the rollout (such that a lease applied by some nodes before
   // the rollout and some nodes after the rollout is serialized the same).
-  // TODO(andrei): Make this non-nullable after the rollout.
   util.hlc.Timestamp proposed_ts  = 5 [(gogoproto.customname) = "ProposedTS",
+    (gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
 
   // The epoch of the lease holder's node liveness entry. If this value is

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1097,9 +1097,9 @@ func TestLeaseEquivalence(t *testing.T) {
 	expire2 := Lease{Replica: r1, Start: ts1, Expiration: ts3.ToTimestamp().Clone()}
 	expire2R2TS2 := Lease{Replica: r2, Start: ts2, Expiration: ts3.ToTimestamp().Clone()}
 
-	proposed1 := Lease{Replica: r1, Start: ts1, Epoch: 1, ProposedTS: &ts1}
-	proposed2 := Lease{Replica: r1, Start: ts1, Epoch: 2, ProposedTS: &ts1}
-	proposed3 := Lease{Replica: r1, Start: ts1, Epoch: 1, ProposedTS: &ts2}
+	proposed1 := Lease{Replica: r1, Start: ts1, Epoch: 1, ProposedTS: ts1}
+	proposed2 := Lease{Replica: r1, Start: ts1, Epoch: 2, ProposedTS: ts1}
+	proposed3 := Lease{Replica: r1, Start: ts1, Epoch: 1, ProposedTS: ts2}
 
 	stasis1 := Lease{Replica: r1, Start: ts1, Epoch: 1, DeprecatedStartStasis: ts1.ToTimestamp().Clone()}
 	stasis2 := Lease{Replica: r1, Start: ts1, Epoch: 1, DeprecatedStartStasis: ts2.ToTimestamp().Clone()}
@@ -1163,7 +1163,7 @@ func TestLeaseEquivalence(t *testing.T) {
 
 		// Similar potential bug triggers, but these were actually handled correctly.
 		DeprecatedStartStasis: new(hlc.Timestamp),
-		ProposedTS:            &hlc.ClockTimestamp{WallTime: 10},
+		ProposedTS:            hlc.ClockTimestamp{WallTime: 10},
 	}
 	postPRLease := prePRLease
 	postPRLease.DeprecatedStartStasis = nil
@@ -1180,7 +1180,7 @@ func TestLeaseEqual(t *testing.T) {
 		Expiration            *hlc.Timestamp
 		Replica               ReplicaDescriptor
 		DeprecatedStartStasis *hlc.Timestamp
-		ProposedTS            *hlc.ClockTimestamp
+		ProposedTS            hlc.ClockTimestamp
 		Epoch                 int64
 		Sequence              LeaseSequence
 		AcquisitionType       LeaseAcquisitionType
@@ -1234,7 +1234,7 @@ func TestLeaseEqual(t *testing.T) {
 		{Start: clockTS},
 		{Expiration: &ts},
 		{Replica: ReplicaDescriptor{NodeID: 1}},
-		{ProposedTS: &clockTS},
+		{ProposedTS: clockTS},
 		{Epoch: 1},
 		{Sequence: 1},
 	}


### PR DESCRIPTION
Addresses a TODO added in 2016 (3d508a11) when this field was introduced. The field has been non-nil since v2.0. We have performed a few raft-level migrations since then (e.g. the lock table migration) so v24.2 clusters have a guarantee that they will never see a lease with a nil ProposedTS.

Epic: None
Release note: None