### PR TITLE
catalog/lease: monitor rangefeed to ensure progress

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -122,6 +122,7 @@ go_test(
         "//pkg/sql/enum",
         "//pkg/sql/isql",
         "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/regions",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/rowenc/valueside",

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -36,6 +36,9 @@ type descriptorState struct {
 	// entering renewal initialization.
 	renewalInProgress int32
 
+	// lastRefresh of this state
+	lastRefreshTime atomic.Int64
+
 	mu struct {
 		syncutil.Mutex
 

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/catkv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -78,6 +79,14 @@ var LeaseJitterFraction = settings.RegisterFloatSetting(
 	"mean duration of sql descriptor leases, this actual duration is jitterred",
 	base.DefaultDescriptorLeaseJitterFraction,
 	settings.Fraction)
+
+var LeaseMonitorRangeFeedTimeout = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"sql.catalog.descriptor_lease_monitor_range_feed.timeout",
+	"if the leasing subsystem does not receive any checkpoints for this timeout,"+
+		" then the node is brought down (a setting of 0 means off).",
+	time.Minute*10,
+)
 
 //go:generate stringer -type=SessionBasedLeasingMode
 type SessionBasedLeasingMode int64
@@ -663,6 +672,7 @@ func acquireNodeLease(
 			if t == nil {
 				return nil, errors.AssertionFailedf("could not find descriptor state for id %d", id)
 			}
+			t.lastRefreshTime.Swap(timeutil.Now().Unix())
 			t.mu.Lock()
 			t.mu.takenOffline = false
 			defer t.mu.Unlock()
@@ -703,7 +713,8 @@ func releaseLease(ctx context.Context, lease *storedLease, m *Manager) (released
 		// Release synchronously to guarantee release before exiting.
 		// It's possible for the context to get cancelled, so return if
 		// it was released.
-		return m.storage.release(ctx, m.stopper, lease)
+		return m.storage.
+			release(ctx, m.stopper, lease)
 	}
 
 	// Release to the store asynchronously, without the descriptorState lock.
@@ -870,9 +881,17 @@ type Manager struct {
 		// a new version has arrived.
 		leasesToExpire []*descriptorVersionState
 
-		// updatesResolvedTimestamp keeps track of a timestamp before which all
-		// descriptor updates have already been seen.
-		updatesResolvedTimestamp hlc.Timestamp
+		// rangeFeedCheckpoints tracks the health of the range by tracking
+		// the number of observed checkpoints.
+		rangeFeedCheckpoints int
+
+		// rangeFeedIsUnavailableTime tracks the time when the unavailability
+		// even was detected, Each the range feed timer detects no check points
+		// this time gets reset. This will be used to refresh stale descriptors.
+		rangeFeedIsUnavailableTime time.Time
+
+		// rangeFeedIsUnavailable tracks if the range feed is currently gunavailable.
+		rangeFeedIsUnavailable bool
 	}
 
 	draining atomic.Value
@@ -975,7 +994,6 @@ func NewLeaseManager(
 	lm.storage.writer = newKVWriter(codec, db.KV(), keys.LeaseTableID, settingsWatcher, lm)
 	lm.stopper.AddCloser(lm.sem.Closer("stopper"))
 	lm.mu.descriptors = make(map[descpb.ID]*descriptorState)
-	lm.mu.updatesResolvedTimestamp = clock.Now()
 	lm.draining.Store(false)
 	return lm
 }
@@ -1432,6 +1450,10 @@ func (m *Manager) watchForUpdates(
 	handleEvent := func(
 		ctx context.Context, ev *kvpb.RangeFeedValue,
 	) {
+		// Detect if rangefeed checkpoints updates should be disabled.
+		if atomic.LoadInt64(&m.testingKnobs.DisableRangeFeedCheckpoint) > 0 {
+			return
+		}
 		if len(ev.Value.RawBytes) == 0 {
 			id, err := m.Codec().DecodeDescMetadataID(ev.Key)
 			if err != nil {
@@ -1462,12 +1484,25 @@ func (m *Manager) watchForUpdates(
 		case descUpdateCh <- mut:
 		}
 	}
+
+	handleCheckpoint := func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+		// Track checkpoints that occur from the rangefeed to make sure progress
+		// is always made.
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if atomic.LoadInt64(&m.testingKnobs.DisableRangeFeedCheckpoint) > 0 {
+			return
+		}
+		m.mu.rangeFeedCheckpoints += 1
+	}
+
 	// Ignore errors here because they indicate that the server is shutting down.
 	// Also note that the range feed automatically shuts down when the server
 	// shuts down, so we don't need to call Close() ourselves.
 	_, _ = m.rangeFeedFactory.RangeFeed(
 		ctx, "lease", []roachpb.Span{descriptorTableSpan}, hlc.Timestamp{}, handleEvent,
 		rangefeed.WithSystemTablePriority(),
+		rangefeed.WithOnCheckpoint(handleCheckpoint),
 	)
 }
 
@@ -1479,6 +1514,43 @@ var leaseRefreshLimit = settings.RegisterIntSetting(
 	"maximum number of descriptors to periodically refresh leases for",
 	500,
 )
+
+// getRangeFeedMonitorSettings determines how long the range feed becomes silent
+// before we started treating it as an availability issue on the cluster.
+func (m *Manager) getRangeFeedMonitorSettings() (timeout time.Duration, monitoringEnabled bool) {
+	timeout = LeaseMonitorRangeFeedTimeout.Get(&m.settings.SV)
+	// Even if the monitoring disabled, the timer will be
+	// used to refresh this setting.
+	checkFrequency := timeout
+	if timeout == 0 {
+		timeout = time.Minute
+	}
+	return checkFrequency, timeout > 0
+}
+
+// checkRangeFeedStatus ensures that the range feed is always checkpointing and
+// receiving data. If we see this for too long, we will treat it as an availability
+// issue for this node.
+func (m *Manager) checkRangeFeedStatus(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lastCheckpoints := m.mu.rangeFeedCheckpoints
+	m.mu.rangeFeedCheckpoints = 0
+	// No checkpoints have occurred on the rangefeed, so we are no longer
+	// getting any updates. At this point there is some type of availability
+	// issue.
+	if lastCheckpoints == 0 {
+		// Keep on updating the timestamp, so that expired descriptors
+		// can catch up.
+		m.mu.rangeFeedIsUnavailableTime = timeutil.Now()
+		m.mu.rangeFeedIsUnavailable = true
+		log.Warningf(ctx, "lease manager range feed has stopped making progress, switching to manual refreshes.")
+	} else if !m.mu.rangeFeedIsUnavailableTime.IsZero() {
+		// Note: The recovery logic will clear out the time.
+		m.mu.rangeFeedIsUnavailable = false
+		log.Warningf(ctx, "lease manager range feed has recovered and can make progress.")
+	}
+}
 
 // PeriodicallyRefreshSomeLeases so that leases are fresh and can serve
 // traffic immediately.
@@ -1498,6 +1570,11 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 		var refreshTimer timeutil.Timer
 		defer refreshTimer.Stop()
 		refreshTimer.Reset(refreshTimerDuration / 2)
+		// Used to make sure that the system.descriptor lease is active.
+		var rangeFeedProgressWatchDog timeutil.Timer
+		rangeFeedProgressWatchDogTimeout,
+			rangeFeedProgressWatchDogEnabled := m.getRangeFeedMonitorSettings()
+		rangeFeedProgressWatchDog.Reset(rangeFeedProgressWatchDogTimeout)
 		for {
 			select {
 			case <-m.stopper.ShouldQuiesce():
@@ -1505,9 +1582,24 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 
 			case <-m.refreshAllLeases:
 				m.refreshSomeLeases(ctx, true /*refreshAll*/)
+			case <-rangeFeedProgressWatchDog.C:
+				rangeFeedProgressWatchDog.Read = true
+				// Detect if the range feed has stopped making
+				// progress.
+				if rangeFeedProgressWatchDogEnabled {
+					m.checkRangeFeedStatus(ctx)
+				}
+				rangeFeedProgressWatchDogTimeout,
+					rangeFeedProgressWatchDogEnabled = m.getRangeFeedMonitorSettings()
+				rangeFeedProgressWatchDog.Reset(rangeFeedProgressWatchDogTimeout)
 			case <-refreshTimer.C:
 				refreshTimer.Read = true
 				refreshTimer.Reset(m.storage.jitteredLeaseDuration() / 2)
+
+				// Check for any react to any range feed availability problems.
+				if err := m.handleRangeFeedAvailability(ctx); err != nil {
+					log.Infof(ctx, "error handling range feed avalibility issue: %v", err)
+				}
 
 				// Clean up session based leases that have expired.
 				m.cleanupExpiredSessionLeases(ctx)
@@ -1522,6 +1614,153 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 			}
 		}
 	})
+}
+
+// getStaleLeasesForRangeFeed figures out which leases are stale and
+// should be manually refreshed.
+func (m *Manager) getStaleLeasesForRangeFeed(
+	ctx context.Context,
+) (staleLeases []*descriptorState, resetUnavailableTime bool) {
+	// Range feed availability checks can be skipped until session based
+	// leasing is active.
+	if !m.sessionBasedLeasingModeAtLeast(ctx, SessionBasedDrain) {
+		return nil, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// If the range feed is working fine, then no descriptors
+	// are stale.
+	if m.mu.rangeFeedIsUnavailableTime.IsZero() {
+		return nil, false
+	}
+	// Otherwise, gather all descriptors which have a stale refresh time.
+	for _, desc := range m.mu.descriptors {
+		if desc.lastRefreshTime.Load() < m.mu.rangeFeedIsUnavailableTime.Unix() {
+			staleLeases = append(staleLeases, desc)
+		}
+	}
+	sort.SliceStable(staleLeases, func(i, j int) bool {
+		return staleLeases[i].id < staleLeases[j].id
+	})
+	return staleLeases, !m.mu.rangeFeedIsUnavailable
+}
+
+// pollAndMaybeRefreshOldLeases if the range feed stops working,
+// our alternative mechanism will manually poll and refresh stale
+// leases.
+func (m *Manager) pollAndMaybeRefreshOldLeases(
+	ctx context.Context, staleLeases []*descriptorState,
+) error {
+	// Fetch all the descriptors that are stale, so that we can
+	// figure out which ones should be refreshed.
+	// Note: In theory we could queue everything for renewal,
+	// but it's cheaper to scan and compare versions in terms
+	// of round trips.
+	idsToFetch := make([]descpb.ID, 0, len(staleLeases))
+	for _, stale := range staleLeases {
+		idsToFetch = append(idsToFetch, stale.id)
+	}
+	kvReader := m.storage.newCatalogReader(ctx)
+	var staleDescs nstree.Catalog
+	err := m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		var err error
+		staleDescs, err = kvReader.GetByIDs(ctx, txn.KV(), idsToFetch, false, catalog.Any)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	wg := sync.WaitGroup{}
+	// Loop over the leases that are "stale" and drop ones which are
+	// unused and refresh ones that have a newer version in storage.
+	maybeCleanupOldVersions := func(desc *descriptorState) []*storedLease {
+		desc.mu.Lock()
+		defer desc.mu.Unlock()
+		latestVersion := desc.mu.active.findNewest()
+		if latestVersion == nil {
+			desc.lastRefreshTime.Store(timeutil.Now().Unix())
+			return nil
+		}
+		latestVersionOfDesc := staleDescs.LookupDescriptor(desc.id)
+		// If the descriptor has been deleted, try to clean it up.
+		if latestVersionOfDesc == nil {
+			desc.lastRefreshTime.Store(timeutil.Now().Unix())
+			storedLeases := desc.removeInactiveVersions()
+			if len(desc.mu.active.data) == 0 && atomic.LoadInt32(&desc.renewalInProgress) == 0 {
+				func() {
+					m.mu.Lock()
+					defer m.mu.Unlock()
+					delete(m.mu.descriptors, desc.id)
+				}()
+			}
+			return storedLeases
+		} else if latestVersion.GetVersion() != latestVersionOfDesc.GetVersion() {
+			// Refresh the descriptor if a new version is available.
+			wg.Add(1)
+			if err := m.stopper.RunAsyncTaskEx(
+				ctx,
+				stop.TaskOpts{
+					TaskName:   fmt.Sprintf("refresh descriptor: %d lease", desc.id),
+					Sem:        m.sem,
+					WaitForSem: true,
+				},
+				func(ctx context.Context) {
+					defer wg.Done()
+					// Pick up the new version and purge all older versions
+					// if possible.
+					if err := purgeOldVersions(
+						ctx, m.storage.db.KV(), desc.id, latestVersionOfDesc.Dropped() /* dropped */, latestVersionOfDesc.GetVersion() /* minVersion */, m,
+					); err != nil {
+						log.Warningf(ctx, "error purging leases for descriptor %d: %s",
+							desc.id, err)
+					}
+				}); err != nil {
+				log.Infof(ctx, "didnt refresh descriptor: %d lease: %s", desc.id, err)
+			}
+			return nil
+		} else {
+			// Otherwise, update the refresh timestamp, since no
+			// change has occurred.
+			desc.lastRefreshTime.Store(timeutil.Now().Unix())
+		}
+		return nil
+	}
+	for _, desc := range staleLeases {
+		storedLeases := maybeCleanupOldVersions(desc)
+		for _, s := range storedLeases {
+			m.storage.release(ctx, m.stopper, s)
+		}
+	}
+	wg.Wait()
+	return nil
+}
+
+// handleRangeFeedAvailability detects if there is any availability issue
+// with the range feed and manually refreshes potentially staled descriptors
+// if that is the case.
+func (m *Manager) handleRangeFeedAvailability(ctx context.Context) error {
+	// Check if there are any leases that need to be evicted or
+	// refreshed because of range feed availability.
+	staleLeases, resetAvailableTime := m.getStaleLeasesForRangeFeed(ctx)
+	// Loop over the stale leases in limited batch sizes, and
+	// refresh them as needed.
+	var MaxBatchSize = int(leaseRefreshLimit.Get(&m.settings.SV))
+	for i := 0; i < len(staleLeases); i += MaxBatchSize {
+		batchSize := min(len(staleLeases), MaxBatchSize)
+		nextBatch := staleLeases[i : i+batchSize]
+		staleLeases = staleLeases[i+batchSize:]
+		if err := m.pollAndMaybeRefreshOldLeases(ctx, nextBatch); err != nil {
+			return err
+		}
+	}
+	// If the range feed has returned, we do one last manual refresh
+	// to have everything catch up.
+	if resetAvailableTime {
+		m.mu.Lock()
+		m.mu.rangeFeedIsUnavailableTime = time.Time{}
+		defer m.mu.Unlock()
+	}
+	return nil
 }
 
 // cleanupExpiredSessionLeases expires session based leases marked for removal,
@@ -1908,4 +2147,17 @@ func (w *waitStatsTracker) end() {
 		w.ws.LastCount = 0
 		w.recSpan.RecordStructured(&w.ws)
 	}
+}
+
+// TestingSetDisableRangeFeedCheckpointFn sets the testing knob used to
+// disable rangefeed checkpoints.
+func (m *Manager) TestingSetDisableRangeFeedCheckpointFn(disable bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mu.rangeFeedCheckpoints = 0
+	var value int64
+	if disable {
+		value = 1
+	}
+	atomic.SwapInt64(&m.testingKnobs.DisableRangeFeedCheckpoint, value)
 }

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/regions"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
@@ -3633,6 +3634,53 @@ func TestAmbiguousResultIsRetried(t *testing.T) {
 	cancel()
 	// Ensure that the query completed successfully.
 	require.NoError(t, <-selectErr)
+}
+
+func TestLeaseDescriptorRangeFeedFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer skip.UnderDuress(t)
+
+	settings := cluster.MakeTestingClusterSettings()
+	ctx := context.Background()
+	// Disable lease renewals so that the TTL time is shorter
+	// for rangefeed problems
+	lease.LeaseMonitorRangeFeedTimeout.Override(ctx, &settings.SV, 30*time.Second)
+	// Expire leases to make this test run faster.
+	lease.LeaseDuration.Override(ctx, &settings.SV, 0)
+	srv := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Settings: settings,
+		}})
+	defer srv.Stopper().Stop(ctx)
+	firstConn := sqlutils.MakeSQLRunner(srv.ServerConn(0))
+	secondConn := sqlutils.MakeSQLRunner(srv.ServerConn(1))
+	firstConn.Exec(t, "CREATE TABLE t1(n int)")
+	require.NoError(t, srv.WaitForFullReplication())
+	tx := secondConn.Begin(t)
+	_, err := tx.Exec("SELECT * FROM t1;")
+	require.NoError(t, err)
+	// On node 1 intentionally disable the rangefeed, so that the watch dog
+	// detects a problem.
+	srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(true)
+	defer srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(false)
+	// This schema change will wait for the connection on
+	// node 1 to release the lease. Because the rangefeed is
+	// disabled it will never know about the new version.
+	firstConn.Exec(t, "ALTER TABLE t1 ADD COLUMN j INT DEFAULT 64")
+	_, err = tx.Exec("INSERT INTO t1 VALUES (32)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Validate that the connection on node 2 can't commit.
+	err = tx.Commit()
+	if !testutils.IsError(err, "pq: restart transaction") {
+		if err != nil {
+			t.Fatalf("unexpected error on commit: %s", pgerror.FullError(err))
+		} else {
+			t.Fatal("no error encountered")
+		}
+	}
 }
 
 // TestLeaseTableWriteFailure is used to ensure that sqlliveness heart-beating

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3639,13 +3639,14 @@ func TestAmbiguousResultIsRetried(t *testing.T) {
 func TestLeaseDescriptorRangeFeedFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer skip.UnderDuress(t)
+	skip.UnderDuress(t)
 
 	settings := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
 	// Disable lease renewals so that the TTL time is shorter
 	// for rangefeed problems
 	lease.LeaseMonitorRangeFeedTimeout.Override(ctx, &settings.SV, 30*time.Second)
+	lease.LeaseMonitorRangeFeedResetTime.Override(ctx, &settings.SV, 10*time.Second)
 	// Expire leases to make this test run faster.
 	lease.LeaseDuration.Override(ctx, &settings.SV, 0)
 	srv := serverutils.StartCluster(t, 3, base.TestClusterArgs{
@@ -3655,15 +3656,15 @@ func TestLeaseDescriptorRangeFeedFailure(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	firstConn := sqlutils.MakeSQLRunner(srv.ServerConn(0))
 	secondConn := sqlutils.MakeSQLRunner(srv.ServerConn(1))
+	// On node 1 intentionally disable the rangefeed, so that the watch dog
+	// detects a problem.
+	srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(true)
+	defer srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(false)
 	firstConn.Exec(t, "CREATE TABLE t1(n int)")
 	require.NoError(t, srv.WaitForFullReplication())
 	tx := secondConn.Begin(t)
 	_, err := tx.Exec("SELECT * FROM t1;")
 	require.NoError(t, err)
-	// On node 1 intentionally disable the rangefeed, so that the watch dog
-	// detects a problem.
-	srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(true)
-	defer srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(false)
 	// This schema change will wait for the connection on
 	// node 1 to release the lease. Because the rangefeed is
 	// disabled it will never know about the new version.

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -12,7 +12,6 @@ package lease
 
 import (
 	"context"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -59,12 +58,8 @@ type ManagerTestingKnobs struct {
 	// To disable the deletion of orphaned leases at server startup.
 	DisableDeleteOrphanedLeases bool
 
-	// VersionPollIntervalForRangefeeds controls the polling interval for the
-	// check whether the requisite version for rangefeed-based notifications has
-	// been finalized.
-	//
-	// TODO(ajwerner): Remove this and replace it with a callback.
-	VersionPollIntervalForRangefeeds time.Duration
+	// DisableRangeFeedCheckpoint is used to disable rangefeed checkpoints
+	DisableRangeFeedCheckpoint int64
 
 	LeaseStoreTestingKnobs StorageTestingKnobs
 }

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1281,28 +1281,26 @@ CREATE TABLE t1.test (k INT PRIMARY KEY, v TEXT);
 
 		locked(func() { require.True(t, mu.txnDeadline.Less(fs.Expiration())) })
 	})
-
-	t.Run("single_tenant_ignore_session_expiry", func(t *testing.T) {
-		// In this test, we check that the session expiry is ignored in a single-tenant
-		// environment. To verify this, we deliberately set the session duration to be
-		// less than the lease duration while overriding the cluster sqlliveness.Session.
-		// On multi-tenant environments, the session expiry will override the lease duration
-		// while setting a transaction deadline. However, in a single tenant environment,
-		// the session expiry should be ignored.
+	t.Run("single_tenant_enforces_session_expiry", func(t *testing.T) {
+		// In this test, we check that the session expiry is enforced a single-tenant
+		// environment.
 		// Open a DB connection on the server and not the tenant to test that the session
 		// expiry is ignored outside of the multi-tenant environment.
 		dbConn := s.SystemLayer().SQLConn(t)
 		defer dbConn.Close()
 		// Set up a dummy database and table to write into for the test.
 		if _, err := dbConn.Exec(`CREATE DATABASE t1;
-	CREATE TABLE t1.test (k INT PRIMARY KEY, v TEXT);
-	`); err != nil {
+	  CREATE TABLE t1.test (k INT PRIMARY KEY, v TEXT);
+	  `); err != nil {
 			t.Fatal(err)
 		}
 
-		// Inject an already expired session to observe that it has no effect.
+		// Deliberately set the session duration to be more than the lease duration
+		// to confirm that the lease duration overrides the session duration while
+		// setting the transaction deadline
+		sessionDuration := base.DefaultDescriptorLeaseDuration + time.Minute
 		fs := &fakeSession{
-			ExpTS: s.Clock().Now().Add(-time.Minute.Nanoseconds(), 0),
+			ExpTS: s.Clock().Now().Add(sessionDuration.Nanoseconds(), 0),
 		}
 		defer setClientSessionOverride(fs)()
 		txn, err := dbConn.Begin()
@@ -1319,7 +1317,7 @@ CREATE TABLE t1.test (k INT PRIMARY KEY, v TEXT);
 		require.NoError(t, err)
 
 		// Confirm that the txnDeadline is not equal to the session expiration.
-		locked(func() { require.True(t, fs.Expiration().Less(mu.txnDeadline)) })
+		locked(func() { require.True(t, fs.Expiration().EqOrdering(mu.txnDeadline)) })
 	})
 }
 


### PR DESCRIPTION
Previously, the lease manager has no way of monitoring the range feed to
ensure that updates were being received. This could be problematic with
session based leasing, which relies on this mechanism to detect new
version. In the expiry based model this would have less severe
consequences and lead to slow schema change (since eventually the old
leases would expire). In the session based model the range feed needs to
be functional, otherwise schema changes will be blocked forever. To
address this, this patch adds logic to bring a node down if the
system.descriptor range feed becomes inactive or doesn't start.

Fixes: #125207

Release note (bug fix): Addressed a bug where schema changes could hang
if the lease range feed stopped getting updates.