### PR TITLE
logical: avoid parsing INSERTs and DELETEs

### DIFF
--- a/pkg/ccl/streamingccl/logical/BUILD.bazel
+++ b/pkg/ccl/streamingccl/logical/BUILD.bazel
@@ -34,6 +34,8 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
+        "//pkg/sql/parser",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/physicalplan",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",

--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/isql",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/testutils",

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -857,6 +858,16 @@ func (txn *wrappedInternalTxn) ExecEx(
 		}
 	}
 	return txn.wrapped.ExecEx(ctx, opName, kvTxn, o, stmt, qargs...)
+}
+
+func (txn *wrappedInternalTxn) ExecParsed(
+	ctx context.Context,
+	opName string,
+	_ *kv.Txn,
+	parsedStmt statements.Statement[tree.Statement],
+	params ...interface{},
+) (int, error) {
+	panic("unimplemented")
 }
 
 func (txn *wrappedInternalTxn) QueryRowEx(

--- a/pkg/sql/isql/BUILD.bazel
+++ b/pkg/sql/isql/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/kv",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/util/admission/admissionpb",

--- a/pkg/sql/isql/isql_db.go
+++ b/pkg/sql/isql/isql_db.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
@@ -88,6 +89,16 @@ type Executor interface {
 		txn *kv.Txn,
 		o sessiondata.InternalExecutorOverride,
 		stmt string,
+		qargs ...interface{},
+	) (int, error)
+
+	// ExecParsed is like Exec but allows the caller to provide an already
+	// parsed statement.
+	ExecParsed(
+		ctx context.Context,
+		opName string,
+		txn *kv.Txn,
+		parsedStmt statements.Statement[tree.Statement],
 		qargs ...interface{},
 	) (int, error)
 


### PR DESCRIPTION
This commit extends the internal executor infrastructure to support taking already parsed statement as an argument. This ability is then utilized in the logical replication ingestion to avoid re-parsing INSERTs and DELETEs for every KV in the batch. In a CPU profile I observed this take up 1.5% of time out of 85% CPU utilization.

Epic: CRDB-39063.

Release note: None