### PR TITLE
streamingccl: remove unused function

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -1353,32 +1353,6 @@ func (c *cutoverFromJobProgress) cutoverReached(ctx context.Context) (bool, erro
 	return false, nil
 }
 
-// frontierForSpan returns the lowest timestamp in the frontier within
-// the given subspans. If the subspans are entirely outside the
-// Frontier's tracked span an empty timestamp is returned.
-func frontierForSpans(f span.Frontier, spans ...roachpb.Span) hlc.Timestamp {
-	var (
-		minTimestamp hlc.Timestamp
-		sawEmptyTS   bool
-	)
-
-	for _, spanToCheck := range spans {
-		f.SpanEntries(spanToCheck, func(frontierSpan roachpb.Span, ts hlc.Timestamp) span.OpResult {
-			if ts.IsEmpty() {
-				sawEmptyTS = true
-			}
-			if minTimestamp.IsEmpty() || ts.Less(minTimestamp) {
-				minTimestamp = ts
-			}
-			return span.ContinueMatch
-		})
-	}
-	if sawEmptyTS {
-		return hlc.Timestamp{}
-	}
-	return minTimestamp
-}
-
 func init() {
 	rowexec.NewStreamIngestionDataProcessor = newStreamIngestionDataProcessor
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -527,47 +527,6 @@ func TestStreamIngestionProcessor(t *testing.T) {
 	})
 }
 
-func TestFrontierForSpans(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	var (
-		spanAB = roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}
-		spanCD = roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}
-		spanEF = roachpb.Span{Key: roachpb.Key("e"), EndKey: roachpb.Key("f")}
-		spanXZ = roachpb.Span{Key: roachpb.Key("x"), EndKey: roachpb.Key("z")}
-	)
-
-	t.Run("returns the lowest timestamp for the matched spans", func(t *testing.T) {
-		f, err := span.MakeFrontier(spanAB, spanCD, spanEF)
-		require.NoError(t, err)
-		_, err = f.Forward(spanAB, hlc.Timestamp{WallTime: 1})
-		require.NoError(t, err)
-		_, err = f.Forward(spanCD, hlc.Timestamp{WallTime: 2})
-		require.NoError(t, err)
-		_, err = f.Forward(spanEF, hlc.Timestamp{WallTime: 3})
-		require.NoError(t, err)
-		require.Equal(t, hlc.Timestamp{WallTime: 1}, frontierForSpans(f, spanAB, spanCD, spanEF))
-		require.Equal(t, hlc.Timestamp{WallTime: 2}, frontierForSpans(f, spanCD, spanEF))
-		require.Equal(t, hlc.Timestamp{WallTime: 3}, frontierForSpans(f, spanEF))
-		require.Equal(t, hlc.Timestamp{WallTime: 1}, frontierForSpans(f, spanAB, spanEF))
-	})
-	t.Run("returns zero if none of the spans overlap", func(t *testing.T) {
-		f, err := span.MakeFrontierAt(hlc.Timestamp{WallTime: 1}, spanAB, spanCD, spanEF)
-		require.NoError(t, err)
-		require.Equal(t, hlc.Timestamp{}, frontierForSpans(f, spanXZ))
-	})
-	t.Run("returns zero if one of the spans is zero", func(t *testing.T) {
-		f, err := span.MakeFrontier(spanAB, spanCD, spanEF)
-		require.NoError(t, err)
-		_, err = f.Forward(spanAB, hlc.Timestamp{WallTime: 1})
-		require.NoError(t, err)
-		// spanCD should still be at zero
-		_, err = f.Forward(spanEF, hlc.Timestamp{WallTime: 3})
-		require.NoError(t, err)
-		require.Equal(t, hlc.Timestamp{}, frontierForSpans(f, spanAB, spanCD, spanEF))
-	})
-}
-
 // getPartitionSpanToTableID maps a partiton's span to the tableID it covers in
 // the source keyspace. It assumes the source used a random_stream_client, which generates keys for
 // a single table span per partition.


### PR DESCRIPTION
This function is no longer used now that we pass the full checkpoint data rather than just the frontier timestamp.

Epic: none
Release note: None