### PR TITLE
sql: allow FK over stored computed columns

### DIFF
--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -53,12 +53,6 @@ func (desc *ColumnDescriptor) CheckCanBeOutboundFKRef() error {
 			desc.Name,
 		)
 	}
-	if desc.IsComputed() {
-		return unimplemented.NewWithIssuef(
-			46672, "computed column %q cannot reference a foreign key",
-			desc.Name,
-		)
-	}
 	return nil
 }
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1033,6 +1033,16 @@ func ResolveFK(
 		}
 	}
 
+	// We disallow any ON UPDATE and ON DELETE action that will modify the fk
+	// column of a computed key. The key value is computed and cannot change.
+	if d.Actions.HasDisallowedActionForComputedFKCol() {
+		for _, originColumn := range originCols {
+			if originColumn.IsComputed() {
+				return sqlerrors.NewInvalidActionOnComputedFKColumnError(d.Actions.HasUpdateAction())
+			}
+		}
+	}
+
 	var validity descpb.ConstraintValidity
 	if ts != NewTable {
 		if validationBehavior == tree.ValidationSkip {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3868,3 +3868,73 @@ statement error pgcode 55000 pq: column "i" is being dropped
 ALTER TABLE foo_bar DROP COLUMN i, ALTER PRIMARY KEY USING COLUMNS (i);
 
 subtest end
+
+subtest alter_add_foreign_key_against_computed_column
+
+statement ok
+CREATE TABLE x (a int8 not null primary key, computed_col int8 null as (a) stored);
+
+statement ok
+CREATE TABLE y (a int8 not null primary key, computed_col int8 null as (a) stored);
+
+statement ok
+INSERT INTO x VALUES (0),(1),(2),(3),(4);
+
+statement ok
+INSERT INTO y VALUES (0),(1),(2);
+
+query II rowsort
+SELECT a,computed_col from y;
+----
+0 0
+1 1
+2 2
+
+statement ok
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x;
+
+statement error .*delete on table "x" violates foreign key constraint.*
+DELETE FROM x WHERE A IN (0,2,4);
+
+statement ok
+ALTER TABLE y DROP CONSTRAINT y_computed_col_fkey;
+
+statement ok
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON DELETE CASCADE;
+
+statement ok
+DELETE FROM x WHERE A IN (0,2);
+
+query II rowsort
+SELECT a,computed_col from y;
+----
+1 1
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON UPDATE CASCADE;
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON UPDATE CASCADE;
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON UPDATE SET DEFAULT;
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON UPDATE SET NULL;
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON UPDATE SET NULL ON DELETE SET DEFAULT;
+
+statement error pq: invalid ON DELETE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON DELETE SET DEFAULT;
+
+statement error pq: invalid ON DELETE action for foreign key constraint containing computed column
+ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON DELETE SET NULL;
+
+statement ok
+DROP TABLE y CASCADE;
+
+statement ok
+DROP TABLE x CASCADE;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -386,21 +386,30 @@ CREATE TABLE y (
 statement ok
 CREATE TABLE x (a INT PRIMARY KEY)
 
-statement error computed column "r" cannot reference a foreign key
+statement ok
 CREATE TABLE y (
   r INT AS (1) STORED REFERENCES x (a)
-)
+);
 
-statement error computed column "r" cannot reference a foreign key
+statement ok
+DROP TABLE y;
+
+statement ok
 CREATE TABLE y (
   r INT AS (1) STORED REFERENCES x
-)
+);
 
-statement error computed column "r" cannot reference a foreign key
+statement ok
+DROP TABLE y;
+
+statement ok
 CREATE TABLE y (
   a INT,
   r INT AS (1) STORED REFERENCES x
-)
+);
+
+statement ok
+DROP TABLE y;
 
 # Tests for computed columns that reference foreign key columns.
 subtest referencing_fks
@@ -485,36 +494,94 @@ CREATE TABLE xx (
   a INT,
   b INT,
   UNIQUE (a, b)
-)
+);
 
-statement error computed column "y" cannot reference a foreign key
+statement ok
+INSERT INTO xx VALUES (3,3);
+
+statement ok
 CREATE TABLE yy (
   x INT,
   y INT AS (3) STORED,
   FOREIGN KEY (x, y) REFERENCES xx (a, b)
-)
-
-statement error computed column "y" cannot reference a foreign key
-CREATE TABLE yy (
-  x INT,
-  y INT AS (3) STORED,
-  FOREIGN KEY (y, x) REFERENCES xx (a, b)
-)
+);
 
 statement ok
-DROP TABLE xx
+INSERT INTO yy VALUES (3);
+
+statement error insert on table "yy" violates foreign key constraint "yy_x_y_fkey"
+INSERT INTO yy VALUES (4);
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON UPDATE CASCADE);
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON UPDATE SET NULL);
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON UPDATE SET DEFAULT);
+
+statement error pq: invalid ON UPDATE action for foreign key constraint containing computed column
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON UPDATE SET DEFAULT ON DELETE SET NULL);
+
+statement error pq: invalid ON DELETE action for foreign key constraint containing computed column
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON DELETE SET NULL);
+
+statement error pq: invalid ON DELETE action for foreign key constraint containing computed column
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON DELETE SET DEFAULT);
+
+statement ok
+CREATE TABLE uu (x INT, y INT AS (3) STORED, FOREIGN KEY (x, y) REFERENCES xx (a, b) ON DELETE CASCADE);
+
+statement ok
+DROP TABLE uu;
+
+statement ok
+DROP TABLE yy;
+
+statement ok
+DROP TABLE xx;
+
+statement ok
+CREATE TABLE aa (
+  a INT,
+  b INT,
+  UNIQUE (a, b)
+);
+
+statement ok
+INSERT INTO aa VALUES (3,3);
+
+statement ok
+CREATE TABLE bb (
+  x INT,
+  y INT AS (3) STORED,
+  FOREIGN KEY (y, x) REFERENCES aa (a, b)
+);
+
+statement ok
+INSERT INTO bb VALUES (3);
+
+statement error insert on table "bb" violates foreign key constraint "bb_y_x_fkey"
+INSERT INTO bb VALUES (4);
+
+statement ok
+DROP TABLE bb;
+
+statement ok
+DROP TABLE aa;
 
 statement ok
 CREATE TABLE y (
   r INT AS (1) STORED,
   INDEX (r)
-)
-
-statement error computed column "r" cannot reference a foreign key
-ALTER TABLE y ADD FOREIGN KEY (r) REFERENCES x (a)
+);
 
 statement ok
-DROP TABLE y
+ALTER TABLE y ADD FOREIGN KEY (r) REFERENCES x (a);
+
+statement ok
+DROP TABLE y;
 
 statement error variable sub-expressions are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE y (

--- a/pkg/sql/sem/tree/constraint.go
+++ b/pkg/sql/sem/tree/constraint.go
@@ -48,6 +48,22 @@ func (node *ReferenceActions) Format(ctx *FmtCtx) {
 	}
 }
 
+// HasUpdateAction returns true if any update action is set.
+func (node *ReferenceActions) HasUpdateAction() bool {
+	// NoAction and Restrict are currently equivalent.
+	return node.Update != NoAction && node.Update != Restrict
+}
+
+// HasDisallowedActionForComputedFKCol return true if an action is set that
+// isn't compatible with an FK over computed columns.
+func (node *ReferenceActions) HasDisallowedActionForComputedFKCol() bool {
+	// We disallow any actions that modify column values. NoAction and Restrict
+	// are equivalent and always allowed. 'ON DELETE CASCADE' is also allowed
+	// since it removes the entire row instead of modifying the computed column.
+	return node.HasUpdateAction() ||
+		(node.Delete != NoAction && node.Delete != Restrict && node.Delete != Cascade)
+}
+
 // ForeignKeyReferenceActionType allows the conversion between a
 // tree.ReferenceAction and a ForeignKeyReference_Action.
 var ForeignKeyReferenceActionType = [...]ReferenceAction{

--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )


### PR DESCRIPTION
Previously, any attempt to construct a foreign key that used a computed column was blocked. This will remove that block as it is now a supported feature.

Even though this is about removing the blocking code, I had to add some new blocking code since we cannot support all options for foreign key. Specifically, any of the ON UPDATE or ON DELETE clauses that would cause an update to the computed column. Since the column value is computed, we cannot allow it to change. Note, we do support ON DELETE CASCADE since that doesn't modify the row rather it removes the row entirely.

There is some duplication of the checks, since it required updates in two codepaths for ALTER TABLE to handle the different schema changer. I tried to modularize as best as possible.

Fixes: #46672
Release note (sql change): Allow foreign keys to be created over computed columns. However, most ON UPDATE and ON DELETE options for foreign key constraints are not allowed with computed columns.  Only the following are supported:
ON UPDATE (NO ACTION|RESTRICT), ON DELETE (NO ACTION|RESTRICT|CASCADE).