### PR TITLE
 streamingccl: tweak node lag replanning policy

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/node_lag_detector.go
+++ b/pkg/ccl/streamingccl/streamingest/node_lag_detector.go
@@ -15,13 +15,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
 var ErrNodeLagging = errors.New("node frontier too far behind other nodes")
 
 // checkLaggingNode returns an error if there exists a destination node lagging
-// more than maxAllowable lag behind any other destination node. This function
+// more than maxAllowable lag behind the mean frontier of all destination nodes. This function
 // assumes that all nodes have finished their initial scan (i.e. have a nonzero hwm).
 func checkLaggingNodes(
 	ctx context.Context, executionDetails []frontierExecutionDetails, maxAllowableLag time.Duration,
@@ -29,18 +30,22 @@ func checkLaggingNodes(
 	if maxAllowableLag == 0 {
 		return nil
 	}
-	laggingNode, minLagDifference := computeMinLagDifference(executionDetails)
-	log.VEventf(ctx, 2, "computed min lag diff: %d lagging node, difference %.2f", laggingNode, minLagDifference.Minutes())
-	if maxAllowableLag < minLagDifference {
-		return errors.Wrapf(ErrNodeLagging, "node %d is %.2f minutes behind the next node. Try replanning", laggingNode, minLagDifference.Minutes())
+	laggingNode, meanLagDifference := computeMeanLagDifference(ctx, executionDetails)
+	log.VEventf(ctx, 2, "computed mean lag diff: %d lagging node, difference %.2f", laggingNode, meanLagDifference.Minutes())
+	if maxAllowableLag < meanLagDifference {
+		return errors.Wrapf(ErrNodeLagging, "node %d is %.2f minutes behind the average frontier. Try replanning", laggingNode, meanLagDifference.Minutes())
 	}
 	return nil
 }
 
-func computeMinLagDifference(
-	executionDetails []frontierExecutionDetails,
+// computeMeanLagDifference computes the difference between the mean frontier by
+// node and the node with the lowest frontier.
+func computeMeanLagDifference(
+	ctx context.Context, executionDetails []frontierExecutionDetails,
 ) (base.SQLInstanceID, time.Duration) {
-	oldestHWM := hlc.MaxTimestamp.GoTime()
+	lowestFrontier := hlc.MaxTimestamp.GoTime()
+
+	// First find the frontier for each node.
 	var laggingNode base.SQLInstanceID
 	destNodeFrontier := make(map[base.SQLInstanceID]time.Time)
 	for _, detail := range executionDetails {
@@ -50,8 +55,8 @@ func computeMinLagDifference(
 		} else if destNodeFrontier[detail.destInstanceID].After(frontier) {
 			destNodeFrontier[detail.destInstanceID] = frontier
 		}
-		if oldestHWM.After(frontier) {
-			oldestHWM = frontier
+		if lowestFrontier.After(frontier) {
+			lowestFrontier = frontier
 			laggingNode = detail.destInstanceID
 		}
 	}
@@ -59,16 +64,17 @@ func computeMinLagDifference(
 		// If there are fewer than 2 nodes in the frontier, we can't compare relative lag.
 		return base.SQLInstanceID(0), 0
 	}
+	meanFrontier := getMeanFrontier(destNodeFrontier)
+	log.VEventf(ctx, 2, "mean frontier: %s, lowest frontier %s", meanFrontier, lowestFrontier)
 
-	minlagDifference := hlc.MaxTimestamp.GoTime().Sub(hlc.MinTimestamp.GoTime())
-	for id, frontier := range destNodeFrontier {
-		if id == laggingNode {
-			continue
-		}
+	return laggingNode, meanFrontier.Sub(lowestFrontier)
+}
 
-		if diff := frontier.Sub(oldestHWM); diff < minlagDifference {
-			minlagDifference = diff
-		}
+func getMeanFrontier(destNodeFrontier map[base.SQLInstanceID]time.Time) time.Time {
+	var sum int64
+	for _, frontier := range destNodeFrontier {
+		sum += frontier.Unix()
 	}
-	return laggingNode, minlagDifference
+	frontierMean := timeutil.Unix(sum/int64(len(destNodeFrontier)), 0)
+	return frontierMean
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -434,11 +434,6 @@ func (sf *streamIngestionFrontier) maybeCheckForLaggingNodes() error {
 			maxLag, checkFreq.Minutes(), sf.lastNodeLagCheck, timeutil.Since(sf.lastNodeLagCheck).Minutes())
 		return nil
 	}
-	// Don't check for lagging nodes if the hwm has yet to advance.
-	if sf.replicatedTimeAtStart.Equal(sf.persistedReplicatedTime) {
-		log.VEventf(ctx, 2, "skipping lag replanning check: hwm has yet to advance past %s", sf.replicatedTimeAtStart)
-		return nil
-	}
 	defer func() {
 		sf.lastNodeLagCheck = timeutil.Now()
 	}()
@@ -465,7 +460,7 @@ func (sf *streamIngestionFrontier) handleLaggingNodeError(ctx context.Context, e
 		sf.replicatedTimeAtLastPositiveLagNodeCheck = sf.persistedReplicatedTime
 		return nil
 	case sf.replicatedTimeAtLastPositiveLagNodeCheck.Equal(sf.persistedReplicatedTime):
-		return errors.Wrapf(err, "hwm has not advanced from %s", sf.persistedReplicatedTime)
+		return errors.Wrapf(err, "replicated time has not advanced from %s", sf.persistedReplicatedTime)
 	default:
 		return errors.Wrapf(err, "unable to handle replanning error with replicated time %s and last node lag check replicated time %s", sf.persistedReplicatedTime, sf.replicatedTimeAtLastPositiveLagNodeCheck)
 	}

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -44,3 +44,22 @@ func (fes RestoreFrontierEntries) Equal(fes2 RestoreFrontierEntries) bool {
 	}
 	return true
 }
+
+// ResolvedSpanEntries is a slice of ResolvedSpanEntries.
+// TODO(msbutler): use generics and combine with above.
+type ResolvedSpanEntries []ResolvedSpan
+
+func (rse ResolvedSpanEntries) Equal(rse2 ResolvedSpanEntries) bool {
+	if len(rse) != len(rse2) {
+		return false
+	}
+	for i := range rse {
+		if !rse[i].Span.Equal(rse2[i].Span) {
+			return false
+		}
+		if !rse[i].Timestamp.Equal(rse2[i].Timestamp) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
This patch changes the policy for when pcr replans based on a lagging node:

- previously, lag node replanning would not occur if the replicated time had
  not advanced during the flow. This patch relaxes this requirement. If one
node is lagging behind all other nodes, and it is preventing the replicated
time from advancing, we really should replan!

- previously, lag node replanning would occur if the lagging node was more than
  x minutes behind the second most lagging node. But, if 2 nodes are lagging
behind all other nodes, we would not replan, even though we should. Instead,
this patch will trigger replanning if the lagging node's frontier is more than
x minutes behind the mean frontier of all participating nodes.

Overall, this patch relaxes the requirements for lag replanning, which will
become much less costly once #125044 lands, as it reduces the amount of wasted
work on each dist sql flow restart.

Informs #124915

Relase note: none