### PR TITLE
[wip] new prototyping for rangefeed scalability work 

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2522,6 +2522,10 @@ type RangeFeedEventSink interface {
 	Send(*RangeFeedEvent) error
 }
 
+type MuxRangeFeedEventSink interface {
+	Send(*MuxRangeFeedEvent) error
+}
+
 // RangeFeedEventProducer is an adapter for receiving rangefeed events with either
 // the legacy RangeFeed RPC, or the MuxRangeFeed RPC.
 type RangeFeedEventProducer interface {

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -198,7 +198,6 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/errorutil",
-        "//pkg/util/future",
         "//pkg/util/growstack",
         "//pkg/util/grpcutil",
         "//pkg/util/grunning",

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "stream.go",
         "task.go",
         "testutil.go",
+        "util_helper.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed",
     visibility = ["//visibility:public"],
@@ -49,6 +50,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_uber_go_atomic//:atomic",
     ],
 )
 

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "resolved_timestamp.go",
         "scheduled_processor.go",
         "scheduler.go",
+        "stream.go",
         "task.go",
         "testutil.go",
     ],

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -429,7 +429,7 @@ func (p *LegacyProcessor) run(
 		// Handle new registrations.
 		case r := <-p.regC:
 			if !p.Span.AsRawSpanWithNoLocals().Contains(r.span) {
-				log.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
+				log.Fatalf(ctx, "registration %v not in Processor's key range %v", r, p.Span)
 			}
 
 			// Add the new registration to the registry.
@@ -582,7 +582,7 @@ func (p *LegacyProcessor) Register(
 	catchUpIter *CatchUpIterator,
 	withDiff bool,
 	withFiltering bool,
-	stream Stream,
+	//stream Stream,
 	disconnectFn func(),
 	done *future.ErrorFuture,
 ) (bool, *Filter) {
@@ -793,15 +793,15 @@ func (p *LegacyProcessor) consumeEvent(ctx context.Context, e *event) {
 	case e.sst != nil:
 		p.consumeSSTable(ctx, e.sst.data, e.sst.span, e.sst.ts, e.alloc)
 	case e.sync != nil:
-		if e.sync.testRegCatchupSpan != nil {
-			if err := p.reg.waitForCaughtUp(ctx, *e.sync.testRegCatchupSpan); err != nil {
-				log.Errorf(
-					ctx,
-					"error waiting for registries to catch up during test, results might be impacted: %s",
-					err,
-				)
-			}
-		}
+		//if e.sync.testRegCatchupSpan != nil {
+		//	if err := p.reg.waitForCaughtUp(ctx, *e.sync.testRegCatchupSpan); err != nil {
+		//		log.Errorf(
+		//			ctx,
+		//			"error waiting for registries to catch up during test, results might be impacted: %s",
+		//			err,
+		//		)
+		//	}
+		//}
 		close(e.sync.c)
 	default:
 		panic(fmt.Sprintf("missing event variant: %+v", e))

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -446,20 +446,20 @@ func (p *LegacyProcessor) run(
 			r.publish(ctx, p.newCheckpointEvent(), nil)
 
 			// Run an output loop for the registry.
-			runOutputLoop := func(ctx context.Context) {
-				r.runOutputLoop(ctx, p.RangeID)
-				select {
-				case p.unregC <- &r:
-					if r.unreg != nil {
-						r.unreg()
-					}
-				case <-p.stoppedC:
-				}
-			}
-			if err := stopper.RunAsyncTask(ctx, "rangefeed: output loop", runOutputLoop); err != nil {
-				r.disconnect(kvpb.NewError(err))
-				p.reg.Unregister(ctx, &r)
-			}
+			//runOutputLoop := func(ctx context.Context) {
+			//	r.runOutputLoop(ctx, p.RangeID)
+			//	select {
+			//	//case p.unregC <- &r:
+			//	//	if r.unreg != nil {
+			//	//		r.unreg()
+			//	//	}
+			//	//case <-p.stoppedC:
+			//	//}
+			//}
+			//if err := stopper.RunAsyncTask(ctx, "rangefeed: output loop", runOutputLoop); err != nil {
+			//	r.disconnect(kvpb.NewError(err))
+			//	p.reg.Unregister(ctx, &r)
+			//}
 
 		// Respond to unregistration requests; these come from registrations that
 		// encounter an error during their output loop.

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -323,7 +323,7 @@ func (p *ScheduledProcessor) Register(
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
 	r := newRegistration(
 		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering,
-		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
+		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream,
 	)
 
 	filter := runRequest(p, func(ctx context.Context, p *ScheduledProcessor) *Filter {
@@ -350,10 +350,8 @@ func (p *ScheduledProcessor) Register(
 		stream.Register(func() {
 			r.cleanup()
 			if p.unregisterClient(&r) {
-				// unreg callback is set by replica to tear down processors that have
-				// zero registrations left and to update event filters.
-				if r.unreg != nil {
-					r.unreg()
+				if disconnectFn != nil {
+					disconnectFn()
 				}
 			}
 		})
@@ -364,8 +362,8 @@ func (p *ScheduledProcessor) Register(
 			if p.unregisterClient(&r) {
 				// unreg callback is set by replica to tear down processors that have
 				// zero registrations left and to update event filters.
-				if r.unreg != nil {
-					r.unreg()
+				if disconnectFn != nil {
+					disconnectFn()
 				}
 			}
 		}

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -1,0 +1,287 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// Responsible to coordinate rangefeed level shutdown.
+type producer struct {
+	syncutil.RWMutex
+	streamId int64
+	rangeID  roachpb.RangeID
+	// TODO(wenyihu6): check if only disconnected need to be protected
+	disconnected bool
+	// clean up callback is needed later after removing registration goroutines
+	rangefeedCleanUp func()
+}
+
+type StreamMuxer struct {
+	wrapped    kvpb.MuxRangeFeedEventSink
+	notify     chan struct{}
+	cleanup    chan int64
+	muxErrorsC chan *kvpb.MuxRangeFeedEvent
+
+	nodeLevelCleanUp func(streamID int64) bool
+
+	prodsMu struct {
+		syncutil.RWMutex
+		prods map[int64]*producer
+	}
+}
+
+// Responsible for sending errors, node and rangefeed level cleanups.
+func NewStreamMuxer(
+	wrapped kvpb.MuxRangeFeedEventSink, nodeLevelCleanUp func(int64) bool,
+) *StreamMuxer {
+	muxer := &StreamMuxer{
+		wrapped: wrapped,
+		notify:  make(chan struct{}, 1),
+		cleanup: make(chan int64, 10),
+		// TODO(wenyihu6): check if 10 is a large enough number
+		muxErrorsC:       make(chan *kvpb.MuxRangeFeedEvent, 10),
+		nodeLevelCleanUp: nodeLevelCleanUp,
+	}
+	//TODO(wenyihu6): check if int32 is enough
+	muxer.prodsMu.prods = make(map[int64]*producer)
+	return muxer
+}
+
+type Muxer interface {
+	Register(streamID int64, rangeID roachpb.RangeID, rangefeedCleanUp func())
+	SendUnbuffered(*kvpb.MuxRangeFeedEvent) error
+	HandleRangefeedDisconnectError(streamId int64, rangeId roachpb.RangeID, err *kvpb.Error)
+}
+
+func (m *StreamMuxer) SendUnbuffered(event *kvpb.MuxRangeFeedEvent) error {
+	return m.wrapped.Send(event)
+}
+
+func (m *StreamMuxer) OutputLoop(ctx context.Context, stopper *stop.Stopper) {
+	// TODO(wenyihu6): do we need to watch stopper.ShouldQuiesce
+	for {
+		select {
+		case muxErr := <-m.muxErrorsC:
+			// nothing we could do if stream is broken TODO(wenyihu6): future send
+			// would also fail and just clean up -> check if we need to do any
+			// additional cleanup
+			if err := m.wrapped.Send(muxErr); err != nil {
+				// think about recursion here maybe you should just do nothing
+				// pass in nil so that we send nithing back to the client again
+				m.cleanupProducers(nil)
+				return
+			}
+		case streamId := <-m.cleanup:
+			m.cleanupProducerIfExists(streamId)
+		case <-ctx.Done():
+			m.cleanupProducers(kvpb.NewError(ctx.Err()))
+			return
+		// case <-m.output.Context().Done(): check if this is needed
+		case <-stopper.ShouldQuiesce():
+			// m.cleanupProducers(ctx, nil)
+			return
+		}
+	}
+}
+
+func (m *StreamMuxer) HandleRangefeedDisconnectError(
+	streamId int64, rangeId roachpb.RangeID, err *kvpb.Error,
+) {
+	p, _ := m.getProducerIfExists(streamId)
+	// even if producer is not found we should still clean up node level
+	// if producer has been removed, then it shouldn't exist in map in node level
+	// and we will ignore
+	// if producer found but disconnected, we should do nothing
+	// repeatedly clean up producer should have no side effects
+	needRangefeedCleanUp := p.setDisconnected()
+
+	// node level clean up first
+	loaded := m.nodeLevelCleanUp(streamId)
+	if loaded {
+		clientErrorEvent := transformSingleFeedErrorToMuxEvent(streamId, rangeId, err)
+		// should we send an error here or wait and push back
+		m.sendErrorToClient(clientErrorEvent)
+	}
+
+	// producer level clean up if needed
+	// err can be nil
+	if needRangefeedCleanUp {
+		m.cleanup <- streamId
+	}
+}
+
+func (m *StreamMuxer) cleanupProducerIfExists(streamId int64) {
+	p := m.popProducerByStreamId(streamId)
+	if p == nil {
+		return
+	}
+	// r.cleanup() should be already called, but call again just in case plus some
+	// p clean up
+	p.rangefeedLevelCleanUp()
+}
+func (m *StreamMuxer) cleanupProducers(streamErr *kvpb.Error) {
+	prods := m.popAllConnectedProducers()
+	for _, p := range prods {
+		loaded := m.nodeLevelCleanUp(p.streamId)
+		// streamErr is nil means stream is broken now when we should just shut down
+		// without sending error back
+		if streamErr != nil && loaded {
+			clientErrorEvent := transformSingleFeedErrorToMuxEvent(p.streamId, p.rangeID, streamErr)
+			m.sendErrorToClient(clientErrorEvent)
+		}
+		p.rangefeedLevelCleanUp()
+	}
+}
+func transformSingleFeedErrorToMuxEvent(
+	streamId int64, rangeID roachpb.RangeID, singleFeedErr *kvpb.Error,
+) *kvpb.MuxRangeFeedEvent {
+	// we should instead just make p to return an actual rangefeedclosed error
+	// rather than allowing nil error here
+	if singleFeedErr == nil {
+		// If the stream was explicitly closed by the client, we expect to see
+		// context.Canceled error.  In this case, return
+		// kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED to the client.
+		singleFeedErr = kvpb.NewError(kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED))
+	}
+
+	ev := &kvpb.MuxRangeFeedEvent{
+		RangeID:  rangeID,
+		StreamID: streamId,
+	}
+	ev.SetValue(&kvpb.RangeFeedError{
+		Error: *singleFeedErr,
+	})
+	return ev
+}
+
+func (m *StreamMuxer) sendErrorToClient(event *kvpb.MuxRangeFeedEvent) {
+	if event == nil {
+		log.Infof(context.Background(), "unexpected event is nil")
+		return
+	}
+	// terminate a stream here
+	m.muxErrorsC <- event
+}
+
+func (m *StreamMuxer) Register(streamID int64, rangeID roachpb.RangeID, cleanup func()) {
+	m.addProducer(streamID, rangeID, cleanup)
+}
+
+func (m *StreamMuxer) addProducer(
+	streamId int64, rangeID roachpb.RangeID, rangefeedCleanUp func(),
+) {
+	m.prodsMu.Lock()
+	defer m.prodsMu.Unlock()
+	if _, ok := m.prodsMu.prods[streamId]; ok {
+		log.Error(context.Background(), "stream already exists")
+	}
+	m.prodsMu.prods[streamId] = &producer{streamId: streamId, rangeID: rangeID, rangefeedCleanUp: rangefeedCleanUp}
+}
+
+func (m *StreamMuxer) popAllConnectedProducers() (prods []*producer) {
+	m.prodsMu.Lock()
+	defer m.prodsMu.Unlock()
+
+	for streamId, p := range m.prodsMu.prods {
+		delete(m.prodsMu.prods, streamId)
+		if !p.isDisconnected() {
+			prods = append(prods, p)
+		}
+	}
+	return prods
+}
+
+func (p *producer) rangefeedLevelCleanUp() {
+	p.Lock()
+	f := p.rangefeedCleanUp
+	p.rangefeedCleanUp = nil
+	p.Unlock()
+	if f != nil {
+		f()
+	}
+}
+
+func (m *StreamMuxer) popProducerByStreamId(streamId int64) *producer {
+	m.prodsMu.Lock()
+	defer m.prodsMu.Unlock()
+
+	p, ok := m.prodsMu.prods[streamId]
+	delete(m.prodsMu.prods, streamId)
+	if !ok {
+		log.Error(context.Background(), "attempt to remove non-existent stream")
+	}
+	return p
+}
+
+func (m *StreamMuxer) getProducerIfExists(streamId int64) (*producer, bool) {
+	m.prodsMu.RLock()
+	defer m.prodsMu.RUnlock()
+	if _, ok := m.prodsMu.prods[streamId]; !ok {
+		return nil, false
+	}
+	return m.prodsMu.prods[streamId], true
+}
+
+func (p *producer) setDisconnected() (needCleanUp bool) {
+	if p == nil {
+		return false
+	}
+	p.RLock()
+	defer p.RUnlock()
+	if p.disconnected {
+		return false
+	}
+	p.disconnected = true
+	return true
+}
+
+func (p *producer) isDisconnected() bool {
+	p.RLock()
+	defer p.RUnlock()
+	return !p.disconnected
+}
+
+type BufferedStream interface {
+	SendUnbuffered(event *kvpb.RangeFeedEvent) error
+	SendError(err *kvpb.Error)
+	Register(rangefeedCleanUp func())
+}
+
+type StreamSink struct {
+	RangeID     roachpb.RangeID
+	StreamID    int64
+	StreamMuxer Muxer
+}
+
+func (s *StreamSink) SendError(err *kvpb.Error) {
+	s.StreamMuxer.HandleRangefeedDisconnectError(s.StreamID, s.RangeID, err)
+}
+
+func (s *StreamSink) Register(rangefeedCleanUp func()) {
+	s.StreamMuxer.Register(s.StreamID, s.RangeID, rangefeedCleanUp)
+}
+
+func (s *StreamSink) SendUnbuffered(event *kvpb.RangeFeedEvent) error {
+	return s.StreamMuxer.SendUnbuffered(&kvpb.MuxRangeFeedEvent{
+		RangeFeedEvent: *event,
+		RangeID:        s.RangeID,
+		StreamID:       s.StreamID,
+	})
+}
+
+var _ BufferedStream = (*StreamSink)(nil)

--- a/pkg/kv/kvserver/rangefeed/testutil.go
+++ b/pkg/kv/kvserver/rangefeed/testutil.go
@@ -11,10 +11,7 @@
 package rangefeed
 
 func NewTestProcessor(id int64) Processor {
-	if id > 0 {
-		return &ScheduledProcessor{
-			scheduler: ClientScheduler{id: id},
-		}
+	return &ScheduledProcessor{
+		scheduler: ClientScheduler{id: id},
 	}
-	return &LegacyProcessor{}
 }

--- a/pkg/kv/kvserver/rangefeed/util_helper.go
+++ b/pkg/kv/kvserver/rangefeed/util_helper.go
@@ -1,0 +1,151 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+type sharedMuxEvent struct {
+	streamID int64
+	rangeID  roachpb.RangeID
+	event    *kvpb.RangeFeedEvent
+	alloc    *SharedBudgetAllocation
+}
+
+// Number of queue elements allocated at once to amortize queue allocations.
+const eventQueueChunkSize = 4000
+
+// idQueueChunk is a queue chunk of a fixed size which idQueue uses to extend
+// its storage. Chunks are kept in the pool to reduce allocations.
+type eventQueueChunk struct {
+	data      [eventQueueChunkSize]sharedMuxEvent
+	nextChunk *eventQueueChunk
+}
+
+var sharedEventQueueChunkSyncPool = sync.Pool{
+	New: func() interface{} {
+		return new(eventQueueChunk)
+	},
+}
+
+func getPooledEventQueueChunk() *eventQueueChunk {
+	return sharedEventQueueChunkSyncPool.Get().(*eventQueueChunk)
+}
+
+func putPooledEventQueueChunk(e *eventQueueChunk) {
+	*e = eventQueueChunk{}
+	sharedEventQueueChunkSyncPool.Put(e)
+}
+
+// muxEventQueue stores pending processor ID's. Internally data is stored in
+// eventQueueChunk sized arrays that are added as needed and discarded once
+// reader and writers finish working with it. Since we only have a single
+// scheduler per store, we don't use a pool as only reuse could happen within
+// the same queue and in that case we can just increase chunk size.
+type muxEventQueue struct {
+	first, last *eventQueueChunk
+	read, write int
+	size        int
+}
+
+func newMuxEventQueue() muxEventQueue {
+	chunk := getPooledEventQueueChunk()
+	return muxEventQueue{
+		first: chunk,
+		last:  chunk,
+	}
+}
+
+func (q *muxEventQueue) pushBack(event sharedMuxEvent) {
+	if q.write == eventQueueChunkSize {
+		nexChunk := getPooledEventQueueChunk()
+		q.last.nextChunk = nexChunk
+		q.last = nexChunk
+		q.write = 0
+	}
+	q.last.data[q.write] = event
+	q.write++
+	q.size++
+}
+
+func (q *muxEventQueue) popFront() (sharedMuxEvent, bool) {
+	//if q.first == q.last && q.read == q.write {
+	//	return sharedMuxEvent{}, false
+	//}
+	if q.size == 0 {
+		return sharedMuxEvent{}, false
+	}
+	if q.read == eventQueueChunkSize {
+		removed := q.first
+		q.first = q.first.nextChunk
+		putPooledEventQueueChunk(removed)
+		q.read = 0
+	}
+	res := q.first.data[q.read]
+	q.first.data[q.read] = sharedMuxEvent{}
+	q.read++
+	q.size--
+	return res, true
+}
+
+// remove releases allocations and zero out entries that belong to particular
+// streamID. Queue size is reduced by amount of removed entries, but empty
+// entries stay until their chunks are removed. Removed entries are not counted
+// against capacity when determining overflow.
+func (q *muxEventQueue) remove(ctx context.Context, streamID int64) {
+	start := q.read
+	for chunk := q.first; chunk != nil; chunk = chunk.nextChunk {
+		max := eventQueueChunkSize
+		if chunk.nextChunk == nil {
+			max = q.write
+		}
+		for i := start; i < max; i++ {
+			if chunk.data[i].streamID == streamID {
+				chunk.data[i].alloc.Release(ctx)
+				chunk.data[i] = sharedMuxEvent{}
+				q.size--
+			}
+		}
+		start = 0
+	}
+}
+
+// removeAll removes aren releases all entries in the queue.
+func (q *muxEventQueue) removeAll(ctx context.Context) {
+	start := q.read
+	for chunk := q.first; chunk != nil; {
+		max := eventQueueChunkSize
+		if chunk.nextChunk == nil {
+			max = q.write
+		}
+		for i := start; i < max; i++ {
+			chunk.data[i].alloc.Release(ctx)
+			chunk.data[i] = sharedMuxEvent{}
+		}
+		next := chunk.nextChunk
+		putPooledEventQueueChunk(chunk)
+		chunk = next
+		start = 0
+	}
+	q.first = q.last
+	q.read = 0
+	q.write = 0
+	q.size = 0
+}
+
+func (q *muxEventQueue) len() int {
+	return q.size
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -74,7 +74,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -3133,22 +3132,17 @@ func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreD
 // the provided stream and returns a future with an optional error when the rangefeed is
 // complete.
 func (s *Store) RangeFeed(
-	args *kvpb.RangeFeedRequest, stream kvpb.RangeFeedEventSink,
-) *future.ErrorFuture {
-	if filter := s.TestingKnobs().TestingRangefeedFilter; filter != nil {
-		if pErr := filter(args, stream); pErr != nil {
-			return future.MakeCompletedErrorFuture(pErr.GoError())
-		}
-	}
+	ctx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.BufferedStream,
+) error {
 
 	if err := verifyKeys(args.Span.Key, args.Span.EndKey, true); err != nil {
-		return future.MakeCompletedErrorFuture(err)
+		return err
 	}
 
 	// Get range and add command to the range for execution.
 	repl, err := s.GetReplica(args.RangeID)
 	if err != nil {
-		return future.MakeCompletedErrorFuture(err)
+		return err
 	}
 	if !repl.IsInitialized() {
 		// (*Store).Send has an optimization for uninitialized replicas to send back
@@ -3156,12 +3150,12 @@ func (s *Store) RangeFeed(
 		// be found. RangeFeeds can always be served from followers and so don't
 		// otherwise return NotLeaseHolderError. For simplicity we also don't return
 		// one here.
-		return future.MakeCompletedErrorFuture(kvpb.NewRangeNotFoundError(args.RangeID, s.StoreID()))
+		return kvpb.NewRangeNotFoundError(args.RangeID, s.StoreID())
 	}
 
 	tenID, _ := repl.TenantID()
 	pacer := s.cfg.KVAdmissionController.AdmitRangefeedRequest(tenID, args)
-	return repl.RangeFeed(args, stream, pacer)
+	return repl.RangeFeed(ctx, args, stream, pacer)
 }
 
 // updateReplicationGauges counts a number of simple replication statistics for

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -20,10 +20,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/disk"
-	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -211,9 +211,8 @@ func (ls *Stores) SendWithWriteBytes(
 // updates to the provided stream and returns a future with an optional error
 // when the rangefeed is complete.
 func (ls *Stores) RangeFeed(
-	args *kvpb.RangeFeedRequest, stream kvpb.RangeFeedEventSink,
-) *future.ErrorFuture {
-	ctx := stream.Context()
+	ctx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.BufferedStream,
+) error {
 	if args.RangeID == 0 {
 		log.Fatal(ctx, "rangefeed request missing range ID")
 	} else if args.Replica.StoreID == 0 {
@@ -222,10 +221,10 @@ func (ls *Stores) RangeFeed(
 
 	store, err := ls.GetStore(args.Replica.StoreID)
 	if err != nil {
-		return future.MakeCompletedErrorFuture(err)
+		return err
 	}
 
-	return store.RangeFeed(args, stream)
+	return store.RangeFeed(ctx, args, stream)
 }
 
 // ReadBootstrapInfo implements the gossip.Storage interface. Read

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -297,7 +297,6 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
-        "//pkg/util/future",
         "//pkg/util/goschedstats",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",


### PR DESCRIPTION
Just prototyping - This patch reduces registration goroutines and removes r.buf at rangefeed level.

TODO: 
- is it okay to send repeated registration error 
- Is it okay to send some event messages after being disconnected -> handlerangefeed shutdown may not happen right away and catch up scan doesn't listen to context cancel 
- Is it okay if you dont see events that happened before disconnect? After disconnecting, do we still want to send the messages buffered before disconnecting? 
- rationalize memory accounting
- tests 

Shutdown logic: https://docs.google.com/document/d/1rQzVYnI4XuWloenEYa_9cvQ5aVYPlhR2cb8IAQKo6_M/edit?usp=sharing