### PR TITLE
kvstorage: fix key aliasing during range descriptor iteration

### DIFF
--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -271,6 +271,7 @@ func IterateRangeDescriptorsFromDisk(
 	lastReportTime := timeutil.Now()
 
 	iter.SeekGE(storage.MVCCKey{Key: keys.LocalRangePrefix})
+	var keyBuf []byte
 	for {
 		if valid, err := iter.Valid(); err != nil {
 			return err
@@ -330,7 +331,9 @@ func IterateRangeDescriptorsFromDisk(
 				return errors.AssertionFailedf("range key has intent with no timestamp")
 			}
 			// Seek to the latest value below the intent timestamp.
-			iter.SeekGE(storage.MVCCKey{Key: key.Key, Timestamp: metaTS.Prev()})
+			// We cannot pass to SeekGE a key that was returned to us from the iterator; make a copy.
+			keyBuf = append(keyBuf[:0], key.Key...)
+			iter.SeekGE(storage.MVCCKey{Key: keyBuf, Timestamp: metaTS.Prev()})
 			continue
 		}
 


### PR DESCRIPTION
In one case, we were passing the key returned by the `MVCCIterator`
back to `SeekGE`. This is not legal, and causes the
`unsafeMVCCIterator` (used in race mode) to trigger a failure.

Fixes: #124386
Release note: None