### PR TITLE
randgen: ignore virtual columns in foreign key mutator

### DIFF
--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -463,6 +463,12 @@ func foreignKeyMutator(
 		for _, def := range table.Defs {
 			switch def := def.(type) {
 			case *tree.ColumnTableDef:
+				if def.Computed.Virtual {
+					// We currently don't support FK references to / from
+					// virtual columns.
+					// TODO(#59671): remove this skip.
+					continue
+				}
 				idx, ok := tableNameToColIdx(table.Table)
 				if !ok {
 					idx = len(cols)


### PR DESCRIPTION
We currently don't support FK references to / from virtual columns, so we need to adjust the FK mutator after a recent change in fef5968922d9219806b673de606704029373202a.

Fixes: #125145.

Release note: None