### PR TITLE
streampb: remove redundant nullable=false from proto

### DIFF
--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -92,9 +92,7 @@ message ReplicationProducerRequest {
 
   // TableNames, if set, are the names of the individual tables that a
   // logical replication ingestion processor are interested in.
-  repeated string table_names = 4 [
-    (gogoproto.nullable) = false
-  ];
+  repeated string table_names = 4;
 }
 
 // StreamPartitionSpec is the stream partition specification.


### PR DESCRIPTION
Saw this when regenerating protos:
```
WARNING: field ReplicationProducerRequest.TableNames is a repeated non-nullable native type, nullable=false has no effect
```

Epic: None
Release note: None