### PR TITLE
log: change fingerprint_id type to string

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2960,7 +2960,6 @@ contains common SQL event/execution details.
 | `Database` | Name of the database that initiated the query. | no |
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
-| `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 | `MaxFullScanRowsEstimate` | Maximum number of rows scanned by a full scan, as estimated by the optimizer. | no |
 | `TotalScanRowsEstimate` | Total number of rows read by all scans in the query, as estimated by the optimizer. | no |
 | `OutputRowsEstimate` | The number of rows output by the query, as estimated by the optimizer. | no |
@@ -3025,6 +3024,7 @@ contains common SQL event/execution details.
 | `SchemaChangerMode` | SchemaChangerMode is the mode that was used to execute the schema change, if any. | no |
 | `SQLInstanceIDs` | SQLInstanceIDs is a list of all the SQL instances used in this statement's execution. | no |
 | `KVNodeIDs` | KVNodeIDs is a list of all the KV nodes used in this statement's execution. | no |
+| `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 
 
 #### Common fields
@@ -3063,7 +3063,6 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `TxnCounter` | TxnCounter is the sequence number of the SQL transaction inside its session. | no |
 | `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
 | `TransactionID` | TransactionID is the id of the transaction. | no |
-| `TransactionFingerprintID` | TransactionFingerprintID is the fingerprint ID of the transaction. This can be used to find the transaction in the console. | no |
 | `Committed` | Committed indicates if the transaction committed successfully. We want to include this value even if it is false. | no |
 | `ImplicitTxn` | ImplicitTxn indicates if the transaction was an implicit one. We want to include this value even if it is false. | no |
 | `StartTimeUnixNanos` | StartTimeUnixNanos is the time the transaction was started. Expressed as unix time in nanoseconds. | no |
@@ -3073,7 +3072,6 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `ErrorText` | ErrorText is the text of the error if any. | partially |
 | `NumRetries` | NumRetries is the number of time when the txn was retried automatically by the server. | no |
 | `LastAutoRetryReason` | LastAutoRetryReason is a string containing the reason for the last automatic retry. | partially |
-| `StatementFingerprintIDs` | StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction. | yes |
 | `NumRows` | NumRows is the total number of rows returned across all statements. | no |
 | `RetryLatNanos` | RetryLatNanos is the amount of time spent retrying the transaction. | no |
 | `CommitLatNanos` | CommitLatNanos is the amount of time spent committing the transaction after all statement operations. | no |
@@ -3083,6 +3081,8 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `RowsWritten` | RowsWritten is the number of rows written to disk. | no |
 | `SampledExecStats` | SampledExecStats is a nested field containing execution statistics. This field will be omitted if the stats were not sampled. | yes |
 | `SkippedTransactions` | SkippedTransactions is the number of transactions that were skipped as part of sampling prior to this one. We only count skipped transactions when telemetry logging is enabled and the sampling mode is set to "transaction". | no |
+| `TransactionFingerprintID` | TransactionFingerprintID is the fingerprint ID of the transaction. This can be used to find the transaction in the console. | no |
+| `StatementFingerprintIDs` | StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction. | no |
 
 
 #### Common fields

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -12,6 +12,7 @@ package appstatspb
 
 import (
 	"math"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -19,11 +20,15 @@ import (
 // StmtFingerprintID is the type of a Statement's fingerprint ID.
 type StmtFingerprintID uint64
 
+func (s StmtFingerprintID) String() string {
+	return strconv.FormatUint(uint64(s), 10)
+}
+
 // ConstructStatementFingerprintID constructs an ID by hashing query with
 // constants redacted, its database, and if it was part of an
 // implicit txn. At the time of writing, these are the axis' we use to bucket
 // queries for stats collection (see stmtKey).
-func ConstructStatementFingerprintID(
+var ConstructStatementFingerprintID = func(
 	stmtNoConstants string, implicitTxn bool, database string,
 ) StmtFingerprintID {
 	fnv := util.MakeFNV64()
@@ -44,6 +49,10 @@ func ConstructStatementFingerprintID(
 // TransactionFingerprintID is the hashed string constructed using the
 // individual statement fingerprint IDs that comprise the transaction.
 type TransactionFingerprintID uint64
+
+func (t TransactionFingerprintID) String() string {
+	return strconv.FormatUint(uint64(t), 10)
+}
 
 // InvalidTransactionFingerprintID denotes an invalid transaction fingerprint ID.
 const InvalidTransactionFingerprintID = TransactionFingerprintID(0)

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -373,7 +373,7 @@ func (p *planner) maybeLogStatementInternal(
 			Database:                              p.CurrentDatabase(),
 			StatementID:                           p.stmt.QueryID.String(),
 			TransactionID:                         txnID,
-			StatementFingerprintID:                uint64(stmtFingerprintID),
+			StatementFingerprintID:                stmtFingerprintID.String(),
 			MaxFullScanRowsEstimate:               p.curPlan.instrumentation.maxFullScanRows,
 			TotalScanRowsEstimate:                 p.curPlan.instrumentation.totalScanRows,
 			OutputRowsEstimate:                    p.curPlan.instrumentation.outputRows,
@@ -467,6 +467,10 @@ func (p *planner) logTransaction(
 
 	sampledTxn := getSampledTransaction()
 	defer releaseSampledTransaction(sampledTxn)
+	statementFingerprintIDStrs := make([]string, 0, len(txnStats.StatementFingerprintIDs))
+	for _, id := range txnStats.StatementFingerprintIDs {
+		statementFingerprintIDStrs = append(statementFingerprintIDStrs, id.String())
+	}
 
 	*sampledTxn = eventpb.SampledTransaction{
 		SkippedTransactions:      int64(skippedTransactions),
@@ -475,7 +479,7 @@ func (p *planner) logTransaction(
 		TxnCounter:               uint32(txnCounter),
 		SessionID:                txnStats.SessionID.String(),
 		TransactionID:            txnStats.TransactionID.String(),
-		TransactionFingerprintID: txnFingerprintID,
+		TransactionFingerprintID: txnFingerprintID.String(),
 		Committed:                txnStats.Committed,
 		ImplicitTxn:              txnStats.ImplicitTxn,
 		StartTimeUnixNanos:       txnStats.StartTime.UnixNano(),
@@ -485,7 +489,7 @@ func (p *planner) logTransaction(
 		ErrorText:                execErrStr,
 		NumRetries:               txnStats.RetryCount,
 		LastAutoRetryReason:      retryErr,
-		StatementFingerprintIDs:  txnStats.StatementFingerprintIDs,
+		StatementFingerprintIDs:  statementFingerprintIDStrs,
 		NumRows:                  int64(txnStats.RowsAffected),
 		RetryLatNanos:            txnStats.RetryLatency.Nanoseconds(),
 		CommitLatNanos:           txnStats.CommitLatency.Nanoseconds(),

--- a/pkg/sql/telemetry_datadriven_test.go
+++ b/pkg/sql/telemetry_datadriven_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -147,6 +149,19 @@ func TestTelemetryLoggingDataDriven(t *testing.T) {
 				txnLogCount := txnsSpy.Count()
 				var stubTimeUnixSecs float64
 				var tracing, useRealTracing bool
+				var stubStatementFingerprintId string
+
+				d.MaybeScanArgs(t, "stubStatementFingerprintId", &stubStatementFingerprintId)
+				if stubStatementFingerprintId != "" {
+					defer testutils.TestingHook(&appstatspb.ConstructStatementFingerprintID,
+						func(stmtNoConstants string, implicitTxn bool, database string) appstatspb.StmtFingerprintID {
+							parseUint, e := strconv.ParseUint(stubStatementFingerprintId, 10, 64)
+							if e != nil {
+								panic(e.Error())
+							}
+							return appstatspb.StmtFingerprintID(parseUint)
+						})()
+				}
 
 				d.MaybeScanArgs(t, "tracing", &tracing)
 				sts.SetTracingStatus(tracing)

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -534,7 +534,7 @@ func TestTelemetryLogging(t *testing.T) {
 
 					stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(tc.queryNoConstants, true, databaseName)
 
-					require.Equal(t, uint64(stmtFingerprintID), sampledQueryFromLog.StatementFingerprintID)
+					require.Equal(t, stmtFingerprintID.String(), sampledQueryFromLog.StatementFingerprintID)
 
 					maxFullScanRowsRe := regexp.MustCompile("\"MaxFullScanRowsEstimate\":[0-9]*")
 					foundFullScan := maxFullScanRowsRe.MatchString(e.Message)

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -36,7 +36,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 13897981974204408897,
+	"StatementFingerprintID": "13897981974204408897",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -49,9 +49,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		13897981974204408897
+		"13897981974204408897"
 	],
-	"TransactionFingerprintID": 8051364883217634206,
+	"TransactionFingerprintID": "8051364883217634206",
 	"User": "root"
 }
 
@@ -67,7 +67,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16048716862824136030,
+	"StatementFingerprintID": "16048716862824136030",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -80,9 +80,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16048716862824136030
+		"16048716862824136030"
 	],
-	"TransactionFingerprintID": 8204366343298189953,
+	"TransactionFingerprintID": "8204366343298189953",
 	"User": "root"
 }
 
@@ -98,7 +98,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360649860,
+	"StatementFingerprintID": "2101516650360649860",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -111,9 +111,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360649860
+		"2101516650360649860"
 	],
-	"TransactionFingerprintID": 12846987492365242203,
+	"TransactionFingerprintID": "12846987492365242203",
 	"User": "root"
 }
 
@@ -152,7 +152,7 @@ SET application_name = '$ internal-console-app';
 	"EventType": "sampled_query",
 	"PlanGist": "Ais=",
 	"Statement": "SET application_name = ‹'$ internal-console-app'›",
-	"StatementFingerprintID": 16494915433690409681,
+	"StatementFingerprintID": "16494915433690409681",
 	"StmtPosInTxn": 1,
 	"Tag": "SET",
 	"User": "root"
@@ -169,7 +169,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 13897981974204408897,
+	"StatementFingerprintID": "13897981974204408897",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -183,9 +183,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsWritten": 0,
 	"SkippedTransactions": 5,
 	"StatementFingerprintIDs": [
-		13897981974204408897
+		"13897981974204408897"
 	],
-	"TransactionFingerprintID": 8051364883217634206,
+	"TransactionFingerprintID": "8051364883217634206",
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16048716862824136030,
+	"StatementFingerprintID": "16048716862824136030",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -214,9 +214,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16048716862824136030
+		"16048716862824136030"
 	],
-	"TransactionFingerprintID": 8204366343298189953,
+	"TransactionFingerprintID": "8204366343298189953",
 	"User": "root"
 }
 
@@ -232,7 +232,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360649860,
+	"StatementFingerprintID": "2101516650360649860",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -245,9 +245,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360649860
+		"2101516650360649860"
 	],
-	"TransactionFingerprintID": 12846987492365242203,
+	"TransactionFingerprintID": "12846987492365242203",
 	"User": "root"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -36,7 +36,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 13897981974204410000,
+	"StatementFingerprintID": 13897981974204408897,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -49,9 +49,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		13897981974204410000
+		13897981974204408897
 	],
-	"TransactionFingerprintID": 8051364883217634000,
+	"TransactionFingerprintID": 8051364883217634206,
 	"User": "root"
 }
 
@@ -67,7 +67,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16048716862824137000,
+	"StatementFingerprintID": 16048716862824136030,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -80,9 +80,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16048716862824137000
+		16048716862824136030
 	],
-	"TransactionFingerprintID": 8204366343298190000,
+	"TransactionFingerprintID": 8204366343298189953,
 	"User": "root"
 }
 
@@ -98,7 +98,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649860,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -111,9 +111,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360650000
+		2101516650360649860
 	],
-	"TransactionFingerprintID": 12846987492365242000,
+	"TransactionFingerprintID": 12846987492365242203,
 	"User": "root"
 }
 
@@ -152,7 +152,7 @@ SET application_name = '$ internal-console-app';
 	"EventType": "sampled_query",
 	"PlanGist": "Ais=",
 	"Statement": "SET application_name = ‹'$ internal-console-app'›",
-	"StatementFingerprintID": 16494915433690409000,
+	"StatementFingerprintID": 16494915433690409681,
 	"StmtPosInTxn": 1,
 	"Tag": "SET",
 	"User": "root"
@@ -169,7 +169,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 13897981974204410000,
+	"StatementFingerprintID": 13897981974204408897,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -183,9 +183,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsWritten": 0,
 	"SkippedTransactions": 5,
 	"StatementFingerprintIDs": [
-		13897981974204410000
+		13897981974204408897
 	],
-	"TransactionFingerprintID": 8051364883217634000,
+	"TransactionFingerprintID": 8051364883217634206,
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16048716862824137000,
+	"StatementFingerprintID": 16048716862824136030,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -214,9 +214,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16048716862824137000
+		16048716862824136030
 	],
-	"TransactionFingerprintID": 8204366343298190000,
+	"TransactionFingerprintID": 8204366343298189953,
 	"User": "root"
 }
 
@@ -232,7 +232,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649860,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -245,9 +245,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360650000
+		2101516650360649860
 	],
-	"TransactionFingerprintID": 12846987492365242000,
+	"TransactionFingerprintID": 12846987492365242203,
 	"User": "root"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/statement_fingerprint_id
+++ b/pkg/sql/testdata/telemetry_logging/logging/statement_fingerprint_id
@@ -1,0 +1,48 @@
+# Test that stub statement fingerprint id value to be max uint64 and ensure that it is represented properly as
+# a string
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.max_event_frequency = 10;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.statement_events_per_transaction.max = 100;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;
+----
+
+spy-sql unixSecs=1 stubStatementFingerprintId=18446744073709551615
+SELECT 1,2
+----
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICBAYE",
+	"Statement": "SELECT ‹1›, ‹2›",
+	"StatementFingerprintID": "18446744073709551615",
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		"18446744073709551615"
+	],
+	"TransactionFingerprintID": "5808590958014384160",
+	"User": "root"
+}

--- a/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
+++ b/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
@@ -27,7 +27,7 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -40,10 +40,10 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360649864,
-		2101516650360649864
+		"2101516650360649864",
+		"2101516650360649864"
 	],
-	"TransactionFingerprintID": 6419625091330320477,
+	"TransactionFingerprintID": "6419625091330320477",
 	"User": "root"
 }
 
@@ -60,7 +60,7 @@ SELECT 5;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 2,
 	"Statement": "SELECT ‹5›",
-	"StatementFingerprintID": 2101516650360649860,
+	"StatementFingerprintID": "2101516650360649860",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -73,9 +73,9 @@ SELECT 5;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360649860
+		"2101516650360649860"
 	],
-	"TransactionFingerprintID": 12846987492365242203,
+	"TransactionFingerprintID": "12846987492365242203",
 	"User": "root"
 }
 
@@ -96,7 +96,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -110,7 +110,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -124,7 +124,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -138,12 +138,12 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		2101516650360649864,
-		2101516650360649864,
-		2101516650360649864,
-		2101516650360649864
+		"2101516650360649864",
+		"2101516650360649864",
+		"2101516650360649864",
+		"2101516650360649864"
 	],
-	"TransactionFingerprintID": 2831371359051261045,
+	"TransactionFingerprintID": "2831371359051261045",
 	"User": "root"
 }
 
@@ -164,7 +164,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -178,7 +178,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -192,7 +192,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -206,7 +206,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹4›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 4,
 	"Tag": "SELECT",
 	"User": "root"
@@ -220,12 +220,12 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		2101516650360649864,
-		2101516650360649864,
-		2101516650360649864,
-		2101516650360649864
+		"2101516650360649864",
+		"2101516650360649864",
+		"2101516650360649864",
+		"2101516650360649864"
 	],
-	"TransactionFingerprintID": 2831371359051261045,
+	"TransactionFingerprintID": "2831371359051261045",
 	"User": "root"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
+++ b/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
@@ -27,7 +27,7 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -40,10 +40,10 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360650000,
-		2101516650360650000
+		2101516650360649864,
+		2101516650360649864
 	],
-	"TransactionFingerprintID": 6419625091330320000,
+	"TransactionFingerprintID": 6419625091330320477,
 	"User": "root"
 }
 
@@ -60,7 +60,7 @@ SELECT 5;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 2,
 	"Statement": "SELECT ‹5›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649860,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -73,9 +73,9 @@ SELECT 5;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360650000
+		2101516650360649860
 	],
-	"TransactionFingerprintID": 12846987492365242000,
+	"TransactionFingerprintID": 12846987492365242203,
 	"User": "root"
 }
 
@@ -96,7 +96,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -110,7 +110,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -124,7 +124,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -138,12 +138,12 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		2101516650360650000,
-		2101516650360650000,
-		2101516650360650000,
-		2101516650360650000
+		2101516650360649864,
+		2101516650360649864,
+		2101516650360649864,
+		2101516650360649864
 	],
-	"TransactionFingerprintID": 2831371359051261000,
+	"TransactionFingerprintID": 2831371359051261045,
 	"User": "root"
 }
 
@@ -164,7 +164,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -178,7 +178,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -192,7 +192,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -206,7 +206,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹4›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 4,
 	"Tag": "SELECT",
 	"User": "root"
@@ -220,11 +220,12 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		2101516650360650000,
-		2101516650360650000,
-		2101516650360650000,
-		2101516650360650000
+		2101516650360649864,
+		2101516650360649864,
+		2101516650360649864,
+		2101516650360649864
 	],
-	"TransactionFingerprintID": 2831371359051261000,
+	"TransactionFingerprintID": 2831371359051261045,
 	"User": "root"
 }
+

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -33,7 +33,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"PlanGist": "Ais=",
 	"SkippedQueries": 1,
 	"Statement": "TRUNCATE TABLE defaultdb.public.t",
-	"StatementFingerprintID": 554456288574568545,
+	"StatementFingerprintID": "554456288574568545",
 	"StmtPosInTxn": 1,
 	"Tag": "TRUNCATE",
 	"User": "root"
@@ -44,7 +44,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746112,
+	"StatementFingerprintID": "6247508841109746112",
 	"StmtPosInTxn": 2,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -57,9 +57,9 @@ BEGIN; TRUNCATE t; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		554456288574568545
+		"554456288574568545"
 	],
-	"TransactionFingerprintID": 12164906773462273982,
+	"TransactionFingerprintID": "12164906773462273982",
 	"User": "root"
 }
 
@@ -79,7 +79,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -93,7 +93,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -107,7 +107,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -118,7 +118,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746112,
+	"StatementFingerprintID": "6247508841109746112",
 	"StmtPosInTxn": 4,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -131,11 +131,11 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360649864,
-		2101516650360649864,
-		2101516650360649864
+		"2101516650360649864",
+		"2101516650360649864",
+		"2101516650360649864"
 	],
-	"TransactionFingerprintID": 5966815618996219535,
+	"TransactionFingerprintID": "5966815618996219535",
 	"User": "root"
 }
 
@@ -158,7 +158,7 @@ SELECT 1, 2
 	"PlanGist": "AgICBAYE",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›, ‹2›",
-	"StatementFingerprintID": 7240897616531531707,
+	"StatementFingerprintID": "7240897616531531707",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -172,9 +172,9 @@ SELECT 1, 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		7240897616531531707
+		"7240897616531531707"
 	],
-	"TransactionFingerprintID": 14636535271870697572,
+	"TransactionFingerprintID": "14636535271870697572",
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT * FROM t LIMIT 2
 	"ScanCount": 1,
 	"SkippedQueries": 2,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹2›",
-	"StatementFingerprintID": 13897981974204408897,
+	"StatementFingerprintID": "13897981974204408897",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -215,9 +215,9 @@ SELECT * FROM t LIMIT 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 2,
 	"StatementFingerprintIDs": [
-		13897981974204408897
+		"13897981974204408897"
 	],
-	"TransactionFingerprintID": 8051364883217634206,
+	"TransactionFingerprintID": "8051364883217634206",
 	"User": "root"
 }
 
@@ -239,7 +239,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"ScanCount": 1,
 	"SkippedQueries": 4,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹4›",
-	"StatementFingerprintID": 13897981974204408909,
+	"StatementFingerprintID": "13897981974204408909",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -252,7 +252,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹5›",
-	"StatementFingerprintID": 13897981974204408909,
+	"StatementFingerprintID": "13897981974204408909",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -263,7 +263,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746112,
+	"StatementFingerprintID": "6247508841109746112",
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -277,10 +277,10 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		13897981974204408909,
-		13897981974204408909
+		"13897981974204408909",
+		"13897981974204408909"
 	],
-	"TransactionFingerprintID": 15727566099450094939,
+	"TransactionFingerprintID": "15727566099450094939",
 	"User": "root"
 }
 
@@ -310,7 +310,7 @@ SELECT 1, 2, 3
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16048716862824136030,
+	"StatementFingerprintID": "16048716862824136030",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -324,9 +324,9 @@ SELECT 1, 2, 3
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16048716862824136030
+		"16048716862824136030"
 	],
-	"TransactionFingerprintID": 8204366343298189953,
+	"TransactionFingerprintID": "8204366343298189953",
 	"User": "root"
 }
 
@@ -363,7 +363,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 7,
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -378,7 +378,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "40001",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 8086151951699049415,
+	"StatementFingerprintID": "8086151951699049415",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -393,7 +393,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360649864,
+	"StatementFingerprintID": "2101516650360649864",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -408,7 +408,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 8086151951699049415,
+	"StatementFingerprintID": "8086151951699049415",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -420,7 +420,7 @@ COMMIT;
 	"EventType": "sampled_query",
 	"NumRetries": 1,
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746112,
+	"StatementFingerprintID": "6247508841109746112",
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -436,10 +436,10 @@ COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		2101516650360649864,
-		8086151951699049415
+		"2101516650360649864",
+		"8086151951699049415"
 	],
-	"TransactionFingerprintID": 3750030760852548370,
+	"TransactionFingerprintID": "3750030760852548370",
 	"User": "root"
 }
 
@@ -466,7 +466,7 @@ pq: division by zero
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "22012",
 	"Statement": "SELECT ‹1› / ‹0›",
-	"StatementFingerprintID": 7375745143010362268,
+	"StatementFingerprintID": "7375745143010362268",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "‹testuser›"
@@ -481,9 +481,9 @@ pq: division by zero
 	"RowsWritten": 0,
 	"SQLSTATE": "22012",
 	"StatementFingerprintIDs": [
-		7375745143010362268
+		"7375745143010362268"
 	],
-	"TransactionFingerprintID": 14499431829946479683,
+	"TransactionFingerprintID": "14499431829946479683",
 	"User": "‹testuser›"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -33,7 +33,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"PlanGist": "Ais=",
 	"SkippedQueries": 1,
 	"Statement": "TRUNCATE TABLE defaultdb.public.t",
-	"StatementFingerprintID": 554456288574568600,
+	"StatementFingerprintID": 554456288574568545,
 	"StmtPosInTxn": 1,
 	"Tag": "TRUNCATE",
 	"User": "root"
@@ -44,7 +44,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746000,
+	"StatementFingerprintID": 6247508841109746112,
 	"StmtPosInTxn": 2,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -57,9 +57,9 @@ BEGIN; TRUNCATE t; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		554456288574568600
+		554456288574568545
 	],
-	"TransactionFingerprintID": 12164906773462274000,
+	"TransactionFingerprintID": 12164906773462273982,
 	"User": "root"
 }
 
@@ -79,7 +79,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -93,7 +93,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -107,7 +107,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -118,7 +118,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746000,
+	"StatementFingerprintID": 6247508841109746112,
 	"StmtPosInTxn": 4,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -131,11 +131,11 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		2101516650360650000,
-		2101516650360650000,
-		2101516650360650000
+		2101516650360649864,
+		2101516650360649864,
+		2101516650360649864
 	],
-	"TransactionFingerprintID": 5966815618996220000,
+	"TransactionFingerprintID": 5966815618996219535,
 	"User": "root"
 }
 
@@ -158,7 +158,7 @@ SELECT 1, 2
 	"PlanGist": "AgICBAYE",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›, ‹2›",
-	"StatementFingerprintID": 7240897616531532000,
+	"StatementFingerprintID": 7240897616531531707,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -172,9 +172,9 @@ SELECT 1, 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		7240897616531532000
+		7240897616531531707
 	],
-	"TransactionFingerprintID": 14636535271870697000,
+	"TransactionFingerprintID": 14636535271870697572,
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT * FROM t LIMIT 2
 	"ScanCount": 1,
 	"SkippedQueries": 2,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹2›",
-	"StatementFingerprintID": 13897981974204410000,
+	"StatementFingerprintID": 13897981974204408897,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -215,9 +215,9 @@ SELECT * FROM t LIMIT 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 2,
 	"StatementFingerprintIDs": [
-		13897981974204410000
+		13897981974204408897
 	],
-	"TransactionFingerprintID": 8051364883217634000,
+	"TransactionFingerprintID": 8051364883217634206,
 	"User": "root"
 }
 
@@ -239,7 +239,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"ScanCount": 1,
 	"SkippedQueries": 4,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹4›",
-	"StatementFingerprintID": 13897981974204410000,
+	"StatementFingerprintID": 13897981974204408909,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -252,7 +252,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹5›",
-	"StatementFingerprintID": 13897981974204410000,
+	"StatementFingerprintID": 13897981974204408909,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -263,7 +263,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746000,
+	"StatementFingerprintID": 6247508841109746112,
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -277,10 +277,10 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		13897981974204410000,
-		13897981974204410000
+		13897981974204408909,
+		13897981974204408909
 	],
-	"TransactionFingerprintID": 15727566099450096000,
+	"TransactionFingerprintID": 15727566099450094939,
 	"User": "root"
 }
 
@@ -310,7 +310,7 @@ SELECT 1, 2, 3
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16048716862824137000,
+	"StatementFingerprintID": 16048716862824136030,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -324,9 +324,9 @@ SELECT 1, 2, 3
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16048716862824137000
+		16048716862824136030
 	],
-	"TransactionFingerprintID": 8204366343298190000,
+	"TransactionFingerprintID": 8204366343298189953,
 	"User": "root"
 }
 
@@ -363,7 +363,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 7,
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -378,7 +378,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "40001",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 8086151951699049000,
+	"StatementFingerprintID": 8086151951699049415,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -393,7 +393,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 2101516650360650000,
+	"StatementFingerprintID": 2101516650360649864,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -408,7 +408,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 8086151951699049000,
+	"StatementFingerprintID": 8086151951699049415,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -420,7 +420,7 @@ COMMIT;
 	"EventType": "sampled_query",
 	"NumRetries": 1,
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 6247508841109746000,
+	"StatementFingerprintID": 6247508841109746112,
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -436,10 +436,10 @@ COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		2101516650360650000,
-		8086151951699049000
+		2101516650360649864,
+		8086151951699049415
 	],
-	"TransactionFingerprintID": 3750030760852548600,
+	"TransactionFingerprintID": 3750030760852548370,
 	"User": "root"
 }
 
@@ -466,7 +466,7 @@ pq: division by zero
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "22012",
 	"Statement": "SELECT ‹1› / ‹0›",
-	"StatementFingerprintID": 7375745143010362000,
+	"StatementFingerprintID": 7375745143010362268,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "‹testuser›"
@@ -481,9 +481,9 @@ pq: division by zero
 	"RowsWritten": 0,
 	"SQLSTATE": "22012",
 	"StatementFingerprintIDs": [
-		7375745143010362000
+		7375745143010362268
 	],
-	"TransactionFingerprintID": 14499431829946480000,
+	"TransactionFingerprintID": 14499431829946479683,
 	"User": "‹testuser›"
 }
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4398,15 +4398,6 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
-	if m.StatementFingerprintID != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"StatementFingerprintID\":"...)
-		b = strconv.AppendUint(b, uint64(m.StatementFingerprintID), 10)
-	}
-
 	if m.MaxFullScanRowsEstimate != 0 {
 		if printComma {
 			b = append(b, ',')
@@ -5020,6 +5011,16 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, ']')
 	}
 
+	if m.StatementFingerprintID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprintID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.StatementFingerprintID)))
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 
@@ -5077,15 +5078,6 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 	b = append(b, "\"TransactionID\":\""...)
 	b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TransactionID)))
 	b = append(b, '"')
-
-	if m.TransactionFingerprintID != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"TransactionFingerprintID\":"...)
-		b = strconv.AppendUint(b, uint64(m.TransactionFingerprintID), 10)
-	}
 
 	if printComma {
 		b = append(b, ',')
@@ -5161,21 +5153,6 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 		b = append(b, '"')
 	}
 
-	if len(m.StatementFingerprintIDs) > 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"StatementFingerprintIDs\":["...)
-		for i, v := range m.StatementFingerprintIDs {
-			if i > 0 {
-				b = append(b, ',')
-			}
-			b = strconv.AppendUint(b, uint64(v), 10)
-		}
-		b = append(b, ']')
-	}
-
 	if printComma {
 		b = append(b, ',')
 	}
@@ -5245,6 +5222,33 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 		printComma = true
 		b = append(b, "\"SkippedTransactions\":"...)
 		b = strconv.AppendInt(b, int64(m.SkippedTransactions), 10)
+	}
+
+	if m.TransactionFingerprintID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TransactionFingerprintID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TransactionFingerprintID)))
+		b = append(b, '"')
+	}
+
+	if len(m.StatementFingerprintIDs) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprintIDs\":["...)
+		for i, v := range m.StatementFingerprintIDs {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '"')
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+			b = append(b, '"')
+		}
+		b = append(b, ']')
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -62,9 +62,6 @@ message SampledQuery {
   // Transaction ID of the query.
   string transaction_id = 11 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // Statement fingerprint ID of the query.
-  uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];
-
   // Maximum number of rows scanned by a full scan, as estimated by the
   // optimizer.
   double max_full_scan_rows_estimate = 14 [(gogoproto.jsontag) = ",omitempty"];
@@ -295,9 +292,17 @@ message SampledQuery {
   // KVNodeIDs is a list of all the KV nodes used in this statement's execution.
   repeated int32 kv_node_ids = 78 [(gogoproto.jsontag) = ',omitempty', (gogoproto.customname) = "KVNodeIDs", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
+  // Statement fingerprint ID of the query.
+  string statement_fingerprint_id = 79 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
   reserved 12;
 
-  // Next available ID: 79.
+  // Previously used for statement_fingerprint_id. Originally this was typed as a uint64
+  // but has been re-typed to be a string due to downstream json parsing issues. For
+  // more details see: https://github.com/cockroachdb/cockroach/issues/123665
+  reserved 13;
+
+  // Next available ID: 80.
 }
 
 // SampledExecStats contains execution statistics that apply to both statements
@@ -422,10 +427,6 @@ message SampledTransaction {
   // TransactionID is the id of the transaction.
   string transaction_id = 6 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',includeempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // TransactionFingerprintID is the fingerprint ID of the transaction.
-  // This can be used to find the transaction in the console.
-  uint64 transaction_fingerprint_id = 7 [(gogoproto.customname) = "TransactionFingerprintID", (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb.TransactionFingerprintID", (gogoproto.nullable) = false, (gogoproto.jsontag) = 'TransactionFingerprintID,'];
-
   // Committed indicates if the transaction committed successfully. We want to include this value even if it is false.
   bool committed = 8 [(gogoproto.jsontag) = ",includeempty"];
 
@@ -453,9 +454,6 @@ message SampledTransaction {
 
   // LastAutoRetryReason is a string containing the reason for the last automatic retry.
   string last_auto_retry_reason = 16 [(gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"mixed\""];
-
-  // StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction.
-  repeated uint64 statement_fingerprint_ids = 17 [(gogoproto.customname) = "StatementFingerprintIDs", (gogoproto.jsontag) = ',omitempty', (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb.StmtFingerprintID"];
 
   // NumRows is the total number of rows returned across all statements.
   int64 num_rows = 18 [(gogoproto.jsontag) = ",includeempty"];
@@ -487,6 +485,27 @@ message SampledTransaction {
   // this one. We only count skipped transactions when telemetry logging is enabled and the sampling
   // mode is set to "transaction".
   int64 skipped_transactions = 26 [(gogoproto.jsontag) = ",omitempty"];
+
+  // TransactionFingerprintID is the fingerprint ID of the transaction.
+  // This can be used to find the transaction in the console.
+  string transaction_fingerprint_id = 27 [(gogoproto.customname) = "TransactionFingerprintID", (gogoproto.jsontag) = 'TransactionFingerprintID,', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction.
+  repeated string statement_fingerprint_ids = 28 [(gogoproto.customname) = "StatementFingerprintIDs", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+
+  // Previously used for transaction_fingerprint_id. Originally this was typed as a uint64
+  // but has been re-typed to be a string due to downstream json parsing issues. For
+  // more details see: https://github.com/cockroachdb/cockroach/issues/123665
+  reserved 7;
+
+  // Previously used for statement_fingerprint_ids. Originally this was typed as a uint64
+  // but has been re-typed to be a string due to downstream json parsing issues. For
+  // more details see: https://github.com/cockroachdb/cockroach/issues/123665
+  reserved 17;
+
+  // Next available ID: 29.
+
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Previously, transaction_fingerprint_id and statement_fingerprint_id were typed as uint64. Somewhere downstream, these uint64 fields were truncated into int64 max ints. As a result, telemetry logs had the same fingerprint id for different sql statements.

To fix, the field name was re-typed as a string to ensure no truncation / type conversion happens.

Epic: none
Fixes: #123665
Release note (bug fix): Fixed a bug where telemetry logs were had the same statement fingerprint id for different sql statements.