### PR TITLE
workload/schemachange: avoid more than 99 UDF parameters

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3961,15 +3961,27 @@ FROM
 			return PickOne(og.params.rng, droppingEnumMembers)
 		},
 		"ParamRefs": func() (string, error) {
-			refs, err := PickBetween(og.params.rng, 1, 99, possibleParamReferences)
+			refs, err := PickBetween(
+				og.params.rng, min(1, len(possibleParamReferences)),
+				98, possibleParamReferences,
+			)
 			if err != nil {
 				return "", err
 			}
-			refsWithDefaults, err := PickBetween(og.params.rng, 1, 99, possibleParamReferencesWithDefaults)
-			if useParamRefs && err == nil {
-				return strings.Join(append(refs, refsWithDefaults...), ", "), nil
+			// The max number to pick is 99-len(refs), since we end up combining
+			// the slices together, and we don't want the total length to exceed 99.
+			refsWithDefaults, err := PickBetween(
+				og.params.rng, min(1, len(possibleParamReferencesWithDefaults)),
+				99-len(refs), possibleParamReferencesWithDefaults,
+			)
+			if err != nil {
+				return "", err
 			}
-			return "", nil //nolint:returnerrcheck
+			refs = append(refs, refsWithDefaults...)
+			if useParamRefs && len(refs) != 0 {
+				return strings.Join(refs, ", "), nil
+			}
+			return "", nil
 		},
 		"ReturnRefs": func() (string, error) {
 			ref, err := PickOne(og.params.rng, possibleReturnReferences)


### PR DESCRIPTION
The check for max number of parameters got broken in 91f7f4b07e54bbfd97f8705a76c4fb18d065b2a5, when we added default parameters.

fixes https://github.com/cockroachdb/cockroach/issues/124390
Release note: None