### PR TITLE
server: reduce log spam on bad certificate

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1866,6 +1866,8 @@ func startServeSQL(
 	// objects when the stopper tells us to shut down.
 	connManager := netutil.MakeTCPServer(ctx, stopper)
 
+	logEvery := log.Every(10 * time.Second)
+
 	_ = stopper.RunAsyncTaskEx(ctx,
 		stop.TaskOpts{TaskName: "pgwire-listener", SpanOpt: stop.SterileRootSpan},
 		func(ctx context.Context) {
@@ -1875,12 +1877,16 @@ func startServeSQL(
 
 				conn, status, err := pgPreServer.PreServe(connCtx, conn, pgwire.SocketTCP)
 				if err != nil {
-					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+					if logEvery.ShouldLog() {
+						log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+					}
 					return
 				}
 
 				if err := serveConn(connCtx, conn, status); err != nil {
-					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+					if logEvery.ShouldLog() {
+						log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+					}
 				}
 			})
 			netutil.FatalIfUnexpected(err)


### PR DESCRIPTION
Previously, log message gets written to the logs more than 500 times per second, and as a result, fills up a 10MB log file twice per minute (thus wrapping the logs very quickly)

To address this, a logEvery wrapper was added to only log when needed.

Fixes: #122622

Release note: None