### PR TITLE
spanconfigreconcilerccl: Skip datadriven test under race or deadlock

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/sqllivenesstestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -85,7 +86,8 @@ import (
 // must be cleared out.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
+	skip.UnderRace(t, "descriptor ID generation is not deterministic under race")
+	skip.UnderDeadlock(t, "descriptor ID generation is not deterministic under deadlock")
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		defer log.Scope(t).Close(t)


### PR DESCRIPTION
This PR skips the data driven test under race or deadlock. The test relies on deterministic descriptor ID generation while comparing the test results with the expected output. The descriptor IDs generated under race and deadlock don't appear to be deterministic.

Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/123455