### PR TITLE
release-23.2: roachtest: use first transient error when checking for flakes

### DIFF
--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -323,6 +323,21 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
+		// 11. When a transient error happens as a result of *another*
+		// transient error, the corresponding issue uses the first
+		// transient error in the chain.
+		{
+			failures: []failure{
+				createFailure(rperrors.TransientFailure(
+					rperrors.NewSSHError(errors.New("oops")), "some_problem",
+				)),
+			},
+			expectedPost:          true,
+			expectedTeam:          "@cockroachdb/test-eng",
+			expectedName:          "ssh_problem",
+			expectedMessagePrefix: testName + " failed",
+			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
+		},
 	}
 
 	reg := makeTestRegistry()

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -492,14 +492,33 @@ func (t *testImpl) failureMsg() string {
 // target. If it does, `refError` is set to that target error value
 // and returns true. Otherwise, it returns false.
 func failuresMatchingError(failures []failure, refError any) bool {
+	// unwrap unwraps the error passed to find the innermost error in the
+	// chain that satisfies the `refError` provided.
+	unwrap := func(err error) bool {
+		var matched bool
+		for {
+			if isRef := errors.As(err, refError); !isRef {
+				break
+			}
+
+			matched = true
+			err = errors.Unwrap(err)
+			if err == nil {
+				break
+			}
+		}
+
+		return matched
+	}
+
 	for _, f := range failures {
 		for _, err := range f.errors {
-			if errors.As(err, refError) {
+			if unwrap(err) {
 				return true
 			}
 		}
 
-		if errors.As(f.squashedErr, refError) {
+		if unwrap(f.squashedErr) {
 			return true
 		}
 	}

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_11.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_11.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -90,6 +90,10 @@ func (te TransientError) Is(other error) bool {
 	return errors.Is(te.Err, other)
 }
 
+func (te TransientError) Unwrap() error {
+	return te.Err
+}
+
 func (te TransientError) ExitCode() int {
 	return transientExitCode
 }


### PR DESCRIPTION
Backport 1/1 commits from #124403.

/cc @cockroachdb/release

----

Previously, roachtest would only look at the outermost error in a chain that matched a `TransientError` (or `ErrorWithOwnership`) when checking for flakes. However, that is in most cases *not* what we want: if a transient error wraps another transient error, the actual reason for the failure is the original (wrapped) error.

Informs: #123887

Release note: None

----

Release justification: test only change.