### PR TITLE
release-23.2: cluster-ui: bump cluster-ui version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.2.6",
+  "version": "23.2.7",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps cluster-ui package.json version to publish
recent changes to npm.

This includes the following Prs:

#120212
#120214
#121383
#122815
#122119

Release note: none