### PR TITLE
raft: don't cap commit index in leader heartbeats

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -347,4 +347,4 @@ trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace 
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez	application
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.	application
 ui.display_timezone	enumeration	etc/utc	the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]	application
-version	version	1000024.1-upgrading-to-1000024.2-step-004	set the active cluster version in the format '<major>.<minor>'	application
+version	version	1000024.1-upgrading-to-1000024.2-step-006	set the active cluster version in the format '<major>.<minor>'	application

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -302,6 +302,6 @@
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-ui-display-timezone" class="anchored"><code>ui.display_timezone</code></div></td><td>enumeration</td><td><code>etc/utc</code></td><td>the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000024.1-upgrading-to-1000024.2-step-004</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000024.1-upgrading-to-1000024.2-step-006</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -251,6 +251,10 @@ const (
 	// system.statement_diagnostics_requests table.
 	V24_2_StmtDiagRedacted
 
+	// V24_2_DisableRaftCommitIndexCapping allows raft leader to send its commit
+	// index in a heartbeat without capping it at the follower's Match index.
+	V24_2_DisableRaftCommitIndexCapping
+
 	// *************************************************
 	// Step (1) Add new versions above this comment.
 	// Do not add new versions to a patch release.
@@ -310,7 +314,8 @@ var versionTable = [numKeys]roachpb.Version{
 	// v24.2 versions. Internal versions must be even.
 	V24_2Start: {Major: 24, Minor: 1, Internal: 2},
 
-	V24_2_StmtDiagRedacted: {Major: 24, Minor: 1, Internal: 4},
+	V24_2_StmtDiagRedacted:              {Major: 24, Minor: 1, Internal: 4},
+	V24_2_DisableRaftCommitIndexCapping: {Major: 24, Minor: 1, Internal: 6},
 
 	// *************************************************
 	// Step (2): Add new versions above this comment.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -386,6 +386,7 @@ func newRaftConfig(
 
 		PreVote:     true,
 		CheckQuorum: storeCfg.RaftEnableCheckQuorum,
+		CRDBVersion: storeCfg.Settings.Version,
 	}
 }
 

--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/raft",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/raft/confchange",
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1974,8 +1974,8 @@ func TestBcastBeat(t *testing.T) {
 	require.Len(t, msgs, 2)
 
 	wantCommitMap := map[uint64]uint64{
-		2: min(sm.raftLog.committed, sm.trk.Progress[2].Match),
-		3: min(sm.raftLog.committed, sm.trk.Progress[3].Match),
+		2: sm.raftLog.committed,
+		3: sm.raftLog.committed,
 	}
 	for i, m := range msgs {
 		require.Equal(t, pb.MsgHeartbeat, m.Type, "#%d", i)

--- a/pkg/raft/raftpb/confstate.go
+++ b/pkg/raft/raftpb/confstate.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by Cockroach Labs, Inc.
+// All modifications are Copyright 2024 Cockroach Labs, Inc.
+//
 // Copyright 2019 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,4 +44,12 @@ func (cs ConfState) Equivalent(cs2 ConfState) error {
 		return fmt.Errorf("ConfStates not equivalent after sorting:\n%+#v\n%+#v\nInputs were:\n%+#v\n%+#v", cs1, cs2, orig1, orig2)
 	}
 	return nil
+}
+
+// DescribeConfState formats the ConfState to a string.
+func DescribeConfState(state ConfState) string {
+	return fmt.Sprintf(
+		"Voters:%v VotersOutgoing:%v Learners:%v LearnersNext:%v AutoLeave:%v",
+		state.Voters, state.VotersOutgoing, state.Learners, state.LearnersNext, state.AutoLeave,
+	)
 }

--- a/pkg/raft/rafttest/BUILD.bazel
+++ b/pkg/raft/rafttest/BUILD.bazel
@@ -33,9 +33,11 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/rafttest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/raft",
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
+        "//pkg/settings/cluster",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
+++ b/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
@@ -23,8 +23,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	clustersettings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/datadriven"
 )
 
@@ -62,6 +64,12 @@ func (env *InteractionEnv) handleAddNodes(t *testing.T, d datadriven.TestData) e
 				arg.Scan(t, i, &cfg.DisableConfChangeValidation)
 			case "step-down-on-removal":
 				arg.Scan(t, i, &cfg.StepDownOnRemoval)
+			case "crdb-version":
+				var k int
+				arg.Scan(t, i, &k)
+				v := clusterversion.Key(k).Version()
+				s := clustersettings.MakeClusterSettingsWithVersions(v, clusterversion.MinSupported.Version())
+				cfg.CRDBVersion = s.Version
 			}
 		}
 	}

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -378,16 +378,16 @@ process-ready 4
 ----
 Ready MustSync=false:
 Messages:
-4->1 MsgHeartbeat Term:3 Log:0/0
-4->2 MsgHeartbeat Term:3 Log:0/0
-4->3 MsgHeartbeat Term:3 Log:0/0
-4->5 MsgHeartbeat Term:3 Log:0/0
-4->6 MsgHeartbeat Term:3 Log:0/0
-4->7 MsgHeartbeat Term:3 Log:0/0
+4->1 MsgHeartbeat Term:3 Log:0/0 Commit:11
+4->2 MsgHeartbeat Term:3 Log:0/0 Commit:11
+4->3 MsgHeartbeat Term:3 Log:0/0 Commit:11
+4->5 MsgHeartbeat Term:3 Log:0/0 Commit:11
+4->6 MsgHeartbeat Term:3 Log:0/0 Commit:11
+4->7 MsgHeartbeat Term:3 Log:0/0 Commit:11
 
 deliver-msgs 1
 ----
-4->1 MsgHeartbeat Term:3 Log:0/0
+4->1 MsgHeartbeat Term:3 Log:0/0 Commit:11
 INFO 1 [term: 2] received a MsgHeartbeat message with higher term from 4 [term: 3]
 INFO 1 became follower at term 3
 

--- a/pkg/raft/testdata/lagging_commit_mixed_cluster_version.txt
+++ b/pkg/raft/testdata/lagging_commit_mixed_cluster_version.txt
@@ -1,6 +1,5 @@
-# This a regression test demonstrating the effect of dropped MsgApp messages on
-# the latency of commit index bumps on a follower. Previously, there would be an
-# unnecessary roundrip before the follower would learn the commit index.
+# This test demonstrates the effect of delayed commit on a follower node after a
+# network hiccup between the leader and this follower.
 
 # Skip logging the boilerplate. Set up a raft group of 3 nodes, and elect node 1
 # as the leader. Nodes 2 and 3 are the followers.
@@ -8,7 +7,13 @@ log-level none
 ----
 ok
 
-add-nodes 3 voters=(1,2,3) index=10
+# Adding two nodes on previous cluster version.
+add-nodes 2 voters=(1, 2) index=10 crdb-version=20
+----
+ok
+
+# Adding one node on cluster version with don't cap commit index active.
+add-nodes 1 voters=(1,2,3) index=10 crdb-version=21
 ----
 ok
 
@@ -122,44 +127,37 @@ status 1
 # The leader still observes that the entries are in-flight to the follower 3,
 # since it hasn't heard from it. Nothing triggers updating the follower's
 # commit index, so we have to wait up to the full heartbeat interval before
-# the leader sends the commit index in a MsgApp message.
+# the leader sends the commit index.
 tick-heartbeat 1
 ----
 ok
 
-# The heartbeat message, however, contains the up-to-date commit index, which
-# allows the follower to bump its commit index earlier than the next MsgApp.
-#
-# Previously, the heartbeat to node 3 would contain Commit:11 capped at this
-# follower's Progress.Match index. In #122690 and #124648, we made it possible
-# to send Commit:13 safely.
+# However, the leader does not push the real commit index to the follower 3. It
+# cuts the commit index at the Progress.Match mark, because it thinks that it is
+# unsafe to send a commit index higher than that.
 process-ready 1
 ----
 Ready MustSync=false:
 Messages:
 1->2 MsgHeartbeat Term:1 Log:0/0 Commit:13
-1->3 MsgHeartbeat Term:1 Log:0/0 Commit:13
+1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
 
-# The heartbeat bumps the follower's commit index to the up-to-date state.
-#
-# Previously, it would take another roundtrip with the leader to update it. As
-# such, the total time it would take the follower to learn the commit index was:
+# Since the heartbeat message does not bump the follower's commit index, it will
+# take another roundtrip with the leader to update it. As such, the total time
+# it takes for the follower to learn the commit index is:
 #
 #   delay = HeartbeatInterval + 3/2 * RTT
 #
-# This was suboptimal, and now it is HeartbeatInterval + 1/2 * RTT.
+# This is suboptimal. It could have taken HeartbeatInterval + 1/2 * RTT, if the
+# leader sent the up-to-date commit index in the heartbeat message.
 #
-# See https://github.com/etcd-io/raft/issues/138 which describes the fix.
+# See https://github.com/etcd-io/raft/issues/138 which aims to fix this.
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:13
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:13
-  CommittedEntries:
-  1/12 EntryNormal "data1"
-  1/13 EntryNormal "data2"
   Messages:
   3->1 MsgHeartbeatResp Term:1 Log:0/0
 > 1 receiving messages
@@ -172,6 +170,10 @@ stabilize 1 3
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
   Ready MustSync=false:
+  HardState Term:1 Vote:1 Commit:13
+  CommittedEntries:
+  1/12 EntryNormal "data1"
+  1/13 EntryNormal "data2"
   Messages:
   3->1 MsgAppResp Term:1 Log:0/13
 > 1 receiving messages

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -132,14 +132,14 @@ stabilize 1
   Ready MustSync=false:
   Messages:
   1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:17
 
 stabilize 2 3
 ----
 > 2 receiving messages
   1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:17
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -64,14 +64,14 @@ process-ready 1
 Ready MustSync=false:
 Messages:
 1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-1->3 MsgHeartbeat Term:1 Log:0/0
+1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
 
 # Iterate until no more work is done by the new peer. It receives the heartbeat
 # and responds.
 stabilize 3
 ----
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
   INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
   INFO 3 became follower at term 1
 > 3 handling Ready

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -94,16 +94,9 @@ func DescribeSoftState(ss SoftState) string {
 	return fmt.Sprintf("Lead:%d State:%s", ss.Lead, ss.RaftState)
 }
 
-func DescribeConfState(state pb.ConfState) string {
-	return fmt.Sprintf(
-		"Voters:%v VotersOutgoing:%v Learners:%v LearnersNext:%v AutoLeave:%v",
-		state.Voters, state.VotersOutgoing, state.Learners, state.LearnersNext, state.AutoLeave,
-	)
-}
-
 func DescribeSnapshot(snap pb.Snapshot) string {
 	m := snap.Metadata
-	return fmt.Sprintf("Index:%d Term:%d ConfState:%s", m.Index, m.Term, DescribeConfState(m.ConfState))
+	return fmt.Sprintf("Index:%d Term:%d ConfState:%s", m.Index, m.Term, pb.DescribeConfState(m.ConfState))
 }
 
 func DescribeReady(rd Ready, f EntryFormatter) string {

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -75,7 +75,6 @@ go_test(
         "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
-        "//pkg/raft",
         "//pkg/raft/confchange",
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",

--- a/pkg/roachpb/metadata_replicas_test.go
+++ b/pkg/roachpb/metadata_replicas_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/confchange"
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -188,7 +188,7 @@ func TestReplicaDescriptorsConfState(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			r := MakeReplicaSet(test.in)
 			cs := r.ConfState()
-			require.Equal(t, test.out, raft.DescribeConfState(cs))
+			require.Equal(t, test.out, raftpb.DescribeConfState(cs))
 		})
 	}
 }


### PR DESCRIPTION
This is a follow up to #122690 which makes raft leader to send the most up-to-date commit index in heartbeats, instead of capping it at the follower's `Match` index. The follower can safely process commit indices that are out of its log bounds.

CockroachDB version gating infrastructure is added to raft to ensure no mixed heartbeat behaviour during cluster upgrade. If a leader running the new code sends a high commit index to a follower running the old code, the follower would crash. The version gate makes sure all followers are upgraded to the new behaviour first.

Resolves #122100