### PR TITLE
server: disallow TCL statements from being executed via the sql over h…

### DIFF
--- a/pkg/server/api_v2_sql.go
+++ b/pkg/server/api_v2_sql.go
@@ -452,6 +452,15 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 						}
 					}()
 
+					if returnType == tree.Ack || stmt.stmt.AST.StatementType() == tree.TypeTCL {
+						// We want to disallow statements that modify txn state (like
+						// BEGIN and COMMIT) because the internal executor does not
+						// expect such statements. We'll lean on the safe side and
+						// prohibit all statements with an ACK return type, similar
+						// to the builtin `crdb_internal.execute_internally(...)`.
+						return errors.New("disallowed statement type")
+					}
+
 					// If the max size has been exceeded by previous statements/transactions
 					// avoid executing, return immediately.
 					err := checkSize(curSize)

--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -973,3 +973,92 @@ sql admin
  },
  "num_statements": 1
 }
+
+sql admin expect-error
+{
+  "database": "system",
+  "execute": true,
+  "statements": [{"sql": "COMMIT"}]
+}
+----
+XXUUU|executing stmt 1: disallowed statement type
+
+sql admin
+{
+  "execute": true,
+  "statements": [
+    {"sql": "ROLLBACK"},
+    {"sql": "SHOW COMMIT TIMESTAMP"},
+    {"sql": "select 1"},
+    {"sql": "SET statement_timeout = '10s';"}
+  ],
+  "separate_txns": true
+}
+----
+{
+ "error": {
+  "code": "XXUUU",
+  "message": "separate transaction payload encountered transaction error(s)",
+  "severity": "ERROR"
+ },
+ "execution": {
+  "txn_results": [
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "XXUUU",
+     "message": "executing stmt 1: disallowed statement type",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "ROLLBACK"
+   },
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "XXUUU",
+     "message": "executing stmt 2: disallowed statement type",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "SHOW COMMIT TIMESTAMP"
+   },
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 1
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "SELECT"
+   },
+   {
+    "end": "1970-01-01T00:00:00Z",
+    "error": {
+     "code": "XXUUU",
+     "message": "executing stmt 4: disallowed statement type",
+     "severity": "ERROR"
+    },
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 4,
+    "tag": "SET"
+   }
+  ]
+ },
+ "num_statements": 4
+}


### PR DESCRIPTION
…ttp api

The sql over http API uses an internal executor which can panic when executing TCL statements. We now disallow TCL statements from being executed via the sql over http api as well as statements with an ACK return type to mirror similar safeguarding behaviour used by the crdb_internal.execute_internally builtin.

Epic: none
Fixes: #124639

Release note: None