### PR TITLE
roachtest: use SHOW JOB rather than SHOW JOBS

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1439,7 +1439,7 @@ func (rrd *replShutdownDriver) getTargetAndWatcherNodes(ctx context.Context) {
 
 func getPhase(rd *replicationDriver, dstJobID jobspb.JobID) c2cPhase {
 	var jobStatus string
-	rd.setup.dst.sysSQL.QueryRow(rd.t, `SELECT status FROM [SHOW JOBS] WHERE job_id=$1`,
+	rd.setup.dst.sysSQL.QueryRow(rd.t, `SELECT status FROM [SHOW JOB $1]`,
 		dstJobID).Scan(&jobStatus)
 	require.Equal(rd.t, jobs.StatusRunning, jobs.Status(jobStatus))
 

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -184,7 +184,7 @@ func registerRestore(r registry.Registry) {
 						return nil
 					case <-jobProgressTick.C:
 						var fraction float32
-						sql.QueryRow(t, `SELECT fraction_completed FROM [SHOW JOBS] WHERE job_id = $1`,
+						sql.QueryRow(t, `SELECT fraction_completed FROM [SHOW JOB $1]`,
 							jobID).Scan(&fraction)
 						t.L().Printf("RESTORE Progress %.2f", fraction)
 						if fraction < pauseAtProgress[pauseIndex] {
@@ -197,7 +197,7 @@ func registerRestore(r registry.Registry) {
 							// The pause job request should not fail unless the job has already succeeded,
 							// in which case, the test should gracefully succeed.
 							var status string
-							sql.QueryRow(t, `SELECT status FROM [SHOW JOBS] WHERE job_id = $1`, jobID).Scan(&status)
+							sql.QueryRow(t, `SELECT status FROM [SHOW JOBS $1]`, jobID).Scan(&status)
 							if status == "succeeded" {
 								return nil
 							}
@@ -205,7 +205,7 @@ func registerRestore(r registry.Registry) {
 						require.NoError(t, err)
 						testutils.SucceedsSoon(t, func() error {
 							var status string
-							sql.QueryRow(t, `SELECT status FROM [SHOW JOBS] WHERE job_id = $1`, jobID).Scan(&status)
+							sql.QueryRow(t, `SELECT status FROM [SHOW JOB $1]`, jobID).Scan(&status)
 							if status != "paused" {
 								return errors.Newf("expected status `paused` but found %s", status)
 							}


### PR DESCRIPTION
The existing query is fine and not too much more expensive since it does end up using the job_id index on the jobs virtual table.  But, it does come with a bit of extra filtering.

Epic: none
Release note: None