### PR TITLE
release-23.2: stats: fix TestCreateStatsProgress

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -356,6 +356,13 @@ func TestCreateStatsProgress(t *testing.T) {
 	}(rowexec.SamplerProgressInterval)
 	rowexec.SamplerProgressInterval = 10
 
+	getLastCreateStatsJobID := func(t testing.TB, db *sqlutils.SQLRunner) jobspb.JobID {
+		var jobID jobspb.JobID
+		db.QueryRow(t, "SELECT id FROM system.jobs WHERE status = 'running' AND "+
+			"job_type = 'CREATE STATS' ORDER BY created DESC LIMIT 1").Scan(&jobID)
+		return jobID
+	}
+
 	var allowRequest chan struct{}
 	var serverArgs base.TestServerArgs
 	filter, setTableID := createStatsRequestFilter(&allowRequest)
@@ -421,7 +428,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	}
 
 	// Fetch the new job ID since we know it's running now.
-	jobID := jobutils.GetLastJobID(t, sqlDB)
+	jobID := getLastCreateStatsJobID(t, sqlDB)
 
 	// Ensure that 0 progress has been recorded since there are no existing
 	// stats available to estimate progress.
@@ -477,7 +484,7 @@ func TestCreateStatsProgress(t *testing.T) {
 	}
 
 	// Fetch the new job ID since we know it's running now.
-	jobID = jobutils.GetLastJobID(t, sqlDB)
+	jobID = getLastCreateStatsJobID(t, sqlDB)
 
 	// Ensure that partial progress has been recorded since there are existing
 	// stats available.

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -245,24 +245,6 @@ func VerifySystemJob(
 	return verifySystemJob(t, db, offset, filterType, string(expectedStatus), "", expected)
 }
 
-// GetJobID gets a particular job's ID.
-func GetJobID(t testing.TB, db *sqlutils.SQLRunner, offset int) jobspb.JobID {
-	var jobID jobspb.JobID
-	db.QueryRow(t, `
-	SELECT job_id FROM crdb_internal.jobs ORDER BY created LIMIT 1 OFFSET $1`, offset,
-	).Scan(&jobID)
-	return jobID
-}
-
-// GetLastJobID gets the most recent job's ID.
-func GetLastJobID(t testing.TB, db *sqlutils.SQLRunner) jobspb.JobID {
-	var jobID jobspb.JobID
-	db.QueryRow(
-		t, `SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1`,
-	).Scan(&jobID)
-	return jobID
-}
-
 // GetJobProgress loads the Progress message associated with the job.
 func GetJobProgress(t *testing.T, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Progress {
 	ret := &jobspb.Progress{}


### PR DESCRIPTION
Backport 1/1 commits from #124570.

/cc @cockroachdb/release

---

This commit fixes a rare flake in `TestCreateStatsProgress` which I think was caused due to the test using "get last job ID" query without specifying the job type. In other words, my hypothesis is that the test could incorrectly pick a job other than CREATE STATS (that happened to be started right after the stats one), and we would never get any progress reported on that other job. This is now fixed by only looking at CREATE STATS jobs. Additionally, the helper function that was only used in this test is now unexported.

Fixes: #121770.

Release note: None

Release justification: test-only change.