### PR TITLE
roachprod: update roachprod GC docker

### DIFF
--- a/pkg/cmd/roachprod/docker/README.md
+++ b/pkg/cmd/roachprod/docker/README.md
@@ -5,7 +5,7 @@ CLI toolchains. The entrypoint for the image will configure the CLI tools using
 files to be mounted into the `/secrets` directory.
 
 In order to update the kubernetes cron job, run `./push.sh` in the current
-directory.
+directory. Make sure that `kubectl` is available before running `./push.sh`.
 
 In order to test the docker build process, you can run the same script with
 `OWNER` and/or `REPO` set: `OWNER=rail ./push.sh`. Note, that the built image

--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:f53b1337f77
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:ece9cc18904
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
The gc dockerfile is updated and new roachprod bindary is deployed.

Fixes: #124599
Epic: none