### PR TITLE
release-24.1.1-rc: sql/stats: evict stats cache entry if user-defined types have changed

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_stats
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_stats
@@ -1,0 +1,127 @@
+# LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
+
+query TTTTT colnames,rowsort
+SHOW REGIONS
+----
+region          zones                   database_names  primary_region_of  secondary_region_of
+ap-southeast-2  {ap-az1,ap-az2,ap-az3}  {}              {}                 {}
+ca-central-1    {ca-az1,ca-az2,ca-az3}  {}              {}                 {}
+us-east-1       {us-az1,us-az2,us-az3}  {}              {}                 {}
+
+query TT colnames,rowsort
+SHOW REGIONS FROM CLUSTER
+----
+region          zones
+ap-southeast-2  {ap-az1,ap-az2,ap-az3}
+ca-central-1    {ca-az1,ca-az2,ca-az3}
+us-east-1       {us-az1,us-az2,us-az3}
+
+# Regression test for #124181: check that we re-load table statistics after
+# running ALTER DATABASE ADD REGION.
+
+statement ok
+CREATE DATABASE db124181 PRIMARY REGION "ap-southeast-2" REGIONS "us-east-1" SURVIVE ZONE FAILURE
+
+statement ok
+USE db124181
+
+query TTTT
+SHOW ENUMS
+----
+public  crdb_internal_region  {ap-southeast-2,us-east-1}  root
+
+statement ok
+CREATE TABLE t124181 (
+  region crdb_internal_region NOT NULL,
+  id UUID NOT NULL DEFAULT gen_random_uuid(),
+  a INT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE INDEX (a)
+) LOCALITY REGIONAL BY ROW AS region
+
+statement ok
+INSERT INTO t124181 (region, a) VALUES ('ap-southeast-2', 0), ('us-east-1', 1)
+
+statement ok
+ANALYZE t124181
+
+let $hist_id_1
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t124181] WHERE column_names = ARRAY['region']
+
+query TIRI colnames,nosort
+SHOW HISTOGRAM $hist_id_1
+----
+upper_bound       range_rows  distinct_range_rows  equal_rows
+'ap-southeast-2'  0           0                    1
+'us-east-1'       0           0                    1
+
+query T
+SELECT jsonb_pretty(stat->'histo_buckets')
+FROM (
+  SELECT jsonb_array_elements(statistics) AS stat
+  FROM [SHOW STATISTICS USING JSON FOR TABLE t124181]
+)
+WHERE stat->>'columns' = '["region"]'
+----
+[
+    {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "ap-southeast-2"
+    },
+    {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "us-east-1"
+    }
+]
+
+# Implicitly add a value to the crdb_internal_region enum.
+statement ok
+ALTER DATABASE db124181 ADD REGION "ca-central-1"
+
+query TTTT
+SHOW ENUMS
+----
+public  crdb_internal_region  {ap-southeast-2,ca-central-1,us-east-1}  root
+
+# Make sure we can still SHOW STATISTICS and SHOW HISTOGRAM.
+let $hist_id_2
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE t124181] WHERE column_names = ARRAY['region']
+
+query TIRI colnames,nosort
+SHOW HISTOGRAM $hist_id_2
+----
+upper_bound       range_rows  distinct_range_rows  equal_rows
+'ap-southeast-2'  0           0                    1
+'us-east-1'       0           0                    1
+
+# Make sure we can still SHOW STATISTICS USING JSON.
+query T
+SELECT jsonb_pretty(stat->'histo_buckets')
+FROM (
+  SELECT jsonb_array_elements(statistics) AS stat
+  FROM [SHOW STATISTICS USING JSON FOR TABLE t124181]
+)
+WHERE stat->>'columns' = '["region"]'
+----
+[
+    {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "ap-southeast-2"
+    },
+    {
+        "distinct_range": 0,
+        "num_eq": 1,
+        "num_range": 0,
+        "upper_bound": "us-east-1"
+    }
+]
+
+# Make sure we can still use the histogram in statistics_builder.
+statement ok
+INSERT INTO t124181 (region, a) VALUES ('ca-central-1', 2)

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 20,
+    shard_count = 21,
     tags = ["cpu:4"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
@@ -149,6 +149,13 @@ func TestCCLLogic_multi_region_show(
 	runCCLLogicTest(t, "multi_region_show")
 }
 
+func TestCCLLogic_multi_region_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "multi_region_stats")
+}
+
 func TestCCLLogic_multi_region_zone_configs(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 16,
+    shard_count = 17,
     tags = ["cpu:4"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
@@ -121,6 +121,13 @@ func TestCCLLogic_multi_region_show(
 	runCCLLogicTest(t, "multi_region_show")
 }
 
+func TestCCLLogic_multi_region_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "multi_region_stats")
+}
+
 func TestCCLLogic_multi_region_survival_goal(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 28,
+    shard_count = 29,
     tags = ["cpu:4"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -177,6 +177,13 @@ func TestCCLLogic_multi_region_show(
 	runCCLLogicTest(t, "multi_region_show")
 }
 
+func TestCCLLogic_multi_region_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "multi_region_stats")
+}
+
 func TestCCLLogic_multi_region_zone_config_extensions(
 	t *testing.T,
 ) {

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -38,6 +39,8 @@ import (
 func TestMrSystemDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "runs too slow")
 
 	ctx := context.Background()
 

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -808,7 +808,7 @@ func (r *Refresher) maybeRefreshStats(
 	rowsAffected int64,
 	asOf time.Duration,
 ) {
-	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */)
+	tableStats, err := r.cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */)
 	if err != nil {
 		log.Errorf(ctx, "failed to get table statistics: %v", err)
 		return

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -263,7 +263,9 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */)
+			tableStats, err := cache.getTableStatsFromCache(
+				ctx, tableID, nil /* forecast */, nil, /* udtCols */
+			)
 			if err != nil {
 				return err
 			}
@@ -271,7 +273,9 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */)
+					stats, err := cache.getTableStatsFromCache(
+						ctx, stat.TableID, nil /* forecast */, nil, /* udtCols */
+					)
 					if err != nil {
 						return err
 					}
@@ -556,7 +560,9 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 		}
 
 		return testutils.SucceedsSoonError(func() error {
-			tableStats, err := cache.getTableStatsFromCache(ctx, tableID, nil /* forecast */)
+			tableStats, err := cache.getTableStatsFromCache(
+				ctx, tableID, nil /* forecast */, nil, /* udtCols */
+			)
 			if err != nil {
 				return err
 			}
@@ -564,7 +570,9 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 			for i := range testData {
 				stat := &testData[i]
 				if stat.TableID != tableID {
-					stats, err := cache.getTableStatsFromCache(ctx, stat.TableID, nil /* forecast */)
+					stats, err := cache.getTableStatsFromCache(
+						ctx, stat.TableID, nil /* forecast */, nil, /* udtCols */
+					)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -113,7 +113,7 @@ func checkStatsForTable(
 
 	// Perform the lookup and refresh, and confirm the
 	// returned stats match the expected values.
-	statsList, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */)
+	statsList, err := sc.getTableStatsFromCache(ctx, tableID, nil /* forecast */, nil /* udtCols */)
 	if err != nil {
 		t.Fatalf("error retrieving stats: %s", err)
 	}
@@ -407,7 +407,7 @@ func TestCacheWait(t *testing.T) {
 		for n := 0; n < 10; n++ {
 			wg.Add(1)
 			go func() {
-				stats, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */)
+				stats, err := sc.getTableStatsFromCache(ctx, id, nil /* forecast */, nil /* udtCols */)
 				if err != nil {
 					t.Error(err)
 				} else if !checkStats(stats, expectedStats[id]) {


### PR DESCRIPTION
Backport 1/3 commits from #124603 and and 1/1 commits from #122386.

/cc @cockroachdb/release

---

**sql/stats: evict stats cache entry if user-defined types have changed**

When adding table statistics to the stats cache, we decode histogram upper bounds into datums. If the histogram column uses a user-defined type, we hydrate the type and use this to decode.

In statistics builder, these histogram upper bound datums are compared against datums in spans and constraints. The comparisons assume that the datums are of equivalent type, but if the user-defined type has changed sometime after loading the stats cache entry, this might not be true.

If the user-defined type has changed, we need to evict and re-load the stats cache entry so that we decode histogram datums with a freshly-hydrated type.

(We were already checking UDT versions when building the optTable in sql.(\*optCatalog).dataSourceForTable, but the newly-built optTable used the existing table statistics instead of refreshing those, too.)

Fixes: #124181

Release note (bug fix): Fix a bug where a change to a user-defined type could cause queries against tables using that type to fail with an error message like:

```
histogram.go:694: span must be fully contained in the bucket
```

The change to the user-defined type could come directly from an ALTER TYPE statement, or indirectly from an ALTER DATABASE ADD REGION or DROP REGION statement (which implicitly change the crdb_internal_region type).

This bug has existed since UDTs were introduced in v20.2.

---

**multiregionccl: skip TestMRSystemDatabase under stress race** 

Closes https://github.com/cockroachdb/cockroach/issues/122363

Release note: None

---

Release justification: fix for a serious production issue.