### PR TITLE
release-23.2: log: change fingerprint_id type to string

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2984,7 +2984,6 @@ contains common SQL event/execution details.
 | `Database` | Name of the database that initiated the query. | no |
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
-| `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 | `MaxFullScanRowsEstimate` | Maximum number of rows scanned by a full scan, as estimated by the optimizer. | no |
 | `TotalScanRowsEstimate` | Total number of rows read by all scans in the query, as estimated by the optimizer. | no |
 | `OutputRowsEstimate` | The number of rows output by the query, as estimated by the optimizer. | no |
@@ -3047,7 +3046,8 @@ contains common SQL event/execution details.
 | `MvccRangeKeyContainedPoints` | RangeKeyContainedPoints collects the count of point keys encountered within the bounds of a range key. For details, see pebble.RangeKeyIteratorStats and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
 | `MvccRangeKeySkippedPoints` | RangeKeySkippedPoints collects the count of the subset of ContainedPoints point keys that were skipped during iteration due to range-key masking. For details, see pkg/storage/engine.go, pebble.RangeKeyIteratorStats, and https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md. | no |
 | `SchemaChangerMode` | SchemaChangerMode is the mode that was used to execute the schema change, if any. | no |
-| `SQLInstanceIDs` | SQLInstanceIDs is a list of all the SQL instance id used in this statements execution. | no |
+| `SQLInstanceIDs` | SQLInstanceIDs is a list of all the SQL instances used in this statement's execution. | no |
+| `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 
 
 #### Common fields
@@ -3086,7 +3086,6 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `TxnCounter` | TxnCounter is the sequence number of the SQL transaction inside its session. | no |
 | `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
 | `TransactionID` | TransactionID is the id of the transaction. | no |
-| `TransactionFingerprintID` | TransactionFingerprintID is the fingerprint ID of the transaction. This can be used to find the transaction in the console. | no |
 | `Committed` | Committed indicates if the transaction committed successfully. We want to include this value even if it is false. | no |
 | `ImplicitTxn` | ImplicitTxn indicates if the transaction was an implicit one. We want to include this value even if it is false. | no |
 | `StartTimeUnixNanos` | StartTimeUnixNanos is the time the transaction was started. Expressed as unix time in nanoseconds. | no |
@@ -3096,7 +3095,6 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `ErrorText` | ErrorText is the text of the error if any. | partially |
 | `NumRetries` | NumRetries is the number of time when the txn was retried automatically by the server. | no |
 | `LastAutoRetryReason` | LastAutoRetryReason is a string containing the reason for the last automatic retry. | partially |
-| `StatementFingerprintIDs` | StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction. | yes |
 | `NumRows` | NumRows is the total number of rows returned across all statements. | no |
 | `RetryLatNanos` | RetryLatNanos is the amount of time spent retrying the transaction. | no |
 | `CommitLatNanos` | CommitLatNanos is the amount of time spent committing the transaction after all statement operations. | no |
@@ -3106,6 +3104,8 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `RowsWritten` | RowsWritten is the number of rows written to disk. | no |
 | `SampledExecStats` | SampledExecStats is a nested field containing execution statistics. This field will be omitted if the stats were not sampled. | yes |
 | `SkippedTransactions` | SkippedTransactions is the number of transactions that were skipped as part of sampling prior to this one. We only count skipped transactions when telemetry logging is enabled and the sampling mode is set to "transaction". | no |
+| `TransactionFingerprintID` | TransactionFingerprintID is the fingerprint ID of the transaction. This can be used to find the transaction in the console. | no |
+| `StatementFingerprintIDs` | StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction. | no |
 
 
 #### Common fields

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -12,6 +12,7 @@ package appstatspb
 
 import (
 	"math"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -19,11 +20,15 @@ import (
 // StmtFingerprintID is the type of a Statement's fingerprint ID.
 type StmtFingerprintID uint64
 
+func (s StmtFingerprintID) String() string {
+	return strconv.FormatUint(uint64(s), 10)
+}
+
 // ConstructStatementFingerprintID constructs an ID by hashing query with
 // constants redacted, its database and failure status, and if it was part of an
 // implicit txn. At the time of writing, these are the axis' we use to bucket
 // queries for stats collection (see stmtKey).
-func ConstructStatementFingerprintID(
+var ConstructStatementFingerprintID = func(
 	stmtNoConstants string, failed bool, implicitTxn bool, database string,
 ) StmtFingerprintID {
 	fnv := util.MakeFNV64()
@@ -49,6 +54,10 @@ func ConstructStatementFingerprintID(
 // TransactionFingerprintID is the hashed string constructed using the
 // individual statement fingerprint IDs that comprise the transaction.
 type TransactionFingerprintID uint64
+
+func (t TransactionFingerprintID) String() string {
+	return strconv.FormatUint(uint64(t), 10)
+}
 
 // InvalidTransactionFingerprintID denotes an invalid transaction fingerprint ID.
 const InvalidTransactionFingerprintID = TransactionFingerprintID(0)

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -369,7 +369,7 @@ func (p *planner) maybeLogStatementInternal(
 			Database:                              p.CurrentDatabase(),
 			StatementID:                           p.stmt.QueryID.String(),
 			TransactionID:                         txnID,
-			StatementFingerprintID:                uint64(stmtFingerprintID),
+			StatementFingerprintID:                stmtFingerprintID.String(),
 			MaxFullScanRowsEstimate:               p.curPlan.instrumentation.maxFullScanRows,
 			TotalScanRowsEstimate:                 p.curPlan.instrumentation.totalScanRows,
 			OutputRowsEstimate:                    p.curPlan.instrumentation.outputRows,
@@ -462,6 +462,10 @@ func (p *planner) logTransaction(
 
 	sampledTxn := getSampledTransaction()
 	defer releaseSampledTransaction(sampledTxn)
+	statementFingerprintIDStrs := make([]string, 0, len(txnStats.StatementFingerprintIDs))
+	for _, id := range txnStats.StatementFingerprintIDs {
+		statementFingerprintIDStrs = append(statementFingerprintIDStrs, id.String())
+	}
 
 	*sampledTxn = eventpb.SampledTransaction{
 		SkippedTransactions:      int64(skippedTransactions),
@@ -470,7 +474,7 @@ func (p *planner) logTransaction(
 		TxnCounter:               uint32(txnCounter),
 		SessionID:                txnStats.SessionID.String(),
 		TransactionID:            txnStats.TransactionID.String(),
-		TransactionFingerprintID: txnFingerprintID,
+		TransactionFingerprintID: txnFingerprintID.String(),
 		Committed:                txnStats.Committed,
 		ImplicitTxn:              txnStats.ImplicitTxn,
 		StartTimeUnixNanos:       txnStats.StartTime.UnixNano(),
@@ -480,7 +484,7 @@ func (p *planner) logTransaction(
 		ErrorText:                execErrStr,
 		NumRetries:               txnStats.RetryCount,
 		LastAutoRetryReason:      retryErr,
-		StatementFingerprintIDs:  txnStats.StatementFingerprintIDs,
+		StatementFingerprintIDs:  statementFingerprintIDStrs,
 		NumRows:                  int64(txnStats.RowsAffected),
 		RetryLatNanos:            txnStats.RetryLatency.Nanoseconds(),
 		CommitLatNanos:           txnStats.CommitLatency.Nanoseconds(),

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -538,7 +538,7 @@ func TestTelemetryLogging(t *testing.T) {
 
 					stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(tc.queryNoConstants, tc.expectedErr != "", true, databaseName)
 
-					require.Equal(t, uint64(stmtFingerprintID), sampledQueryFromLog.StatementFingerprintID)
+					require.Equal(t, stmtFingerprintID.String(), sampledQueryFromLog.StatementFingerprintID)
 
 					maxFullScanRowsRe := regexp.MustCompile("\"MaxFullScanRowsEstimate\":[0-9]*")
 					foundFullScan := maxFullScanRowsRe.MatchString(e.Message)

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -36,7 +36,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 17888549871399373000,
+	"StatementFingerprintID": 17888549871399372520,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -49,9 +49,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		17888549871399373000
+		17888549871399372520
 	],
-	"TransactionFingerprintID": 6278959165882708000,
+	"TransactionFingerprintID": 6278959165882708279,
 	"User": "root"
 }
 
@@ -67,7 +67,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16698501115058330000,
+	"StatementFingerprintID": 16698501115058330309,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -80,9 +80,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16698501115058330000
+		16698501115058330309
 	],
-	"TransactionFingerprintID": 5250989384299556000,
+	"TransactionFingerprintID": 5250989384299556122,
 	"User": "root"
 }
 
@@ -98,7 +98,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736494000,
+	"StatementFingerprintID": 15578946620736492917,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -111,9 +111,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		15578946620736494000
+		15578946620736492917
 	],
-	"TransactionFingerprintID": 8597429024882746000,
+	"TransactionFingerprintID": 8597429024882746026,
 	"User": "root"
 }
 
@@ -152,7 +152,7 @@ SET application_name = '$ internal-console-app';
 	"EventType": "sampled_query",
 	"PlanGist": "Ais=",
 	"Statement": "SET application_name = ‹'$ internal-console-app'›",
-	"StatementFingerprintID": 13549091137440920000,
+	"StatementFingerprintID": 13549091137440919938,
 	"StmtPosInTxn": 1,
 	"Tag": "SET",
 	"User": "root"
@@ -169,7 +169,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 17888549871399373000,
+	"StatementFingerprintID": 17888549871399372520,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -183,9 +183,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsWritten": 0,
 	"SkippedTransactions": 5,
 	"StatementFingerprintIDs": [
-		17888549871399373000
+		17888549871399372520
 	],
-	"TransactionFingerprintID": 6278959165882708000,
+	"TransactionFingerprintID": 6278959165882708279,
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16698501115058330000,
+	"StatementFingerprintID": 16698501115058330309,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -214,9 +214,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16698501115058330000
+		16698501115058330309
 	],
-	"TransactionFingerprintID": 5250989384299556000,
+	"TransactionFingerprintID": 5250989384299556122,
 	"User": "root"
 }
 
@@ -232,7 +232,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736494000,
+	"StatementFingerprintID": 15578946620736492917,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -245,9 +245,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		15578946620736494000
+		15578946620736492917
 	],
-	"TransactionFingerprintID": 8597429024882746000,
+	"TransactionFingerprintID": 8597429024882746026,
 	"User": "root"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -36,7 +36,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 17888549871399372520,
+	"StatementFingerprintID": "17888549871399372520",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -49,9 +49,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		17888549871399372520
+		"17888549871399372520"
 	],
-	"TransactionFingerprintID": 6278959165882708279,
+	"TransactionFingerprintID": "6278959165882708279",
 	"User": "root"
 }
 
@@ -67,7 +67,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16698501115058330309,
+	"StatementFingerprintID": "16698501115058330309",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -80,9 +80,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16698501115058330309
+		"16698501115058330309"
 	],
-	"TransactionFingerprintID": 5250989384299556122,
+	"TransactionFingerprintID": "5250989384299556122",
 	"User": "root"
 }
 
@@ -98,7 +98,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736492917,
+	"StatementFingerprintID": "15578946620736492917",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -111,9 +111,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		15578946620736492917
+		"15578946620736492917"
 	],
-	"TransactionFingerprintID": 8597429024882746026,
+	"TransactionFingerprintID": "8597429024882746026",
 	"User": "root"
 }
 
@@ -152,7 +152,7 @@ SET application_name = '$ internal-console-app';
 	"EventType": "sampled_query",
 	"PlanGist": "Ais=",
 	"Statement": "SET application_name = ‹'$ internal-console-app'›",
-	"StatementFingerprintID": 13549091137440919938,
+	"StatementFingerprintID": "13549091137440919938",
 	"StmtPosInTxn": 1,
 	"Tag": "SET",
 	"User": "root"
@@ -169,7 +169,7 @@ SELECT * FROM t LIMIT 1;
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
-	"StatementFingerprintID": 17888549871399372520,
+	"StatementFingerprintID": "17888549871399372520",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -183,9 +183,9 @@ SELECT * FROM t LIMIT 1;
 	"RowsWritten": 0,
 	"SkippedTransactions": 5,
 	"StatementFingerprintIDs": [
-		17888549871399372520
+		"17888549871399372520"
 	],
-	"TransactionFingerprintID": 6278959165882708279,
+	"TransactionFingerprintID": "6278959165882708279",
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT 1, 2, 3;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16698501115058330309,
+	"StatementFingerprintID": "16698501115058330309",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -214,9 +214,9 @@ SELECT 1, 2, 3;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16698501115058330309
+		"16698501115058330309"
 	],
-	"TransactionFingerprintID": 5250989384299556122,
+	"TransactionFingerprintID": "5250989384299556122",
 	"User": "root"
 }
 
@@ -232,7 +232,7 @@ SELECT 'hello';
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736492917,
+	"StatementFingerprintID": "15578946620736492917",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -245,9 +245,9 @@ SELECT 'hello';
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		15578946620736492917
+		"15578946620736492917"
 	],
-	"TransactionFingerprintID": 8597429024882746026,
+	"TransactionFingerprintID": "8597429024882746026",
 	"User": "root"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/statement_fingerprint_id
+++ b/pkg/sql/testdata/telemetry_logging/logging/statement_fingerprint_id
@@ -1,0 +1,48 @@
+# Test that stub statement fingerprint id value to be max uint64 and ensure that it is represented properly as
+# a string
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.max_event_frequency = 10;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.statement_events_per_transaction.max = 100;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;
+----
+
+spy-sql unixSecs=1 stubStatementFingerprintId=18446744073709551615
+SELECT 1,2
+----
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICBAYE",
+	"Statement": "SELECT ‹1›, ‹2›",
+	"StatementFingerprintID": "18446744073709551615",
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		"18446744073709551615"
+	],
+	"TransactionFingerprintID": "5808590958014384160",
+	"User": "root"
+}

--- a/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
+++ b/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
@@ -27,7 +27,7 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -40,10 +40,10 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16085855936700856000,
-		16085855936700856000
+		16085855936700855359,
+		16085855936700855359
 	],
-	"TransactionFingerprintID": 14263644654231036000,
+	"TransactionFingerprintID": 14263644654231036319,
 	"User": "root"
 }
 
@@ -60,7 +60,7 @@ SELECT 5;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 2,
 	"Statement": "SELECT ‹5›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855347,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -73,9 +73,9 @@ SELECT 5;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16085855936700856000
+		16085855936700855347
 	],
-	"TransactionFingerprintID": 8097417102642120000,
+	"TransactionFingerprintID": 8097417102642119660,
 	"User": "root"
 }
 
@@ -96,7 +96,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -110,7 +110,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -124,7 +124,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -138,12 +138,12 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16085855936700856000,
-		16085855936700856000,
-		16085855936700856000,
-		16085855936700856000
+		16085855936700855359,
+		16085855936700855359,
+		16085855936700855359,
+		16085855936700855359
 	],
-	"TransactionFingerprintID": 63991751604173224,
+	"TransactionFingerprintID": 63991751604173225,
 	"User": "root"
 }
 
@@ -164,7 +164,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -178,7 +178,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -192,7 +192,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -206,7 +206,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹4›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 4,
 	"Tag": "SELECT",
 	"User": "root"
@@ -220,11 +220,11 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16085855936700856000,
-		16085855936700856000,
-		16085855936700856000,
-		16085855936700856000
+		16085855936700855359,
+		16085855936700855359,
+		16085855936700855359,
+		16085855936700855359
 	],
-	"TransactionFingerprintID": 63991751604173224,
+	"TransactionFingerprintID": 63991751604173225,
 	"User": "root"
 }

--- a/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
+++ b/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
@@ -27,7 +27,7 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -40,10 +40,10 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16085855936700855359,
-		16085855936700855359
+		"16085855936700855359",
+		"16085855936700855359"
 	],
-	"TransactionFingerprintID": 14263644654231036319,
+	"TransactionFingerprintID": "14263644654231036319",
 	"User": "root"
 }
 
@@ -60,7 +60,7 @@ SELECT 5;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 2,
 	"Statement": "SELECT ‹5›",
-	"StatementFingerprintID": 16085855936700855347,
+	"StatementFingerprintID": "16085855936700855347",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -73,9 +73,9 @@ SELECT 5;
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16085855936700855347
+		"16085855936700855347"
 	],
-	"TransactionFingerprintID": 8097417102642119660,
+	"TransactionFingerprintID": "8097417102642119660",
 	"User": "root"
 }
 
@@ -96,7 +96,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -110,7 +110,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -124,7 +124,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -138,12 +138,12 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16085855936700855359,
-		16085855936700855359,
-		16085855936700855359,
-		16085855936700855359
+		"16085855936700855359",
+		"16085855936700855359",
+		"16085855936700855359",
+		"16085855936700855359"
 	],
-	"TransactionFingerprintID": 63991751604173225,
+	"TransactionFingerprintID": "63991751604173225",
 	"User": "root"
 }
 
@@ -164,7 +164,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -178,7 +178,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -192,7 +192,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -206,7 +206,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹4›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 4,
 	"Tag": "SELECT",
 	"User": "root"
@@ -220,11 +220,11 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16085855936700855359,
-		16085855936700855359,
-		16085855936700855359,
-		16085855936700855359
+		"16085855936700855359",
+		"16085855936700855359",
+		"16085855936700855359",
+		"16085855936700855359"
 	],
-	"TransactionFingerprintID": 63991751604173225,
+	"TransactionFingerprintID": "63991751604173225",
 	"User": "root"
 }

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -33,7 +33,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"PlanGist": "Ais=",
 	"SkippedQueries": 1,
 	"Statement": "TRUNCATE TABLE defaultdb.public.t",
-	"StatementFingerprintID": 802230861479752300,
+	"StatementFingerprintID": 802230861479752304,
 	"StmtPosInTxn": 1,
 	"Tag": "TRUNCATE",
 	"User": "root"
@@ -44,7 +44,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729698000,
+	"StatementFingerprintID": 14457747517729697511,
 	"StmtPosInTxn": 2,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -57,9 +57,9 @@ BEGIN; TRUNCATE t; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		802230861479752300
+		802230861479752304
 	],
-	"TransactionFingerprintID": 11835923794509859000,
+	"TransactionFingerprintID": 11835923794509858223,
 	"User": "root"
 }
 
@@ -79,7 +79,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -93,7 +93,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -107,7 +107,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 16085855936700856000,
+	"StatementFingerprintID": 16085855936700855359,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -118,7 +118,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729698000,
+	"StatementFingerprintID": 14457747517729697511,
 	"StmtPosInTxn": 4,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -131,11 +131,11 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16085855936700856000,
-		16085855936700856000,
-		16085855936700856000
+		16085855936700855359,
+		16085855936700855359,
+		16085855936700855359
 	],
-	"TransactionFingerprintID": 17099066530943440000,
+	"TransactionFingerprintID": 17099066530943440146,
 	"User": "root"
 }
 
@@ -158,7 +158,7 @@ SELECT 1, 2
 	"PlanGist": "AgICBAYE",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›, ‹2›",
-	"StatementFingerprintID": 1569305422589581000,
+	"StatementFingerprintID": 1569305422589581018,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -172,9 +172,9 @@ SELECT 1, 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		1569305422589581000
+		1569305422589581018
 	],
-	"TransactionFingerprintID": 13449146770429469000,
+	"TransactionFingerprintID": 13449146770429468933,
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT * FROM t LIMIT 2
 	"ScanCount": 1,
 	"SkippedQueries": 2,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹2›",
-	"StatementFingerprintID": 17888549871399373000,
+	"StatementFingerprintID": 17888549871399372520,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -215,9 +215,9 @@ SELECT * FROM t LIMIT 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 2,
 	"StatementFingerprintIDs": [
-		17888549871399373000
+		17888549871399372520
 	],
-	"TransactionFingerprintID": 6278959165882708000,
+	"TransactionFingerprintID": 6278959165882708279,
 	"User": "root"
 }
 
@@ -239,7 +239,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"ScanCount": 1,
 	"SkippedQueries": 4,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹4›",
-	"StatementFingerprintID": 17888549871399373000,
+	"StatementFingerprintID": 17888549871399372516,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -252,7 +252,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹5›",
-	"StatementFingerprintID": 17888549871399373000,
+	"StatementFingerprintID": 17888549871399372516,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -263,7 +263,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729698000,
+	"StatementFingerprintID": 14457747517729697511,
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -277,10 +277,10 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		17888549871399373000,
-		17888549871399373000
+		17888549871399372516,
+		17888549871399372516
 	],
-	"TransactionFingerprintID": 5223910247858315000,
+	"TransactionFingerprintID": 5223910247858315685,
 	"User": "root"
 }
 
@@ -310,7 +310,7 @@ SELECT 1, 2, 3
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16698501115058330000,
+	"StatementFingerprintID": 16698501115058330309,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -324,9 +324,9 @@ SELECT 1, 2, 3
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16698501115058330000
+		16698501115058330309
 	],
-	"TransactionFingerprintID": 5250989384299556000,
+	"TransactionFingerprintID": 5250989384299556122,
 	"User": "root"
 }
 
@@ -363,7 +363,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 7,
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736494000,
+	"StatementFingerprintID": 15578946620736492921,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -378,7 +378,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "40001",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 17115235937825139000,
+	"StatementFingerprintID": 17115235937825138449,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -393,7 +393,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736494000,
+	"StatementFingerprintID": 15578946620736492921,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -408,7 +408,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 9891387630896048000,
+	"StatementFingerprintID": 9891387630896047206,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -420,7 +420,7 @@ COMMIT;
 	"EventType": "sampled_query",
 	"NumRetries": 1,
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729698000,
+	"StatementFingerprintID": 14457747517729697511,
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -436,10 +436,10 @@ COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		15578946620736494000,
-		9891387630896048000
+		15578946620736492921,
+		9891387630896047206
 	],
-	"TransactionFingerprintID": 823601646009140400,
+	"TransactionFingerprintID": 823601646009140340,
 	"User": "root"
 }
 
@@ -466,7 +466,7 @@ pq: division by zero
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "22012",
 	"Statement": "SELECT ‹1› / ‹0›",
-	"StatementFingerprintID": 16154612194363576000,
+	"StatementFingerprintID": 16154612194363576960,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "‹testuser›"
@@ -481,9 +481,9 @@ pq: division by zero
 	"RowsWritten": 0,
 	"SQLSTATE": "22012",
 	"StatementFingerprintIDs": [
-		16154612194363576000
+		16154612194363576960
 	],
-	"TransactionFingerprintID": 5715924995226314000,
+	"TransactionFingerprintID": 5715924995226314079,
 	"User": "‹testuser›"
 }
 

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -33,7 +33,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"PlanGist": "Ais=",
 	"SkippedQueries": 1,
 	"Statement": "TRUNCATE TABLE defaultdb.public.t",
-	"StatementFingerprintID": 802230861479752304,
+	"StatementFingerprintID": "802230861479752304",
 	"StmtPosInTxn": 1,
 	"Tag": "TRUNCATE",
 	"User": "root"
@@ -44,7 +44,7 @@ BEGIN; TRUNCATE t; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729697511,
+	"StatementFingerprintID": "14457747517729697511",
 	"StmtPosInTxn": 2,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -57,9 +57,9 @@ BEGIN; TRUNCATE t; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		802230861479752304
+		"802230861479752304"
 	],
-	"TransactionFingerprintID": 11835923794509858223,
+	"TransactionFingerprintID": "11835923794509858223",
 	"User": "root"
 }
 
@@ -79,7 +79,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -93,7 +93,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹2›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -107,7 +107,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹3›",
-	"StatementFingerprintID": 16085855936700855359,
+	"StatementFingerprintID": "16085855936700855359",
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
 	"User": "root"
@@ -118,7 +118,7 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729697511,
+	"StatementFingerprintID": "14457747517729697511",
 	"StmtPosInTxn": 4,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -131,11 +131,11 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"RowsRead": 0,
 	"RowsWritten": 0,
 	"StatementFingerprintIDs": [
-		16085855936700855359,
-		16085855936700855359,
-		16085855936700855359
+		"16085855936700855359",
+		"16085855936700855359",
+		"16085855936700855359"
 	],
-	"TransactionFingerprintID": 17099066530943440146,
+	"TransactionFingerprintID": "17099066530943440146",
 	"User": "root"
 }
 
@@ -158,7 +158,7 @@ SELECT 1, 2
 	"PlanGist": "AgICBAYE",
 	"SkippedQueries": 1,
 	"Statement": "SELECT ‹1›, ‹2›",
-	"StatementFingerprintID": 1569305422589581018,
+	"StatementFingerprintID": "1569305422589581018",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -172,9 +172,9 @@ SELECT 1, 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		1569305422589581018
+		"1569305422589581018"
 	],
-	"TransactionFingerprintID": 13449146770429468933,
+	"TransactionFingerprintID": "13449146770429468933",
 	"User": "root"
 }
 
@@ -201,7 +201,7 @@ SELECT * FROM t LIMIT 2
 	"ScanCount": 1,
 	"SkippedQueries": 2,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹2›",
-	"StatementFingerprintID": 17888549871399372520,
+	"StatementFingerprintID": "17888549871399372520",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -215,9 +215,9 @@ SELECT * FROM t LIMIT 2
 	"RowsWritten": 0,
 	"SkippedTransactions": 2,
 	"StatementFingerprintIDs": [
-		17888549871399372520
+		"17888549871399372520"
 	],
-	"TransactionFingerprintID": 6278959165882708279,
+	"TransactionFingerprintID": "6278959165882708279",
 	"User": "root"
 }
 
@@ -239,7 +239,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"ScanCount": 1,
 	"SkippedQueries": 4,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹4›",
-	"StatementFingerprintID": 17888549871399372516,
+	"StatementFingerprintID": "17888549871399372516",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -252,7 +252,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,
 	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹5›",
-	"StatementFingerprintID": 17888549871399372516,
+	"StatementFingerprintID": "17888549871399372516",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -263,7 +263,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"Distribution": "local",
 	"EventType": "sampled_query",
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729697511,
+	"StatementFingerprintID": "14457747517729697511",
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -277,10 +277,10 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		17888549871399372516,
-		17888549871399372516
+		"17888549871399372516",
+		"17888549871399372516"
 	],
-	"TransactionFingerprintID": 5223910247858315685,
+	"TransactionFingerprintID": "5223910247858315685",
 	"User": "root"
 }
 
@@ -310,7 +310,7 @@ SELECT 1, 2, 3
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICBgYG",
 	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
-	"StatementFingerprintID": 16698501115058330309,
+	"StatementFingerprintID": "16698501115058330309",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -324,9 +324,9 @@ SELECT 1, 2, 3
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		16698501115058330309
+		"16698501115058330309"
 	],
-	"TransactionFingerprintID": 5250989384299556122,
+	"TransactionFingerprintID": "5250989384299556122",
 	"User": "root"
 }
 
@@ -363,7 +363,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SkippedQueries": 7,
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736492921,
+	"StatementFingerprintID": "15578946620736492921",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -378,7 +378,7 @@ COMMIT;
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "40001",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 17115235937825138449,
+	"StatementFingerprintID": "17115235937825138449",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -393,7 +393,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT ‹'hello'›",
-	"StatementFingerprintID": 15578946620736492921,
+	"StatementFingerprintID": "15578946620736492921",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "root"
@@ -408,7 +408,7 @@ COMMIT;
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
 	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
-	"StatementFingerprintID": 9891387630896047206,
+	"StatementFingerprintID": "9891387630896047206",
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",
 	"User": "root"
@@ -420,7 +420,7 @@ COMMIT;
 	"EventType": "sampled_query",
 	"NumRetries": 1,
 	"Statement": "COMMIT TRANSACTION",
-	"StatementFingerprintID": 14457747517729697511,
+	"StatementFingerprintID": "14457747517729697511",
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
@@ -436,10 +436,10 @@ COMMIT;
 	"RowsWritten": 0,
 	"SkippedTransactions": 1,
 	"StatementFingerprintIDs": [
-		15578946620736492921,
-		9891387630896047206
+		"15578946620736492921",
+		"9891387630896047206"
 	],
-	"TransactionFingerprintID": 823601646009140340,
+	"TransactionFingerprintID": "823601646009140340",
 	"User": "root"
 }
 
@@ -466,7 +466,7 @@ pq: division by zero
 	"PlanGist": "AgICAgYC",
 	"SQLSTATE": "22012",
 	"Statement": "SELECT ‹1› / ‹0›",
-	"StatementFingerprintID": 16154612194363576960,
+	"StatementFingerprintID": "16154612194363576960",
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
 	"User": "‹testuser›"
@@ -481,9 +481,9 @@ pq: division by zero
 	"RowsWritten": 0,
 	"SQLSTATE": "22012",
 	"StatementFingerprintIDs": [
-		16154612194363576960
+		"16154612194363576960"
 	],
-	"TransactionFingerprintID": 5715924995226314079,
+	"TransactionFingerprintID": "5715924995226314079",
 	"User": "‹testuser›"
 }
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4432,15 +4432,6 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
-	if m.StatementFingerprintID != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"StatementFingerprintID\":"...)
-		b = strconv.AppendUint(b, uint64(m.StatementFingerprintID), 10)
-	}
-
 	if m.MaxFullScanRowsEstimate != 0 {
 		if printComma {
 			b = append(b, ',')
@@ -5039,6 +5030,16 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, ']')
 	}
 
+	if m.StatementFingerprintID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprintID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.StatementFingerprintID)))
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 
@@ -5096,15 +5097,6 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 	b = append(b, "\"TransactionID\":\""...)
 	b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TransactionID)))
 	b = append(b, '"')
-
-	if m.TransactionFingerprintID != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"TransactionFingerprintID\":"...)
-		b = strconv.AppendUint(b, uint64(m.TransactionFingerprintID), 10)
-	}
 
 	if printComma {
 		b = append(b, ',')
@@ -5180,21 +5172,6 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 		b = append(b, '"')
 	}
 
-	if len(m.StatementFingerprintIDs) > 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"StatementFingerprintIDs\":["...)
-		for i, v := range m.StatementFingerprintIDs {
-			if i > 0 {
-				b = append(b, ',')
-			}
-			b = strconv.AppendUint(b, uint64(v), 10)
-		}
-		b = append(b, ']')
-	}
-
 	if printComma {
 		b = append(b, ',')
 	}
@@ -5264,6 +5241,33 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 		printComma = true
 		b = append(b, "\"SkippedTransactions\":"...)
 		b = strconv.AppendInt(b, int64(m.SkippedTransactions), 10)
+	}
+
+	if m.TransactionFingerprintID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TransactionFingerprintID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TransactionFingerprintID)))
+		b = append(b, '"')
+	}
+
+	if len(m.StatementFingerprintIDs) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprintIDs\":["...)
+		for i, v := range m.StatementFingerprintIDs {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '"')
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+			b = append(b, '"')
+		}
+		b = append(b, ']')
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -62,9 +62,6 @@ message SampledQuery {
   // Transaction ID of the query.
   string transaction_id = 11 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // Statement fingerprint ID of the query.
-  uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];
-
   // Maximum number of rows scanned by a full scan, as estimated by the
   // optimizer.
   double max_full_scan_rows_estimate = 14 [(gogoproto.jsontag) = ",omitempty"];
@@ -288,12 +285,26 @@ message SampledQuery {
   // if any.
   string schema_changer_mode = 76 [(gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // SQLInstanceIDs is a list of all the SQL instance id used in this statements execution.
+  // SQLInstanceIDs is a list of all the SQL instances used in this statement's
+  // execution.
   repeated int32 sql_instance_ids = 77 [(gogoproto.jsontag) = ',omitempty', (gogoproto.customname) = "SQLInstanceIDs", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+
+  // Statement fingerprint ID of the query.
+  string statement_fingerprint_id = 79 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
   reserved 12;
 
-  // Next available ID: 78.
+  // Previously used for statement_fingerprint_id. Originally this was typed as a uint64
+  // but has been re-typed to be a string due to downstream json parsing issues. For
+  // more details see: https://github.com/cockroachdb/cockroach/issues/123665
+  reserved 13;
+
+  // PR #124681 used this field for KVNodeIDs, but isn't being backported to 23.2. Instead, it
+  // is reserved for visibility and to ensure compatability in the future.
+  reserved 78;
+
+  // Next available ID: 80.
 }
 
 // SampledExecStats contains execution statistics that apply to both statements
@@ -418,10 +429,6 @@ message SampledTransaction {
   // TransactionID is the id of the transaction.
   string transaction_id = 6 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',includeempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // TransactionFingerprintID is the fingerprint ID of the transaction.
-  // This can be used to find the transaction in the console.
-  uint64 transaction_fingerprint_id = 7 [(gogoproto.customname) = "TransactionFingerprintID", (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb.TransactionFingerprintID", (gogoproto.nullable) = false, (gogoproto.jsontag) = 'TransactionFingerprintID,'];
-
   // Committed indicates if the transaction committed successfully. We want to include this value even if it is false.
   bool committed = 8 [(gogoproto.jsontag) = ",includeempty"];
 
@@ -449,9 +456,6 @@ message SampledTransaction {
 
   // LastAutoRetryReason is a string containing the reason for the last automatic retry.
   string last_auto_retry_reason = 16 [(gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"mixed\""];
-
-  // StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction.
-  repeated uint64 statement_fingerprint_ids = 17 [(gogoproto.customname) = "StatementFingerprintIDs", (gogoproto.jsontag) = ',omitempty', (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb.StmtFingerprintID"];
 
   // NumRows is the total number of rows returned across all statements.
   int64 num_rows = 18 [(gogoproto.jsontag) = ",includeempty"];
@@ -483,6 +487,27 @@ message SampledTransaction {
   // this one. We only count skipped transactions when telemetry logging is enabled and the sampling
   // mode is set to "transaction".
   int64 skipped_transactions = 26 [(gogoproto.jsontag) = ",omitempty"];
+
+  // TransactionFingerprintID is the fingerprint ID of the transaction.
+  // This can be used to find the transaction in the console.
+  string transaction_fingerprint_id = 27 [(gogoproto.customname) = "TransactionFingerprintID", (gogoproto.jsontag) = 'TransactionFingerprintID,', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // StatementFingerprintIDs is an array of statement fingerprint IDs belonging to this transaction.
+  repeated string statement_fingerprint_ids = 28 [(gogoproto.customname) = "StatementFingerprintIDs", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+
+  // Previously used for transaction_fingerprint_id. Originally this was typed as a uint64
+  // but has been re-typed to be a string due to downstream json parsing issues. For
+  // more details see: https://github.com/cockroachdb/cockroach/issues/123665
+  reserved 7;
+
+  // Previously used for statement_fingerprint_ids. Originally this was typed as a uint64
+  // but has been re-typed to be a string due to downstream json parsing issues. For
+  // more details see: https://github.com/cockroachdb/cockroach/issues/123665
+  reserved 17;
+
+  // Next available ID: 29.
+
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Backport 2/2 commits from #124628.

/cc @cockroachdb/release

---

Previously, transaction_fingerprint_id and statement_fingerprint_id were typed as uint64. Somewhere downstream, these uint64 fields were truncated into int64 max ints. As a result, telemetry logs had the same fingerprint id for different sql statements.

To fix, the field name was re-typed as a string to ensure no truncation / type conversion happens.

Epic: none
Fixes: #123665
Release note (bug fix): Fixed a bug where telemetry logs were had the same statement fingerprint id for different sql statements.


---

This backport required the following changes that aren't in the original commits from #124628:

1. reserved field number 78. This field was used in #124681, but doesn't need to be backported. Instead of including this field in the `SampledQuery` message, we are just reserving the field number
2. the signature of `ConstructStatementFingerprintID` changed in `24.1` so `telemetry_datadriven_test.go` has been updated to reflect this.