### PR TITLE
jobs: release registration before clearing claim

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -481,6 +481,7 @@ func (r *Registry) maybeClearLease(job *Job, jobErr error) {
 	if jobErr == nil {
 		return
 	}
+	r.unregister(job.ID())
 	r.clearLeaseForJobID(job.ID(), r.db.Executor(), nil /* txn */)
 }
 


### PR DESCRIPTION
Previously we would release our registration from the map after we cleared the claim from the row. This meant there was a period where an unclaimed job row still had a map entry in a resumer.

If in the brief window before we cleared the map entry the pause-request to paused loop re-ran, it would observe the map entry and assume that the resumer that owned that entry would clear its claim, skipping removing the claim.

However it was possible that the claim loop could also run in that window, placing a new claim on the job, that then isn't cleared by the pause loop due to the lingering map entry.

Instead we now remove from the map before we commit the txn removing the claim.

Release note: none.
Epic: none.