### PR TITLE
release-23.1: storage: calculate total capacity off of max percentage

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -724,6 +724,15 @@ func maxInflightBytesFrom(maxInflightMsgs int, maxSizePerMsg uint64) uint64 {
 	return math.MaxUint64
 }
 
+// StoreSize configures the maximum allowable size for a store.
+// Can be specified either as a percentage of total capacity or
+// an absolute byte size; if both are specified, the percentage takes
+// precedence.
+type StoreSize struct {
+	Bytes   int64
+	Percent float64
+}
+
 // StorageConfig contains storage configs for all storage engine.
 type StorageConfig struct {
 	Attrs roachpb.Attributes
@@ -736,7 +745,7 @@ type StorageConfig struct {
 	MustExist bool
 	// MaxSize is used for calculating free space and making rebalancing
 	// decisions. Zero indicates that there is no maximum size.
-	MaxSize int64
+	MaxSize StoreSize
 	// BallastSize is the amount reserved by a ballast file for manual
 	// out-of-disk recovery.
 	BallastSize int64

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -248,7 +248,7 @@ func TestPebbleEncryption(t *testing.T) {
 		storage.PebbleConfig{
 			StorageConfig: base.StorageConfig{
 				Attrs:             roachpb.Attributes{},
-				MaxSize:           512 << 20,
+				MaxSize:           base.StoreSize{Bytes: 512 << 20},
 				Settings:          cluster.MakeTestingClusterSettings(),
 				UseFileRegistry:   true,
 				EncryptionOptions: encOptionsBytes,
@@ -297,7 +297,7 @@ func TestPebbleEncryption(t *testing.T) {
 			StorageConfig: base.StorageConfig{
 				Settings:          cluster.MakeTestingClusterSettings(),
 				Attrs:             roachpb.Attributes{},
-				MaxSize:           512 << 20,
+				MaxSize:           base.StoreSize{Bytes: 512 << 20},
 				UseFileRegistry:   true,
 				EncryptionOptions: encOptionsBytes,
 			},
@@ -384,7 +384,7 @@ func TestPebbleEncryption2(t *testing.T) {
 				StorageConfig: base.StorageConfig{
 					Settings:          cluster.MakeTestingClusterSettings(),
 					Attrs:             roachpb.Attributes{},
-					MaxSize:           512 << 20,
+					MaxSize:           base.StoreSize{Bytes: 512 << 20},
 					UseFileRegistry:   true,
 					EncryptionOptions: encOptionsBytes,
 				},

--- a/pkg/kv/kvserver/kvstorage/cluster_version_test.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version_test.go
@@ -114,7 +114,7 @@ func TestClusterVersionWriteSynthesize(t *testing.T) {
 		st := cluster.MakeTestingClusterSettingsWithVersions(binV, minV, false /* initializeVersion */)
 		eng, err := storage.Open(
 			ctx, storage.InMemory(), st,
-			storage.ForTesting, storage.MaxSize(1<<20),
+			storage.ForTesting, storage.MaxSizeBytes(1<<20),
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1345,7 +1345,7 @@ func SendEmptySnapshot(
 		storage.InMemory(),
 		cluster.MakeClusterSettings(),
 		storage.CacheSize(1<<20 /* 1 MiB */),
-		storage.MaxSize(512<<20 /* 512 MiB */))
+		storage.MaxSizeBytes(512<<20 /* 512 MiB */))
 	if err != nil {
 		return err
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -791,7 +791,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				return Engines{}, errors.Errorf("%f%% of memory is only %s bytes, which is below the minimum requirement of %s",
 					spec.Size.Percent, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(base.MinimumStoreSize))
 			}
-			addCfgOpt(storage.MaxSize(sizeInBytes))
+			addCfgOpt(storage.MaxSizeBytes(sizeInBytes))
 			addCfgOpt(storage.CacheSize(cfg.CacheSize))
 
 			detail(redact.Sprintf("store %d: in-memory, size %s", i, humanizeutil.IBytes(sizeInBytes)))
@@ -813,9 +813,13 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 					spec.Size.Percent, spec.Path, humanizeutil.IBytes(sizeInBytes), humanizeutil.IBytes(base.MinimumStoreSize))
 			}
 
-			detail(redact.Sprintf("store %d: max size %s, max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
-
-			addCfgOpt(storage.MaxSize(sizeInBytes))
+			if spec.Size.Percent > 0 {
+				detail(redact.Sprintf("store %d: max size %s (calculated from %.2f percent of total), max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), spec.Size.Percent, openFileLimitPerStore))
+				addCfgOpt(storage.MaxSizePercent(spec.Size.Percent / 100))
+			} else {
+				detail(redact.Sprintf("store %d: max size %s, max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
+				addCfgOpt(storage.MaxSizeBytes(sizeInBytes))
+			}
 			addCfgOpt(storage.BallastSize(storage.BallastSizeBytes(spec, du)))
 			addCfgOpt(storage.Caches(pebbleCache, tableCache))
 			// TODO(radu): move up all remaining settings below so they apply to in-memory stores as well.

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -48,7 +48,7 @@ func TestCachedSettingsStoreAndLoad(t *testing.T) {
 	ctx := context.Background()
 	engine, err := storage.Open(ctx, storage.InMemory(),
 		cluster.MakeClusterSettings(),
-		storage.MaxSize(512<<20 /* 512 MiB */),
+		storage.MaxSizeBytes(512<<20 /* 512 MiB */),
 		storage.ForTesting)
 	require.NoError(t, err)
 	defer engine.Close()

--- a/pkg/server/sticky_vfs.go
+++ b/pkg/server/sticky_vfs.go
@@ -136,7 +136,7 @@ func (registry *stickyVFSRegistryImpl) Open(
 	options := []storage.ConfigOption{
 		storage.Attributes(spec.Attributes),
 		storage.CacheSize(cfg.CacheSize),
-		storage.MaxSize(spec.Size.InBytes),
+		storage.MaxSizeBytes(spec.Size.InBytes),
 		storage.EncryptionAtRest(spec.EncryptionOptions),
 		storage.ForStickyEngineTesting,
 	}

--- a/pkg/storage/in_mem.go
+++ b/pkg/storage/in_mem.go
@@ -52,7 +52,7 @@ func InMemFromFS(
 func NewDefaultInMemForTesting(opts ...ConfigOption) Engine {
 	eng, err := Open(
 		context.Background(), InMemory(), cluster.MakeTestingClusterSettings(),
-		ForTesting, MaxSize(1<<20), CombineOptions(opts...),
+		ForTesting, MaxSizeBytes(1<<20), CombineOptions(opts...),
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -3801,7 +3801,7 @@ func generateBytes(rng *rand.Rand, min int, max int) []byte {
 }
 
 func createEngWithSeparatedIntents(t *testing.T) Engine {
-	eng, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), MaxSize(1<<20))
+	eng, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), MaxSizeBytes(1<<20))
 	require.NoError(t, err)
 	return eng
 }

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -87,9 +87,25 @@ func Attributes(attrs roachpb.Attributes) ConfigOption {
 	}
 }
 
-// MaxSize sets the intended maximum store size. MaxSize is used for
-// calculating free space and making rebalancing decisions.
-func MaxSize(size int64) ConfigOption {
+// MaxSizeBytes ets the intended maximum store size as an absolute byte
+// value. MaxSizeBytes is used for calculating free space and making rebalancing
+// decisions.
+func MaxSizeBytes(size int64) ConfigOption {
+	return maxSize(base.StoreSize{Bytes: size})
+}
+
+// MaxSizePercent ets the intended maximum store size as the specified percentage
+// of total capacity. MaxSizePercent is used for calculating free space and making
+// rebalancing decisions.
+func MaxSizePercent(percent float64) ConfigOption {
+	return maxSize(base.StoreSize{Percent: percent})
+}
+
+// maxSize sets the intended maximum store size. MaxSize is used for
+// calculating free space and making rebalancing decisions. Either an
+// absolute size or a percentage of total capacity can be specified;
+// if both are specified, the percentage is used.
+func maxSize(size base.StoreSize) ConfigOption {
 	return func(cfg *engineConfig) error {
 		cfg.MaxSize = size
 		return nil

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -751,7 +751,7 @@ type Pebble struct {
 	auxDir       string
 	ballastPath  string
 	ballastSize  int64
-	maxSize      int64
+	maxSize      base.StoreSize
 	attrs        roachpb.Attributes
 	properties   roachpb.StoreProperties
 	settings     *cluster.Settings
@@ -1686,8 +1686,8 @@ func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
 		// part of the actual file system here can throw off allocator
 		// rebalancing in a hard-to-trace manner. See #7050.
 		return roachpb.StoreCapacity{
-			Capacity:  p.maxSize,
-			Available: p.maxSize,
+			Capacity:  p.maxSize.Bytes,
+			Available: p.maxSize.Bytes,
 		}, nil
 	} else if err != nil {
 		return roachpb.StoreCapacity{}, err
@@ -1763,7 +1763,7 @@ func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
 	// If no size limitation have been placed on the store size or if the
 	// limitation is greater than what's available, just return the actual
 	// totals.
-	if p.maxSize == 0 || p.maxSize >= fsuTotal || p.path == "" {
+	if ((p.maxSize.Bytes == 0 || p.maxSize.Bytes >= fsuTotal) && p.maxSize.Percent == 0) || p.path == "" {
 		return roachpb.StoreCapacity{
 			Capacity:  fsuTotal,
 			Available: fsuAvail,
@@ -1771,7 +1771,12 @@ func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
 		}, nil
 	}
 
-	available := p.maxSize - totalUsedBytes
+	maxSize := p.maxSize.Bytes
+	if p.maxSize.Percent != 0 {
+		maxSize = int64(float64(fsuTotal) * p.maxSize.Percent)
+	}
+
+	available := maxSize - totalUsedBytes
 	if available > fsuAvail {
 		available = fsuAvail
 	}
@@ -1780,7 +1785,7 @@ func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
 	}
 
 	return roachpb.StoreCapacity{
-		Capacity:  p.maxSize,
+		Capacity:  maxSize,
 		Available: available,
 		Used:      totalUsedBytes,
 	}, nil

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -65,7 +65,7 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 	sstWriter.Close()
 
 	ctx := context.Background()
-	engine, err := Open(context.Background(), InMemory(), cs, MaxSize(1<<20))
+	engine, err := Open(context.Background(), InMemory(), cs, MaxSizeBytes(1<<20))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -157,7 +157,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		storage.InMemory(),
 		cfg.Settings,
 		storage.CacheSize(0),
-		storage.MaxSize(50<<20 /* 50 MiB */),
+		storage.MaxSizeBytes(50<<20 /* 50 MiB */),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #124999.

/cc @cockroachdb/release

---

Previously, we stored the maxSize of a pebble store in bytes in the Pebble struct, even if the max size for that store was specified as a percentage of the total available size. This change updates this to store the percentage separately, and calculate the available / used bytes on the fly from the total size of the disk. This allows us to better report metrics when the underlying size of the disk or volume changes during the life of the node.

Fixes #123911.

Epic: none

Release note (ops change): Improve disk usage metric reporting over volumes that dynamically change their size over the life of the cockroach process.

Release justification: Fixes metrics for disk capacity / available bytes when running on dynamically resizable partitions or volumes.