### PR TITLE
streamingccl: unskip TestTenantStreamingReplanOnLag

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -855,8 +855,6 @@ func TestStreamingReplanOnLag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 120688)
-
 	skip.UnderDuressWithIssue(t, 115850, "time to scatter ranges takes too long under duress")
 	skip.UnderMetamorphic(t, "time to scatter ranges takes too long under non-default settings")
 


### PR DESCRIPTION
Fixes #120688

Release note: none