### PR TITLE
spanconfigtestcluster: don't set SkipWaitingForMVCCGC

### DIFF
--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -61,10 +61,10 @@ func (h *Handle) InitializeTenant(ctx context.Context, tenID roachpb.TenantID) *
 		tenantState.cleanup = func() {} // noop
 	} else {
 		serverGCJobKnobs := testServer.SystemLayer().TestingKnobs().GCJob
-		tenantGCJobKnobs := sql.GCJobTestingKnobs{SkipWaitingForMVCCGC: true}
+		// Copy the GC job knobs from the server to the tenant.
+		tenantGCJobKnobs := sql.GCJobTestingKnobs{}
 		if serverGCJobKnobs != nil {
 			tenantGCJobKnobs = *serverGCJobKnobs.(*sql.GCJobTestingKnobs)
-			tenantGCJobKnobs.SkipWaitingForMVCCGC = true
 		}
 		tenantArgs := base.TestTenantArgs{
 			TenantID: tenID,


### PR DESCRIPTION
This knob is no longer needed, and it seems to cause a rare flake with an error `relation "[107]" does not exist`. This is because part of the spanconfigsplitter test is to lookup a dropped a descriptor, and with the knob set, the descriptor can be removed too quickly for the test to be able to look at it.

fixes https://github.com/cockroachdb/cockroach/issues/123951
fixes https://github.com/cockroachdb/cockroach/issues/123823
Release note: None