### PR TITLE
kvclient/rangefeed: allow user to resume rangefeed with span frontier

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -318,10 +318,15 @@ func encodeSpecForSpans(
 	previousReplicatedTime hlc.Timestamp,
 	spans []roachpb.Span,
 ) []byte {
+	var progress []jobspb.ResolvedSpan
+	for _, span := range spans {
+		progress = append(progress, jobspb.ResolvedSpan{Span: span, Timestamp: previousReplicatedTime})
+	}
 	spec := &streampb.StreamPartitionSpec{
 		InitialScanTimestamp:        initialScanTime,
 		PreviousReplicatedTimestamp: previousReplicatedTime,
 		Spans:                       spans,
+		Progress:                    progress,
 		Config: streampb.StreamPartitionSpec_ExecutionConfig{
 			MinCheckpointFrequency: 10 * time.Millisecond,
 		},

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
         "//pkg/util/quotapool",
         "//pkg/util/retry",
         "//pkg/util/shuffle",
+        "//pkg/util/span",
         "//pkg/util/startup",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/metamorphic",
         "//pkg/util/mon",
+        "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/stop",

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/errors"
 )
 
@@ -77,6 +78,16 @@ func (dbc *dbAdapter) RangeFeed(
 	opts ...kvcoord.RangeFeedOption,
 ) error {
 	return dbc.distSender.RangeFeed(ctx, spans, startFrom, eventC, opts...)
+}
+
+// RangeFeedFromFrontier is part of the DB interface.
+func (dbc *dbAdapter) RangeFeedFromFrontier(
+	ctx context.Context,
+	frontier span.Frontier,
+	eventC chan<- kvcoord.RangeFeedMessage,
+	opts ...kvcoord.RangeFeedOption,
+) error {
+	return dbc.distSender.RangeFeedFromFrontier(ctx, frontier, eventC, opts...)
 }
 
 // Scan is part of the DB interface.

--- a/pkg/kv/kvclient/rangefeed/mocks_generated_test.go
+++ b/pkg/kv/kvclient/rangefeed/mocks_generated_test.go
@@ -12,6 +12,7 @@ import (
 	kvcoord "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	hlc "github.com/cockroachdb/cockroach/pkg/util/hlc"
+	span "github.com/cockroachdb/cockroach/pkg/util/span"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -55,6 +56,25 @@ func (mr *MockDBMockRecorder) RangeFeed(arg0, arg1, arg2, arg3 interface{}, arg4
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeFeed", reflect.TypeOf((*MockDB)(nil).RangeFeed), varargs...)
+}
+
+// RangeFeedFromFrontier mocks base method.
+func (m *MockDB) RangeFeedFromFrontier(arg0 context.Context, arg1 span.Frontier, arg2 chan<- kvcoord.RangeFeedMessage, arg3 ...kvcoord.RangeFeedOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RangeFeedFromFrontier", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RangeFeedFromFrontier indicates an expected call of RangeFeedFromFrontier.
+func (mr *MockDBMockRecorder) RangeFeedFromFrontier(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeFeedFromFrontier", reflect.TypeOf((*MockDB)(nil).RangeFeedFromFrontier), varargs...)
 }
 
 // Scan mocks base method.


### PR DESCRIPTION
This patch changes the semantics of the new StartFromFrontier rangefeed method to resume the rangefeed from the passed in frontier, after the initial scan completes. Previously the rangefeed would resume from the frontier's low water mark, which would result in wasted work from the previous rangefeed run.

Informs #124915

Release note: none