### PR TITLE
githooks: add commit message reminder about bug fixes and GitHub issues

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -119,6 +119,8 @@ ${cchar}Release note (backwards-incompatible change): \\
 ${cchar}Release note (performance improvement): \\
 ${cchar}Release note (cluster virtualization): \\
 ${cchar}Release note (bug fix): \\
+${cchar}              ^-- ensure there is a corresponding GitHub issue labeled \\
+${cchar}                  with C-bug and earliest known release branch \\
 
 ;
 "


### PR DESCRIPTION
This commit updates the commit message reminder for the `bug fix` category of release notes as follows:
```
 #Release note (bug fix):
 #              ^-- ensure there is a corresponding GitHub issue labeled
 #                  with C-bug and earliest known release branch
```
Release note: None