### PR TITLE
roachprod: separate load balancer commands

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -203,10 +203,12 @@ func initFlags() {
 
 	pgurlCmd.Flags().BoolVar(&external,
 		"external", false, "return pgurls for external connections")
-	pgurlCmd.Flags().StringVar(&pgurlCertsDir,
-		"certs-dir", install.CockroachNodeCertsDir, "cert dir to use for secure connections")
+	for _, cmd := range []*cobra.Command{pgurlCmd, loadBalancerPGUrl} {
+		cmd.Flags().StringVar(&pgurlCertsDir,
+			"certs-dir", install.CockroachNodeCertsDir, "cert dir to use for secure connections")
+	}
 
-	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd} {
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, loadBalancerPGUrl} {
 		cmd.Flags().StringVar(&authMode,
 			"auth-mode", defaultAuthMode, fmt.Sprintf("form of authentication to use, valid auth-modes: %v", maps.Keys(pgAuthModes)))
 	}
@@ -435,7 +437,7 @@ func initFlags() {
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd, updateTargetsCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, createLoadBalancerCmd, sqlCmd, pgurlCmd, loadBalancerPGUrl, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd, updateTargetsCmd} {
 		// TODO(renato): remove --secure once the default of secure
 		// clusters has existed in roachprod long enough.
 		cmd.Flags().BoolVar(&secure,
@@ -443,7 +445,7 @@ func initFlags() {
 		cmd.Flags().BoolVar(&insecure,
 			"insecure", insecure, "use an insecure cluster")
 	}
-	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, loadBalanceCmd, jaegerStartCmd} {
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, createLoadBalancerCmd, loadBalancerPGUrl, loadBalancerIP, jaegerStartCmd} {
 		cmd.Flags().StringVar(&virtualClusterName,
 			"cluster", "", "specific virtual cluster to connect to")
 		cmd.Flags().IntVar(&sqlInstance,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1133,13 +1133,6 @@ var pgurlCmd = &cobra.Command{
 	Short: "generate pgurls for the nodes in a cluster",
 	Long: fmt.Sprintf(`Generate pgurls for the nodes in a cluster.
 
-The command generates postgres urls for the specified nodes in a cluster.
-Both the nodes or a load balancer can be specified as the target of the pgurl.
-
-Examples of <cluster>:
-	cluster-name:1-3
-	cluster-name:lb
-
 %[1]s
 `, strings.TrimSpace(AuthModeHelp)),
 	Args: cobra.ExactArgs(1),

--- a/pkg/roachprod/install/nodes.go
+++ b/pkg/roachprod/install/nodes.go
@@ -44,9 +44,7 @@ func ListNodes(s string, numNodesInCluster int) (Nodes, error) {
 		return nil, errors.AssertionFailedf("invalid number of nodes %d", numNodesInCluster)
 	}
 
-	// "lb" is a special value that also returns all nodes, but is used to
-	// indicate that a load balancer should be used.
-	if s == "all" || strings.ToLower(s) == "lb" {
+	if s == "all" {
 		return allNodes(numNodesInCluster), nil
 	}
 


### PR DESCRIPTION
Previously, load balance was a single command intended to create a load balancer
for a cluster and service, but the command could become a bit convoluted as we
start adding more commands around load balancers. This change adds IP and
postgres URL resolution as subcommands to the load balancer command and
removes it from the existing PgURL command for better separation of logic.

Release Note: None
Epic: None