### PR TITLE
roachtest: port multitenant-multiregion to new APIs

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -66,12 +66,6 @@ type createTenantOptions struct {
 }
 type createTenantOpt func(*createTenantOptions)
 
-func createTenantRegion(region string) createTenantOpt {
-	return func(c *createTenantOptions) {
-		c.region = region
-	}
-}
-
 func createTenantNodeInternal(
 	ctx context.Context,
 	t test.Test,


### PR DESCRIPTION
This commit ports the `acceptance/multitenant-multiregion` roachtest to use the recently introduced roachprod API to manage virtual clusters.
It also removes the previous brittle logic for log checking.

Fixes: #124029
Release note: None