### PR TITLE
storage: calculate total capacity off of max percentage

### DIFF
--- a/pkg/kv/kvserver/kvstorage/cluster_version_test.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version_test.go
@@ -114,7 +114,7 @@ func TestClusterVersionWriteSynthesize(t *testing.T) {
 		st := cluster.MakeTestingClusterSettingsWithVersions(binV, minV, false /* initializeVersion */)
 		eng, err := storage.Open(
 			ctx, storage.InMemory(), st,
-			storage.ForTesting, storage.MaxSize(1<<20),
+			storage.ForTesting, storage.MaxSizeBytes(1<<20),
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1690,7 +1690,7 @@ func SendEmptySnapshot(
 		storage.InMemory(),
 		cluster.MakeClusterSettings(),
 		storage.CacheSize(1<<20 /* 1 MiB */),
-		storage.MaxSize(512<<20 /* 512 MiB */))
+		storage.MaxSizeBytes(512<<20 /* 512 MiB */))
 	if err != nil {
 		return err
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -804,7 +804,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				return Engines{}, errors.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
 					spec.Size.Percent, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(base.MinimumStoreSize))
 			}
-			addCfgOpt(storage.MaxSize(sizeInBytes))
+			addCfgOpt(storage.MaxSizeBytes(sizeInBytes))
 			addCfgOpt(storage.CacheSize(cfg.CacheSize))
 			addCfgOpt(storage.RemoteStorageFactory(cfg.EarlyBootExternalStorageAccessor))
 
@@ -830,9 +830,13 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				return Engines{}, errors.Wrap(err, "creating disk monitor")
 			}
 
-			detail(redact.Sprintf("store %d: max size %s, max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
-
-			addCfgOpt(storage.MaxSize(sizeInBytes))
+			if spec.Size.Percent > 0 {
+				detail(redact.Sprintf("store %d: max size %s (calculated from %.2f percent of total), max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), spec.Size.Percent, openFileLimitPerStore))
+				addCfgOpt(storage.MaxSizePercent(spec.Size.Percent / 100))
+			} else {
+				detail(redact.Sprintf("store %d: max size %s, max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
+				addCfgOpt(storage.MaxSizeBytes(sizeInBytes))
+			}
 			addCfgOpt(storage.BallastSize(storage.BallastSizeBytes(spec, du)))
 			addCfgOpt(storage.Caches(pebbleCache, tableCache))
 			// TODO(radu): move up all remaining settings below so they apply to in-memory stores as well.

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -51,7 +51,7 @@ func TestCachedSettingsStoreAndLoad(t *testing.T) {
 	ctx := context.Background()
 	engine, err := storage.Open(ctx, storage.InMemory(),
 		cluster.MakeClusterSettings(),
-		storage.MaxSize(512<<20 /* 512 MiB */),
+		storage.MaxSizeBytes(512<<20 /* 512 MiB */),
 		storage.ForTesting)
 	require.NoError(t, err)
 	defer engine.Close()

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -34,7 +34,7 @@ import (
 func NewDefaultInMemForTesting(opts ...ConfigOption) Engine {
 	eng, err := Open(
 		context.Background(), InMemory(), cluster.MakeTestingClusterSettings(),
-		ForTesting, MaxSize(1<<20), CombineOptions(opts...),
+		ForTesting, MaxSizeBytes(1<<20), CombineOptions(opts...),
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -3853,7 +3853,7 @@ func generateBytes(rng *rand.Rand, min int, max int) []byte {
 
 func createEngWithSeparatedIntents(t *testing.T) Engine {
 	eng, err := Open(context.Background(), InMemory(),
-		cluster.MakeTestingClusterSettings(), MaxSize(1<<20))
+		cluster.MakeTestingClusterSettings(), MaxSizeBytes(1<<20))
 	require.NoError(t, err)
 	return eng
 }

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -91,9 +91,34 @@ func Attributes(attrs roachpb.Attributes) ConfigOption {
 	}
 }
 
-// MaxSize sets the intended maximum store size. MaxSize is used for
-// calculating free space and making rebalancing decisions.
-func MaxSize(size int64) ConfigOption {
+// storeSize configures the maximum allowable size for a store.
+// Can be specified either as a percentage of total capacity or
+// an absolute byte size; if both are specified, the percentage takes
+// precedence.
+type storeSize struct {
+	bytes   int64
+	percent float64
+}
+
+// MaxSizeBytes ets the intended maximum store size as an absolute byte
+// value. MaxSizeBytes is used for calculating free space and making rebalancing
+// decisions.
+func MaxSizeBytes(size int64) ConfigOption {
+	return maxSize(storeSize{bytes: size})
+}
+
+// MaxSizePercent ets the intended maximum store size as the specified percentage
+// of total capacity. MaxSizePercent is used for calculating free space and making
+// rebalancing decisions.
+func MaxSizePercent(percent float64) ConfigOption {
+	return maxSize(storeSize{percent: percent})
+}
+
+// maxSize sets the intended maximum store size. MaxSize is used for
+// calculating free space and making rebalancing decisions. Either an
+// absolute size or a percentage of total capacity can be specified;
+// if both are specified, the percentage is used.
+func maxSize(size storeSize) ConfigOption {
 	return func(cfg *engineConfig) error {
 		cfg.maxSize = size
 		return nil

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -72,7 +72,7 @@ func TestCheckSSTConflictsMaxLockConflicts(t *testing.T) {
 	sstWriter.Close()
 
 	ctx := context.Background()
-	engine, err := Open(context.Background(), InMemory(), cs, MaxSize(1<<20))
+	engine, err := Open(context.Background(), InMemory(), cs, MaxSizeBytes(1<<20))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -161,7 +161,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		storage.InMemory(),
 		cfg.Settings,
 		storage.CacheSize(0),
-		storage.MaxSize(50<<20 /* 50 MiB */),
+		storage.MaxSizeBytes(50<<20 /* 50 MiB */),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Previously, we stored the maxSize of a pebble store in bytes in the Pebble struct, even if the max size for that store was specified as a percentage of the total available size. This change updates this to store the percentage separately, and calculate the available / used bytes on the fly from the total size of the disk. This allows us to better report metrics when the underlying size of the disk or volume changes during the life of the node.

Fixes #123911.

Epic: none

Release note (ops change): Improve disk usage metric reporting over volumes that dynamically change their size over the life of the cockroach process.