### PR TITLE
tenantcostclient: convert tenant cost client to use token terminology

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -21,8 +20,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// TestLimiterNotify tests that low RU notifications are sent at the expected
-// times.
+// TestLimiterNotify tests that low tokens notifications are sent at the
+// expected times.
 func TestLimiterNotify(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -73,18 +72,18 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	lim.Reconfigure(ts.Now(), args)
 	checkNoNotification()
-	check("30.00 RU filling @ 10.00 RU/s")
+	check("30.00 tokens filling @ 10.00 tokens/s")
 
-	lim.RemoveRU(ts.Now(), 20)
+	lim.RemoveTokens(ts.Now(), 20)
 	// No notification: we did not go below the threshold.
 	checkNoNotification()
 	// Now we should get a notification.
-	lim.RemoveRU(ts.Now(), 8)
+	lim.RemoveTokens(ts.Now(), 8)
 	checkNotification()
-	check("2.00 RU filling @ 10.00 RU/s")
+	check("2.00 tokens filling @ 10.00 tokens/s")
 
 	// We only get one notification (until we Reconfigure or StartNotification).
-	lim.RemoveRU(ts.Now(), 1)
+	lim.RemoveTokens(ts.Now(), 1)
 	checkNoNotification()
 
 	// Reconfigure without enough tokens to meet the threshold and ensure we get
@@ -95,7 +94,7 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	lim.Reconfigure(ts.Now(), args)
 	checkNotification()
-	check("2.00 RU filling @ 0.00 RU/s")
+	check("2.00 tokens filling @ 0.00 tokens/s")
 
 	// Reconfigure with enough tokens to exceed threshold and ensure there is no
 	// notification.
@@ -105,7 +104,7 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	lim.Reconfigure(ts.Now(), args)
 	checkNoNotification()
-	check("82.00 RU filling @ 1.00 RU/s")
+	check("82.00 tokens filling @ 1.00 tokens/s")
 
 	// Call SetupNotification with a high threshold and ensure notification.
 	lim.SetupNotification(ts.Now(), 83)
@@ -123,10 +122,10 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	lim.Reconfigure(ts.Now(), args)
 	checkNoNotification()
-	check("105.00 RU filling @ 10.00 RU/s")
+	check("105.00 tokens filling @ 10.00 tokens/s")
 
 	// Try a fulfilled Acquire that doesn't drop below threshold.
-	fulfill := func(amount tenantcostmodel.RU) {
+	fulfill := func(amount float64) {
 		t.Helper()
 		req := &waitRequest{needed: amount}
 		if ok, _ := req.Acquire(ctx, &lim); !ok {
@@ -136,18 +135,18 @@ func TestLimiterNotify(t *testing.T) {
 
 	fulfill(10)
 	checkNoNotification()
-	check("95.00 RU filling @ 10.00 RU/s")
+	check("95.00 tokens filling @ 10.00 tokens/s")
 
 	// Try a fulfilled Acquire that does drop below the threshold.
 	fulfill(60)
 	checkNotification()
-	check("35.00 RU filling @ 10.00 RU/s")
+	check("35.00 tokens filling @ 10.00 tokens/s")
 
 	// Refill bucket.
 	ts.Advance(5 * time.Second)
 	fulfill(0)
 	checkNoNotification()
-	check("85.00 RU filling @ 10.00 RU/s")
+	check("85.00 tokens filling @ 10.00 tokens/s")
 	lim.SetupNotification(ts.Now(), 5)
 
 	// Fail to fulfill a request and expect a notification.
@@ -156,9 +155,9 @@ func TestLimiterNotify(t *testing.T) {
 		t.Fatalf("fulfilled incorrectly")
 	}
 	checkNotification()
-	check("85.00 RU filling @ 10.00 RU/s (100.00 waiting RU)")
+	check("85.00 tokens filling @ 10.00 tokens/s (100.00 waiting tokens)")
 
-	// Add enough RU to fulfill the waiting request and trigger a notification.
+	// Add enough tokens to fulfill the waiting request and trigger a notification.
 	args = limiterReconfigureArgs{
 		NewTokens:       15,
 		NotifyThreshold: 5,
@@ -168,7 +167,7 @@ func TestLimiterNotify(t *testing.T) {
 		t.Fatalf("failed to fulfill")
 	}
 	checkNotification()
-	check("0.00 RU filling @ 0.00 RU/s")
+	check("0.00 tokens filling @ 0.00 tokens/s")
 
 	// Ensure that MaxTokens is enforced.
 	args = limiterReconfigureArgs{
@@ -177,7 +176,7 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	lim.Reconfigure(ts.Now(), args)
 	checkNoNotification()
-	check("50.00 RU filling @ 0.00 RU/s (limited to 50.00 RU)")
+	check("50.00 tokens filling @ 0.00 tokens/s (limited to 50.00 tokens)")
 }
 
 // TestLimiterMetrics tests that limiter metrics are updated.

--- a/pkg/ccl/multitenantccl/tenantcostclient/test_utils.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/test_utils.go
@@ -28,9 +28,9 @@ const (
 	// tick.
 	TickProcessed
 
-	// LowRUNotification indicates that the main loop handled a "low RU"
+	// LowTokensNotification indicates that the main loop handled a "low RU"
 	// notification from the token bucket.
-	LowRUNotification
+	LowTokensNotification
 
 	// TokenBucketResponseProcessed indicates that we have processed a
 	// (successful) request to the global token bucket.

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/debt
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/debt
@@ -1,11 +1,12 @@
 # Test token bucket that has gone into debt.
 
-# Set up throttling at 1000 RU/s.
+# Set up throttling at 1000 tokens/s.
 configure
 throttle: 1000
 ----
 
-# Issue 2K RU write that triggers fetch of more RU and also sets throttle rate.
+# Issue 2K RU write that triggers fetch of more tokens and also sets throttle
+# rate.
 write bytes=2045952
 ----
 
@@ -15,7 +16,7 @@ token-bucket-response
 
 token-bucket
 ----
-3000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+3000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Consume 5K RUs that causes bucket to go into debt.
 cpu
@@ -29,7 +30,7 @@ advance wait=true
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (996.67 waiting debt @ 498.33 RU/s)
+0.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (996.67 waiting debt @ 498.33 tokens/s)
 
 # Verify that a small write doesn't have to wait a second for the entire debt
 # to be paid.
@@ -51,9 +52,9 @@ await label=w1
 
 token-bucket
 ----
-47.17 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (946.83 waiting debt @ 498.33 RU/s)
+47.17 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (946.83 waiting debt @ 498.33 tokens/s)
 
-# Consume enough RUs that the debt cannot be paid within debtApplySecs.
+# Consume enough tokens that the debt cannot be paid within debtApplySecs.
 pgwire-egress
 4096000
 ----
@@ -65,7 +66,7 @@ advance wait=true
 
 token-bucket
 ----
--1399.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (2000.00 waiting debt @ 1000.00 RU/s)
+-1399.67 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (2000.00 waiting debt @ 1000.00 tokens/s)
 
 # Advance and ensure that waiting debt is reduced.
 advance
@@ -75,7 +76,7 @@ advance
 
 token-bucket
 ----
--1399.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (1600.00 waiting debt @ 1000.00 RU/s)
+-1399.67 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (1600.00 waiting debt @ 1000.00 tokens/s)
 
 advance wait=true
 1s
@@ -84,9 +85,10 @@ advance wait=true
 
 token-bucket
 ----
--1399.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (600.00 waiting debt @ 300.00 RU/s)
+-1399.67 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (600.00 waiting debt @ 300.00 tokens/s)
 
-# Advance again and ensure that both available RUs and waiting debt are reduced.
+# Advance again and ensure that both available tokens and waiting debt are
+# reduced.
 advance wait=true
 1s
 ----
@@ -94,4 +96,4 @@ advance wait=true
 
 token-bucket
 ----
--699.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (300.00 waiting debt @ 150.00 RU/s)
+-699.67 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (300.00 waiting debt @ 150.00 tokens/s)

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/external-io
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/external-io
@@ -1,11 +1,11 @@
 # Test external IO ingress and egress.
 
-# Set up throttling at 1K RU/s.
+# Set up throttling at 1K tokens/s.
 configure
 throttle: 1000
 ----
 
-# Perform external IO egress that triggers fetch of more RU and sets up
+# Perform external IO egress that triggers fetch of more tokens and sets up
 # throttling.
 external-egress bytes=1024000
 ----
@@ -16,7 +16,7 @@ token-bucket-response
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+4000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Perform 1G bytes of external IO ingress, which should not affect RU.
 external-ingress bytes=1024000000000
@@ -24,7 +24,7 @@ external-ingress bytes=1024000000000
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+4000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Block on external IO.
 external-egress bytes=6144000 label=e1
@@ -40,7 +40,7 @@ not-completed label=e1
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (6000.00 waiting RU)
+4000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (6000.00 waiting tokens)
 
 # Fill token bucket with an additional 2K RU, which should unblock the waiting
 # external IO operation.
@@ -54,4 +54,4 @@ await label=e1
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+0.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
@@ -5,7 +5,7 @@ configure
 fallback_rate: 1000
 ----
 
-# Issue a write that triggers fetch of more RU and also sets fallback rate.
+# Issue a write that triggers fetch of more tokens and also sets fallback rate.
 write bytes=6141952
 ----
 
@@ -15,7 +15,7 @@ token-bucket-response
 
 token-bucket
 ----
-15000.00 RU filling @ 0.00 RU/s
+15000.00 tokens filling @ 0.00 tokens/s
 
 # Trigger failure of further requests.
 configure
@@ -28,7 +28,7 @@ write bytes=12285952
 ----
 
 wait-for-event
-low-ru
+low-tokens
 ----
 
 # Expect failure of the token bucket request.
@@ -44,7 +44,7 @@ advance wait=true
 
 token-bucket
 ----
-3000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+3000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Issue another 5K write which must wait until the fallback rate adds 2K to the
 # bucket in order to complete.
@@ -66,7 +66,7 @@ not-completed label=w1
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (5000.00 waiting RU)
+4000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (5000.00 waiting tokens)
 
 # Advance another second and ensure that the write request was completed.
 advance wait=true
@@ -79,7 +79,7 @@ await label=w1
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+0.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 wait-for-event
 token-bucket-response-error

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
@@ -6,22 +6,23 @@ throttle: 100
 fallback_rate: 1000
 ----
 
-# Issue a 3K write that triggers fetch of more RU and also sets fallback rate.
+# Issue a 3K write that triggers fetch of more tokens and also sets fallback
+# rate.
 write bytes=3069952
 ----
 
 wait-for-event
-low-ru
+low-tokens
 ----
 
 wait-for-event
 token-bucket-response
 ----
 
-# Response sets up throttled rate of 100 RU/s.
+# Response sets up throttled rate of 100 tokens/s.
 token-bucket
 ----
-2000.00 RU filling @ 100.00 RU/s (limited to 6000.00 RU)
+2000.00 tokens filling @ 100.00 tokens/s (limited to 6000.00 tokens)
 
 # Force error on next fetch.
 configure
@@ -48,7 +49,7 @@ advance wait=true
 
 token-bucket
 ----
-3100.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+3100.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Advance 1 second and ensure bucket is replenished at fallback rate.
 advance wait=true
@@ -58,7 +59,7 @@ advance wait=true
 
 token-bucket
 ----
-4100.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+4100.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 wait-for-event
 token-bucket-response-error

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
@@ -1,13 +1,13 @@
 # This test verifies the following condition:
-#  - we have a large request blocked, requiring more RU than the "low RU"
-#    notification threshold.
-#  - the bucket has more RUs available than the notification threshold.
+#  - we have a large request blocked, requiring more tokens than the "low
+#    tokens" notification threshold.
+#  - the bucket has more tokens available than the notification threshold.
 
 configure
 throttle: 1000
 ----
 
-# Fire off a write that needs significantly more than the initial RUs.
+# Fire off a write that needs significantly more than the initial tokens.
 write bytes=15357952 label=w1
 ----
 
@@ -16,10 +16,10 @@ timers
 00:00:09.000
 00:00:10.000
 
-# Ensure that low RU notification is sent even though the token bucket still has
-# 10K RUs (waiting RUs need to be taken into account).
+# Ensure that low tokens notification is sent even though the token bucket still
+# has 10K tokens (waiting tokens need to be taken into account).
 wait-for-event
-low-ru
+low-tokens
 ----
 
 wait-for-event
@@ -31,7 +31,7 @@ not-completed label=w1
 
 token-bucket
 ----
-5000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (15000.00 waiting RU)
+5000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (15000.00 waiting tokens)
 
 # Advance time to just short of trickle renewal and trigger tick event.
 advance wait=true
@@ -41,7 +41,7 @@ advance wait=true
 
 token-bucket
 ----
-13750.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (15000.00 waiting RU)
+13750.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (15000.00 waiting tokens)
 
 # Now advance time to trigger trickle renewal (but do not trigger tick in order
 # to avoid a race that makes test non-deterministic).
@@ -61,7 +61,7 @@ timers
 
 token-bucket
 ----
-14000.00 RU filling @ 1100.00 RU/s (limited to 16000.00 RU) (15000.00 waiting RU)
+14000.00 tokens filling @ 1100.00 tokens/s (limited to 16000.00 tokens) (15000.00 waiting tokens)
 
 # One more second to fulfill waiting write.
 advance
@@ -74,10 +74,10 @@ await label=w1
 
 token-bucket
 ----
-100.00 RU filling @ 1100.00 RU/s (limited to 16000.00 RU)
+100.00 tokens filling @ 1100.00 tokens/s (limited to 16000.00 tokens)
 
 # Un-throttle central token bucket and ensure that another large write goes
-# through after requesting more RUs.
+# through after requesting more tokens.
 configure
 ----
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru-race
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru-race
@@ -20,7 +20,7 @@ write bytes=1021952
 ----
 
 wait-for-event
-low-ru
+low-tokens
 ----
 
 # Unblock the in-progress request.
@@ -42,4 +42,4 @@ token-bucket-response
 
 token-bucket
 ----
-10000.00 RU filling @ 0.00 RU/s
+10000.00 tokens filling @ 0.00 tokens/s

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
@@ -1,6 +1,6 @@
 # Throttle at an extremely limited rate.
 
-# Set up throttling at just 1 RU/s.
+# Set up throttling at just 1 tokens/s.
 configure
 throttle: 1
 ----
@@ -15,7 +15,7 @@ token-bucket-response
 
 token-bucket
 ----
-2000.00 RU filling @ 1.00 RU/s (limited to 5010.00 RU)
+2000.00 tokens filling @ 1.00 tokens/s (limited to 5010.00 tokens)
 
 # Issue another 4K RU write that should block.
 write bytes=4093952 label=w1
@@ -39,12 +39,12 @@ not-completed label=w1
 
 token-bucket
 ----
-2008.00 RU filling @ 1.00 RU/s (limited to 5010.00 RU) (4000.00 waiting RU)
+2008.00 tokens filling @ 1.00 tokens/s (limited to 5010.00 tokens) (4000.00 waiting tokens)
 
 # Advance 1 more second, which should trigger a token bucket request to extend
 # the trickle duration. Note that the trickle grant will not have been fully
 # consumed at the time more is requested. The remainder will be rolled into the
-# new trickle grant (i.e. 1.10 RU/s rather than 1.00 RU/s).
+# new trickle grant (i.e. 1.10 tokens/s rather than 1.00 tokens/s).
 advance
 1s
 ----
@@ -56,7 +56,7 @@ token-bucket-response
 
 token-bucket
 ----
-2009.00 RU filling @ 1.10 RU/s (limited to 5011.00 RU) (4000.00 waiting RU)
+2009.00 tokens filling @ 1.10 tokens/s (limited to 5011.00 tokens) (4000.00 waiting tokens)
 
 advance
 1991s

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-tokens
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-tokens
@@ -1,8 +1,8 @@
 # This test verifies that after the server does not fully grant a request, the
-# client will not trigger low RU notifications.
+# client will not trigger low tokens notifications.
 
-# When throttle = -1, the server will refuse to grant any RUs, either directly
-# or via a trickle.
+# When throttle = -1, the server will refuse to grant any tokens, either
+# directly or via a trickle.
 configure
 throttle: -1
 ----
@@ -17,21 +17,21 @@ token-bucket-response
 
 token-bucket
 ----
-4000.00 RU filling @ 0.00 RU/s
+4000.00 tokens filling @ 0.00 tokens/s
 
-# Allow server to grant more RUs.
+# Allow server to grant more tokens.
 configure
 throttle: 0
 ----
 
-# Issue another 1K RU write and expect no low RU notification and therefore no
-# call to the server.
+# Issue another 1K RU write and expect no low tokens notification and therefore
+# no call to the server.
 write bytes=1021952
 ----
 
 token-bucket
 ----
-3000.00 RU filling @ 0.00 RU/s
+3000.00 tokens filling @ 0.00 tokens/s
 
 # Advance time and ensure there's no change to the bucket.
 advance wait=true
@@ -41,4 +41,4 @@ advance wait=true
 
 token-bucket
 ----
-3000.00 RU filling @ 0.00 RU/s
+3000.00 tokens filling @ 0.00 tokens/s

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/no-tokens
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/no-tokens
@@ -1,7 +1,7 @@
-# Test case when provider is completely out of RUs.
+# Test case when provider is completely out of tokens.
 
-# When throttle = -1, the provider will refuse to grant any RUs, either directly
-# or via a trickle.
+# When throttle = -1, the provider will refuse to grant any tokens, either
+# directly or via a trickle.
 configure
 throttle: -1
 ----
@@ -19,7 +19,7 @@ await label=w1
 
 token-bucket
 ----
-0.00 RU filling @ 0.00 RU/s
+0.00 tokens filling @ 0.00 tokens/s
 
 # Advance time and ensure there's no change to the bucket.
 advance wait=true
@@ -29,7 +29,7 @@ advance wait=true
 
 token-bucket
 ----
-0.00 RU filling @ 0.00 RU/s
+0.00 tokens filling @ 0.00 tokens/s
 
 # Issue a blocking read.
 read bytes=1024 label=r1
@@ -51,14 +51,14 @@ not-completed label=r1
 
 token-bucket
 ----
-0.00 RU filling @ 0.00 RU/s (0.64 waiting RU)
+0.00 tokens filling @ 0.00 tokens/s (0.64 waiting tokens)
 
 # Expect maximum delay.
 timers
 ----
 00:33:21.000
 
-# Simulate case where more RUs have been made available.
+# Simulate case where more tokens have been made available.
 configure
 throttle: 0
 ----

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
@@ -1,7 +1,7 @@
-# By default, the test provider grants all RUs immediately. Test cases where it
-# instead throttles usage to a limited rate.
+# By default, the test provider grants all tokens immediately. Test cases where
+# it instead throttles usage to a limited rate.
 
-# Set up throttling at 1K RU/s.
+# Set up throttling at 1K tokens/s.
 configure
 throttle: 1000
 ----
@@ -16,7 +16,7 @@ token-bucket-response
 
 token-bucket
 ----
-2000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+2000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Issue 4K RU write that should block as long as it takes to accumulate 2K RUs
 # with a 1K fill rate.
@@ -38,7 +38,7 @@ await label=w1
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
+0.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens)
 
 # Create 20K debt in bucket.
 pgwire-egress
@@ -57,7 +57,7 @@ advance wait=true
 
 token-bucket
 ----
--19000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (1000.00 waiting debt @ 500.00 RU/s)
+-19000.00 tokens filling @ 1000.00 tokens/s (limited to 15000.00 tokens) (1000.00 waiting debt @ 500.00 tokens/s)
 
 # The debt in the token bucket is greater than what one trickle duration can
 # cover. Ensure that another write blocks for entire trickle duration, plus
@@ -76,11 +76,11 @@ wait-for-event
 token-bucket-response
 ----
 
-# Ensure that fill rate has been updated to include RU leftover from previous
-# trickle, as well as the RU from the new trickle.
+# Ensure that fill rate has been updated to include tokens left over from
+# previous trickle, as well as the tokens from the new trickle.
 token-bucket
 ----
--15000.00 RU filling @ 1100.00 RU/s (limited to 16000.00 RU)
+-15000.00 tokens filling @ 1100.00 tokens/s (limited to 16000.00 tokens)
 
 timers
 ----


### PR DESCRIPTION
Convert the tenant cost client  to use token terminology rather than RU terminology. We are generalizing the tenant cost code to support vCPUs as an alternate measure of cost, and want more generic code that is agnostic to the particular unit of cost.

This PR is purely mechanical and kept separate in order to reduce the size of later reviews.

Epic: CC-28471

Release note: None