### PR TITLE
dev: move local loopback cache line from `~/.bazelrc` to `.bazelrc.user`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=95
+DEV_VERSION=96
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -153,16 +153,9 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	// testing knob.
 	skipCacheCheck := d.knobs.skipCacheCheckDuringBuild || d.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
 	if !skipCacheCheck {
-		bazelRcLine, err := d.setUpCache(ctx)
+		_, err := d.setUpCache(ctx)
 		if err != nil {
-			log.Println(err)
-		}
-		msg, err := d.checkPresenceInBazelRc(bazelRcLine)
-		if err != nil {
-			log.Printf("error while checking .bazel.rc: %v\n", err)
-		}
-		if msg != "" {
-			log.Println(msg)
+			return err
 		}
 	}
 

--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -72,18 +72,8 @@ func (d *dev) cache(cmd *cobra.Command, _ []string) error {
 			log.Printf("%v\n", err)
 		}
 	}
-	bazelRcLine, err := d.setUpCache(ctx)
-	if err != nil {
-		return err
-	}
-	errStr, err := d.checkPresenceInBazelRc(bazelRcLine)
-	if err != nil {
-		return err
-	}
-	if errStr != "" {
-		return fmt.Errorf("%s", errStr)
-	}
-	return nil
+	_, err := d.setUpCache(ctx)
+	return err
 }
 
 func bazelRemoteCacheDir() (string, error) {


### PR DESCRIPTION
There hasn't been any particular reason we put it in `~/.bazelrc` before, except that it "doesn't hurt" to have it in the home directory, where you get to take advantage of it in any Bazel workspace you happen to be using. However, as we want to add opt-in support for remote execution to `dev` (which is incompatible with using the local loopback cache), it now makes more sense to opt in to this on a workspace-by-workspace basis. That means it properly belongs in `.bazelrc.user` instead.

Here we update the relevant `dev doctor` check to look in `.bazelrc.user` instead, and update the auto-fix to delete the line from `~/.bazelrc` if it's there.

Part of: CRDB-34610
Epic: CRDB-34137
Release note: None