### PR TITLE
colexecdisk: fix incorrect context capture in partitionerToOperator

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -668,6 +668,10 @@ func (s *externalSorter) Close(ctx context.Context) error {
 // to the last n current partitions to be merged.
 func (s *externalSorter) createPartitionerToOperators(n int) {
 	oldPartitioners := s.partitionerToOperators
+	for i := range oldPartitioners {
+		// Prepare the partitioner for reuse.
+		oldPartitioners[i].Reset(s.Ctx)
+	}
 	if len(oldPartitioners) < n {
 		s.partitionerToOperators = make([]*partitionerToOperator, n)
 		copy(s.partitionerToOperators, oldPartitioners)

--- a/pkg/sql/colexec/colexecdisk/utils.go
+++ b/pkg/sql/colexec/colexecdisk/utils.go
@@ -47,7 +47,16 @@ type partitionerToOperator struct {
 	batch        coldata.Batch
 }
 
-var _ colexecop.Operator = &partitionerToOperator{}
+var _ colexecop.ResettableOperator = &partitionerToOperator{}
+
+func (p *partitionerToOperator) Reset(ctx context.Context) {
+	// When resetting we simply want to update the context - this will allow us
+	// to make Init a no-op and reuse already allocated batch. If Init hasn't
+	// been called yet, then Reset is a no-op.
+	if p.Ctx != nil {
+		p.Ctx = ctx
+	}
+}
 
 func (p *partitionerToOperator) Init(ctx context.Context) {
 	if !p.InitHelper.Init(ctx) {


### PR DESCRIPTION
This commit fixes recently exposed minor issue with how `partitionerToOperator` captures the context. In particular, these operators are reused multiple times by the external sort and the hash-based partitioner for each new partition, and previously these operator would capture the context that was provided on the first call to `Init`. In case of the external sort, that context comes from the ordered synchronizer which has a tracing span that is finished after each partition, so the captured context would have already finished span that can be problematic down the line.

The fix in this commit is to make the operator resettable so that the new context is captured every time the operator is reused. Calling `Reset` is already in place in the hash-based partitioner (because other operators are reused there too), and this commit adds a call in the external sort.

Fixes: #125177.

Release note: None