### PR TITLE
acceptance: use docker mirror for flyway

### DIFF
--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   flyway:
     depends_on:
       - cockroach
-    image: flyway/flyway:9.3
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/flyway/flyway:9.3
     volumes:
       - ./sql:/sql
     command: migrate -user=root -url=jdbc:postgresql://cockroach:26257/defaultdb -locations=filesystem:/sql


### PR DESCRIPTION
Previously, we pulled the `flyway/flyway` image from dockerhub and hit the rate limit from time to time.

This PR uses our mirror to pull the image.

Fixes: #124448
Release note: None