### PR TITLE
changefeedccl: update doc link for rangefeed setting

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -757,7 +757,7 @@ func validateSettings(ctx context.Context, needsRangeFeed bool, execCfg *sql.Exe
 	// requires the `kv.rangefeed.enabled` setting to be true.
 	if needsRangeFeed && !kvserver.RangefeedEnabled.Get(&execCfg.Settings.SV) {
 		return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
-			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
+			docs.URL(`create-and-configure-changefeeds.html#enable-rangefeeds`))
 	}
 
 	return nil


### PR DESCRIPTION
Updated a link from
https://www.cockroachlabs.com/docs/v24.1/change-data-capture.html#enable-rangefeeds-to-reduce-latency to
https://www.cockroachlabs.com/docs/v24.1/create-and-configure-changefeeds.html#enable-rangefeeds (v24.1 in this example).

Epic: none
Fixes: #123483

Release note: None