### PR TITLE
testccl: handle different type of connection closed errors

### DIFF
--- a/pkg/ccl/testccl/sqlccl/run_control_test.go
+++ b/pkg/ccl/testccl/sqlccl/run_control_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -220,7 +221,7 @@ func testCancelSession(t *testing.T, hasActiveSession bool) {
 				_, err = conn1.ExecContext(ctx, "SELECT 1")
 			}
 
-			if !errors.Is(err, gosqldriver.ErrBadConn) {
+			if !errors.Is(err, gosqldriver.ErrBadConn) && !testutils.IsError(err, "connection reset by peer") {
 				t.Fatalf("session not canceled; actual error: %s", err)
 			}
 		})
@@ -268,8 +269,8 @@ func TestCancelMultipleSessions(t *testing.T) {
 			// Verify that the connections on node 1 are closed.
 			for i := 0; i < 2; i++ {
 				_, err := conns[i].ExecContext(ctx, "SELECT 1")
-				if !errors.Is(err, gosqldriver.ErrBadConn) {
-					t.Fatalf("session %d not canceled; actual error: %s", i, err)
+				if !errors.Is(err, gosqldriver.ErrBadConn) && !testutils.IsError(err, "connection reset by peer") {
+					t.Fatalf("session %d not canceled; actual error: %v", i, err)
 				}
 			}
 		})


### PR DESCRIPTION
After a65fea782a5fc3803289b05827e4c8f12980c3c6 was merged, it became possible for the connection to get closed quicker. If it does, then the lib/pq logic that checks for bad connections may not run before getting a response from the server, so instead lib/pq will return a "connection reset by peer" error. If that does happen, then due to the lib/pq error handling logic ([1] and [2]), only the next query will result in ErrBadConn, and the current one will return a network error.

[1] - https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/error.go#L500-L502
[2] - https://github.com/lib/pq/pull/730

fixes https://github.com/cockroachdb/cockroach/issues/124452
fixes https://github.com/cockroachdb/cockroach/issues/124465
Release note: None