### PR TITLE
streamingccl: correctly insert MVCC timestamp into table

### DIFF
--- a/pkg/ccl/streamingccl/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_writer_processor.go
@@ -828,7 +828,7 @@ func makeInsertQuery(fqTableName string, td catalog.TableDescriptor) string {
 	originTSIdx := argIdx
 	baseQuery := `
 INSERT INTO %s (%s, crdb_internal_origin_timestamp)
-VALUES (%s, %d)
+VALUES (%s, $%d)
 ON CONFLICT ON CONSTRAINT %s
 DO UPDATE SET
 %s,


### PR DESCRIPTION
We refactored this query and introduced a bug. If we are sticking with this column-based timestamp storage, we need to get some tests around this code.

Epic: none
Release note: None