### PR TITLE
acceptance: use `docker compose`

### DIFF
--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -118,7 +118,8 @@ func TestComposeCompare(t *testing.T) {
 		}
 	}
 	cmd := exec.Command(
-		"docker-compose",
+		"docker",
+		"compose",
 		"-f", dockerComposeYml,
 		"--no-ansi",
 		"up",

--- a/scripts/localmetrics/README.md
+++ b/scripts/localmetrics/README.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```
-docker-compose up -d
+docker compose up -d
 ./import-csv.sh < (curl https://gist.githubusercontent.com/tbg/98d9814f624629833e6cfb7d25cb8258/raw/70a96d50032361f864b240dbd9f1c36c385b7515/sample.csv)
 # User/Pass admin/x
 open http://127.0.0.1:3000
@@ -17,7 +17,7 @@ The source of this could be a `debug zip` (pending [#50432]), or
 
 `./cockroach debug tsdump --format=csv --host=... > dump.csv`.
 
-### Step 2: `docker-compose up -d`
+### Step 2: `docker compose up -d`
 
 Not much more to be said. Unsurprisingly, this needs Docker to work. Omit the
 `-d` if you want to see what's going on behind the scenes. It may take a moment
@@ -46,7 +46,7 @@ Replace ./grafana/dashboards/home.json if you want the changes to persist.
 
 TODO(tbg): auto-generate a better home.json from `pkg/ts/catalog`.
 
-### Step 5: docker-compose stop
+### Step 5: docker compose stop
 
 To avoid hogging resources on your machine. The postgres database is on your
 local file system, so it will remain. If you want to nuke everything, use


### PR DESCRIPTION
Previously, we used `docker-compose` (V1) to run acceptance tests. `docker compose` is a plugin now and not a separate command, which supports V2 compose files. See
https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2 for the details.

Epic: none
Release note: None