### PR TITLE
drt: add date to roachtest_ops.log entries

### DIFF
--- a/pkg/roachprod/logger/log.go
+++ b/pkg/roachprod/logger/log.go
@@ -23,7 +23,7 @@ import (
 )
 
 // The flags used by the internal loggers.
-const logFlags = log.Lshortfile | log.Ltime | log.LUTC
+const logFlags = log.Lshortfile | log.Ltime | log.LUTC | log.Ldate
 
 // Config configures a logger.
 type Config struct {


### PR DESCRIPTION
Previously, roachtest_ops.log entries show the current timestamp in hh:mm:ss without the timezone. This makes correlating logs quite tricky. This patch add date and timezone to the logs.

Fixes: #125304
Release note: None