### PR TITLE
gossip: add callback observability

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -187,6 +187,10 @@
 <tr><td>STORAGE</td><td>gcbytesage</td><td>Cumulative age of non-live data</td><td>Age</td><td>GAUGE</td><td>SECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>gossip.bytes.received</td><td>Number of received gossip bytes</td><td>Gossip Bytes</td><td>COUNTER</td><td>BYTES</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>gossip.bytes.sent</td><td>Number of sent gossip bytes</td><td>Gossip Bytes</td><td>COUNTER</td><td>BYTES</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>gossip.callbacks.pending</td><td>Number of gossip callbacks waiting to be processed</td><td>Callbacks</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>gossip.callbacks.pending_duration</td><td>Duration of gossip callback queueing to be processed</td><td>Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>gossip.callbacks.processed</td><td>Number of gossip callbacks processed</td><td>Callbacks</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>gossip.callbacks.processing_duration</td><td>Duration of gossip callback processing</td><td>Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>gossip.connections.incoming</td><td>Number of active incoming gossip connections</td><td>Connections</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>gossip.connections.outgoing</td><td>Number of active outgoing gossip connections</td><td>Connections</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>gossip.connections.refused</td><td>Number of refused incoming gossip connections</td><td>Connections</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -170,6 +170,30 @@ var (
 		Measurement: "Gossip Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
+	MetaCallbacksProcessed = metric.Metadata{
+		Name:        "gossip.callbacks.processed",
+		Help:        "Number of gossip callbacks processed",
+		Measurement: "Callbacks",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaCallbacksPending = metric.Metadata{
+		Name:        "gossip.callbacks.pending",
+		Help:        "Number of gossip callbacks waiting to be processed",
+		Measurement: "Callbacks",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaCallbacksProcessingDuration = metric.Metadata{
+		Name:        "gossip.callbacks.processing_duration",
+		Help:        "Duration of gossip callback processing",
+		Measurement: "Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	MetaCallbacksPendingDuration = metric.Metadata{
+		Name:        "gossip.callbacks.pending_duration",
+		Help:        "Duration of gossip callback queueing to be processed",
+		Measurement: "Duration",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 )
 
 // KeyNotPresentError is returned by gossip when queried for a key that doesn't

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -36,7 +36,7 @@ func newTestInfoStore() (*infoStore, *stop.Stopper) {
 	stopper := stop.NewStopper()
 	nc := &base.NodeIDContainer{}
 	nc.Set(context.Background(), 1)
-	is := newInfoStore(log.MakeTestingAmbientCtxWithNewTracer(), nc, emptyAddr, stopper)
+	is := newInfoStore(log.MakeTestingAmbientCtxWithNewTracer(), nc, emptyAddr, stopper, makeMetrics())
 	return is, stopper
 }
 

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -85,7 +85,7 @@ func newServer(
 		serverMetrics:  makeMetrics(),
 	}
 
-	s.mu.is = newInfoStore(s.AmbientContext, nodeID, util.UnresolvedAddr{}, stopper)
+	s.mu.is = newInfoStore(s.AmbientContext, nodeID, util.UnresolvedAddr{}, stopper, s.nodeMetrics)
 	s.mu.incoming = makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsIncomingGauge))
 	s.mu.nodeMap = make(map[util.UnresolvedAddr]serverInfo)
 	s.mu.ready = make(chan struct{})

--- a/pkg/gossip/status.go
+++ b/pkg/gossip/status.go
@@ -13,17 +13,28 @@ package gossip
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/redact"
 )
 
+// minCallbackDurationToRecord is the minimum duration for which we record
+// callback pending and callback processing durations. This skews the histogram,
+// but avoids recording very short durations which are not interesting and
+// which. will be dominated by the overhead of recording the duration itself.
+const minCallbackDurationToRecord = 10 * time.Millisecond
+
 // Metrics contains gossip metrics used per node and server.
 type Metrics struct {
-	ConnectionsRefused *metric.Counter
-	BytesReceived      *metric.Counter
-	BytesSent          *metric.Counter
-	InfosReceived      *metric.Counter
-	InfosSent          *metric.Counter
+	ConnectionsRefused          *metric.Counter
+	BytesReceived               *metric.Counter
+	BytesSent                   *metric.Counter
+	InfosReceived               *metric.Counter
+	InfosSent                   *metric.Counter
+	CallbacksProcessed          *metric.Counter
+	CallbacksPending            *metric.Gauge
+	CallbacksProcessingDuration metric.IHistogram
+	CallbacksPendingDuration    metric.IHistogram
 }
 
 func makeMetrics() Metrics {
@@ -33,6 +44,20 @@ func makeMetrics() Metrics {
 		BytesSent:          metric.NewCounter(MetaBytesSent),
 		InfosReceived:      metric.NewCounter(MetaInfosReceived),
 		InfosSent:          metric.NewCounter(MetaInfosSent),
+		CallbacksProcessed: metric.NewCounter(MetaCallbacksProcessed),
+		CallbacksPending:   metric.NewGauge(MetaCallbacksPending),
+		CallbacksProcessingDuration: metric.NewHistogram(metric.HistogramOptions{
+			Mode:         metric.HistogramModePreferHdrLatency,
+			Metadata:     MetaCallbacksProcessingDuration,
+			Duration:     base.DefaultHistogramWindowInterval(),
+			BucketConfig: metric.IOLatencyBuckets,
+		}),
+		CallbacksPendingDuration: metric.NewHistogram(metric.HistogramOptions{
+			Mode:         metric.HistogramModePreferHdrLatency,
+			Metadata:     MetaCallbacksPendingDuration,
+			Duration:     base.DefaultHistogramWindowInterval(),
+			BucketConfig: metric.IOLatencyBuckets,
+		}),
 	}
 }
 


### PR DESCRIPTION
Closes #125081.

This commit adds the following four metrics, which provide observability into gossip callback processing:
* gossip.callbacks.processed
* gossip.callbacks.pending
* gossip.callbacks.processing_duration
* gossip.callbacks.pending_duration

Release note: None