### PR TITLE
roachtest: use dmsetup disk-staller for operation

### DIFF
--- a/pkg/cmd/roachtest/operations/disk_stall.go
+++ b/pkg/cmd/roachtest/operations/disk_stall.go
@@ -12,6 +12,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -51,9 +52,9 @@ func runDiskStall(
 
 	nodes := c.All()
 	nid := nodes[rng.Intn(len(nodes))]
-	o.Status("stalling disk on node %d", nid)
-	ds := roachtestutil.MakeCgroupDiskStaller(o, c, false, false)
+	ds := roachtestutil.MakeDmsetupDiskStaller(o, c)
 
+	o.Status(fmt.Sprintf("stalling disk on node %d", nid))
 	ds.Stall(ctx, c.Node(nid))
 
 	return &cleanupDiskStall{
@@ -64,7 +65,7 @@ func runDiskStall(
 
 func registerDiskStall(r registry.Registry) {
 	r.AddOperation(registry.OperationSpec{
-		Name:             "disk-stall/cgroup",
+		Name:             "disk-stall/dmsetup",
 		Owner:            registry.OwnerStorage,
 		Timeout:          10 * time.Minute,
 		CompatibleClouds: registry.OnlyGCE,

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -68,7 +68,7 @@ func runDiskStalledWALFailover(
 		fmt.Sprintf("COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s", maxSyncDur))
 
 	t.Status("setting up disk staller")
-	s := &dmsetupDiskStaller{t: t, c: c, logsToo: true}
+	s := roachtestutil.MakeDmsetupDiskStaller(t, c)
 	s.Setup(ctx)
 	defer s.Cleanup(ctx)
 
@@ -191,7 +191,7 @@ func runDiskStalledWALFailover(
 // appropriately.
 func registerDiskStalledDetection(r registry.Registry) {
 	stallers := map[string]func(test.Test, cluster.Cluster) diskStaller{
-		"dmsetup": func(t test.Test, c cluster.Cluster) diskStaller { return &dmsetupDiskStaller{t: t, c: c} },
+		"dmsetup": func(t test.Test, c cluster.Cluster) diskStaller { return roachtestutil.MakeDmsetupDiskStaller(t, c) },
 		"cgroup/read-write/logs-too=false": func(t test.Test, c cluster.Cluster) diskStaller {
 			return roachtestutil.MakeCgroupDiskStaller(t, c, true, false)
 		},
@@ -437,61 +437,3 @@ func getProcessMonotonicTimestamp(
 }
 
 type diskStaller = roachtestutil.DiskStaller
-
-type dmsetupDiskStaller struct {
-	t test.Test
-	c cluster.Cluster
-	// If logsToo=true the logs directory will be updated to be a symlink
-	// pointing into the store directory.
-	logsToo bool
-}
-
-var _ diskStaller = (*dmsetupDiskStaller)(nil)
-
-func (s *dmsetupDiskStaller) device(nodes option.NodeListOption) string {
-	return roachtestutil.GetDiskDevice(s.t, s.c, nodes)
-}
-
-func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
-	dev := s.device(s.c.All())
-	// snapd will run "snapd auto-import /dev/dm-0" via udev triggers when
-	// /dev/dm-0 is created. This possibly interferes with the dmsetup create
-	// reload, so uninstall snapd.
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get purge -y snapd`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount -f /mnt/data1 || true`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
-	err := s.c.RunE(ctx, option.WithNodes(s.c.All()), `echo "0 $(sudo blockdev --getsz `+dev+`) linear `+dev+` 0" | `+
-		`sudo dmsetup create data1`)
-	if err != nil {
-		// This has occasionally been seen to fail with "Device or resource busy",
-		// with no clear explanation. Try to find out who it is.
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "sudo bash -c 'ps aux; dmsetup status; mount; lsof'")
-		s.t.Fatal(err)
-	}
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo mount /dev/mapper/data1 /mnt/data1`)
-
-	if s.logsToo {
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "mkdir -p {store-dir}/logs")
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "rm -f logs && ln -s {store-dir}/logs logs || true")
-	}
-}
-
-func (s *dmsetupDiskStaller) Cleanup(ctx context.Context) {
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup resume data1`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount /mnt/data1`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo mount /mnt/data1`)
-	// Reinstall snapd in case subsequent tests need it.
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get install -y snapd`)
-}
-
-func (s *dmsetupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
-	s.c.Run(ctx, option.WithNodes(nodes), `sudo dmsetup suspend --noflush --nolockfs data1`)
-}
-
-func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
-	s.c.Run(ctx, option.WithNodes(nodes), `sudo dmsetup resume data1`)
-}
-
-func (s *dmsetupDiskStaller) DataDir() string { return "{store-dir}" }
-func (s *dmsetupDiskStaller) LogDir() string  { return "logs" }

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1190,7 +1191,7 @@ func makeFailerWithoutLocalNoop(
 			c:             c,
 			m:             m,
 			startSettings: settings,
-			staller:       &dmsetupDiskStaller{t: t, c: c},
+			staller:       roachtestutil.MakeDmsetupDiskStaller(t, c),
 		}
 	case failureModePause:
 		return &pauseFailer{


### PR DESCRIPTION
The cgroup-based disk staller has some weird interactions with nvme ssds on GCP, where the cockroach process can become unkillable if it is waiting on some disk operations on a disk that is stalled using cgroup settings. This change updates the disk-stall operation to use the dmsetup-based disk staller, which should hopefully be more stable under this mode of operation.

Epic: none

Release note: None