### PR TITLE
rangefeed: fix get usage with pool

### DIFF
--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -483,7 +483,7 @@ func (p *ScheduledProcessor) enqueueEventInternal(
 			}()
 		}
 	}
-	ev := getPooledEvent(e)
+	ev := getPooledEventAndShallowCopy(e)
 	ev.alloc = alloc
 	if timeout == 0 {
 		// Timeout is zero if no timeout was requested or timeout is already set on
@@ -550,7 +550,8 @@ func (p *ScheduledProcessor) syncEventC() {
 // syncSendAndWait allows sync event to be sent and waited on its channel.
 // Exposed to allow special test syneEvents that contain span to be sent.
 func (p *ScheduledProcessor) syncSendAndWait(se *syncEvent) {
-	ev := getPooledEvent(event{sync: se})
+	ev := getPooledEvent()
+	ev.sync = se
 	select {
 	case p.eventC <- ev:
 		// This shouldn't happen as there should be no sync events after disconnect,


### PR DESCRIPTION
Previously, we would sometimes pass an externally created struct to the get pool
function and copy by value, leading to unnecessary memory allocation and
defeating the purpose of using a pool to manage lifecycle of struct objects.
This patch fixes it by either passing the specific field for initialization or
simply getting a new struct pointer directly from the pool.

Release note: none
Epic: none