### PR TITLE
stats: fix TestCreateStatsProgress

### DIFF
--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -216,15 +216,6 @@ func GetJobID(t testing.TB, db *sqlutils.SQLRunner, offset int) jobspb.JobID {
 	return jobID
 }
 
-// GetLastJobID gets the most recent job's ID.
-func GetLastJobID(t testing.TB, db *sqlutils.SQLRunner) jobspb.JobID {
-	var jobID jobspb.JobID
-	db.QueryRow(t,
-		"SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1",
-	).Scan(&jobID)
-	return jobID
-}
-
 // GetJobProgress loads the Progress message associated with the job.
 func GetJobProgress(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Progress {
 	ret := &jobspb.Progress{}


### PR DESCRIPTION
This commit fixes a rare flake in `TestCreateStatsProgress` which I think was caused due to the test using "get last job ID" query without specifying the job type. In other words, my hypothesis is that the test could incorrectly pick a job other than CREATE STATS (that happened to be started right after the stats one), and we would never get any progress reported on that other job. This is now fixed by only looking at CREATE STATS jobs. Additionally, the helper function that was only used in this test is now unexported.

Fixes: #121770.

Release note: None