### PR TITLE
sqlsmith: fix non-determinism with collated strings and limits

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -608,6 +608,9 @@ func sortRowsWithFloatComp(rowMatrix1, rowMatrix2 [][]string, colTypes []string)
 // to rowMatrix2 and outputs a diff or message related to the comparison. If a
 // string comparison of the rows fails, and they contain floats or decimals, it
 // performs an approximate comparison of the values.
+// TODO(yuzefovich): if we extend this logic to handle COLLATED STRINGs in a
+// special way (i.e. using DB connection), then we can remove some code
+// introduced in #124677.
 func unsortedMatricesDiffWithFloatComp(
 	rowMatrix1, rowMatrix2 [][]string, colTypes []string,
 ) (string, error) {
@@ -664,6 +667,9 @@ func unsortedMatricesDiffWithFloatComp(
 }
 
 // unsortedMatricesDiff sorts and compares rows of data.
+// TODO(yuzefovich): if we extend this logic to handle COLLATED STRINGs in a
+// special way (i.e. using DB connection), then we can remove some code
+// introduced in #124677.
 func unsortedMatricesDiff(rowMatrix1, rowMatrix2 [][]string) string {
 	var rows1 []string
 	for _, row := range rowMatrix1 {


### PR DESCRIPTION
We recently merged a change to generate queries with "deterministic limits". That option is necessary in some of our roachtests where we compare outputs of two queries that must be the same. We perform the check - mostly - by comparing the strings directly. However, some collated strings are equal when they differ when comparing them directly as strings (e.g. `e'\x00':::STRING COLLATE en_US` vs `e'\x01':::STRING COLLATE en_US`), which makes some queries produce non-deterministic results even with all columns in the ORDER BY clause. Fixing how we check the expected output is not easy, so we simply reject stmts that require collated strings to be in the ORDER BY clause.

Fixes: #124000.

Release note: None