### PR TITLE
roachprod: add ZFS option for AWS

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1604,9 +1604,9 @@ func Create(
 		for _, provider := range createVMOpts.VMProviders {
 			// TODO(DarrylWong): support zfs on other providers, see: #123775.
 			// Once done, revisit all tests that set zfs to see if they can run on non GCE.
-			if provider != gce.ProviderName {
+			if !(provider == gce.ProviderName || provider == aws.ProviderName) {
 				return fmt.Errorf(
-					"creating a node with --filesystem=zfs is currently only supported on gce",
+					"creating a node with --filesystem=zfs is currently not supported in %q", provider,
 				)
 			}
 		}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1189,7 +1189,7 @@ func (p *Provider) runInstance(
 			extraMountOpts = "nobarrier"
 		}
 	}
-	filename, err := writeStartupScript(name, extraMountOpts, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
+	filename, err := writeStartupScript(name, extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
 	if err != nil {
 		return errors.Wrapf(err, "could not write AWS startup script to temp file")
 	}


### PR DESCRIPTION
Previously, onle GCE clusters supports ZFS. This PR
adds support for AWS. We also refactor GCE and AWS
startup scripts to make them closely resemble,
leaving the only diff wrt how local and persistent
drives are discovered.

Epic: none
Informs: #123775

Release note: None