### PR TITLE
catalog: collecting virtual schemas can be expensive for some ORM queries 

### DIFF
--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/hydrateddesccache"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/catkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
@@ -30,7 +29,7 @@ type CollectionFactory struct {
 	settings                             *cluster.Settings
 	codec                                keys.SQLCodec
 	leaseMgr                             *lease.Manager
-	virtualSchemas                       catalog.VirtualSchemas
+	virtualSchemas                       VirtualCatalogHolder
 	hydrated                             *hydrateddesccache.Cache
 	systemDatabase                       *catkv.SystemDatabaseCache
 	spanConfigSplitter                   spanconfig.Splitter
@@ -72,7 +71,7 @@ func NewCollectionFactory(
 	ctx context.Context,
 	settings *cluster.Settings,
 	leaseMgr *lease.Manager,
-	virtualSchemas catalog.VirtualSchemas,
+	virtualSchemas VirtualCatalogHolder,
 	hydrated *hydrateddesccache.Cache,
 	spanConfigSplitter spanconfig.Splitter,
 	spanConfigLimiter spanconfig.Limiter,

--- a/pkg/sql/catalog/nstree/catalog_mutable.go
+++ b/pkg/sql/catalog/nstree/catalog_mutable.go
@@ -50,12 +50,24 @@ func (mc *MutableCatalog) ensureForID(id descpb.ID) *byIDEntry {
 	newEntry := &byIDEntry{
 		id: id,
 	}
-	if replaced := mc.byID.upsert(newEntry); replaced != nil {
-		*newEntry = *(replaced.(*byIDEntry))
+	if replaced := mc.ensureForIDWithEntry(newEntry); replaced != nil {
+		*newEntry = *replaced
 	} else {
 		mc.byteSize += newEntry.ByteSize()
 	}
 	return newEntry
+}
+
+// ensureForWithEntry upserts the entry and returns either the current entry or
+// the one that has replaced.
+func (mc *MutableCatalog) ensureForIDWithEntry(newEntry *byIDEntry) *byIDEntry {
+	mc.maybeInitialize()
+	if replaced := mc.byID.upsert(newEntry); replaced != nil {
+		return replaced.(*byIDEntry)
+	} else {
+		mc.byteSize += newEntry.ByteSize()
+	}
+	return nil
 }
 
 func (mc *MutableCatalog) maybeGetByID(id descpb.ID) *byIDEntry {
@@ -73,12 +85,22 @@ func (mc *MutableCatalog) ensureForName(key catalog.NameKey) *byNameEntry {
 		parentSchemaID: key.GetParentSchemaID(),
 		name:           key.GetName(),
 	}
+	if replaced := mc.ensureForNameWithEntry(newEntry); replaced != nil {
+		*newEntry = *replaced
+	}
+	return newEntry
+}
+
+// ensureForNameWithEntry upserts the entry and returns either the current entry or
+// the one that has replaced.
+func (mc *MutableCatalog) ensureForNameWithEntry(newEntry *byNameEntry) *byNameEntry {
+	mc.maybeInitialize()
 	if replaced := mc.byName.upsert(newEntry); replaced != nil {
-		*newEntry = *(replaced.(*byNameEntry))
+		return replaced.(*byNameEntry)
 	} else {
 		mc.byteSize += newEntry.ByteSize()
 	}
-	return newEntry
+	return nil
 }
 
 // DeleteByName removes all by-name mappings from the MutableCatalog.
@@ -197,17 +219,23 @@ func (mc *MutableCatalog) AddAll(c Catalog) {
 		return
 	}
 	_ = c.byName.ascend(func(entry catalog.NameEntry) error {
-		e := mc.ensureForName(entry)
-		mc.byteSize -= e.ByteSize()
-		*e = *(entry.(*byNameEntry))
-		mc.byteSize += e.ByteSize()
+		ne := entry.(*byNameEntry)
+		e := mc.ensureForNameWithEntry(ne)
+		if e != nil {
+			// Update the size since the entry was replaced.
+			mc.byteSize -= e.ByteSize()
+			mc.byteSize += ne.ByteSize()
+		}
 		return nil
 	})
 	_ = c.byID.ascend(func(entry catalog.NameEntry) error {
-		e := mc.ensureForID(entry.GetID())
-		mc.byteSize -= e.ByteSize()
-		*e = *(entry.(*byIDEntry))
-		mc.byteSize += e.ByteSize()
+		ne := entry.(*byIDEntry)
+		e := mc.ensureForIDWithEntry(ne)
+		if e != nil {
+			// Update the size since the entry was replaced.
+			mc.byteSize -= e.ByteSize()
+			mc.byteSize += ne.ByteSize()
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
Previously, when running ORM queries with larger schemas or our ORM query bench test we noticed that aggregating virtual schema objects could take a big chunk of time. This was because converting the internal the VirtualTable / VirtualSchemas into a nstree.Catalog was not cheap. To address this, this patch will:

1. Convert the VirtualTable / VirtualSchemas into a nstree.Catalog which can be used between collections (the entire state here is immutable).
2. Reduce some extra copies that happen when copying betwen nstree.Catalog objects, by allowing references to be ingested.

Fixes: #124750

```Orignal:
BenchmarkORMQueries/asyncpg_types         	       1	16914664491 ns/op	         0 roundtrips	6151796312 B/op	33275332 allocs/op
After having a shared nstree.Catalog object:
BenchmarkORMQueries/asyncpg_types         	       1	13252306945 ns/op	         0 roundtrips	5442736128 B/op	29586155 allocs/op
After optimizing MutableCatalog.AddAll:
BenchmarkORMQueries/asyncpg_types         	       1	12399752839 ns/op	         0 roundtrips	4602288096 B/op	27474078 allocs/op
````