### PR TITLE
sql: initialize ULID entropy lazily

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -589,7 +589,6 @@ go_library(
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/tsearch",
         "//pkg/util/uint128",
-        "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	crypto_rand "crypto/rand"
 	"fmt"
 	"io"
 	"math"
@@ -86,7 +85,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
-	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -1695,6 +1693,11 @@ type connExecutor struct {
 		// this field by value so that the same RNG is reused throughout the
 		// whole session.
 		external eval.RNGFactory
+		// ulidEntropy is used to power gen_random_ulid builtin. It is important
+		// to store this field by value so that the same source is reused
+		// throughout the whole session. Under the hood it'll use 'external' RNG
+		// as the entropy source.
+		ulidEntropy eval.ULIDEntropyFactory
 	}
 
 	// mu contains of all elements of the struct that can be changed
@@ -3720,8 +3723,8 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			DescIDGenerator:                ex.getDescIDGenerator(),
 			RangeStatsFetcher:              p.execCfg.RangeStatsFetcher,
 			JobsProfiler:                   p,
-			ULIDEntropy:                    ulid.Monotonic(crypto_rand.Reader, 0),
 			RNGFactory:                     &ex.rng.external,
+			ULIDEntropyFactory:             &ex.rng.ulidEntropy,
 		},
 		Tracing:              &ex.sessionTracing,
 		MemMetrics:           &ex.memMetrics,

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/util/tochar",
         "//pkg/util/tracing",
         "//pkg/util/tracing/grpcinterceptor",
-        "//pkg/util/ulid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -12,7 +12,6 @@ package distsql
 
 import (
 	"context"
-	crypto_rand "crypto/rand"
 	"io"
 	"time"
 
@@ -42,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/grpcinterceptor"
-	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -362,7 +360,6 @@ func (ds *ServerImpl) setupFlow(
 			SchemaTelemetryController: ds.ServerConfig.SchemaTelemetryController,
 			IndexUsageStatsController: ds.ServerConfig.IndexUsageStatsController,
 			RangeStatsFetcher:         ds.ServerConfig.RangeStatsFetcher,
-			ULIDEntropy:               ulid.Monotonic(crypto_rand.Reader, 0),
 		}
 		// Most processors will override this Context with their own context in
 		// ProcessorBase. StartInternal().

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	crypto_rand "crypto/rand"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -59,7 +58,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -554,7 +552,6 @@ func internalExtendedEvalCtx(
 			ConsistencyChecker:             execCfg.ConsistencyChecker,
 			StmtDiagnosticsRequestInserter: execCfg.StmtDiagnosticsRecorder.InsertRequest,
 			RangeStatsFetcher:              execCfg.RangeStatsFetcher,
-			ULIDEntropy:                    ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 		Tracing:         &SessionTracing{},
 		Descs:           tables,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	crypto_rand "crypto/rand"
 	"fmt"
 	"math"
 	"strings"
@@ -68,7 +67,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -2657,7 +2655,6 @@ func createSchemaChangeEvalCtx(
 			Locality:             execCfg.Locality,
 			OriginalLocality:     execCfg.Locality,
 			Tracer:               execCfg.AmbientCtx.Tracer,
-			ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 	}
 	// TODO(andrei): This is wrong (just like on the main code path on

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/mon",
-        "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -12,14 +12,12 @@ package scbuild
 
 import (
 	"context"
-	crypto_rand "crypto/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 )
 
 var _ scbuildstmt.TreeContextBuilder = buildCtx{}
@@ -59,7 +57,6 @@ func newEvalCtx(ctx context.Context, d Dependencies) *eval.Context {
 		Settings:             d.ClusterSettings(),
 		Codec:                d.Codec(),
 		DescIDGenerator:      d.DescIDGenerator(),
-		ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 	}
 	evalCtx.SetDeprecatedContext(ctx)
 	return evalCtx

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -818,7 +818,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
 			Fn: func(_ context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				uv := ulid.MustNew(ulid.Now(), evalCtx.ULIDEntropy)
+				uv := ulid.MustNew(ulid.Now(), evalCtx.GetULIDEntropy())
 				return tree.NewDUuid(tree.DUuid{UUID: uuid.UUID(uv)}), nil
 			},
 			Info:       "Generates a random ULID and returns it as a value of UUID type.",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -288,11 +288,6 @@ type Context struct {
 	// during local execution. It may be unset.
 	RoutineSender DeferredRoutineSender
 
-	// ULIDEntropy is the entropy source for ULID generation.
-	// TODO(yuzefovich): consider making its allocation lazy, similar to how
-	// RNG is done, or use the RNG somehow.
-	ULIDEntropy ulid.MonotonicReader
-
 	// RNGFactory, if set, provides the random number generator for the "random"
 	// built-in function.
 	//
@@ -300,11 +295,24 @@ type Context struct {
 	// is exported only for the connExecutor to pass its "external" RNGFactory.
 	RNGFactory *RNGFactory
 
-	// internal provides the random number generator for the "random" built-in
-	// function if RNGFactory is not set. This field exists to allow not setting
-	// RNGFactory on the code paths that don't need to preserve usage of the
-	// same RNG within a session.
+	// internalRNGFactory provides the random number generator for the "random"
+	// built-in function if RNGFactory is not set. This field exists to allow
+	// not setting RNGFactory on the code paths that don't need to preserve
+	// usage of the same RNG within a session.
 	internalRNGFactory RNGFactory
+
+	// ULIDEntropyFactory, if set, is the entropy source for ULID generation.
+	//
+	// NB: do not access this field directly - use GetULIDEntropy() instead.
+	// This field is exported only for the connExecutor to pass its "external"
+	// ULIDEntropyFactory.
+	ULIDEntropyFactory *ULIDEntropyFactory
+
+	// internalULIDEntropyFactory is the entropy source for ULID generation if
+	// ULIDEntropyFactory is not set. This field exists to allow not setting
+	// ULIDEntropyFactory on the code paths that don't need to preserve usage of
+	// the same RNG within a session.
+	internalULIDEntropyFactory ULIDEntropyFactory
 }
 
 // RNGFactory is a simple wrapper to preserve the RNG throughout the session.
@@ -326,6 +334,28 @@ func (r *RNGFactory) getOrCreate() *rand.Rand {
 		r.rng, _ = randutil.NewPseudoRand()
 	}
 	return r.rng
+}
+
+// ULIDEntropyFactory is a simple wrapper to preserve the ULID entropy
+// throughout the session.
+type ULIDEntropyFactory struct {
+	entropy ulid.MonotonicReader
+}
+
+// GetULIDEntropy returns the ULID entropy of the Context (which is lazily
+// instantiated if necessary).
+func (ec *Context) GetULIDEntropy() ulid.MonotonicReader {
+	if ec.ULIDEntropyFactory != nil {
+		return ec.ULIDEntropyFactory.getOrCreate(ec.GetRNG())
+	}
+	return ec.internalULIDEntropyFactory.getOrCreate(ec.GetRNG())
+}
+
+func (f *ULIDEntropyFactory) getOrCreate(rng *rand.Rand) ulid.MonotonicReader {
+	if f.entropy == nil {
+		f.entropy = ulid.Monotonic(rng, 0 /* inc */)
+	}
+	return f.entropy
 }
 
 // JobsProfiler is the interface used to fetch job specific execution details


### PR DESCRIPTION
This commit is similar to 9e1fdbaf585154640f73e9440ea344e589406016 in spirit and applies the "lazy allocation" optimization to ULID entropy. We now create `ulid.MonotonicReader` the first time `gen_random_ulid` is invoked. Additionally, we now use the same RNG as the one that powers `random` builtin as the entropy source for ULID generation.

Epic: CRDB-39063.

Release note: None