### PR TITLE
roachprod: delete cluster config on GC

### DIFF
--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/roachprod/vm/local",
         "//pkg/server/debug/replay",
         "//pkg/util/ctxgroup",
-        "//pkg/util/envutil",
         "//pkg/util/httputil",
         "//pkg/util/retry",
         "//pkg/util/syncutil",

--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/promhelperclient",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/timeutil",

--- a/pkg/roachprod/promhelperclient/BUILD.bazel
+++ b/pkg/roachprod/promhelperclient/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/promhelperclient",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/vm/gce",
         "//pkg/util/httputil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_google_cloud_go_storage//:storage",


### PR DESCRIPTION
currently, prometheus cluster configs are not deleted on gc. This makes stale entries to remain. This PR deletes the cluster configs on GC.

There is another minor fix for promhelpers access. The access to cloud storage was failing due to missing credentials.

Fixes: #124599
Epic: none