### PR TITLE
jobs: add ability to assert claim on load

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -883,7 +883,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 		// Re-load the job in order to update our progress object, which
 		// may have been updated since the flow started.
-		reloadedJob, reloadErr := p.ExecCfg().JobRegistry.LoadClaimedJob(ctx, b.job.ID())
+		reloadedJob, reloadErr := p.ExecCfg().JobRegistry.LoadAdoptedJob(ctx, b.job.ID())
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1273,7 +1273,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.js = newJobState(nil, cf.flowCtx.Cfg.Settings, cf.metrics, timeutil.DefaultTimeSource{})
 
 	if cf.spec.JobID != 0 {
-		job, err := cf.flowCtx.Cfg.JobRegistry.LoadClaimedJob(ctx, cf.spec.JobID)
+		job, err := cf.flowCtx.Cfg.JobRegistry.LoadAdoptedJob(ctx, cf.spec.JobID)
 		if err != nil {
 			cf.MoveToDraining(err)
 			return

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1338,7 +1338,7 @@ func reconcileJobStateWithLocalState(
 ) error {
 	// Re-load the job in order to update our progress object, which may have
 	// been updated by the changeFrontier processor since the flow started.
-	reloadedJob, reloadErr := execCfg.JobRegistry.LoadClaimedJob(ctx, jobID)
+	reloadedJob, reloadErr := execCfg.JobRegistry.LoadAdoptedJob(ctx, jobID)
 	if reloadErr != nil {
 		log.Warningf(ctx, `CHANGEFEED job %d could not reload job progress (%s); `+
 			`job should be retried later`, jobID, reloadErr)

--- a/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
+++ b/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
@@ -80,6 +80,7 @@ func makeSpanConfigIngestor(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	ingestionJob *jobs.Job,
+	session sqlliveness.Session,
 	sourceTenantID roachpb.TenantID,
 	stopperCh chan struct{},
 ) (*spanConfigIngestor, error) {
@@ -109,7 +110,7 @@ func makeSpanConfigIngestor(
 	return &spanConfigIngestor{
 		accessor:                 execCfg.SpanConfigKVAccessor,
 		settings:                 execCfg.Settings,
-		session:                  ingestionJob.Session(),
+		session:                  session,
 		client:                   client,
 		rekeyer:                  rekeyer,
 		stopperCh:                stopperCh,

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -190,7 +190,17 @@ func startDistIngestion(
 		if err != nil {
 			return err
 		}
-		ingestor, err := makeSpanConfigIngestor(ctx, execCtx.ExecCfg(), ingestionJob, sourceTenantID, spanConfigIngestStopper)
+		session, err := execCtx.ExecCfg().SQLLiveness.Session(ctx)
+		if err != nil {
+			return err
+		}
+		if session.ID() != ingestionJob.SessionID() {
+			return errors.Newf("session ID mismatch (%s != %s) when starting span config ingestion",
+				session.ID(),
+				ingestionJob.SessionID(),
+			)
+		}
+		ingestor, err := makeSpanConfigIngestor(ctx, execCtx.ExecCfg(), ingestionJob, session, sourceTenantID, spanConfigIngestStopper)
 		if err != nil {
 			return err
 		}

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -226,7 +226,7 @@ func (r *Registry) filterAlreadyRunningAndCancelFromPreviousSessions(
 	defer r.mu.Unlock()
 	// Process all current adopted jobs in our in-memory jobs map.
 	for id, aj := range r.mu.adoptedJobs {
-		if aj.session.ID() != s.ID() {
+		if aj.sessionID != s.ID() {
 			log.Warningf(ctx, "job %d: running without having a live claim; canceling", id)
 			aj.cancel()
 			delete(r.mu.adoptedJobs, id)
@@ -269,7 +269,7 @@ func (r *Registry) resumeJob(
 	if opts, ok := getRegisterOptions(payload.Type()); ok && opts.disableTenantCostControl {
 		resumeCtx = multitenant.WithTenantCostControlExemption(resumeCtx)
 	}
-	if alreadyAdopted := r.addAdoptedJob(jobID, s, cancel, resumer); alreadyAdopted {
+	if alreadyAdopted := r.addAdoptedJob(jobID, s.ID(), cancel, resumer); alreadyAdopted {
 		// Not needing the context after all. Avoid leaking resources.
 		cancel()
 		return nil
@@ -379,7 +379,7 @@ func (r *Registry) loadJobForResume(
 	job.mu.payload = *payload
 	job.mu.progress = *progress
 	job.mu.status = status
-	job.session = s
+	job.sessionID = s.ID()
 	return job, nil
 }
 
@@ -390,7 +390,7 @@ func (r *Registry) loadJobForResume(
 // false, it means that the job is already registered as running and should not
 // be run again.
 func (r *Registry) addAdoptedJob(
-	jobID jobspb.JobID, session sqlliveness.Session, cancel context.CancelFunc, resumer Resumer,
+	jobID jobspb.JobID, sessionID sqlliveness.SessionID, cancel context.CancelFunc, resumer Resumer,
 ) (alreadyAdopted bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -400,10 +400,10 @@ func (r *Registry) addAdoptedJob(
 	}
 
 	r.mu.adoptedJobs[jobID] = &adoptedJob{
-		session: session,
-		cancel:  cancel,
-		isIdle:  false,
-		resumer: resumer,
+		sessionID: sessionID,
+		cancel:    cancel,
+		isIdle:    false,
+		resumer:   resumer,
 	}
 	return false
 }

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -63,13 +63,13 @@ func (i *InfoStorage) checkClaimSession(ctx context.Context) error {
 
 	if row == nil {
 		return errors.Errorf(
-			"expected session %q for job ID %d but found none", i.j.Session().ID(), i.j.ID())
+			"expected session %q for job ID %d but found none", i.j.SessionID(), i.j.ID())
 	}
 
 	storedSession := []byte(*row[0].(*tree.DBytes))
-	if !bytes.Equal(storedSession, i.j.Session().ID().UnsafeBytes()) {
+	if !bytes.Equal(storedSession, i.j.SessionID().UnsafeBytes()) {
 		return errors.Errorf(
-			"expected session %q but found %q", i.j.Session().ID(), sqlliveness.SessionID(storedSession))
+			"expected session %q but found %q", i.j.SessionID(), sqlliveness.SessionID(storedSession))
 	}
 	i.claimChecked = true
 
@@ -152,7 +152,7 @@ func (i InfoStorage) doWrite(
 
 	j := i.j
 
-	if j.Session() != nil {
+	if !j.SessionID().IsEmpty() {
 		if err := i.checkClaimSession(ctx); err != nil {
 			return err
 		}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -54,7 +54,7 @@ type Job struct {
 
 	id        jobspb.JobID
 	createdBy *CreatedByInfo
-	session   sqlliveness.Session
+	sessionID sqlliveness.SessionID
 	mu        struct {
 		syncutil.Mutex
 		payload  jobspb.Payload
@@ -232,8 +232,8 @@ func (j *Job) ID() jobspb.JobID {
 }
 
 // Session returns the underlying sqlliveness.Session associated with the job.
-func (j *Job) Session() sqlliveness.Session {
-	return j.session
+func (j *Job) SessionID() sqlliveness.SessionID {
+	return j.sessionID
 }
 
 // CreatedBy returns name/id of this job creator.  This will be nil if this information
@@ -709,12 +709,12 @@ func (u Updater) load(ctx context.Context) (retErr error) {
 
 	var err error
 	var row tree.Datums
-	if j.session == nil {
+	if j.sessionID.IsEmpty() {
 		row, err = u.txn.QueryRowEx(ctx, "load-job-query", u.txn.KV(), sess,
 			queryNoSessionID, j.ID())
 	} else {
 		row, err = u.txn.QueryRowEx(ctx, "load-job-query", u.txn.KV(), sess,
-			queryWithSessionID, j.ID(), j.session.ID().UnsafeBytes())
+			queryWithSessionID, j.ID(), j.sessionID.UnsafeBytes())
 	}
 	if err != nil {
 		return err
@@ -811,7 +811,7 @@ func (sj *StartableJob) Start(ctx context.Context) (err error) {
 			"StartableJob %d cannot be started more than once", sj.ID())
 	}
 
-	if sj.session == nil {
+	if sj.sessionID.IsEmpty() {
 		return errors.AssertionFailedf(
 			"StartableJob %d cannot be started without sqlliveness session", sj.ID())
 	}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -52,8 +52,8 @@ import (
 // adoptedJobs represents the epoch and cancellation of a job id being run by
 // the registry.
 type adoptedJob struct {
-	session sqlliveness.Session
-	isIdle  bool
+	sessionID sqlliveness.SessionID
+	isIdle    bool
 	// Reference to the Resumer that is currently running the job.
 	resumer Resumer
 	// Calling the func will cancel the context the job was resumed with.
@@ -554,7 +554,7 @@ func (r *Registry) CreateJobWithTxn(
 		if err != nil {
 			return errors.Wrap(err, "error getting live session")
 		}
-		j.session = s
+		j.sessionID = s.ID()
 		start := timeutil.Now()
 		if txn != nil {
 			start = txn.KV().ReadTimestamp().GoTime()
@@ -804,7 +804,7 @@ func (r *Registry) CreateStartableJobWithTxn(
 		// Using a new context allows for independent lifetimes and cancellation.
 		resumerCtx, cancel = r.makeCtx()
 
-		if alreadyAdopted := r.addAdoptedJob(jobID, j.session, cancel, resumer); alreadyAdopted {
+		if alreadyAdopted := r.addAdoptedJob(jobID, j.sessionID, cancel, resumer); alreadyAdopted {
 			log.Fatalf(
 				ctx,
 				"job %d: was just created but found in registered adopted jobs",
@@ -838,13 +838,29 @@ func (r *Registry) LoadJob(ctx context.Context, jobID jobspb.JobID) (*Job, error
 	return r.LoadJobWithTxn(ctx, jobID, nil)
 }
 
-// LoadClaimedJob loads an existing job with the given jobID from the
-// system.jobs table. The job must have already been claimed by this
+// LoadAdoptedJob loads an existing job with the given jobID from the
+// system.jobs table. The job must have already been adopted by this
 // Registry.
-func (r *Registry) LoadClaimedJob(ctx context.Context, jobID jobspb.JobID) (*Job, error) {
-	j, err := r.getClaimedJob(jobID)
+func (r *Registry) LoadAdoptedJob(ctx context.Context, jobID jobspb.JobID) (*Job, error) {
+	j, err := r.getAdoptedJob(jobID)
 	if err != nil {
 		return nil, err
+	}
+	if err := j.NoTxn().load(ctx); err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+// LoadClaimedJob loads the given job if it is claimed by the given
+// session ID.
+func (r *Registry) LoadClaimedJob(
+	ctx context.Context, jobID jobspb.JobID, sessionID sqlliveness.SessionID,
+) (*Job, error) {
+	j := &Job{
+		id:        jobID,
+		sessionID: sessionID,
+		registry:  r,
 	}
 	if err := j.NoTxn().load(ctx); err != nil {
 		return nil, err
@@ -1128,7 +1144,7 @@ func (r *Registry) maybeCancelJobs(ctx context.Context, s sqlliveness.Session) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for id, aj := range r.mu.adoptedJobs {
-		if aj.session.ID() != s.ID() {
+		if aj.sessionID != s.ID() {
 			log.Warningf(ctx, "job %d: running without having a live claim; killed.", id)
 			aj.cancel()
 			delete(r.mu.adoptedJobs, id)
@@ -1875,7 +1891,7 @@ func (r *Registry) GetResumerForClaimedJob(jobID jobspb.JobID) (Resumer, error) 
 	return aj.resumer, nil
 }
 
-func (r *Registry) getClaimedJob(jobID jobspb.JobID) (*Job, error) {
+func (r *Registry) getAdoptedJob(jobID jobspb.JobID) (*Job, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -1884,9 +1900,9 @@ func (r *Registry) getClaimedJob(jobID jobspb.JobID) (*Job, error) {
 		return nil, &JobNotFoundError{jobID: jobID}
 	}
 	return &Job{
-		id:       jobID,
-		session:  aj.session,
-		registry: r,
+		id:        jobID,
+		sessionID: aj.sessionID,
+		registry:  r,
 	}, nil
 }
 

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -131,17 +131,17 @@ WHERE id = $1
 	if progress, err = UnmarshalProgress(row[2]); err != nil {
 		return err
 	}
-	if j.session != nil {
+	if !j.sessionID.IsEmpty() {
 		if row[3] == tree.DNull {
 			return errors.Errorf(
 				"with status %q: expected session %q but found NULL",
-				status, j.session.ID())
+				status, j.sessionID)
 		}
 		storedSession := []byte(*row[3].(*tree.DBytes))
-		if !bytes.Equal(storedSession, j.session.ID().UnsafeBytes()) {
+		if !bytes.Equal(storedSession, j.sessionID.UnsafeBytes()) {
 			return errors.Errorf(
 				"with status %q: expected session %q but found %q",
-				status, j.session.ID(), sqlliveness.SessionID(storedSession))
+				status, j.sessionID, sqlliveness.SessionID(storedSession))
 		}
 	} else {
 		log.VInfof(ctx, 1, "job %d: update called with no session ID", j.ID())

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1342,7 +1342,7 @@ func ingestWithRetry(
 
 		// Re-load the job in order to update our progress object, which
 		// may have been updated since the flow started.
-		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadClaimedJob(ctx, job.ID())
+		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadAdoptedJob(ctx, job.ID())
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return res, ctx.Err()

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -78,6 +78,11 @@ func (s SessionID) String() string {
 	return hex.EncodeToString(encoding.UnsafeConvertStringToBytes(string(s)))
 }
 
+// IsEmpty returns true if the session ID is zero-valued.
+func (s SessionID) IsEmpty() bool {
+	return s == ""
+}
+
 // SafeValue implements the redact.SafeValue interface.
 func (s SessionID) SafeValue() {}
 


### PR DESCRIPTION
Previously LoadClaimedJob could only be used on the node that had been adopted on this node, making it a bit of a misnomer.

This renames LoadClaimedJob to LoadAdoptedJobs and adds a new LoadClaimedJob that loads a job only if it is claimed by the given session ID.

In a follow-up commit we hope to use this new function so that we can load the job record during job execution from a DistSQL processor on a remote node while still asserting the claim is valid.

Epic: none
Release note: None