### PR TITLE
util/mon: disable recently added assertion for now

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -653,12 +653,13 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 				// Ignore mm itself if it is short-living.
 				numShortLiving--
 			}
-			if numShortLiving > 0 {
-				panic(errors.AssertionFailedf(
-					"found %d short-living non-stopped monitors in %s\n%s",
-					numShortLiving, mm.name, sb.String(),
-				))
-			}
+			// TODO(#124848): uncomment this.
+			//if numShortLiving > 0 {
+			//	panic(errors.AssertionFailedf(
+			//		"found %d short-living non-stopped monitors in %s\n%s",
+			//		numShortLiving, mm.name, sb.String(),
+			//	))
+			//}
 		}
 	}
 


### PR DESCRIPTION
There are some more issues to address (probably around the server shutdown), so let's disable the recently added assertion that all short-living monitors are stopped when the parent is stopped.

Informs: #124848
Informs: #124849
Informs: #124850
Epic: None

Release note: None