### PR TITLE
sql: sample internal queries before including into closed session cache

### DIFF
--- a/pkg/sql/closed_session_cache_test.go
+++ b/pkg/sql/closed_session_cache_test.go
@@ -56,8 +56,8 @@ func TestSessionCacheBasic(t *testing.T) {
 				})
 				cache = NewClosedSessionCache(st, monitor, time.Now)
 
-				ClosedSessionCacheCapacity.Override(ctx, &st.SV, int64(capacity))
-				ClosedSessionCacheTimeToLive.Override(ctx, &st.SV, int64(timeToLive))
+				closedSessionCacheCapacity.Override(ctx, &st.SV, int64(capacity))
+				closedSessionCacheTimeToLive.Override(ctx, &st.SV, int64(timeToLive))
 
 				return fmt.Sprintf("cache_size: %d", cache.size())
 			case "addSession":

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2205,9 +2205,16 @@ func (ex *connExecutor) run(
 
 	defer func() {
 		ex.server.cfg.SessionRegistry.deregister(sessionID, ex.queryCancelKey)
-		addErr := ex.server.cfg.ClosedSessionCache.add(ctx, sessionID, ex.serialize())
-		if addErr != nil {
-			err = errors.CombineErrors(err, addErr)
+		addToClosedSessionCache := ex.executorType == executorTypeExec
+		if ex.executorType == executorTypeInternal {
+			rate := closedSessionCacheInternalSamplingProbability.Get(&ex.server.cfg.Settings.SV)
+			addToClosedSessionCache = ex.rng.internal.Float64() < rate
+		}
+		if addToClosedSessionCache {
+			addErr := ex.server.cfg.ClosedSessionCache.add(ctx, sessionID, ex.serialize())
+			if addErr != nil {
+				err = errors.CombineErrors(err, addErr)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Serializing the connExecutor can have non-trivial overhead. In a CPU profile I observed on the cluster with logical replication running (which executes many INSERTs via the Internal Executor), this overhead was 1.2% of CPU (out of 85%).

I don't think we're getting much benefit from _closed_ internal sessions, so this commit introduces sampling (controlled by the newly-added `sql.closed_session_cache.internal_queries.sample_rate` cluster setting) in order to decide whether a particular internal session is included into the closed sessions cache. The setting default to 0.01 and is undocumented since this feature is likely to be useful for DB engineers.

Epic: CRDB-39063.

Release note: None