### PR TITLE
ui: fix outside event handler event listener

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/outsideEventHandler/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/outsideEventHandler/index.tsx
@@ -38,17 +38,21 @@ export class OutsideEventHandler extends React.Component<OutsideEventHandlerProp
     this.removeEventListener();
   }
 
-  onClick = (event: any): void => {
+  onClick = (event: PointerEvent): void => {
+    if (!(event.target instanceof Node)) {
+      return;
+    }
+    const target = event.target;
+
     const { onOutsideClick, ignoreClickOnRefs = [] } = this.props;
     const isChildEl =
-      this.nodeRef.current &&
-      this.nodeRef.current.contains(event.target.target);
+      this.nodeRef.current && this.nodeRef.current.contains(target);
 
     const isOutsideIgnoredEl = ignoreClickOnRefs.some(outsideIgnoredRef => {
       if (!outsideIgnoredRef || !outsideIgnoredRef.current) {
         return false;
       }
-      return outsideIgnoredRef.current.contains(event.target);
+      return outsideIgnoredRef.current.contains(target);
     });
 
     if (!isChildEl && !isOutsideIgnoredEl) {
@@ -57,11 +61,11 @@ export class OutsideEventHandler extends React.Component<OutsideEventHandlerProp
   };
 
   addEventListener = (): void => {
-    addEventListener("click", this.onClick);
+    document.addEventListener("click", this.onClick);
   };
 
   removeEventListener = (): void => {
-    removeEventListener("click", this.onClick);
+    document.removeEventListener("click", this.onClick);
   };
 
   render(): React.ReactElement {

--- a/pkg/ui/workspaces/cluster-ui/src/outsideEventHandler/outsideEventHandler.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/outsideEventHandler/outsideEventHandler.spec.tsx
@@ -1,0 +1,84 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { createRef } from "react";
+import { render, waitFor } from "@testing-library/react";
+
+import { OutsideEventHandler } from "./index";
+
+describe("OutsideEventHandler", () => {
+  async function renderComponent() {
+    const onOutsideClick = jest.fn();
+    const onInsideClick = jest.fn();
+    const outside = createRef<HTMLDivElement>();
+    const ignored = createRef<HTMLDivElement>();
+    const inside = createRef<HTMLButtonElement>();
+    render(
+      <div>
+        <div ref={outside}>outside</div>
+        <OutsideEventHandler
+          onOutsideClick={onOutsideClick}
+          ignoreClickOnRefs={[ignored]}
+        >
+          <button ref={inside} onClick={onInsideClick}>
+            inside
+          </button>
+        </OutsideEventHandler>
+        <div ref={ignored}>ignored</div>
+      </div>,
+    );
+
+    await waitFor(() => {
+      expect(inside.current).toBeTruthy();
+      expect(outside.current).toBeTruthy();
+      expect(ignored.current).toBeTruthy();
+    });
+
+    return {
+      onOutsideClick,
+      onInsideClick,
+      outside,
+      ignored,
+      inside,
+    };
+  }
+
+  it("should call onOutsideClick when clicking outside the component", async () => {
+    const { onOutsideClick, onInsideClick, outside } = await renderComponent();
+    // Click outside the component
+    outside.current.click();
+
+    await waitFor(() => {
+      expect(onOutsideClick).toHaveBeenCalled();
+      expect(onInsideClick).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not call onOutsideClick when clicking inside the component", async () => {
+    const { onOutsideClick, onInsideClick, inside } = await renderComponent();
+    // Click inside the component.
+    inside.current.click();
+
+    await waitFor(() => {
+      expect(onInsideClick).toHaveBeenCalled();
+      expect(onOutsideClick).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should not call onOutsideClick when clicking on the ignored ref", async () => {
+    const { onOutsideClick, ignored } = await renderComponent();
+    // Click on the ignored ref.
+    ignored.current.click();
+
+    await waitFor(() => {
+      expect(onOutsideClick).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
OutsideEventHandler is used to wrap componenents that subscribe to click events outside of the wrapped element. This commit fixes a bug caused by some recent refactoring that caused the outsideeventhandler event to trigger for inside clicks as well.

This manifested in a bug where the Dropdown component used by databases and insights pages became unresponsive.

Epic: none

Release note: None