### PR TITLE
release-24.1: roachtest: export $root for roachtest weekly

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -4,7 +4,10 @@ set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
+# N.B. export variables like `root` s.t. they can be used by scripts called below.
+set -a
 source "$dir/teamcity-support.sh"
+set +a
 
 if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-weekly-bazel $(date)" -N "" -f ~/.ssh/id_rsa


### PR DESCRIPTION
Backport 1/1 commits from #124957.

/cc @cockroachdb/release

---

The `roachtest_compile_bits.sh` now require `$root` to be defined, see #124592 for details. This change adds the required exports to the `roachtest_weekly_impl.sh` script.

Release justification: Test only change.
Release Note: None
Epic: None
