### PR TITLE
release: use origin repo as head for origin-based PRs

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -216,8 +216,12 @@ func (r prRepo) push() error {
 }
 
 func (r prRepo) createPullRequest() (string, error) {
+	head := fmt.Sprintf("%s:%s", r.githubUsername, r.prBranch)
+	if r.pushToOrigin {
+		head = r.prBranch
+	}
 	parts := []string{
-		"gh", "pr", "create", "--base", r.branch, "--head", fmt.Sprintf("%s:%s", r.githubUsername, r.prBranch),
+		"gh", "pr", "create", "--base", r.branch, "--head", head,
 	}
 	title, body, _ := strings.Cut(r.commitMessage, "\n")
 	if title == "" {


### PR DESCRIPTION
Previously, we added a feature to push PRs branches to the origin repo. Unfortunately, the PR command still references the not-origin repo.

This change fixes the head repository reference for origin PRs.

Epic: none
Release note: None