### PR TITLE
opt: set cardinality to zero for joins with False filters

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2672,14 +2672,14 @@ func (h *joinPropsHelper) cardinality() props.Cardinality {
 
 	switch h.joinType {
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
-		if right.IsZero() {
+		if right.IsZero() || h.filterIsFalse {
 			return left
 		}
 		// Anti join cardinality never exceeds left input cardinality, and
 		// allows zero rows.
 		return left.AsLowAs(0)
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
-		if right.IsZero() {
+		if right.IsZero() || h.filterIsFalse {
 			return props.ZeroCardinality
 		}
 		// Semi join cardinality never exceeds left input cardinality, and

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -551,6 +551,93 @@ project
       │         └── unfiltered-cols: (7-11)
       └── filters (true)
 
+# Semi-join with empty right input. The cardinality should be zero.
+expr
+(SemiJoin
+  (Values
+    [
+      (Tuple [ (Const 1 "int") (Const 10 "int") ] "tuple{int}" )
+      (Tuple [ (Const 2 "int") (Const 20 "int") ] "tuple{int}" )
+      (Tuple [ (Const 3 "int") (Const 30 "int") ] "tuple{int}" )
+    ]
+    [ (Cols [ (NewColumn "x" "int") (NewColumn "y" "int") ]) ]
+  )
+  (Select (Scan [ (Table "uv") (Cols "u,v") ]) [ (False) ])
+  [ (Eq (Var "x") (Var "u")) ]
+  []
+)
+----
+semi-join (hash)
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── cardinality: [0 - 0]
+ ├── prune: (2)
+ ├── values
+ │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── prune: (1,2)
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 10 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 20 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         ├── const: 3 [type=int]
+ │         └── const: 30 [type=int]
+ ├── select
+ │    ├── columns: u:3(int) v:4(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── prune: (3,4)
+ │    ├── scan uv
+ │    │    ├── columns: u:3(int) v:4(int!null)
+ │    │    └── prune: (3,4)
+ │    └── filters
+ │         └── false [type=bool, constraints=(contradiction; tight)]
+ └── filters
+      └── eq [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+           ├── variable: x:1 [type=int]
+           └── variable: u:3 [type=int]
+
+# Semi-join with False filters. The cardinality should be zero.
+expr
+(SemiJoin
+  (Values
+    [
+      (Tuple [ (Const 1 "int") (Const 10 "int") ] "tuple{int}" )
+      (Tuple [ (Const 2 "int") (Const 20 "int") ] "tuple{int}" )
+      (Tuple [ (Const 3 "int") (Const 30 "int") ] "tuple{int}" )
+    ]
+    [ (Cols [ (NewColumn "x" "int") (NewColumn "y" "int") ]) ]
+  )
+  (Scan [ (Table "uv") (Cols "u,v") ])
+  [ (False) ]
+  []
+)
+----
+semi-join (cross)
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── cardinality: [0 - 0]
+ ├── prune: (1,2)
+ ├── values
+ │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── prune: (1,2)
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 10 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 20 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         ├── const: 3 [type=int]
+ │         └── const: 30 [type=int]
+ ├── scan uv
+ │    ├── columns: u:3(int) v:4(int!null)
+ │    ├── prune: (3,4)
+ │    └── unfiltered-cols: (3-7)
+ └── filters
+      └── false [type=bool, constraints=(contradiction; tight)]
+
 # Semi-join-apply.
 opt
 SELECT * FROM xysd WHERE EXISTS(SELECT * FROM uv WHERE v=x OFFSET 1)
@@ -651,6 +738,95 @@ anti-join (hash)
       └── eq [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
            ├── variable: x:1 [type=int]
            └── variable: u:7 [type=int]
+
+# Anti-join with empty right input. The cardinality of the left input should be
+# passed through.
+expr
+(AntiJoin
+  (Values
+    [
+      (Tuple [ (Const 1 "int") (Const 10 "int") ] "tuple{int}" )
+      (Tuple [ (Const 2 "int") (Const 20 "int") ] "tuple{int}" )
+      (Tuple [ (Const 3 "int") (Const 30 "int") ] "tuple{int}" )
+    ]
+    [ (Cols [ (NewColumn "x" "int") (NewColumn "y" "int") ]) ]
+  )
+  (Select (Scan [ (Table "uv") (Cols "u,v") ]) [ (False) ])
+  [ (Eq (Var "x") (Var "u")) ]
+  []
+)
+----
+anti-join (hash)
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── cardinality: [3 - 3]
+ ├── prune: (2)
+ ├── values
+ │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── prune: (1,2)
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 10 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 20 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         ├── const: 3 [type=int]
+ │         └── const: 30 [type=int]
+ ├── select
+ │    ├── columns: u:3(int) v:4(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── prune: (3,4)
+ │    ├── scan uv
+ │    │    ├── columns: u:3(int) v:4(int!null)
+ │    │    └── prune: (3,4)
+ │    └── filters
+ │         └── false [type=bool, constraints=(contradiction; tight)]
+ └── filters
+      └── eq [type=bool, outer=(1,3), constraints=(/1: (/NULL - ]; /3: (/NULL - ]), fd=(1)==(3), (3)==(1)]
+           ├── variable: x:1 [type=int]
+           └── variable: u:3 [type=int]
+
+# Anti-join with False filters. The cardinality of the left input should be
+# passed through.
+expr
+(AntiJoin
+  (Values
+    [
+      (Tuple [ (Const 1 "int") (Const 10 "int") ] "tuple{int}" )
+      (Tuple [ (Const 2 "int") (Const 20 "int") ] "tuple{int}" )
+      (Tuple [ (Const 3 "int") (Const 30 "int") ] "tuple{int}" )
+    ]
+    [ (Cols [ (NewColumn "x" "int") (NewColumn "y" "int") ]) ]
+  )
+  (Scan [ (Table "uv") (Cols "u,v") ])
+  [ (False) ]
+  []
+)
+----
+anti-join (cross)
+ ├── columns: x:1(int!null) y:2(int!null)
+ ├── cardinality: [3 - 3]
+ ├── prune: (1,2)
+ ├── values
+ │    ├── columns: x:1(int!null) y:2(int!null)
+ │    ├── cardinality: [3 - 3]
+ │    ├── prune: (1,2)
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 10 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 20 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         ├── const: 3 [type=int]
+ │         └── const: 30 [type=int]
+ ├── scan uv
+ │    ├── columns: u:3(int) v:4(int!null)
+ │    ├── prune: (3,4)
+ │    └── unfiltered-cols: (3-7)
+ └── filters
+      └── false [type=bool, constraints=(contradiction; tight)]
 
 # Anti-join-apply.
 opt

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1448,8 +1448,9 @@ expr format=show-all colstat=7 colstat=8 colstat=(7, 8) colstat=1 colstat=2 cols
 semi-join (lookup t.public.def)
  ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(int)
  ├── key columns: [1 2] = [6 7]
+ ├── cardinality: [0 - 0]
  ├── stats: [rows=0, distinct(1)=0, null(1)=0, distinct(2)=0, null(2)=0, distinct(3)=0, null(3)=0, distinct(7)=0, null(7)=0, distinct(8)=0, null(8)=0, distinct(7,8)=0, null(7,8)=0, distinct(1-3)=0, null(1-3)=0]
- ├── cost: 2135.9206
+ ├── cost: 2135.9106
  ├── key: (1,2)
  ├── fd: (1,2)-->(3)
  ├── interesting orderings: (+1,+2)

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -295,3 +295,40 @@ project
  └── projections
       ├── NULL [as="?column?":7, type=unknown]
       └── CASE x:1 WHEN y:2 THEN CAST(NULL AS INT8) ELSE x:1 END [as=nullif:8, type=int, outer=(1,2)]
+
+# Regression test for #124831 - don't panic due to statistics assertion with
+# optimizer rules disabled.
+exec-ddl
+CREATE TABLE t124831 (a INT, b INT);
+----
+
+norm disable=(SimplifyZeroCardinalityGroup,EliminateExistsZeroRows,SimplifyZeroCardinalitySemiJoin,PushFilterIntoJoinLeft)
+SELECT a FROM t124831 WHERE NULL::INT IN (SELECT 1 LIMIT b);
+----
+project
+ ├── columns: a:1(int)
+ ├── cardinality: [0 - 0]
+ ├── immutable
+ ├── stats: [rows=0]
+ └── semi-join-apply
+      ├── columns: a:1(int) b:2(int)
+      ├── cardinality: [0 - 0]
+      ├── immutable
+      ├── stats: [rows=0]
+      ├── scan t124831
+      │    ├── columns: a:1(int) b:2(int)
+      │    └── stats: [rows=1000]
+      ├── limit
+      │    ├── outer: (2)
+      │    ├── cardinality: [1 - 1]
+      │    ├── immutable
+      │    ├── stats: [rows=1]
+      │    ├── key: ()
+      │    ├── values
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── stats: [rows=1]
+      │    │    ├── key: ()
+      │    │    └── () [type=tuple]
+      │    └── b:2 [type=int]
+      └── filters
+           └── false [type=bool, constraints=(contradiction; tight)]


### PR DESCRIPTION
This patch fixes a panic that could occur with some optimization rules disabled. This issue was that a `SemiJoin` or `SemiJoinApply` set the row-count to zero when the filters are a contradiction. Previously, the cardinality was not set under the same circumstances, which ran into an assertion that row-count can only be exeactly zero if cardinality is also zero. This patch updates the cardinality when the join filters are False.

Fixes #124831

Release note: None