### PR TITLE
release-23.2.6-rc: update licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,5 @@
 Source code in this repository is variously licensed under the Business Source
-License 1.1 (BSL), the CockroachDB Community License (CCL), the MIT license, and
-BSD-style licenses. A copy of each license can be found in the licenses
-directory. Source code in a given file is licensed under the BSL and the
-copyright belongs to The Cockroach Authors unless otherwise noted at the
-beginning of the file.
-
-Running `make` will produce a binary that includes CCL-licensed code and is thus
-subject to the terms of the CCL. To produce a binary that is free of CCL-
-licensed code, run `make buildoss`.
+License 1.1 (BSL), the CockroachDB Community License (CCL), the MIT license,
+BSD-style licenses, and other licenses specified in the source code. Source
+code in a given file is licensed under the BSL and the copyright belongs to The
+Cockroach Authors unless otherwise noted at the beginning of the file.

--- a/licenses/LICENSE.txt
+++ b/licenses/LICENSE.txt
@@ -1,0 +1,12 @@
+CockroachDB is variously licensed under the Business Source License 1.1 (BSL)
+and/or the CockroachDB Community License (CCL). You can see which license
+applies to the various CockroachDB features on this page:
+https://www.cockroachlabs.com/docs/stable/licensing-faqs#feature-licensing. The
+default license for anything not listed is the CCL.
+
+The CockroachDB Community License is available at
+https://www.cockroachlabs.com/cockroachdb-community-license/.
+
+You can find the applicable Business Source License by reviewing the BSL
+license in the Licenses folder for the applicable version of CockroachDB at
+https://github.com/cockroachdb/cockroach.

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -187,17 +187,29 @@ func run(
 					)
 				}
 			} else {
+				licenseFiles := []release.ArchiveFile{
+					{
+						LocalAbsolutePath: filepath.Join(o.PkgDir, "licenses", "LICENSE.txt"),
+						ArchiveFilePath:   "LICENSE.txt",
+					},
+					{
+						LocalAbsolutePath: filepath.Join(o.PkgDir, "licenses", "THIRD-PARTY-NOTICES.txt"),
+						ArchiveFilePath:   "THIRD-PARTY-NOTICES.txt",
+					},
+				}
 				for _, provider := range providers {
 					crdbFiles := append(
 						[]release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.AbsolutePath, "cockroach")},
 						release.MakeCRDBLibraryArchiveFiles(o.PkgDir, o.Platform)...,
 					)
+					crdbFiles = append(crdbFiles, licenseFiles...)
 					crdbBody, err := release.CreateArchive(o.Platform, o.VersionStr, "cockroach", crdbFiles)
 					if err != nil {
 						log.Fatalf("cannot create crdb release archive %s", err)
 					}
 
 					sqlFiles := []release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.CockroachSQLAbsolutePath, "cockroach-sql")}
+					sqlFiles = append(sqlFiles, licenseFiles...)
 					sqlBody, err := release.CreateArchive(o.Platform, o.VersionStr, "cockroach-sql", sqlFiles)
 					if err != nil {
 						log.Fatalf("cannot create sql release archive %s", err)

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -81,11 +81,15 @@ func (s *mockStorage) PutObject(i *release.PutObjectInput) error {
 type mockExecRunner struct {
 	fakeBazelBin string
 	cmds         []string
+	pkgDir       string
 }
 
 func (r *mockExecRunner) run(c *exec.Cmd) ([]byte, error) {
 	if r.fakeBazelBin == "" {
 		panic("r.fakeBazelBin not set")
+	}
+	if r.pkgDir == "" {
+		panic("r.pkgDir not set")
 	}
 	if c.Dir == "" {
 		return nil, fmt.Errorf("`Dir` must be specified")
@@ -132,6 +136,8 @@ func (r *mockExecRunner) run(c *exec.Cmd) ([]byte, error) {
 			}
 		}
 		paths = append(paths, path, pathSQL)
+		paths = append(paths, filepath.Join(r.pkgDir, "licenses", "LICENSE.txt"))
+		paths = append(paths, filepath.Join(r.pkgDir, "licenses", "THIRD-PARTY-NOTICES.txt"))
 		ext := release.SharedLibraryExtensionFromPlatform(platform)
 		if platform != release.PlatformMacOSArm && platform != release.PlatformWindows {
 			for _, lib := range release.CRDBSharedLibraries {
@@ -473,6 +479,7 @@ func TestProvisional(t *testing.T) {
 			fakeBazelBin, cleanup := testutils.TempDir(t)
 			defer cleanup()
 			runner.fakeBazelBin = fakeBazelBin
+			runner.pkgDir = dir
 			flags := test.flags
 			flags.pkgDir = dir
 			execFn := release.ExecFn{MockExecFn: runner.run}


### PR DESCRIPTION
Backport 1/1 commits from #124660.

/cc @cockroachdb/release

---

Backport 1/1 commits from #123756.

/cc @cockroachdb/release

---

Part of: REL-932
Release note: None
Release justification: not part of the product
