### PR TITLE
geopb: make SpatialObject.MemSize a bit more precise

### DIFF
--- a/pkg/geo/geopb/geopb.go
+++ b/pkg/geo/geopb/geopb.go
@@ -20,13 +20,19 @@ func (b *SpatialObject) EWKBHex() string {
 	return fmt.Sprintf("%X", b.EWKB)
 }
 
-// MemSize returns the size of the spatial object in memory.
-func (b *SpatialObject) MemSize() uintptr {
+// MemSize returns the size of the spatial object in memory. If deterministic is
+// true, then only length of EWKB slice is included - this option should only be
+// used when determinism is favored over precision.
+func (b *SpatialObject) MemSize(deterministic bool) uintptr {
 	var bboxSize uintptr
 	if bbox := b.BoundingBox; bbox != nil {
 		bboxSize = unsafe.Sizeof(*bbox)
 	}
-	return unsafe.Sizeof(*b) + bboxSize + uintptr(len(b.EWKB))
+	ewkbSize := uintptr(cap(b.EWKB))
+	if deterministic {
+		ewkbSize = uintptr(len(b.EWKB))
+	}
+	return unsafe.Sizeof(*b) + bboxSize + ewkbSize
 }
 
 // MultiType returns the corresponding multi-type for a shape type, or unset

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -6751,7 +6751,7 @@ The parent_only boolean is always ignored.`,
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				geo := tree.MustBeDGeometry(args[0])
-				return tree.NewDInt(tree.DInt(geo.Size())), nil
+				return tree.NewDInt(tree.DInt(geo.DeterministicMemSize())), nil
 			},
 			Info:       "Returns the amount of memory space (in bytes) the geometry takes.",
 			Volatility: volatility.Immutable,

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3549,7 +3549,14 @@ func (d *DGeography) Format(ctx *FmtCtx) {
 
 // Size implements the Datum interface.
 func (d *DGeography) Size() uintptr {
-	return d.Geography.SpatialObjectRef().MemSize()
+	return d.Geography.SpatialObjectRef().MemSize(false /* deterministic */)
+}
+
+// DeterministicMemSize returns size of this DGeography object that will not
+// depend on runtime conditions like pre-allocated slice capacity. This comes at
+// the expense of having less precise information.
+func (d *DGeography) DeterministicMemSize() uintptr {
+	return d.Geography.SpatialObjectRef().MemSize(true /* deterministic */)
 }
 
 // ToJSON converts the DGeography to JSON.
@@ -3676,7 +3683,14 @@ func (d *DGeometry) Format(ctx *FmtCtx) {
 
 // Size implements the Datum interface.
 func (d *DGeometry) Size() uintptr {
-	return d.Geometry.SpatialObjectRef().MemSize()
+	return d.Geometry.SpatialObjectRef().MemSize(false /* deterministic */)
+}
+
+// DeterministicMemSize returns size of this DGeometry object that will not
+// depend on runtime conditions like pre-allocated slice capacity. This comes at
+// the expense of having less precise information.
+func (d *DGeometry) DeterministicMemSize() uintptr {
+	return d.Geometry.SpatialObjectRef().MemSize(true /* deterministic */)
 }
 
 // ToJSON converts the DGeometry to JSON.

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -1346,11 +1346,12 @@ func TestNewDefaultDatum(t *testing.T) {
 func TestGeospatialSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testCases := []struct {
-		wkt      string
-		expected uintptr
+		wkt               string
+		size              uintptr
+		deterministicSize uintptr
 	}{
-		{"SRID=4004;POINT EMPTY", 73},
-		{"SRID=4326;LINESTRING(0 0, 10 0)", 125},
+		{"SRID=4004;POINT EMPTY", 112, 73},
+		{"SRID=4326;LINESTRING(0 0, 10 0)", 144, 125},
 	}
 
 	for _, tc := range testCases {
@@ -1358,12 +1359,14 @@ func TestGeospatialSize(t *testing.T) {
 			t.Run("geometry", func(t *testing.T) {
 				g, err := tree.ParseDGeometry(tc.wkt)
 				require.NoError(t, err)
-				require.Equal(t, tc.expected, g.Size())
+				require.Equal(t, tc.size, g.Size())
+				require.Equal(t, tc.deterministicSize, g.DeterministicMemSize())
 			})
 			t.Run("geography", func(t *testing.T) {
 				g, err := tree.ParseDGeography(tc.wkt)
 				require.NoError(t, err)
-				require.Equal(t, tc.expected, g.Size())
+				require.Equal(t, tc.size, g.Size())
+				require.Equal(t, tc.deterministicSize, g.DeterministicMemSize())
 			})
 		})
 	}


### PR DESCRIPTION
Previously, we only included the length of the serialized byte slice, but now we'll include the capacity (which is a better representation of the memory footprint). For example, this will provide better initial estimate in `st_memcollect` aggregate builtins. In some experimental testing this estimate appears to be an over-estimate (instead of an under-estimate as it used to be) which seems beneficial (more stability).

There is a caveat, though, that we expose the size via `st_memsize` builtin, and in order to make it return deterministic results (i.e. independent of how the memory is allocated), we'll preserve the "deterministic size" function too (only used for `st_memsize` and in tests).

Fixes: #124232.

Release note: None