### PR TITLE
release-23.2: roachtest: surface cloud cluster spec info in artifacts

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1381,6 +1382,60 @@ func (c *clusterImpl) FetchDebugZip(
 				continue
 			}
 			return errors.Wrap(c.Get(ctx, c.l, zipName /* src */, path /* dest */, c.Node(node)), "cluster.FetchDebugZip")
+		}
+		return nil
+	})
+}
+
+// FetchVMSpecs downloads the VM specs from the cluster using `roachprod get`.
+// The logs will be placed in the test's artifacts dir.
+func (c *clusterImpl) FetchVMSpecs(ctx context.Context, l *logger.Logger) error {
+	if c.IsLocal() {
+		return nil
+	}
+
+	l.Printf("fetching VM specs")
+
+	vmSpecsFolder := filepath.Join(c.t.ArtifactsDir(), "vm_specs")
+	if err := os.MkdirAll(vmSpecsFolder, 0755); err != nil {
+		return err
+	}
+
+	// Don't hang forever if we can't fetch the VM specs.
+	return timeutil.RunWithTimeout(ctx, "fetch logs", 5*time.Minute, func(ctx context.Context) error {
+		cachedCluster, err := getCachedCluster(c.name)
+		if err != nil {
+			return err
+		}
+		providerToVMs := bucketVMsByProvider(cachedCluster)
+
+		for provider, vms := range providerToVMs {
+			p := vm.Providers[provider]
+			vmSpecs, err := p.GetVMSpecs(vms)
+			if err != nil {
+				l.Errorf("failed to get VM spec for provider %s: %s", provider, err)
+				continue
+			}
+			for _, vmSpec := range vmSpecs {
+				name, ok := vmSpec["name"].(string)
+				if !ok {
+					l.Errorf("failed to create spec files for VM\n%v", vmSpec)
+					continue
+				}
+
+				dest := filepath.Join(vmSpecsFolder, name+".json")
+				specJSON, err := json.MarshalIndent(vmSpec, "", "  ")
+				if err != nil {
+					l.Errorf("Failed to marshal JSON: %v", err)
+					continue
+				}
+
+				err = os.WriteFile(dest, specJSON, 0644)
+				if err != nil {
+					l.Printf("Failed to write spec to file for %s\n", name)
+					continue
+				}
+			}
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -942,7 +942,7 @@ func getGoCoverArtifacts(ctx context.Context, c *clusterImpl, t test.Test) {
 // this returns. This happens when the test doesn't respond to cancellation.
 //
 // Args:
-// c: The cluster on which the test will run. runTest() does not wipe or destroy  the cluster.
+// c: The cluster on which the test will run. runTest() does not wipe or destroy the cluster.
 func (r *testRunner) runTest(
 	ctx context.Context,
 	t *testImpl,
@@ -1335,7 +1335,7 @@ func (r *testRunner) teardownTest(
 func (r *testRunner) collectArtifacts(
 	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool, timeout time.Duration,
 ) error {
-	// Collecting artifacts may hang so we run it in a goroutine which is abandoned
+	// Collecting artifacts may hang, so we run it in a goroutine which is abandoned
 	// after a timeout.
 	artifactsCollectedCh := make(chan struct{})
 	_ = r.stopper.RunAsyncTask(ctx, "collect-artifacts", func(ctx context.Context) {
@@ -1420,6 +1420,9 @@ func (r *testRunner) collectArtifacts(
 		}
 		if err := c.FetchDebugZip(ctx, t.L(), "debug.zip"); err != nil {
 			t.L().Printf("failed to collect zip: %s", err)
+		}
+		if err := c.FetchVMSpecs(ctx, t.L()); err != nil {
+			t.L().Errorf("failed to collect VM specs: %s", err)
 		}
 	})
 

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -255,6 +255,10 @@ type Provider struct {
 	IAMProfile string
 }
 
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 const (
 	defaultSSDMachineType = "m6id.xlarge"
 	defaultMachineType    = "m6i.xlarge"

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -97,6 +97,10 @@ type Provider struct {
 	}
 }
 
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -32,6 +32,10 @@ type provider struct {
 	unimplemented string
 }
 
+func (p *provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (p *provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -331,6 +331,29 @@ type Provider struct {
 	ServiceAccount string
 }
 
+// GetVMSpecs returns a json list of VM specs, provided by GCE
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	if p.GetProject() == "" {
+		return nil, errors.New("project name cannot be empty")
+	}
+	if vms == nil {
+		return nil, errors.New("vms cannot be nil")
+	}
+	// Extract the spec of all VMs.
+	var vmSpecs []map[string]interface{}
+	for _, vmInstance := range vms {
+		var vmSpec map[string]interface{}
+		vmFullResourceName := "projects/" + p.GetProject() + "/zones/" + vmInstance.Zone + "/instances/" + vmInstance.Name
+		args := []string{"compute", "instances", "describe", vmFullResourceName, "--format=json"}
+
+		if err := runJSONCommand(args, &vmSpec); err != nil {
+			return nil, errors.Wrapf(err, "error describing instance %s in zone %s", vmInstance.Name, vmInstance.Zone)
+		}
+		vmSpecs = append(vmSpecs, vmSpec)
+	}
+	return vmSpecs, nil
+}
+
 type snapshotJson struct {
 	CreationSizeBytes  string    `json:"creationSizeBytes"`
 	CreationTimestamp  time.Time `json:"creationTimestamp"`

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -125,6 +125,10 @@ type Provider struct {
 	vm.DNSProvider
 }
 
+func (p *Provider) GetVMSpecs(vms vm.List) ([]map[string]interface{}, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -476,6 +476,8 @@ type Provider interface {
 	ListVolumeSnapshots(l *logger.Logger, vslo VolumeSnapshotListOpts) ([]VolumeSnapshot, error)
 	// DeleteVolumeSnapshots permanently deletes the given snapshots.
 	DeleteVolumeSnapshots(l *logger.Logger, snapshot ...VolumeSnapshot) error
+	// GetVMSpecs returns a json list of VM specs, according to a specific cloud provider.
+	GetVMSpecs(vms List) ([]map[string]interface{}, error)
 }
 
 // DeleteCluster is an optional capability for a Provider which can


### PR DESCRIPTION
Backport 1/1 commits from #124243.

/cc @cockroachdb/release

---

Previously, getting the spec of the VMs on which a roachtest ran was tricky to derive.
This was inadequate because it's often necessary to understand the particulars of a roachtest run's environment.
To address this, this patch creates a json file per VM describing its spec. These files are stored under `artifacts/vm_spec`.

Epic: none
Fixes: #112707
Release note: None

---

Release justification: Test only changes