### PR TITLE
roachtest: export sysbench results to roachperf

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -11,8 +11,13 @@
 package tests
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -21,8 +26,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/errors"
+	roachprodErrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,6 +135,9 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 		t.Fatal(err)
 	}
 
+	// Keep track of the start time for roachperf. Note that this is just an
+	// estimate and not as accurate as what a workload histogram would give.
+	var start time.Time
 	m := c.NewMonitor(ctx, roachNodes)
 	m.Go(func(ctx context.Context) error {
 		t.Status("preparing workload")
@@ -136,12 +146,16 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 
 		t.Status("running workload")
 		cmd := opts.cmd(true /* haproxy */) + " run"
+		start = timeutil.Now()
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(loadNode), cmd)
 
 		// Sysbench occasionally segfaults. When that happens, don't fail the
 		// test.
-		if result.RemoteExitStatus == errors.SegmentationFaultExitCode {
+		if result.RemoteExitStatus == roachprodErrors.SegmentationFaultExitCode {
 			t.L().Printf("sysbench segfaulted; passing test anyway")
+			return nil
+		} else if result.RemoteExitStatus == roachprodErrors.IllegalInstruction {
+			t.L().Printf("sysbench crashed with illegal instruction; passing test anyway")
 			return nil
 		}
 
@@ -149,7 +163,8 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 			return err
 		}
 
-		return nil
+		t.Status("exporting results")
+		return exportSysbenchResults(t, result.Stdout, start)
 	})
 	m.Wait()
 }
@@ -169,6 +184,7 @@ func registerSysbench(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
+			Benchmark:        true,
 			Owner:            registry.OwnerTestEng,
 			Cluster:          r.MakeClusterSpec(n+1, spec.CPU(cpus)),
 			CompatibleClouds: registry.AllExceptAWS,
@@ -178,4 +194,102 @@ func registerSysbench(r registry.Registry) {
 			},
 		})
 	}
+}
+
+type sysbenchMetrics struct {
+	Time         int64  `json:"time"`
+	Threads      string `json:"threads"`
+	Transactions string `json:"transactions"`
+	Qps          string `json:"qps"`
+	ReadQps      string `json:"readQps"`
+	WriteQps     string `json:"writeQps"`
+	OtherQps     string `json:"otherQps"`
+	P95Latency   string `json:"p95Latency"`
+	Errors       string `json:"errors"`
+	Reconnects   string `json:"reconnects"`
+}
+
+// exportSysbenchResults parses the output of `sysbench` into a JSON file
+// and writes it to the perf directory that roachperf expects. Sysbench does
+// have a way to customize the report output via injecting a custom
+// `sysbench.hooks.report_intermediate` hook, but then we would lose the
+// human-readable output in the test itself.
+func exportSysbenchResults(t test.Test, result string, start time.Time) error {
+	// Parse the results into a JSON file that roachperf understands.
+	// The output of the results look like:
+	// 		1. Start up information.
+	//		2. Benchmark metrics timeseries every second.
+	//		3. Benchmark metrics summary.
+	//
+	// For roachperf, we care about 2, so filter out any line that
+	// doesn't start with a timestamp.
+	//
+	// An example line of this output:
+	// [ 1s ] thds: 256 tps: 2696.16 qps: 57806.17 (r/w/o: 40988.38/11147.98/5669.82) lat (ms,95%): 196.89 err/s: 21.96 reconn/s: 0.00
+
+	filter := "\\[ [\\d]+s \\].*"
+	regex, err := regexp.Compile(filter)
+	if err != nil {
+		return err
+	}
+
+	var metricBytes []byte
+
+	var snapshotsFound int
+	s := bufio.NewScanner(strings.NewReader(result))
+	for s.Scan() {
+		if matched := regex.MatchString(s.Text()); !matched {
+			continue
+		}
+		snapshotsFound++
+
+		// Remove the timestamp to make subsequent parsing easier.
+		_, output, _ := strings.Cut(s.Text(), "] ")
+		fields := strings.Fields(output)
+		if len(fields) != 15 {
+			return errors.Errorf("metrics output in unexpected format, expected 15 fields got: %d", len(fields))
+		}
+
+		// Individual QPS is formatted like: (r/w/o: 40988.38/11147.98/5669.82),
+		// so we need to handle it separately.
+		qpsByType := strings.Split(strings.Trim(fields[7], "()"), "/")
+		if len(qpsByType) != 3 {
+			return errors.Errorf("QPS metrics output in unexpected format, expected 3 fields got: %d", len(qpsByType))
+		}
+		snapshotTick := sysbenchMetrics{
+			Time:         start.Unix(),
+			Threads:      fields[1],
+			Transactions: fields[3],
+			Qps:          fields[5],
+			ReadQps:      qpsByType[0],
+			WriteQps:     qpsByType[1],
+			OtherQps:     qpsByType[2],
+			P95Latency:   fields[10],
+			Errors:       fields[12],
+			Reconnects:   fields[14],
+		}
+
+		snapshotTickBytes, err := json.Marshal(snapshotTick)
+		if err != nil {
+			return errors.Errorf("error marshaling metrics")
+		}
+		metricBytes = append(metricBytes, snapshotTickBytes...)
+		metricBytes = append(metricBytes, []byte("\n")...)
+		start = start.Add(time.Second)
+	}
+	// Guard against the possibility that the format changed and we no longer
+	// get any output.
+	if snapshotsFound == 0 {
+		return errors.Errorf("No lines started with expected format: %s", filter)
+	}
+	t.L().Printf("exportSysbenchResults: %d lines parsed", snapshotsFound)
+
+	// Copy the metrics to the artifacts directory, so it can be exported to roachperf.
+	// Assume single node artifacts, since the metrics we get are aggregated amongst the cluster.
+	perfDir := fmt.Sprintf("%s/1.perf", t.ArtifactsDir())
+	if err := os.MkdirAll(perfDir, 0755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(fmt.Sprintf("%s/stats.json", perfDir), metricBytes, 0666)
 }

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -37,6 +37,7 @@ const (
 )
 
 const (
+	IllegalInstruction        = 132
 	SegmentationFaultExitCode = 139
 )
 


### PR DESCRIPTION
This change parses the results of sysbench tests to JSON, so they can be exported to roachperf.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-38187
Fixes: https://github.com/cockroachdb/cockroach/issues/123071
Release note: none

_________________________________________

See https://github.com/cockroachdb/roachperf/pull/167 for the corresponding roachperf PR.

![image](https://github.com/cockroachdb/cockroach/assets/56486370/81c64038-2325-4938-b5a2-d069f17d7520)