### PR TITLE
tree: make empty array error condition stricter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3938,3 +3938,22 @@ statement ok
 DROP TABLE x CASCADE;
 
 subtest end
+
+subtest add_default_empty_array
+
+statement ok
+CREATE TABLE t_114316 (i INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE t_114316 ADD COLUMN a INT[] DEFAULT ARRAY[]::OID[]
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_114316];
+----
+CREATE TABLE public.t_114316 (
+  i INT8 NOT NULL,
+  a INT8[] NULL DEFAULT ARRAY[]:::OID[],
+  CONSTRAINT t_114316_pkey PRIMARY KEY (i ASC)
+)
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -262,17 +262,17 @@ SELECT CASE WHEN x > 1 THEN true ELSE NULL OR false END FROM (VALUES (1), (2)) A
 NULL
 true
 
-# Error "cannot determine type of empty array" should apply no matter the
-# operator, `>`, or `<`.
-query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
+query B
 SELECT ARRAY[]::TIMESTAMPTZ[] >
-       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);
+       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL])
+----
+false
 
-# Error "cannot determine type of empty array" should apply no matter the
-# operator, `>`, or `<`.
-query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
+query B
 SELECT ARRAY[]::TIMESTAMPTZ[] <
-       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);
+       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL])
+----
+true
 
 # Regression test for #102110. Ensure CASE is typed correctly.
 statement ok

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1890,10 +1890,12 @@ func (expr *Array) TypeCheck(
 	}
 
 	if len(expr.Exprs) == 0 {
-		if desiredParam.Family() == types.AnyFamily {
-			return nil, errAmbiguousArrayType
+		if expr.typ == nil || expr.typ.Family() != types.ArrayFamily {
+			if desiredParam.Family() == types.AnyFamily {
+				return nil, errAmbiguousArrayType
+			}
+			expr.typ = types.MakeArray(desiredParam)
 		}
-		expr.typ = types.MakeArray(desiredParam)
 		return expr, nil
 	}
 


### PR DESCRIPTION
There's no need to return the error about not knowing the empty array's
type if we were provided a type annotation.

fixes https://github.com/cockroachdb/cockroach/issues/114316
Release note (bug fix): Fixed an issue where adding a column with a
default value of an empty array would not succeed.