### PR TITLE
release: automatically detect if version is latest

### DIFF
--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -30,6 +30,12 @@ if [[ -z "$build_name" ]] ; then
     echo "Unsupported version \"${NAME}\". Must be of the format \"vMAJOR.MINOR.PATCH\"."
     exit 0
 fi
+
+PUBLISH_LATEST=
+if is_latest "$build_name"; then
+  PUBLISH_LATEST=true
+fi
+
 # Hard coded release number used only by the RedHat images
 rhel_release=1
 rhel_project_id=5e61ea74fe2231a0c2860382

--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -116,3 +116,15 @@ function is_release_or_master_build(){
   #                                                ^ calver prefix, e.g. 25.1
   # We don't strictly match the suffix to allow different ones, e.g. "rc" or have none.
 }
+
+# Compare the passed version to the latest published version. Returns 0 if the
+# passed version is the latest. Supports stable versions only.
+function is_latest() {
+  version=$1
+  url="https://get.cockroachdb.com/api/is_latest?version=$version"
+  maybe_latest="$(curl -fsSL "$url" || echo "")"
+  if [[ $maybe_latest == "yes" ]]; then
+    return 0
+  fi
+  return 1
+}

--- a/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
@@ -14,6 +14,11 @@ if [[ $version == *"-"* ]]; then
   exit 0
 fi
 
+PUBLISH_LATEST=
+if is_latest "$version"; then
+  PUBLISH_LATEST=true
+fi
+
 # Hard coded release number used only by the RedHat images
 rhel_release=1
 rhel_project_id=5e61ea74fe2231a0c2860382

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -24,6 +24,11 @@ if ! echo "${version}" | grep -E -o '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9
   exit 1
 fi
 
+PUBLISH_LATEST=
+if is_latest "$version"; then
+  PUBLISH_LATEST=true
+fi
+
 release_branch=$(echo "${version}" | grep -E -o '^v[0-9]+\.[0-9]+')
 
 if [[ -z "${DRY_RUN}" ]] ; then

--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -21,6 +21,11 @@ if [[ -z "$build_name" ]] ; then
     exit 1
 fi
 
+PUBLISH_LATEST=
+if is_latest "$build_name"; then
+  PUBLISH_LATEST=true
+fi
+
 release_branch=$(echo ${build_name} | grep -E -o '^v[0-9]+\.[0-9]+')
 
 if [[ -z "${DRY_RUN}" ]] ; then


### PR DESCRIPTION
Previously, we relied on manually set variable to distinguish latest versions. This has been error-prone.

This PR uses the releases DB to detect if the current version is latest.

Epic: none
Release note: None