### PR TITLE
colcontainer: add more memory accounting to disk queue

### DIFF
--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -578,11 +578,9 @@ func getValueBytesAndOffsets(
 	return valueBytes, offsets[:batchLength+1]
 }
 
-// Release should be called once the converter is no longer needed so that its
+// Close should be called once the converter is no longer needed so that its
 // memory could be GCed.
-// TODO(yuzefovich): consider renaming this to Close in order to not be confused
-// with execreleasable.Releasable interface.
-func (c *ArrowBatchConverter) Release(ctx context.Context) {
+func (c *ArrowBatchConverter) Close(ctx context.Context) {
 	if c.acc != nil {
 		c.acc.Shrink(ctx, c.accountedFor)
 	}

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -50,7 +50,7 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 	typs, b := randomBatch(testAllocator)
 	c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional, testMemAcc)
 	require.NoError(t, err)
-	defer c.Release(context.Background())
+	defer c.Close(context.Background())
 
 	// Make a copy of the original batch because the converter modifies and casts
 	// data without copying for performance reasons.
@@ -104,7 +104,7 @@ func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 		dest := testAllocator.NewMemBatchWithMaxCapacity(typs)
 		c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional, testMemAcc)
 		require.NoError(t, err)
-		defer c.Release(context.Background())
+		defer c.Close(context.Background())
 		r, err := colserde.NewRecordBatchSerializer(typs)
 		require.NoError(t, err)
 
@@ -225,7 +225,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 		func(b *testing.B, batch coldata.Batch, typ *types.T) {
 			c, err := colserde.NewArrowBatchConverter([]*types.T{typ}, colserde.BiDirectional, testMemAcc)
 			require.NoError(b, err)
-			defer c.Release(ctx)
+			defer c.Close(ctx)
 			var data []array.Data
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -242,7 +242,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 		func(b *testing.B, batch coldata.Batch, typ *types.T) {
 			c, err := colserde.NewArrowBatchConverter([]*types.T{typ}, colserde.BiDirectional, testMemAcc)
 			require.NoError(b, err)
-			defer c.Release(ctx)
+			defer c.Close(ctx)
 			data, err := c.BatchToArrow(ctx, batch)
 			dataCopy := make([]array.Data, len(data))
 			require.NoError(b, err)

--- a/pkg/col/colserde/conversion_test.go
+++ b/pkg/col/colserde/conversion_test.go
@@ -36,7 +36,7 @@ func BenchmarkConversion(b *testing.B) {
 		"Serialize",
 		func(b *testing.B, batch coldata.Batch, typ *types.T) {
 			c, s := createSerializer(typ)
-			defer c.Release(ctx)
+			defer c.Close(ctx)
 			var buf bytes.Buffer
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -59,7 +59,7 @@ func BenchmarkConversion(b *testing.B) {
 			var serialized []byte
 			{
 				c, s := createSerializer(typ)
-				defer c.Release(ctx)
+				defer c.Close(ctx)
 				var buf bytes.Buffer
 				data, _ := c.BatchToArrow(ctx, batch)
 				if len(data) != 1 {

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -58,9 +58,9 @@ type FileSerializer struct {
 // NewFileSerializer creates a FileSerializer for the given types. The caller is
 // responsible for closing the given writer as well as the given memory account.
 func NewFileSerializer(
-	w io.Writer, typs []*types.T, acc *mon.BoundAccount,
+	w io.Writer, typs []*types.T, memAcc *mon.BoundAccount,
 ) (*FileSerializer, error) {
-	a, err := NewArrowBatchConverter(typs, BatchToArrowOnly, acc)
+	a, err := NewArrowBatchConverter(typs, BatchToArrowOnly, memAcc)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (s *FileSerializer) Finish() error {
 
 // Close releases the resources of the serializer.
 func (s *FileSerializer) Close(ctx context.Context) {
-	s.a.Release(ctx)
+	s.a.Close(ctx)
 }
 
 // FileDeserializer decodes columnar data batches from files encoded according
@@ -230,7 +230,7 @@ func newFileDeserializer(
 
 // Close releases any resources held by this deserializer.
 func (d *FileDeserializer) Close(ctx context.Context) error {
-	d.a.Release(ctx)
+	d.a.Close(ctx)
 	return d.bufCloseFn()
 }
 

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -349,7 +349,7 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 
 	c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional, testMemAcc)
 	require.NoError(t, err)
-	defer c.Release(context.Background())
+	defer c.Close(context.Background())
 	r, err := colserde.NewRecordBatchSerializer(typs)
 	require.NoError(t, err)
 	require.NoError(t, roundTripBatch(src, dest, c, r))

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -124,7 +124,7 @@ type PartitionedDiskQueue struct {
 	// share the accounts given that they only grow or shrink and never get
 	// closed.
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 }
 
 var _ PartitionedQueue = &PartitionedDiskQueue{}
@@ -145,7 +145,7 @@ func NewPartitionedDiskQueue(
 	fdSemaphore semaphore.Semaphore,
 	partitionerStrategy PartitionerStrategy,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 ) *PartitionedDiskQueue {
 	return &PartitionedDiskQueue{
 		typs:                     typs,
@@ -156,7 +156,7 @@ func NewPartitionedDiskQueue(
 		lastEnqueuedPartitionIdx: -1,
 		fdSemaphore:              fdSemaphore,
 		diskAcc:                  diskAcc,
-		converterMemAcc:          converterMemAcc,
+		diskQueueMemAcc:          diskQueueMemAcc,
 	}
 }
 
@@ -250,7 +250,7 @@ func (p *PartitionedDiskQueue) Enqueue(
 			p.acquireNewFD(ctx)
 		}
 		// Partition has not been created yet.
-		q, err := NewDiskQueue(ctx, p.typs, p.cfg, p.diskAcc, p.converterMemAcc)
+		q, err := NewDiskQueue(ctx, p.typs, p.cfg, p.diskAcc, p.diskQueueMemAcc)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -704,7 +704,7 @@ func makeNewHashAggregatorArgs(
 			DiskAcc: args.MonitorRegistry.CreateDiskAccount(
 				ctx, flowCtx, hashAggregatorMemMonitorName+"-spilling-queue", args.Spec.ProcessorID,
 			),
-			ConverterMemAcc: accounts[4],
+			DiskQueueMemAcc: accounts[4],
 		},
 		hashAggregatorMemMonitorName
 }
@@ -1990,11 +1990,11 @@ func (r opResult) finishBufferedWindowerArgs(
 		accounts := monitorRegistry.CreateUnlimitedMemAccounts(ctx, flowCtx, opName, processorID, 3 /* numAccounts */)
 		mainAcc = accounts[0]
 		args.BufferAllocator = colmem.NewAllocator(ctx, accounts[1], factory)
-		args.ConverterMemAcc = accounts[2]
+		args.DiskQueueMemAcc = accounts[2]
 	} else {
 		accounts := monitorRegistry.CreateUnlimitedMemAccounts(ctx, flowCtx, opName, processorID, 2 /* numAccounts */)
 		mainAcc = accounts[0]
-		args.ConverterMemAcc = accounts[1]
+		args.DiskQueueMemAcc = accounts[1]
 	}
 	args.MainAllocator = colmem.NewAllocator(ctx, mainAcc, factory)
 }

--- a/pkg/sql/colexec/colexecdisk/external_distinct.go
+++ b/pkg/sql/colexec/colexecdisk/external_distinct.go
@@ -36,7 +36,7 @@ func NewExternalDistinct(
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	inMemUnorderedDistinct colexecop.Operator,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 ) (colexecop.Operator, colexecop.Closer) {
 	distinctSpec := args.Spec.Core.Distinct
 	distinctCols := distinctSpec.DistinctColumns
@@ -100,7 +100,7 @@ func NewExternalDistinct(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
-		converterMemAcc,
+		diskQueueMemAcc,
 		numRequiredActivePartitions,
 	)
 	// The last thing we need to do is making sure that the output has the

--- a/pkg/sql/colexec/colexecdisk/external_hash_aggregator.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_aggregator.go
@@ -40,7 +40,7 @@ func NewExternalHashAggregator(
 	newHashAggArgs *colexecagg.NewHashAggregatorArgs,
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 	outputOrdering execinfrapb.Ordering,
 ) (colexecop.Operator, colexecop.Closer) {
 	inMemMainOpConstructor := func(partitionedInputs []*partitionerToOperator) colexecop.ResettableOperator {
@@ -78,7 +78,7 @@ func NewExternalHashAggregator(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
-		converterMemAcc,
+		diskQueueMemAcc,
 		ehaNumRequiredActivePartitions,
 	)
 	// The last thing we need to do is making sure that the output has the

--- a/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
@@ -68,7 +68,7 @@ func NewExternalHashJoiner(
 	leftInput, rightInput colexecop.Operator,
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 ) colexecop.ClosableOperator {
 	// This memory limit will restrict the size of the batches output by the
 	// in-memory hash joiner in the main strategy as well as by the merge joiner
@@ -116,7 +116,7 @@ func NewExternalHashJoiner(
 		return colexecjoin.NewMergeJoinOp(
 			unlimitedAllocator, memoryLimit, args.DiskQueueCfg, fdSemaphore, spec.JoinType,
 			leftPartitionSorter, rightPartitionSorter, spec.Left.SourceTypes,
-			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc, converterMemAcc, flowCtx.EvalCtx,
+			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc, diskQueueMemAcc, flowCtx.EvalCtx,
 		)
 	}
 	return newHashBasedPartitioner(
@@ -130,7 +130,7 @@ func NewExternalHashJoiner(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
-		converterMemAcc,
+		diskQueueMemAcc,
 		colexecop.ExternalHJMinPartitions,
 	)
 }

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -240,7 +240,7 @@ func NewExternalSorter(
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 	testingVecFDsToAcquire int,
 ) colexecop.Operator {
 	if diskQueueCfg.BufferSizeBytes > 0 && maxNumberPartitions == 0 {
@@ -313,7 +313,7 @@ func NewExternalSorter(
 		partitionerCreator: func() colcontainer.PartitionedQueue {
 			return colcontainer.NewPartitionedDiskQueue(
 				inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore,
-				colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc, converterMemAcc,
+				colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc, diskQueueMemAcc,
 			)
 		},
 		inputTypes:           inputTypes,

--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -194,8 +194,9 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	// keeping the remaining 0.2 for the output batch (which is never utilized).
 	// This logic lives in createDiskBackedSorter in execplan.go.
 	//
-	// To allow some drift we add another 0.2.
-	expMax := int64(float64(memoryLimit) * 2.8)
+	// To allow some drift (for things like memory used by the disk queue) we
+	// add another 0.7.
+	expMax := int64(float64(memoryLimit) * 3.3)
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)
 	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -228,7 +228,7 @@ func newHashBasedPartitioner(
 		fdSemaphore semaphore.Semaphore,
 	) colexecop.ResettableOperator,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 	numRequiredActivePartitions int,
 ) *hashBasedPartitioner {
 	// Make a copy of the DiskQueueCfg and set defaults for the partitioning
@@ -250,7 +250,7 @@ func newHashBasedPartitioner(
 	for i := range inputs {
 		partitioners[i] = colcontainer.NewPartitionedDiskQueue(
 			inputTypes[i], diskQueueCfg, partitionedDiskQueueSemaphore,
-			colcontainer.PartitionerStrategyDefault, diskAcc, converterMemAcc,
+			colcontainer.PartitionerStrategyDefault, diskAcc, diskQueueMemAcc,
 		)
 		partitionedInputs[i] = newPartitionerToOperator(
 			unlimitedAllocator, inputTypes[i], partitioners[i],

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -39,7 +39,7 @@ func NewCrossJoiner(
 	leftTypes []*types.T,
 	rightTypes []*types.T,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 ) colexecop.ClosableOperator {
 	c := &crossJoiner{
 		crossJoinerBase: newCrossJoinerBase(
@@ -51,7 +51,7 @@ func NewCrossJoiner(
 			diskQueueCfg,
 			fdSemaphore,
 			diskAcc,
-			converterMemAcc,
+			diskQueueMemAcc,
 		),
 		TwoInputInitHelper: colexecop.MakeTwoInputInitHelper(left, right),
 		outputTypes:        joinType.MakeOutputTypes(leftTypes, rightTypes),
@@ -327,7 +327,7 @@ func newCrossJoinerBase(
 	cfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 ) *crossJoinerBase {
 	base := &crossJoinerBase{
 		joinType: joinType,
@@ -349,7 +349,7 @@ func newCrossJoinerBase(
 				DiskQueueCfg:       cfg,
 				FDSemaphore:        fdSemaphore,
 				DiskAcc:            diskAcc,
-				ConverterMemAcc:    converterMemAcc,
+				DiskQueueMemAcc:    diskQueueMemAcc,
 			},
 		),
 	}

--- a/pkg/sql/colexec/colexecutils/deserializer.go
+++ b/pkg/sql/colexec/colexecutils/deserializer.go
@@ -81,7 +81,7 @@ func (d *Deserializer) Deserialize(serializedBatch []byte) coldata.Batch {
 // Close closes the Deserializer. Safe to be called even if Init wasn't called.
 func (d *Deserializer) Close(ctx context.Context) {
 	if d.converter != nil {
-		d.converter.Release(ctx)
+		d.converter.Close(ctx)
 	}
 	*d = Deserializer{}
 }

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -61,7 +61,7 @@ type SpillingBuffer struct {
 	diskQueue       colcontainer.RewindableQueue
 	fdSemaphore     semaphore.Semaphore
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 
 	dequeueScratch            coldata.Batch
 	lastDequeuedBatchMemUsage int64
@@ -104,7 +104,7 @@ func NewSpillingBuffer(
 	fdSemaphore semaphore.Semaphore,
 	inputTypes []*types.T,
 	diskAcc *mon.BoundAccount,
-	converterMemAcc *mon.BoundAccount,
+	diskQueueMemAcc *mon.BoundAccount,
 	colIdxs ...int,
 ) *SpillingBuffer {
 	if colIdxs == nil {
@@ -138,7 +138,7 @@ func NewSpillingBuffer(
 		diskQueueCfg:       diskQueueCfg,
 		fdSemaphore:        fdSemaphore,
 		diskAcc:            diskAcc,
-		converterMemAcc:    converterMemAcc,
+		diskQueueMemAcc:    diskQueueMemAcc,
 	}
 }
 
@@ -182,7 +182,7 @@ func (b *SpillingBuffer) AppendTuples(
 			}
 		}
 		if b.diskQueue, err = colcontainer.NewRewindableDiskQueue(
-			ctx, b.storedTypes, b.diskQueueCfg, b.diskAcc, b.converterMemAcc,
+			ctx, b.storedTypes, b.diskQueueCfg, b.diskAcc, b.diskQueueMemAcc,
 		); err != nil {
 			colexecerror.InternalError(err)
 		}

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -88,7 +88,7 @@ type SpillingQueue struct {
 	}
 
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 }
 
 // spillingQueueInitialItemsLen is the initial capacity of the in-memory buffer
@@ -106,7 +106,7 @@ type NewSpillingQueueArgs struct {
 	DiskQueueCfg       colcontainer.DiskQueueCfg
 	FDSemaphore        semaphore.Semaphore
 	DiskAcc            *mon.BoundAccount
-	ConverterMemAcc    *mon.BoundAccount
+	DiskQueueMemAcc    *mon.BoundAccount
 }
 
 // NewSpillingQueue creates a new SpillingQueue. An unlimited allocator must be
@@ -127,7 +127,7 @@ func NewSpillingQueue(args *NewSpillingQueueArgs) *SpillingQueue {
 		diskQueueCfg:       args.DiskQueueCfg,
 		fdSemaphore:        args.FDSemaphore,
 		diskAcc:            args.DiskAcc,
-		converterMemAcc:    args.ConverterMemAcc,
+		diskQueueMemAcc:    args.DiskQueueMemAcc,
 	}
 }
 
@@ -441,9 +441,9 @@ func (q *SpillingQueue) maybeSpillToDisk(ctx context.Context) error {
 	log.VEvent(ctx, 1, "spilled to disk")
 	var diskQueue colcontainer.Queue
 	if q.rewindable {
-		diskQueue, err = colcontainer.NewRewindableDiskQueue(ctx, q.typs, q.diskQueueCfg, q.diskAcc, q.converterMemAcc)
+		diskQueue, err = colcontainer.NewRewindableDiskQueue(ctx, q.typs, q.diskQueueCfg, q.diskAcc, q.diskQueueMemAcc)
 	} else {
-		diskQueue, err = colcontainer.NewDiskQueue(ctx, q.typs, q.diskQueueCfg, q.diskAcc, q.converterMemAcc)
+		diskQueue, err = colcontainer.NewDiskQueue(ctx, q.typs, q.diskQueueCfg, q.diskAcc, q.diskQueueMemAcc)
 	}
 	if err != nil {
 		return err

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -127,7 +127,7 @@ func TestSpillingQueue(t *testing.T) {
 						DiskQueueCfg:       queueCfg,
 						FDSemaphore:        colexecop.NewTestingSemaphore(2),
 						DiskAcc:            testDiskAcc,
-						ConverterMemAcc:    testMemAcc,
+						DiskQueueMemAcc:    testMemAcc,
 					},
 				)
 			} else {
@@ -139,7 +139,7 @@ func TestSpillingQueue(t *testing.T) {
 						DiskQueueCfg:       queueCfg,
 						FDSemaphore:        colexecop.NewTestingSemaphore(2),
 						DiskAcc:            testDiskAcc,
-						ConverterMemAcc:    testMemAcc,
+						DiskQueueMemAcc:    testMemAcc,
 					},
 				)
 			}
@@ -296,7 +296,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 			DiskQueueCfg:       queueCfg,
 			FDSemaphore:        colexecop.NewTestingSemaphore(2),
 			DiskAcc:            testDiskAcc,
-			ConverterMemAcc:    testMemAcc,
+			DiskQueueMemAcc:    testMemAcc,
 		},
 	)
 
@@ -363,7 +363,7 @@ func TestSpillingQueueMemoryAccounting(t *testing.T) {
 				DiskQueueCfg:       queueCfg,
 				FDSemaphore:        colexecop.NewTestingSemaphore(2),
 				DiskAcc:            testDiskAcc,
-				ConverterMemAcc:    testMemAcc,
+				DiskQueueMemAcc:    testMemAcc,
 			}
 			var q *SpillingQueue
 			if rewindable {
@@ -468,7 +468,7 @@ func TestSpillingQueueMovingTailWhenSpilling(t *testing.T) {
 			DiskQueueCfg:       queueCfg,
 			FDSemaphore:        colexecop.NewTestingSemaphore(2),
 			DiskAcc:            testDiskAcc,
-			ConverterMemAcc:    testMemAcc,
+			DiskQueueMemAcc:    testMemAcc,
 		}
 		q := NewSpillingQueue(newQueueArgs)
 

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -48,7 +48,7 @@ func newBufferedWindowOperator(
 			fdSemaphore:     args.FdSemaphore,
 			outputTypes:     outputTypes,
 			diskAcc:         args.DiskAcc,
-			converterMemAcc: args.ConverterMemAcc,
+			diskQueueMemAcc: args.DiskQueueMemAcc,
 			outputColIdx:    args.OutputColIdx,
 		},
 		windower: windower,
@@ -150,7 +150,7 @@ type windowInitFields struct {
 	fdSemaphore     semaphore.Semaphore
 	outputTypes     []*types.T
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 	outputColIdx    int
 }
 
@@ -211,7 +211,7 @@ func (b *bufferedWindowOp) Init(ctx context.Context) {
 			DiskQueueCfg:       b.diskQueueCfg,
 			FDSemaphore:        b.fdSemaphore,
 			DiskAcc:            b.diskAcc,
-			ConverterMemAcc:    b.converterMemAcc,
+			DiskQueueMemAcc:    b.diskQueueMemAcc,
 		},
 	)
 	b.windower.startNewPartition()

--- a/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
+++ b/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
@@ -36,7 +36,7 @@ func NewCountRowsOperator(
 	colsToStore := framer.getColsToStore(nil /* oldColsToStore */)
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	windower := &countRowsWindowAggregator{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
@@ -69,7 +69,7 @@ func New_UPPERCASE_NAMEOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	base := _OP_NAMEBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/first_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/first_value.eg.go
@@ -44,7 +44,7 @@ func NewFirstValueOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	base := firstValueBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -37,7 +37,7 @@ func NewLagOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, argIdx,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, argIdx,
 	)
 	base := lagBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/last_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/last_value.eg.go
@@ -44,7 +44,7 @@ func NewLastValueOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	base := lastValueBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/lead.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lead.eg.go
@@ -37,7 +37,7 @@ func NewLeadOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, argIdx,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, argIdx,
 	)
 	base := leadBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -59,7 +59,7 @@ func New_UPPERCASE_NAMEOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, argIdx,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, argIdx,
 	)
 	base := _OP_NAMEBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/nth_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/nth_value.eg.go
@@ -46,7 +46,7 @@ func NewNthValueOperator(
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	base := nthValueBase{
 		partitionSeekerBase: partitionSeekerBase{

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -60,7 +60,7 @@ func NewRelativeRankOperator(
 		fdSemaphore:     args.FdSemaphore,
 		inputTypes:      args.InputTypes,
 		diskAcc:         args.DiskAcc,
-		converterMemAcc: args.ConverterMemAcc,
+		diskQueueMemAcc: args.DiskQueueMemAcc,
 	}
 	switch windowFn {
 	case execinfrapb.WindowerSpec_PERCENT_RANK:
@@ -134,7 +134,7 @@ type relativeRankInitFields struct {
 	inputTypes   []*types.T
 
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 }
 
 type relativeRankSizesState struct {
@@ -192,7 +192,7 @@ func (r *percentRankNoPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
@@ -375,7 +375,7 @@ func (r *percentRankWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -388,7 +388,7 @@ func (r *percentRankWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
@@ -658,7 +658,7 @@ func (r *cumeDistNoPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -671,7 +671,7 @@ func (r *cumeDistNoPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
@@ -926,7 +926,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -939,7 +939,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -952,7 +952,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -70,7 +70,7 @@ func NewRelativeRankOperator(
 		fdSemaphore:     args.FdSemaphore,
 		inputTypes:      args.InputTypes,
 		diskAcc:         args.DiskAcc,
-		converterMemAcc: args.ConverterMemAcc,
+		diskQueueMemAcc: args.DiskQueueMemAcc,
 	}
 	switch windowFn {
 	case execinfrapb.WindowerSpec_PERCENT_RANK:
@@ -208,7 +208,7 @@ type relativeRankInitFields struct {
 	inputTypes   []*types.T
 
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 }
 
 type relativeRankSizesState struct {
@@ -284,7 +284,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -299,7 +299,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -313,7 +313,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
-			ConverterMemAcc:    r.converterMemAcc,
+			DiskQueueMemAcc:    r.diskQueueMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())

--- a/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
@@ -65,7 +65,7 @@ func NewWindowAggregatorOperator(
 	colsToStore := framer.getColsToStore(append([]int{}, argIdxs...))
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	inputIdxs := make([]uint32, len(argIdxs))
 	for i := range inputIdxs {

--- a/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
@@ -67,7 +67,7 @@ func NewWindowAggregatorOperator(
 	colsToStore := framer.getColsToStore(append([]int{}, argIdxs...))
 	buffer := colexecutils.NewSpillingBuffer(
 		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
-		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+		args.InputTypes, args.DiskAcc, args.DiskQueueMemAcc, colsToStore...,
 	)
 	inputIdxs := make([]uint32, len(argIdxs))
 	for i := range inputIdxs {

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1164,7 +1164,7 @@ func BenchmarkWindowFunctions(b *testing.B) {
 			QueueCfg:        queueCfg,
 			FdSemaphore:     colexecop.NewTestingSemaphore(fdLimit),
 			DiskAcc:         testDiskAcc,
-			ConverterMemAcc: testMemAcc,
+			DiskQueueMemAcc: testMemAcc,
 			Input:           source,
 			InputTypes:      sourceTypes,
 			OutputColIdx:    outputIdx,

--- a/pkg/sql/colexec/colexecwindow/window_functions_util.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_util.go
@@ -34,7 +34,7 @@ type WindowArgs struct {
 	QueueCfg        colcontainer.DiskQueueCfg
 	FdSemaphore     semaphore.Semaphore
 	DiskAcc         *mon.BoundAccount
-	ConverterMemAcc *mon.BoundAccount
+	DiskQueueMemAcc *mon.BoundAccount
 	Input           colexecop.Operator
 	InputTypes      []*types.T
 	OutputColIdx    int

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -518,7 +518,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 								DiskQueueCfg:       queueCfg,
 								FDSemaphore:        &colexecop.TestingSemaphore{},
 								DiskAcc:            testDiskAcc,
-								ConverterMemAcc:    testMemAcc,
+								DiskQueueMemAcc:    testMemAcc,
 							},
 						)
 					},
@@ -584,7 +584,7 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 				DiskQueueCfg:       queueCfg,
 				FDSemaphore:        &colexecop.TestingSemaphore{},
 				DiskAcc:            testDiskAcc,
-				ConverterMemAcc:    testMemAcc,
+				DiskQueueMemAcc:    testMemAcc,
 			},
 		)
 	}

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -83,7 +83,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 
 			c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional, testMemAcc)
 			require.NoError(t, err)
-			defer c.Release(ctx)
+			defer c.Close(ctx)
 			r, err := colserde.NewRecordBatchSerializer(typs)
 			require.NoError(t, err)
 			arrowOp := newArrowTestOperator(columnarizer, c, r, typs)

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -174,7 +174,7 @@ func (c *cFetcherWrapper) Close(ctx context.Context) {
 		c.detachedFetcherMon = nil
 	}
 	if c.converter != nil {
-		c.converter.Release(ctx)
+		c.converter.Close(ctx)
 		c.converter = nil
 	}
 	c.buf = bytes.Buffer{}

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -309,7 +309,7 @@ func TestInboxShutdown(t *testing.T) {
 									wg.Add(1)
 									go func() {
 										defer wg.Done()
-										defer c.Release(context.Background())
+										defer c.Close(context.Background())
 										arrowData, err := c.BatchToArrow(context.Background(), batch)
 										if err != nil {
 											errCh <- err

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -124,7 +124,7 @@ func NewOutbox(
 func (o *Outbox) close(ctx context.Context) {
 	o.scratch.buf = nil
 	o.scratch.msg = nil
-	o.converter.Release(ctx)
+	o.converter.Close(ctx)
 	// Unset the input (which is a deselector operator) so that its output batch
 	// could be garbage collected. This allows us to release all memory
 	// registered with the allocator (the allocator is shared by the outbox and

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -179,7 +179,7 @@ type routerOutputOpArgs struct {
 	// when it is exceeded.
 	memoryLimit     int64
 	diskAcc         *mon.BoundAccount
-	converterMemAcc *mon.BoundAccount
+	diskQueueMemAcc *mon.BoundAccount
 	cfg             colcontainer.DiskQueueCfg
 	fdSemaphore     semaphore.Semaphore
 
@@ -210,7 +210,7 @@ func newRouterOutputOp(args routerOutputOpArgs) *routerOutputOp {
 			DiskQueueCfg:       args.cfg,
 			FDSemaphore:        args.fdSemaphore,
 			DiskAcc:            args.diskAcc,
-			ConverterMemAcc:    args.converterMemAcc,
+			DiskQueueMemAcc:    args.diskQueueMemAcc,
 		},
 	)
 
@@ -481,7 +481,7 @@ func NewHashRouter(
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	diskAccounts []*mon.BoundAccount,
-	converterMemAccounts []*mon.BoundAccount,
+	diskQueueMemAccounts []*mon.BoundAccount,
 ) (*HashRouter, []colexecop.DrainableClosableOperator) {
 	outputs := make([]routerOutput, len(unlimitedAllocators))
 	outputsAsOps := make([]colexecop.DrainableClosableOperator, len(unlimitedAllocators))
@@ -507,7 +507,7 @@ func NewHashRouter(
 				unlimitedAllocator:  unlimitedAllocators[i],
 				memoryLimit:         memoryLimitPerOutput,
 				diskAcc:             diskAccounts[i],
-				converterMemAcc:     converterMemAccounts[i],
+				diskQueueMemAcc:     diskQueueMemAccounts[i],
 				cfg:                 diskQueueCfg,
 				fdSemaphore:         fdSemaphore,
 				unblockedEventsChan: unblockEventsChan,

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -170,7 +170,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				// Create an allocator for each output.
 				allocators := make([]*colmem.Allocator, numHashRouterOutputs)
 				diskAccounts := make([]*mon.BoundAccount, numHashRouterOutputs)
-				converterMemAccounts := make([]*mon.BoundAccount, numHashRouterOutputs)
+				diskQueueMemAccounts := make([]*mon.BoundAccount, numHashRouterOutputs)
 				for i := range allocators {
 					acc := testMemMonitor.MakeBoundAccount()
 					defer acc.Close(ctxRemote)
@@ -178,9 +178,9 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					diskAcc := testDiskMonitor.MakeBoundAccount()
 					diskAccounts[i] = &diskAcc
 					defer diskAcc.Close(ctxRemote)
-					converterMemAcc := testMemMonitor.MakeBoundAccount()
-					converterMemAccounts[i] = &converterMemAcc
-					defer converterMemAcc.Close(ctx)
+					diskQueueMemAcc := testMemMonitor.MakeBoundAccount()
+					diskQueueMemAccounts[i] = &diskQueueMemAcc
+					defer diskQueueMemAcc.Close(ctx)
 				}
 				createMetadataSourceForID := func(id int) colexecop.MetadataSource {
 					return colexectestutils.CallbackMetadataSource{
@@ -211,7 +211,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					queueCfg,
 					&colexecop.TestingSemaphore{},
 					diskAccounts,
-					converterMemAccounts,
+					diskQueueMemAccounts,
 				)
 				for i := 0; i < numInboxes; i++ {
 					inboxMemAccount := testMemMonitor.MakeBoundAccount()


### PR DESCRIPTION
**colserde,colcontainer: some renaming**

This commit renames `ArrowBatchConverter.Release` to `Close` since this better represents the meaning of the method.

It also renames `converterMemAcc` to `diskQueueMemAcc`. `converterMemAcc` is a memory account that was introduced in 292277791f7ed263309953437a303577b1654ca6 when we started reusing some of the scratch slices between `BatchToArrow` calls, so it was named to highlight that single purpose. The following commit will start using the same memory account for other purposes by the disk queue, so this rename is done accordingly. Note that the arrow batch converter is careful to only grow and shrink by its precise "accounted for" usage, and given that there is no concurrency when dealing with disk queue operations, it's safe to reuse the same account.

The only context in which we still keep `converterMemAcc` wording is in the outbox where we already do the memory accounting that will be added to the disk queue in the following commit.

**colcontainer: add more memory accounting to disk queue**

This commit fixes an oversight where some of the memory used by the disk queue wasn't being accounted for. It includes three usages:
- the "write buffer" `bytes.Buffer` where all writes are accumulated into before being flushed to disk in `compressAndFlush`.
- the "compressed write scratch" where `snappy` library encodes the writes before flushing them to disk.
- the "compressed read scratch" where `snappy` library decodes the reads coming from disk. Note that in this case, sometimes the underlying memory is reused with the "write buffer" from the first usage, so some care had to be taken to not double count the memory.

Note that we reuse already present memory account in the disk queue for all of these usages since we're being precise about resizing the account according to each (as well as when the same account is used in the arrow batch converter).

A single test needed minor adjustment since it was reusing the same memory account for unlimited allocator and disk queue mem account (which isn't allowed).

Fixes: #112669.

Release note: None