### PR TITLE
perf: modify YCSB for LDR testing

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -279,7 +279,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xab32e4f5e899eb2f,
 		`tpch`:       0xe4fd28db230b9149,
-		`ycsb`:       0x1244ea1c29ef67f6,
+		`ycsb`:       0xcfd3f148a01a2c47,
 	}
 
 	var a bufalloc.ByteAllocator

--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -127,6 +127,11 @@ var ycsbMeta = workload.Meta{
 		g.flags.Meta = map[string]workload.FlagMeta{
 			`read-modify-write-in-txn`: {RuntimeOnly: true},
 			`workload`:                 {RuntimeOnly: true},
+			`read-freq`:                {RuntimeOnly: true},
+			`insert-freq`:              {RuntimeOnly: true},
+			`update-freq`:              {RuntimeOnly: true},
+			`scan-freq`:                {RuntimeOnly: true},
+			`read-modify-write-freq`:   {RuntimeOnly: true},
 		}
 		g.flags.BoolVar(&g.timeString, `time-string`, false, `Prepend field[0-9] data with current time in microsecond precision.`)
 		g.flags.BoolVar(&g.insertHash, `insert-hash`, true, `Key to be hashed or ordered.`)
@@ -139,11 +144,16 @@ var ycsbMeta = workload.Meta{
 		g.flags.BoolVar(&g.rmwInTxn, `read-modify-write-in-txn`, false, `Run workload F's read-modify-write operation in an explicit transaction.`)
 		g.flags.BoolVar(&g.sfu, `select-for-update`, true, `Use SELECT FOR UPDATE syntax in read-modify-write operation, if run in an explicit transactions.`)
 		g.flags.IntVar(&g.splits, `splits`, 0, `Number of splits to perform before starting normal operations.`)
-		g.flags.StringVar(&g.workload, `workload`, `B`, `Workload type. Choose from A-F.`)
-		g.flags.StringVar(&g.requestDistribution, `request-distribution`, ``, `Distribution for request key generation [zipfian, uniform, latest]. The default for workloads A, B, C, E, and F is zipfian, and the default for workload D is latest.`)
+		g.flags.StringVar(&g.workload, `workload`, `B`, `Workload type. Choose from A-F or CUSTOM. (default B)`)
+		g.flags.StringVar(&g.requestDistribution, `request-distribution`, ``, `Distribution for request key generation [zipfian, uniform, latest]. The default for workloads A, B, C, E, F and CUSTOM is zipfian, and the default for workload D is latest.`)
 		g.flags.StringVar(&g.scanLengthDistribution, `scan-length-distribution`, `uniform`, `Distribution for scan length generation [zipfian, uniform]. Primarily used for workload E.`)
 		g.flags.Uint64Var(&g.minScanLength, `min-scan-length`, 1, `The minimum length for scan operations. Primarily used for workload E.`)
 		g.flags.Uint64Var(&g.maxScanLength, `max-scan-length`, 1000, `The maximum length for scan operations. Primarily used for workload E.`)
+		g.flags.Float32Var(&g.readFreq, `read-freq`, 0.0, `Percentage of reads in the workload. Used in conjunction with --workload=CUSTOM to specify an alternative workload mix. (default 0.0)`)
+		g.flags.Float32Var(&g.insertFreq, `insert-freq`, 0.0, `Percentage of inserts in the workload. Used in conjunction --workload=CUSTOM to specify an alternative workload mix. (default 0.0)`)
+		g.flags.Float32Var(&g.updateFreq, `update-freq`, 0.0, `Percentage of updates in the workload. Used in conjunction with --workload=CUSTOM to specify an alternative workload mix. (default 0.0)`)
+		g.flags.Float32Var(&g.scanFreq, `scan-freq`, 0.0, `Percentage of scans in the workload. Used in conjunction with --workload=CUSTOM to specify an alternative workload mix. (default 0.0)`)
+		g.flags.Float32Var(&g.readModifyWriteFreq, `read-modify-write-freq`, 0.0, `Percentage of read-modify-writes in the workload. Used in conjunction with --workload=CUSTOM to specify an alternative workload mix. (default 0.0)`)
 		RandomSeed.AddFlag(&g.flags)
 
 		// TODO(dan): g.flags.Uint64Var(&g.maxWrites, `max-writes`,
@@ -170,6 +180,16 @@ func (g *ycsb) Hooks() workload.Hooks {
 		Validate: func() error {
 			g.workload = strings.ToUpper(g.workload)
 			var defaultReqDist string
+			incomingFreqSum := g.readFreq + g.insertFreq + g.updateFreq + g.scanFreq + g.readModifyWriteFreq
+			if g.workload == "CUSTOM" {
+				if incomingFreqSum != 1.0 {
+					return errors.Errorf("Custom workload frequencies do not sum to 1.0")
+				}
+			} else {
+				if incomingFreqSum != 0.0 {
+					return errors.Errorf("Custom workload frequencies set with non-custom workload")
+				}
+			}
 			switch g.workload {
 			case "A":
 				g.readFreq = 0.5
@@ -193,6 +213,8 @@ func (g *ycsb) Hooks() workload.Hooks {
 			case "F":
 				g.readFreq = 0.5
 				g.readModifyWriteFreq = 0.5
+				defaultReqDist = "zipfian"
+			case "CUSTOM":
 				defaultReqDist = "zipfian"
 			default:
 				return errors.Errorf("Unknown workload: %q", g.workload)
@@ -284,6 +306,11 @@ func preferColumnFamilies(workload string) bool {
 		// read-modify-write transactions. Using column families breaks the
 		// contention between all updates to different columns of the same row,
 		// so we use them by default.
+		return true
+	case "CUSTOM":
+		// We have no idea what workload is going to be run with the "custom"
+		// option. Default to true and rely on the user to set the --families
+		// flag if they don't want column families.
 		return true
 	default:
 		panic(fmt.Sprintf("unexpected workload: %s", workload))
@@ -575,7 +602,7 @@ type ycsbWorker struct {
 	scanLengthGen randGenerator // used to generate length of scan operations
 	rng           *rand.Rand    // used to generate random strings for the values
 	hashFunc      hash.Hash64
-	hashBuf       [8]byte
+	hashBuf       [binary.MaxVarintLen64]byte
 }
 
 func (yw *ycsbWorker) run(ctx context.Context) error {
@@ -619,7 +646,7 @@ const (
 )
 
 func (yw *ycsbWorker) hashKey(key uint64) uint64 {
-	yw.hashBuf = [8]byte{} // clear hashBuf
+	yw.hashBuf = [binary.MaxVarintLen64]byte{} // clear hashBuf
 	binary.PutUvarint(yw.hashBuf[:], key)
 	yw.hashFunc.Reset()
 	if _, err := yw.hashFunc.Write(yw.hashBuf[:]); err != nil {


### PR DESCRIPTION
For testing of logical data replication, there is a need to create a write only workload with a schema that contains several columns (i.e. not kv, which has only two). This can easily be tucked into ycsb with an internal-only workload "G". I'd understand if folks didn't want to muddy the ycsb waters with this workload modification, but doing it this way allows us to make faster progress on the LDR side, so I figured I'd give it a try.

Epic: CRDB-38996
Release note: None