### PR TITLE
allocator: pre-size store ID slice in StorePool.GetStoreList

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -1113,7 +1113,7 @@ func (sp *StorePool) GetStoreList(filter StoreFilter) (StoreList, int, Throttled
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
 
-	var storeIDs roachpb.StoreIDSlice
+	storeIDs := make(roachpb.StoreIDSlice, 0, len(sp.DetailsMu.StoreDetails))
 	for storeID := range sp.DetailsMu.StoreDetails {
 		storeIDs = append(storeIDs, storeID)
 	}


### PR DESCRIPTION
We know the needed capacity, so use it.

In a 1,600 store cluster, this slice resizing was responsible for 0.16% of CPU.

<img width="1583" alt="Screenshot 2024-06-05 at 2 20 59 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/db5cafd4-9a37-480f-8b4e-1a63821656ea">


Epic: None
Release note: None