### PR TITLE
sql: add tracing for locks requested by a scan

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -325,6 +325,7 @@ Matt Jibson <matt.jibson@gmail.com> <@cockroachlabs.com>
 Matt Sherman <sherman@cockroachlabs.com>
 Matt Linville <linville@cockroachlabs.com>
 Matt Tracy <matt.r.tracy@gmail.com> <matt@cockroachlabs.com>
+Matt White <matt.white@cockroachlabs.com>
 Matthew O'Connor <matthew@squareup.com> <matthew.t.oconnor@gmail.com>
 Matthew Todd <todd@cockroachlabs.com> <matthew@matthewtodd.org>
 Max Lang <max@cockroachlabs.com> <maxwell.g.lang@gmail.com>

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -80,7 +80,7 @@ CPut /Table/106/1/4/0 -> /TUPLE/
 query T kvtrace
 UPDATE d SET b='[1]' WHERE a=4
 ----
-Scan /Table/106/1/4/0
+Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/
 InitPut /Table/106/2/Arr/1/4/0 -> /BYTES/
 
@@ -88,7 +88,7 @@ InitPut /Table/106/2/Arr/1/4/0 -> /BYTES/
 query T kvtrace
 UPDATE d SET b=NULL WHERE a=4
 ----
-Scan /Table/106/1/4/0
+Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/
 Del /Table/106/2/Arr/1/4/0
 
@@ -224,7 +224,7 @@ CPut /Table/108/1/2/0 -> /TUPLE/
 query T kvtrace
 UPDATE f SET b = ARRAY[0,15,7,10] WHERE a = 0
 ----
-Scan /Table/108/1/0/0
+Scan /Table/108/1/0/0 lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/0/0 -> /TUPLE/
 Del /Table/108/2/1/0/0
 InitPut /Table/108/2/15/0/0 -> /BYTES/

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -92,7 +92,7 @@ CPut /Table/106/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo
 query T kvtrace
 UPDATE t SET j = '[1]' WHERE k = 4
 ----
-Scan /Table/106/1/4/0
+Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
 InitPut /Table/106/2/333/Arr/1/4/0 -> /BYTES/
 InitPut /Table/106/3/333/"foo"/Arr/1/4/0 -> /BYTES/
@@ -101,7 +101,7 @@ InitPut /Table/106/3/333/"foo"/Arr/1/4/0 -> /BYTES/
 query T kvtrace
 UPDATE t SET j = NULL WHERE k = 4
 ----
-Scan /Table/106/1/4/0
+Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo
 Del /Table/106/2/333/Arr/1/4/0
 Del /Table/106/3/333/"foo"/Arr/1/4/0
@@ -125,7 +125,7 @@ InitPut /Table/106/3/NULL/"foo"/"a"/"b"/5/0 -> /BYTES/
 query T kvtrace
 UPDATE t SET i = 333 WHERE k = 5
 ----
-Scan /Table/106/1/5/0
+Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/5/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/
 Del /Table/106/2/NULL/"a"/"b"/5/0
 InitPut /Table/106/2/333/"a"/"b"/5/0 -> /BYTES/
@@ -136,7 +136,7 @@ InitPut /Table/106/3/333/"foo"/"a"/"b"/5/0 -> /BYTES/
 query T kvtrace
 UPDATE t SET i = NULL WHERE k = 5
 ----
-Scan /Table/106/1/5/0
+Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/5/0 -> /TUPLE/3:3:Bytes/foo/
 Del /Table/106/2/333/"a"/"b"/5/0
 InitPut /Table/106/2/NULL/"a"/"b"/5/0 -> /BYTES/

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -332,7 +332,7 @@ INSERT INTO t VALUES(13, 11, 'foo')
 query T kvtrace
 UPDATE t SET c = 'baz' WHERE a = 5
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/baz
 
 # Update a row that matches no partial indexes before the update, but does match
@@ -340,7 +340,7 @@ Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/baz
 query T kvtrace
 UPDATE t SET b = 11 WHERE a = 5
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 Del /Table/112/2/4/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/ (expecting does not exist)
@@ -351,7 +351,7 @@ CPut /Table/112/3/11/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPDATE t SET c = 'baz' WHERE a = 6
 ----
-Scan /Table/112/1/6/0
+Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 
 # Update a row that matches the first partial index before and after the update
@@ -359,7 +359,7 @@ Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 query T kvtrace
 UPDATE t SET b = 12 WHERE a = 6
 ----
-Scan /Table/112/1/6/0
+Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
 Del /Table/112/2/11/6/0
 CPut /Table/112/2/12/6/0 -> /BYTES/ (expecting does not exist)
@@ -371,7 +371,7 @@ CPut /Table/112/3/12/6/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPDATE t SET b = 9 WHERE a = 6
 ----
-Scan /Table/112/1/6/0
+Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
 Del /Table/112/2/12/6/0
 CPut /Table/112/2/9/6/0 -> /BYTES/ (expecting does not exist)
@@ -382,7 +382,7 @@ Del /Table/112/3/12/6/0
 query T kvtrace
 UPDATE t SET c = 'baz', b = 12 WHERE a = 13
 ----
-Scan /Table/112/1/13/0
+Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
 Del /Table/112/2/11/13/0
 CPut /Table/112/2/12/13/0 -> /BYTES/ (expecting does not exist)
@@ -394,7 +394,7 @@ Del /Table/112/4/"foo"/13/0
 query T kvtrace
 UPDATE t SET c = 'foo', b = 11 WHERE a = 13
 ----
-Scan /Table/112/1/13/0
+Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 Del /Table/112/2/12/13/0
 CPut /Table/112/2/11/13/0 -> /BYTES/ (expecting does not exist)
@@ -410,7 +410,7 @@ INSERT INTO u VALUES (1, 2, 3)
 query T kvtrace
 UPDATE u SET v = 11 WHERE k = 1
 ----
-Scan /Table/113/1/1/0
+Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/11
 CPut /Table/113/2/2/1/0 -> /BYTES/ (expecting does not exist)
 
@@ -419,7 +419,7 @@ CPut /Table/113/2/2/1/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPDATE u SET v = 3 WHERE k = 1
 ----
-Scan /Table/113/1/1/0
+Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 Del /Table/113/2/2/1/0
 
@@ -436,7 +436,7 @@ INSERT INTO t VALUES(20, 11, 'bar')
 query T kvtrace
 UPDATE t SET a = 21 WHERE a = 20
 ----
-Scan /Table/112/1/20/0
+Scan /Table/112/1/20/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/11/20/0
 Del /Table/112/3/11/20/0
 Del /Table/112/1/20/0
@@ -450,7 +450,7 @@ InitPut /Table/112/3/11/21/0 -> /BYTES/
 query T kvtrace
 UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
 ----
-Scan /Table/112/1/21/0
+Scan /Table/112/1/21/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/11/21/0
 Del /Table/112/3/11/21/0
 Del /Table/112/1/21/0
@@ -560,7 +560,7 @@ DELETE FROM u
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 InitPut /Table/112/2/4/5/0 -> /BYTES/
 
@@ -569,7 +569,7 @@ InitPut /Table/112/2/4/5/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (5, 3, 'foo') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
 Del /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
@@ -579,7 +579,7 @@ CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 INSERT INTO t VALUES (5, 7, 'foo') ON CONFLICT (a) DO UPDATE SET b = 11
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 Del /Table/112/2/3/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/ (expecting does not exist)
@@ -591,7 +591,7 @@ CPut /Table/112/3/11/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 4, c = 'foo'
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 Del /Table/112/2/11/5/0
 CPut /Table/112/2/4/5/0 -> /BYTES/ (expecting does not exist)
@@ -603,7 +603,7 @@ CPut /Table/112/4/"foo"/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
 Del /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
@@ -613,7 +613,7 @@ CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET c = 'foobar'
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
 Del /Table/112/4/"foo"/5/0
 CPut /Table/112/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
@@ -622,7 +622,7 @@ CPut /Table/112/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 INSERT INTO t VALUES (6, 11, 'baz') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/6/0
+Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 InitPut /Table/112/2/11/6/0 -> /BYTES/
 InitPut /Table/112/3/11/6/0 -> /BYTES/
@@ -632,7 +632,7 @@ InitPut /Table/112/3/11/6/0 -> /BYTES/
 query T kvtrace
 INSERT INTO u VALUES (1, 2, 3) ON CONFLICT (k) DO UPDATE SET u = 5
 ----
-Scan /Table/113/1/1/0
+Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Insert a conflicting row that does not match the partial index with predicate
@@ -640,7 +640,7 @@ CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 query T kvtrace
 INSERT INTO u VALUES (1, 4, 6) ON CONFLICT (k) DO UPDATE SET v = 8
 ----
-Scan /Table/113/1/1/0
+Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/8
 
 # Insert a non-conflicting row that matches the partial index with predicate
@@ -648,7 +648,7 @@ Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/8
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 5
 ----
-Scan /Table/113/1/2/0
+Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/113/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
 InitPut /Table/113/2/3/2/0 -> /BYTES/
 
@@ -657,7 +657,7 @@ InitPut /Table/113/2/3/2/0 -> /BYTES/
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 4, v = 12
 ----
-Scan /Table/113/1/2/0
+Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
 Del /Table/113/2/3/2/0
 CPut /Table/113/2/4/2/0 -> /BYTES/ (expecting does not exist)
@@ -677,7 +677,7 @@ DELETE FROM u
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 5
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 InitPut /Table/112/2/4/5/0 -> /BYTES/
 
@@ -686,7 +686,7 @@ InitPut /Table/112/2/4/5/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/4/5/0
 Del /Table/112/1/5/0
 CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
@@ -697,7 +697,7 @@ InitPut /Table/112/2/4/6/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo'
 ----
-Scan /Table/112/1/6/0
+Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/4/6/0
 Del /Table/112/1/6/0
 CPut /Table/112/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
@@ -710,7 +710,7 @@ InitPut /Table/112/4/"foo"/7/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
 ----
-Scan /Table/112/1/7/0
+Scan /Table/112/1/7/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/4/7/0
 Del /Table/112/4/"foo"/7/0
 Del /Table/112/1/7/0
@@ -723,7 +723,7 @@ InitPut /Table/112/3/11/8/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foobar'
 ----
-Scan /Table/112/1/8/0
+Scan /Table/112/1/8/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/11/8/0
 Del /Table/112/3/11/8/0
 Del /Table/112/1/8/0
@@ -746,7 +746,7 @@ DELETE FROM u
 query T kvtrace
 UPSERT INTO t VALUES (5, 4, 'bar')
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 InitPut /Table/112/2/4/5/0 -> /BYTES/
 
@@ -755,7 +755,7 @@ InitPut /Table/112/2/4/5/0 -> /BYTES/
 query T kvtrace
 UPSERT INTO t VALUES (5, 3, 'bar')
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
 Del /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
@@ -765,7 +765,7 @@ CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPSERT INTO t VALUES (5, 11, 'bar')
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 Del /Table/112/2/3/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/ (expecting does not exist)
@@ -777,7 +777,7 @@ CPut /Table/112/3/11/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPSERT INTO t VALUES (5, 3, 'foo')
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
 Del /Table/112/2/11/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
@@ -789,7 +789,7 @@ CPut /Table/112/4/"foo"/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPSERT INTO t VALUES (5, 4, 'foo')
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 Del /Table/112/2/3/5/0
 CPut /Table/112/2/4/5/0 -> /BYTES/ (expecting does not exist)
@@ -799,7 +799,7 @@ CPut /Table/112/2/4/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPSERT INTO t VALUES (5, 4, 'foobar')
 ----
-Scan /Table/112/1/5/0
+Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
 Del /Table/112/4/"foo"/5/0
 CPut /Table/112/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
@@ -808,7 +808,7 @@ CPut /Table/112/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
 query T kvtrace
 UPSERT INTO t VALUES (9, 11, 'baz')
 ----
-Scan /Table/112/1/9/0
+Scan /Table/112/1/9/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/112/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 InitPut /Table/112/2/11/9/0 -> /BYTES/
 InitPut /Table/112/3/11/9/0 -> /BYTES/
@@ -818,7 +818,7 @@ InitPut /Table/112/3/11/9/0 -> /BYTES/
 query T kvtrace
 UPSERT INTO u VALUES (1, 2, 3)
 ----
-Scan /Table/113/1/1/0
+Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Upsert a conflicting row that does not match the partial index with predicate
@@ -826,7 +826,7 @@ CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 query T kvtrace
 UPSERT INTO u VALUES (1, 4, 6)
 ----
-Scan /Table/113/1/1/0
+Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/6
 
 # Upsert a non-conflicting row that matches the partial index with predicate
@@ -834,7 +834,7 @@ Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/6
 query T kvtrace
 UPSERT INTO u VALUES (2, 3, 11)
 ----
-Scan /Table/113/1/2/0
+Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/113/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
 InitPut /Table/113/2/3/2/0 -> /BYTES/
 
@@ -843,7 +843,7 @@ InitPut /Table/113/2/3/2/0 -> /BYTES/
 query T kvtrace
 UPSERT INTO u VALUES (2, 4, 12)
 ----
-Scan /Table/113/1/2/0
+Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
 Del /Table/113/2/3/2/0
 CPut /Table/113/2/4/2/0 -> /BYTES/ (expecting does not exist)
@@ -913,14 +913,14 @@ INSERT INTO inv VALUES (2, '{"x": "y", "num": 2}', 'baz');
 query T kvtrace
 UPDATE inv SET c = 'bar' WHERE a = 1
 ----
-Scan /Table/107/1/1/0
+Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/
 
 # Update the JSON of a row in the partial index.
 query T kvtrace
 UPDATE inv SET b = '{"x": "y", "num": 3}' WHERE a = 1
 ----
-Scan /Table/107/1/1/0
+Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/
 Del /Table/107/2/"num"/1/1/0
 InitPut /Table/107/2/"num"/3/1/0 -> /BYTES/
@@ -929,7 +929,7 @@ InitPut /Table/107/2/"num"/3/1/0 -> /BYTES/
 query T kvtrace
 UPDATE inv SET c = 'fud' WHERE a = 1
 ----
-Scan /Table/107/1/1/0
+Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/
 Del /Table/107/2/"num"/3/1/0
 Del /Table/107/2/"x"/"y"/1/0
@@ -938,21 +938,21 @@ Del /Table/107/2/"x"/"y"/1/0
 query T kvtrace
 UPDATE inv SET c = 'boo' WHERE a = 2
 ----
-Scan /Table/107/1/2/0
+Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/2/0 -> /TUPLE/
 
 # Update the JSON of a row not in the partial index.
 query T kvtrace
 UPDATE inv SET b = '{"x": "y", "num": 4}' WHERE a = 2
 ----
-Scan /Table/107/1/2/0
+Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/2/0 -> /TUPLE/
 
 # Update a non-JSON column so that the row is added to the partial index.
 query T kvtrace
 UPDATE inv SET c = 'bar' WHERE a = 2
 ----
-Scan /Table/107/1/2/0
+Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/2/0 -> /TUPLE/
 InitPut /Table/107/2/"num"/4/2/0 -> /BYTES/
 InitPut /Table/107/2/"x"/"y"/2/0 -> /BYTES/
@@ -961,7 +961,7 @@ InitPut /Table/107/2/"x"/"y"/2/0 -> /BYTES/
 query T kvtrace
 UPDATE inv SET a = 4 WHERE a = 2
 ----
-Scan /Table/107/1/2/0
+Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
 Del /Table/107/2/"num"/4/2/0
 Del /Table/107/2/"x"/"y"/2/0
 Del /Table/107/1/2/0
@@ -973,7 +973,7 @@ InitPut /Table/107/2/"x"/"y"/4/0 -> /BYTES/
 query T kvtrace
 UPDATE inv SET a = 3 WHERE a = 1
 ----
-Scan /Table/107/1/1/0
+Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Del /Table/107/1/1/0
 CPut /Table/107/1/3/0 -> /TUPLE/
 
@@ -985,7 +985,7 @@ INSERT INTO inv VALUES (10, '{"a": "b"}', 'foo'), (11, '{"a": "b"}', 'baz')
 query T kvtrace
 UPDATE inv SET c = 'foo' WHERE a IN (10, 11)
 ----
-Scan /Table/107/1/1{0-2}
+Scan /Table/107/1/1{0-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/10/0 -> /TUPLE/
 Put /Table/107/1/11/0 -> /TUPLE/
 InitPut /Table/107/2/"a"/"b"/11/0 -> /BYTES/
@@ -998,7 +998,7 @@ INSERT INTO inv VALUES (12, '{"a": "b"}', 'foo'), (13, '{"a": "b"}', 'baz')
 query T kvtrace
 UPDATE inv SET c = 'fud' WHERE a IN (12, 13)
 ----
-Scan /Table/107/1/1{2-4}
+Scan /Table/107/1/1{2-4} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/12/0 -> /TUPLE/
 Del /Table/107/2/"a"/"b"/12/0
 Put /Table/107/1/13/0 -> /TUPLE/
@@ -1012,7 +1012,7 @@ Put /Table/107/1/13/0 -> /TUPLE/
 query T kvtrace
 UPSERT INTO inv VALUES (4, '{"x": "y", "num": 4}', 'foo')
 ----
-Scan /Table/107/1/4/0
+Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/
 
 # Upsert a conflicting row with different JSON from the existing row in the
@@ -1020,7 +1020,7 @@ Put /Table/107/1/4/0 -> /TUPLE/
 query T kvtrace
 UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'foo')
 ----
-Scan /Table/107/1/4/0
+Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/
 Del /Table/107/2/"num"/4/4/0
 InitPut /Table/107/2/"num"/6/4/0 -> /BYTES/
@@ -1029,7 +1029,7 @@ InitPut /Table/107/2/"num"/6/4/0 -> /BYTES/
 query T kvtrace
 UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'fud')
 ----
-Scan /Table/107/1/4/0
+Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/
 Del /Table/107/2/"num"/6/4/0
 Del /Table/107/2/"x"/"y"/4/0
@@ -1038,7 +1038,7 @@ Del /Table/107/2/"x"/"y"/4/0
 query T kvtrace
 UPSERT INTO inv VALUES (5, '{"x": "y", "num": 7}', 'bar')
 ----
-Scan /Table/107/1/5/0
+Scan /Table/107/1/5/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/107/1/5/0 -> /TUPLE/
 InitPut /Table/107/2/"num"/7/5/0 -> /BYTES/
 InitPut /Table/107/2/"x"/"y"/5/0 -> /BYTES/
@@ -1047,7 +1047,7 @@ InitPut /Table/107/2/"x"/"y"/5/0 -> /BYTES/
 query T kvtrace
 UPSERT INTO inv VALUES (6, '{"x": "y", "num": 8}', 'baz')
 ----
-Scan /Table/107/1/6/0
+Scan /Table/107/1/6/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/107/1/6/0 -> /TUPLE/
 
 # Regression test for #57085. Cascading DELETEs should not issue DEL operations

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -46,7 +46,7 @@ CPut /Table/106/1/102/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1102.2
 query T kvtrace(prefix=/Table/106/)
 UPDATE t SET a = a + 100
 ----
-Scan /Table/106/{1-2}
+Scan /Table/106/{1-2} lock Exclusive (Block, Unreplicated)
 Del /Table/106/1/100/0
 Del /Table/106/1/100/1/1
 CPut /Table/106/1/200/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -139,7 +139,7 @@ SET tracing = off
 query TT
 $trace_query
 ----
-colbatchscan  Scan /Table/109/{1-2}
+colbatchscan  Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv2/kv2_pkey/-9222809086901354496/k/v -> /1/2
 count         Put /Table/109/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 count         fast path completed

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -805,7 +805,7 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-Scan /Table/115/{1-2}
+Scan /Table/115/{1-2} lock Exclusive (Block, Unreplicated)
 fetched: /tu/tu_pkey/1 -> <undecoded>
 fetched: /tu/tu_pkey/1 -> <undecoded>
 fetched: /tu/tu_pkey/1/c/d -> /3/4
@@ -820,7 +820,7 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-Scan /Table/115/{1-2}
+Scan /Table/115/{1-2} lock Exclusive (Block, Unreplicated)
 fetched: /tu/tu_pkey/1 -> <undecoded>
 fetched: /tu/tu_pkey/1/b -> 2
 fetched: /tu/tu_pkey/1/c/d -> /4/4

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -914,7 +914,7 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
-colbatchscan  Scan /Table/120/1/2/0
+colbatchscan  Scan /Table/120/1/2/0 lock Exclusive (Block, Unreplicated)
 count         CPut /Table/120/1/2/0 -> /TUPLE/2:2:Int/3
 count         InitPut /Table/120/2/3/0 -> /BYTES/0x8a
 count         fast path completed
@@ -927,7 +927,7 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
-colbatchscan  Scan /Table/120/1/1/0
+colbatchscan  Scan /Table/120/1/1/0 lock Exclusive (Block, Unreplicated)
 count         CPut /Table/120/1/1/0 -> /TUPLE/2:2:Int/2
 count         InitPut /Table/120/2/2/0 -> /BYTES/0x89
 count         fast path completed
@@ -941,7 +941,7 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
-colbatchscan  Scan /Table/120/1/2/0
+colbatchscan  Scan /Table/120/1/2/0 lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv/kv_pkey/2/v -> /3
 count         Put /Table/120/1/2/0 -> /TUPLE/2:2:Int/2
 count         Del /Table/120/2/3/0

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -12,6 +12,7 @@ package row
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -532,7 +533,11 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	// Note that spansToRequests below might modify spans, so we need to log the
 	// spans before that.
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEventf(ctx, 2, "Scan %s", f.spans.BoundedString(1024 /* bytesHint */))
+		lockStr := ""
+		if f.lockStrength != lock.None {
+			lockStr = fmt.Sprintf(" lock %s (%s, %s)", f.lockStrength.String(), f.lockWaitPolicy.String(), f.lockDurability.String())
+		}
+		log.VEventf(ctx, 2, "Scan %s%s", f.spans.BoundedString(1024 /* bytesHint */), lockStr)
 	}
 
 	ba := &kvpb.BatchRequest{}

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -12,6 +12,7 @@ package row
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -87,7 +88,11 @@ func (f *txnKVStreamer) SetupNextFetch(
 	}
 	f.reset(ctx)
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEventf(ctx, 2, "Scan %s", spans.BoundedString(1024 /* bytesHint */))
+		lockStr := ""
+		if f.lockStrength != lock.None {
+			lockStr = fmt.Sprintf(" lock %s (%s)", f.lockStrength.String(), f.lockDurability.String())
+		}
+		log.VEventf(ctx, 2, "Scan %s%s", spans.BoundedString(1024 /* bytesHint */), lockStr)
 	}
 	// Make sure to nil out the requests past the length that will be used in
 	// spansToRequests so that we lose references to the underlying Get and Scan

--- a/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
@@ -38,20 +38,20 @@ Put /Table/106/2/1/100/0 -> /BYTES/0x0a020389
 kvtrace
 UPDATE ti SET c = 200 WHERE a = 2
 ----
-Scan /Table/106/1/2/0
+Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/200
 Put /Table/106/2/2/200/0 -> /BYTES/0x0a02038a
 
 kvtrace
 UPDATE ti SET c = 1 WHERE a = 2
 ----
-Scan /Table/106/1/2/0
+Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/1
 Put (delete) /Table/106/2/2/200/0
 
 kvtrace
 UPDATE ti SET c = 200 WHERE a = 2
 ----
-Scan /Table/106/1/2/0
+Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/200
 Put /Table/106/2/2/200/0 -> /BYTES/0x0a02038a

--- a/pkg/sql/testdata/index_mutations/delete_preserving_update
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_update
@@ -21,7 +21,7 @@ INSERT INTO ti VALUES (1, 2, 100)
 kvtrace
 UPDATE ti SET b = b + 1, c = c + 1
 ----
-Scan /Table/106/{1-2}
+Scan /Table/106/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
 Put (delete) /Table/106/2/2/100/1/0
 Put /Table/106/2/3/101/1/0 -> /BYTES/0x0a0103
@@ -50,14 +50,14 @@ INSERT INTO tpi VALUES (3, 4, 'bar')
 kvtrace
 UPDATE tpi SET b = b + 1
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/5/1:3:Bytes/bar
 
 # Update a row that didn't match the partial index before but matches after.
 kvtrace
 UPDATE tpi SET b = b - 3, c = 'foo'
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
 Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
@@ -67,7 +67,7 @@ Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 kvtrace
 UPDATE tpi SET b = b - 1
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
 Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
@@ -76,7 +76,7 @@ Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 kvtrace
 UPDATE tpi SET b = b + 1, c = 'foobar'
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
 Put (delete) /Table/107/2/"foo"/3/0
 Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
@@ -85,7 +85,7 @@ Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
 kvtrace
 UPDATE tpi SET c = 'baz'
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/baz
 Put (delete) /Table/107/2/"foobar"/3/0
 
@@ -113,7 +113,7 @@ INSERT INTO tei VALUES (1, 2, 100)
 kvtrace
 UPDATE tei SET a = a + 1, b = b + 100
 ----
-Scan /Table/108/{1-2}
+Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Put (delete) /Table/108/2/102/1/0
 Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
@@ -123,7 +123,7 @@ Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
 kvtrace
 UPDATE tei SET a = a + 1, b = b - 1
 ----
-Scan /Table/108/{1-2}
+Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/199
 Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
 
@@ -151,7 +151,7 @@ INSERT INTO tii VALUES (1, ARRAY[1, 2, 3, 2, 2, NULL, 3])
 kvtrace
 UPDATE tii SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
-Scan /Table/109/{1-2}
+Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/
 Put (delete) /Table/109/2/NULL/1/0
 Put (delete) /Table/109/2/1/1/0
@@ -186,7 +186,7 @@ INSERT INTO tmi VALUES (1, 2, '{"a": "foo", "b": "bar"}'::json)
 kvtrace
 UPDATE tmi SET b = 3, c = '{"a": "foobar", "c": "baz"}'::json
 ----
-Scan /Table/110/{1-2}
+Scan /Table/110/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/
 Put (delete) /Table/110/2/2/"a"/"foo"/1/0
 Put (delete) /Table/110/2/2/"b"/"bar"/1/0

--- a/pkg/sql/testdata/index_mutations/delete_preserving_upsert
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_upsert
@@ -21,7 +21,7 @@ INSERT INTO ti VALUES (1, 2, 100), (2, 3, 200), (3, 4, 300)
 kvtrace
 UPSERT INTO ti VALUES (1, 3, 101)
 ----
-Scan /Table/106/1/1/0
+Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
 Put (delete) /Table/106/2/2/100/1/0
 Put /Table/106/2/3/101/1/0 -> /BYTES/0x0a0103
@@ -50,14 +50,14 @@ INSERT INTO tpi VALUES (1, 2, 'bar'), (2, 3, 'bar'), (3, 4, 'foo')
 kvtrace
 UPSERT INTO tpi VALUES (1, 3, 'bar')
 ----
-Scan /Table/107/1/1/0
+Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
 
 # Upsert a row that didn't match the partial index before but matches after.
 kvtrace
 UPSERT INTO tpi VALUES (3, 2, 'foo')
 ----
-Scan /Table/107/1/3/0
+Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
 Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
@@ -67,7 +67,7 @@ Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 kvtrace
 UPSERT INTO tpi VALUES (3, 1, 'foo')
 ----
-Scan /Table/107/1/3/0
+Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
 Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
@@ -76,7 +76,7 @@ Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 kvtrace
 UPSERT INTO tpi VALUES (3, 2, 'foobar')
 ----
-Scan /Table/107/1/3/0
+Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
 Put (delete) /Table/107/2/"foo"/3/0
 Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
@@ -85,7 +85,7 @@ Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
 kvtrace
 UPSERT INTO tpi VALUES (3, 1, 'baz')
 ----
-Scan /Table/107/1/3/0
+Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/baz
 Put (delete) /Table/107/2/"foobar"/3/0
 
@@ -159,7 +159,7 @@ INSERT INTO tii VALUES (1, ARRAY[1, 2, 3, 2, 2, NULL, 3])
 kvtrace
 UPSERT INTO tii VALUES (1, ARRAY[1, 2, 2, NULL, 4, 4])
 ----
-Scan /Table/109/1/1/0
+Scan /Table/109/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/
 Put (delete) /Table/109/2/NULL/1/0
 Put (delete) /Table/109/2/1/1/0
@@ -193,7 +193,7 @@ INSERT INTO tmi VALUES (1, 2, '{"a": "foo", "b": "bar"}'::json)
 kvtrace
 UPSERT INTO tmi VALUES (1, 3, '{"a": "foobar", "c": "baz"}'::json)
 ----
-Scan /Table/110/1/1/0
+Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/
 Put (delete) /Table/110/2/2/"a"/"foo"/1/0
 Put (delete) /Table/110/2/2/"b"/"bar"/1/0
@@ -227,7 +227,7 @@ DELETE FROM tui WHERE a = 2
 kvtrace
 UPSERT INTO tui VALUES (1, 3, 200)
 ----
-Scan /Table/111/1/1/0
+Scan /Table/111/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/111/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Put (delete) /Table/111/2/2/100/0
 Put /Table/111/2/3/200/0 -> /BYTES/0x0a020389
@@ -257,7 +257,7 @@ INSERT INTO mcf VALUES (1, 2, 'bar'), (2, 3, 'bar'), (3, 4, 'foo')
 kvtrace
 UPSERT INTO mcf VALUES (1, 1, 'baz')
 ----
-Scan /Table/112/1/{1-2}
+Scan /Table/112/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/1/0 -> /TUPLE/2:2:Int/1
 Put /Table/112/1/1/1/1 -> /BYTES/baz
 Put (delete) /Table/112/2/2/1/0
@@ -267,7 +267,7 @@ Put /Table/112/2/1/1/0 -> /BYTES/0x0a0103
 kvtrace
 UPSERT INTO mcf VALUES (1, 1, 'bat')
 ----
-Scan /Table/112/1/{1-2}
+Scan /Table/112/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/1/0 -> /TUPLE/2:2:Int/1
 Put /Table/112/1/1/1/1 -> /BYTES/bat
 Put /Table/112/2/1/1/0 -> /BYTES/0x0a0103

--- a/pkg/sql/testdata/index_mutations/merging
+++ b/pkg/sql/testdata/index_mutations/merging
@@ -28,7 +28,7 @@ Put /Table/106/2/1/0 -> /BYTES/0x8b
 kvtrace
 UPDATE ti SET b = 2 WHERE a = 4
 ----
-Scan /Table/106/1/4/0
+Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/2:2:Int/2
 Del /Table/106/2/4/0
 Put /Table/106/2/2/0 -> /BYTES/0x8c
@@ -36,14 +36,14 @@ Put /Table/106/2/2/0 -> /BYTES/0x8c
 kvtrace
 UPSERT INTO ti VALUES (5, 1)
 ----
-Scan /Table/106/1/5/0
+Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 CPut /Table/106/1/5/0 -> /TUPLE/2:2:Int/1
 Put /Table/106/2/1/0 -> /BYTES/0x8d
 
 kvtrace
 UPSERT INTO ti VALUES (2, 1)
 ----
-Scan /Table/106/1/2/0
+Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/1
 Del /Table/106/2/2/0
 Put /Table/106/2/1/0 -> /BYTES/0x8a
@@ -58,7 +58,7 @@ Put /Table/106/2/1/0 -> /BYTES/0x8e
 kvtrace
 INSERT INTO ti VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 ----
-Scan /Table/106/1/1/0
+Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/2
 Del /Table/106/2/1/0
 Put /Table/106/2/2/0 -> /BYTES/0x89
@@ -87,14 +87,14 @@ INSERT INTO tpfp VALUES (3, 4, 'bar')
 kvtrace
 UPDATE tpfp SET b = b + 1
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/5/1:3:Bytes/bar
 
 # Update a row that didn't match the partial index before but matches after.
 kvtrace
 UPDATE tpfp SET b = b - 3, c = 'foo'
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
 Put /Table/107/2/"foo"/0 -> /BYTES/0x8b
 
@@ -103,7 +103,7 @@ Put /Table/107/2/"foo"/0 -> /BYTES/0x8b
 kvtrace
 UPDATE tpfp SET b = b - 1
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
 
 # Update a row that matches the partial index before and after, and the index
@@ -111,7 +111,7 @@ Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
 kvtrace
 UPDATE tpfp SET b = b + 1, c = 'foobar'
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
 Del /Table/107/2/"foo"/0
 Put /Table/107/2/"foobar"/0 -> /BYTES/0x8b
@@ -120,7 +120,7 @@ Put /Table/107/2/"foobar"/0 -> /BYTES/0x8b
 kvtrace
 UPDATE tpfp SET c = 'baz'
 ----
-Scan /Table/107/{1-2}
+Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/baz
 Del /Table/107/2/"foobar"/0
 
@@ -145,7 +145,7 @@ INSERT INTO tefp VALUES (1, 2, 100)
 kvtrace
 UPDATE tefp SET a = a + 1, b = b + 100
 ----
-Scan /Table/108/{1-2}
+Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Del /Table/108/2/102/0
 CPut /Table/108/2/203/0 -> /BYTES/0x89 (expecting does not exist)
@@ -154,7 +154,7 @@ CPut /Table/108/2/203/0 -> /BYTES/0x89 (expecting does not exist)
 kvtrace
 UPDATE tefp SET a = a + 1, b = b - 1
 ----
-Scan /Table/108/{1-2}
+Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/199
 
 # ---------------------------------------------------------
@@ -181,7 +181,7 @@ INSERT INTO tifp VALUES (1, ARRAY[1, 2, 3, 2, 2, NULL, 3])
 kvtrace
 UPDATE tifp SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
-Scan /Table/109/{1-2}
+Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/
 Del /Table/109/2/3/1/0
 Put /Table/109/2/4/1/0 -> /BYTES/
@@ -209,7 +209,7 @@ INSERT INTO tmfp VALUES (1, 2, '{"a": "foo", "b": "bar"}'::json)
 kvtrace
 UPDATE tmfp SET b = 3, c = '{"a": "foobar", "c": "baz"}'::json
 ----
-Scan /Table/110/{1-2}
+Scan /Table/110/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/
 Del /Table/110/2/2/"a"/"foo"/1/0
 Del /Table/110/2/2/"b"/"bar"/1/0


### PR DESCRIPTION
Previously, we would only log the spans requested by a scan. To provide additional visibility about lock acquisition, we now include information about locking modes requested by a scan.

Fixes: #115016

Release note: None