### PR TITLE
admission: add retry logic in TestWorkQueue

### DIFF
--- a/pkg/util/admission/testdata/replicated_write_admission/tenant_fairness
+++ b/pkg/util/admission/testdata/replicated_write_admission/tenant_fairness
@@ -59,7 +59,7 @@ granter adjust-tokens=+0B
 print
 ----
 physical-stats: work-count=4 written-bytes=4B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=2 top-tenant=t2
+[regular work queue]: len(tenant-heap)=2 top-tenant=t1
  tenant=t1 weight=1 fifo-threshold=low-pri used=1B
   [0: pri=normal-pri create-time=1.002µs size=1B range=r1 origin=n1 log-position=4/21]
  tenant=t2 weight=1 fifo-threshold=low-pri used=1B

--- a/pkg/util/admission/testdata/replicated_write_admission/tenant_weights
+++ b/pkg/util/admission/testdata/replicated_write_admission/tenant_weights
@@ -49,7 +49,7 @@ admit tenant=t2 pri=normal-pri create-time=1.005us size=1B range=r2 origin=n1 lo
 print
 ----
 physical-stats: work-count=10 written-bytes=10B ingested-bytes=0B
-[regular work queue]: len(tenant-heap)=2 top-tenant=t1
+[regular work queue]: len(tenant-heap)=2 top-tenant=t2
  tenant=t1 weight=2 fifo-threshold=low-pri used=0B
   [0: pri=normal-pri create-time=1.001µs size=1B range=r1 origin=n1 log-position=4/20]
   [1: pri=normal-pri create-time=1.002µs size=1B range=r1 origin=n1 log-position=4/21]
@@ -75,8 +75,8 @@ granter class=regular adjust-tokens=+7B
 # towards the tenant with the higher weight (t2).
 grant class=regular
 ----
-admitted [tenant=t1 pri=normal-pri create-time=1.001µs size=1B range=r1 origin=n1 log-position=4/20]
 admitted [tenant=t2 pri=normal-pri create-time=1.001µs size=1B range=r2 origin=n1 log-position=5/20]
+admitted [tenant=t1 pri=normal-pri create-time=1.001µs size=1B range=r1 origin=n1 log-position=4/20]
 admitted [tenant=t2 pri=normal-pri create-time=1.002µs size=1B range=r2 origin=n1 log-position=5/21]
 admitted [tenant=t2 pri=normal-pri create-time=1.003µs size=1B range=r2 origin=n1 log-position=5/22]
 admitted [tenant=t1 pri=normal-pri create-time=1.002µs size=1B range=r1 origin=n1 log-position=4/21]

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -63,7 +63,7 @@ granted: returned 1
 # favor of tenant 71.
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 71
+closed epoch: 0 tenantHeap len: 2 top tenant: 53
  tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 2, epoch: 0, qt: 100] [1: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
  tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -74,7 +74,7 @@ id 3: admit failed
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 71
+closed epoch: 0 tenantHeap len: 2 top tenant: 53
  tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 3, epoch: 0, qt: 100]
  tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: low-pri, ct: 4, epoch: 0, qt: 100]
 
@@ -551,20 +551,20 @@ admit id=2 tenant=10 priority=0 create-time-millis=1 bypass=false
 
 print
 ----
-closed epoch: 0 tenantHeap len: 2 top tenant: 5
+closed epoch: 0 tenantHeap len: 2 top tenant: 10
  tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  tenant-id: 10 used: 0, w: 11, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=1
 ----
 continueGrantChain 1
-id 1: admit succeeded
+id 2: admit succeeded
 granted: returned 1
 
 granted chain-id=2
 ----
 continueGrantChain 2
-id 2: admit succeeded
+id 1: admit succeeded
 granted: returned 1
 
 # Both tenants are using 1 slot.
@@ -721,7 +721,7 @@ closed epoch: 0 tenantHeap len: 8 top tenant: 1
 # Set weights for 7 out of the 8 tenants.
 set-tenant-weights weights=1:2,2:3,3:4,4:5,5:6,7:8,8:9
 ----
-closed epoch: 0 tenantHeap len: 8 top tenant: 1
+closed epoch: 0 tenantHeap len: 8 top tenant: 8
  tenant-id: 1 used: 0, w: 2, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  tenant-id: 2 used: 0, w: 3, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
  tenant-id: 3 used: 0, w: 4, fifo: -128 waiting work heap: [0: pri: normal-pri, ct: 1, epoch: 0, qt: 100]
@@ -734,49 +734,49 @@ closed epoch: 0 tenantHeap len: 8 top tenant: 1
 granted chain-id=1
 ----
 continueGrantChain 1
-id 1: admit succeeded
+id 8: admit succeeded
 granted: returned 1
 
 granted chain-id=2
 ----
 continueGrantChain 2
-id 8: admit succeeded
+id 7: admit succeeded
 granted: returned 1
 
 granted chain-id=3
 ----
 continueGrantChain 3
-id 7: admit succeeded
+id 5: admit succeeded
 granted: returned 1
 
 granted chain-id=4
 ----
 continueGrantChain 4
-id 6: admit succeeded
+id 4: admit succeeded
 granted: returned 1
 
 granted chain-id=5
 ----
 continueGrantChain 5
-id 5: admit succeeded
+id 3: admit succeeded
 granted: returned 1
 
 granted chain-id=6
 ----
 continueGrantChain 6
-id 4: admit succeeded
+id 2: admit succeeded
 granted: returned 1
 
 granted chain-id=7
 ----
 continueGrantChain 7
-id 3: admit succeeded
+id 1: admit succeeded
 granted: returned 1
 
 granted chain-id=8
 ----
 continueGrantChain 8
-id 2: admit succeeded
+id 6: admit succeeded
 granted: returned 1
 
 print


### PR DESCRIPTION
This test used to flake due to racing goroutines since it used a simple `time.Sleep()`. This patch adds a retry loop if the output is different than what it expects. It will retry up to a maximum of 2s.

It also removes non-determinism from `tenantHeap` priority ordering and the stringify functions of each of the heaps.

Fixes: #124481

Release note: None