### PR TITLE
roachtest: Revert "roachtest: don't inhibit cluster reuse on DNS deletion errors"

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2990,8 +2990,7 @@ func (c *clusterImpl) WipeForReuse(
 
 	// Clear DNS records for the cluster.
 	if err := c.DestroyDNS(ctx, l); err != nil {
-		// Log and swallow the error.
-		l.PrintfCtx(ctx, "failed to destroy DNS records for cluster %s: %v", c.name, err)
+		return err
 	}
 	// Overwrite the spec of the cluster with the one coming from the test. In
 	// particular, this overwrites the reuse policy to reflect what the test


### PR DESCRIPTION
This reverts commit 596a3a2ee3685ed84b13758f7a9fd01c9864714e (PR #124678). That commit made roachtest tolerate DNS record deletion errors, so that clusters can be reused even though their DNS records failed to be cleaned up. This seems to have been a bad idea, though, since stale DNS records can be a problem for reused clusters; see
https://github.com/cockroachdb/cockroach/pull/124678#issuecomment-2130416545

I now understand that there are two types of DNS records - normal ones (`A` records?) and `SRV` records. The former are associated with roachprod VMs. The latter are associated with cockroach nodes from host or virtual clusters, and are used for some sort of service discovery. It is the destruction of these SRV records that the original patch dealt with. Failure to delete these records might have consequences for the future tests using the cluster.

Epic: none
Release note: None