### PR TITLE
acceptance: extend timeout for TestDockerNodeJS

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -74,7 +74,8 @@ func TestDockerNodeJS(t *testing.T) {
 	export SHOULD_FAIL=%v
 	# Get access to globally installed node modules.
 	export NODE_PATH=$NODE_PATH:/usr/lib/node
-	/usr/lib/node/.bin/mocha .
+	# Have a 10 second timeout on promises, in case the server is slow.
+	/usr/lib/node/.bin/mocha -t 10000 . 
 	`
 
 	ctx := context.Background()


### PR DESCRIPTION
Previously, TestDockerNodeJS could fail because it only had 2 seconds
timeouts for tests. One of these tests would make a new index for it and
populate the table, which could take more time then the timeout, leading
to intermittent failures. To address this, this patch increases the
timeout to 10 seconds for the test suite.

Fixes: #125013

Release note: None