### PR TITLE
acceptance: use `docker compose` (part 2)

### DIFF
--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cockroach:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   kdc:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   kdc:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -74,8 +74,13 @@ func testCompose(t *testing.T, path string, exitCodeFrom string) {
 		t.Fatalf(err.Error())
 	}
 	cmd := exec.Command(
-		"docker-compose",
-		"--no-ansi",
+		"docker",
+		"compose",
+		// NB: Using --compatibility here in order to preserve compose V1 hostnames
+		// (with underscores) instead of V2 hostnames (with -), because the
+		// hostnames are hardcoded in the Kerberos keys.
+		"--compatibility",
+		"--ansi=never",
 		"-f", path,
 		"up",
 		"--force-recreate",

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cockroach1:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -121,7 +121,7 @@ func TestComposeCompare(t *testing.T) {
 		"docker",
 		"compose",
 		"-f", dockerComposeYml,
-		"--no-ansi",
+		"--ansi=never",
 		"up",
 		"--force-recreate",
 		"--exit-code-from", "test",


### PR DESCRIPTION
Previously, we used docker-compose (V1) to run acceptance tests. docker compose is a plugin now and not a separate command, which supports V2 compose files. See
https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2 for the details.

* Use `--compatibility` for acceptance tests in order to use the old style hostnames with underscores, because they are hard coded in the Kerberos server keys.
* Update `--ansi` argument usage.
* Remove deprecated `version` header.

See also: #124865

Fixes: #124864
Release note: None