### PR TITLE
flowinfra: reapply "flowinfra: fix incomplete shutdown in some cases"

### DIFF
--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -626,8 +626,9 @@ func (f *FlowBase) MemUsage() int64 {
 func (f *FlowBase) Cancel() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.mu.status == flowFinished {
-		// The Flow is already done, nothing to cancel.
+	if f.mu.status == flowFinished || f.mu.ctxCancel == nil {
+		// The Flow is already done, nothing to cancel. ctxCancel can be nil in
+		// some tests.
 		return
 	}
 	f.mu.ctxCancel()

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -314,6 +314,16 @@ func (fr *FlowRegistry) RegisterFlow(
 			// drain all the processors.
 			numTimedOutReceivers := fr.cancelPendingStreams(id, errNoInboundStreamConnection)
 			if numTimedOutReceivers != 0 {
+				// The whole plan will error out. So far we only pushed the
+				// error to the timed out receivers, and eventually it'll make
+				// its way to the DistSQLReceiver which will transition the plan
+				// into draining state. However, non-timed out streams will only
+				// learn about the error and the draining state the next time
+				// the producer sends something on the stream which might not
+				// happen for a while. To speed up the shutdown of the whole
+				// plan we cancel the flow on this node which will trigger quick
+				// ungraceful shutdown of the whole plan.
+				f.Cancel()
 				// The span in the context might be finished by the time this runs. In
 				// principle, we could ForkSpan() beforehand, but we don't want to
 				// create the extra span every time.


### PR DESCRIPTION
This reverts commit 9a138526370bdaf785e544997e0c932ebc2f7c34 effectively reapplying #118287.

It turns out that #118287 tickled a real bug in mixed-version 23.2-24.1 multi-tenant environment that has now been fixed in #123520. I confirmed that `multitenant-upgrade` passes with this change cherry-picked all the time whereas reverting #123520 (while keeping this change and working on b56a70a5e9854ea90d47a79e841805fd49260f00, before bumping cluster version to 24.2) makes it fail half of the time.

Fixes: #119065