### PR TITLE
util: clean up retry

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -690,7 +690,7 @@ func (n *Node) waitUntilLive(dur time.Duration) error {
 		Multiplier:     2,
 		Closer:         closer,
 	}
-	for r := retry.Start(opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		var pid int
 		n.Lock()
 		if n.cmd != nil {

--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -687,7 +687,6 @@ func (n *Node) waitUntilLive(dur time.Duration) error {
 	opts := retry.Options{
 		InitialBackoff: time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
-		Multiplier:     2,
 		Closer:         closer,
 	}
 	for r := retry.Start(ctx, opts); r.Next(); {

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -756,18 +755,6 @@ func (cfg RaftConfig) NodeLivenessDurations() (livenessActive, livenessRenewal t
 // gossips it.
 func (cfg RaftConfig) SentinelGossipTTL() time.Duration {
 	return cfg.RangeLeaseDuration
-}
-
-// DefaultRetryOptions should be used for retrying most
-// network-dependent operations.
-func DefaultRetryOptions() retry.Options {
-	// TODO(bdarnell): This should vary with network latency.
-	// Derive the retry options from a configured or measured
-	// estimate of latency.
-	return retry.Options{
-		InitialBackoff: 50 * time.Millisecond,
-		MaxBackoff:     1 * time.Second,
-	}
 }
 
 // maxInflightBytesFrom returns the minimal value for RaftMaxInflightBytes

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -767,7 +767,6 @@ func DefaultRetryOptions() retry.Options {
 	return retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
 	}
 }
 

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -66,7 +66,7 @@ func BenchmarkPgbenchQueryParallel(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			src := rand.New(rand.NewSource(5432))
-			r := retry.Start(retryOpts)
+			r := retry.Start(context.Background(), retryOpts)
 			var err error
 			for pb.Next() {
 				r.Reset()

--- a/pkg/bench/pgbench_test.go
+++ b/pkg/bench/pgbench_test.go
@@ -60,7 +60,6 @@ func BenchmarkPgbenchQueryParallel(b *testing.B) {
 		retryOpts := retry.Options{
 			InitialBackoff: 1 * time.Millisecond,
 			MaxBackoff:     200 * time.Millisecond,
-			Multiplier:     2,
 		}
 
 		b.ResetTimer()

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -838,7 +838,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	var res roachpb.RowCount
 	var lastProgress float32
 	var numBackupInstances int
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		res, numBackupInstances, err = backup(
 			ctx,
 			p,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -177,7 +177,7 @@ func restoreWithRetry(
 		currentPersistedSpans  jobspb.RestoreFrontierEntries
 	)
 
-	for r := retry.StartWithCtx(restoreCtx, retryOpts); r.Next(); {
+	for r := retry.Start(restoreCtx, retryOpts); r.Next(); {
 		res, err = restore(
 			restoreCtx,
 			execCtx,

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -526,7 +526,7 @@ func (r *restoreResumer) sendDownloadWorker(
 		ctx, tsp := tracing.ChildSpan(ctx, "backupccl.sendDownloadWorker")
 		defer tsp.Finish()
 
-		for rt := retry.StartWithCtx(
+		for rt := retry.Start(
 			ctx, retry.Options{InitialBackoff: time.Millisecond * 100, MaxBackoff: time.Second * 10},
 		); ; rt.Next() {
 			if err := ctx.Err(); err != nil {
@@ -658,7 +658,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	}
 
 	var lastProgressUpdate time.Time
-	for rt := retry.StartWithCtx(
+	for rt := retry.Start(
 		ctx, retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second * 10},
 	); ; rt.Next() {
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -678,7 +678,7 @@ var jobRecordRetryOpts = retry.Options{
 
 // waitForCheckpoint waits for the specified job to have a non-empty checkpoint
 func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
-	for r := retry.Start(jobRecordRetryOpts); ; {
+	for r := retry.Start(context.Background(), jobRecordRetryOpts); ; {
 		t.Log("waiting for checkpoint")
 		progress := loadProgress(t, jf, jr)
 		if p := progress.GetChangefeed(); p != nil && p.Checkpoint != nil && len(p.Checkpoint.Spans) > 0 {
@@ -693,7 +693,7 @@ func waitForCheckpoint(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Reg
 
 // waitForHighwater waits for the specified job to have a non-nil highwater.
 func waitForHighwater(t *testing.T, jf cdctest.EnterpriseTestFeed, jr *jobs.Registry) {
-	for r := retry.Start(jobRecordRetryOpts); ; {
+	for r := retry.Start(context.Background(), jobRecordRetryOpts); ; {
 		t.Log("waiting for highwater")
 		progress := loadProgress(t, jf, jr)
 		if hw := progress.GetHighWater(); hw != nil && !hw.IsEmpty() {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -671,7 +671,6 @@ var jobRecordPollFrequency = 3 * time.Second
 
 var jobRecordRetryOpts = retry.Options{
 	InitialBackoff: jobRecordPollFrequency,
-	Multiplier:     2,
 	MaxBackoff:     1 * time.Minute,
 	MaxRetries:     10,
 }

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -151,7 +151,7 @@ func (p *scanRequestScanner) tryAcquireMemory(
 
 	// We failed to acquire memory for this export.  Begin retry loop -- we may succeed
 	// in the future, once somebody releases memory.
-	for attempt := retry.StartWithCtx(ctx, retryOpts); attempt.Next(); {
+	for attempt := retry.Start(ctx, retryOpts); attempt.Next(); {
 		// Sink implements memory allocator interface, so acquire
 		// memory needed to hold scan reply.
 		if logMemAcquireEvery.ShouldLog() {

--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -36,7 +36,7 @@ func getRetry(ctx context.Context) Retry {
 		}
 	}
 
-	return Retry{Retry: retry.StartWithCtx(ctx, opts)}
+	return Retry{Retry: retry.Start(ctx, opts)}
 }
 
 func testingUseFastRetry() func() {

--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -24,14 +24,12 @@ var useFastRetry = envutil.EnvOrDefaultBool(
 func getRetry(ctx context.Context) Retry {
 	opts := retry.Options{
 		InitialBackoff: 5 * time.Second,
-		Multiplier:     2,
 		MaxBackoff:     10 * time.Minute,
 	}
 
 	if useFastRetry {
 		opts = retry.Options{
 			InitialBackoff: 5 * time.Millisecond,
-			Multiplier:     2,
 			MaxBackoff:     250 * time.Millisecond,
 		}
 	}

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -280,7 +280,7 @@ func (r *confluentSchemaRegistry) doWithRetry(ctx context.Context, fn func() err
 	// actionable issues in the operator's environment that which they might be
 	// able to resolve if we made them visible in a failure instead.
 	var err error
-	for retrier := retry.StartWithCtx(ctx, r.retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, r.retryOpts); retrier.Next(); {
 		err = fn()
 		if err == nil {
 			return nil

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -164,13 +163,11 @@ func newConfluentSchemaRegistry(
 		return nil, err
 	}
 
-	retryOpts := base.DefaultRetryOptions()
-	retryOpts.MaxRetries = 5
 	reg := schemaRegistryWithCache{
 		base: &confluentSchemaRegistry{
 			baseURL:    u,
 			client:     httpClient,
-			retryOpts:  retryOpts,
+			retryOpts:  retry.Options{MaxRetries: 5},
 			sliMetrics: sliMetrics,
 		},
 		cache: src,

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -772,7 +772,6 @@ func defaultRetryConfig() retry.Options {
 	opts := retry.Options{
 		InitialBackoff: 500 * time.Millisecond,
 		MaxRetries:     3,
-		Multiplier:     2,
 	}
 	// max backoff should be initial * 2 ^ maxRetries
 	opts.MaxBackoff = opts.InitialBackoff * time.Duration(int(math.Pow(2.0, float64(opts.MaxRetries))))

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -205,7 +205,7 @@ func (c *connector) dialTenantCluster(
 	var err error
 
 	isRetry := false
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		// Track the number of dial retries.
 		if isRetry && c.DialTenantRetries != nil {
 			c.DialTenantRetries.Inc(1)

--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/storageccl",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/cloud",
         "//pkg/kv/kvpb",
         "//pkg/settings",

--- a/pkg/ccl/storageccl/external_sst_reader.go
+++ b/pkg/ccl/storageccl/external_sst_reader.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -50,7 +49,7 @@ func getFileWithRetry(
 	var f ioctx.ReadCloserCtx
 	var sz int64
 	const maxAttempts = 3
-	if err := retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxAttempts, func() error {
+	if err := retry.WithMaxAttempts(ctx, retry.Options{}, maxAttempts, func() error {
 		var err error
 		f, sz, err = e.ReadFile(ctx, basename, cloud.ReadOptions{})
 		return err

--- a/pkg/ccl/streamingccl/logical/logical_replication_job.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_job.go
@@ -380,7 +380,7 @@ func (r *logicalReplicationResumer) ingestWithRetries(
 	ro := getRetryPolicy(execCtx.ExecCfg().StreamingTestingKnobs)
 	var err error
 	var lastReplicatedTime hlc.Timestamp
-	for retrier := retry.Start(ro); retrier.Next(); {
+	for retrier := retry.Start(ctx, ro); retrier.Next(); {
 		err = r.ingest(ctx, execCtx)
 		if err == nil {
 			break

--- a/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
+++ b/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
@@ -259,7 +259,7 @@ func (sc *spanConfigIngestor) flushEvents(ctx context.Context) error {
 		MaxRetries:     5,
 	}
 
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		sessionStart, sessionExpiration := sc.session.Start(), sc.session.Expiration()
 		if sessionExpiration.IsEmpty() {
 			return errors.Errorf("sqlliveness session has expired")

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -855,7 +855,7 @@ func waitUntilProducerActive(
 	// Make sure the producer job is active before start the stream replication.
 	var status streampb.StreamReplicationStatus
 	var err error
-	for r := retry.Start(ro); r.Next(); {
+	for r := retry.Start(ctx, ro); r.Next(); {
 		status, err = client.Heartbeat(ctx, streamID, heartbeatTimestamp)
 		if err != nil {
 			return errors.Wrapf(err, "failed to resume ingestion job %d due to producer job %d error",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -848,7 +848,6 @@ func waitUntilProducerActive(
 ) error {
 	ro := retry.Options{
 		InitialBackoff: 1 * time.Second,
-		Multiplier:     2,
 		MaxBackoff:     5 * time.Second,
 		MaxRetries:     4,
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -243,7 +243,7 @@ func ingestWithRetries(
 	ro := getRetryPolicy(execCtx.ExecCfg().StreamingTestingKnobs)
 	var err error
 	var lastReplicatedTime hlc.Timestamp
-	for r := retry.Start(ro); r.Next(); {
+	for r := retry.Start(ctx, ro); r.Next(); {
 		err = ingest(ctx, execCtx, resumer)
 		if err == nil {
 			break

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -771,7 +771,7 @@ func (c *transientCluster) waitForNodeIDReadiness(
 	ctx context.Context, idx int, errCh chan error, timeoutCh <-chan time.Time,
 ) error {
 	retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond, MaxBackoff: time.Second}
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		c.infoLog(ctx, "waiting for server %d to know its node ID", idx)
 		select {
 		// Errors or premature shutdown.
@@ -814,7 +814,7 @@ func (c *transientCluster) waitForSQLReadiness(
 	baseCtx context.Context, idx int, errCh chan error, timeoutCh <-chan time.Time,
 ) error {
 	retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond, MaxBackoff: time.Second}
-	for r := retry.StartWithCtx(baseCtx, retryOpts); r.Next(); {
+	for r := retry.Start(baseCtx, retryOpts); r.Next(); {
 		ctx := logtags.AddTag(baseCtx, "n", c.servers[idx].NodeID())
 		c.infoLog(ctx, "waiting for server %d to become ready", idx)
 		select {
@@ -2161,7 +2161,7 @@ func (c *transientCluster) lockDir(
 	}
 
 	every := log.Every(1 * time.Second)
-	for retry := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 20}); retry.Next(); {
+	for retry := retry.Start(ctx, retry.Options{MaxRetries: 20}); retry.Next(); {
 		if err := tlsLock.TryLock(); err != nil {
 			if errors.Is(err, lockfile.ErrBusy) {
 				if every.ShouldLog() {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -108,7 +108,7 @@ func dialAndCheckHealth(ctx context.Context) error {
 		return err
 	}
 
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		if err := timeutil.RunWithTimeout(
 			ctx, "init-open-conn", 5*time.Second, tryConnect,
 		); err != nil {

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -535,7 +535,7 @@ func runDecommissionNodeImpl(
 	}
 
 	prevResponse := serverpb.DecommissionStatusResponse{}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		req := &serverpb.DecommissionRequest{
 			NodeIDs:          nodeIDs,
 			TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONING,

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -469,7 +469,6 @@ func runDecommissionNodeImpl(
 	minReplicaCount := int64(math.MaxInt64)
 	opts := retry.Options{
 		InitialBackoff: 5 * time.Millisecond,
-		Multiplier:     2,
 		MaxBackoff:     20 * time.Second,
 	}
 

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -136,7 +135,7 @@ func DelayedRetry(
 	ctx, sp := tracing.ChildSpan(ctx, fmt.Sprintf("cloud.DelayedRetry.%s", opName))
 	defer sp.Finish()
 
-	return retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), MaxDelayedRetryAttempts, func() error {
+	return retry.WithMaxAttempts(ctx, retry.Options{}, MaxDelayedRetryAttempts, func() error {
 		err := fn()
 		if err == nil {
 			return nil

--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -70,7 +70,6 @@ var HTTPRetryOptions = retry.Options{
 	InitialBackoff: 100 * time.Millisecond,
 	MaxBackoff:     2 * time.Second,
 	MaxRetries:     32,
-	Multiplier:     4,
 }
 
 var httpMetrics = settings.RegisterBoolSetting(

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -114,7 +114,7 @@ func (h *httpStorage) openStreamAt(
 		headers = map[string]string{"Range": fmt.Sprintf("bytes=%d-", pos)}
 	}
 
-	for attempt, retries := 0, retry.StartWithCtx(ctx, cloud.HTTPRetryOptions); retries.Next(); attempt++ {
+	for attempt, retries := 0, retry.Start(ctx, cloud.HTTPRetryOptions); retries.Next(); attempt++ {
 		resp, err := h.req(ctx, "GET", url, nil, headers)
 		if err == nil {
 			return resp, err

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -234,7 +234,7 @@ func TestHttpGet(t *testing.T) {
 					InitialBackoff: 500 * time.Microsecond,
 					MaxBackoff:     5 * time.Millisecond,
 				}
-				for attempt := retry.StartWithCtx(ctx, opts); attempt.Next(); {
+				for attempt := retry.Start(ctx, opts); attempt.Next(); {
 					s.CloseClientConnections()
 				}
 				return nil

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -305,7 +305,7 @@ func checkDMSReplicated(
 	// both tables have the same number of rows.
 	t.L().Printf("testing all data gets replicated")
 	if err := func() error {
-		for r := retry.StartWithCtx(ctx, waitForReplicationRetryOpts); r.Next(); {
+		for r := retry.Start(ctx, waitForReplicationRetryOpts); r.Next(); {
 			err := func() error {
 				var numRows int
 				if err := targetPGConn.QueryRow("SELECT count(1) FROM test_table").Scan(&numRows); err != nil {
@@ -351,7 +351,7 @@ func checkDMSReplicated(
 
 	t.L().Printf("testing all subsequent updates get replicated")
 	if err := func() error {
-		for r := retry.StartWithCtx(ctx, waitForReplicationRetryOpts); r.Next(); {
+		for r := retry.Start(ctx, waitForReplicationRetryOpts); r.Next(); {
 			err := func() error {
 				var countOfDeletedRow int
 				if err := targetPGConn.QueryRow("SELECT count(1) FROM test_table WHERE id = $1", deleteRowID).Scan(&countOfDeletedRow); err != nil {
@@ -397,7 +397,7 @@ func checkDMSNoPKTableError(ctx context.Context, t test.Test, dmsCli *dms.Client
 	}
 	t.L().Printf("testing no pk table has a table error")
 	if err := func() error {
-		for r := retry.StartWithCtx(ctx, waitForTableError); r.Next(); {
+		for r := retry.Start(ctx, waitForTableError); r.Next(); {
 			err := func() error {
 				dmsTasks, err := dmsCli.DescribeReplicationTasks(ctx, dmsDescribeTasksInput(t.BuildVersion(), "test_table_no_pk"))
 				if err != nil {
@@ -435,7 +435,7 @@ func checkFullLargeDataLoad(ctx context.Context, t test.Test, dmsCli *dms.Client
 	}
 	t.L().Printf("testing all rows from test_table_large replicate")
 	var numRows, nonUpdate = 0, 0
-	for r := retry.StartWithCtx(ctx, waitForFullLoad); r.Next(); {
+	for r := retry.Start(ctx, waitForFullLoad); r.Next(); {
 		err := func() error {
 			dmsTasks, err := dmsCli.DescribeReplicationTasks(ctx, dmsDescribeTasksInput(t.BuildVersion(), "test_table_large"))
 			if err != nil {
@@ -804,7 +804,7 @@ func setupDMSEndpointsAndTask(
 		}); err != nil {
 			return errors.Wrapf(err, "error initiating a test connection")
 		}
-		r := retry.StartWithCtx(ctx, retry.Options{
+		r := retry.Start(ctx, retry.Options{
 			InitialBackoff: 30 * time.Second,
 			MaxBackoff:     time.Minute,
 			MaxRetries:     10,
@@ -876,7 +876,7 @@ func setupDMSEndpointsAndTask(
 		}
 
 		t.L().Printf("starting replication task")
-		r := retry.StartWithCtx(ctx, retry.Options{
+		r := retry.Start(ctx, retry.Options{
 			InitialBackoff: 10 * time.Second,
 			MaxBackoff:     20 * time.Second,
 			MaxRetries:     10,
@@ -910,7 +910,7 @@ func dmsTaskStatusChecker(
 	ctx context.Context, dmsCli *dms.Client, input *dms.DescribeReplicationTasksInput, status string,
 ) error {
 	closer := make(chan struct{})
-	r := retry.StartWithCtx(ctx, retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     30 * time.Second,
 		Closer:         closer,
@@ -1141,7 +1141,7 @@ func tearDownRDSInstances(ctx context.Context, t test.Test, rdsCli *rds.Client) 
 				// group but the cluster takes a while to wind down. Ideally, we wait
 				// for the cluster to get deleted. However, there is no provided
 				// NewDBClusterDeletedWaiter, so we just have to retry it by hand.
-				r := retry.StartWithCtx(ctx, retry.Options{
+				r := retry.Start(ctx, retry.Options{
 					InitialBackoff: 30 * time.Second,
 					MaxBackoff:     time.Minute,
 					MaxRetries:     60,

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -103,7 +103,7 @@ func repeatRunE(
 	args ...string,
 ) error {
 	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -136,7 +136,7 @@ func repeatRunWithDetailsSingleNode(
 		lastResult install.RunResultDetails
 		lastError  error
 	)
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return lastResult, ctx.Err()
 		}
@@ -165,7 +165,7 @@ func repeatGitCloneE(
 	node option.NodeListOption,
 ) error {
 	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -218,7 +218,7 @@ func repeatGetLatestTag(
 		return i
 	}
 	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, canaryRetryOptions); r.Next(); {
+	for attempt, r := 0, retry.Start(ctx, canaryRetryOptions); r.Next(); {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -88,7 +88,6 @@ func maybeAddGithubLink(issue string) string {
 
 var canaryRetryOptions = retry.Options{
 	InitialBackoff: 10 * time.Second,
-	Multiplier:     2,
 	MaxBackoff:     5 * time.Minute,
 	MaxRetries:     10,
 }

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -86,7 +86,7 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 	rOpts := base.DefaultRetryOptions()
 	rOpts.MaxRetries = 5
 	rOpts.MaxBackoff = 10 * time.Second
-	r := retry.StartWithCtx(ctx, rOpts)
+	r := retry.Start(ctx, rOpts)
 	succeeded := false
 	for r.Next() {
 		start = timeutil.Now()

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
@@ -83,9 +82,7 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 	var start time.Time
 	var det install.RunResultDetails
 
-	rOpts := base.DefaultRetryOptions()
-	rOpts.MaxRetries = 5
-	rOpts.MaxBackoff = 10 * time.Second
+	rOpts := retry.Options{MaxRetries: 5, MaxBackoff: 10 * time.Second}
 	r := retry.Start(ctx, rOpts)
 	succeeded := false
 	for r.Next() {

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -399,7 +399,6 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 	retryOpts := retry.Options{
 		InitialBackoff: time.Second,
 		MaxBackoff:     5 * time.Second,
-		Multiplier:     2,
 	}
 
 	warningFilter := []string{
@@ -1030,7 +1029,6 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 		retryOpts   = retry.Options{
 			InitialBackoff: time.Second,
 			MaxBackoff:     5 * time.Second,
-			Multiplier:     2,
 		}
 		// The expected output of decommission while the node is about to be drained/is draining.
 		expReplicasTransferred = [][]string{

--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -206,7 +206,7 @@ func (ep *tpccChaosEventProcessor) queryPrometheus(
 	rOpts := base.DefaultRetryOptions()
 	rOpts.MaxRetries = 5
 	var warnings promv1.Warnings
-	for r := retry.Start(rOpts); r.Next(); {
+	for r := retry.Start(ctx, rOpts); r.Next(); {
 		val, warnings, err = ep.promClient.Query(
 			ctx,
 			q,

--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -203,8 +202,7 @@ func (ep *tpccChaosEventProcessor) checkMetrics(
 func (ep *tpccChaosEventProcessor) queryPrometheus(
 	ctx context.Context, l *logger.Logger, q string, ts time.Time,
 ) (val model.Value, err error) {
-	rOpts := base.DefaultRetryOptions()
-	rOpts.MaxRetries = 5
+	rOpts := retry.Options{MaxRetries: 5}
 	var warnings promv1.Warnings
 	for r := retry.Start(ctx, rOpts); r.Next(); {
 		val, warnings, err = ep.promClient.Query(

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -502,7 +502,7 @@ func initFollowerReadsDB(
 	// Wait until the table has completed up-replication.
 	t.L().Printf("waiting for up-replication...")
 	retryOpts := retry.Options{MaxBackoff: 15 * time.Second}
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		// Check that the table has the expected number and location of voting and
 		// non-voting replicas. The valid location sets can be larger than the
 		// expected number of replicas, in which case, multiple valid combinations
@@ -563,7 +563,7 @@ func initFollowerReadsDB(
 	}
 
 	if topology.multiRegion {
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Check that one of these replicas exists in each region. Do so by
 			// parsing the replica_localities array using the same pattern as the
 			// one used by SHOW REGIONS.
@@ -584,7 +584,7 @@ func initFollowerReadsDB(
 		}
 
 		if topology.deadPrimaryRegion {
-			for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+			for r := retry.Start(ctx, retryOpts); r.Next(); {
 				// If we're going to be killing nodes in a multi-region cluster, make
 				// sure system ranges have all upreplicated as expected as well. Do so
 				// using replication reports.

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -82,7 +82,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 					// Wait for ranges to rebalance across all three regions.
 					t.L().Printf("checking replica balance")
 					retryOpts := retry.Options{MaxBackoff: 15 * time.Second}
-					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+					for r := retry.Start(ctx, retryOpts); r.Next(); {
 						WaitForUpdatedReplicationReport(ctx, t, conn)
 
 						var ok bool
@@ -103,7 +103,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 					// Wait for leases to adhere to preferences, if they aren't
 					// already.
 					t.L().Printf("checking lease preferences")
-					for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+					for r := retry.Start(ctx, retryOpts); r.Next(); {
 						var ok bool
 						if err := conn.QueryRowContext(ctx, `
 							SELECT lease_holder <= $1

--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -239,7 +239,7 @@ func (j jepsenConfig) prepareBinary(
 			"test -x lein || (curl -o lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && chmod +x lein)")
 	} else {
 		var err error
-		for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 3, InitialBackoff: 5 * time.Second}); r.Next(); {
+		for r := retry.Start(ctx, retry.Options{MaxRetries: 3, InitialBackoff: 5 * time.Second}); r.Next(); {
 			if ctx.Err() != nil {
 				t.Fatal()
 			}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1511,7 +1511,7 @@ func (mvb *mixedVersionBackup) waitForDBs(
 	}
 
 	for _, dbName := range mvb.dbs {
-		r := retry.StartWithCtx(ctx, retryOptions)
+		r := retry.Start(ctx, retryOptions)
 		var err error
 		for r.Next() {
 			q := "SELECT 1 FROM [SHOW DATABASES] WHERE database_name = $1"
@@ -1632,7 +1632,7 @@ func (u *CommonTestUtils) waitForJobSuccess(
 	if internalSystemJobs {
 		jobsQuery = fmt.Sprintf("(%s)", jobutils.InternalSystemJobsBaseQuery)
 	}
-	r := retry.StartWithCtx(ctx, backupCompletionRetryOptions)
+	r := retry.Start(ctx, backupCompletionRetryOptions)
 	for r.Next() {
 		var status string
 		var payloadBytes []byte

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -91,7 +91,6 @@ var (
 	backupCompletionRetryOptions = retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     1 * time.Minute,
-		Multiplier:     1.5,
 		MaxRetries:     80,
 	}
 
@@ -1506,7 +1505,6 @@ func (mvb *mixedVersionBackup) waitForDBs(
 	retryOptions := retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     1 * time.Minute,
-		Multiplier:     1.5,
 		MaxRetries:     20,
 	}
 

--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -133,7 +133,7 @@ func runGetRequests(
 	}
 
 	// Now we'll wait for the flush to occur and request stats from the persisted tables.
-	r := retry.StartWithCtx(ctx, retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     30 * time.Second,
 		MaxRetries:     6, // 6 * 30s = 3m, which is well past the flush interval.

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -291,7 +291,7 @@ func waitForZeroReplicasOnN3(ctx context.Context, t test.Test, db *gosql.DB) {
 	deadline := timeutil.Now().Add(storeDeadTimeout + time.Minute)
 	// We don't use exponential backoff here because we don't expect it to succeed
 	// immediately.
-	for r := retry.StartWithCtx(ctx, retry.Options{
+	for r := retry.Start(ctx, retry.Options{
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     10 * time.Second,
 	}); r.Next() && timeutil.Now().Before(deadline); {

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -614,7 +614,6 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 		return retry.Options{
 			InitialBackoff:      10 * time.Second,
 			MaxBackoff:          time.Minute,
-			Multiplier:          2.0,
 			RandomizationFactor: 1.0,
 			Closer:              ch,
 		}, ch

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -159,7 +159,7 @@ func WaitForUpdatedReplicationReport(ctx context.Context, t test.Test, db *gosql
 	// Wait for a new report with a timestamp after tStart to ensure
 	// that the report picks up any new tables or zones.
 	tStart := timeutil.Now()
-	for r := retry.StartWithCtx(ctx, retry.Options{}); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		var count int
 		var gen gosql.NullTime
 		if err := db.QueryRowContext(

--- a/pkg/jobs/ingeststopped/ingesting_checker.go
+++ b/pkg/jobs/ingeststopped/ingesting_checker.go
@@ -37,7 +37,7 @@ func WaitForNoIngestingNodes(
 	ctx, sp := tracing.ChildSpan(ctx, "WaitForNoIngestingNodes")
 	defer sp.Finish()
 
-	retries := retry.StartWithCtx(ctx, retry.Options{
+	retries := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Second,
 		MaxBackoff:     time.Second * 10,
 	})

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -94,7 +94,7 @@ func (r *Registry) waitForJobsToBeTerminalOrPaused(
 		maxBackoff = *r.knobs.IntervalOverrides.WaitForJobsMaxDelay
 	}
 
-	ret := retry.StartWithCtx(ctx, retry.Options{
+	ret := retry.Start(ctx, retry.Options{
 		InitialBackoff: initialBackoff,
 		MaxBackoff:     maxBackoff,
 		Multiplier:     1.5,

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -97,7 +97,6 @@ func (r *Registry) waitForJobsToBeTerminalOrPaused(
 	ret := retry.Start(ctx, retry.Options{
 		InitialBackoff: initialBackoff,
 		MaxBackoff:     maxBackoff,
-		Multiplier:     1.5,
 
 		// Setting the closer here will terminate the loop if the job finishes
 		// before the first InitialBackoff period.

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -832,7 +832,7 @@ func (b *SSTBatcher) addSSTable(
 				Multiplier:     2,
 				MaxRetries:     10,
 			}
-			for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+			for r := retry.Start(ctx, opts); r.Next(); {
 				log.VEventf(ctx, 4, "sending %s AddSSTable [%s,%s)", sz(len(item.sstBytes)), item.start, item.end)
 				// If this SST is "too small", the fixed costs associated with adding an
 				// SST – in terms of triggering flushes, extra compactions, etc – would

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -829,7 +829,6 @@ func (b *SSTBatcher) addSSTable(
 			var err error
 			opts := retry.Options{
 				InitialBackoff: 30 * time.Millisecond,
-				Multiplier:     2,
 				MaxRetries:     10,
 			}
 			for r := retry.Start(ctx, opts); r.Next(); {

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -1188,12 +1188,11 @@ func getOneRow(runErr error, b *Batch) (KeyValue, error) {
 func IncrementValRetryable(ctx context.Context, db *DB, key roachpb.Key, inc int64) (int64, error) {
 	var err error
 	var res KeyValue
-	retryOpts := base.DefaultRetryOptions()
 	// This is likely not necessary, but adds extra safety since this methods is
 	// called from a number of places.
 	ctx, cancel := db.Context().Stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
-	for r := retry.Start(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		res, err = db.Inc(ctx, key, inc)
 		if errors.HasType(err, (*kvpb.UnhandledRetryableError)(nil)) ||
 			errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -838,7 +837,7 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 	ds.dontReorderReplicas = cfg.TestingKnobs.DontReorderReplicas
 	ds.routeToLeaseholderFirst = cfg.TestingKnobs.RouteToLeaseholderFirst || metamorphicRouteToLeaseholderFirst
 	ds.dontConsiderConnHealth = cfg.TestingKnobs.DontConsiderConnHealth
-	ds.rpcRetryOptions = base.DefaultRetryOptions()
+	ds.rpcRetryOptions = retry.Options{}
 	// TODO(arul): The rpcRetryOptions passed in here from server/tenant don't
 	// set a max retries limit. Should they?
 	if cfg.RPCRetryOptions != nil {

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2035,7 +2035,7 @@ func (ds *DistSender) sendPartialBatch(
 	tBegin, attempts := timeutil.Now(), int64(0) // for slow log message
 	// prevTok maintains the EvictionToken used on the previous iteration.
 	var prevTok rangecache.EvictionToken
-	for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, ds.rpcRetryOptions); r.Next(); {
 		attempts++
 		pErr = nil
 		// If we've invalidated the descriptor on a send failure, re-lookup.
@@ -2616,7 +2616,7 @@ func (ds *DistSender) sendToReplicas(
 	// TODO(andrei): now that requests wait on lease transfers to complete on
 	// outgoing leaseholders instead of immediately redirecting, we should
 	// rethink this backoff policy.
-	inTransferRetry := retry.StartWithCtx(ctx, ds.rpcRetryOptions)
+	inTransferRetry := retry.Start(ctx, ds.rpcRetryOptions)
 	inTransferRetry.Next() // The first call to Next does not block.
 	var sameReplicaRetries int
 	var prevReplica roachpb.ReplicaDescriptor

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -264,7 +264,7 @@ func (s *activeMuxRangeFeed) start(ctx context.Context, m *rangefeedMuxer) error
 	}
 
 	// Start a retry loop for sending the batch to the range.
-	for r := retry.StartWithCtx(ctx, m.ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, m.ds.rpcRetryOptions); r.Next(); {
 		// If we've cleared the descriptor on failure, re-lookup.
 		if !s.token.Valid() {
 			ri, err := m.ds.getRoutingInfo(ctx, s.rSpan.Key, rangecache.EvictionToken{}, false)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -641,7 +641,7 @@ func (ds *DistSender) partialRangeFeed(
 	span := rs.AsRawSpanWithNoLocals()
 
 	// Start a retry loop for sending the batch to the range.
-	for r := retry.StartWithCtx(ctx, ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, ds.rpcRetryOptions); r.Next(); {
 		// If we've cleared the descriptor on a send failure, re-lookup.
 		if !token.Valid() {
 			var err error

--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -22,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -79,8 +79,7 @@ func NewDistSenderForLocalTestCluster(
 	stopper *stop.Stopper,
 	g *gossip.Gossip,
 ) *DistSender {
-	retryOpts := base.DefaultRetryOptions()
-	retryOpts.Closer = stopper.ShouldQuiesce()
+	retryOpts := retry.Options{Closer: stopper.ShouldQuiesce()}
 	senderTransportFactory := SenderTransportFactory(tracer, stores)
 	return NewDistSender(DistSenderConfig{
 		AmbientCtx:         log.MakeTestingAmbientContext(tracer),

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -201,7 +201,7 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 	// Retry loop for looking up next range in the span. The retry loop
 	// deals with retryable range descriptor lookups.
 	var err error
-	for r := retry.StartWithCtx(ctx, ri.ds.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, ri.ds.rpcRetryOptions); r.Next(); {
 		// Note that we pass an empty eviction token here because ri.token
 		// corresponds to the previous range.
 		var rngInfo rangecache.EvictionToken

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -991,7 +991,7 @@ func (c *connector) getClient(ctx context.Context) (*client, error) {
 // dialAddrs attempts to dial each of the configured addresses in a retry loop.
 // The method will only return a non-nil error on context cancellation.
 func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
-	for r := retry.StartWithCtx(ctx, c.rpcRetryOptions); r.Next(); {
+	for r := retry.Start(ctx, c.rpcRetryOptions); r.Next(); {
 		// Try each address on each retry iteration (in random order).
 		for _, i := range rand.Perm(len(c.addrs)) {
 			addr := c.addrs[i]

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -284,7 +284,7 @@ var useMuxRangeFeed = metamorphic.ConstantWithTestBool("use-mux-rangefeed", true
 // indicates that an initial scan error is non-recoverable.
 func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier) {
 	defer f.running.Done()
-	r := retry.StartWithCtx(ctx, f.retryOptions)
+	r := retry.Start(ctx, f.retryOptions)
 	restartLogEvery := log.Every(10 * time.Second)
 
 	if f.withInitialScan {

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -202,7 +202,7 @@ func Start[E rangefeedbuffer.Event](
 		defer cancel()
 
 		const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
-		for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+		for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 			started := timeutil.Now()
 			if err := c.Run(ctx); err != nil {
 				if errors.Is(err, context.Canceled) {

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -202,7 +202,7 @@ func Start[E rangefeedbuffer.Event](
 		defer cancel()
 
 		const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
-		for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+		for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 			started := timeutil.Now()
 			if err := c.Run(ctx); err != nil {
 				if errors.Is(err, context.Canceled) {

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -153,7 +153,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 	case *ClosureTxnOperation:
 		// Use a backoff loop to avoid thrashing on txn aborts. Don't wait between
 		// epochs of the same transaction to avoid waiting while holding locks.
-		retryOnAbort := retry.StartWithCtx(ctx, retry.Options{
+		retryOnAbort := retry.Start(ctx, retry.Options{
 			InitialBackoff: 1 * time.Millisecond,
 			MaxBackoff:     250 * time.Millisecond,
 		})
@@ -655,7 +655,7 @@ func resultInit(ctx context.Context, err error) Result {
 func getRangeDesc(ctx context.Context, key roachpb.Key, dbs ...*kv.DB) roachpb.RangeDescriptor {
 	var dbIdx int
 	var opts = retry.Options{}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); dbIdx = (dbIdx + 1) % len(dbs) {
+	for r := retry.Start(ctx, opts); r.Next(); dbIdx = (dbIdx + 1) % len(dbs) {
 		sender := dbs[dbIdx].NonTransactionalSender()
 		descs, _, err := kv.RangeLookup(ctx, sender, key, kvpb.CONSISTENT, 0, false)
 		if err != nil {

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -531,7 +531,7 @@ func (rp ReplicaPlanner) findRemoveVoter(
 
 	var candidates []roachpb.ReplicaDescriptor
 	deadline := timeutil.Now().Add(timeout)
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next() && timeutil.Now().Before(deadline); {
+	for r := retry.Start(ctx, retryOpts); r.Next() && timeutil.Now().Before(deadline); {
 		lastReplAdded, lastAddedTime := repl.LastReplicaAdded()
 		if timeutil.Since(lastAddedTime) > newReplicaGracePeriod {
 			lastReplAdded = 0

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -525,7 +525,6 @@ func (rp ReplicaPlanner) findRemoveVoter(
 	retryOpts := retry.Options{
 		InitialBackoff: time.Millisecond,
 		MaxBackoff:     200 * time.Millisecond,
-		Multiplier:     2,
 	}
 	timeout := 5 * time.Second
 

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1357,7 +1357,7 @@ func verifyCanReadFromAllRepls(
 		repl := repls[i]
 		g.Go(func() (err error) {
 			var shouldRetry bool
-			for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); <-r.NextCh() {
+			for r := retry.Start(ctx, retryOptions); r.Next(); <-r.NextCh() {
 				if shouldRetry, err = f(repl.Send(ctx, baRead)); !shouldRetry {
 					return err
 				}

--- a/pkg/kv/kvserver/idalloc/BUILD.bazel
+++ b/pkg/kv/kvserver/idalloc/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/idalloc",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -106,7 +106,7 @@ func (ia *Allocator) start() {
 		for {
 			var newValue int64
 			var err error
-			for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
 					func(ctx context.Context) {
 						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, ia.opts.BlockSize)

--- a/pkg/kv/kvserver/idalloc/id_alloc.go
+++ b/pkg/kv/kvserver/idalloc/id_alloc.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -106,7 +105,7 @@ func (ia *Allocator) start() {
 		for {
 			var newValue int64
 			var err error
-			for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 				if stopperErr := ia.opts.Stopper.RunTask(ctx, "idalloc: allocating block",
 					func(ctx context.Context) {
 						newValue, err = ia.opts.Incrementer(ctx, ia.opts.Key, ia.opts.BlockSize)

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/gossip",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -379,7 +378,7 @@ func (nl *NodeLiveness) SetDraining(
 	ctx = nl.ambientCtx.AnnotateCtx(ctx)
 	retryCtx, cancel := nl.stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
-	for r := retry.Start(retryCtx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(retryCtx, retry.Options{}); r.Next(); {
 		oldLivenessRec, ok := nl.cache.self()
 		if !ok {
 			// There was a cache miss, let's now fetch the record from KV
@@ -1065,9 +1064,7 @@ func (nl *NodeLiveness) updateLiveness(
 	if err := nl.verifyDiskHealth(ctx); err != nil {
 		return Record{}, err
 	}
-	retryOpts := base.DefaultRetryOptions()
-	retryOpts.Closer = nl.stopper.ShouldQuiesce()
-	for r := retry.Start(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		written, err := nl.updateLivenessAttempt(ctx, update, handleCondFailed)
 		if err != nil {
 			if errors.HasType(err, (*errRetryLiveness)(nil)) {

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -150,7 +150,7 @@ func (ls *storageImpl) Update(
 // NB: An existing liveness record is not overwritten by this method, we return
 // an error instead.
 func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error {
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// We start off at epoch=0, entrusting the initial heartbeat to increment it
 		// to epoch=1 to signal the very first time the node is up and running.
 		liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0}

--- a/pkg/kv/kvserver/liveness/storage.go
+++ b/pkg/kv/kvserver/liveness/storage.go
@@ -13,7 +13,6 @@ package liveness
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -150,7 +149,7 @@ func (ls *storageImpl) Update(
 // NB: An existing liveness record is not overwritten by this method, we return
 // an error instead.
 func (ls *storageImpl) Create(ctx context.Context, nodeID roachpb.NodeID) error {
-	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		// We start off at epoch=0, entrusting the initial heartbeat to increment it
 		// to epoch=1 to signal the very first time the node is up and running.
 		liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0}

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -747,7 +747,7 @@ func visitNodeWithRetry(
 	node roachpb.NodeDescriptor,
 ) error {
 	var err error
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
 		addr := node.AddressForLocality(loc)
 		var conn *grpc.ClientConn
@@ -800,7 +800,7 @@ func makeVisitNode(g *gossip.Gossip, loc roachpb.Locality, rpcCtx *rpc.Context) 
 		if err != nil {
 			return err
 		}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
 			addr := node.AddressForLocality(loc)
 			var conn *grpc.ClientConn

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -48,7 +48,6 @@ const retrieveKeyspaceHealthTimeout = time.Minute
 var fanOutConnectionRetryOptions = retry.Options{
 	MaxRetries:     3,
 	InitialBackoff: time.Second,
-	Multiplier:     1,
 }
 
 var errMarkRetry = errors.New("retryable")

--- a/pkg/kv/kvserver/range_log.go
+++ b/pkg/kv/kvserver/range_log.go
@@ -241,13 +241,12 @@ func writeToRangeLogTable(
 		const perAttemptTimeout = 20 * time.Second
 		const maxAttempts = 3
 		retryOpts := base.DefaultRetryOptions()
-		retryOpts.Closer = asyncCtx.Done()
 		retryOpts.MaxRetries = maxAttempts
 
 		if err := stopper.RunAsyncTask(
 			asyncCtx, "rangelog-async", func(ctx context.Context) {
 				defer stopCancel()
-				for r := retry.Start(retryOpts); r.Next(); {
+				for r := retry.Start(asyncCtx, retryOpts); r.Next(); {
 					if err := timeutil.RunWithTimeout(ctx, "rangelog-timeout", perAttemptTimeout, func(ctx context.Context) error {
 						return s.cfg.RangeLogWriter.WriteRangeLogEvent(ctx, txn.DB(), logEvent)
 					}); err != nil {

--- a/pkg/kv/kvserver/range_log.go
+++ b/pkg/kv/kvserver/range_log.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -239,9 +238,7 @@ func writeToRangeLogTable(
 		asyncCtx, stopCancel := stopper.WithCancelOnQuiesce(asyncCtx)
 
 		const perAttemptTimeout = 20 * time.Second
-		const maxAttempts = 3
-		retryOpts := base.DefaultRetryOptions()
-		retryOpts.MaxRetries = maxAttempts
+		retryOpts := retry.Options{MaxRetries: 3}
 
 		if err := stopper.RunAsyncTask(
 			asyncCtx, "rangelog-async", func(ctx context.Context) {

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -592,7 +592,7 @@ func (r *registration) waitForCaughtUp(ctx context.Context) error {
 		MaxBackoff:     10 * time.Second,
 		MaxRetries:     50,
 	}
-	for re := retry.StartWithCtx(ctx, opts); re.Next(); {
+	for re := retry.Start(ctx, opts); re.Next(); {
 		r.mu.Lock()
 		caughtUp := len(r.buf) == 0 && r.mu.caughtUp
 		r.mu.Unlock()

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -588,7 +588,6 @@ func (reg *registry) forOverlappingRegs(
 func (r *registration) waitForCaughtUp(ctx context.Context) error {
 	opts := retry.Options{
 		InitialBackoff: 5 * time.Millisecond,
-		Multiplier:     2,
 		MaxBackoff:     10 * time.Second,
 		MaxRetries:     50,
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -17,7 +17,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -2219,7 +2218,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 	err = r.store.stopper.RunAsyncTask(taskCtx, "wait-for-merge", func(ctx context.Context) {
 		defer cancel()
 		var pushTxnRes *kvpb.PushTxnResponse
-		for retry := retry.Start(ctx, base.DefaultRetryOptions()); retry.Next(); {
+		for retry := retry.Start(ctx, retry.Options{}); retry.Next(); {
 			// Wait for the merge transaction to complete by attempting to push it. We
 			// don't want to accidentally abort the merge transaction, so we use the
 			// minimum transaction priority. Note that a push type of
@@ -2262,7 +2261,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 			// record before our PushTxn arrived. To figure out what happened, we
 			// need to look in meta2.
 			var getRes *kvpb.GetResponse
-			for retry := retry.Start(ctx, base.DefaultRetryOptions()); retry.Next(); {
+			for retry := retry.Start(ctx, retry.Options{}); retry.Next(); {
 				metaKey := keys.RangeMetaKey(desc.EndKey)
 				res, pErr := kv.SendWrappedWith(ctx, r.store.DB().NonTransactionalSender(), kvpb.Header{
 					// Use READ_UNCOMMITTED to avoid trying to resolve intents, since

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -658,7 +658,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 	retryOpts.RandomizationFactor = 0.5
 	var lastErr error
 	splitRetryLogLimiter := log.Every(10 * time.Second)
-	for retryable := retry.StartWithCtx(ctx, retryOpts); retryable.Next(); {
+	for retryable := retry.Start(ctx, retryOpts); retryable.Next(); {
 		// The replica may have been destroyed since the start of the retry loop.
 		// We need to explicitly check this condition. Having a valid lease, as we
 		// verify below, does not imply that the range still exists: even after a
@@ -1020,7 +1020,7 @@ func (r *Replica) WaitForLeaseAppliedIndex(
 		Multiplier:     2,
 		MaxBackoff:     time.Second,
 	}
-	for retry := retry.StartWithCtx(ctx, retryOpts); retry.Next(); {
+	for retry := retry.Start(ctx, retryOpts); retry.Next(); {
 		if currentLAI := r.GetLeaseAppliedIndex(); currentLAI >= lai {
 			return currentLAI, nil
 		}
@@ -1926,7 +1926,7 @@ func (r *Replica) initializeRaftLearners(
 	descriptorOK := false
 	start := timeutil.Now()
 	retOpts := retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetries: 10}
-	for re := retry.StartWithCtx(ctx, retOpts); re.Next(); {
+	for re := retry.Start(ctx, retOpts); re.Next(); {
 		rDesc := r.Desc()
 		if rDesc.Generation >= desc.Generation {
 			descriptorOK = true
@@ -2346,7 +2346,7 @@ func prepareChangeReplicasTrigger(
 func within10s(ctx context.Context, fn func() error) error {
 	retOpts := retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetries: 10}
 	var err error
-	for re := retry.StartWithCtx(ctx, retOpts); re.Next(); {
+	for re := retry.Start(ctx, retOpts); re.Next(); {
 		err = fn()
 		if err == nil {
 			return nil
@@ -3607,7 +3607,7 @@ func (r *Replica) relocateReplicas(
 
 	every := log.Every(time.Minute)
 	for {
-		for re := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: 5 * time.Second}); re.Next(); {
+		for re := retry.Start(ctx, retry.Options{MaxBackoff: 5 * time.Second}); re.Next(); {
 			if err := ctx.Err(); err != nil {
 				return rangeDesc, err
 			}
@@ -4142,7 +4142,7 @@ func (r *Replica) adminScatter(
 	}
 
 	// Loop until we hit an error or until we hit `maxAttempts` for the range.
-	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+	for re := retry.Start(ctx, retryOpts); re.Next(); {
 		if currentAttempt == maxAttempts {
 			break
 		}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1017,7 +1017,6 @@ func (r *Replica) WaitForLeaseAppliedIndex(
 ) (kvpb.LeaseAppliedIndex, error) {
 	retryOpts := retry.Options{
 		InitialBackoff: 10 * time.Millisecond,
-		Multiplier:     2,
 		MaxBackoff:     time.Second,
 	}
 	for retry := retry.Start(ctx, retryOpts); retry.Next(); {
@@ -4111,7 +4110,6 @@ func (r *Replica) adminScatter(
 	retryOpts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
 		MaxRetries:     5,
 	}
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -18,7 +18,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -651,14 +650,9 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 	ctx context.Context, updateDesc func(*roachpb.RangeDescriptor) error,
 ) *kvpb.Error {
 	// Retry forever as long as we see errors we know will resolve.
-	retryOpts := base.DefaultRetryOptions()
-	// Randomize quite a lot just in case someone else also interferes with us
-	// in a retry loop. Note that this is speculative; there wasn't an incident
-	// that suggested this.
-	retryOpts.RandomizationFactor = 0.5
 	var lastErr error
 	splitRetryLogLimiter := log.Every(10 * time.Second)
-	for retryable := retry.Start(ctx, retryOpts); retryable.Next(); {
+	for retryable := retry.Start(ctx, retry.Options{}); retryable.Next(); {
 		// The replica may have been destroyed since the start of the retry loop.
 		// We need to explicitly check this condition. Having a valid lease, as we
 		// verify below, does not imply that the range still exists: even after a

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1077,7 +1077,6 @@ func (r *Replica) AdminTransferLease(
 	retryOpts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
 		MaxRetries:     10,
 	}
 	if count := r.store.TestingKnobs().LeaseTransferRejectedRetryLoopCount; count != 0 {

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1083,7 +1083,7 @@ func (r *Replica) AdminTransferLease(
 	if count := r.store.TestingKnobs().LeaseTransferRejectedRetryLoopCount; count != 0 {
 		retryOpts.MaxRetries = count
 	}
-	transferRejectedRetry := retry.StartWithCtx(ctx, retryOpts)
+	transferRejectedRetry := retry.Start(ctx, retryOpts)
 	transferRejectedRetry.Next() // The first call to Next does not block.
 
 	// Loop while there's an extension in progress.

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -646,7 +646,7 @@ func (rq *replicateQueue) process(
 	// Use a retry loop in order to backoff in the case of snapshot errors,
 	// usually signaling that a rebalancing reservation could not be made with the
 	// selected target.
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		requeue, err := rq.processOneChangeWithTracing(ctx, repl, desc, &conf)
 		if isSnapshotError(err) {
 			// If ChangeReplicas failed because the snapshot failed, we attempt to

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -633,7 +633,6 @@ func (rq *replicateQueue) process(
 	retryOpts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
 		MaxRetries:     5,
 	}
 	// TODO(baptist): Change to Replica.SpanConfig() once the refactor is done to

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1977,7 +1977,6 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 			opts := retry.Options{
 				InitialBackoff: 10 * time.Millisecond,
 				MaxBackoff:     time.Second,
-				Multiplier:     2,
 			}
 			everySecond := log.Every(time.Second)
 			var err error

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1982,7 +1982,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 			everySecond := log.Every(time.Second)
 			var err error
 			// Avoid retry.ForDuration because of https://github.com/cockroachdb/cockroach/issues/25091.
-			for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+			for r := retry.Start(ctx, opts); r.Next(); {
 				err = nil
 				if numRemaining := transferAllAway(ctx); numRemaining > 0 {
 					// Report progress to the Drain RPC.
@@ -3893,7 +3893,7 @@ func (s *Store) WaitForSpanConfigSubscription(ctx context.Context) error {
 		return nil // nothing to do here
 	}
 
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		if !s.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty() {
 			return nil
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3892,7 +3892,7 @@ func (s *Store) WaitForSpanConfigSubscription(ctx context.Context) error {
 		return nil // nothing to do here
 	}
 
-	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		if !s.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty() {
 			return nil
 		}

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -68,7 +68,7 @@ func (s *Store) getOrCreateReplica(
 	// process of being removed or may need to be removed. Retries in the loop
 	// imply that a removal is actually being carried out, not that we're waiting
 	// on a queue.
-	r := retry.Start(retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Microsecond,
 		// Set the backoff up to only a small amount to wait for data that
 		// might need to be cleared.

--- a/pkg/kv/kvserver/store_gossip.go
+++ b/pkg/kv/kvserver/store_gossip.go
@@ -127,8 +127,9 @@ func (s *Store) startGossip() {
 				// making it impossible to get an epoch-based range lease), in which
 				// case we want to retry quickly.
 				retryOptions := base.DefaultRetryOptions()
-				retryOptions.Closer = s.stopper.ShouldQuiesce()
-				for r := retry.Start(retryOptions); r.Next(); {
+				retryCtx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
+				defer cancel()
+				for r := retry.Start(retryCtx, retryOptions); r.Next(); {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key)); repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
 						if err := gossipFn.fn(annotatedCtx, repl); err != nil {

--- a/pkg/kv/kvserver/store_gossip.go
+++ b/pkg/kv/kvserver/store_gossip.go
@@ -16,7 +16,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -126,10 +125,9 @@ func (s *Store) startGossip() {
 				// temporarily fail (e.g. because node liveness hasn't initialized yet
 				// making it impossible to get an epoch-based range lease), in which
 				// case we want to retry quickly.
-				retryOptions := base.DefaultRetryOptions()
 				retryCtx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
 				defer cancel()
-				for r := retry.Start(retryCtx, retryOptions); r.Next(); {
+				for r := retry.Start(retryCtx, retry.Options{}); r.Next(); {
 					if repl := s.LookupReplica(roachpb.RKey(gossipFn.key)); repl != nil {
 						annotatedCtx := repl.AnnotateCtx(ctx)
 						if err := gossipFn.fn(annotatedCtx, repl); err != nil {

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -84,7 +84,7 @@ func (is Server) WaitForApplication(
 		// TODO(benesch): Once Replica changefeeds land, see if we can implement
 		// this request handler without polling.
 		retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Long-lived references to replicas are frowned upon, so re-fetch the
 			// replica on every turn of the loop.
 			repl, err := s.GetReplica(req.RangeID)
@@ -127,7 +127,7 @@ func (is Server) WaitForReplicaInit(
 	resp := &WaitForReplicaInitResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader, func(ctx context.Context, s *Store) error {
 		retryOpts := retry.Options{InitialBackoff: 10 * time.Millisecond}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Long-lived references to replicas are frowned upon, so re-fetch the
 			// replica on every turn of the loop.
 			if repl, err := s.GetReplica(req.RangeID); err == nil && repl.IsInitialized() {

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -892,7 +892,7 @@ func (q *Queue) startQueryPusherTxn(
 		func(ctx context.Context) {
 			// We use a backoff/retry here in case the pusher transaction
 			// doesn't yet exist.
-			for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 				var pErr *kvpb.Error
 				var updatedPusher *roachpb.Transaction
 				updatedPusher, waitingTxns, pErr = q.queryTxnStatus(

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -892,7 +892,7 @@ func (q *Queue) startQueryPusherTxn(
 		func(ctx context.Context) {
 			// We use a backoff/retry here in case the pusher transaction
 			// doesn't yet exist.
-			for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+			for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 				var pErr *kvpb.Error
 				var updatedPusher *roachpb.Transaction
 				updatedPusher, waitingTxns, pErr = q.queryTxnStatus(

--- a/pkg/kv/range_lookup.go
+++ b/pkg/kv/range_lookup.go
@@ -196,7 +196,7 @@ func RangeLookup(
 		Multiplier:     2,
 	}
 
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		// Determine the "Range Metadata Key" for the provided key.
 		rkey, err := addrForDir(prefetchReverse)(key)
 		if err != nil {

--- a/pkg/kv/range_lookup.go
+++ b/pkg/kv/range_lookup.go
@@ -193,7 +193,6 @@ func RangeLookup(
 	opts := retry.Options{
 		InitialBackoff: 1 * time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
-		Multiplier:     2,
 	}
 
 	for r := retry.Start(ctx, opts); r.Next(); {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -160,7 +160,7 @@ func runWithMaybeRetry(
 	var res = &RunResultDetails{}
 	var cmdErr, err error
 
-	for r := retry.StartWithCtx(ctx, *retryOpts); r.Next(); {
+	for r := retry.Start(ctx, *retryOpts); r.Next(); {
 		res, err = f(ctx)
 		if err != nil {
 			// non retryable roachprod error

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -34,7 +34,6 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 			InitialBackoff: time.Second,
 			MaxBackoff:     30 * time.Second,
 			Multiplier:     2,
-			Closer:         s.stopper.ShouldQuiesce(),
 		}
 
 		// Check if auto upgrade is disabled for test purposes.
@@ -51,7 +50,7 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 			}
 		}
 
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			clusterVersion, err := s.clusterVersion(ctx)
 			if err != nil {
 				log.Errorf(ctx, "unable to retrieve cluster version: %v", err)
@@ -95,12 +94,11 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 				InitialBackoff: 5 * time.Second,
 				MaxBackoff:     10 * time.Second,
 				Multiplier:     2,
-				Closer:         s.stopper.ShouldQuiesce(),
 			}
 
 			// Run the set cluster setting version statement in a transaction
 			// until success.
-			for ur := retry.StartWithCtx(ctx, upgradeRetryOpts); ur.Next(); {
+			for ur := retry.Start(ctx, upgradeRetryOpts); ur.Next(); {
 				if _, err := s.sqlServer.internalExecutor.ExecEx(
 					ctx, "set-version", nil, /* txn */
 					sessiondata.NodeUserSessionDataOverride,

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -33,7 +33,6 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 		retryOpts := retry.Options{
 			InitialBackoff: time.Second,
 			MaxBackoff:     30 * time.Second,
-			Multiplier:     2,
 		}
 
 		// Check if auto upgrade is disabled for test purposes.
@@ -93,7 +92,6 @@ func (s *topLevelServer) startAttemptUpgrade(ctx context.Context) error {
 			upgradeRetryOpts := retry.Options{
 				InitialBackoff: 5 * time.Second,
 				MaxBackoff:     10 * time.Second,
-				Multiplier:     2,
 			}
 
 			// Run the set cluster setting version statement in a transaction

--- a/pkg/server/loss_of_quorum.go
+++ b/pkg/server/loss_of_quorum.go
@@ -157,7 +157,7 @@ func maybeRunLossOfQuorumRecoveryCleanup(
 			MaxBackoff:     time.Hour,
 			Multiplier:     2,
 		}
-		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Nodes are already dead, but are in active state. Internal checks doesn't
 			// allow us throwing nodes away, and they need to go through legal state
 			// transitions within liveness to succeed. To achieve that we mark nodes as

--- a/pkg/server/loss_of_quorum.go
+++ b/pkg/server/loss_of_quorum.go
@@ -155,7 +155,6 @@ func maybeRunLossOfQuorumRecoveryCleanup(
 		retryOpts := retry.Options{
 			InitialBackoff: 10 * time.Second,
 			MaxBackoff:     time.Hour,
-			Multiplier:     2,
 		}
 		for r := retry.Start(ctx, retryOpts); r.Next(); {
 			// Nodes are already dead, but are in active state. Internal checks doesn't

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2288,7 +2288,7 @@ func (s *topLevelServer) runIdempontentSQLForInitType(
 		MaxBackoff:     10 * time.Second,
 		InitialBackoff: time.Second,
 	}
-	for r := retry.StartWithCtx(ctx, rOpts); r.Next(); {
+	for r := retry.Start(ctx, rOpts); r.Next(); {
 		if err := initAttempt(); err != nil {
 			log.Errorf(ctx, "cluster initialization attempt failed: %s", err.Error())
 			continue

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -445,9 +445,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		clientTestingKnobs = *kvKnobs.(*kvcoord.ClientTestingKnobs)
 	}
 	retryOpts := cfg.RetryOptions
-	if retryOpts == (retry.Options{}) {
-		retryOpts = base.DefaultRetryOptions()
-	}
 	retryOpts.Closer = stopper.ShouldQuiesce()
 	distSenderCfg := kvcoord.DistSenderConfig{
 		AmbientCtx:         cfg.AmbientCtx,

--- a/pkg/server/server_controller_channel_orchestrator.go
+++ b/pkg/server/server_controller_channel_orchestrator.go
@@ -346,12 +346,6 @@ func (o *channelOrchestrator) startControlledServer(
 		ctx, cancel = ctlStopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		// Stop retrying startup/initialization if we are being shut
-		// down early.
-		retryOpts := retry.Options{
-			Closer: ctlStopper.ShouldQuiesce(),
-		}
-
 		// tenantStopper is the stopper specific to one tenant server
 		// instance. We define a new tenantStopper on every attempt to
 		// instantiate the tenant server below. It is then linked to
@@ -360,7 +354,7 @@ func (o *channelOrchestrator) startControlledServer(
 		var tenantStopper *stop.Stopper
 
 		var tenantServer orchestratedServer
-		for retry := retry.StartWithCtx(ctx, retryOpts); retry.Next(); {
+		for retry := retry.Start(ctx, retry.Options{}); retry.Next(); {
 			tenantStopper = stop.NewStopper()
 
 			// Task that is solely responsible for propagating ungraceful exits.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -491,7 +491,7 @@ func (r *refreshInstanceSessionListener) OnSessionDeleted(
 	ctx context.Context,
 ) (createAnotherSession bool) {
 	if err := r.cfg.stopper.RunAsyncTask(ctx, "refresh-instance-session", func(ctx context.Context) {
-		for i := retry.StartWithCtx(ctx, retry.Options{MaxBackoff: time.Second * 5}); i.Next(); {
+		for i := retry.Start(ctx, retry.Options{MaxBackoff: time.Second * 5}); i.Next(); {
 			select {
 			case <-r.cfg.stopper.ShouldQuiesce():
 				return

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -76,6 +76,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logmetrics"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -1158,7 +1159,7 @@ func makeTenantSQLServerArgs(
 	if dsKnobsP, ok := baseCfg.TestingKnobs.KVClient.(*kvcoord.ClientTestingKnobs); ok {
 		dsKnobs = *dsKnobsP
 	}
-	rpcRetryOptions := base.DefaultRetryOptions()
+	rpcRetryOptions := retry.Options{}
 
 	tcCfg := kvtenant.ConnectorConfig{
 		TenantID:          sqlCfg.TenantID,

--- a/pkg/server/tenant_auto_upgrade.go
+++ b/pkg/server/tenant_auto_upgrade.go
@@ -138,12 +138,11 @@ func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) (bool, error)
 		InitialBackoff: 5 * time.Second,
 		MaxBackoff:     10 * time.Second,
 		Multiplier:     2,
-		Closer:         s.stopper.ShouldQuiesce(),
 	}
 
 	// Run the set cluster setting version statement in a transaction
 	// until success.
-	for ur := retry.StartWithCtx(ctx, upgradeRetryOpts); ur.Next(); {
+	for ur := retry.Start(ctx, upgradeRetryOpts); ur.Next(); {
 		if _, err := s.internalExecutor.ExecEx(
 			ctx, "set-version", nil, /* txn */
 			sessiondata.NodeUserSessionDataOverride,

--- a/pkg/server/tenant_auto_upgrade.go
+++ b/pkg/server/tenant_auto_upgrade.go
@@ -137,7 +137,6 @@ func (s *SQLServer) startAttemptTenantUpgrade(ctx context.Context) (bool, error)
 	upgradeRetryOpts := retry.Options{
 		InitialBackoff: 5 * time.Second,
 		MaxBackoff:     10 * time.Second,
-		Multiplier:     2,
 	}
 
 	// Run the set cluster setting version statement in a transaction

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -432,7 +432,7 @@ func (ts *testServer) HeartbeatNodeLiveness() error {
 
 	var err error
 	ctx := context.Background()
-	for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 5}); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{MaxRetries: 5}); r.Next(); {
 		if err = nl.Heartbeat(ctx, l); !errors.Is(err, liveness.ErrEpochIncremented) {
 			break
 		}

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -157,7 +157,7 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 
 	var lastCheckpoint = hlc.Timestamp{}
 	const aWhile = 5 * time.Minute // arbitrary but much longer than a retry
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		started := timeutil.Now()
 		if err := rc.Reconcile(ctx, lastCheckpoint, r.job.Session(), func() error {
 			if onCheckpointInterceptor != nil {

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -447,7 +447,7 @@ func updateSpanConfigRecords(
 		MaxRetries:     5,
 	}
 
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		sessionStart, sessionExpiration := session.Start(), session.Expiration()
 		if sessionExpiration.IsEmpty() {
 			return errors.Errorf("sqlliveness session has expired")

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descs",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/keys",

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -122,7 +122,7 @@ func CheckTwoVersionInvariant(
 	decAfterWait := descsCol.leased.lm.IncGaugeAfterLeaseDuration(lease.GaugeWaitForTwoVersionViolation)
 	defer decAfterWait()
 	// Wait until all older version leases have been released or expired.
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// Use the current clock time.
 		now := clock.Now()
 		count, err := lease.CountLeases(ctx, db, codec, regions, settings, withNewVersion, now, false /*forAnyVersion*/)

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -13,7 +13,6 @@ package descs
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	clustersettings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -122,7 +121,7 @@ func CheckTwoVersionInvariant(
 	decAfterWait := descsCol.leased.lm.IncGaugeAfterLeaseDuration(lease.GaugeWaitForTwoVersionViolation)
 	defer decAfterWait()
 	// Wait until all older version leases have been released or expired.
-	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		// Use the current clock time.
 		now := clock.Now()
 		count, err := lease.CountLeases(ctx, db, codec, regions, settings, withNewVersion, now, false /*forAnyVersion*/)

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -155,7 +155,7 @@ func (m *Manager) PublishMultiple(
 ) (map[descpb.ID]catalog.Descriptor, error) {
 	errLeaseVersionChanged := errors.New("lease version changed")
 	// Retry while getting errLeaseVersionChanged.
-	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// Wait until there are no unexpired leases on the previous versions
 		// of the descriptors.
 		expectedVersions := make(map[descpb.ID]descpb.DescriptorVersion)

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -155,12 +154,12 @@ func (m *Manager) PublishMultiple(
 ) (map[descpb.ID]catalog.Descriptor, error) {
 	errLeaseVersionChanged := errors.New("lease version changed")
 	// Retry while getting errLeaseVersionChanged.
-	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		// Wait until there are no unexpired leases on the previous versions
 		// of the descriptors.
 		expectedVersions := make(map[descpb.ID]descpb.DescriptorVersion)
 		for _, id := range ids {
-			expected, err := m.WaitForOneVersion(ctx, id, nil, base.DefaultRetryOptions())
+			expected, err := m.WaitForOneVersion(ctx, id, nil, retry.Options{})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1680,11 +1680,10 @@ SELECT COALESCE(l."descID", s."desc_id") as "descID", COALESCE(l.version, s.vers
 		sqlQuery := fmt.Sprintf(query, instanceID)
 
 		var rows []tree.Datums
-		retryOptions := base.DefaultRetryOptions()
 		retryCtx, cancel := m.stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 		// The retry is required because of errors caused by node restarts. Retry 30 times.
-		if err := retry.WithMaxAttempts(retryCtx, retryOptions, 30, func() error {
+		if err := retry.WithMaxAttempts(retryCtx, retry.Options{}, 30, func() error {
 			return m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 				if err := txn.KV().SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: timeThreshold}); err != nil {
 					return err

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3980,7 +3980,7 @@ func TestLongLeaseWaitMetrics(t *testing.T) {
 		lease.LeaseDuration.Override(ctx, &st.SV, 0)
 		close(startWaiters)
 
-		r := retry.StartWithCtx(ctx, retry.Options{})
+		r := retry.Start(ctx, retry.Options{})
 		// Wait until long waits are detected in our metrics.
 		for r.Next() {
 			if srv.MustGetSQLCounter("sql.leases.long_wait_for_no_version") == 0 {
@@ -4014,7 +4014,7 @@ func TestLongLeaseWaitMetrics(t *testing.T) {
 	// Waits for one version of the descriptor to exist.
 	grp.GoCtx(func(ctx context.Context) error {
 		<-startWaiters
-		r := retry.StartWithCtx(ctx, retry.Options{})
+		r := retry.Start(ctx, retry.Options{})
 		for r.Next() {
 			// Wait for the two versions to exist.
 			if srv.MustGetSQLCounter("sql.leases.long_wait_for_two_version_invariant") == 0 {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2725,7 +2725,7 @@ func TestHistoricalDescriptorAcquire(t *testing.T) {
 	// recent version with the name column before doing so.
 	cachedDatabaseRegions, err := regions.NewCachedDatabaseRegions(ctx, s.DB(), s.LeaseManager().(*lease.Manager))
 	require.NoError(t, err)
-	_, err = s.LeaseManager().(*lease.Manager).WaitForOneVersion(ctx, tableID.Load().(descpb.ID), cachedDatabaseRegions, base.DefaultRetryOptions())
+	_, err = s.LeaseManager().(*lease.Manager).WaitForOneVersion(ctx, tableID.Load().(descpb.ID), cachedDatabaseRegions, retry.Options{})
 	require.NoError(t, err, "Failed to wait for one version of descriptor: %s", err)
 	acquiredDescriptor, err := s.LeaseManager().(*lease.Manager).Acquire(ctx, ts1, tableID.Load().(descpb.ID))
 	assert.NoError(t, err)

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -297,7 +297,6 @@ func (s storage) release(
 	ctx context.Context, stopper *stop.Stopper, lease *storedLease,
 ) (released bool) {
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
-	retryOptions := base.DefaultRetryOptions()
 	retryCtx, cancel := stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
 
@@ -322,7 +321,7 @@ func (s storage) release(
 	}()
 	// This transaction is idempotent; the retry was put in place because of
 	// NodeUnavailableErrors.
-	for r := retry.Start(retryCtx, retryOptions); r.Next(); {
+	for r := retry.Start(retryCtx, retry.Options{}); r.Next(); {
 		log.VEventf(ctx, 2, "storage releasing lease %+v", lease)
 		instanceID := s.nodeIDContainer.SQLInstanceID()
 		if instanceID == 0 {

--- a/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
+++ b/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
@@ -139,7 +139,7 @@ func updateSchedule(ctx context.Context, db isql.DB, st *cluster.Settings, clust
 		InitialBackoff: time.Second,
 		MaxBackoff:     10 * time.Minute,
 	}
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			// Ensure schedule exists.
 			var sj *jobs.ScheduledJob

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -660,7 +660,7 @@ func validateUniqueConstraint(
 		Multiplier:     1.5,
 		MaxRetries:     5,
 	}
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		values, err = txn.QueryRowEx(ctx, "validate unique constraint", txn.KV(), sessionDataOverride, query)
 		if err == nil {
 			break

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -657,7 +657,6 @@ func validateUniqueConstraint(
 	var values tree.Datums
 	retryOptions := retry.Options{
 		InitialBackoff: 20 * time.Millisecond,
-		Multiplier:     1.5,
 		MaxRetries:     5,
 	}
 	for r := retry.Start(ctx, retryOptions); r.Next(); {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -131,7 +131,7 @@ func (s *fdCountingSemaphore) Acquire(ctx context.Context, n int) error {
 		RandomizationFactor: 0.25,
 		MaxRetries:          s.acquireMaxRetries,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		if s.TryAcquire(n) {
 			return nil
 		}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -126,10 +126,8 @@ func (s *fdCountingSemaphore) Acquire(ctx context.Context, n int) error {
 	// in the retry loop before timing out with the default value of the
 	// 'sql.distsql.acquire_vec_fds.max_retries' cluster settings.
 	opts := retry.Options{
-		InitialBackoff:      100 * time.Millisecond,
-		Multiplier:          2.0,
-		RandomizationFactor: 0.25,
-		MaxRetries:          s.acquireMaxRetries,
+		InitialBackoff: 100 * time.Millisecond,
+		MaxRetries:     s.acquireMaxRetries,
 	}
 	for r := retry.Start(ctx, opts); r.Next(); {
 		if s.TryAcquire(n) {

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1136,7 +1136,7 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 		// careful here.
 		rOpts.MaxRetries = 1
 	}
-	r := retry.StartWithCtx(ctx, rOpts)
+	r := retry.Start(ctx, rOpts)
 	for r.Next() {
 		if err = c.insertRowsInternal(ctx, finalBatch); err == nil {
 			// We're done with this batch of rows, so reset the buffered data

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -20,7 +20,6 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -1128,8 +1127,7 @@ func (c *copyMachine) doneWithRows(ctx context.Context) error {
 func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 	var err error
 
-	rOpts := base.DefaultRetryOptions()
-	rOpts.MaxRetries = int(c.p.SessionData().CopyNumRetriesPerBatch)
+	rOpts := retry.Options{MaxRetries: int(c.p.SessionData().CopyNumRetriesPerBatch)}
 	if rOpts.MaxRetries < 1 {
 		// MaxRetries == 0 means infinite number of attempts, and although
 		// CopyNumRetriesPerBatch should always be a positive number, let's be

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -643,9 +643,8 @@ func asyncWriteToOtelAndSystemEventsTable(
 			// (retriable errors are already processed automatically
 			// by db.Txn)
 			retryOpts := base.DefaultRetryOptions()
-			retryOpts.Closer = ctx.Done()
 			retryOpts.MaxRetries = int(maxAttempts)
-			for r := retry.Start(retryOpts); r.Next(); {
+			for r := retry.Start(ctx, retryOpts); r.Next(); {
 				// Don't try too long to write if the system table is unavailable.
 				if err := timeutil.RunWithTimeout(ctx, "record-events", perAttemptTimeout, func(ctx context.Context) error {
 					return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -642,8 +642,7 @@ func asyncWriteToOtelAndSystemEventsTable(
 			// non-retriable errors on the cluster during the table write.
 			// (retriable errors are already processed automatically
 			// by db.Txn)
-			retryOpts := base.DefaultRetryOptions()
-			retryOpts.MaxRetries = int(maxAttempts)
+			retryOpts := retry.Options{MaxRetries: int(maxAttempts)}
 			for r := retry.Start(ctx, retryOpts); r.Next(); {
 				// Don't try too long to write if the system table is unavailable.
 				if err := timeutil.RunWithTimeout(ctx, "record-events", perAttemptTimeout, func(ctx context.Context) error {

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -43,7 +43,7 @@ func GetConnForOutbox(
 	ctx context.Context, dialer Dialer, sqlInstanceID base.SQLInstanceID, timeout time.Duration,
 ) (conn *grpc.ClientConn, err error) {
 	firstConnectionAttempt := timeutil.Now()
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		conn, err = dialer.DialNoBreaker(ctx, roachpb.NodeID(sqlInstanceID), rpc.DefaultClass)
 		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
 			break

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -43,7 +43,7 @@ func GetConnForOutbox(
 	ctx context.Context, dialer Dialer, sqlInstanceID base.SQLInstanceID, timeout time.Duration,
 ) (conn *grpc.ClientConn, err error) {
 	firstConnectionAttempt := timeutil.Now()
-	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		conn, err = dialer.DialNoBreaker(ctx, roachpb.NodeID(sqlInstanceID), rpc.DefaultClass)
 		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
 			break

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1310,7 +1310,7 @@ func ingestWithRetry(
 	var err error
 	// State to decide when to exit the retry loop.
 	lastProgressChange, lastProgress := timeutil.Now(), getFractionCompleted(job)
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		for {
 			res, err = distImport(
 				ctx, execCtx, job, tables, typeDescs, from, format, walltime, testingKnobs, procsPerNode,

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -676,7 +676,7 @@ func queryJobUntil(
 	t *testing.T, db sqlutils.DBHandle, jobID jobspb.JobID, isDone func(js jobState) bool,
 ) (js jobState) {
 	t.Helper()
-	for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(context.Background(), base.DefaultRetryOptions()); r.Next(); {
 		js = queryJob(db, jobID)
 		if js.err != nil || isDone(js) {
 			break

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -676,7 +676,7 @@ func queryJobUntil(
 	t *testing.T, db sqlutils.DBHandle, jobID jobspb.JobID, isDone func(js jobState) bool,
 ) (js jobState) {
 	t.Helper()
-	for r := retry.Start(context.Background(), base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(context.Background(), retry.Options{}); r.Next(); {
 		js = queryJob(db, jobID)
 		if js.err != nil || isDone(js) {
 			break

--- a/pkg/sql/importer/rollback_job.go
+++ b/pkg/sql/importer/rollback_job.go
@@ -52,7 +52,7 @@ func (r *importRollbackResumer) Resume(ctx context.Context, execCtx interface{})
 		InitialBackoff: 10 * time.Second,
 		MaxBackoff:     10 * time.Minute,
 	}
-	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+	for re := retry.Start(ctx, retryOpts); re.Next(); {
 		err := r.rollbackTable(ctx, cfg, tableID)
 		if err != nil {
 			log.Errorf(ctx, "rollback of table %d failed: %s", tableID, err.Error())

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1816,7 +1816,6 @@ func (ief *InternalDB) txn(
 		}
 		retryOpts := retry.Options{
 			InitialBackoff: time.Millisecond,
-			Multiplier:     1.5,
 			MaxBackoff:     time.Second,
 		}
 		lm := ief.server.cfg.LeaseManager

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -142,7 +142,7 @@ func (p *planner) waitForDescriptorSchemaChanges(
 	// Wait for the descriptor to no longer be claimed by a schema change.
 	start := timeutil.Now()
 	logEvery := log.Every(10 * time.Second)
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
 		now := p.ExecCfg().Clock.Now()
 		var isBlocked bool
 		var blockingJobIDs []catpb.JobID

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -142,7 +141,7 @@ func (p *planner) waitForDescriptorSchemaChanges(
 	// Wait for the descriptor to no longer be claimed by a schema change.
 	start := timeutil.Now()
 	logEvery := log.Every(10 * time.Second)
-	for r := retry.Start(ctx, base.DefaultRetryOptions()); r.Next(); {
+	for r := retry.Start(ctx, retry.Options{}); r.Next(); {
 		now := p.ExecCfg().Clock.Now()
 		var isBlocked bool
 		var blockingJobIDs []catpb.JobID

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1455,7 +1455,6 @@ func WaitToUpdateLeases(
 	retryOpts := retry.Options{
 		InitialBackoff: time.Millisecond,
 		MaxBackoff:     time.Second,
-		Multiplier:     1.5,
 	}
 	start := timeutil.Now()
 	log.Infof(ctx, "waiting for a single version...")
@@ -2717,7 +2716,6 @@ func (r schemaChangeResumer) Resume(ctx context.Context, execCtx interface{}) er
 		opts := retry.Options{
 			InitialBackoff: 20 * time.Millisecond,
 			MaxBackoff:     schemaChangeJobMaxRetryBackoff.Get(p.ExecCfg().SV()),
-			Multiplier:     1.5,
 		}
 
 		// The schema change may have to be retried if it is not first in line or

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2724,7 +2724,7 @@ func (r schemaChangeResumer) Resume(ctx context.Context, execCtx interface{}) er
 		// for other retriable reasons so we run it in an exponential backoff retry
 		// loop. The loop terminates only if the context is canceled.
 		var scErr error
-		for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+		for r := retry.Start(ctx, opts); r.Next(); {
 			// Note that r.Next always returns true on first run so exec will be
 			// called at least once before there is a chance for this loop to exit.
 			if err := p.ExecCfg().JobRegistry.CheckPausepoint("schemachanger.before.exec"); err != nil {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -255,7 +255,7 @@ CREATE INDEX foo ON t.test (v)
 	}
 
 	// Wait until index is created.
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
 		if len(tableDesc.PublicNonPrimaryIndexes()) == 1 {
@@ -281,7 +281,7 @@ CREATE INDEX foo ON t.test (v)
 
 	mTest.Exec(t, `ALTER INDEX t.test@foo RENAME TO ufo`)
 
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		// Ensure that the version gets incremented.
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
@@ -302,7 +302,7 @@ CREATE INDEX foo ON t.test (v)
 		mTest.Exec(t, fmt.Sprintf(`CREATE INDEX foo%d ON t.test (v)`, i))
 	}
 	// Wait until indexes are created.
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(
 			kvDB, keys.SystemSQLCodec, "t", "test")
 		if len(tableDesc.PublicNonPrimaryIndexes()) == count+1 {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -251,7 +251,6 @@ CREATE INDEX foo ON t.test (v)
 	retryOpts := retry.Options{
 		InitialBackoff: 20 * time.Millisecond,
 		MaxBackoff:     200 * time.Millisecond,
-		Multiplier:     2,
 	}
 
 	// Wait until index is created.

--- a/pkg/sql/schemachanger/corpus/corpus.go
+++ b/pkg/sql/schemachanger/corpus/corpus.go
@@ -11,6 +11,7 @@
 package corpus
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -210,7 +211,7 @@ func (cc *Collector) UpdateCorpus() error {
 // lockCorpus locks the corpus file on disk for reading/writing.
 func (cr *Reader) lockCorpus() (unlockFn func(), err error) {
 	var f *os.File
-	r := retry.Start(retry.Options{})
+	r := retry.Start(context.Background(), retry.Options{})
 	// File creation/deletion is atomic so use it to lock the corpus on disk.
 	// Note: On Linux/Unix we can do better and use unix.Flock, but that won't
 	// be platform independent.

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -300,7 +300,7 @@ func (s *Storage) createInstanceRow(
 		MaxBackoff:     200 * time.Millisecond,
 		Multiplier:     2,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		log.Infof(ctx, "assigning instance id to rpc addr %s and sql addr %s", rpcAddr, sqlAddr)
 		instanceID, err := assignInstance()
 		// Instance was successfully assigned an ID.

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -298,7 +298,6 @@ func (s *Storage) createInstanceRow(
 	opts := retry.Options{
 		InitialBackoff: 50 * time.Millisecond,
 		MaxBackoff:     200 * time.Millisecond,
-		Multiplier:     2,
 	}
 	for r := retry.Start(ctx, opts); r.Next(); {
 		log.Infof(ctx, "assigning instance id to rpc addr %s and sql addr %s", rpcAddr, sqlAddr)

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -214,7 +214,7 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 		Multiplier:     1.5,
 	}
 	everySecond := log.Every(time.Second)
-	for i, r := 0, retry.StartWithCtx(ctx, opts); r.Next(); {
+	for i, r := 0, retry.Start(ctx, opts); r.Next(); {
 		// If we fail to insert the session, then reset the start time
 		// and expiration, since otherwise there is a danger of inserting
 		// an expired session.
@@ -274,7 +274,7 @@ func (l *Instance) extendSession(ctx context.Context, s *session) (bool, error) 
 	var err error
 	var found bool
 	// Retry until success or until the context is canceled.
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		if found, exp, err = l.storage.Update(ctx, s.ID(), exp); err != nil {
 			if ctx.Err() != nil {
 				break

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -211,7 +211,6 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 	opts := retry.Options{
 		InitialBackoff: 10 * time.Millisecond,
 		MaxBackoff:     2 * time.Second,
-		Multiplier:     1.5,
 	}
 	everySecond := log.Every(time.Second)
 	for i, r := 0, retry.Start(ctx, opts); r.Next(); {
@@ -269,7 +268,6 @@ func (l *Instance) extendSession(ctx context.Context, s *session) (bool, error) 
 	opts := retry.Options{
 		InitialBackoff: 10 * time.Millisecond,
 		MaxBackoff:     2 * time.Second,
-		Multiplier:     1.5,
 	}
 	var err error
 	var found bool

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -164,7 +164,7 @@ func (j *jobMonitor) updateSchedule(ctx context.Context, cronExpr string) {
 		InitialBackoff: time.Second,
 		MaxBackoff:     10 * time.Minute,
 	}
-	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
+	for r := retry.Start(ctx, retryOptions); r.Next(); {
 		if err = j.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			// We check if we can get load the schedule, if the schedule cannot be
 			// loaded because it's not found, we recreate the schedule.

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -462,7 +462,6 @@ func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(
 			retry.Options{
 				InitialBackoff: 1 * time.Second,
 				MaxBackoff:     1 * time.Minute,
-				Multiplier:     2,
 				Closer:         closerCh,
 			},
 			5, // maxAttempts

--- a/pkg/sql/tenant_update.go
+++ b/pkg/sql/tenant_update.go
@@ -334,7 +334,7 @@ func stepTenantServiceState(
 		log.Infof(ctx, "waiting for all nodes to stop service for tenant %d", inInfo.ID)
 		if err := timeutil.RunWithTimeout(ctx, "wait-for-tenant-stop", 10*time.Minute, func(ctx context.Context) error {
 			retryOpts := retry.Options{MaxBackoff: 10 * time.Second}
-			for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+			for re := retry.Start(ctx, retryOpts); re.Next(); {
 				resp, err := statusSrv.TenantServiceStatus(ctx, &serverpb.TenantServiceStatusRequest{TenantID: inInfo.ID})
 				if err != nil {
 					return errors.Wrap(err, "failed waiting for tenant service status")

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1325,7 +1325,7 @@ func (t *typeSchemaChanger) execWithRetry(ctx context.Context) error {
 		MaxBackoff:     20 * time.Second,
 		Multiplier:     1.5,
 	}
-	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+	for r := retry.Start(ctx, opts); r.Next(); {
 		if err := t.execCfg.JobRegistry.CheckPausepoint("typeschemachanger.before.exec"); err != nil {
 			return err
 		}

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1323,7 +1323,6 @@ func (t *typeSchemaChanger) execWithRetry(ctx context.Context) error {
 	opts := retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     20 * time.Second,
-		Multiplier:     1.5,
 	}
 	for r := retry.Start(ctx, opts); r.Next(); {
 		if err := t.execCfg.JobRegistry.CheckPausepoint("typeschemachanger.before.exec"); err != nil {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1426,7 +1426,7 @@ func (tc *TestCluster) WaitForFullReplication() error {
 	}
 
 	notReplicated := true
-	for r := retry.Start(opts); r.Next() && notReplicated; {
+	for r := retry.Start(context.Background(), opts); r.Next() && notReplicated; {
 		notReplicated = false
 		for _, s := range tc.Servers {
 			err := s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
@@ -1777,7 +1777,7 @@ func (tc *TestCluster) RestartServerWithInspect(
 	return timeutil.RunWithTimeout(
 		ctx, "check-conn", 15*time.Second,
 		func(ctx context.Context) error {
-			r := retry.StartWithCtx(ctx, retry.Options{
+			r := retry.Start(ctx, retry.Options{
 				InitialBackoff: 1 * time.Millisecond,
 				MaxBackoff:     100 * time.Millisecond,
 			})

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1422,7 +1422,6 @@ func (tc *TestCluster) WaitForFullReplication() error {
 	opts := retry.Options{
 		InitialBackoff: time.Millisecond * 10,
 		MaxBackoff:     time.Millisecond * 100,
-		Multiplier:     2,
 	}
 
 	notReplicated := true

--- a/pkg/upgrade/upgradecluster/tenant_cluster.go
+++ b/pkg/upgrade/upgradecluster/tenant_cluster.go
@@ -292,7 +292,7 @@ func (t *TenantCluster) UntilClusterStable(ctx context.Context, fn func() error)
 
 	// TODO(ajstorm): this could use a test to validate that the retry behavior
 	//  does what we expect. I've tested it manually in the debugger for now.
-	for retrier := retry.StartWithCtx(ctx, retryOpts); retrier.Next(); {
+	for retrier := retry.Start(ctx, retryOpts); retrier.Next(); {
 		if err := fn(); err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/v24_1_session_based_lease.go
+++ b/pkg/upgrade/upgrades/v24_1_session_based_lease.go
@@ -86,7 +86,7 @@ SELECT
 FROM
 	expected AS e, current AS c;
 `
-	r := retry.StartWithCtx(ctx, retry.Options{
+	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Millisecond * 500,
 		Multiplier:     2,
 		MaxBackoff:     time.Second * 10,

--- a/pkg/upgrade/upgrades/v24_1_session_based_lease.go
+++ b/pkg/upgrade/upgrades/v24_1_session_based_lease.go
@@ -88,7 +88,6 @@ FROM
 `
 	r := retry.Start(ctx, retry.Options{
 		InitialBackoff: time.Millisecond * 500,
-		Multiplier:     2,
 		MaxBackoff:     time.Second * 10,
 	})
 	for r.Next() {

--- a/pkg/upgrade/upgrades/version_starvation_test.go
+++ b/pkg/upgrade/upgrades/version_starvation_test.go
@@ -92,7 +92,7 @@ func TestLeasingClusterVersionStarvation(t *testing.T) {
 			return
 		}
 		resumeBump <- struct{}{}
-		for retry := retry.Start(retry.Options{}); retry.Next(); {
+		for retry := retry.Start(ctx, retry.Options{}); retry.Next(); {
 			_, err = tx.Exec("SELECT name from system.settings where name='version' FOR UPDATE")
 			if err != nil {
 				rollbackErr := tx.Rollback()

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -27,7 +27,7 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 		MaxRetries:     10,
 	}
 
-	r := Start(opts)
+	r := Start(context.Background(), opts)
 	r.opts.RandomizationFactor = 0
 	for i := 0; i < 10; i++ {
 		d := r.retryIn()
@@ -47,7 +47,7 @@ func TestRetryExceedsMaxAttempts(t *testing.T) {
 	}
 
 	attempts := 0
-	for r := Start(opts); r.Next(); attempts++ {
+	for r := Start(context.Background(), opts); r.Next(); attempts++ {
 	}
 
 	if expAttempts := opts.MaxRetries + 1; attempts != expAttempts {
@@ -68,7 +68,7 @@ func TestRetryReset(t *testing.T) {
 	attempts := 0
 	// Backoff loop has 1 allowed retry; we always call Reset, so
 	// just make sure we get to 2 attempts and then break.
-	for r := Start(opts); r.Next(); attempts++ {
+	for r := Start(context.Background(), opts); r.Next(); attempts++ {
 		if attempts == expAttempts {
 			break
 		}
@@ -92,7 +92,7 @@ func TestRetryStop(t *testing.T) {
 	var attempts int
 
 	// Create a retry loop which will never stop without stopper.
-	for r := Start(opts); r.Next(); attempts++ {
+	for r := Start(context.Background(), opts); r.Next(); attempts++ {
 		go close(closer)
 		// Don't race the stopper, just wait for it to do its thing.
 		<-opts.Closer
@@ -111,7 +111,7 @@ func TestRetryNextCh(t *testing.T) {
 		Multiplier:     2,
 		MaxRetries:     1,
 	}
-	for r := Start(opts); attempts < 3; attempts++ {
+	for r := Start(context.Background(), opts); attempts < 3; attempts++ {
 		c := r.NextCh()
 		if r.currentAttempt != attempts {
 			t.Errorf("expected attempt=%d; got %d", attempts, r.currentAttempt)

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -23,7 +23,6 @@ func TestRetryExceedsMaxBackoff(t *testing.T) {
 	opts := Options{
 		InitialBackoff: time.Microsecond * 10,
 		MaxBackoff:     time.Microsecond * 100,
-		Multiplier:     2,
 		MaxRetries:     10,
 	}
 
@@ -42,7 +41,6 @@ func TestRetryExceedsMaxAttempts(t *testing.T) {
 	opts := Options{
 		InitialBackoff: time.Microsecond * 10,
 		MaxBackoff:     time.Second,
-		Multiplier:     2,
 		MaxRetries:     1,
 	}
 
@@ -59,7 +57,6 @@ func TestRetryReset(t *testing.T) {
 	opts := Options{
 		InitialBackoff: time.Microsecond * 10,
 		MaxBackoff:     time.Second,
-		Multiplier:     2,
 		MaxRetries:     1,
 	}
 
@@ -85,7 +82,6 @@ func TestRetryStop(t *testing.T) {
 	opts := Options{
 		InitialBackoff: time.Second,
 		MaxBackoff:     time.Second,
-		Multiplier:     2,
 		Closer:         closer,
 	}
 
@@ -108,7 +104,6 @@ func TestRetryNextCh(t *testing.T) {
 
 	opts := Options{
 		InitialBackoff: time.Millisecond,
-		Multiplier:     2,
 		MaxRetries:     1,
 	}
 	for r := Start(context.Background(), opts); attempts < 3; attempts++ {
@@ -184,7 +179,6 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
 				MaxBackoff:     time.Microsecond * 20,
-				Multiplier:     2,
 				MaxRetries:     1,
 			},
 			retryFunc:   noErrFunc,
@@ -199,7 +193,6 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
 				MaxBackoff:     time.Microsecond * 20,
-				Multiplier:     2,
 				MaxRetries:     1,
 			},
 			retryFunc:   errorUntilAttemptNumFunc(1),
@@ -214,7 +207,6 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
 				MaxBackoff:     time.Microsecond * 20,
-				Multiplier:     2,
 				MaxRetries:     1,
 			},
 			retryFunc:   errWithAttemptsCounterFunc,
@@ -230,7 +222,6 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
 				MaxBackoff:     time.Microsecond * 20,
-				Multiplier:     2,
 				MaxRetries:     0,
 			},
 			retryFunc:   errWithAttemptsCounterFunc,
@@ -246,7 +237,6 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
 				MaxBackoff:     time.Microsecond * 20,
-				Multiplier:     2,
 				MaxRetries:     1,
 			},
 			retryFunc:   errWithAttemptsCounterFunc,
@@ -265,7 +255,6 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 			opts: Options{
 				InitialBackoff: time.Microsecond * 10,
 				MaxBackoff:     time.Microsecond * 20,
-				Multiplier:     2,
 				MaxRetries:     1,
 				Closer:         closeCh,
 			},

--- a/pkg/util/startup/retry.go
+++ b/pkg/util/startup/retry.go
@@ -138,7 +138,7 @@ func RunIdempotentWithRetryEx[T any](
 	var err error
 	retryOpts := startupRetryOpts
 	retryOpts.Closer = quiesce
-	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+	for r := retry.Start(ctx, retryOpts); r.Next(); {
 		result, err = f(ctx)
 		if err == nil {
 			break

--- a/pkg/util/startup/retry.go
+++ b/pkg/util/startup/retry.go
@@ -78,7 +78,6 @@ type startupRetryKey struct{}
 var startupRetryOpts = retry.Options{
 	InitialBackoff: 100 * time.Millisecond,
 	MaxBackoff:     3 * time.Second,
-	Multiplier:     2,
 }
 
 // runningStartup is a counter showing number of concurrently running server

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -442,7 +442,7 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		cancel()
 	}).Stop()
 	if prepareErr := func(ctx context.Context) error {
-		retry := retry.StartWithCtx(ctx, retry.Options{})
+		retry := retry.Start(ctx, retry.Options{})
 		var err error
 		for retry.Next() {
 			if err != nil {


### PR DESCRIPTION
Previously there were two retry.Start methods one that took a context and one that didn't. There have been several bugs related to calling the one without the context. This commit requires a context is passed to Start and removes the other version.

Epic: None

Release note: None