### PR TITLE
roachtest: disable schemachange/leasing-benchmark for azure

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -134,6 +134,11 @@ type ClusterSpec struct {
 		VolumeThroughput int
 		Zones            string
 	}
+
+	// Azure-specific arguments. These values apply only on clusters instantiated on Azure.
+	Azure struct {
+		Zones string
+	}
 }
 
 // MakeClusterSpec makes a ClusterSpec.
@@ -425,6 +430,10 @@ func (s *ClusterSpec) RoachprodOpts(
 	case GCE:
 		if s.GCE.Zones != "" {
 			zonesStr = s.GCE.Zones
+		}
+	case Azure:
+		if s.Azure.Zones != "" {
+			zonesStr = s.Azure.Zones
 		}
 	}
 	var zones []string

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -266,3 +266,18 @@ func AWSZones(zones string) Option {
 		spec.AWS.Zones = zones
 	}
 }
+
+// AzureZones is a node option which requests Geo-distributed nodes; only applies
+// when the test runs on Azure.
+//
+// Note that this overrides the --zones flag and is useful for tests that
+// require running on specific zones.
+//
+// TODO(darrylwong): Something is not quite right when creating
+// zones that have overlapping address spaces, i.e. eastus and westus.
+// See: https://github.com/cockroachdb/cockroach/issues/124612
+func AzureZones(zones string) Option {
+	return func(spec *ClusterSpec) {
+		spec.Azure.Zones = zones
+	}
+}

--- a/pkg/cmd/roachtest/tests/multiregion_leasing.go
+++ b/pkg/cmd/roachtest/tests/multiregion_leasing.go
@@ -230,7 +230,7 @@ func registerSchemaChangeMultiRegionBenchmarkLeasing(r registry.Registry) {
 			spec.GCEZones("us-west1-b,us-east1-b,australia-southeast1-a"),
 			spec.AWSZones("us-east-1a,us-west-2b,ap-southeast-2b"),
 		),
-		CompatibleClouds: registry.AllExceptLocal,
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.AWS),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.DefaultLeases,
 		Timeout:          2 * time.Hour,

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -32,11 +32,12 @@ type ProviderOpts struct {
 }
 
 // These default locations support availability zones. At the time of
-// this comment, `westus` did not.
+// this comment, `westus` did not and `westus2` is consistently out of
+// capacity.
 var defaultLocations = []string{
 	"eastus",
 	"canadacentral",
-	"westus2",
+	"westus3",
 }
 
 var defaultZone = "1"


### PR DESCRIPTION
This test uses geo zones which are not currently supported for roachprod azure.

This change also changes the default azure location of westus2 to westus3. westus2 is usually out of capacity, causing roachtests that use it to be skipped more than half the time.

Fixes: https://github.com/cockroachdb/cockroach/issues/123947
Release note: none
Epic: none