### PR TITLE
sql: remove recently added allocation

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1509,7 +1509,7 @@ StatsLoop:
 			// Ignore dropped columns (they are handled below).
 			if col != nil {
 				if err := h.TypeCheck(
-					col.GetType(), desc.GetName(), s.Columns[0], s.CreatedAt,
+					col.GetType(), desc.GetName(), s.Columns[0], s.CreatedAt, time.Time{}, /* createdAtTime */
 				); err != nil {
 					return pgerror.WithCandidateCode(err, pgcode.DatatypeMismatch)
 				}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1805,9 +1805,8 @@ func (os *optTableStat) init(
 	// adjustment.
 	if len(os.columnOrdinals) == 1 {
 		col := tab.getCol(os.columnOrdinals[0])
-		createdAt := string(tree.PGWireFormatTimestamp(stat.CreatedAt, nil, nil))
 		if err := stat.HistogramData.TypeCheck(
-			col.GetType(), string(tab.Name()), col.GetName(), createdAt,
+			col.GetType(), string(tab.Name()), col.GetName(), "" /* createdAt */, stat.CreatedAt,
 		); err != nil {
 			// Column type in the histogram differs from column type in the
 			// table. This is only possible if we somehow re-used the same column ID


### PR DESCRIPTION
This commit removes an allocation that was added recently in 72f97c816d79ec76b5a9cb72cf5ae95b191f2d1d. Namely, we no longer eagerly format the "createdAt" string when performing the type-check of the single-column histograms. In a heap profile of active-active setup this allocation was responsible for 3% of all allocated objects.

Epic: CRDB-39063.

Release note: None