### PR TITLE
backupccl: remove a warning from TestDataDriven

### DIFF
--- a/pkg/ccl/backupccl/backuptestutils/testutils.go
+++ b/pkg/ccl/backupccl/backuptestutils/testutils.go
@@ -62,10 +62,11 @@ type bankWorkloadArgs struct {
 }
 
 type backupTestOptions struct {
-	bankArgs        *bankWorkloadArgs
-	dataDir         string
-	testClusterArgs base.TestClusterArgs
-	initFunc        func(*testcluster.TestCluster)
+	bankArgs                   *bankWorkloadArgs
+	dataDir                    string
+	testClusterArgs            base.TestClusterArgs
+	initFunc                   func(*testcluster.TestCluster)
+	skipInvalidDescriptorCheck bool
 }
 
 func WithParams(p base.TestClusterArgs) BackupTestArg {
@@ -91,6 +92,12 @@ func WithInitFunc(f func(*testcluster.TestCluster)) BackupTestArg {
 func WithTempDir(dir string) BackupTestArg {
 	return func(o *backupTestOptions) {
 		o.dataDir = dir
+	}
+}
+
+func WithSkipInvalidDescriptorCheck() BackupTestArg {
+	return func(o *backupTestOptions) {
+		o.skipInvalidDescriptorCheck = true
 	}
 }
 
@@ -158,7 +165,9 @@ func StartBackupRestoreTestCluster(
 	}
 
 	return tc, sqlDB, opts.dataDir, func() {
-		CheckForInvalidDescriptors(t, tc.Conns[0])
+		if !opts.skipInvalidDescriptorCheck {
+			CheckForInvalidDescriptors(t, tc.Conns[0])
+		}
 		tc.Stopper().Stop(ctx) // cleans up in memory storage's auxiliary dirs
 		dirCleanupFunc()
 	}

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -212,6 +212,11 @@ func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 	opts := []backuptestutils.BackupTestArg{
 		backuptestutils.WithParams(params),
 		backuptestutils.WithTempDir(cfg.iodir),
+		// We can skip the check for invalid descriptors because we do it in
+		// datadrivenTestState.cleanup explicitly, and having it in the cleanup
+		// function returned by StartBackupRestoreTestCluster fails anyway since
+		// we stop the first node before executing cleanupFns.
+		backuptestutils.WithSkipInvalidDescriptorCheck(),
 	}
 	if cfg.iodir == "" {
 		opts = append(opts, backuptestutils.WithBank(cfg.splits))


### PR DESCRIPTION
Previously, we would always see a warning of the form
```
    testutils.go:266: Warning: Could not check for invalid descriptors: sql: database is closed
```
at the end of TestDataDriven because the check for invalid descriptors is included as a cleanup function which is executed after stopping the first node in the cluster. The check performed by `backuptestutils` helper is actually redundant since we do this check explicitly in the data-driven test, so this commit adds an option to skip it from the helper.

Epic: None

Release note: None