### PR TITLE
release-23.2: pkg/server: remove flaky assertion from TestHotRangesResponse

### DIFF
--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -384,18 +384,10 @@ func TestHotRangesResponse(t *testing.T) {
 				if r.Desc.RangeID == 0 || (len(r.Desc.StartKey) == 0 && len(r.Desc.EndKey) == 0) {
 					t.Errorf("unexpected empty/unpopulated range descriptor: %+v", r.Desc)
 				}
-				if r.QueriesPerSecond > 0 {
-					if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 && r.ReadBytesPerSecond == 0 && r.WriteBytesPerSecond == 0 {
-						t.Errorf("qps %.2f > 0, expected either reads=%.2f, writes=%.2f, readBytes=%.2f or writeBytes=%.2f to be non-zero",
-							r.QueriesPerSecond, r.ReadsPerSecond, r.WritesPerSecond, r.ReadBytesPerSecond, r.WriteBytesPerSecond)
-					}
-					// If the architecture doesn't support sampling CPU, it
-					// will also be zero.
-					if grunning.Supported() && r.CPUTimePerSecond == 0 {
-						t.Errorf("qps %.2f > 0, expected cpu=%.2f to be non-zero",
-							r.QueriesPerSecond, r.CPUTimePerSecond)
-					}
-				}
+				// NB: Assertions against ReadsPerSecond, WritesPerSecond, ReadBytesPerSecond, WriteBytesPerSecond, and
+				// CPUTimePerSecond were explicitly removed from this test for older release branches (<24.1). This is because
+				// the values were flaky, but the fix made (https://github.com/cockroachdb/cockroach/pull/119723) was not able
+				// to be backported as it made critical changes to KV QPS calculations that are too risky for backport.
 				if r.QueriesPerSecond > lastQPS {
 					t.Errorf("unexpected increase in qps between ranges; prev=%.2f, current=%.2f, desc=%v",
 						lastQPS, r.QueriesPerSecond, r.Desc)
@@ -403,7 +395,6 @@ func TestHotRangesResponse(t *testing.T) {
 				lastQPS = r.QueriesPerSecond
 			}
 		}
-
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/125222

The assertions removed in this patch are known to be flaky. The root of
the problem was addressed in
https://github.com/cockroachdb/cockroach/pull/119723, but due to
the fact that the changes affected KV QPS calculations in a critical
way, we decided not to backport.

The result is that older release branches continue to experience flakes
for this test, which has become quite noisy.

Our solution is to remove the flaky assertions while leaving the
remainder of the test.

Release note: none

Release justification: test-only fix to a flaky test.