### PR TITLE
kv,sql: make more errors redaction-friendly; wrap with PG code during bulk adding

### DIFF
--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -1603,8 +1603,19 @@ func (e *RefreshFailedError) Type() ErrorDetailType {
 var _ ErrorDetailInterface = &RefreshFailedError{}
 
 func (e *InsufficientSpaceError) Error() string {
-	return fmt.Sprintf("store %d has insufficient remaining capacity to %s (remaining: %s / %.1f%%, min required: %.1f%%)",
-		e.StoreID, e.Op, humanizeutil.IBytes(e.Available), float64(e.Available)/float64(e.Capacity)*100, e.Required*100)
+	return fmt.Sprint(e)
+}
+
+// Format implements fmt.Formatter.
+func (e *InsufficientSpaceError) Format(s fmt.State, verb rune) {
+	errors.FormatError(e, s, verb)
+}
+
+// SafeFormatError implements errors.SafeFormatter.
+func (e *InsufficientSpaceError) SafeFormatError(p errors.Printer) (next error) {
+	p.Printf("store %d has insufficient remaining capacity to %s (remaining: %s / %.1f%%, min required: %.1f%%)",
+		e.StoreID, redact.SafeString(e.Op), humanizeutil.IBytes(e.Available), float64(e.Available)/float64(e.Capacity)*100, e.Required*100)
+	return nil
 }
 
 // NewNotLeaseHolderError returns a NotLeaseHolderError initialized with the

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
 )
 
 // BulkAdderOptions is used to configure the behavior of a BulkAdder.
@@ -111,7 +112,17 @@ type DuplicateKeyError struct {
 }
 
 func (d *DuplicateKeyError) Error() string {
-	return fmt.Sprintf("duplicate key: %s", d.Key)
+	return fmt.Sprint(d)
+}
+
+// Format implements fmt.Formatter.
+func (d *DuplicateKeyError) Format(s fmt.State, verb rune) {
+	errors.FormatError(d, s, verb)
+}
+
+func (d *DuplicateKeyError) SafeFormatError(p errors.Printer) (next error) {
+	p.Printf("duplicate key: %s", d.Key)
+	return nil
 }
 
 // NewDuplicateKeyError constructs a DuplicateKeyError, copying its input.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -346,8 +346,7 @@ func CheckSSTConflicts(
 			allowShadow := !disallowShadowingBelow.IsEmpty() &&
 				disallowShadowingBelow.LessEq(extKey.Timestamp) && bytes.Equal(extValueRaw, sstValueRaw)
 			if !allowShadow {
-				return errors.Errorf(
-					"ingested key collides with an existing one: %s", sstKey.Key)
+				return kvpb.NewKeyCollisionError(sstKey.Key, sstValueRaw)
 			}
 		}
 


### PR DESCRIPTION
### kv: make InsufficientSpaceError and DuplicateKeyError redaction-friendly

Especially for InsufficientSpaceError, it is useful to see the
non-sensitive error message in Splunk. Currently, the entire error text
gets redacted, since SafeFormatError was not implemented.

---

### storage, sql: wrap more errors during bulk adding with PG codes

This will make the error a little more friendly to the user.

fixes #117504
Release note: None