### PR TITLE
sqlstatsccl: skip TestSQLStatsRegions under duress

### DIFF
--- a/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
+++ b/pkg/ccl/testccl/sqlstatsccl/sql_stats_test.go
@@ -37,8 +37,7 @@ func TestSQLStatsRegions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "test is to slow for race")
-	skip.UnderStress(t, "test is too heavy to run under stress")
+	skip.UnderDuress(t, "test is too heavy for special configs")
 
 	// We build a small multiregion cluster, with the proper settings for
 	// multi-region tenants, then run tests over both the system tenant


### PR DESCRIPTION
This test is quite heavy, and it was already skipped under stress and race, so this commit skips it under deadlock too.

Fixes: #125201.

Release note: None