### PR TITLE
roachtest: exclude stats.json from artifacts.zip

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1132,10 +1132,19 @@ type RunCmdOptions struct {
 	remoteOptions           []remoteSessionOption
 }
 
+// Default RunCmdOptions enable combining output (stdout and stderr) and capturing ssh (verbose) debug output.
 func defaultCmdOpts(debugName string) RunCmdOptions {
 	return RunCmdOptions{
 		combinedOut:   true,
 		remoteOptions: []remoteSessionOption{withDebugName(debugName)},
+	}
+}
+
+// Unlike defaultCmdOpts, ssh (verbose) debug output capture is _disabled_.
+func cmdOptsWithDebugDisabled() RunCmdOptions {
+	return RunCmdOptions{
+		combinedOut:   true,
+		remoteOptions: []remoteSessionOption{withDebugDisabled()},
 	}
 }
 
@@ -1375,7 +1384,8 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 			res := &RunResultDetails{Node: node}
 			var err error
 			cmd := fmt.Sprintf("test -e %s", vm.DisksInitializedFile)
-			opts := defaultCmdOpts("wait-init")
+			// N.B. we disable ssh debug output capture, lest we end up with _thousands_ of useless .log files.
+			opts := cmdOptsWithDebugDisabled()
 			for j := 0; j < 600; j++ {
 				res, err = c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 				if err != nil {


### PR DESCRIPTION
Upon test completion, the test runner invokes `zipArtifacts()` in order to reduce the footprint of all test-specific logs retained by TC. In case of a successful benchmark, performance artifacts (i.e., stats.json) are fetched. Historically, those do not get zipped. Instead, they are uploaded (as is) into GCS.

In [1], a new pattern was introduced, wherein `stats.json` is written directly on the test runner node, as opposed to, on some remote (cluster) node. Since `zipArtifacts` runs _before_ fetching performance artifacts, `stats.json` is effectively evaporated; i.e., the CI script no longer finds it.

This PR adds an exclusion filter to `zipArtifacts`, to ignore all paths ending in `stats.json`.

Unrelated, we also disable _verbose_ ssh
logging for `roachprod.SetupSSH`, which can result in _thousands_ of useless logs; this was observed in the same CI run, while debugging the "disappering" `stats.json` issue.

[1] https://github.com/cockroachdb/cockroach/pull/124664

Epic: none
Informs: #124827

Release note: None