### PR TITLE
backupccl: add keyRewriter.RewriteSpan

### DIFF
--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -226,22 +226,10 @@ func assertCommonPrefix(span roachpb.Span, elidedPrefixType execinfrapb.ElidePre
 func rewriteSpan(
 	kr *KeyRewriter, span roachpb.Span, elidedPrefixType execinfrapb.ElidePrefix,
 ) (roachpb.Span, error) {
-	var (
-		ok  bool
-		err error
-	)
-	if err = assertCommonPrefix(span, elidedPrefixType); err != nil {
-		return span, err
+	if err := assertCommonPrefix(span, elidedPrefixType); err != nil {
+		return roachpb.Span{}, err
 	}
-	span.Key, ok, err = kr.RewriteKey(span.Key, 0)
-	if !ok || err != nil {
-		return span, errors.Wrapf(err, "span start key %s was not rewritten", span.Key)
-	}
-	span.EndKey, ok, err = kr.RewriteKey(span.EndKey, 0)
-	if !ok || err != nil {
-		return span, errors.Wrapf(err, "span end key %s was not rewritten ", span.Key)
-	}
-	return span, nil
+	return kr.RewriteSpan(span)
 }
 
 // linkExternalFiles runs through all entries produced by genSpans and links in


### PR DESCRIPTION
Span bounds should always be rewritten, even when they fall within the tables for which individual keys are elided during a restore, such as the liveness table. This elision is typically controlled by the key rewriter returning false for keys in these tables, indicating that they should not be restored. However if it returns false when one of these keys appears as a span boundary, we still want to rewrite it. Previously when the rewrite of one of these keys incorrectly returned false, we would return false from rewriteSpan. Unfortunately, this early return was done quietly, leaving the span half rewritten.

This pulls span rewriting into the key rewriter, parameterizing various methods to know when they are rewriting span bounds versus keys, so that they only check for and return false for keys in the elided tables when rewriting a key and not a span.

Release note: none.
Epic: none.