### PR TITLE
roachtest: skip node distribution check on c2c/BulkOps

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1257,8 +1257,11 @@ func registerClusterToCluster(r registry.Registry) {
 			// replanning and distributed catch up scans fix the poor initial plan. If
 			// max accepted latency doubles, then there's likely a regression.
 			maxAcceptedLatency: 1 * time.Hour,
-			clouds:             registry.AllExceptAWS,
-			suites:             registry.Suites(registry.Nightly),
+			// Skipping node distribution check because there is little data on the
+			// source when the replication stream begins.
+			skipNodeDistributionCheck: true,
+			clouds:                    registry.AllExceptAWS,
+			suites:                    registry.Suites(registry.Nightly),
 		},
 		{
 			name:               "c2c/BulkOps/singleImport",


### PR DESCRIPTION
Fixes #123175

Release note: none