### PR TITLE
cdc: mark flow disk monitor as long living

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -316,8 +316,8 @@ func startDistChangefeed(
 		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID)
 
 		// CDC DistSQL flows are long-living, so we want to mark the flow memory
-		// monitor accordingly.
-		planCtx.MarkFlowMonitorAsLongLiving = true
+		// and disk monitors accordingly.
+		planCtx.MarkFlowMonitorsAsLongLiving = true
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
 		// p is the physical plan, recv is the distsqlreceiver

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -810,17 +810,15 @@ func makeSystemServerWithOptions(
 ) (testServer TestServerWithSystem, cleanup func()) {
 	systemServer, systemDB, clusterCleanup := startTestFullServer(t, options)
 	return TestServerWithSystem{
-			TestServer: TestServer{
-				DB:           systemDB,
-				Server:       systemServer,
-				TestingKnobs: *systemServer.SystemLayer().TestingKnobs(),
-				Codec:        keys.SystemSQLCodec,
-			},
-			SystemServer: systemServer,
-			SystemDB:     systemDB,
-		}, func() {
-			clusterCleanup()
-		}
+		TestServer: TestServer{
+			DB:           systemDB,
+			Server:       systemServer,
+			TestingKnobs: *systemServer.SystemLayer().TestingKnobs(),
+			Codec:        keys.SystemSQLCodec,
+		},
+		SystemServer: systemServer,
+		SystemDB:     systemDB,
+	}, clusterCleanup
 }
 
 func makeTenantServer(
@@ -1103,7 +1101,7 @@ func cdcTestNamed(t *testing.T, name string, testFn cdcTestFn, testOpts ...feedT
 	testFnWithSystem := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
 		testFn(t, s.TestServer, f)
 	}
-	cdcTestNamedWithSystem(t, "", testFnWithSystem, testOpts...)
+	cdcTestNamedWithSystem(t, name, testFnWithSystem, testOpts...)
 }
 
 func cdcTestWithSystem(t *testing.T, testFn cdcTestWithSystemFn, testOpts ...feedTestOption) {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -919,10 +919,11 @@ type PlanningCtx struct {
 	// This is true if plan is a simple insert that can be vectorized.
 	isVectorInsert bool
 
-	// MarkFlowMonitorAsLongLiving, if set, instructs the DistSQL runner to mark
-	// the "flow" memory monitor as long-living one, thus exempting it from
-	// having to be stopped when the txn monitor is stopped.
-	MarkFlowMonitorAsLongLiving bool
+	// MarkFlowMonitorsAsLongLiving, if set, instructs the DistSQL runner to
+	// mark the "flow" memory and disk monitors as long-living ones, thus
+	// exempting them from having to be stopped when the parent monitors are
+	// stopped.
+	MarkFlowMonitorsAsLongLiving bool
 }
 
 var _ physicalplan.ExprContext = &PlanningCtx{}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -696,7 +696,7 @@ func (dsp *DistSQLPlanner) Run(
 	localState.Txn = txn
 	localState.LocalProcs = plan.LocalProcessors
 	localState.LocalVectorSources = plan.LocalVectorSources
-	localState.MarkFlowMonitorAsLongLiving = planCtx.MarkFlowMonitorAsLongLiving
+	localState.MarkFlowMonitorsAsLongLiving = planCtx.MarkFlowMonitorsAsLongLiving
 	if planCtx.planner != nil {
 		// Note that the planner's collection will only be used for local plans.
 		localState.Collection = planCtx.planner.Descriptors()


### PR DESCRIPTION
We already mark the flow memory monitor used in CDC DistSQL flows as "long-living" (due to a race on a server shutdown), and we need to do the same for the flow disk monitor.

Fixes: #125139.

Release note: None