### PR TITLE
roachprod: add cluster shrink support to gce

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -170,6 +170,26 @@ across the zones of the cluster).
 	}),
 }
 
+var shrinkCmd = &cobra.Command{
+	Use:   `shrink <cluster> <num-nodes>`,
+	Short: `shrink a cluster by removing nodes`,
+	Long: `shrink a cluster by removing the specified number of nodes.
+
+The cluster has to be a managed cluster (i.e., a cluster created with the
+gce-managed flag). Only Google Cloud clusters currently support removing nodes.
+Nodes are removed from the tail end of the cluster. Removing nodes from the
+middle of the cluster is not supported yet.
+`,
+	Args: cobra.ExactArgs(2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		count, err := strconv.ParseInt(args[1], 10, 8)
+		if err != nil || count < 1 {
+			return errors.Wrapf(err, "invalid num-nodes argument")
+		}
+		return roachprod.Shrink(context.Background(), config.Logger, args[0], int(count))
+	}),
+}
+
 var setupSSHCmd = &cobra.Command{
 	Use:   "setup-ssh <cluster>",
 	Short: "set up ssh for a cluster",
@@ -1872,6 +1892,7 @@ func main() {
 	rootCmd.AddCommand(
 		createCmd,
 		growCmd,
+		shrinkCmd,
 		resetCmd,
 		destroyCmd,
 		extendCmd,

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -348,14 +348,35 @@ func GrowCluster(l *logger.Logger, c *Cluster, NumNodes int) error {
 	}
 
 	providers := c.Clouds()
-	if len(providers) != 1 && providers[0] != gce.ProviderName {
-		return errors.Errorf("cluster %s is not on gce, growing a cluster is currently only supported on %s",
+	if len(providers) != 1 || providers[0] != gce.ProviderName {
+		return errors.Errorf("cannot grow cluster %s, growing a cluster is currently only supported on %s",
 			c.Name, gce.ProviderName)
 	}
 
 	// Only GCE supports expanding a cluster.
 	return vm.ForProvider(gce.ProviderName, func(p vm.Provider) error {
 		return p.Grow(l, c.VMs, c.Name, names)
+	})
+}
+
+// ShrinkCluster removes tail nodes from an existing cluster.
+func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
+	providers := c.Clouds()
+	if len(providers) != 1 || providers[0] != gce.ProviderName {
+		return errors.Errorf("cannot shrink cluster %s, shrinking a cluster is currently only supported on %s",
+			c.Name, gce.ProviderName)
+	}
+
+	if numNodes >= len(c.VMs) {
+		return errors.Errorf("cannot shrink cluster %s by %d nodes, only %d nodes in cluster",
+			c.Name, numNodes, len(c.VMs))
+	}
+	// Always delete from the tail.
+	vmsToDelete := c.VMs[len(c.VMs)-numNodes:]
+
+	// Only GCE supports shrinking a cluster.
+	return vm.ForProvider(gce.ProviderName, func(p vm.Provider) error {
+		return p.Shrink(l, vmsToDelete, c.Name)
 	})
 }
 

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -339,10 +339,10 @@ func CreateCluster(
 }
 
 // GrowCluster adds new nodes to an existing cluster.
-func GrowCluster(l *logger.Logger, c *Cluster, NumNodes int) error {
-	names := make([]string, 0, NumNodes)
+func GrowCluster(l *logger.Logger, c *Cluster, numNodes int) error {
+	names := make([]string, 0, numNodes)
 	offset := len(c.VMs) + 1
-	for i := offset; i < offset+NumNodes; i++ {
+	for i := offset; i < offset+numNodes; i++ {
 		vmName := vm.Name(c.Name, i)
 		names = append(names, vmName)
 	}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1643,6 +1643,20 @@ func Grow(ctx context.Context, l *logger.Logger, clusterName string, numNodes in
 	return SetupSSH(ctx, l, clusterName)
 }
 
+func Shrink(ctx context.Context, l *logger.Logger, clusterName string, numNodes int) error {
+	c, err := getClusterFromCache(l, clusterName)
+	if err != nil {
+		return err
+	}
+
+	err = cloud.ShrinkCluster(l, &c.Cluster, numNodes)
+	if err != nil {
+		return err
+	}
+	_, err = Sync(l, vm.ListOptions{})
+	return err
+}
+
 // GC garbage-collects expired clusters, unused SSH key pairs in AWS, and unused
 // DNS records.
 func GC(l *logger.Logger, dryrun bool) error {

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -657,6 +657,10 @@ func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) Shrink(*logger.Logger, vm.List, string) error {
+	panic("unimplemented")
+}
+
 // waitForIPs waits until AWS reports both internal and external IP addresses
 // for all newly created VMs. If we did not wait for these IPs then attempts to
 // list the new VMs after the creation might find VMs without an external IP.

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -156,6 +156,10 @@ func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) Shrink(*logger.Logger, vm.List, string) error {
+	panic("unimplemented")
+}
+
 func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -128,6 +128,10 @@ func (p *provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	return errors.Newf("%s", p.unimplemented)
 }
 
+func (p *provider) Shrink(*logger.Logger, vm.List, string) error {
+	return errors.Newf("%s", p.unimplemented)
+}
+
 // Delete implements vm.Provider and returns Unimplemented.
 func (p *provider) Delete(l *logger.Logger, vms vm.List) error {
 	return errors.Newf("%s", p.unimplemented)

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -270,6 +270,10 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	return errors.New("unimplemented")
 }
 
+func (p *Provider) Shrink(l *logger.Logger, vmsToDelete vm.List, clusterName string) error {
+	return errors.New("unimplemented")
+}
+
 // Delete is part of the vm.Provider interface.
 func (p *Provider) Delete(l *logger.Logger, vms vm.List) error {
 	panic("DeleteCluster should be used")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -458,6 +458,7 @@ type Provider interface {
 	ConfigSSH(l *logger.Logger, zones []string) error
 	Create(l *logger.Logger, names []string, opts CreateOpts, providerOpts ProviderOpts) error
 	Grow(l *logger.Logger, vms List, clusterName string, names []string) error
+	Shrink(l *logger.Logger, vmsToRemove List, clusterName string) error
 	Reset(l *logger.Logger, vms List) error
 	Delete(l *logger.Logger, vms List) error
 	Extend(l *logger.Logger, vms List, lifetime time.Duration) error


### PR DESCRIPTION
This change adds the ability to VM providers to shrink Google managed instance
group clusters. Groups will not be destroyed if it is empty after a shrink
operation. This is to allow a grow operation to re-use any existing group zones.

Epic: CRDB-33832
See: #119367

Release Note: None