### PR TITLE
spanconfig: enable rangefeed on all spans of a secondary tenant

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
@@ -205,10 +205,10 @@ CREATE MATERIALIZED VIEW mv AS SELECT 1;
 
 mutations tenant=10
 ----
-upsert /Tenant/10/Table/10{6-7}            range default
-upsert /Tenant/10/Table/10{7-8}            range default
-upsert /Tenant/10/Table/11{2-3}            range default
-upsert /Tenant/10/Table/11{3-4}            range default
+upsert /Tenant/10/Table/10{6-7}            rangefeed_enabled=true
+upsert /Tenant/10/Table/10{7-8}            rangefeed_enabled=true
+upsert /Tenant/10/Table/11{2-3}            rangefeed_enabled=true
+upsert /Tenant/10/Table/11{3-4}            rangefeed_enabled=true
 
 state offset=81
 ----
@@ -255,9 +255,9 @@ state offset=81
 /Tenant/10/Table/6{4-5}                    database system (tenant)
 /Tenant/10/Table/6{5-6}                    database system (tenant)
 /Tenant/10/Table/6{6-7}                    database system (tenant)
-/Tenant/10/Table/10{6-7}                   range default
-/Tenant/10/Table/10{7-8}                   range default
-/Tenant/10/Table/11{2-3}                   range default
-/Tenant/10/Table/11{3-4}                   range default
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
+/Tenant/10/Table/11{2-3}                   rangefeed_enabled=true
+/Tenant/10/Table/11{3-4}                   rangefeed_enabled=true
 /Tenant/11{-\x00}                          database system (tenant)
 /Tenant/12{-\x00}                          database system (tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
@@ -134,8 +134,8 @@ CREATE TABLE db.t2();
 
 mutations tenant=10
 ----
-upsert /Tenant/10/Table/10{6-7}            range default
-upsert /Tenant/10/Table/10{7-8}            range default
+upsert /Tenant/10/Table/10{6-7}            rangefeed_enabled=true
+upsert /Tenant/10/Table/10{7-8}            rangefeed_enabled=true
 
 # Write a protected timestamp record on the cluster as a secondary tenant.
 protect record-id=3 ts=3 cluster tenant=10

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
@@ -172,8 +172,8 @@ CREATE TABLE db.t2();
 
 mutations tenant=10
 ----
-upsert /Tenant/10/Table/10{6-7}            range default
-upsert /Tenant/10/Table/10{7-8}            range default
+upsert /Tenant/10/Table/10{6-7}            rangefeed_enabled=true
+upsert /Tenant/10/Table/10{7-8}            rangefeed_enabled=true
 
 # Start the reconciliation loop for the tenant=11. It should have a modified
 # RANGE DEFAULT. Check against the underlying KV state, the SQL view of the
@@ -229,8 +229,8 @@ state offset=81
 /Tenant/10/Table/6{4-5}                    database system (tenant)
 /Tenant/10/Table/6{5-6}                    database system (tenant)
 /Tenant/10/Table/6{6-7}                    database system (tenant)
-/Tenant/10/Table/10{6-7}                   range default
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 /Tenant/11{-/Table/4}                      ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
 /Tenant/11/Table/{4-5}                     ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
 /Tenant/11/Table/{5-6}                     ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
@@ -308,5 +308,5 @@ CREATE TABLE db.t2();
 
 mutations tenant=11
 ----
-upsert /Tenant/11/Table/10{6-7}            ttl_seconds=18000
-upsert /Tenant/11/Table/10{7-8}            ttl_seconds=18000
+upsert /Tenant/11/Table/10{6-7}            ttl_seconds=18000 rangefeed_enabled=true
+upsert /Tenant/11/Table/10{7-8}            ttl_seconds=18000 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/databases
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/databases
@@ -22,8 +22,8 @@ SELECT id FROM system.namespace WHERE name='t2'
 # We expect there to be span config entries for tables t1 and t2.
 translate  database=db
 ----
-/Tenant/10/Table/10{6-7}                   range default
-/Tenant/10/Table/11{0-1}                   range default
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true
+/Tenant/10/Table/11{0-1}                   rangefeed_enabled=true
 
 # Alter zone config fields on the database and one of the tables to ensure
 # things are cascading.
@@ -34,15 +34,15 @@ ALTER TABLE db.t1 CONFIGURE ZONE USING num_voters=5;
 
 translate  database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
-/Tenant/10/Table/11{0-1}                   num_replicas=7
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/11{0-1}                   num_replicas=7 rangefeed_enabled=true
 
 # Translating the tables in the database individually should result in the same
 # config as above.
 translate  database=db table=t1
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true
 
 translate  database=db table=t2
 ----
-/Tenant/10/Table/11{0-1}                   num_replicas=7
+/Tenant/10/Table/11{0-1}                   num_replicas=7 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/exclude_data_from_backup
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/exclude_data_from_backup
@@ -17,8 +17,8 @@ SELECT id FROM system.namespace WHERE name='t2'
 # We only expect there to be span config entries for tables t1 and t2.
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   range default
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 # Alter table t1 to mark its data ephemeral.
 exec-sql
@@ -27,19 +27,19 @@ ALTER TABLE db.t1 SET (exclude_data_from_backup = true)
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   exclude_data_from_backup=true
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true exclude_data_from_backup=true
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 # Translating the tables in the database individually should result in the same
 # config as above.
 
 translate database=db table=t1
 ----
-/Tenant/10/Table/10{6-7}                   exclude_data_from_backup=true
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true exclude_data_from_backup=true
 
 translate database=db table=t2
 ----
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 
 # Write a protection record as a "backup" to test the translation of the
@@ -57,8 +57,8 @@ descs 104
 # `ignore_if_excluded_from_backup` for the record written by the backup only.
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}] exclude_data_from_backup=true
-/Tenant/10/Table/10{7-8}                   protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}]
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}] exclude_data_from_backup=true
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}]
 
 # Alter table t1 to unmark its data ephemeral.
 exec-sql
@@ -67,5 +67,5 @@ ALTER TABLE db.t1 SET (exclude_data_from_backup = false);
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}]
-/Tenant/10/Table/10{7-8}                   protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}]
+/Tenant/10/Table/10{6-7}                   rangefeed_enabled=true protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}]
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true protection_policies=[{ts: 1,ignore_if_excluded_from_backup: true} {ts: 2}]

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/full_translate
@@ -73,9 +73,9 @@ full-translate
 /Tenant/10/Table/6{4-5}                    database system (tenant)
 /Tenant/10/Table/6{5-6}                    database system (tenant)
 /Tenant/10/Table/6{6-7}                    database system (tenant)
-/Tenant/10/Table/11{0-1}                   range default
-/Tenant/10/Table/11{1-2}                   range default
-/Tenant/10/Table/11{2-3}                   range default
+/Tenant/10/Table/11{0-1}                   rangefeed_enabled=true
+/Tenant/10/Table/11{1-2}                   rangefeed_enabled=true
+/Tenant/10/Table/11{2-3}                   rangefeed_enabled=true
 
 # We should expect the same for RANGE DEFAULT.
 translate named-zone=default
@@ -136,6 +136,6 @@ translate named-zone=default
 /Tenant/10/Table/6{4-5}                    database system (tenant)
 /Tenant/10/Table/6{5-6}                    database system (tenant)
 /Tenant/10/Table/6{6-7}                    database system (tenant)
-/Tenant/10/Table/11{0-1}                   range default
-/Tenant/10/Table/11{1-2}                   range default
-/Tenant/10/Table/11{2-3}                   range default
+/Tenant/10/Table/11{0-1}                   rangefeed_enabled=true
+/Tenant/10/Table/11{1-2}                   rangefeed_enabled=true
+/Tenant/10/Table/11{2-3}                   rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
@@ -51,9 +51,9 @@ INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 #               the same as the table's config.
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  num_replicas=7
-/Tenant/10/Table/106/{2-3}                 num_replicas=7 num_voters=5
-/Tenant/10/Table/10{6/3-7}                 num_replicas=7
+/Tenant/10/Table/106{-/2}                  num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{2-3}                 num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/10{6/3-7}                 num_replicas=7 rangefeed_enabled=true
 
 # Configure GC ttl on the database and override it for the index. The table
 # continues to hold a placeholder zone config.
@@ -64,9 +64,9 @@ ALTER INDEX db.t@idx CONFIGURE ZONE USING gc.ttlseconds = 25
 
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/10{6/3-7}                 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{2-3}                 ttl_seconds=25 num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/10{6/3-7}                 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
 
 # Configure a zone config field on the table, so that it is no longer a
 # placeholder zone config.
@@ -89,9 +89,9 @@ INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/10{6/3-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/10{6/3-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
 
 block-gc-jobs
 ----
@@ -105,12 +105,12 @@ ALTER INDEX db.t@idx2 CONFIGURE ZONE USING gc.ttlseconds = 1;
 # Both the newly added index and the temporary index have the configured zone configuration.
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
-/Tenant/10/Table/106/{5-6}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
-/Tenant/10/Table/10{6/6-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{5-6}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/10{6/6-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
 
 unblock-gc-jobs
 ----
@@ -122,11 +122,11 @@ SHOW JOBS WHEN COMPLETE (SELECT job_id FROM [SHOW JOBS])
 # The zone configuration for the temporary index is cleaned up
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
-/Tenant/10/Table/10{6/5-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/10{6/5-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true
 
 # Create and drop an index inside the same transaction. The related
 # zone configuration should also be cleaned up.
@@ -139,4 +139,4 @@ DROP INDEX db.t2@idx
 
 translate database=db table=t2
 ----
-/Tenant/10/Table/10{7-8}                   ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/10{7-8}                   ttl_seconds=3600 num_replicas=7 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/misc
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/misc
@@ -10,8 +10,8 @@ ALTER TABLE db.t1 CONFIGURE ZONE USING gc.ttlseconds=1;
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   ttl_seconds=1
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{6-7}                   ttl_seconds=1 rangefeed_enabled=true
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 # Drop the table.
 exec-sql
@@ -21,7 +21,7 @@ DROP TABLE db.t1;
 # We should no longer see the dropped table's spans.
 translate database=db
 ----
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 # Same as above, except this time the translation starts from the table's ID.
 translate id=56
@@ -41,7 +41,7 @@ mark-database-offline database=db
 
 translate database=db
 ----
-/Tenant/10/Table/10{7-8}                   ttl_seconds=10
+/Tenant/10/Table/10{7-8}                   ttl_seconds=10 rangefeed_enabled=true
 
 # Delete the bespoke zone config on db. t2 should fallback to the RANGE DEFAULT
 # zone config even though all descriptors are offline.
@@ -51,11 +51,11 @@ DELETE FROM system.zones WHERE id = 104;
 
 translate database=db
 ----
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 translate database=db table=t2
 ----
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{7-8}                   rangefeed_enabled=true
 
 mark-database-public database=db
 ----
@@ -73,11 +73,11 @@ mark-table-offline database=db table=t2
 # database.
 translate database=db table=t2
 ----
-/Tenant/10/Table/10{7-8}                   ttl_seconds=11
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11 rangefeed_enabled=true
 
 translate database=db
 ----
-/Tenant/10/Table/10{7-8}                   ttl_seconds=11
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11 rangefeed_enabled=true
 
 # Mark the table as public again.
 mark-table-public database=db table=t2
@@ -85,7 +85,7 @@ mark-table-public database=db table=t2
 
 translate database=db table=t2
 ----
-/Tenant/10/Table/10{7-8}                   ttl_seconds=11
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11 rangefeed_enabled=true
 
 subtest end
 
@@ -97,7 +97,7 @@ CREATE TYPE db.typ AS ENUM();
 
 translate database=db
 ----
-/Tenant/10/Table/10{7-8}                   ttl_seconds=11
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11 rangefeed_enabled=true
 
 # Test that non-existent IDs do not generate span configurations either.
 translate id=500

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/partitions_primary_index
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/partitions_primary_index
@@ -55,7 +55,7 @@ TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
 # there is just one entry here which covers the entire table's span.
 translate database=db table=t
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true
 
 
 exec-sql
@@ -68,10 +68,10 @@ ALTER PARTITION one_two OF TABLE db.t CONFIGURE ZONE USING global_reads=true
 # have the table's zone configuration.
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/1/1}                num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 num_voters=5
-/Tenant/10/Table/10{6/1/3-7}               num_replicas=7 num_voters=5
+/Tenant/10/Table/106{-/1/1}                num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/10{6/1/3-7}               num_replicas=7 num_voters=5 rangefeed_enabled=true
 
 # Change two fields on the second partition. One of them (num_voters) is an
 # override on the value set on the database's zone config. The other, gc.ttlseconds,
@@ -85,12 +85,12 @@ ALTER PARTITION three_four OF TABLE db.t CONFIGURE ZONE USING num_voters=3
 # have the correct values of gc.ttlseconds (5) and num_voters (3).
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/1/1}                num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{3-4}               ttl_seconds=5 num_replicas=7 num_voters=3
-/Tenant/10/Table/106/1/{4-5}               ttl_seconds=5 num_replicas=7 num_voters=3
-/Tenant/10/Table/10{6/1/5-7}               num_replicas=7 num_voters=5
+/Tenant/10/Table/106{-/1/1}                num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{3-4}               ttl_seconds=5 num_replicas=7 num_voters=3 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{4-5}               ttl_seconds=5 num_replicas=7 num_voters=3 rangefeed_enabled=true
+/Tenant/10/Table/10{6/1/5-7}               num_replicas=7 num_voters=5 rangefeed_enabled=true
 
 exec-sql
 ALTER PARTITION default OF TABLE db.t CONFIGURE ZONE USING num_voters=6
@@ -107,14 +107,14 @@ ALTER PARTITION default OF TABLE db.t CONFIGURE ZONE USING num_voters=6
 # set to 6, as that's what we did above.
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/1}                  num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1{-/1}                num_replicas=7 num_voters=6
-/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 num_voters=5
-/Tenant/10/Table/106/1/{3-4}               ttl_seconds=5 num_replicas=7 num_voters=3
-/Tenant/10/Table/106/1/{4-5}               ttl_seconds=5 num_replicas=7 num_voters=3
-/Tenant/10/Table/106/{1/5-2}               num_replicas=7 num_voters=6
-/Tenant/10/Table/10{6/2-7}                 num_replicas=7 num_voters=5
+/Tenant/10/Table/106{-/1}                  num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1{-/1}                num_replicas=7 num_voters=6 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{3-4}               ttl_seconds=5 num_replicas=7 num_voters=3 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{4-5}               ttl_seconds=5 num_replicas=7 num_voters=3 rangefeed_enabled=true
+/Tenant/10/Table/106/{1/5-2}               num_replicas=7 num_voters=6 rangefeed_enabled=true
+/Tenant/10/Table/10{6/2-7}                 num_replicas=7 num_voters=5 rangefeed_enabled=true
 
 # Discard the table's zone configuration. This essentially means that the table
 # has a "placeholder" zone config (to capture partition subzone configs).
@@ -128,11 +128,11 @@ ALTER TABLE db.t CONFIGURE ZONE DISCARD
 # table above (which is where num_voters=5 was coming from).
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/1}                  num_replicas=7
-/Tenant/10/Table/106/1{-/1}                num_replicas=7 num_voters=6
-/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7
-/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7
-/Tenant/10/Table/106/1/{3-4}               ttl_seconds=5 num_replicas=7 num_voters=3
-/Tenant/10/Table/106/1/{4-5}               ttl_seconds=5 num_replicas=7 num_voters=3
-/Tenant/10/Table/106/{1/5-2}               num_replicas=7 num_voters=6
-/Tenant/10/Table/10{6/2-7}                 num_replicas=7
+/Tenant/10/Table/106{-/1}                  num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/1{-/1}                num_replicas=7 num_voters=6 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{1-2}               global_reads=true num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{2-3}               global_reads=true num_replicas=7 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{3-4}               ttl_seconds=5 num_replicas=7 num_voters=3 rangefeed_enabled=true
+/Tenant/10/Table/106/1/{4-5}               ttl_seconds=5 num_replicas=7 num_voters=3 rangefeed_enabled=true
+/Tenant/10/Table/106/{1/5-2}               num_replicas=7 num_voters=6 rangefeed_enabled=true
+/Tenant/10/Table/10{6/2-7}                 num_replicas=7 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
@@ -31,8 +31,8 @@ descs 104
 # We should still see the protectedts translate onto the offline db.
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 protection_policies=[{ts: 9}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7 protection_policies=[{ts: 9}]
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 9}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true protection_policies=[{ts: 9}]
 
 release record-id=9
 ----
@@ -42,8 +42,8 @@ mark-database-public database=db
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true
 
 # Write a protected timestamp on t1.
 protect record-id=1 ts=1
@@ -52,8 +52,8 @@ descs 106
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 protection_policies=[{ts: 1}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 1}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true
 
 # Write a protected timestamp on db, so we should see it on both t1 and t2.
 protect record-id=2 ts=2
@@ -62,8 +62,8 @@ descs 104
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 protection_policies=[{ts: 1} {ts: 2}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7 protection_policies=[{ts: 2}]
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 1} {ts: 2}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true protection_policies=[{ts: 2}]
 
 
 # Write a protected timestamp on the tenant cluster.
@@ -82,8 +82,8 @@ translate system-span-configurations
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 protection_policies=[{ts: 1} {ts: 2}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7 protection_policies=[{ts: 2}]
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 1} {ts: 2}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true protection_policies=[{ts: 2}]
 
 # Release the protected timestamp on table t1
 release record-id=1
@@ -95,8 +95,8 @@ translate system-span-configurations
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 protection_policies=[{ts: 2}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7 protection_policies=[{ts: 2}]
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 2}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true protection_policies=[{ts: 2}]
 
 # Release the protected timestamp on database db
 release record-id=2
@@ -108,8 +108,8 @@ translate system-span-configurations
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 rangefeed_enabled=true
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true
 
 # Create an index on t1 to ensure that subzones also see protected timestamps.
 exec-sql
@@ -140,7 +140,7 @@ translate system-span-configurations
 
 translate database=db
 ----
-/Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-/Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-/Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 protection_policies=[{ts: 5}]
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+/Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 5}]
+/Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 5}]
+/Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 rangefeed_enabled=true protection_policies=[{ts: 5}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 rangefeed_enabled=true

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -337,6 +337,9 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 		// We exclude system tables from strict GC enforcement, it's only really
 		// applicable to user tables.
 		tableSpanConfig.GCPolicy.IgnoreStrictEnforcement = true
+	} else if !s.codec.ForSystemTenant() {
+		// Enable rangefeed on non-system spans of a secondary tenant.
+		tableSpanConfig.RangefeedEnabled = true
 	}
 
 	// Set the ProtectionPolicies on the table's SpanConfig to include protected
@@ -448,6 +451,9 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 		if isSystemDesc { // same as above
 			subzoneSpanConfig.RangefeedEnabled = true
 			subzoneSpanConfig.GCPolicy.IgnoreStrictEnforcement = true
+		} else if !s.codec.ForSystemTenant() {
+			// Enable rangefeed on non-system spans of a secondary tenant.
+			subzoneSpanConfig.RangefeedEnabled = true
 		}
 		record, err := spanconfig.MakeRecord(
 			spanconfig.MakeTargetFromSpan(roachpb.Span{Key: span.Key, EndKey: span.EndKey}), subzoneSpanConfig)


### PR DESCRIPTION
Rangefeed was not enabled for all non-system spans of a secondary tenant. This commit fixes that.

Epic: none

Fixes: #124445

Release note: None