### PR TITLE
backupccl: indicate if manifest entry contains range keys

### DIFF
--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -55,6 +55,8 @@ message BackupManifest {
     // ApproximatePhysicalSize is the approximate size of the physical bytes in
     // compressed SST form.
     uint64 approximate_physical_size = 11;
+
+    bool has_range_keys = 12;
   }
 
   message DescriptorRevision {


### PR DESCRIPTION
Epic: none

Release note: none