### PR TITLE
sql/delegate: include composite types in SHOW TYPES

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -165,6 +165,9 @@ CREATE TYPE t AS (a tab)
 statement error composite types that reference user-defined types not yet supported
 CREATE TYPE t AS (a pg_catalog.pg_class)
 
+statement ok
+DROP TYPE e
+
 # Test that if an composite type value is being used by a default expression or
 # computed column, we disallow dropping it.
 subtest drop_used_composite_type_values
@@ -252,3 +255,43 @@ ALTER TABLE a DROP CONSTRAINT check_a
 statement ok
 DROP TYPE t;
 DROP TABLE a
+
+subtest show_types
+
+statement ok
+CREATE TYPE ct1 AS (a INT, b TEXT);
+CREATE TYPE et1 AS ENUM ('a', 'b', 'c');
+CREATE SCHEMA sc1;
+CREATE TYPE sc1.ct2 AS (x INT, y INT);
+CREATE TYPE sc1.ct3 AS ();
+
+query TTT nosort
+SHOW TYPES
+----
+public  ct1   root
+public  et1   root
+sc1     ct2   root
+sc1     ct3   root
+
+statement ok
+DROP TYPE sc1.ct3;
+DROP TYPE sc1.ct2;
+DROP SCHEMA sc1;
+DROP TYPE et1;
+DROP TYPE ct1;
+
+statement ok
+CREATE DATABASE "CaseSensitiveDatabase";
+USE "CaseSensitiveDatabase";
+CREATE TYPE ct4 AS (a INT, b TEXT); 
+CREATE TYPE et5 AS ENUM ('a', 'b', 'c');
+
+query TTT nosort
+SHOW TYPES
+----
+public  ct4   root
+public  et5   root
+
+statement ok
+DROP DATABASE "CaseSensitiveDatabase";
+USE test;


### PR DESCRIPTION
SHOW TYPES previously only included the enumerated types. In 23.1 composite types were added, but we forgot to update SHOW TYPES. This corrects that by including composite types in the catalog lookup.

Unlike other SHOW statements, there is no way to filter out schema. So, this will return composite types for all schemas. We do a lookup to ResolveSchema, knowing it won't find a schema, in order to get the current database name.

I query pg_catalog.pg_type to get the types. But there are a bunch of internal types in their that need to be omitted:
- anything from any of the known internal schemas are skipped: information_schema, pg_catalog, crdb_internal, and pg_extension.
- each time a table is created, a type for the table descriptor is added. I query typrelid to filter out the table descriptor. It must be 0, for enums, or refer back to its own oid so that we know its a standalone type.

Fixes: #119734
Release note (bug fix): SHOW TYPES includes user defined composite types. It omitted those types ever since composite types were added in 23.1.