### PR TITLE
release-24.1: cluster-ui: bump cluster-ui npm version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.1.0",
+  "version": "24.1.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
bumps the cluster-ui version from `24.1.0` to `24.1.1`

The previous commit which updated the package.json version from `24.1.0-prerelease.0` to `24.1.0` did not result in the Cluster UI package being published to npm because 24.1.0 already exists. Bumping to
`24.1.1` should result in a new published package
in npm.

Epic: None
Release note: None