### PR TITLE
sql: avoid some setting retrievals for internal executors

### DIFF
--- a/pkg/sql/audit_logging.go
+++ b/pkg/sql/audit_logging.go
@@ -149,11 +149,11 @@ func (p *planner) initializeReducedAuditConfig(ctx context.Context) {
 // shouldNotRoleBasedAudit checks if we should do any auditing work for
 // RoleBasedAuditEvents.
 func (p *planner) shouldNotRoleBasedAudit(execType executorType) bool {
+	// Do not emit audit events for internal executors.
 	// Do not do audit work if role-based auditing is not enabled.
 	// Do not emit audit events for reserved users/roles. This does not omit the
 	// root user.
-	// Do not emit audit events for internal executors.
-	return !auditlogging.UserAuditEnabled(p.execCfg.Settings) ||
-		p.User().IsReserved() ||
-		execType == executorTypeInternal
+	return execType == executorTypeInternal ||
+		!auditlogging.UserAuditEnabled(p.execCfg.Settings) ||
+		p.User().IsReserved()
 }

--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -30,8 +30,8 @@ import (
 func (ex *connExecutor) maybeAutoCommitBeforeDDL(
 	ctx context.Context, ast tree.Statement,
 ) (fsm.Event, fsm.EventPayload) {
-	if tree.CanModifySchema(ast) &&
-		ex.executorType != executorTypeInternal &&
+	if ex.executorType != executorTypeInternal &&
+		tree.CanModifySchema(ast) &&
 		ex.sessionData().AutoCommitBeforeDDL &&
 		(!ex.planner.EvalContext().TxnIsSingleStmt || !ex.implicitTxn()) &&
 		ex.extraTxnState.firstStmtExecuted {

--- a/pkg/sql/idxrecommendations/idx_recommendations_cache.go
+++ b/pkg/sql/idxrecommendations/idx_recommendations_cache.go
@@ -165,17 +165,13 @@ func (idxRec *IndexRecCache) UpdateIndexRecommendations(
 	return recInfo.recommendations
 }
 
-// statementCanHaveRecommendation returns true if that type of statement can have recommendations
-// generated for it. We only want to recommend if the statement is DML, recommendations are enabled and
-// is not internal.
+// statementCanHaveRecommendation returns true if that type of statement can
+// have recommendations generated for it. We only want to recommend for
+// non-internal DML statements when recommendations are enabled.
 func (idxRec *IndexRecCache) statementCanHaveRecommendation(
 	stmtType tree.StatementType, isInternal bool,
 ) bool {
-	if !sqlstats.SampleIndexRecommendation.Get(&idxRec.st.SV) || stmtType != tree.TypeDML || isInternal {
-		return false
-	}
-
-	return true
+	return !isInternal && stmtType == tree.TypeDML && sqlstats.SampleIndexRecommendation.Get(&idxRec.st.SV)
 }
 
 func (idxRec *IndexRecCache) getIndexRecommendationAndInfo(


### PR DESCRIPTION
This commit audits all code that checks whether the connExecutor is used by the internal queries and adjusts the code so that the executor type check is done before any `*Setting.Get` retrievals in the conditions. Whenever overall condition can be short-circuited based on the executor type, this will avoid those `Get`s which is a minor perf improvement.

Epic: None

Release note: None