### PR TITLE
release-23.2: types: add an error code for enum value not being public

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -214,7 +214,7 @@ SELECT enum_last('c'::build)
 ----
 f
 
-statement error pq: enum value \"g\" is not yet public
+statement error  pq: cannot use enum value \"g\": enum value is not yet public
 INSERT INTO new_enum_values VALUES ('g')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1733,7 +1733,7 @@ statement ok
 ALTER TYPE greeting ADD VALUE 'salud' AFTER 'hello'
 
 # The insert should fail but with awareness that 'salud' is an enum type.
-statement error pq: enum value "salud" is not yet public
+statement error pq: cannot use enum value \"salud\": enum value is not yet public
 INSERT INTO tab2 VALUES ('salud')
 
 statement ok

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2696,7 +2696,7 @@ func (t *T) EnumGetIdxOfPhysical(phys []byte) (int, error) {
 }
 
 // EnumValueNotYetPublicError enum value is not public yet.
-var EnumValueNotYetPublicError = errors.New("enum value is not yet public")
+var EnumValueNotYetPublicError = pgerror.New(pgcode.InvalidParameterValue, "enum value is not yet public")
 
 // EnumGetIdxOfLogical returns the index within the TypeMeta's slice of
 // enum logical representations that matches the input string.

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2695,6 +2695,9 @@ func (t *T) EnumGetIdxOfPhysical(phys []byte) (int, error) {
 	return 0, err
 }
 
+// EnumValueNotYetPublicError enum value is not public yet.
+var EnumValueNotYetPublicError = errors.New("enum value is not yet public")
+
 // EnumGetIdxOfLogical returns the index within the TypeMeta's slice of
 // enum logical representations that matches the input string.
 func (t *T) EnumGetIdxOfLogical(logical string) (int, error) {
@@ -2707,7 +2710,7 @@ func (t *T) EnumGetIdxOfLogical(logical string) (int, error) {
 			// written until all nodes in the cluster are able to decode the
 			// physical representation.
 			if t.TypeMeta.EnumData.IsMemberReadOnly[i] {
-				return 0, errors.Newf("enum value %q is not yet public", logical)
+				return 0, errors.WithMessagef(EnumValueNotYetPublicError, "cannot use enum value %q", logical)
 			}
 			return i, nil
 		}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "regionliveness: detect if the region enum is not public" (#116376)
  * 1/1 commits from "workload/schemachange: fix expected errors for enum ref in UDF" (#120672)

Please see individual PRs for details.

/cc @cockroachdb/release

Fixes: #124839
Release justification: low risk change to an error code