### PR TITLE
acceptance: preserve logs for TestDockerCLI tests in remote execution

### DIFF
--- a/pkg/acceptance/cluster/BUILD.bazel
+++ b/pkg/acceptance/cluster/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/security",
         "//pkg/security/certnames",
         "//pkg/security/username",
+        "//pkg/testutils/datapathutils",
         "//pkg/util/log",
         "//pkg/util/log/logflags",
         "//pkg/util/log/severity",

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -173,7 +174,7 @@ func CreateDocker(
 	clusterIDS := clusterID.Short()
 
 	if volumesDir == "" {
-		volumesDir, err = os.MkdirTemp("", fmt.Sprintf("cockroach-acceptance-%s", clusterIDS))
+		volumesDir, err = os.MkdirTemp(datapathutils.DebuggableTempDir(), fmt.Sprintf("cockroach-acceptance-%s", clusterIDS))
 		maybePanic(err)
 	} else {
 		volumesDir = filepath.Join(volumesDir, clusterIDS)


### PR DESCRIPTION
The cleanup logic in (*cluster.DockerCluster).Cleanup takes care to preserve the logs directory if requested. Under remote execution, we need to make sure to use a temporary directory that will be captured by the remote executor.

fixes https://github.com/cockroachdb/cockroach/issues/125096
Release note: None