### PR TITLE
opt/bench: fix up recently added query to EndToEnd benchmark

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -455,9 +455,10 @@ var queries = [...]benchQuery{
 		args:  []interface{}{"'abc'"},
 	},
 	{
-		name:  "json-insert",
-		query: "INSERT INTO json_table(k, i, j) VALUES ($1, $2, $3)",
-		args:  []interface{}{1, 10, `'{"a": "foo", "b": "bar", "c": [2, 3, "baz", true, false, null]}'`},
+		name:    "json-insert",
+		query:   `INSERT INTO json_table(k, i, j) VALUES (1, 10, '{"a": "foo", "b": "bar", "c": [2, 3, "baz", true, false, null]}')`,
+		args:    []interface{}{},
+		cleanup: "TRUNCATE TABLE json_table",
 	},
 	{
 		name: "batch-insert-one",


### PR DESCRIPTION
For some reason, the JSON parser is not happy when we're using the placeholders for the JSON type (due to using escape characters somewhere in the driver), so this commit inlines the placeholder values into the query (we already do this for a couple of other queries). Additionally, we forgot to perform the cleanup to avoid duplicate key violations.

Fixes: #124526.

Release note: None