### PR TITLE
distsql: improve unhealthy node detection in SQL instances-based planning.

### DIFF
--- a/pkg/rpc/nodedialer/BUILD.bazel
+++ b/pkg/rpc/nodedialer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/rpc/nodedialer",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/kv/kvbase",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1025,6 +1025,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.stopper,
 			isAvailable,
 			cfg.kvNodeDialer.ConnHealthTryDial, // only used by system tenant
+			cfg.sqlInstanceDialer.ConnHealthTryDialInstance,
 			cfg.sqlInstanceDialer,
 			codec,
 			cfg.sqlInstanceReader,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -335,6 +335,7 @@ func startConnExecutor(
 			stopper,
 			func(base.SQLInstanceID) bool { return true }, // everybody is available
 			nil, /* connHealthCheckerSystem */
+			nil, /* instanceConnHealthChecker */
 			nil, /* sqlInstanceDialer */
 			keys.SystemSQLCodec,
 			nil, /* sqlAddressResolver */

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -176,6 +176,7 @@ func NewDistSQLPlanner(
 	stopper *stop.Stopper,
 	isAvailable func(base.SQLInstanceID) bool,
 	connHealthCheckerSystem func(roachpb.NodeID, rpc.ConnectionClass) error, // will only be used by the system tenant
+	instanceConnHealthChecker func(base.SQLInstanceID, string) error,
 	sqlInstanceDialer *nodedialer.Dialer,
 	codec keys.SQLCodec,
 	sqlAddressResolver sqlinstance.AddressResolver,
@@ -189,9 +190,10 @@ func NewDistSQLPlanner(
 		gossip:               gw,
 		sqlInstanceDialer:    sqlInstanceDialer,
 		nodeHealth: distSQLNodeHealth{
-			gossip:      gw,
-			connHealth:  connHealthCheckerSystem,
-			isAvailable: isAvailable,
+			gossip:             gw,
+			connHealthSystem:   connHealthCheckerSystem,
+			connHealthInstance: instanceConnHealthChecker,
+			isAvailable:        isAvailable,
 		},
 		distSender:         distSender,
 		nodeDescs:          nodeDescs,
@@ -231,6 +233,8 @@ func (dsp *DistSQLPlanner) GetAllInstancesByLocality(
 	if err != nil {
 		return nil, err
 	}
+	all, _ = dsp.filterUnhealthyInstances(all, nil /* nodeStatusesCache */)
+
 	log.VEventf(ctx, 2, "resolved sql instances: %v", all)
 	var pos int
 	for _, n := range all {
@@ -1244,23 +1248,24 @@ func MakeSpanPartitionWithRangeCount(
 }
 
 type distSQLNodeHealth struct {
-	gossip      gossip.OptionalGossip
-	isAvailable func(base.SQLInstanceID) bool
-	connHealth  func(roachpb.NodeID, rpc.ConnectionClass) error
+	gossip             gossip.OptionalGossip
+	isAvailable        func(base.SQLInstanceID) bool
+	connHealthSystem   func(roachpb.NodeID, rpc.ConnectionClass) error
+	connHealthInstance func(base.SQLInstanceID, string) error
 }
 
 func (h *distSQLNodeHealth) checkSystem(
 	ctx context.Context, sqlInstanceID base.SQLInstanceID,
 ) error {
 	{
-		// NB: as of #22658, ConnHealth does not work as expected; see the
+		// NB: as of #22658, connHealthSystem does not work as expected; see the
 		// comment within. We still keep this code for now because in
 		// practice, once the node is down it will prevent using this node
 		// 90% of the time (it gets used around once per second as an
 		// artifact of rpcContext's reconnection mechanism at the time of
 		// writing). This is better than having it used in 100% of cases
 		// (until the liveness check below kicks in).
-		if err := h.connHealth(roachpb.NodeID(sqlInstanceID), rpc.DefaultClass); err != nil {
+		if err := h.connHealthSystem(roachpb.NodeID(sqlInstanceID), rpc.DefaultClass); err != nil {
 			// This host isn't known to be healthy. Don't use it (use the gateway
 			// instead). Note: this can never happen for our sqlInstanceID (which
 			// always has its address in the nodeMap).
@@ -1556,6 +1561,29 @@ func (dsp *DistSQLPlanner) deprecatedHealthySQLInstanceIDForKVNodeIDSystem(
 	return sqlInstanceID, reason
 }
 
+// checkInstanceHealth returns the instance health status by dialing the node.
+// It also caches the result to avoid redialing for a query.
+func (dsp *DistSQLPlanner) checkInstanceHealth(
+	instanceID base.SQLInstanceID,
+	instanceRPCAddr string,
+	nodeStatusesCache map[base.SQLInstanceID]NodeStatus,
+) NodeStatus {
+	if nodeStatusesCache != nil {
+		if status, ok := nodeStatusesCache[instanceID]; ok {
+			return status
+		}
+	}
+	status := NodeOK
+	if err := dsp.nodeHealth.connHealthInstance(instanceID, instanceRPCAddr); err != nil {
+		status = NodeUnhealthy
+	}
+
+	if nodeStatusesCache != nil {
+		nodeStatusesCache[instanceID] = status
+	}
+	return status
+}
+
 // healthySQLInstanceIDForKVNodeHostedInstanceResolver returns the SQL instance
 // ID for an instance that is hosted in the process of a KV node. Currently SQL
 // instances that run in KV node processes have IDs fixed to be equal to the KV
@@ -1566,27 +1594,30 @@ func (dsp *DistSQLPlanner) deprecatedHealthySQLInstanceIDForKVNodeIDSystem(
 //
 // If the given node is not healthy, the gateway node is returned.
 func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeHostedInstanceResolver(
-	ctx context.Context,
+	ctx context.Context, planCtx *PlanningCtx,
 ) func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
-	allHealthy, err := dsp.sqlAddressResolver.GetAllInstances(ctx)
+	allInstances, err := dsp.sqlAddressResolver.GetAllInstances(ctx)
 	if err != nil {
 		log.Warningf(ctx, "could not get all instances: %v", err)
 		return dsp.alwaysUseGatewayWithReason(SpanPartitionReason_GATEWAY_ON_ERROR)
 	}
 
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEventf(ctx, 2, "healthy SQL instances available for distributed planning: %v", allHealthy)
+		log.VEventf(ctx, 2, "all SQL instances available for distributed planning: %v", allInstances)
 	}
 
-	healthyNodes := make(map[base.SQLInstanceID]struct{}, len(allHealthy))
-	for _, n := range allHealthy {
-		healthyNodes[n.InstanceID] = struct{}{}
+	instances := make(map[base.SQLInstanceID]sqlinstance.InstanceInfo, len(allInstances))
+	for _, n := range allInstances {
+		instances[n.InstanceID] = n
 	}
 
 	return func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 		sqlInstance := base.SQLInstanceID(nodeID)
-		if _, ok := healthyNodes[sqlInstance]; ok {
-			return sqlInstance, SpanPartitionReason_TARGET_HEALTHY
+		if n, ok := instances[sqlInstance]; ok {
+			if status := dsp.checkInstanceHealth(
+				sqlInstance, n.InstanceRPCAddr, planCtx.nodeStatuses); status == NodeOK {
+				return sqlInstance, SpanPartitionReason_TARGET_HEALTHY
+			}
 		}
 		log.VWarningf(ctx, 1, "not planning on node %d", sqlInstance)
 		return dsp.gatewaySQLInstanceID, SpanPartitionReason_GATEWAY_TARGET_UNHEALTHY
@@ -1637,6 +1668,27 @@ func (dsp *DistSQLPlanner) shouldPickGateway(
 	return partitionsOnGateway < bias*averageDistributionOnNonGatewayInstances
 }
 
+// filterUnhealthyInstances dials the instances and filters out unhealthy
+// instances.
+func (dsp *DistSQLPlanner) filterUnhealthyInstances(
+	instances []sqlinstance.InstanceInfo, nodeStatusesCache map[base.SQLInstanceID]NodeStatus,
+) ([]sqlinstance.InstanceInfo, []sqlinstance.InstanceInfo) {
+	var unhealthyInstances []sqlinstance.InstanceInfo
+	// In-place filter out unhealthy instances
+	var j int
+	for _, n := range instances {
+		// Gateway is always considered healthy
+		if n.InstanceID == dsp.gatewaySQLInstanceID ||
+			dsp.checkInstanceHealth(n.InstanceID, n.InstanceRPCAddr, nodeStatusesCache) == NodeOK {
+			instances[j] = n
+			j++
+		} else {
+			unhealthyInstances = append(unhealthyInstances, n)
+		}
+	}
+	return instances[:j], unhealthyInstances
+}
+
 // makeInstanceResolver returns a function that can choose the SQL instance ID
 // for a provided KV node ID.
 func (dsp *DistSQLPlanner) makeInstanceResolver(
@@ -1647,14 +1699,17 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 
 	var mixedProcessSameNodeResolver func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason)
 	if mixedProcessMode {
-		mixedProcessSameNodeResolver = dsp.healthySQLInstanceIDForKVNodeHostedInstanceResolver(ctx)
+		mixedProcessSameNodeResolver = dsp.healthySQLInstanceIDForKVNodeHostedInstanceResolver(ctx, planCtx)
 	}
 
 	if mixedProcessMode && locFilter.Empty() {
 		return mixedProcessSameNodeResolver, nil
 	}
 
-	// GetAllInstances only returns healthy instances.
+	// GetAllInstances returns mostly healthy nodes, except those that have
+	// recently gone down and not yet been updated in the sql_instances cache. The
+	// filtering out of these nodes is deferred to the resolver using the
+	// filterUnhealthyInstances function.
 	instances, err := dsp.sqlAddressResolver.GetAllInstances(ctx)
 	if err != nil {
 		return nil, err
@@ -1705,10 +1760,25 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 		log.VEventf(ctx, 2, "healthy SQL instances available for distributed planning: %v", instances)
 	}
 
+	filterUnhealthyInstances := func() []sqlinstance.InstanceInfo {
+		// Instances that have gone down might still be present in the sql_instances
+		// cache. Therefore, we filter out these unhealthy nodes by dialing them.
+		healthy, unhealthy := dsp.filterUnhealthyInstances(instances, planCtx.nodeStatuses)
+		if len(unhealthy) != 0 && log.ExpensiveLogEnabled(ctx, 2) {
+			log.Eventf(ctx, "not planning on unhealthy instances : %v", unhealthy)
+		}
+		return healthy
+	}
+
 	// If we were able to determine the locality information for at least some
 	// instances, use the locality-aware resolver.
 	if instancesHaveLocality {
 		resolver := func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
+			instances = filterUnhealthyInstances()
+			if len(instances) == 0 {
+				log.Eventf(ctx, "no healthy sql instances available for planning, using the gateway")
+				return dsp.gatewaySQLInstanceID, SpanPartitionReason_GATEWAY_NO_HEALTHY_INSTANCES
+			}
 			// Lookup the node localities to compare to the instance localities.
 			nodeDesc, err := dsp.nodeDescs.GetNodeDescriptor(nodeID)
 			if err != nil {
@@ -1769,6 +1839,12 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 	})
 	var i int
 	resolver := func(roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
+		instances := filterUnhealthyInstances()
+		if len(instances) == 0 {
+			log.Eventf(ctx, "no healthy sql instances available for planning, only using the gateway")
+			return dsp.gatewaySQLInstanceID, SpanPartitionReason_GATEWAY_NO_HEALTHY_INSTANCES
+		}
+
 		id := instances[i%len(instances)].InstanceID
 		i++
 		return id, SpanPartitionReason_ROUND_ROBIN

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -385,102 +386,286 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	}
 }
 
-func TestDistSQLDeadHosts(t *testing.T) {
+func TestDistSQLUnavailableHosts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 
-	skip.UnderShort(t, "takes 20s")
-
-	const n = 100
 	const numNodes = 5
 
-	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-		ServerArgs:      base.TestServerArgs{UseDatabase: "test"},
-	})
-	defer tc.Stopper().Stop(context.Background())
+	const n = 100
 
-	db := tc.ServerConn(0)
-	db.SetMaxOpenConns(1)
-	r := sqlutils.MakeSQLRunner(db)
-	r.Exec(t, "CREATE DATABASE test")
-
-	r.Exec(t, "CREATE TABLE t (x INT PRIMARY KEY, xsquared INT)")
-
-	for i := 0; i < numNodes; i++ {
-		r.Exec(t, fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES (%d)", n*i/5))
-	}
-
-	// Evenly spread the ranges between the first 4 nodes. Only the last range
-	// has a replica on the fifth node.
-	for i := 0; i < numNodes; i++ {
-		r.Exec(t, fmt.Sprintf(
-			"ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[%d,%d,%d], %d)",
-			i+1, (i+1)%4+1, (i+2)%4+1, n*i/5,
-		))
-	}
-	r.CheckQueryResults(t,
-		`SELECT IF(substring(start_key for 1)='…',start_key,NULL),
-            IF(substring(end_key for 1)='…',end_key,NULL),
-            lease_holder, replicas FROM [SHOW RANGES FROM TABLE t WITH DETAILS]`,
-		[][]string{
-			{"NULL", "…/1/0", "1", "{1}"},
-			{"…/1/0", "…/1/20", "1", "{1,2,3}"},
-			{"…/1/20", "…/1/40", "2", "{2,3,4}"},
-			{"…/1/40", "…/1/60", "3", "{1,3,4}"},
-			{"…/1/60", "…/1/80", "4", "{1,2,4}"},
-			{"…/1/80", "NULL", "5", "{2,3,5}"},
-		},
+	type tenantMode int
+	const (
+		singleTenant tenantMode = iota
+		sharedProcess
+		externalProcess
 	)
 
-	r.Exec(t, fmt.Sprintf("INSERT INTO t SELECT i, i*i FROM generate_series(1, %d) AS g(i)", n))
+	startAndSetupCluster := func(t *testing.T, mode tenantMode) (
+		serverutils.TestClusterInterface, *sqlutils.SQLRunner) {
+		tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				UseDatabase:       "test",
+				DefaultTestTenant: base.TestControlsTenantsExplicitly,
+			},
+		})
 
-	r.Exec(t, "SET DISTSQL = ON")
+		var db *gosql.DB
+		switch mode {
+		case singleTenant:
+			db = tc.ServerConn(0)
+		case sharedProcess:
+			for i := range tc.NumServers() {
+				_, tenantDB, err := tc.Server(i).TenantController().StartSharedProcessTenant(
+					ctx, base.TestSharedProcessTenantArgs{TenantName: "app"})
+				require.NoError(t, err)
+				if db == nil {
+					db = tenantDB
+				}
+			}
+		case externalProcess:
+			for i := range tc.NumServers() {
+				s := tc.Server(i)
+				tenant, err := s.TenantController().StartTenant(
+					ctx, base.TestTenantArgs{
+						TenantID: serverutils.TestTenantID(),
+						Locality: s.ApplicationLayer().Locality(),
+					})
+				require.NoError(t, err)
+				if db == nil {
+					db = tenant.SQLConn(t)
+				}
+			}
 
-	// Run a query that uses the entire table and is easy to verify.
-	runQuery := func() error {
-		log.Infof(context.Background(), "running test query")
+			// Grant capability to run RELOCATE to secondary (test) tenant.
+			systemDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t))
+			systemDB.Exec(t,
+				`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`,
+				serverutils.TestTenantID().ToUint64())
+		}
+
+		// Connect to node 1 (gateway node)
+		db.SetMaxOpenConns(1)
+		r := sqlutils.MakeSQLRunner(db)
+
+		r.Exec(t, "CREATE DATABASE test")
+		r.Exec(t, "CREATE TABLE t (x INT PRIMARY KEY, xsquared INT)")
+
+		for i := 0; i < numNodes; i++ {
+			r.Exec(t, fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES (%d)", n*i/5))
+		}
+
+		// Evenly spread the ranges between the first 4 nodes. Only the last range
+		// has a replica on the fifth node.
+		for i := 0; i < numNodes; i++ {
+			r.Exec(t, fmt.Sprintf(
+				"ALTER TABLE t RELOCATE VALUES (ARRAY[%d,%d,%d], %d)",
+				i+1, (i+1)%4+1, (i+2)%4+1, n*i/5,
+			))
+		}
+
+		r.Exec(t, fmt.Sprintf("INSERT INTO t SELECT i, i*i FROM generate_series(1, %d) AS g(i)", n))
+		return tc, r
+	}
+
+	// Use a query that uses the entire table and is easy to verify.
+	const query = "SELECT sum(xsquared) FROM t"
+
+	runQuery := func(t *testing.T, r *sqlutils.SQLRunner) error {
 		var res int
-		if err := db.QueryRow("SELECT sum(xsquared) FROM t").Scan(&res); err != nil {
-			return err
-		}
+		r.QueryRow(t, query).Scan(&res)
 		if exp := (n * (n + 1) * (2*n + 1)) / 6; res != exp {
-			t.Fatalf("incorrect result %d, expected %d", res, exp)
+			return errors.Errorf("incorrect result %d, expected %d", res, exp)
 		}
-		log.Infof(context.Background(), "test query OK")
 		return nil
 	}
-	if err := runQuery(); err != nil {
-		t.Error(err)
+
+	checkQueryPlan := func(t *testing.T, r *sqlutils.SQLRunner, expectedPlans []string) error {
+		planQuery := fmt.Sprintf("SELECT info FROM [EXPLAIN (DISTSQL, SHAPE) %s] WHERE info LIKE 'Diagram%%'", query)
+		var result string
+		r.QueryRow(t, planQuery).Scan(&result)
+		for _, expected := range expectedPlans {
+			if result == expected {
+				return nil
+			}
+		}
+		if len(expectedPlans) == 1 {
+			return errors.Errorf("query '%s':\nexpected:\n%v\ngot:\n%s\n", planQuery, expectedPlans[0], result)
+		}
+		return errors.Errorf("query '%s':\nexpected one of:\n%v\ngot:\n%s\n",
+			planQuery, strings.Join(expectedPlans, "\n"), result)
 	}
 
-	// Verify the plan (should include all 5 nodes).
-	r.CheckQueryResults(t,
-		"SELECT info FROM [EXPLAIN (DISTSQL, SHAPE) SELECT sum(xsquared) FROM t] WHERE info LIKE 'Diagram%'",
-		[][]string{{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklV9ro0wUxu_fTyEHXtrCiI4aY7xqaVwaNv2zMcsulFBm46krNU46M9KWku--GNutcRtR40XAceZ5fvOcmZNXkI8p-BAG0-B8riXZPde-zK4vtdvg5830bHKlHY8n4Tz8NiVaeHF2E5xob1Nlvjp-lo85ExidlGvUQvtxEcyCUmY6-RpoR-OExYKt_j8CAhmP8IqtUIJ_CxQIWEDABgIOEBjAgsBa8CVKyUUx5XW7YBI9g28SSLJ1rorhBYElFwj-K6hEpQg-zNmvFGfIIhSGCQQiVCxJtzbqVN2tH_AFCJzzNF9l0tfesYFAuGbFiG5YJiw2BHiuPmykYjGCTytckzH45oa0RzuLY4ExU1wYg12y8Pvl8Sk92Wtr1WwHe20_3PKMiwjLrX1YLTbNYNTsRmbXyOhuIrR9sWifYhmWqRtO-3rRLnSVWNzD6uXu2FrtQ7F6heKYuuG2D8XqQlcJZXhYKMMdW7t9KHavUFxTN7z2odhd6CqheIeF4u3YOu1DcXqF4pl660ScLmiVREaHJTLq0mJnKNc8k1jreZ87mTUnnRbNEaMYy04qeS6WeCP4cju3fL3eCm0HIpSq_ErLl0n2_kkqgWz19x-iqkQblawdJVpVGtSVrGamLlB2o5SzX4nWlZy-23PrSoNGJXc_k1VXcvsyDetKw0Ylbz-TXVfy-jJ5daVR8zEw90M5_5zN5mPeQDUqrs59yp_ukgh8MN8e_ZOf9weKBSyWxf0Nf_Onrez8ZV3cvnuWSiRwyR5wjArFKskSqZIl-ErkuNn89ycAAP__hKt0rw=="}},
-	)
+	t.Run("unhealthy-nodes-in-single-tenant-mode", func(t *testing.T) {
+		skip.UnderDuress(t, "takes 20s")
 
-	// Stop node 5.
-	tc.StopServer(4)
+		tc, r := startAndSetupCluster(t, singleTenant)
+		defer tc.Stopper().Stop(context.Background())
 
-	testutils.SucceedsSoon(t, runQuery)
-
-	// The leaseholder for the last range should have moved to either node 2 or 3.
-	query := "SELECT info FROM [EXPLAIN (DISTSQL, SHAPE) SELECT sum(xsquared) FROM t] WHERE info LIKE 'Diagram%'"
-	exp2 := [][]string{{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF9vmzAUxd_3KawrTW0lR2AgJOOpVcPUaOmfhUybVEWVF24pKsGpbdRWVb77BLQrQQ0CygMStvmd43Pt-wLqIQEPAn_mny5InN4K8n1-eU6u_T9Xs5PpBTmcTINF8HNGSXB2cuUfkdelKlsfPqmHjEsMj8p_9JL8PvPnfomZTX_45GAS80jy9dcDoJCKEC_4GhV418CAggUUbKDgwJLCRooVKiVkPv1SLJ6GT-CZFOJ0k-l8eElhJSSC9wI61gmCBwv-N8E58hClYQKFEDWPk0JCH-ubzT0-A4VTkWTrVHnkzTJQCDY8HxkYlgnLLQWR6XcZpXmE4LGKr-kEPHNL21s7iSKJEddCGs6us-DX-eExO9ora9Vknb2y72pZKmSI5dbepZbbZmPjbsbsmrHxjjHWvlSsT6kMyxwYTvtqsS7uKqEMP1et4Y6s1T4Uq1cojjkwXJPwNCSMCH2HsnVAVhenlYDczwXk7sja7QOyewXkmgNj3P7U2F3cVUIZfS6UUZfWMke1EanC2l3_WMmsKQ1Y3hQwjLDsIEpkcoVXUqyKteXnZQEqBkJUupxl5cc0fZtSWiJf_--MVRJrJFk7JFYlOXWS1Uj61sGT3Uhy9pNYneT03d2wTho2ktz9nqw6ye3rya2TRo2k8X5Pdp007utplJ_R20Q83sQheGC-PoMPXm8P5D_wSOUXJbgTjwV28bzJj_ktTxRSOOf3OEGNch2nsdLxCjwtM9xuv_wLAAD__6oi7LA="}}
-	exp3 := [][]string{{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF9vmzAUxd_3KawrTW0lR2AgJOOpVcPUaOmfhUybVEWVF24pKsGpbdRWVb77BLQrQQ0CygMStvmd43Pt-wLqIQEPAn_mny5InN4K8n1-eU6u_T9Xs5PpBTmcTINF8HNGSXB2cuUfkdelKlsfPqmHjEsMj8p_9JL8PvPnfomZTX_45GAS80jy9dcDoJCKEC_4GhV418CAggUUbKDgwJLCRooVKiVkPv1SLJ6GT-CZFOJ0k-l8eElhJSSC9wI61gmCBwv-N8E58hClYQKFEDWPk0JCH-ubzT0-A4VTkWTrVHnkzTJQCDY8HxkYlgnLLQWR6XcZpXmE4LGKr-kEPHNL21s7iSKJEddCGs6us-DX-eExO9ora9Vknb2y72pZKmSI5dbepZbbZmPjbsbsmrHxjjHWvlSsT6kMyxwYjkl4GhJGhL5D2bpyrIvTSkDDz1VuuCNrtQ_I6hWQYw4Mt_1xtrq4q4Tifi4Ud0fWbh-K3SsU1xwY4_ah2F3cVUIZfS6UUZfWMke1EanC2l3_WMmsKQ1Y3hQwjLDsIEpkcoVXUqyKteXnZQEqBkJUupxl5cc0fZtSWiJf_--MVRJrJFk7JFYlOXWS1Uj61sGT3Uhy9pNYneT03d2wTho2ktz9nqw6ye3rya2TRo2k8X5Pdp007utplJ_R20Q83sQheGC-PoMPXm8P5D_wSOUXJbgTjwV28bzJj_ktTxRSOOf3OEGNch2nsdLxCjwtM9xuv_wLAAD__7Co7LA="}}
-
-	res := r.QueryStr(t, query)
-	if !reflect.DeepEqual(res, exp2) && !reflect.DeepEqual(res, exp3) {
-		t.Errorf("query '%s': expected:\neither\n%vor\n%v\ngot:\n%v\n",
-			query, sqlutils.MatrixToStr(exp2), sqlutils.MatrixToStr(exp3), sqlutils.MatrixToStr(res),
+		r.CheckQueryResults(t,
+			`SELECT IF(substring(start_key for 1)='…',start_key,NULL),
+							IF(substring(end_key for 1)='…',end_key,NULL),
+							lease_holder, replicas FROM [SHOW RANGES FROM TABLE t WITH DETAILS]`,
+			[][]string{
+				{"NULL", "…/1/0", "1", "{1}"},
+				{"…/1/0", "…/1/20", "1", "{1,2,3}"},
+				{"…/1/20", "…/1/40", "2", "{2,3,4}"},
+				{"…/1/40", "…/1/60", "3", "{1,3,4}"},
+				{"…/1/60", "…/1/80", "4", "{1,2,4}"},
+				{"…/1/80", "NULL", "5", "{2,3,5}"},
+			},
 		)
-	}
 
-	// Stop node 4; note that no range had replicas on both 4 and 5.
-	tc.StopServer(3)
+		require.NoError(t, runQuery(t, r))
 
-	testutils.SucceedsSoon(t, runQuery)
+		// Verify the plan should include all 5 nodes.
+		require.NoError(t, checkQueryPlan(t, r,
+			[]string{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklV9ro0wUxu_fTyEHXtrCiI4aY7xqaVwaNv2zMcsulFBm46krNU46M9KWku--GNutcRtR40XAceZ5fvOcmZNXkI8p-BAG0-B8riXZPde-zK4vtdvg5830bHKlHY8n4Tz8NiVaeHF2E5xob1Nlvjp-lo85ExidlGvUQvtxEcyCUmY6-RpoR-OExYKt_j8CAhmP8IqtUIJ_CxQIWEDABgIOEBjAgsBa8CVKyUUx5XW7YBI9g28SSLJ1rorhBYElFwj-K6hEpQg-zNmvFGfIIhSGCQQiVCxJtzbqVN2tH_AFCJzzNF9l0tfesYFAuGbFiG5YJiw2BHiuPmykYjGCTytckzH45oa0RzuLY4ExU1wYg12y8Pvl8Sk92Wtr1WwHe20_3PKMiwjLrX1YLTbNYNTsRmbXyOhuIrR9sWifYhmWqRtO-3rRLnSVWNzD6uXu2FrtQ7F6heKYuuG2D8XqQlcJZXhYKMMdW7t9KHavUFxTN7z2odhd6CqheIeF4u3YOu1DcXqF4pl660ScLmiVREaHJTLq0mJnKNc8k1jreZ87mTUnnRbNEaMYy04qeS6WeCP4cju3fL3eCm0HIpSq_ErLl0n2_kkqgWz19x-iqkQblawdJVpVGtSVrGamLlB2o5SzX4nWlZy-23PrSoNGJXc_k1VXcvsyDetKw0Ylbz-TXVfy-jJ5daVR8zEw90M5_5zN5mPeQDUqrs59yp_ukgh8MN8e_ZOf9weKBSyWxf0Nf_Onrez8ZV3cvnuWSiRwyR5wjArFKskSqZIl-ErkuNn89ycAAP__hKt0rw=="}))
+
+		// Stop node 5.
+		tc.StopServer(4)
+
+		plans := []string{
+			// 5th range is planned on 1st node (gateway)
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklV9ro0wUxu_fTyEHXtrCiI4aY7xqaVwaNv2zMcsulFBm46krNU46M9KWku--GNutcRtR40XAceZ5fvOcmZNXkI8p-BAG0-B8riXZPde-zK4vtdvg5830bHKlHY8n4Tz8NiVaeHF2E5xob1Nlvjp-lo85ExidlGvUQvtxEcyCUmY6-RpoR-OExYKt_j8CAhmP8IqtUIJ_CxQIWEDABgIOEBjAgsBa8CVKyUUx5XW7YBI9g28SSLJ1rorhBYElFwj-K6hEpQg-zNmvFGfIIhSGCQQiVCxJtzbqVN2tH_AFCJzzNF9l0tfesYFAuGbFiG5YJiw2BHiuPmykYjGCTytckzH45oa0RzuLY4ExU1wYg12y8Pvl8Sk92Wtr1WwHe20_3PKMiwjLrX1YLTbNYNTsRmbXyOhuIrR9sWifYhmWqRtO-3rRLnSVWNzD6uXu2FrtQ7F6heKYuuG2D8XqQlcJZXhYKMMdW7t9KHavUFxTN7z2odhd6CqheIeF4u3YOu1DcXqF4pl660ScLmiVREaHJTLq0mJnKNc8k1jreZ87mTUnnRbNEaMYy04qeS6WeCP4cju3fL3eCm0HIpSq_ErLl0n2_kkqgWz19x-iqkQblawdJVpVGtSVrGamLlB2o5SzX4nWlZy-23PrSoNGJXc_k1VXcvsyDetKw0Ylbz-TXVfy-jJ5daVR8zEw90M5_5zN5mPeQDUqrs59yp_ukgh8MN8e_ZOf9weKBSyWxf0Nf_Onrez8ZV3cvnuWSiRwyR5wjArFKskSqZIl-ErkuNn89ycAAP__hKt0rw==",
+			// 5th range is planned on 2nd node
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF9vmzAUxd_3KawrTW0lR2AgJOOpVcPUaOmfhUybVEWVF24pKsGpbdRWVb77BLQrQQ0CygMStvmd43Pt-wLqIQEPAn_mny5InN4K8n1-eU6u_T9Xs5PpBTmcTINF8HNGSXB2cuUfkdelKlsfPqmHjEsMj8p_9JL8PvPnfomZTX_45GAS80jy9dcDoJCKEC_4GhV418CAggUUbKDgwJLCRooVKiVkPv1SLJ6GT-CZFOJ0k-l8eElhJSSC9wI61gmCBwv-N8E58hClYQKFEDWPk0JCH-ubzT0-A4VTkWTrVHnkzTJQCDY8HxkYlgnLLQWR6XcZpXmE4LGKr-kEPHNL21s7iSKJEddCGs6us-DX-eExO9ora9Vknb2y72pZKmSI5dbepZbbZmPjbsbsmrHxjjHWvlSsT6kMyxwYjkl4GhJGhL5D2bpyrIvTSkDDz1VuuCNrtQ_I6hWQYw4Mt_1xtrq4q4Tifi4Ud0fWbh-K3SsU1xwY4_ah2F3cVUIZfS6UUZfWMke1EanC2l3_WMmsKQ1Y3hQwjLDsIEpkcoVXUqyKteXnZQEqBkJUupxl5cc0fZtSWiJf_--MVRJrJFk7JFYlOXWS1Uj61sGT3Uhy9pNYneT03d2wTho2ktz9nqw6ye3rya2TRo2k8X5Pdp007utplJ_R20Q83sQheGC-PoMPXm8P5D_wSOUXJbgTjwV28bzJj_ktTxRSOOf3OEGNch2nsdLxCjwtM9xuv_wLAAD__7Co7LA=",
+			// 5th range is planned on 3rd node
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF9vmzAUxd_3KawrTW0lR2AgJOOpVcPUaOmfhUybVEWVF24pKsGpbdRWVb77BLQrQQ0CygMStvmd43Pt-wLqIQEPAn_mny5InN4K8n1-eU6u_T9Xs5PpBTmcTINF8HNGSXB2cuUfkdelKlsfPqmHjEsMj8p_9JL8PvPnfomZTX_45GAS80jy9dcDoJCKEC_4GhV418CAggUUbKDgwJLCRooVKiVkPv1SLJ6GT-CZFOJ0k-l8eElhJSSC9wI61gmCBwv-N8E58hClYQKFEDWPk0JCH-ubzT0-A4VTkWTrVHnkzTJQCDY8HxkYlgnLLQWR6XcZpXmE4LGKr-kEPHNL21s7iSKJEddCGs6us-DX-eExO9ora9Vknb2y72pZKmSI5dbepZbbZmPjbsbsmrHxjjHWvlSsT6kMyxwYTvtqsS7uKqEMP1et4Y6s1T4Uq1cojjkwXJPwNCSMCH2HsnVAVhenlYDczwXk7sja7QOyewXkmgNj3P7U2F3cVUIZfS6UUZfWMke1EanC2l3_WMmsKQ1Y3hQwjLDsIEpkcoVXUqyKteXnZQEqBkJUupxl5cc0fZtSWiJf_--MVRJrJFk7JFYlOXWS1Uj61sGT3Uhy9pNYneT03d2wTho2ktz9nqw6ye3rya2TRo2k8X5Pdp007utplJ_R20Q83sQheGC-PoMPXm8P5D_wSOUXJbgTjwV28bzJj_ktTxRSOOf3OEGNch2nsdLxCjwtM9xuv_wLAAD__6oi7LA=",
+		}
+
+		// It can be either planned on gateway if lease for range 5 haven't moved or
+		// node 2/3 if it did.
+		testutils.SucceedsWithin(t, func() error {
+			return checkQueryPlan(t, r, plans)
+		}, 2*time.Second)
+
+		// Now run the query to ensure the correct result
+		require.NoError(t, runQuery(t, r))
+
+		// The leaseholder for the last range should have moved to either node 2 or 3.
+		require.NoError(t, checkQueryPlan(t, r, plans[1:3]))
+		// Stop node 4; note that no range had replicas on both 4 and 5.
+
+		tc.StopServer(3)
+
+		require.NoError(t, runQuery(t, r))
+	})
+
+	t.Run("unhealthy-nodes-in-shared-mode", func(t *testing.T) {
+		skip.UnderDuress(t, "takes 20s")
+
+		tc, r := startAndSetupCluster(t, sharedProcess)
+		defer tc.Stopper().Stop(context.Background())
+
+		r.CheckQueryResults(t,
+			`SELECT IF(substring(start_key for 1)='…',start_key,NULL),
+							IF(substring(end_key for 1)='…',end_key,NULL),
+							lease_holder, replicas FROM [SHOW RANGES FROM TABLE t WITH DETAILS]`,
+			[][]string{
+				{"NULL", "…/Table/106/1/0", "1", "{1}"},
+				{"…/Table/106/1/0", "…/Table/106/1/20", "1", "{1,2,3}"},
+				{"…/Table/106/1/20", "…/Table/106/1/40", "2", "{2,3,4}"},
+				{"…/Table/106/1/40", "…/Table/106/1/60", "3", "{1,3,4}"},
+				{"…/Table/106/1/60", "…/Table/106/1/80", "4", "{1,2,4}"},
+				{"…/Table/106/1/80", "NULL", "5", "{2,3,5}"},
+			},
+		)
+
+		require.NoError(t, runQuery(t, r))
+
+		// Verify the plan should include all 5 nodes.
+		require.NoError(t, checkQueryPlan(t, r,
+			[]string{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklV9vmzAUxd_3KdCVpraSq2AghPDUqmFqtPTPQqZNqqLKC7cMleDUNmqrKt99IjQNYQVB4CERxj7n8Lv25Q3kUwwu-N7Eu5hpUfLAtW_Tmyvtzvt9OzkfX2vHo7E_839MiOZfnt96J9r7VJkuj1_kU8oEBif5GjXXfl16Uy-XmYy_e9rRKGKhYMuvR0Ag4QFesyVKcO-AAgEDCJhAwAICfZgTWAm-QCm5yKa8bRaMgxdwdQJRskpVNjwnsOACwX0DFakYwYUZ-xPjFFmAoqcDgQAVi-KNjTpT96tHfAUCFzxOl4l0tW1sIOCvWDbSo7rdo6f5X8_QYb4mwFO1s5SKhQguLWQcj8DV16R5zPMwFBgyxUWvv5_S_3l1fEZPKm2Nkm2_0nbnliZcBJi_5s5qvq4PRvV2ycxSMrpPhDYvHD28cD1D39bOal472iZpAZHdrXb2nq3RHJDRAZD1AchuDshok7QAaNAN0GDP1mwOyOwAyP4A5DQHZLZJWgDkdAPk7NlazQFZHQA574CMxnSsNjELdIbd6AzbtOQpyhVPJJZ65OdOesnplGbNFIMQ884reSoWeCv4YjM3v73ZCG0GApQqf0rzm3GyfSSVQLb8-KIUlWitkrGnRItK_bKSUZ-pTSizVsqqVqJlJevQ17PLSv1aJbs6k1FWsg_NNCgrDWqVnOpMZlnJOTSTU1Ya1m8DvTqU9d_erN_mNamG2dF5iPnzfRSAC_r7dfrJz_aCbAELZXZ-_b_8eSM7e11lp--BxRIJXLFHHKFCsYySSKpoAa4SKa7XX_4FAAD__5H-gCw="}))
+
+		// Stop node 5.
+		tc.StopServer(4)
+
+		// Verify that the 5th node is not included in the plan before any query is
+		// run, as running a query would update the leaseholder in the cache. In
+		// this plan, ranges for the 5th node should be assigned to the gateway node
+		// (node 1).
+		testutils.SucceedsWithin(t, func() error {
+			return checkQueryPlan(t, r,
+				[]string{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklV9vmzAUxd_3KdCVpraSq2AghPDUqmFqtPTPQqZNqqLKC7cMleDUNmqrKt99IjQNYQVB4CERxj7n8Lv25Q3kUwwu-N7Eu5hpUfLAtW_Tmyvtzvt9OzkfX2vHo7E_839MiOZfnt96J9r7VJkuj1_kU8oEBif5GjXXfl16Uy-XmYy_e9rRKGKhYMuvR0Ag4QFesyVKcO-AAgEDCJhAwAICfZgTWAm-QCm5yKa8bRaMgxdwdQJRskpVNjwnsOACwX0DFakYwYUZ-xPjFFmAoqcDgQAVi-KNjTpT96tHfAUCFzxOl4l0tW1sIOCvWDbSo7rdo6f5X8_QYb4mwFO1s5SKhQguLWQcj8DV16R5zPMwFBgyxUWvv5_S_3l1fEZPKm2Nkm2_0nbnliZcBJi_5s5qvq4PRvV2ycxSMrpPhDYvHD28cD1D39bOal472iZpAZHdrXb2nq3RHJDRAZD1AchuDshok7QAaNAN0GDP1mwOyOwAyP4A5DQHZLZJWgDkdAPk7NlazQFZHQA574CMxnSsNjELdIbd6AzbtOQpyhVPJJZ65OdOesnplGbNFIMQ884reSoWeCv4YjM3v73ZCG0GApQqf0rzm3GyfSSVQLb8-KIUlWitkrGnRItK_bKSUZ-pTSizVsqqVqJlJevQ17PLSv1aJbs6k1FWsg_NNCgrDWqVnOpMZlnJOTSTU1Ya1m8DvTqU9d_erN_mNamG2dF5iPnzfRSAC_r7dfrJz_aCbAELZXZ-_b_8eSM7e11lp--BxRIJXLFHHKFCsYySSKpoAa4SKa7XX_4FAAD__5H-gCw="})
+		}, 2*time.Second)
+
+		// Now run the query to ensure the correct result
+		require.NoError(t, runQuery(t, r))
+
+		// The leaseholder for the last range should now have moved to either node 2
+		// or 3.
+		require.NoError(t, checkQueryPlan(t, r,
+			[]string{
+				"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF1ro04Uxu__n2I48KctTImjxmS9amlcGjZ92ZhlF0oos_HUSo1jZ0baUvLdF7VpjDSiiRcJzsvveeY543kH9RyDC7438S5mJEoeBPk-vbkid96f28n5-Jocj8b-zP85ocS_PL_1TsjHUpUtj1_Vc8YlBiflHj0nvy-9qVdiJuMfHjkaRTyUfPn_EVBIRIDXfIkK3DtgQMEEChZQsGFOIZVigUoJmU-_F4vHwSu4BoUoSTOdD88pLIREcN9BRzpGcGHG_8Y4RR6g7BlAIUDNo7iQ0Gf6Pn3CN6BwIeJsmSiXrC0DBT_l-UiPGU6PnZZ_PdOA-YqCyPRGUmkeIris4nE8AtdY0fY2z8NQYsi1kD1726X_6-r4jJ3slDVrsvZO2Y1alggZYHnMjdR81Wxs2M2YVTM23DLG2peN7V-2nmmsK2e3rxzr4rQSUP-wyvW3ZM32AZkHBGR_BuQYhCcBYUToR5StwzK7uK6E5RwWlrMla7UPyzogLOczrGH722R1cVoJaHBYQIMu7WeKKhWJwlo_-FrJqCmdsrxxYBBi2WWUyOQCb6VYFGvL15sCVAwEqHQ5y8qXcbKeUloiX352zyqJNZLMLRKrkuw6yWwkfevgyWok2btJrE6y9z1dv07qN5Kc3Z7MOsnZ15NTJw0aScPdnqw6abivp0F-Rx9i8XIfBeCC8fGcfvGzfiDfwEOVfyj-o3gpsLO3NL_mDzxWSOGKP-EINcpllERKRwtwtcxwtfrvXwAAAP__hnf14A==",
+				"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF1ro04Uxu__n2I48KctTImjxmS9amlcGjZ92ZhlF0oos_HUSo1jZ0baUvLdF7VpjDSiiRcJzsvveeY543kH9RyDC7438S5mJEoeBPk-vbkid96f28n5-Jocj8b-zP85ocS_PL_1TsjHUpUtj1_Vc8YlBiflHj0nvy-9qVdiJuMfHjkaRTyUfPn_EVBIRIDXfIkK3DtgQMEEChZQsGFOIZVigUoJmU-_F4vHwSu4BoUoSTOdD88pLIREcN9BRzpGcGHG_8Y4RR6g7BlAIUDNo7iQ0Gf6Pn3CN6BwIeJsmSiXrC0DBT_l-UiPGU6PnZZ_PdOA-YqCyPRGUmkeIris4nE8AtdY0fY2z8NQYsi1kD1726X_6-r4jJ3slDVrsvZO2Y1alggZYHnMjdR81Wxs2M2YVTM23DLG2peN7V-2nmmsK2cbhCcBYUToR5Stq8i6uK6E1T-siv0tWbN9WOYBYdmfYTntr7nZxWklIOewgJwtWat9QNYBATmfAQ3bB2R1cVoJaHBYQIMu7WeKKhWJwlo_-FrJqCmdsrxxYBBi2WWUyOQCb6VYFGvL15sCVAwEqHQ5y8qXcbKeUloiX352zyqJNZLMLRKrkuw6yWwkfevgyWok2btJrE6y9z1dv07qN5Kc3Z7MOsnZ15NTJw0aScPdnqw6abivp0F-Rx9i8XIfBeCC8fGcfvGzfiDfwEOVfyj-o3gpsLO3NL_mDzxWSOGKP-EINcpllERKRwtwtcxwtfrvXwAAAP__oDX14A==",
+			}))
+	})
+
+	t.Run("unhealthy-nodes-in-external-mode", func(t *testing.T) {
+		skip.UnderDuress(t, "takes 20s")
+
+		tc, r := startAndSetupCluster(t, externalProcess)
+		defer tc.Stopper().Stop(context.Background())
+
+		r.CheckQueryResults(t,
+			`SELECT IF(substring(start_key for 1)='…',start_key,NULL),
+							IF(substring(end_key for 1)='…',end_key,NULL),
+							lease_holder, replicas FROM [SHOW RANGES FROM TABLE t WITH DETAILS]`,
+			[][]string{
+				{"NULL", "…/Table/106/1/0", "1", "{1}"},
+				{"…/Table/106/1/0", "…/Table/106/1/20", "1", "{1,2,3}"},
+				{"…/Table/106/1/20", "…/Table/106/1/40", "2", "{2,3,4}"},
+				{"…/Table/106/1/40", "…/Table/106/1/60", "3", "{1,3,4}"},
+				{"…/Table/106/1/60", "…/Table/106/1/80", "4", "{1,2,4}"},
+				{"…/Table/106/1/80", "NULL", "5", "{2,3,5}"},
+			},
+		)
+
+		require.NoError(t, runQuery(t, r))
+
+		r.Exec(t, "SELECT crdb_internal.set_vmodule('distsql_physical_planner=1')")
+
+		// Verify the plan should include all 5 nodes.
+		require.NoError(t, checkQueryPlan(t, r,
+			[]string{"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklV9vmzAUxd_3KdCVpraSq2AghPDUqmFqtPTPQqZNqqLKC7cMleDUNmqrKt99IjQNYQVB4CERxj7n8Lv25Q3kUwwu-N7Eu5hpUfLAtW_Tmyvtzvt9OzkfX2vHo7E_839MiOZfnt96J9r7VJkuj1_kU8oEBif5GjXXfl16Uy-XmYy_e9rRKGKhYMuvR0Ag4QFesyVKcO-AAgEDCJhAwAICfZgTWAm-QCm5yKa8bRaMgxdwdQJRskpVNjwnsOACwX0DFakYwYUZ-xPjFFmAoqcDgQAVi-KNjTpT96tHfAUCFzxOl4l0tW1sIOCvWDbSo7rdo6f5X8_QYb4mwFO1s5SKhQguLWQcj8DV16R5zPMwFBgyxUWvv5_S_3l1fEZPKm2Nkm2_0nbnliZcBJi_5s5qvq4PRvV2ycxSMrpPhDYvHD28cD1D39bOal472iZpAZHdrXb2nq3RHJDRAZD1AchuDshok7QAaNAN0GDP1mwOyOwAyP4A5DQHZLZJWgDkdAPk7NlazQFZHQA574CMxnSsNjELdIbd6AzbtOQpyhVPJJZ65OdOesnplGbNFIMQ884reSoWeCv4YjM3v73ZCG0GApQqf0rzm3GyfSSVQLb8-KIUlWitkrGnRItK_bKSUZ-pTSizVsqqVqJlJevQ17PLSv1aJbs6k1FWsg_NNCgrDWqVnOpMZlnJOTSTU1Ya1m8DvTqU9d_erN_mNamG2dF5iPnzfRSAC_r7dfrJz_aCbAELZXZ-_b_8eSM7e11lp--BxRIJXLFHHKFCsYySSKpoAa4SKa7XX_4FAAD__5H-gCw="}))
+
+		// Stop node 5.
+		tc.StopServer(4)
+
+		// Since we only stopped the server, the storage node would be still up. So
+		// our range for the 5th storage node could be randomly planned on any of the
+		// remaining nodes as all of them are equally "close" here.
+		expectedPlans := []string{
+			// Planned on 1st node
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF1ro04Uxu__n2I48KctTImjxmS9amlcGjZ92ZhlF0oos_HUSo1jZ0baUvLdF7VpjDSiiRcJzsvveeY543kH9RyDC7438S5mJEoeBPk-vbkid96f28n5-Jocj8b-zP85ocS_PL_1TsjHUpUtj1_Vc8YlBiflHj0nvy-9qVdiJuMfHjkaRTyUfPn_EVBIRIDXfIkK3DtgQMEEChZQsGFOIZVigUoJmU-_F4vHwSu4BoUoSTOdD88pLIREcN9BRzpGcGHG_8Y4RR6g7BlAIUDNo7iQ0Gf6Pn3CN6BwIeJsmSiXrC0DBT_l-UiPGU6PnZZ_PdMgPAkII0I_ooT5ioLI9EZeaR4iuKzidzwC11jR9pbPw1BiyLWQPXvbsf_r6viMneyUNWuy9k7ZjVqWCBlgeeSN1HzVbGzYzZhVMzbcMsbal5DtX8KeaayraButK8e6OK0E1D-scv0tWbN9QOYBAdmfATntAzK7OK0E5BwWkLMla7UPyDogIOczoGH7gKwuTisBDQ4LaNCl5UxRpSJRWOsBXysZNaVTljcLDEIsO4sSmVzgrRSLYm35elOAioEAlS5nWfkyTtZTSkvky8-OWSWxRpK5RWJVkl0nmY2kbx08WY0kezeJ1Un2vqfr10n9RpKz25NZJzn7enLqpEEjabjbk1UnDff1NMjv6EMsXu6jAFwwPp7TL37WD-QbeKjyD8V_FC8FdvaW5tf8gccKKVzxJxyhRrmMkkjpaAGulhmuVv_9CwAA__-0ofXg",
+
+			// Planned on 2nd node
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF1ro04Uxu__n2I48KctTImjxmS9amlcGjZ92ZhlF0oos_HUSo1jZ0baUvLdF7VpjDSiiRcJzsvveeY543kH9RyDC7438S5mJEoeBPk-vbkid96f28n5-Jocj8b-zP85ocS_PL_1TsjHUpUtj1_Vc8YlBiflHj0nvy-9qVdiJuMfHjkaRTyUfPn_EVBIRIDXfIkK3DtgQMEEChZQsGFOIZVigUoJmU-_F4vHwSu4BoUoSTOdD88pLIREcN9BRzpGcGHG_8Y4RR6g7BlAIUDNo7iQ0Gf6Pn3CN6BwIeJsmSiXrC0DBT_l-UiPGU6PnZZ_PdOA-YqCyPRGUmkeIris4nE8AtdY0fY2z8NQYsi1kD1726X_6-r4jJ3slDVrsvZO2Y1alggZYHnMjdR81Wxs2M2YVTM23DLG2peN7V-2nmmsK2cbhCcBYUToR5Stq8i6uK6E1T-siv0tWbN9WOYBYdmfYTntr7nZxWklIOewgJwtWat9QNYBATmfAQ3bB2R1cVoJaHBYQIMu7WeKKhWJwlo_-FrJqCmdsrxxYBBi2WWUyOQCb6VYFGvL15sCVAwEqHQ5y8qXcbKeUloiX352zyqJNZLMLRKrkuw6yWwkfevgyWok2btJrE6y9z1dv07qN5Kc3Z7MOsnZ15NTJw0aScPdnqw6abivp0F-Rx9i8XIfBeCC8fGcfvGzfiDfwEOVfyj-o3gpsLO3NL_mDzxWSOGKP-EINcpllERKRwtwtcxwtfrvXwAAAP__oDX14A==",
+
+			// Planned on 3rd node
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF1ro04Uxu__n2I48KctTImjxmS9amlcGjZ92ZhlF0oos_HUSo1jZ0baUvLdF7VpjDSiiRcJzsvveeY543kH9RyDC7438S5mJEoeBPk-vbkid96f28n5-Jocj8b-zP85ocS_PL_1TsjHUpUtj1_Vc8YlBiflHj0nvy-9qVdiJuMfHjkaRTyUfPn_EVBIRIDXfIkK3DtgQMEEChZQsGFOIZVigUoJmU-_F4vHwSu4BoUoSTOdD88pLIREcN9BRzpGcGHG_8Y4RR6g7BlAIUDNo7iQ0Gf6Pn3CN6BwIeJsmSiXrC0DBT_l-UiPGU6PnZZ_PdOA-YqCyPRGUmkeIris4nE8AtdY0fY2z8NQYsi1kD1726X_6-r4jJ3slDVrsvZO2Y1alggZYHnMjdR81Wxs2M2YVTM23DLG2peN7V-2nmmsK2e3rxzr4rQSUP-wyvW3ZM32AZkHBGR_BuQYhCcBYUToR5StwzK7uK6E5RwWlrMla7UPyzogLOczrGH722R1cVoJaHBYQIMu7WeKKhWJwlo_-FrJqCmdsrxxYBBi2WWUyOQCb6VYFGvL15sCVAwEqHQ5y8qXcbKeUloiX352zyqJNZLMLRKrkuw6yWwkfevgyWok2btJrE6y9z1dv07qN5Kc3Z7MOsnZ15NTJw0aScPdnqw6abivp0F-Rx9i8XIfBeCC8fGcfvGzfiDfwEOVfyj-o3gpsLO3NL_mDzxWSOGKP-EINcpllERKRwtwtcxwtfrvXwAAAP__hnf14A==",
+
+			// Planned on 4th node
+			"Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyklF9ro0AUxd_3U8iFpS1MiaPGZH1qaVwqm_7ZmGUXSiiz8daVqmNnRtpS8t0XtWmMNKKJDwnOn985c-5430A-xeCA707di7kWpQ9c-z67udLu3D-303PvWjueeP7c_zklmn95fuueaO9LZZ4cv8innAkMTqo9aqH9vnRnboWZej9c7WgSsVCw5OsREEh5gNcsQQnOHVAgYAABEwhYsCCQCb5EKbkopt_KxV7wAo5OIEqzXBXDCwJLLhCcN1CRihEcmLO_Mc6QBSgGOhAIULEoLiXUmbrPHvEVCFzwOE9S6Whry0DAz1gxMqC6PaCn1d_A0GGxIsBztZGUioUIDq159Cbg6CvS3eZ5GAoMmeJiYG279H9dHZ_Rk52yRkPW2im7UctTLgKsjrmRWqzajY37GTMbxsZbxmj3stH9yzYw9HXlrO6Vo32c1gIaHla54Zas0T0g44CArI-A7O4BGX2c1gKyDwvI3pI1uwdkHhCQ_R6Q0Tkds4_NWjqjw9IZ9ek3M5QZTyU2GsDnSnpD6ZQWnQKDEKu2Inkulngr-LJcW73elKByIECpqllavXjpekoqgSz5aJd1Em0lGVskWidZTZLRSvrWw5PZSrJ2k2iTZO17umGTNGwl2bs9GU2Sva8nu0katZLGuz2ZTdJ4X0-j4o4-xPz5PgrAAf39Of3kZ_1AsYGFsvhQ_H_8ucTOX7Pimj-wWCKBK_aIE1QokiiNpIqW4CiR42r15X8AAAD__-4H8WQ=",
+		}
+
+		// Verify that the 5th node is exclude from the plan before running any query.
+		// Otherwise if we do `runQuery` first that would be fix any caches that the
+		// 5th node is down after failure to reach out to that node. Our aim here is
+		// how soon our physical planning detects such unhealthy nodes and avoid
+		// planning on them. After stress testing 3 seconds seems appropriate.
+		testutils.SucceedsWithin(t, func() error {
+			return checkQueryPlan(t, r, expectedPlans)
+		}, 3*time.Second)
+
+		// Now run the query to ensure the correct result
+		if err := runQuery(t, r); err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestDistSQLDrainingHosts(t *testing.T) {
@@ -1153,6 +1338,16 @@ func TestPartitionSpans(t *testing.T) {
 			nID.Reset(tsp.nodes[tc.gatewayNode-1].NodeID)
 
 			gw := gossip.MakeOptionalGossip(mockGossip)
+
+			connHealth := func(nodeId roachpb.NodeID) error {
+				for _, n := range tc.deadNodes {
+					if int(nodeId) == n {
+						return fmt.Errorf("test node is unhealthy")
+					}
+				}
+				return nil
+			}
+
 			dsp := DistSQLPlanner{
 				st:                   cluster.MakeTestingClusterSettings(),
 				gatewaySQLInstanceID: base.SQLInstanceID(tsp.nodes[tc.gatewayNode-1].NodeID),
@@ -1161,13 +1356,11 @@ func TestPartitionSpans(t *testing.T) {
 				gossip:               gw,
 				nodeHealth: distSQLNodeHealth{
 					gossip: gw,
-					connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
-						for _, n := range tc.deadNodes {
-							if int(node) == n {
-								return fmt.Errorf("test node is unhealthy")
-							}
-						}
-						return nil
+					connHealthSystem: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
+						return connHealth(node)
+					},
+					connHealthInstance: func(sqlInstance base.SQLInstanceID, _ string) error {
+						return connHealth(roachpb.NodeID(sqlInstance))
 					},
 					isAvailable: func(base.SQLInstanceID) bool {
 						return true
@@ -1528,7 +1721,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		gossip:               gw,
 		nodeHealth: distSQLNodeHealth{
 			gossip: gw,
-			connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
+			connHealthSystem: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
 				_, err := mockGossip.GetNodeIDAddress(node)
 				return err
 			},
@@ -1626,9 +1819,9 @@ func TestCheckNodeHealth(t *testing.T) {
 	for _, test := range livenessTests {
 		t.Run("liveness", func(t *testing.T) {
 			h := distSQLNodeHealth{
-				gossip:      gw,
-				connHealth:  connHealthy,
-				isAvailable: test.isAvailable,
+				gossip:           gw,
+				connHealthSystem: connHealthy,
+				isAvailable:      test.isAvailable,
 			}
 			if err := h.checkSystem(context.Background(), sqlInstanceID); !testutils.IsError(err, test.exp) {
 				t.Fatalf("expected %v, got %v", test.exp, err)
@@ -1647,9 +1840,9 @@ func TestCheckNodeHealth(t *testing.T) {
 	for _, test := range connHealthTests {
 		t.Run("connHealth", func(t *testing.T) {
 			h := distSQLNodeHealth{
-				gossip:      gw,
-				connHealth:  test.connHealth,
-				isAvailable: available,
+				gossip:           gw,
+				connHealthSystem: test.connHealth,
+				isAvailable:      available,
 			}
 			if err := h.checkSystem(context.Background(), sqlInstanceID); !testutils.IsError(err, test.exp) {
 				t.Fatalf("expected %v, got %v", test.exp, err)

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -107,6 +107,8 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningTenant(
 	if err != nil {
 		return nil, nil, err
 	}
+	pods, _ = dsp.filterUnhealthyInstances(pods, planCtx.nodeStatuses)
+
 	sqlInstanceIDs := make([]base.SQLInstanceID, 0, len(pods))
 	for _, pod := range pods {
 		if ok, _ := pod.Locality.Matches(localityFilter); ok {


### PR DESCRIPTION
The distsql planner currently uses different strategies to avoid planning
on unhealthy nodes in single and multi-tenant deployments. For
single-tenant deployments, we check for a healthy gRPC connection and use
information from the gossip protocol, which allows for quick detection. For
multi-tenant deployments, we rely on the sql_instances system table cache
to check if an instance is healthy. However, this cache may not update for
over half a minute (40 seconds in my tests) after a node goes down, leading
to planning on an unhealthy instance, which are later retried-as-local at the gateway.

To prevent planning on dead SQL instances, the resolver now ensures it does
not consider such instances by first establishing a healthy gRPC
connection. This means that in shared-process mode, if an instance is found
to be unhealthy, the gateway will be used. In external mode, such a node
would be excluded from the candidates for locality-based matching or
round-robin selection.

Fixes: #120774

Epic CRDB-39091

Release note: None