### PR TITLE
kvserver: enable skip of merge/consistency queue on external bytes

### DIFF
--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -53,7 +53,7 @@ var skipConsitencyQueueForExternalBytes = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"server.consistency_check.skip_external_bytes.enabled",
 	"skip the consistency queue for external bytes",
-	false,
+	true,
 )
 
 // consistencyCheckRateBurstFactor we use this to set the burst parameter on the

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -60,7 +60,7 @@ var SkipMergeQueueForExternalBytes = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.range_merge.skip_external_bytes.enabled",
 	"skip the merge queue for external bytes",
-	false,
+	true,
 )
 
 // mergeQueue manages a queue of ranges slated to be merged with their right-


### PR DESCRIPTION
Release note: none.
Epic: none.