### PR TITLE
pkg/obs/logstream: skip TestBlockedFlush

### DIFF
--- a/pkg/obs/logstream/BUILD.bazel
+++ b/pkg/obs/logstream/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     embed = [":logstream"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",

--- a/pkg/obs/logstream/async_processor_router_test.go
+++ b/pkg/obs/logstream/async_processor_router_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -281,6 +282,7 @@ func TestCtxDoneFlushesBeforeExit(t *testing.T) {
 
 // Test that we still accept & buffer new events while a flush is in-flight, and the flush channel buffer is full.
 func TestBlockedFlush(t *testing.T) {
+	skip.WithIssue(t, 125290 /*githubIssueID*/)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()


### PR DESCRIPTION
Relates to: https://github.com/cockroachdb/cockroach/issues/125290

There seems to be some kind of deadlock happening in the test related to the channels used to coordinate the various goroutines involved.

We've been unable to reproduce this locally, so it will require some deeper investigation. In the meantime, we'll skip the test to unblock master while we investigate.

Release note: none

Epic: none