### PR TITLE
sql: move ValidateNoRepeatKeysInZone to zonepb pkg

### DIFF
--- a/pkg/config/zonepb/BUILD.bazel
+++ b/pkg/config/zonepb/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/util/envutil",
         "//pkg/util/log",

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -2413,7 +2413,7 @@ func (n *alterDatabaseSetZoneConfigExtensionNode) startExec(params runParams) er
 		}
 
 		// Validate that there are no conflicts in the zone setup.
-		if err := validateNoRepeatKeysInZone(newZone); err != nil {
+		if err := zonepb.ValidateNoRepeatKeysInZone(newZone); err != nil {
 			return err
 		}
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -915,7 +915,7 @@ func generateAndValidateZoneConfigForMultiRegionDatabase(
 		return zonepb.ZoneConfig{}, pgerror.Wrap(err, pgcode.CheckViolation, "could not validate zone config")
 	}
 
-	if err := validateNoRepeatKeysInZone(&dbZoneConfig); err != nil {
+	if err := zonepb.ValidateNoRepeatKeysInZone(&dbZoneConfig); err != nil {
 		return zonepb.ZoneConfig{}, err
 	}
 

--- a/pkg/sql/set_zone_config_test.go
+++ b/pkg/sql/set_zone_config_test.go
@@ -58,7 +58,7 @@ func TestValidateNoRepeatKeysInZone(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = validateNoRepeatKeysInZone(&zone)
+		err = zonepb.ValidateNoRepeatKeysInZone(&zone)
 		if err != nil && expectSuccess {
 			t.Errorf("expected success for %q; got %v", constraint, err)
 		} else if err == nil && !expectSuccess {


### PR DESCRIPTION
This patch refactors the `ValidateNoRepeatKeysInZone` function to a package accesible to the DSC.

Informs: #117574
Release note: None