### PR TITLE
sql: statement_timeout should also cancel synchronous rollback

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -688,6 +688,9 @@ func (ex *connExecutor) execStmtInOpenState(
 			timerDuration,
 			func() {
 				cancelQuery()
+				// Also cancel the transactions context, so that there is no danger
+				// getting stuck rolling back.
+				ex.state.txnCancelFn()
 				queryTimedOut = true
 				queryDoneAfterFunc <- struct{}{}
 			})
@@ -850,6 +853,10 @@ func (ex *connExecutor) execStmtInOpenState(
 				resToPushErr.SetError(errToPush)
 				retPayload = eventNonRetriableErrPayload{err: errToPush}
 				resErr = errToPush
+				// Cancel the txn if we are inside an implicit txn too.
+				if ex.implicitTxn() && ex.state.txnCancelFn != nil {
+					ex.state.txnCancelFn()
+				}
 			}
 		})
 

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -785,6 +785,85 @@ func TestRetriableErrorDuringPrepare(t *testing.T) {
 	defer func() { _ = stmt.Close() }()
 }
 
+// TestStatementCancelRollback confirms that rollbacks because of statement
+// timeouts are *always* asynchronous.
+func TestStatementCancelRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t)
+
+	for _, useStatementTimeout := range []bool{true, false} {
+		t.Run(fmt.Sprintf("Cancel with statement timeout=%t", useStatementTimeout),
+			func(t *testing.T) {
+				hookEnabled := atomic.Bool{}
+				rollbackCompleted := make(chan struct{})
+				rollbackExpected := make(chan struct{})
+				var codec keys.SQLCodec
+				var queryCtx context.Context
+				var cancelFn context.CancelFunc
+				if useStatementTimeout {
+					queryCtx, cancelFn = context.WithCancel(ctx)
+				} else {
+					queryCtx, cancelFn = context.WithTimeout(ctx, 1*time.Second)
+				}
+				defer cancelFn()
+				s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+					Knobs: base.TestingKnobs{
+						Store: &kvserver.StoreTestingKnobs{
+							TestingRequestFilter: func(ctx context.Context, request *kvpb.BatchRequest) *kvpb.Error {
+								// Once the hook is enabled we are expecting a txn rollback involving
+								// the system.descriptor key, because the first tihng accessed by the
+								// txn below is the descriptor table.
+								if hookEnabled.Load() {
+									if request.IsSingleEndTxnRequest() {
+										if !request.Requests[0].GetEndTxn().Commit {
+											_, tblID, err := codec.DecodeTablePrefix(request.Header.Txn.TxnMeta.Key)
+											if err != nil {
+												return nil
+											}
+											if tblID == keys.DescriptorTableID {
+												// This channel will only be closed once the "synchronous" rollback returns.
+												<-rollbackExpected
+												close(rollbackCompleted)
+												hookEnabled.Swap(false)
+											}
+										}
+									}
+								}
+								return nil
+							},
+						},
+					},
+				})
+				codec = s.ApplicationLayer().Codec()
+				defer s.Stopper().Stop(context.Background())
+				conn, err := sqlDB.Conn(context.Background())
+				require.NoError(t, err)
+
+				hookEnabled.Swap(true)
+				if useStatementTimeout {
+					_, err = conn.ExecContext(queryCtx, "SET statement_timeout='1s'")
+					require.NoError(t, err)
+				}
+				_, err = conn.ExecContext(queryCtx, "CREATE TABLE t1(n int);SELECT * FROM pg_sleep(5)")
+				expectedError := "query execution canceled due to statement timeout"
+				if !useStatementTimeout {
+					expectedError = "pq: query execution canceled"
+				}
+				require.ErrorContains(t,
+					err,
+					expectedError,
+					"expected timeout error")
+				// Because the rollback is asynchronous due to the timeout, we expected
+				// to just return here. Any rollbacks involving the descriptor key above are
+				// *blocked*.
+				close(rollbackExpected)
+				// Confirm the async rollback happened.
+				<-rollbackCompleted
+			})
+	}
+}
+
 // TestRetriableErrorDuringUpgradedTransaction ensures that a retriable error
 // that happens during a transaction that was upgraded from an implicit
 // transaction into an explicit transaction does not cause the BEGIN to be

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -94,6 +94,10 @@ type txnState struct {
 	// tracing. This context is hijacked when session tracing is enabled.
 	Ctx context.Context
 
+	// txnCancelFn is a function that can be used to cancel the current
+	// txn context.
+	txnCancelFn context.CancelFunc
+
 	// recordingThreshold, is not zero, indicates that sp is recording and that
 	// the recording should be dumped to the log if execution of the transaction
 	// took more than this.
@@ -204,17 +208,18 @@ func (ts *txnState) resetForNewSQLTxn(
 	// (automatic or user-directed) retries. The span is closed by finishSQLTxn().
 	opName := sqlTxnName
 	alreadyRecording := tranCtx.sessionTracing.Enabled()
-
+	ctx, cancelFn := context.WithCancel(connCtx)
 	var sp *tracing.Span
 	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
 	if alreadyRecording || duration > 0 {
-		ts.Ctx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName,
+		ts.Ctx, sp = tracing.EnsureChildSpan(ctx, tranCtx.tracer, opName,
 			tracing.WithRecording(tracingpb.RecordingVerbose))
 	} else if ts.testingForceRealTracingSpans {
-		ts.Ctx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName, tracing.WithForceRealSpan())
+		ts.Ctx, sp = tracing.EnsureChildSpan(ctx, tranCtx.tracer, opName, tracing.WithForceRealSpan())
 	} else {
-		ts.Ctx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName)
+		ts.Ctx, sp = tracing.EnsureChildSpan(ctx, tranCtx.tracer, opName)
 	}
+	ts.txnCancelFn = cancelFn
 	if txnType == implicitTxn {
 		sp.SetTag("implicit", attribute.StringValue("true"))
 	}
@@ -292,6 +297,9 @@ func (ts *txnState) finishSQLTxn() (txnID uuid.UUID, commitTimestamp hlc.Timesta
 	}
 
 	sp.Finish()
+	if ts.txnCancelFn != nil {
+		ts.txnCancelFn()
+	}
 	ts.Ctx = nil
 	ts.recordingThreshold = 0
 	return func() (txnID uuid.UUID, timestamp hlc.Timestamp) {
@@ -326,6 +334,9 @@ func (ts *txnState) finishExternalTxn() {
 		if sp := tracing.SpanFromContext(ts.Ctx); sp != nil {
 			sp.Finish()
 		}
+	}
+	if ts.txnCancelFn != nil {
+		ts.txnCancelFn()
 	}
 	ts.Ctx = nil
 	ts.mu.Lock()


### PR DESCRIPTION
Previously, when a statement_timeout was hit in an implicit transaction, we would end up waiting for the rollback to complete, which could on its own take a fairly long time. To address this, this patch also cancels the transactions context when a rollback due to a statement timeout occurs in implicit transactions.

Fixes: #124987

Release note: None