### PR TITLE
security: remove node principal error check in cert loader

### DIFF
--- a/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
+++ b/pkg/cli/interactive_tests/test_cert_advisory_validation.tcl
@@ -51,12 +51,6 @@ eexpect $prompt
 send "COCKROACH_CERT_NODE_USER=foo.bar $argv cert create-node localhost --certs-dir=$certs_dir --ca-key=$certs_dir/ca.key\r"
 eexpect $prompt
 
-start_test "Check that the server reports an error if the node cert does not contain a node principal."
-send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --advertise-addr=localhost\r"
-eexpect "cannot load certificates"
-expect $prompt
-end_test
-
 start_test "Check that the cert principal map can allow the use of non-standard cert principal."
 send "$argv start-single-node --store=$db_dir --certs-dir=$certs_dir --cert-principal-map=foo.bar:node --advertise-addr=localhost\r"
 eexpect "node starting"

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -423,28 +423,3 @@ func parseCertificate(ci *CertInfo) error {
 	ci.ExpirationTime = expires
 	return nil
 }
-
-// validateDualPurposeNodeCert takes a CertInfo and a parsed certificate and checks the
-// values of certain fields.
-// This should only be called on the NodePem CertInfo when there is no specific
-// client certificate for the 'node' user.
-// Fields required for a valid server certificate are already checked.
-func validateDualPurposeNodeCert(ci *CertInfo) error {
-	if ci == nil {
-		return errors.Errorf("no node certificate found")
-	}
-
-	if ci.Error != nil {
-		return ci.Error
-	}
-
-	// The first certificate is used in client auth.
-	cert := ci.ParsedCertificates[0]
-	principals := getCertificatePrincipals(cert)
-	if !Contains(principals, username.NodeUser) {
-		return errors.Errorf("client/server node certificate has principals %q, expected %q",
-			principals, username.NodeUser)
-	}
-
-	return nil
-}

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -369,9 +369,9 @@ func (cm *CertificateManager) LoadCertificates() error {
 
 	if nodeClientCert == nil && nodeCert != nil {
 		// No client certificate for node, but we have a node certificate. Check that
-		// it contains the required client fields.
-		if err := validateDualPurposeNodeCert(nodeCert); err != nil {
-			return makeErrorf(err, "validating node cert")
+		// if it is a valid certificate and can be used as a client node cert.
+		if nodeCert.Error != nil {
+			return makeErrorf(nodeCert.Error, "validating node cert")
 		}
 	}
 

--- a/pkg/security/certificate_manager_test.go
+++ b/pkg/security/certificate_manager_test.go
@@ -121,15 +121,8 @@ func TestManagerWithPrincipalMap(t *testing.T) {
 		return ci.Error
 	}
 
+	// at this point certificate need not have principals match node user
 	setCertPrincipalMap("")
-	require.Regexp(t, `node certificate has principals \["node.crdb.io" "foo"\]`, newCertificateManager())
-
-	// We can map the "node.crdb.io" principal to "node".
-	setCertPrincipalMap("node.crdb.io:node")
-	require.NoError(t, newCertificateManager())
-
-	// We can map the "foo" principal to "node".
-	setCertPrincipalMap("foo:node")
 	require.NoError(t, newCertificateManager())
 
 	// Renaming "client.testuser.crt" to "client.foo.crt" allows us to load it


### PR DESCRIPTION
Currently for node certificates which also serve dual purpose as a client
certificate we validate that any of the principals of the cert match the node
user. Going forward, this check won't be necessary as we will allow certificates
with arbitrary principals as client does not have enough context to validate
certs. The validation of the certificate is responsibility of the server, and we
should use `cert-principal-map` or `*-cert-distinguished-name` to set
appropriate principals for client and server certs.

fixes CRDB-38958
Epic None

Release note: None