### PR TITLE
roachprod: add ui spinners

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2382,13 +2382,16 @@ func (c *SyncedCluster) Get(
 		err   error
 	}
 
-	var writer ui.Writer
 	results := make(chan result, len(nodes))
-	lines := make([]string, len(nodes))
-	var linesMu syncutil.Mutex
+
+	spinner := ui.NewDefaultTaskSpinner(l, "")
+	nodeTaskStatus := func(nodeID Node, msg string, done bool) {
+		spinner.TaskStatus(nodeID, fmt.Sprintf("  %2d: %s", nodeID, msg), done)
+	}
 
 	var wg sync.WaitGroup
 	for i := range nodes {
+		nodeTaskStatus(nodes[i], "copying", false)
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -2411,9 +2414,7 @@ func (c *SyncedCluster) Get(
 			}
 
 			progress := func(p float64) {
-				linesMu.Lock()
-				defer linesMu.Unlock()
-				lines[i] = formatProgress(p)
+				nodeTaskStatus(nodes[i], formatProgress(p), false)
 			}
 
 			if c.IsLocal() {
@@ -2526,67 +2527,21 @@ func (c *SyncedCluster) Get(
 		close(results)
 	}()
 
-	var ticker *time.Ticker
-	if config.Quiet {
-		ticker = time.NewTicker(100 * time.Millisecond)
-	} else {
-		ticker = time.NewTicker(1000 * time.Millisecond)
-	}
-	defer ticker.Stop()
+	defer spinner.Start()()
 	haveErr := false
-
-	var spinner = []string{"|", "/", "-", "\\"}
-	spinnerIdx := 0
-
-	for done := false; !done; {
-		select {
-		case <-ticker.C:
-			if config.Quiet && l.File == nil {
-				fmt.Printf(".")
-			}
-		case r, ok := <-results:
-			done = !ok
-			if ok {
-				func() {
-					linesMu.Lock()
-					defer linesMu.Unlock()
-					if r.err != nil {
-						haveErr = true
-						lines[r.index] = r.err.Error()
-					} else {
-						lines[r.index] = "done"
-					}
-				}()
-			}
+	for {
+		r, ok := <-results
+		if !ok {
+			break
 		}
-		if !config.Quiet && l.File == nil {
-			func() {
-				linesMu.Lock()
-				defer linesMu.Unlock()
-				for i := range lines {
-					fmt.Fprintf(&writer, "  %2d: ", nodes[i])
-					if lines[i] != "" {
-						fmt.Fprintf(&writer, "%s", lines[i])
-					} else {
-						fmt.Fprintf(&writer, "%s", spinner[spinnerIdx%len(spinner)])
-					}
-					fmt.Fprintf(&writer, "\n")
-				}
-			}()
-			_ = writer.Flush(l.Stdout)
-			spinnerIdx++
+		if r.err != nil {
+			haveErr = true
+			nodeTaskStatus(nodes[r.index], r.err.Error(), true)
+		} else {
+			nodeTaskStatus(nodes[r.index], "done", true)
 		}
 	}
-
-	if config.Quiet && l.File != nil {
-		func() {
-			linesMu.Lock()
-			defer linesMu.Unlock()
-			for i := range lines {
-				l.Printf("  %2d: %s", nodes[i], lines[i])
-			}
-		}()
-	}
+	spinner.MaybeLogTasks(l)
 
 	if haveErr {
 		return errors.Newf("get %s failed", src)

--- a/pkg/roachprod/ui/BUILD.bazel
+++ b/pkg/roachprod/ui/BUILD.bazel
@@ -4,8 +4,15 @@ go_library(
     name = "ui",
     srcs = [
         "collate_errors.go",
+        "spinner.go",
         "writer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/ui",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachprod/config",
+        "//pkg/roachprod/logger",
+        "//pkg/util/syncutil",
+        "@org_golang_x_sync//errgroup",
+    ],
 )

--- a/pkg/roachprod/ui/spinner.go
+++ b/pkg/roachprod/ui/spinner.go
@@ -1,0 +1,254 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ui
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"golang.org/x/sync/errgroup"
+)
+
+type Spinner struct {
+	msg          syncutil.AtomicString
+	tickCallback func()
+	quiet, term  bool
+	out          io.Writer
+	waitGroup    sync.WaitGroup
+	stopChan     chan struct{}
+	started      bool
+	mu           syncutil.Mutex
+}
+
+type CountingSpinner struct {
+	*Spinner
+	baseMsg       syncutil.AtomicString
+	count         int32
+	expectedTotal int
+}
+
+type SpinnerGroup struct {
+	errgroup.Group
+	spinner   *CountingSpinner
+	completed int32
+}
+
+var spinnerLoop = []string{"|", "/", "-", "\\"}
+
+// NewSpinner creates a new Spinner. If quiet is true, the spinner will only
+// print the message and not the spinner itself, but will still print dots every
+// second to indicate progress. If term is false the spinner will not print
+// dots to indicate progress (usually false when the output is a file).
+func NewSpinner(msg string, out io.Writer, quiet, term bool) *Spinner {
+	atomicMsg := syncutil.AtomicString{}
+	atomicMsg.Set(msg)
+	return &Spinner{
+		msg:      atomicMsg,
+		quiet:    quiet,
+		term:     term,
+		out:      out,
+		stopChan: make(chan struct{}),
+	}
+}
+
+// NewDefaultSpinner creates a new Spinner with the default configuration. It
+// will use the quiet settings from the roachprod config package and use the
+// logger's stdout, and file to determine if term should be true.
+func NewDefaultSpinner(l *logger.Logger, msg string) *Spinner {
+	return NewSpinner(msg, l.Stdout, config.Quiet, l.File == nil)
+}
+
+// SetTickCallback sets a callback function that will be called every time
+// before the spinner ticks. This can be used to update the message of the
+// spinner before it ticks.
+func (s *Spinner) SetTickCallback(cb func()) {
+	s.tickCallback = cb
+}
+
+// Start starts the spinner. It returns a function that can be called to stop
+// the spinner. If the spinner is already started, it does nothing.
+func (s *Spinner) Start() func() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.started {
+		return s.Stop
+	}
+	s.started = true
+
+	if s.quiet {
+		fmt.Fprintf(s.out, "%s", s.msg.Get())
+		if !s.term {
+			fmt.Fprintf(s.out, "\n")
+		}
+	}
+	go func() {
+		defer s.waitGroup.Done()
+		s.waitGroup.Add(1)
+
+		var writer Writer
+		tickerDuration := 100 * time.Millisecond
+		if s.quiet {
+			tickerDuration = 1000 * time.Millisecond
+		}
+		ticker := time.NewTicker(tickerDuration)
+		defer ticker.Stop()
+		done := false
+		spinnerIdx := 0
+
+		for !done {
+			select {
+			case <-ticker.C:
+				if s.tickCallback != nil {
+					s.tickCallback()
+				}
+				if s.quiet && s.term {
+					fmt.Fprintf(s.out, ".")
+				}
+			case <-s.stopChan:
+				done = true
+			}
+			if !s.quiet {
+				fmt.Fprint(&writer, s.msg.Get())
+				if !done {
+					fmt.Fprintf(&writer, " %s", spinnerLoop[spinnerIdx%len(spinnerLoop)])
+				}
+				fmt.Fprintf(&writer, "\n")
+				_ = writer.Flush(s.out)
+				spinnerIdx++
+			}
+		}
+		if s.quiet && s.term {
+			fmt.Fprintf(s.out, "\n")
+		}
+	}()
+	return s.Stop
+}
+
+// Stop stops the spinner. If the spinner is not started, it does nothing.
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.started {
+		return
+	}
+	close(s.stopChan)
+	s.waitGroup.Wait()
+	s.stopChan = make(chan struct{})
+	s.waitGroup = sync.WaitGroup{}
+}
+
+// Status sets the message of the spinner atomically. If the spinner is started,
+// the updated message will be displayed on the next tick. In quiet mode, this
+// will not have any effect and only the initial message will be displayed.
+func (s *Spinner) Status(msg string) {
+	s.msg.Set(msg)
+}
+
+// NewCountingSpinner creates a new CountingSpinner. It is a wrapper around
+// Spinner, but also keeps count of completed items and displays it in the
+// message. The expectedTotal parameter is the total number of expected items
+// that will be processed.
+func NewCountingSpinner(spinner *Spinner, expectedTotal int) *CountingSpinner {
+	baseMsg := syncutil.AtomicString{}
+	baseMsg.Set(spinner.msg.Get())
+	return &CountingSpinner{
+		Spinner:       spinner,
+		baseMsg:       baseMsg,
+		expectedTotal: expectedTotal,
+	}
+}
+
+// NewDefaultCountingSpinner creates a new CountingSpinner with the default
+// configuration. See NewDefaultSpinner for more information.
+func NewDefaultCountingSpinner(l *logger.Logger, msg string, expectedTotal int) *CountingSpinner {
+	return NewCountingSpinner(NewDefaultSpinner(l, msg), expectedTotal)
+}
+
+// Start starts the embedded spinner, but updates the initial message to include
+// the count of completed items. It returns a function that can be called to
+// stop the spinner.
+func (s *CountingSpinner) Start() func() {
+	if !s.quiet {
+		s.CountStatus(0)
+	}
+	return s.Spinner.Start()
+}
+
+// updateStatus sets the embedded spinner's message to the base message with the
+// count appended to it.
+func (s *CountingSpinner) updateStatus() {
+	count := atomic.LoadInt32(&s.count)
+	s.Spinner.Status(fmt.Sprintf("%s %d/%d", s.baseMsg.Get(), count, s.expectedTotal))
+}
+
+// Status changes the base message of the counting spinner. The count will be
+// appended to the new base message.
+func (s *CountingSpinner) Status(msg string) {
+	s.baseMsg.Set(msg)
+	s.updateStatus()
+}
+
+// CountStatus sets the number of completed items atomically. This will update
+// the message of the embedded spinner to reflect the new count.
+func (s *CountingSpinner) CountStatus(count int) {
+	atomic.StoreInt32(&s.count, int32(count))
+	s.updateStatus()
+}
+
+// NewSpinnerGroup creates a new SpinnerGroup from the given CountingSpinner.
+// SpinnerGroup is a wrapper around an `errgroup.Group` that also keeps track
+// of the number of completed tasks and displays it in the spinner.
+func NewSpinnerGroup(spinner *CountingSpinner) *SpinnerGroup {
+	return &SpinnerGroup{
+		spinner: spinner,
+	}
+}
+
+// NewDefaultSpinnerGroup creates a new SpinnerGroup with the default configuration.
+func NewDefaultSpinnerGroup(l *logger.Logger, msg string, expectedTotal int) *SpinnerGroup {
+	return NewSpinnerGroup(NewDefaultCountingSpinner(l, msg, expectedTotal))
+}
+
+// Go adds a new task to the SpinnerGroup. The task should be a function that
+// returns an error. The task will be executed in a separate goroutine and the
+// SpinnerGroup will keep track of the number of completed tasks.
+func (g *SpinnerGroup) Go(f func() error) {
+	g.Group.Go(func() error {
+		defer func() {
+			atomic.AddInt32(&g.completed, 1)
+		}()
+		return f()
+	})
+}
+
+// Wait waits for all tasks in the SpinnerGroup to complete. It will update the
+// status of the embedded counting spinner to reflect the number of completed
+// tasks.
+func (g *SpinnerGroup) Wait() error {
+	updateStatus := func() {
+		count := atomic.LoadInt32(&g.completed)
+		if !g.spinner.quiet {
+			g.spinner.CountStatus(int(count))
+		}
+	}
+	g.spinner.SetTickCallback(updateStatus)
+
+	defer g.spinner.Start()()
+	err := g.Group.Wait()
+	updateStatus()
+	return err
+}

--- a/pkg/roachprod/ui/spinner.go
+++ b/pkg/roachprod/ui/spinner.go
@@ -13,6 +13,7 @@ package ui
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,7 +25,8 @@ import (
 )
 
 type Spinner struct {
-	msg          syncutil.AtomicString
+	msgTemplate  syncutil.AtomicString
+	startMsg     string
 	tickCallback func()
 	quiet, term  bool
 	out          io.Writer
@@ -36,9 +38,18 @@ type Spinner struct {
 
 type CountingSpinner struct {
 	*Spinner
-	baseMsg       syncutil.AtomicString
 	count         int32
 	expectedTotal int
+}
+
+type TaskSpinner struct {
+	*Spinner
+	tasks map[interface{}]struct {
+		msg  string
+		done bool
+	}
+	taskOrder []interface{}
+	tasksMu   syncutil.Mutex
 }
 
 type SpinnerGroup struct {
@@ -49,19 +60,26 @@ type SpinnerGroup struct {
 
 var spinnerLoop = []string{"|", "/", "-", "\\"}
 
+const spinnerTemplate = "{%}"
+
 // NewSpinner creates a new Spinner. If quiet is true, the spinner will only
 // print the message and not the spinner itself, but will still print dots every
-// second to indicate progress. If term is false the spinner will not print
-// dots to indicate progress (usually false when the output is a file).
+// second to indicate progress. If term is false the spinner will not print dots
+// to indicate progress (usually false when the output is a file). The msg
+// parameter is the initial message of the spinner and can be left empty if no
+// initial message is desired.
 func NewSpinner(msg string, out io.Writer, quiet, term bool) *Spinner {
-	atomicMsg := syncutil.AtomicString{}
-	atomicMsg.Set(msg)
+	msgTemplate := syncutil.AtomicString{}
+	if msg != "" {
+		msgTemplate.Set(msg + " " + spinnerTemplate)
+	}
 	return &Spinner{
-		msg:      atomicMsg,
-		quiet:    quiet,
-		term:     term,
-		out:      out,
-		stopChan: make(chan struct{}),
+		msgTemplate: msgTemplate,
+		startMsg:    msg,
+		quiet:       quiet,
+		term:        term,
+		out:         out,
+		stopChan:    make(chan struct{}),
 	}
 }
 
@@ -79,6 +97,15 @@ func (s *Spinner) SetTickCallback(cb func()) {
 	s.tickCallback = cb
 }
 
+func (s *Spinner) renderTemplate(spinnerIdx int, done bool) string {
+	msg := s.msgTemplate.Get()
+	spinner := ""
+	if !done {
+		spinner = spinnerLoop[spinnerIdx%len(spinnerLoop)]
+	}
+	return strings.Replace(msg, spinnerTemplate, spinner, -1)
+}
+
 // Start starts the spinner. It returns a function that can be called to stop
 // the spinner. If the spinner is already started, it does nothing.
 func (s *Spinner) Start() func() {
@@ -89,8 +116,9 @@ func (s *Spinner) Start() func() {
 	}
 	s.started = true
 
-	if s.quiet {
-		fmt.Fprintf(s.out, "%s", s.msg.Get())
+	if s.startMsg != "" && s.quiet {
+		fmt.Fprintf(s.out, "%s", s.startMsg)
+		// Print a newline since we won't be printing dots.
 		if !s.term {
 			fmt.Fprintf(s.out, "\n")
 		}
@@ -122,15 +150,13 @@ func (s *Spinner) Start() func() {
 				done = true
 			}
 			if !s.quiet {
-				fmt.Fprint(&writer, s.msg.Get())
-				if !done {
-					fmt.Fprintf(&writer, " %s", spinnerLoop[spinnerIdx%len(spinnerLoop)])
-				}
+				fmt.Fprint(&writer, s.renderTemplate(spinnerIdx, done))
 				fmt.Fprintf(&writer, "\n")
 				_ = writer.Flush(s.out)
 				spinnerIdx++
 			}
 		}
+		// This newline is only required if we have been printing dots.
 		if s.quiet && s.term {
 			fmt.Fprintf(s.out, "\n")
 		}
@@ -155,7 +181,13 @@ func (s *Spinner) Stop() {
 // the updated message will be displayed on the next tick. In quiet mode, this
 // will not have any effect and only the initial message will be displayed.
 func (s *Spinner) Status(msg string) {
-	s.msg.Set(msg)
+	msg = msg + " " + spinnerTemplate
+	s.statusTemplate(msg)
+}
+
+// statusTemplate sets the internal template message of the spinner atomically.
+func (s *Spinner) statusTemplate(msg string) {
+	s.msgTemplate.Set(msg)
 }
 
 // NewCountingSpinner creates a new CountingSpinner. It is a wrapper around
@@ -163,11 +195,8 @@ func (s *Spinner) Status(msg string) {
 // message. The expectedTotal parameter is the total number of expected items
 // that will be processed.
 func NewCountingSpinner(spinner *Spinner, expectedTotal int) *CountingSpinner {
-	baseMsg := syncutil.AtomicString{}
-	baseMsg.Set(spinner.msg.Get())
 	return &CountingSpinner{
 		Spinner:       spinner,
-		baseMsg:       baseMsg,
 		expectedTotal: expectedTotal,
 	}
 }
@@ -192,14 +221,7 @@ func (s *CountingSpinner) Start() func() {
 // count appended to it.
 func (s *CountingSpinner) updateStatus() {
 	count := atomic.LoadInt32(&s.count)
-	s.Spinner.Status(fmt.Sprintf("%s %d/%d", s.baseMsg.Get(), count, s.expectedTotal))
-}
-
-// Status changes the base message of the counting spinner. The count will be
-// appended to the new base message.
-func (s *CountingSpinner) Status(msg string) {
-	s.baseMsg.Set(msg)
-	s.updateStatus()
+	s.Spinner.Status(fmt.Sprintf("%s %d/%d", s.startMsg, count, s.expectedTotal))
 }
 
 // CountStatus sets the number of completed items atomically. This will update
@@ -251,4 +273,66 @@ func (g *SpinnerGroup) Wait() error {
 	err := g.Group.Wait()
 	updateStatus()
 	return err
+}
+
+// NewTaskSpinner creates a new TaskSpinner. It is a wrapper around Spinner that
+// keeps track of the status of multiple tasks.
+func NewTaskSpinner(spinner *Spinner) *TaskSpinner {
+	return &TaskSpinner{
+		Spinner: spinner,
+		tasks: make(map[interface{}]struct {
+			msg  string
+			done bool
+		}),
+	}
+}
+
+// NewDefaultTaskSpinner creates a new TaskSpinner with the default configuration.
+func NewDefaultTaskSpinner(l *logger.Logger, msg string) *TaskSpinner {
+	return NewTaskSpinner(NewDefaultSpinner(l, msg))
+}
+
+func (t *TaskSpinner) TaskStatus(taskKey interface{}, msg string, done bool) {
+	t.tasksMu.Lock()
+	defer t.tasksMu.Unlock()
+	if _, ok := t.tasks[taskKey]; !ok {
+		t.taskOrder = append(t.taskOrder, taskKey)
+	}
+	t.tasks[taskKey] = struct {
+		msg  string
+		done bool
+	}{
+		msg:  msg,
+		done: done,
+	}
+	t.updateStatus()
+}
+
+func (t *TaskSpinner) updateStatus() {
+	var status strings.Builder
+	if t.startMsg != "" {
+		status.WriteString(t.startMsg + "\n")
+	}
+	for idx, taskKey := range t.taskOrder {
+		if idx > 0 {
+			status.WriteString("\n")
+		}
+		status.WriteString(t.tasks[taskKey].msg)
+		if !t.tasks[taskKey].done {
+			status.WriteString(" " + spinnerTemplate)
+		}
+	}
+	t.Spinner.statusTemplate(status.String())
+}
+
+// MaybeLogTasks logs the status of all tasks if the spinner is in quiet mode
+// and not in a terminal.
+func (t *TaskSpinner) MaybeLogTasks(l *logger.Logger) {
+	t.tasksMu.Lock()
+	defer t.tasksMu.Unlock()
+	if t.quiet && !t.term {
+		for _, taskKey := range t.taskOrder {
+			l.Printf("%s\n", t.tasks[taskKey].msg)
+		}
+	}
 }

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
         "//pkg/util/syncutil",

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -2004,7 +2004,7 @@ func loadBalancerResourceName(clusterName string, port int, resourceType string)
 // group. Additionally, a health check is created for the given port. A proxy is
 // used to support global load balancing. The different parts of the load
 // balancer are created sequentially, as they depend on each other.
-func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) error {
+func (p *Provider) CreateLoadBalancer(l *logger.Logger, vms vm.List, port int) error {
 	if err := checkSDKVersion("450.0.0" /* minVersion */, "required by load balancers"); err != nil {
 		return err
 	}
@@ -2024,14 +2024,18 @@ func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) e
 		return errors.Errorf("no managed instance groups found for cluster %s", clusterName)
 	}
 
+	var args []string
 	healthCheckName := loadBalancerResourceName(clusterName, port, "health-check")
-	args := []string{"compute", "health-checks", "create", "tcp",
-		healthCheckName,
-		"--project", project,
-		"--port", strconv.Itoa(port),
-	}
-	cmd := exec.Command("gcloud", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := func() ([]byte, error) {
+		defer ui.NewDefaultSpinner(l, "created health check").Start()()
+		args = []string{"compute", "health-checks", "create", "tcp",
+			healthCheckName,
+			"--project", project,
+			"--port", strconv.Itoa(port),
+		}
+		cmd := exec.Command("gcloud", args...)
+		return cmd.CombinedOutput()
+	}()
 	if err != nil {
 		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
 	}
@@ -2047,8 +2051,11 @@ func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) e
 		"--timeout", "5m",
 		"--port-name", "cockroach",
 	}
-	cmd = exec.Command("gcloud", args...)
-	output, err = cmd.CombinedOutput()
+	output, err = func() ([]byte, error) {
+		defer ui.NewDefaultSpinner(l, "creating load balancer backend").Start()()
+		cmd := exec.Command("gcloud", args...)
+		return cmd.CombinedOutput()
+	}()
 	if err != nil {
 		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
 	}
@@ -2056,49 +2063,64 @@ func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) e
 	// Add the instance group to the backend service. This has to be done
 	// sequentially, and for each zone, because gcloud does not allow adding
 	// multiple instance groups in parallel.
-	for _, group := range groups {
-		args = []string{"compute", "backend-services", "add-backend", loadBalancerName,
-			"--project", project,
-			"--global",
-			"--instance-group", group.Name,
-			"--instance-group-zone", group.Zone,
-			"--balancing-mode", "UTILIZATION",
-			"--max-utilization", "0.8",
+	output, err = func() ([]byte, error) {
+		spinner := ui.NewDefaultCountingSpinner(l, "adding backends to load balancer", len(groups))
+		defer spinner.Start()()
+		for n, group := range groups {
+			args = []string{"compute", "backend-services", "add-backend", loadBalancerName,
+				"--project", project,
+				"--global",
+				"--instance-group", group.Name,
+				"--instance-group-zone", group.Zone,
+				"--balancing-mode", "UTILIZATION",
+				"--max-utilization", "0.8",
+			}
+			cmd := exec.Command("gcloud", args...)
+			output, err = cmd.CombinedOutput()
+			if err != nil {
+				return output, err
+			}
+			spinner.CountStatus(n + 1)
 		}
-		cmd = exec.Command("gcloud", args...)
-		output, err = cmd.CombinedOutput()
-		if err != nil {
-			return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
-		}
-	}
-
-	proxyName := loadBalancerResourceName(clusterName, port, "proxy")
-	args = []string{"compute", "target-tcp-proxies", "create", proxyName,
-		"--project", project,
-		"--backend-service", loadBalancerName,
-		"--proxy-header", "NONE",
-	}
-	cmd = exec.Command("gcloud", args...)
-	output, err = cmd.CombinedOutput()
+		return nil, nil
+	}()
 	if err != nil {
 		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
 	}
 
-	args = []string{"compute", "forwarding-rules", "create",
-		loadBalancerResourceName(clusterName, port, "forwarding-rule"),
-		"--project", project,
-		"--global",
-		"--target-tcp-proxy", proxyName,
-		"--ports", strconv.Itoa(port),
+	proxyName := loadBalancerResourceName(clusterName, port, "proxy")
+	output, err = func() ([]byte, error) {
+		defer ui.NewDefaultSpinner(l, "creating load balancer proxy").Start()()
+		args = []string{"compute", "target-tcp-proxies", "create", proxyName,
+			"--project", project,
+			"--backend-service", loadBalancerName,
+			"--proxy-header", "NONE",
+		}
+		cmd := exec.Command("gcloud", args...)
+		return cmd.CombinedOutput()
+	}()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
 	}
-	cmd = exec.Command("gcloud", args...)
-	output, err = cmd.CombinedOutput()
+
+	output, err = func() ([]byte, error) {
+		defer ui.NewDefaultSpinner(l, "creating load balancer forwarding rule").Start()()
+		args = []string{"compute", "forwarding-rules", "create",
+			loadBalancerResourceName(clusterName, port, "forwarding-rule"),
+			"--project", project,
+			"--global",
+			"--target-tcp-proxy", proxyName,
+			"--ports", strconv.Itoa(port),
+		}
+		cmd := exec.Command("gcloud", args...)
+		return cmd.CombinedOutput()
+	}()
 	if err != nil {
 		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
 	}
 
 	// Named ports can be set in parallel for all instance groups.
-	var g errgroup.Group
+	g := ui.NewDefaultSpinnerGroup(l, "setting named ports on instance groups", len(groups))
 	for _, group := range groups {
 		groupArgs := []string{"compute", "instance-groups", "set-named-ports", group.Name,
 			"--project", project,


### PR DESCRIPTION
Previously, long-running tasks in roachprod had to implement its own logic for
displaying a spinner to indicate progress to the user when running a CLI
command. This logic generally needed to take quiet mode, and file vs. terminal
into account.

This change adds three new reusable implementations: Spinner, CountingSpinner,
GroupSpinner. Spinner is the most basic and renders the spinner when
appropriate. CountingSpinner adds the concept of completed tasks and keeps track
of the count. GroupSpinner is a drop-in replacement for `errgroup.Group` and
adds progress tracking via a CountingSpinner to the group.

Release Note: None
Epic: None