### PR TITLE
kvserver: bump max range size in TestUnsplittableRange

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2999,7 +2999,7 @@ func TestUnsplittableRange(t *testing.T) {
 	ttl := 1 * time.Hour
 	defer zonepb.TestingSetMinRangeMaxBytes(1 << 16)()
 	const minBytes = 1 << 12
-	const maxBytes = 1 << 17
+	const maxBytes = 1 << 18
 	manualClock := hlc.NewHybridManualClock()
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMinBytes = proto.Int64(minBytes)


### PR DESCRIPTION
In another PR, I'm adding a substantial number of new statistics. I believe this is increasing the size of one of the system ranges to the point that it is above the max range size specified by this test.

When being split that system range ends up in purgatory as well, and the assertion that there is 1 range in purgatory at the end of the test is violated.

Here, I bump the max size so that my PR doesn't perturb this test.

Epic: none
Release note: None