### PR TITLE
release-23.1: kv: avoid O(stores) work in updatePausedFollowersLocked

### DIFF
--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -239,14 +239,14 @@ func (osm *ioThresholdMap) AbovePauseThreshold(id roachpb.StoreID) bool {
 	return sc > osm.threshold
 }
 
-func (osm *ioThresholdMap) NumAbovePauseThreshold() int {
-	var n int
-	for id := range osm.m {
-		if osm.AbovePauseThreshold(id) {
-			n++
+func (osm *ioThresholdMap) AnyAbovePauseThreshold(repls roachpb.ReplicaSet) bool {
+	descs := repls.Descriptors()
+	for i := range descs {
+		if osm.AbovePauseThreshold(descs[i].StoreID) {
+			return true
 		}
 	}
-	return n
+	return false
 }
 
 func (osm *ioThresholdMap) IOThreshold(id roachpb.StoreID) *admissionpb.IOThreshold {
@@ -308,7 +308,7 @@ func (osm *ioThresholds) Replace(
 func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMap *ioThresholdMap) {
 	r.mu.pausedFollowers = nil
 
-	if ioThresholdMap.NumAbovePauseThreshold() == 0 {
+	if !ioThresholdMap.AnyAbovePauseThreshold(r.descRLocked().Replicas()) {
 		return
 	}
 


### PR DESCRIPTION
Backport 1/3 commits from #125310.

/cc @cockroachdb/release

---

Fixes #125308.

This commit avoids O(stores) work in Replica.updatePausedFollowersLocked, which is called on every tick.

Release note: None

Release justification: avoids expensive O(stores) work on each tick.