### PR TITLE
roachtest: don't inhibit cluster reuse on DNS deletion errors

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2996,7 +2996,8 @@ func (c *clusterImpl) WipeForReuse(
 
 	// Clear DNS records for the cluster.
 	if err := c.DestroyDNS(ctx, l); err != nil {
-		return err
+		// Log and swallow the error.
+		l.PrintfCtx(ctx, "failed to destroy DNS records for cluster %s: %v", c.name, err)
 	}
 	// Overwrite the spec of the cluster with the one coming from the test. In
 	// particular, this overwrites the reuse policy to reflect what the test


### PR DESCRIPTION
Before this patch, a failure to delete a cluster's DNS records resulted in roachtest refusing to reuse that cluster for other tests. In general, refusing to reuse a cluster that has not been completely wiped is a sane policy (on the argument that the next test running on that cluster might be impacted by the cluster's dirty state), but DNS records in particular don't matter. So, let's be more tolerant of such errors.

For people outside of CRL, that DNS deletion seems to always fail (probably because no DNS record was created in the first place) -- so this patch helps me in particular.

Epic: None
Release note: None