### PR TITLE
backupccl: bump up restore worker count

### DIFF
--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -46,8 +46,8 @@ import (
 var onlineRestoreLinkWorkers = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"backup.restore.online_worker_count",
-	"workers to use for online restore worker phase",
-	8,
+	"workers to use for online restore link phase",
+	32,
 	settings.PositiveInt,
 )
 


### PR DESCRIPTION
Release note: none.
Epic: none.