### PR TITLE
workload/schemachange: expect incomparable types

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1029,6 +1029,10 @@ SELECT count(*) FROM %s
 
 	numJoinRows, err := og.scanInt(ctx, tx, q)
 	if err != nil {
+		// UndefinedFunction errors mean that the column type is not comparable.
+		if pgErr := new(pgconn.PgError); errors.As(err, &pgErr) && pgcode.MakeCode(pgErr.Code) == pgcode.UndefinedFunction {
+			return false, nil
+		}
 		return false, err
 	}
 	return numJoinRows == childRows, err


### PR DESCRIPTION
This patch ensures that our schemachange workload will
allow for invalid columns of incomparable types to pass the
`rowsSatisfyFkConstraint` check -- as they are expected to
fail later on with a foreign key violation.

Epic: none

Fixes: #124719
Release note: None