### PR TITLE
kv: avoid O(stores) work in updatePausedFollowersLocked

### DIFF
--- a/pkg/kv/kvserver/replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker_test.go
@@ -47,7 +47,7 @@ func TestReplicaUnavailableError(t *testing.T) {
 	ctx := context.Background()
 
 	rue := errors.Mark(
-		replicaUnavailableError(wrappedErr, desc, desc.Replicas().AsProto()[0], lm, &rs, ts),
+		replicaUnavailableError(wrappedErr, desc, desc.Replicas().Descriptors()[0], lm, &rs, ts),
 		circuit.ErrBreakerOpen)
 
 	// A Protobuf roundtrip retains the error details.

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -37,7 +37,7 @@ func (r *Replica) maybeAcquireProposalQuota(
 
 	r.mu.RLock()
 	quotaPool := r.mu.proposalQuota
-	desc := *r.mu.state.Desc
+	desc := r.mu.state.Desc
 	r.mu.RUnlock()
 
 	// Quota acquisition only takes place on the leader replica,
@@ -74,7 +74,7 @@ func (r *Replica) maybeAcquireProposalQuota(
 	return alloc, err
 }
 
-func quotaPoolEnabledForRange(desc roachpb.RangeDescriptor) bool {
+func quotaPoolEnabledForRange(desc *roachpb.RangeDescriptor) bool {
 	// The NodeLiveness range does not use a quota pool. We don't want to
 	// throttle updates to the NodeLiveness range even if a follower is falling
 	// behind because this could result in cascading failures.

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -104,7 +104,7 @@ func computeExpendableOverloadedFollowers(
 	var liveOverloadedNonVoterCandidates map[roachpb.ReplicaID]struct{}
 	var prs map[uint64]tracker.Progress
 
-	for _, replDesc := range d.replDescs.AsProto() {
+	for _, replDesc := range d.replDescs.Descriptors() {
 		if pausable := d.ioOverloadMap.AbovePauseThreshold(replDesc.StoreID); !pausable || replDesc.ReplicaID == d.self {
 			continue
 		}
@@ -299,7 +299,10 @@ func (osm *ioThresholds) Replace(
 func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMap *ioThresholdMap) {
 	r.mu.pausedFollowers = nil
 
-	if !ioThresholdMap.AnyAbovePauseThreshold(r.descRLocked().Replicas()) {
+	desc := r.descRLocked()
+	repls := desc.Replicas()
+
+	if !ioThresholdMap.AnyAbovePauseThreshold(repls) {
 		return
 	}
 
@@ -309,7 +312,7 @@ func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMa
 		return
 	}
 
-	if !quotaPoolEnabledForRange(*r.descRLocked()) {
+	if !quotaPoolEnabledForRange(desc) {
 		// If the quota pool isn't enabled (like for the liveness range), play it
 		// safe. The range is unlikely to be a major contributor to any follower's
 		// I/O and wish to reduce the likelihood of a problem in replication pausing
@@ -340,11 +343,11 @@ func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMa
 	now := r.store.Clock().Now().GoTime()
 	d := computeExpendableOverloadedFollowersInput{
 		self:          r.replicaID,
-		replDescs:     r.descRLocked().Replicas(),
+		replDescs:     repls,
 		ioOverloadMap: ioThresholdMap,
 		getProgressMap: func(_ context.Context) map[uint64]tracker.Progress {
 			prs := r.mu.internalRaftGroup.Status().Progress
-			updateRaftProgressFromActivity(ctx, prs, r.descRLocked().Replicas().AsProto(), func(id roachpb.ReplicaID) bool {
+			updateRaftProgressFromActivity(ctx, prs, repls.Descriptors(), func(id roachpb.ReplicaID) bool {
 				return r.mu.lastUpdateTimes.isFollowerActiveSince(id, now, r.store.cfg.RangeLeaseDuration)
 			})
 			return prs

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -230,14 +230,14 @@ func (osm *ioThresholdMap) AbovePauseThreshold(id roachpb.StoreID) bool {
 	return sc > osm.threshold
 }
 
-func (osm *ioThresholdMap) NumAbovePauseThreshold() int {
-	var n int
-	for id := range osm.m {
-		if osm.AbovePauseThreshold(id) {
-			n++
+func (osm *ioThresholdMap) AnyAbovePauseThreshold(repls roachpb.ReplicaSet) bool {
+	descs := repls.Descriptors()
+	for i := range descs {
+		if osm.AbovePauseThreshold(descs[i].StoreID) {
+			return true
 		}
 	}
-	return n
+	return false
 }
 
 func (osm *ioThresholdMap) IOThreshold(id roachpb.StoreID) *admissionpb.IOThreshold {
@@ -299,7 +299,7 @@ func (osm *ioThresholds) Replace(
 func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMap *ioThresholdMap) {
 	r.mu.pausedFollowers = nil
 
-	if ioThresholdMap.NumAbovePauseThreshold() == 0 {
+	if !ioThresholdMap.AnyAbovePauseThreshold(r.descRLocked().Replicas()) {
 		return
 	}
 

--- a/pkg/kv/kvserver/replica_raft_overload_test.go
+++ b/pkg/kv/kvserver/replica_raft_overload_test.go
@@ -113,7 +113,7 @@ func TestReplicaRaftOverload_computeExpendableOverloadedFollowers(t *testing.T) 
 
 				// First, set up a progress map in which all replicas are tracked and are live.
 				m := map[uint64]tracker.Progress{}
-				for _, replDesc := range replDescs.AsProto() {
+				for _, replDesc := range replDescs.Descriptors() {
 					pr := tracker.Progress{
 						State:        tracker.StateReplicate,
 						Match:        match[replDesc.ReplicaID],

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10082,7 +10082,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	// Verify no quiescence when a follower is paused.
 	test(false, func(q *testQuiescer) *testQuiescer {
 		q.paused = map[roachpb.ReplicaID]struct{}{
-			q.desc.Replicas().AsProto()[0].ReplicaID: {},
+			q.desc.Replicas().Descriptors()[0].ReplicaID: {},
 		}
 		return q
 	})

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -221,7 +221,7 @@ func (r *RangeDescriptor) Replicas() ReplicaSet {
 // SetReplicas overwrites the set of nodes/stores on which replicas of this
 // range are stored.
 func (r *RangeDescriptor) SetReplicas(replicas ReplicaSet) {
-	r.InternalReplicas = replicas.AsProto()
+	r.InternalReplicas = replicas.Descriptors()
 }
 
 // SetReplicaType changes the type of the replica with the given ID to the given

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -273,14 +273,6 @@ func (d ReplicaSet) FilterToDescriptors(
 	return out
 }
 
-// AsProto returns the protobuf representation of these replicas, suitable for
-// setting the InternalReplicas field of a RangeDescriptor. When possible the
-// SetReplicas method of RangeDescriptor should be used instead, this is only
-// here for the convenience of tests.
-func (d ReplicaSet) AsProto() []ReplicaDescriptor {
-	return d.wrapped
-}
-
 // DeepCopy returns a copy of this set of replicas. Modifications to the
 // returned set will not affect this one and vice-versa.
 func (d ReplicaSet) DeepCopy() ReplicaSet {


### PR DESCRIPTION
Fixes #125308.

This commit avoids O(stores) work in Replica.updatePausedFollowersLocked, which is called on every tick.

Release note: None