### PR TITLE
release-23.2.6-rc: acceptance: use `docker compose`

### DIFF
--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cockroach:
     image: ubuntu:xenial-20210804

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   kdc:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   kdc:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -73,8 +73,13 @@ func testCompose(t *testing.T, path string, exitCodeFrom string) {
 		t.Fatalf(err.Error())
 	}
 	cmd := exec.Command(
-		"docker-compose",
-		"--no-ansi",
+		"docker",
+		"compose",
+		// NB: Using --compatibility here in order to preserve compose V1 hostnames
+		// (with underscores) instead of V2 hostnames (with -), because the
+		// hostnames are hardcoded in the Kerberos keys.
+		"--compatibility",
+		"--ansi=never",
 		"-f", path,
 		"up",
 		"--force-recreate",

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   cockroach1:
     image: ubuntu:xenial-20170214

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -123,7 +123,7 @@ func TestComposeCompare(t *testing.T) {
 		"docker",
 		"compose",
 		"-f", dockerComposeYml,
-		"--no-ansi",
+		"--ansi=never",
 		"up",
 		"--force-recreate",
 		"--exit-code-from", "test",

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -120,7 +120,8 @@ func TestComposeCompare(t *testing.T) {
 		}
 	}
 	cmd := exec.Command(
-		"docker-compose",
+		"docker",
+		"compose",
 		"-f", dockerComposeYml,
 		"--no-ansi",
 		"up",

--- a/scripts/localmetrics/README.md
+++ b/scripts/localmetrics/README.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```
-docker-compose up -d
+docker compose up -d
 ./import-csv.sh < (curl https://gist.githubusercontent.com/tbg/98d9814f624629833e6cfb7d25cb8258/raw/70a96d50032361f864b240dbd9f1c36c385b7515/sample.csv)
 # User/Pass admin/x
 open http://127.0.0.1:3000
@@ -17,7 +17,7 @@ The source of this could be a `debug zip` (pending [#50432]), or
 
 `./cockroach debug tsdump --format=csv --host=... > dump.csv`.
 
-### Step 2: `docker-compose up -d`
+### Step 2: `docker compose up -d`
 
 Not much more to be said. Unsurprisingly, this needs Docker to work. Omit the
 `-d` if you want to see what's going on behind the scenes. It may take a moment
@@ -46,7 +46,7 @@ Replace ./grafana/dashboards/home.json if you want the changes to persist.
 
 TODO(tbg): auto-generate a better home.json from `pkg/ts/catalog`.
 
-### Step 5: docker-compose stop
+### Step 5: docker compose stop
 
 To avoid hogging resources on your machine. The postgres database is on your
 local file system, so it will remain. If you want to nuke everything, use


### PR DESCRIPTION
Backport:
  * 1/1 commits from "release-23.2: acceptance: use `docker compose`" (#124868)
  * 1/1 commits from "release-23.2: acceptance: use `docker compose` (part 2)" (#124918)

Please see individual PRs for details.

/cc @cockroachdb/release
Release justification: test-only changes
