### PR TITLE
colexecutils: assert allocator and disk queue use different accounts

### DIFF
--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -60,6 +60,8 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	nTuples := 2*coldata.BatchSize() + 1
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	diskQueueMemAcc := testMemMonitor.MakeBoundAccount()
+	defer diskQueueMemAcc.Close(ctx)
 	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int, types.Bytes, types.Decimal}
 	colsLeft := make([]*coldata.Vec, len(typs))
@@ -101,7 +103,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 		leftMJSource, rightMJSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-		testDiskAcc, testMemAcc, evalCtx,
+		testDiskAcc, &diskQueueMemAcc, evalCtx,
 	)
 	mj.Init(ctx)
 	hj := NewHashJoiner(NewHashJoinerArgs{

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -107,6 +107,11 @@ func NewSpillingBuffer(
 	diskQueueMemAcc *mon.BoundAccount,
 	colIdxs ...int,
 ) *SpillingBuffer {
+	if unlimitedAllocator.Acc() == diskQueueMemAcc {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"memory accounts for allocator and disk queue must be different",
+		))
+	}
 	if colIdxs == nil {
 		colIdxs = make([]int, len(inputTypes))
 		for i := range colIdxs {

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -115,6 +115,11 @@ type NewSpillingQueueArgs struct {
 // If fdSemaphore is nil, no Acquire or Release calls will happen. The caller
 // may want to do this if requesting FDs up front.
 func NewSpillingQueue(args *NewSpillingQueueArgs) *SpillingQueue {
+	if args.UnlimitedAllocator.Acc() == args.DiskQueueMemAcc {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"memory accounts for allocator and disk queue must be different",
+		))
+	}
 	var items []coldata.Batch
 	if args.MemoryLimit > 0 {
 		items = make([]coldata.Batch, spillingQueueInitialItemsLen)

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1739,6 +1739,8 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	nTuples := coldata.BatchSize() * 4
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	diskQueueMemAcc := testMemMonitor.MakeBoundAccount()
+	defer diskQueueMemAcc.Close(ctx)
 	typs := []*types.T{types.Int}
 	colsLeft := []*coldata.Vec{testAllocator.NewVec(typs[0], nTuples)}
 	colsRight := []*coldata.Vec{testAllocator.NewVec(typs[0], nTuples)}
@@ -1756,7 +1758,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 		leftSource, rightSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-		testDiskAcc, testMemAcc, &evalCtx,
+		testDiskAcc, &diskQueueMemAcc, &evalCtx,
 	)
 	a.Init(ctx)
 	i, count, expVal := 0, 0, int64(0)
@@ -1808,6 +1810,8 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	diskQueueMemAcc := testMemMonitor.MakeBoundAccount()
+	defer diskQueueMemAcc.Close(ctx)
 	for _, numInputBatches := range []int{1, 2, 16} {
 		t.Run(fmt.Sprintf("numInputBatches=%d", numInputBatches),
 			func(t *testing.T) {
@@ -1826,7 +1830,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 					leftSource, rightSource, typs, typs,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-					testDiskAcc, testMemAcc, &evalCtx,
+					testDiskAcc, &diskQueueMemAcc, &evalCtx,
 				)
 				a.Init(ctx)
 				i := 0
@@ -1864,6 +1868,8 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	diskQueueMemAcc := testMemMonitor.MakeBoundAccount()
+	defer diskQueueMemAcc.Close(ctx)
 	for _, groupSize := range []int{coldata.BatchSize() / 8, coldata.BatchSize() / 4, coldata.BatchSize() / 2} {
 		if groupSize == 0 {
 			// We might be varying coldata.BatchSize() so that when it is divided by
@@ -1901,7 +1907,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
-						testDiskAcc, testMemAcc, &evalCtx,
+						testDiskAcc, &diskQueueMemAcc, &evalCtx,
 					)
 					a.Init(ctx)
 					i := 0
@@ -2007,6 +2013,8 @@ func TestMergeJoinerRandomized(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(t, true /* inMem */)
 	defer cleanup()
+	diskQueueMemAcc := testMemMonitor.MakeBoundAccount()
+	defer diskQueueMemAcc.Close(ctx)
 	for _, numInputBatches := range []int{1, 2, 16, 256} {
 		for _, maxRunLength := range []int64{2, 3, 100} {
 			for _, skipValues := range []bool{false, true} {
@@ -2024,7 +2032,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-						testDiskAcc, testMemAcc, &evalCtx,
+						testDiskAcc, &diskQueueMemAcc, &evalCtx,
 					)
 					a.Init(ctx)
 					i := 0

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -502,6 +502,11 @@ func (a *Allocator) Used() int64 {
 	return a.acc.Used()
 }
 
+// Acc returns the memory account of the Allocator.
+func (a *Allocator) Acc() *mon.BoundAccount {
+	return a.acc
+}
+
 // adjustMemoryUsage adjusts the number of bytes currently allocated through
 // this allocator by delta bytes (which can be both positive or negative).
 //


### PR DESCRIPTION
With the recent addition of memory accounting in the disk queue, it's no longer ok to have the unlimited allocator used by components to share its memory account with the disk queue (since `Allocator.ReleaseAll` shrinks by the total usage, possibly leading to the disk queue to shrink its usage when the account reports 0 bytes). This commit introduces some assertions around it for the spilling queue and the spilling buffer and fixes a few tests that violated them. In production, we already had separate memory accounts, so only tests are affected.

Fixes: #125198.

Release note: None