### PR TITLE
release-23.1: tree: make empty array error condition stricter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3330,3 +3330,24 @@ CREATE UNIQUE INDEX ON public.t_118626(c) WHERE n>= 1;
 
 statement ok
 ALTER TABLE public.t_118626 ALTER PRIMARY KEY USING COLUMNS(b);
+
+subtest end
+
+subtest add_default_empty_array
+
+statement ok
+CREATE TABLE t_114316 (i INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE t_114316 ADD COLUMN a INT[] DEFAULT ARRAY[]::OID[]
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_114316];
+----
+CREATE TABLE public.t_114316 (
+  i INT8 NOT NULL,
+  a INT8[] NULL DEFAULT ARRAY[]:::OID[],
+  CONSTRAINT t_114316_pkey PRIMARY KEY (i ASC)
+)
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -262,14 +262,14 @@ SELECT CASE WHEN x > 1 THEN true ELSE NULL OR false END FROM (VALUES (1), (2)) A
 NULL
 true
 
-# Error "cannot determine type of empty array" should apply no matter the
-# operator, `>`, or `<`.
-query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
+query B
 SELECT ARRAY[]::TIMESTAMPTZ[] >
-       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);
+       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL])
+----
+false
 
-# Error "cannot determine type of empty array" should apply no matter the
-# operator, `>`, or `<`.
-query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
+query B
 SELECT ARRAY[]::TIMESTAMPTZ[] <
-       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);
+       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL])
+----
+true

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1649,10 +1649,12 @@ func (expr *Array) TypeCheck(
 	}
 
 	if len(expr.Exprs) == 0 {
-		if desiredParam.Family() == types.AnyFamily {
-			return nil, errAmbiguousArrayType
+		if expr.typ == nil || expr.typ.Family() != types.ArrayFamily {
+			if desiredParam.Family() == types.AnyFamily {
+				return nil, errAmbiguousArrayType
+			}
+			expr.typ = types.MakeArray(desiredParam)
 		}
-		expr.typ = types.MakeArray(desiredParam)
 		return expr, nil
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #125284.

/cc @cockroachdb/release

Release justification: low risk bug fix

---

There's no need to return the error about not knowing the empty array's
type if we were provided a type annotation.

fixes https://github.com/cockroachdb/cockroach/issues/114316
Release note (bug fix): Fixed an issue where adding a column with a
default value of an empty array would not succeed.
