### PR TITLE
sql: deflake distsql_stats logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2807,7 +2807,7 @@ NULL  {m}  1000  1000  true
 NULL  {n}  1000  50    true
 NULL  {o}  1000  33    true
 
-query T
+query T retry
 EXPLAIN SELECT * FROM mno WHERE n = 1 AND o = 9
 ----
 distribution: full


### PR DESCRIPTION
I stressed this for a while and was not able to reproduce it. However, I have a theory: the failing statement is racing the rangefeed that invalidates the stats cache, and occasionally starts planning before the rangefeed causes the stale entry to be evicted from the cache.

(SHOW STATISTICS does not go through the stats cache, which is why we can hit this even after that statement succeeds.)

A retry on the first non-SHOW-STATISTICS statement after ANALYZE should work. (This is also what we did in #81560.)

Fixes: #121424

Release note: None