### PR TITLE
roachprod: log error on delete config

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -365,8 +365,10 @@ func DestroyCluster(l *logger.Logger, c *Cluster) error {
 	for _, node := range c.VMs {
 		if _, ok := promhelperclient.SupportedPromProjects[node.Project]; ok &&
 			node.Provider == gce.ProviderName {
-			_ = promhelperclient.NewPromClient().DeleteClusterConfig(context.Background(),
-				c.Name, false, l)
+			if err := promhelperclient.NewPromClient().DeleteClusterConfig(context.Background(),
+				c.Name, false, l); err != nil {
+				l.Errorf("Failed to delete the cluster config: %v", err)
+			}
 			break
 		}
 	}


### PR DESCRIPTION
currently, the promhelpers delete error
is not logged. This change is to log the same.
This is needed to see the failure in gc logs.

Fixes: #124599
Epic: none