### PR TITLE
raft: support lazy appends

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -207,6 +207,14 @@ type Config struct {
 	// throughput limit of 10 MB/s for this group. With RTT of 400ms, this drops
 	// to 2.5 MB/s. See Little's law to understand the maths behind.
 	MaxInflightBytes uint64
+	// EnableLazyAppends makes raft hold off constructing log append messages in
+	// response to Step() calls, for the StateReplicate followers. The messages
+	// can be triggered via a separate RawNode.SendAppend method.
+	//
+	// This way, the application has better control when raft may call Storage
+	// methods and allocate memory for entries and messages. This provides flow
+	// control for leader->follower log replication streams.
+	EnableLazyAppends bool
 
 	// CheckQuorum specifies if the leader should check quorum activity. Leader
 	// steps down when quorum is not active for an electionTimeout.
@@ -342,6 +350,10 @@ type raft struct {
 	// Messages in this list have the type MsgAppResp, MsgVoteResp, or
 	// MsgPreVoteResp. See the comment in raft.send for details.
 	msgsAfterAppend []pb.Message
+	// enableLazyAppends delays append message construction and sending until the
+	// RawNode is explicitly requested to do so. This provides control over the
+	// follower replication flows.
+	enableLazyAppends bool
 
 	// the leader id
 	lead uint64
@@ -425,6 +437,7 @@ func newRaft(c *Config) *raft {
 		maxMsgSize:                  entryEncodingSize(c.MaxSizePerMsg),
 		maxUncommittedSize:          entryPayloadSize(c.MaxUncommittedEntriesSize),
 		trk:                         tracker.MakeProgressTracker(c.MaxInflightMsgs, c.MaxInflightBytes),
+		enableLazyAppends:           c.EnableLazyAppends,
 		electionTimeout:             c.ElectionTick,
 		heartbeatTimeout:            c.HeartbeatTick,
 		logger:                      c.Logger,
@@ -593,11 +606,19 @@ func (r *raft) send(m pb.Message) {
 // if the follower log and commit index are up-to-date, the flow is paused (for
 // reasons like in-flight limits), or the message could not be constructed.
 func (r *raft) maybeSendAppend(to uint64) bool {
-	pr := r.trk.Progress[to]
+	return r.maybeSendAppendImpl(to, r.enableLazyAppends)
+}
 
+// maybeSendAppendImpl is the same as maybeSendAppend, but it supports the lazy
+// mode for StateReplicate, in which appends are not sent.
+func (r *raft) maybeSendAppendImpl(to uint64, lazy bool) bool {
+	pr := r.trk.Progress[to]
 	last, commit := r.raftLog.lastIndex(), r.raftLog.committed
 	msgAppType := pr.ShouldSendMsgApp(last, commit)
 	if msgAppType == tracker.MsgAppNone {
+		return false
+	}
+	if lazy && pr.State == tracker.StateReplicate && msgAppType == tracker.MsgAppWithEntries {
 		return false
 	}
 

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -596,7 +596,8 @@ func (r *raft) maybeSendAppend(to uint64) bool {
 	pr := r.trk.Progress[to]
 
 	last, commit := r.raftLog.lastIndex(), r.raftLog.committed
-	if !pr.ShouldSendMsgApp(last, commit) {
+	msgAppType := pr.ShouldSendMsgApp(last, commit)
+	if msgAppType == tracker.MsgAppNone {
 		return false
 	}
 
@@ -609,7 +610,7 @@ func (r *raft) maybeSendAppend(to uint64) bool {
 	}
 
 	var entries []pb.Entry
-	if pr.CanSendEntries(last) {
+	if msgAppType == tracker.MsgAppWithEntries {
 		if entries, err = r.raftLog.entries(pr.Next, r.maxMsgSize); err != nil {
 			// Send a snapshot if we failed to get the entries.
 			return r.maybeSendSnapshot(to, pr)

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -125,6 +125,38 @@ func (rn *RawNode) Ready() Ready {
 	return rd
 }
 
+// SendAppend sends a log replication (MsgApp) message to a particular node. The
+// message will be available via next Ready.
+//
+// It may also send a snapshot (MsgSnap) instead, if the log can't be read (e.g.
+// it was already compacted at the follower's Next index).
+//
+// The total size of log entries in the message is <= Config.MaxSizePerMsg, with
+// the exception that the last entry can bring a size < maxSize to a size
+// exceeding maxSize.
+//
+// This method is used when Config.EnableLazyAppends is true. Typically, it
+// should be called before processing Ready, for all node IDs in StateReplicate
+// which have pending replication work.
+//
+// TODO(pav-kv): deprecate Config.MsgSizePerMsg, and pass the maxSize in, for an
+// accurate and flexible size control.
+//
+// TODO(pav-kv): integrate with Admission Control, which will be calling this
+// under two conditions: the node's Next <= raftLog.lastIndex (i.e. the "send
+// queue" is not empty), and there are some acquired "send tokens" (hence the
+// need for maxSize parameter).
+//
+// TODO(pav-kv): since the caller is tracking the replication state, it knows
+// Next, and might also have a good idea on the number and sizes of entries to
+// send. Pass additional parameters, and do safety checks.
+func (rn *RawNode) SendAppend(to uint64) bool {
+	if !rn.raft.enableLazyAppends || to == rn.raft.id {
+		return false
+	}
+	return rn.raft.maybeSendAppendImpl(to, false /* lazy */)
+}
+
 // readyWithoutAccept returns a Ready. This is a read-only operation, i.e. there
 // is no obligation that the Ready must be handled.
 func (rn *RawNode) readyWithoutAccept() Ready {


### PR DESCRIPTION
This PR introduces the "lazy appends" API in raft `RawNode`. In this mode, all `MsgApp` messages with a non-empty `Entries` slice in `StateReplicate` are sent using the `RawNode.SendAppend` method. This gives the caller (typically, the one handling `Ready` processing) direct control of when the raft node accesses `Storage` and sends replication messages. The API will be used by Replication Admission Control, which ultimately helps solving follower overload issues.

Previously, all `MsgApp` messages would be sent eagerly as soon as the node sees that a follower is behind. Any message `Step`-ped into raft could cause an immediate read of entries from `Storage` and a message construction.

The new behaviour is disabled by default, and hidden by `Config.EnableLazyAppends` flag. In the future, it will be the default.

PR #124948 demonstrates the usage of this API, and its effect can be seen in the `testdata` traces of the data-driven tests: messages typically contain more entries, since their construction is delayed until `Ready` processing.

Epic: CRDB-37515