### PR TITLE
release-23.2: changefeedccl: use new bulk oracle for changefeed planning

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//pkg/ccl/changefeedccl/kvevent",
         "//pkg/ccl/changefeedccl/kvfeed",
         "//pkg/ccl/changefeedccl/schemafeed",
+        "//pkg/ccl/kvccl/kvfollowerreadsccl",
         "//pkg/ccl/utilccl",
         "//pkg/cloud",
         "//pkg/cloud/externalconn",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6171,7 +6171,7 @@ func TestChangefeedHandlesRollingRestart(t *testing.T) {
 								t.Fatal("did not get signal to proceed")
 							}
 						},
-						// Handle tarnsient changefeed error.  We expect to see node drain error.
+						// Handle transient changefeed error.  We expect to see node drain error.
 						// When we do, notify drainNotification, and reset node drain channel.
 						HandleDistChangefeedError: func(err error) error {
 							errCh <- err


### PR DESCRIPTION
Backport 1/1 commits from #120077.

/cc @cockroachdb/release

---

This change uses the BulkOracle by default as part of changefeed planning, instead of the bin packing oracle. This will allow changefeeds to have plans that randomly assign spans to any replica, including followers if enabled, following locality filter constraints.

A new cluster setting, `changefeed.random_replica_selection.enabled`, protects this change. When enabled (disabled by default in this backport), changefeeds will use the new BulkOracle for planning. If disabled, changefeeds will use the previous bin packing oracle.

Epic: none
Fixes: #119777
Fixes: #114611

Release note (enterprise change): Changefeeds now use the BulkOracle for planning, which distributes work evenly across all replica in the locality filter, including followers if enabled. This is enabled with the cluster setting
`changefeed.random_replica_selection.enabled`. If disabled (by default in this backport), changefeed planning reverts to its previous bin packing oracle.

Release justification: CDC can have unbalanced plans that lead to poor performance when using execution locality due to planning only on leaseholders or the gateway node. This change backports the bulk oracle which can result in better plans and has had some air miles in 24.1 in CDC as well as in DR bulk operations. Its usage is gated behind a cluster setting that is disabled by default.