### PR TITLE
server: remove custom ScanInterval args in test

### DIFF
--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -486,11 +486,6 @@ func TestAdminAPITableStats(t *testing.T) {
 	const nodeCount = 3
 	tc := testcluster.StartTestCluster(t, nodeCount, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationAuto,
-		ServerArgs: base.TestServerArgs{
-			ScanInterval:    time.Millisecond,
-			ScanMinIdleTime: time.Millisecond,
-			ScanMaxIdleTime: time.Millisecond,
-		},
 	})
 	defer tc.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
These args might be causing undesired behavior in this test that causes loss of quorum. I believe they're here to make the test fast, but we'd prefer a less flaky one even if it's a bit slow.

Resolves #123937

Release note: None