### PR TITLE
release-23.1: sql: drop user/role did not detect usage by types

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -249,6 +249,19 @@ func (n *DropRoleNode) startExec(params runParams) error {
 					ObjectName: tn.String(),
 				})
 		}
+		for _, u := range typDesc.GetPrivileges().Users {
+			if _, ok := userNames[u.User()]; ok {
+				tn, err := getTypeNameFromTypeDescriptor(lCtx, typDesc)
+				if err != nil {
+					return err
+				}
+				if privilegeObjectFormatter.Len() > 0 {
+					privilegeObjectFormatter.WriteString(", ")
+				}
+				privilegeObjectFormatter.FormatNode(&tn)
+				break
+			}
+		}
 	}
 	for _, fnDesc := range lCtx.fnDescs {
 		if _, ok := userNames[fnDesc.GetPrivileges().Owner()]; ok {

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1846,3 +1846,29 @@ database_name  schema_name  object_name    object_type          grantee  privile
 NULL           NULL         connection1    external_connection  roach    USAGE           false
 test           public       mood           type                 roach    USAGE           false
 test           public       test_sequence  sequence             roach    USAGE           false
+
+# Validates that drop role will be prevented if the role is in use by
+# any schema objects. This is validates and prevents the regression found
+# in #124441
+subtest drop_role_block_validation
+
+statement ok
+CREATE DATABASE block_db;
+USE block_db;
+CREATE TABLE t(n int);
+CREATE TYPE  typ AS ENUM ('open', 'closed', 'inactive');
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE ROLE block_user;
+GRANT ALL ON DATABASE block_db to block_user;
+GRANT ALL ON SCHEMA public to block_user;
+GRANT ALL ON TABLE t to block_user;
+GRANT ALL ON TYPE typ to block_user;
+GRANT ALL ON FUNCTION f to block_user;
+
+statement error pgcode 2BP01 cannot drop role/user block_user: grants still exist on block_db, block_db.public.t, block_db.public, block_db.public.typ, block_db.public.f
+DROP ROLE block_user
+
+statement ok
+USE defaultdb;
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #124611.

/cc @cockroachdb/release

---

Previously, it was possible to drop a user / role in use by a type because the detection logic only checked ownership. To address this, this patch will check if the user exists within any types before allowing the drop to go through.

Note: An automated repair during upgrade exists to fix descriptors with this issue, since they can break SHOW GRANTS. The same repair query can also be invoked manually.

Fixes: #124441

Release note (bug fix): Drop role/user could leave references behind inside types, which could prevent SHOW GRANTS from working

Release justification: low risk fix that blocks an operation that could lead to description corruption (breaking SHOW GRANTS)
