### PR TITLE
release-23.1: opt: don't lose equality FDs when columns are constant

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3647,7 +3647,7 @@ project
  ├── immutable
  ├── stats: [rows=1.031997]
  ├── cost: 122.172083
- ├── fd: ()-->(2,5,17,20)
+ ├── fd: ()-->(2,5,17,20), (5)==(20), (20)==(5)
  ├── distribution: ap-southeast-2
  ├── prune: (2-5,10,17-20)
  └── inner-join (lookup xyz [as=x])

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -148,7 +148,7 @@ project
       │              ├── columns: v:8(int!null) n:13(int!null)
       │              ├── outer: (1)
       │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │              ├── fd: ()-->(8,13)
+      │              ├── fd: ()-->(8,13), (8)==(13), (13)==(8)
       │              ├── interesting orderings: (+13)
       │              ├── scan uv
       │              │    ├── columns: v:8(int!null)
@@ -2913,3 +2913,111 @@ left-join (hash)
       └── eq [type=bool, outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
            ├── variable: r_b:2 [type=int]
            └── variable: b:7 [type=int]
+
+# Regression test for #119441 - marking a set of columns constant should not
+# remove equalities among them.
+exec-ddl
+CREATE TABLE table1_119441 (col1_5 REGTYPE NULL, col1_8 BYTES, col1_11 STRING, col1_12 STRING, INDEX (col1_11));
+----
+
+exec-ddl
+CREATE TABLE table2_119441 (col2_1 INT4, col2_2 STRING, col2_3 BYTES);
+----
+
+exec-ddl
+CREATE TABLE table3_119441 (col3_5 VARCHAR NOT NULL, col3_11 CHAR, col3_16 INT8);
+----
+
+opt
+SELECT (
+  SELECT baz.col3_5 FROM table1_119441
+  JOIN table2_119441 ON (table1_119441.col1_8) = (table2_119441.col2_3) AND (table1_119441.col1_12) = (table2_119441.col2_2) AND (table1_119441.col1_11) = (table2_119441.col2_2)
+  JOIN (SELECT baz.col3_11, table3_119441.col3_16 FROM table3_119441 ORDER BY table3_119441.col3_16 LIMIT 6) AS t(foo, bar)
+  ON table1_119441.col1_11 = foo AND table2_119441.col2_1 = bar AND table1_119441.col1_12 = foo
+  LIMIT 1
+)
+FROM table3_119441 AS baz;
+----
+project
+ ├── columns: col3_5:28(varchar)
+ ├── prune: (28)
+ ├── reject-nulls: (28)
+ ├── left-join-apply
+ │    ├── columns: baz.col3_5:1(varchar!null) baz.col3_11:2(char) col3_5:27(varchar)
+ │    ├── prune: (27)
+ │    ├── reject-nulls: (27)
+ │    ├── scan table3_119441 [as=baz]
+ │    │    ├── columns: baz.col3_5:1(varchar!null) baz.col3_11:2(char)
+ │    │    ├── prune: (1,2)
+ │    │    └── unfiltered-cols: (1-6)
+ │    ├── project
+ │    │    ├── columns: col3_5:27(varchar)
+ │    │    ├── outer: (1,2)
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(27)
+ │    │    ├── prune: (27)
+ │    │    ├── limit
+ │    │    │    ├── columns: col1_8:8(bytes!null) col1_11:9(string!null) col1_12:10(string!null) col2_1:14(int4!null) col2_2:15(string!null) col2_3:16(bytes!null) table3_119441.col3_16:22(int!null)
+ │    │    │    ├── outer: (2)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(8-10,14-16,22), (10)==(9,15), (8)==(16), (16)==(8), (15)==(9,10), (14)==(22), (22)==(14), (9)==(10,15)
+ │    │    │    ├── interesting orderings: (+(9|10)) (+22)
+ │    │    │    ├── inner-join (hash)
+ │    │    │    │    ├── columns: col1_8:8(bytes!null) col1_11:9(string!null) col1_12:10(string!null) col2_1:14(int4!null) col2_2:15(string!null) col2_3:16(bytes!null) table3_119441.col3_16:22(int!null)
+ │    │    │    │    ├── outer: (2)
+ │    │    │    │    ├── fd: ()-->(9,10,15), (9)==(10,15), (10)==(9,15), (8)==(16), (16)==(8), (15)==(9,10), (14)==(22), (22)==(14)
+ │    │    │    │    ├── limit hint: 1.00
+ │    │    │    │    ├── interesting orderings: (+(9|10)) (+22)
+ │    │    │    │    ├── top-k
+ │    │    │    │    │    ├── columns: table3_119441.col3_16:22(int)
+ │    │    │    │    │    ├── internal-ordering: +22
+ │    │    │    │    │    ├── k: 6
+ │    │    │    │    │    ├── cardinality: [0 - 6]
+ │    │    │    │    │    ├── interesting orderings: (+22)
+ │    │    │    │    │    └── scan table3_119441
+ │    │    │    │    │         ├── columns: table3_119441.col3_16:22(int)
+ │    │    │    │    │         └── prune: (22)
+ │    │    │    │    ├── inner-join (hash)
+ │    │    │    │    │    ├── columns: col1_8:8(bytes!null) col1_11:9(string!null) col1_12:10(string!null) col2_1:14(int4) col2_2:15(string!null) col2_3:16(bytes!null)
+ │    │    │    │    │    ├── fd: (9)==(10,15), (10)==(9,15), (8)==(16), (16)==(8), (15)==(9,10)
+ │    │    │    │    │    ├── prune: (14)
+ │    │    │    │    │    ├── interesting orderings: (+(9|10))
+ │    │    │    │    │    ├── scan table2_119441
+ │    │    │    │    │    │    ├── columns: col2_1:14(int4) col2_2:15(string) col2_3:16(bytes)
+ │    │    │    │    │    │    ├── prune: (14-16)
+ │    │    │    │    │    │    └── unfiltered-cols: (14-19)
+ │    │    │    │    │    ├── select
+ │    │    │    │    │    │    ├── columns: col1_8:8(bytes) col1_11:9(string!null) col1_12:10(string!null)
+ │    │    │    │    │    │    ├── fd: (9)==(10), (10)==(9)
+ │    │    │    │    │    │    ├── prune: (8)
+ │    │    │    │    │    │    ├── interesting orderings: (+(9|10))
+ │    │    │    │    │    │    ├── scan table1_119441
+ │    │    │    │    │    │    │    ├── columns: col1_8:8(bytes) col1_11:9(string) col1_12:10(string)
+ │    │    │    │    │    │    │    ├── prune: (8-10)
+ │    │    │    │    │    │    │    └── interesting orderings: (+9)
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         └── eq [type=bool, outer=(9,10), constraints=(/9: (/NULL - ]; /10: (/NULL - ]), fd=(9)==(10), (10)==(9)]
+ │    │    │    │    │    │              ├── variable: col1_11:9 [type=string]
+ │    │    │    │    │    │              └── variable: col1_12:10 [type=string]
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         ├── eq [type=bool, outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+ │    │    │    │    │         │    ├── variable: col1_8:8 [type=bytes]
+ │    │    │    │    │         │    └── variable: col2_3:16 [type=bytes]
+ │    │    │    │    │         └── eq [type=bool, outer=(9,15), constraints=(/9: (/NULL - ]; /15: (/NULL - ]), fd=(9)==(15), (15)==(9)]
+ │    │    │    │    │              ├── variable: col1_11:9 [type=string]
+ │    │    │    │    │              └── variable: col2_2:15 [type=string]
+ │    │    │    │    └── filters
+ │    │    │    │         ├── eq [type=bool, outer=(14,22), constraints=(/14: (/NULL - ]; /22: (/NULL - ]), fd=(14)==(22), (22)==(14)]
+ │    │    │    │         │    ├── variable: col2_1:14 [type=int4]
+ │    │    │    │         │    └── variable: table3_119441.col3_16:22 [type=int]
+ │    │    │    │         └── eq [type=bool, outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    │    │    │              ├── variable: col1_11:9 [type=string]
+ │    │    │    │              └── variable: baz.col3_11:2 [type=char]
+ │    │    │    └── const: 1 [type=int]
+ │    │    └── projections
+ │    │         └── variable: baz.col3_5:1 [as=col3_5:27, type=varchar, outer=(1)]
+ │    └── filters (true)
+ └── projections
+      └── variable: col3_5:27 [as=col3_5:28, type=varchar, outer=(27)]

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -1088,7 +1088,7 @@ func (f *FuncDepSet) ProjectCols(cols opt.ColSet) {
 		// constant columns from dependants for nicer presentation.
 		if !fd.to.SubsetOf(cols) {
 			fd.to = fd.to.Intersection(cols)
-			if !fd.isConstant() {
+			if !fd.isConstant() && !fd.equiv {
 				fd.to.DifferenceWith(constCols)
 			}
 			if !fd.removeToCols(fd.from) {


### PR DESCRIPTION
Backport 1/1 commits from #124949.

/cc @cockroachdb/release

---

Previously, there was a minor bug in the functional dependency logic that could lost track of an equivalence between columns if they were all discovered to be constant. This patch makes an exception in the constant-pruning logic for equalities, since an equivalence provides additional information to a set of constant columns. While this omission couldn't cause incorrect results, it could cause the optimizer to encounter an assertion failure in test-only builds.

Fixes #119441

Release note: None

---

Release justification: low-risk bug fix to prevent test flakes