### PR TITLE
cli: support format flag in cockroach-sql cli

### DIFF
--- a/pkg/cmd/cockroach-sql/main.go
+++ b/pkg/cmd/cockroach-sql/main.go
@@ -87,6 +87,8 @@ func runMain() error {
 	// Configure the command-line flags.
 	clientflags.AddBaseFlags(sqlCmd, &copts, &copts.Insecure, &copts.CertsDir)
 	clientflags.AddSQLFlags(sqlCmd, &copts, cfg, true /* isShell */, false /* isDemo */)
+	// Configure the format flag
+	cliflagcfg.VarFlagDepth(1, sqlCmd.PersistentFlags(), &cfg.ExecCtx.TableDisplayFormat, cliflags.TableDisplayFormat)
 
 	// Apply the configuration defaults from environment variables.
 	// This must occur before the parameters are parsed by cobra, so


### PR DESCRIPTION
Cockroach-sql and `cockroach sql` are currently out of sync in terms of what flags they support. This PR adds support for the `format` flag in `cockroach-sql` by refactoring the way we add the format flag for our commands.

Informs: #123382

Epic: CRDB-38336

Release note (bug fix): Fixes a bug introduced in v22.1 where `cockroach-sql` doesn't recognize the `--format` flag.