### PR TITLE
streamingccl: add LDR metrics page to db console

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/logicalDataReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/logicalDataReplication.tsx
@@ -1,0 +1,70 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { AxisUnits, util } from "@cockroachlabs/cluster-ui";
+
+import LineGraph from "src/views/cluster/components/linegraph";
+import { Metric, Axis } from "src/views/shared/components/metricQuery";
+import { cockroach } from "src/js/protos";
+
+import { GraphDashboardProps } from "./dashboardUtils";
+
+import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
+
+export default function (props: GraphDashboardProps) {
+  const { storeSources, tenantSource } = props;
+
+  return [
+    <LineGraph
+      title="Logical Bytes"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      tooltip={`Rate at which the logical bytes (sum of keys + values) are ingested by all logical replication jobs`}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        <Metric
+          name="cr.node.logical_replication.logical_bytes"
+          title="Logical Bytes"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+    <LineGraph
+      title="Replication Lag"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      tooltip={`Replication lag between source and destination cluster`}
+    >
+      <Axis units={AxisUnits.Duration} label="duration">
+        <Metric
+          downsampler={TimeSeriesQueryAggregator.MIN}
+          aggregator={TimeSeriesQueryAggregator.MAX}
+          name="cr.node.logical_replication.replicated_time_seconds"
+          title="Replication Lag"
+          transform={datapoints =>
+            datapoints
+              .filter(d => d.value !== 0)
+              .map(d =>
+                d.value
+                  ? {
+                      ...d,
+                      value:
+                        d.timestamp_nanos.toNumber() -
+                        util.SecondsToNano(d.value),
+                    }
+                  : d,
+              )
+          }
+        />
+      </Axis>
+    </LineGraph>,
+  ];
+}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -94,6 +94,7 @@ import changefeedsDashboard from "./dashboards/changefeeds";
 import overloadDashboard from "./dashboards/overload";
 import ttlDashboard from "./dashboards/ttl";
 import crossClusterReplicationDashboard from "./dashboards/crossClusterReplication";
+import logicalDataReplicationDashboard from "./dashboards/logicalDataReplication";
 import networkingDashboard from "./dashboards/networking";
 import ClusterSummaryBar from "./summaryBar";
 
@@ -160,6 +161,11 @@ const dashboards: { [key: string]: GraphDashboard } = {
   crossClusterReplication: {
     label: "Physical Cluster Replication",
     component: crossClusterReplicationDashboard,
+    isKvDashboard: true,
+  },
+  logicalDataReplication: {
+    label: "Logical Data Replication",
+    component: logicalDataReplicationDashboard,
     isKvDashboard: true,
   },
 };


### PR DESCRIPTION
This patch adds the Logical Data Replication metrics page to the db console. The new page contains a Replication Lag graph and a Logical Bytes throughput graph.

Epic: None

Release note: none