### PR TITLE
build: adjust pebble metamorphic race run

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -22,9 +22,9 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --c
                                       --test_timeout=14400 \
                                       --test_sharding_strategy=disabled \
                                       --define gotags=bazel,invariants \
-                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 30m -stderr -p 1" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 40m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \
-                                      --test_arg -ops --test_arg "uniform:5000-10000" \
+                                      --test_arg -ops --test_arg "uniform:2000-5000" \
                                       --test_output streamed \
     || exit_status=$?
 


### PR DESCRIPTION
Adjust the nightly metamorphic race run to avoid timeouts: increase
the single-run timeout from 30m to 40m and decrease the number of ops
from 5000-10000 to 2000-5000.

Fixes https://github.com/cockroachdb/pebble/issues/3625