### PR TITLE
release-23.1: sql/schemachanger: fix bugs with the STORING() clause of CREATE INDEX.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -437,3 +437,41 @@ CREATE INDEX ON v (b);
 statement ok
 CREATE INDEX ON v ((b>0));
 
+# Repro of issue found in #124511 when using the declarative schema changer.
+# Using utf8 character in column name that is included in STORED() clause is not
+# being seen as a duplicate of an existing index.
+subtest create_index_with_utf8_col_names
+
+statement ok
+CREATE TABLE tab_w0_7 (
+   "col\u000b7ͪ%q_w0_10" UUID,
+   c2 STRING,
+   PRIMARY KEY(c2, "col\u000b7ͪ%q_w0_10")
+);
+
+statement error index ".*" already contains column ".*".*
+CREATE INDEX tab_w0_7_i1 on tab_w0_7 (c2) STORING ("col\u000b7ͪ%q_w0_10");
+
+statement error index ".*" already contains column ".*".*
+CREATE INDEX tab_w0_7_i1 on tab_w0_7 ("col\u000b7ͪ%q_w0_10") STORING ("col\u000b7ͪ%q_w0_10");
+
+statement ok
+DROP TABLE tab_w0_7;
+
+# Repro of issue found in #124511 when using the declarative schema changer. We
+# need to block when attempting to include a virtual column in a STORED()
+# clause.
+subtest create_index_with_stored_virtual_col
+
+statement ok
+CREATE TABLE tab1 (
+  c1 UUID PRIMARY KEY,
+  c2 UUID AS (c1) VIRTUAL,
+  c3 STRING
+);
+
+statement error index cannot store virtual column c2
+CREATE INDEX tab1_i1 ON tab1 (c3) STORING (c2);
+
+statement ok
+DROP TABLE tab1;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -260,12 +260,21 @@ func newUndefinedOpclassError(opclass tree.Name) error {
 
 // checkColumnAccessibilityForIndex validate that any columns that are explicitly referenced in a column for storage or
 // as a key are either accessible and not system columns.
-func checkColumnAccessibilityForIndex(colName string, column *scpb.Column, store bool) {
+func checkColumnAccessibilityForIndex(
+	colName string, column *scpb.Column, columnType *scpb.ColumnType, store bool,
+) {
 	if column.IsInaccessible {
 		panic(pgerror.Newf(
 			pgcode.UndefinedColumn,
 			"column %q is inaccessible and cannot be referenced",
 			colName))
+	}
+
+	if columnType.IsVirtual && store {
+		panic(pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"index cannot store virtual column %v", colName,
+		))
 	}
 
 	if column.IsSystemColumn {
@@ -543,7 +552,7 @@ func addColumnsForSecondaryIndex(
 		}
 	}
 	for _, storingNode := range n.Storing {
-		colName := storingNode.String()
+		colName := storingNode.Normalize()
 		if _, found := columnRefs[colName]; found {
 			panic(pgerror.Newf(pgcode.InvalidObjectDefinition,
 				"index %q already contains column %q", n.Name, colName))
@@ -573,7 +582,7 @@ func addColumnsForSecondaryIndex(
 		columnElem := mustRetrieveColumnElem(b, tableID, colID)
 		// Column should be accessible.
 		if columnNode.Expr == nil {
-			checkColumnAccessibilityForIndex(string(colName), columnElem, false)
+			checkColumnAccessibilityForIndex(string(colName), columnElem, columnTypeElem, false)
 		}
 		keyColNames[i] = string(colName)
 		idxSpec.columns = append(idxSpec.columns, &scpb.IndexColumn{
@@ -605,8 +614,10 @@ func addColumnsForSecondaryIndex(
 		// earlier so this covers any extra columns.
 		columnName := mustRetrieveColumnNameElem(b, e.TableID, e.ColumnID)
 		if _, found := columnRefs[columnName.Name]; found {
-			panic(pgerror.Newf(pgcode.InvalidObjectDefinition,
-				"index %q already contains column %q", n.Name, columnName.Name))
+			panic(errors.WithDetailf(
+				pgerror.Newf(pgcode.InvalidObjectDefinition,
+					"index %q already contains column %q", n.Name, columnName.Name),
+				"column %q is part of the primary index and therefore implicit in all indexes", columnName.Name))
 		}
 		columnRefs[columnName.Name] = struct{}{}
 		keySuffixColumns = append(keySuffixColumns, e)
@@ -633,7 +644,8 @@ func addColumnsForSecondaryIndex(
 			RequiredPrivilege: privilege.CREATE,
 		})
 		_, _, column := scpb.FindColumn(colElts)
-		checkColumnAccessibilityForIndex(storingNode.String(), column, true)
+		columnTypeElem := mustRetrieveColumnTypeElem(b, tableID, column.ColumnID)
+		checkColumnAccessibilityForIndex(storingNode.String(), column, columnTypeElem, true)
 		c := &scpb.IndexColumn{
 			TableID:       idxSpec.secondary.TableID,
 			IndexID:       idxSpec.secondary.IndexID,


### PR DESCRIPTION
Backport 1/1 commits from #124981.

/cc @cockroachdb/release

Release justifcation: low risk bug fix

---

Issue #124511 uncovered two problems with the Declarative Schema Changer (DSC):

1. If a column name contains a UTF-8 character and is included in the STORING() clause, the DSC cannot detect that it duplicates the primary key.
2. If a virtual column is included in the STORING() clause, the DSC does not catch this upfront, unlike the legacy schema changer, leading to an internal error.

The first problem occurs because we build the list of columns referenced in an index by their names. These names are normalized to handle UTF-8 encoding. However, when checking if a storing column is already referenced, we weren't using the normalized version of the string, resulting in a mismatch.

The second problem arises from inadequate checks to detect if a virtual column is included in the STORING() clause. Adding a check for this resolves the issue.

Fixes #124511
Fixes https://github.com/cockroachdb/cockroach/issues/124515
Release note (bug fix): fixed handling in the DSC when columns are included in the STORING() clause of CREATE INDEX. We now check if the column is virtual up front, and properly detect when a column is already handled by an existing index when the column name has UTF-8 characters.
