### PR TITLE
sql,changefeedccl: miscellaneous cleanup of server shutdown

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -315,12 +315,15 @@ func startDistChangefeed(
 
 		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID)
 
-		// CDC DistSQL flows are long-living, so we want to mark the flow memory
-		// monitor accordingly.
-		planCtx.MarkFlowMonitorAsLongLiving = true
+		// Make sure to use special changefeed monitor going forward as the
+		// parent monitor for the DistSQL infrastructure. This is needed to
+		// prevent a race between the connection that started the changefeed
+		// closing (which closes the current planner's monitor) and changefeed
+		// DistSQL flow being cleaned up.
+		planCtx.OverridePlannerMon = execCfg.DistSQLSrv.ChangefeedMonitor
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
-		// p is the physical plan, recv is the distsqlreceiver
+		// p is the physical plan, recv is the DistSQLReceiver.
 		dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)
 		return resultRows.Err()
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -183,9 +183,6 @@ func newChangeAggregatorProcessor(
 	}()
 
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changeagg-mem")
-	// CDC DistSQL flows are long-living, so we mark the memory monitors
-	// accordingly.
-	memMonitor.MarkLongLiving()
 	ca := &changeAggregator{
 		flowCtx:           flowCtx,
 		spec:              spec,
@@ -399,10 +396,7 @@ func (ca *changeAggregator) startKVFeed(
 	opts changefeedbase.StatementOptions,
 ) (kvevent.Reader, chan struct{}, chan error, error) {
 	cfg := ca.flowCtx.Cfg
-	// CDC DistSQL flows are long-living, so we mark the memory monitors
-	// accordingly.
-	const longLiving = true
-	kvFeedMemMon := mon.NewMonitorInheritWithLimit("kvFeed", memLimit, parentMemMon, longLiving)
+	kvFeedMemMon := mon.NewMonitorInheritWithLimit("kvFeed", memLimit, parentMemMon, false /* longLiving */)
 	kvFeedMemMon.StartNoReserved(ctx, parentMemMon)
 	buf := kvevent.NewThrottlingBuffer(
 		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV, &ca.metrics.KVFeedMetrics),
@@ -1122,9 +1116,6 @@ func newChangeFrontierProcessor(
 	post *execinfrapb.PostProcessSpec,
 ) (execinfra.Processor, error) {
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changefntr-mem")
-	// CDC DistSQL flows are long-living, so we mark the memory monitors
-	// accordingly.
-	memMonitor.MarkLongLiving()
 	sf, err := makeSchemaChangeFrontier(hlc.Timestamp{}, spec.TrackedSpans...)
 	if err != nil {
 		return nil, err

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -297,6 +297,10 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 // ccl code.
 var MakeChangefeedMetricsHook func(time.Duration) metric.Struct
 
+// MakeChangefeedMemoryMetricsHook allows for registration of changefeed memory
+// metrics from ccl code.
+var MakeChangefeedMemoryMetricsHook func(time.Duration) (curCount *metric.Gauge, maxHist metric.IHistogram)
+
 // MakeStreamIngestMetricsHook allows for registration of streaming metrics from
 // ccl code.
 var MakeStreamIngestMetricsHook func(duration time.Duration) metric.Struct

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1024,6 +1024,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.TableStatCacheSize,
 			cfg.Settings,
 			cfg.internalDB,
+			cfg.stopper,
 		),
 
 		QueryCache:                 querycache.New(cfg.QueryCacheSize),

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -696,17 +696,26 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	bulkMetrics := bulk.MakeBulkMetrics(cfg.HistogramWindowInterval())
 	cfg.registry.AddMetricStruct(bulkMetrics)
 	bulkMemoryMonitor.SetMetrics(bulkMetrics.CurBytesCount, bulkMetrics.MaxBytesHist)
-	bulkMemoryMonitor.StartNoReserved(context.Background(), rootSQLMemoryMonitor)
+	bulkMemoryMonitor.StartNoReserved(ctx, rootSQLMemoryMonitor)
 
 	backfillMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "backfill-mon")
 	backfillMemoryMonitor.MarkLongLiving()
 	backupMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "backup-mon")
 	backupMemoryMonitor.MarkLongLiving()
 
+	changefeedMemoryMonitor := mon.NewMonitorInheritWithLimit(
+		"changefeed-mon", 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
+	)
+	if jobs.MakeChangefeedMemoryMetricsHook != nil {
+		changefeedCurCount, changefeedMaxHist := jobs.MakeChangefeedMemoryMetricsHook(cfg.HistogramWindowInterval())
+		changefeedMemoryMonitor.SetMetrics(changefeedCurCount, changefeedMaxHist)
+	}
+	changefeedMemoryMonitor.StartNoReserved(ctx, rootSQLMemoryMonitor)
+
 	serverCacheMemoryMonitor := mon.NewMonitorInheritWithLimit(
 		"server-cache-mon", 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
 	)
-	serverCacheMemoryMonitor.StartNoReserved(context.Background(), rootSQLMemoryMonitor)
+	serverCacheMemoryMonitor.StartNoReserved(ctx, rootSQLMemoryMonitor)
 
 	// Set up the DistSQL temp engine.
 
@@ -821,6 +830,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		ParentDiskMonitor: cfg.TempStorageConfig.Mon,
 		BackfillerMonitor: backfillMemoryMonitor,
 		BackupMonitor:     backupMemoryMonitor,
+		ChangefeedMonitor: changefeedMemoryMonitor,
 		BulkSenderLimiter: bulkSenderLimiter,
 
 		ParentMemoryMonitor: rootSQLMemoryMonitor,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -184,15 +184,12 @@ func (ds *ServerImpl) setDraining(drain bool) error {
 
 // setupFlow creates a Flow.
 //
-// Args:
-// reserved: Specifies the upfront memory reservation that the flow takes
+//   - reserved: specifies the upfront memory reservation that the flow takes
+//     ownership of. This account is already closed if an error is returned or
+//     will be closed through Flow.Cleanup.
 //
-//	ownership of. This account is already closed if an error is returned or
-//	will be closed through Flow.Cleanup.
-//
-// localState: Specifies if the flow runs entirely on this node and, if it does,
-//
-//	specifies the txn and other attributes.
+//   - localState: specifies if the flow runs entirely on this node and, if it
+//     does, specifies the txn and other attributes.
 //
 // Note: unless an error is returned, the returned context contains a span that
 // must be finished through Flow.Cleanup.
@@ -263,11 +260,10 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	monitor = mon.NewMonitor(mon.Options{
-		Name:       "flow " + redact.RedactableString(req.Flow.FlowID.Short()),
-		CurCount:   ds.Metrics.CurBytesCount,
-		MaxHist:    ds.Metrics.MaxBytesHist,
-		Settings:   ds.Settings,
-		LongLiving: localState.MarkFlowMonitorAsLongLiving,
+		Name:     "flow " + redact.RedactableString(req.Flow.FlowID.Short()),
+		CurCount: ds.Metrics.CurBytesCount,
+		MaxHist:  ds.Metrics.MaxBytesHist,
+		Settings: ds.Settings,
 	})
 	monitor.Start(ctx, parentMonitor, reserved)
 	diskMonitor = execinfra.NewMonitor(ctx, ds.ParentDiskMonitor, "flow-disk-monitor")
@@ -560,11 +556,6 @@ type LocalState struct {
 	// mapping to coldata.Batch, use any to avoid injecting new
 	// dependencies.
 	LocalVectorSources map[int32]any
-
-	// MarkFlowMonitorAsLongLiving, if set, instructs the DistSQL runner to mark
-	// the "flow" memory monitor as long-living one, thus exempting it from
-	// having to be stopped when the txn monitor is stopped.
-	MarkFlowMonitorAsLongLiving bool
 }
 
 // MustUseLeafTxn returns true if a LeafTxn must be used. It is valid to call

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -919,10 +920,9 @@ type PlanningCtx struct {
 	// This is true if plan is a simple insert that can be vectorized.
 	isVectorInsert bool
 
-	// MarkFlowMonitorAsLongLiving, if set, instructs the DistSQL runner to mark
-	// the "flow" memory monitor as long-living one, thus exempting it from
-	// having to be stopped when the txn monitor is stopped.
-	MarkFlowMonitorAsLongLiving bool
+	// OverridePlannerMon, if set, will be used instead of the Planner.Mon() as
+	// the parent monitor for the DistSQL flow.
+	OverridePlannerMon *mon.BytesMonitor
 }
 
 var _ physicalplan.ExprContext = &PlanningCtx{}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -466,7 +466,11 @@ func (dsp *DistSQLPlanner) setupFlows(
 		batchReceiver = recv
 	}
 	origCtx := ctx
-	ctx, flow, opChains, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, evalCtx.Planner.Mon(), &setupReq, recv, batchReceiver, localState)
+	parentMonitor := evalCtx.Planner.Mon()
+	if planCtx.OverridePlannerMon != nil {
+		parentMonitor = planCtx.OverridePlannerMon
+	}
+	ctx, flow, opChains, err := dsp.distSQLSrv.SetupLocalSyncFlow(ctx, parentMonitor, &setupReq, recv, batchReceiver, localState)
 	if err == nil && planCtx.saveFlows != nil {
 		err = planCtx.saveFlows(flows, opChains, planCtx.infra.LocalProcessors, isVectorized)
 	}
@@ -696,7 +700,6 @@ func (dsp *DistSQLPlanner) Run(
 	localState.Txn = txn
 	localState.LocalProcs = plan.LocalProcessors
 	localState.LocalVectorSources = plan.LocalVectorSources
-	localState.MarkFlowMonitorAsLongLiving = planCtx.MarkFlowMonitorAsLongLiving
 	if planCtx.planner != nil {
 		// Note that the planner's collection will only be used for local plans.
 		localState.Collection = planCtx.planner.Descriptors()

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -116,6 +116,9 @@ type ServerConfig struct {
 	// used during restore.
 	RestoreMonitor *mon.BytesMonitor
 
+	// ChangefeedMonitor is the parent monitor for all CDC DistSQL flows.
+	ChangefeedMonitor *mon.BytesMonitor
+
 	// BulkSenderLimiter is the concurrency limiter that is shared across all of
 	// the processes in a given sql server when sending bulk ingest (AddSST) reqs.
 	BulkSenderLimiter limit.ConcurrentRequestLimiter

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -546,7 +546,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 					"cannot execute prepared %v statement",
 					planHook.name,
 				)
-			}, header, nil), nil
+			}, header, nil /* subplans */, p.execCfg.DistSQLPlanner.stopper), nil
 		}
 
 		if fn, header, subplans, avoidBuffering, err := planHook.fn(ctx, stmt, p); err != nil {
@@ -555,7 +555,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 			if avoidBuffering {
 				p.curPlan.avoidBuffering = true
 			}
-			return newHookFnNode(planHook.name, fn, header, subplans), nil
+			return newHookFnNode(planHook.name, fn, header, subplans, p.execCfg.DistSQLPlanner.stopper), nil
 		}
 	}
 	return nil, nil

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -61,7 +61,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
-        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -71,6 +71,7 @@ func TestMaybeRefreshStats(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	refresher := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -195,6 +196,7 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	r := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -297,6 +299,7 @@ func BenchmarkEnsureAllTables(b *testing.B) {
 				10, /* cacheSize */
 				s.ClusterSettings(),
 				s.InternalDB().(descs.DB),
+				s.AppStopper(),
 			)
 			require.NoError(b, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 			r := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -370,6 +373,7 @@ func TestAverageRefreshTime(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	refresher := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -617,6 +621,7 @@ func TestAutoStatsReadOnlyTables(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	refresher := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -672,6 +677,7 @@ func TestAutoStatsOnStartupClusterSettingOff(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	refresher := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -719,6 +725,7 @@ func TestNoRetryOnFailure(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	r := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
@@ -836,6 +843,7 @@ func TestAnalyzeSystemTables(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -48,6 +48,7 @@ func TestDeleteOldStatsForColumns(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		db,
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 
@@ -348,6 +349,7 @@ func TestDeleteOldStatsForOtherColumns(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, cache.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 	testData := []TableStatisticProto{

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -236,7 +236,7 @@ func TestCacheBasic(t *testing.T) {
 	// Create a cache and iteratively query the cache for each tableID. This
 	// will result in the cache getting populated. When the stats cache size is
 	// exceeded, entries should be evicted according to the LRU policy.
-	sc := NewTableStatisticsCache(2 /* cacheSize */, s.ClusterSettings(), db)
+	sc := NewTableStatisticsCache(2 /* cacheSize */, s.ClusterSettings(), db, s.AppStopper())
 	require.NoError(t, sc.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 	for _, tableID := range tableIDs {
 		checkStatsForTable(ctx, t, sc, expectedStats[tableID], tableID)
@@ -338,7 +338,7 @@ func TestCacheUserDefinedTypes(t *testing.T) {
 	insqlDB := s.InternalDB().(descs.DB)
 
 	// Make a stats cache.
-	sc := NewTableStatisticsCache(1, s.ClusterSettings(), insqlDB)
+	sc := NewTableStatisticsCache(1, s.ClusterSettings(), insqlDB, s.AppStopper())
 	require.NoError(t, sc.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 	tbl := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "t", "tt")
 	// Get stats for our table. We are ensuring here that the access to the stats
@@ -391,7 +391,7 @@ func TestCacheWait(t *testing.T) {
 		tableIDs = append(tableIDs, tableID)
 	}
 	sort.Sort(tableIDs)
-	sc := NewTableStatisticsCache(len(tableIDs) /* cacheSize */, s.ClusterSettings(), db)
+	sc := NewTableStatisticsCache(len(tableIDs) /* cacheSize */, s.ClusterSettings(), db, s.AppStopper())
 	require.NoError(t, sc.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 	for _, tableID := range tableIDs {
 		checkStatsForTable(ctx, t, sc, expectedStats[tableID], tableID)
@@ -443,6 +443,7 @@ func TestCacheAutoRefresh(t *testing.T) {
 		10, /* cacheSize */
 		s.ClusterSettings(),
 		s.InternalDB().(descs.DB),
+		s.AppStopper(),
 	)
 	require.NoError(t, sc.Start(ctx, s.Codec(), s.RangeFeedFactory().(*rangefeed.Factory)))
 


### PR DESCRIPTION
**stats: refresh stats cache entries in async tasks**

Previously, we would use "vanilla" goroutines when refreshing stats entries (triggered by the rangefeed), but this has a downside of not respecting the stopper signal to shutdown. That could cause the "short-living monitors are not stopped" assertion to fire on the server shutdown in tests. This commit prevents that by using the stopper to start async tasks for the entry refresh (which has additional benefits like recovering from panics).

Fixes: #125329.

**sql: use async task for plan hook goroutine**

This commit is similar in spirit as the previous one and replaces usage of the "vanilla" goroutine with an async task connected to the stopper for the hookFn plan node. This allows us to synchronize the server shutdown and cancellation of the hook task.

Fixes: #125139.

**changefeedccl: create separate root changefeed memory monitor**

This commit introduces a "root" changefeed memory monitor that will be the parent for all CDC DistSQL flows. The primary motivation behind this change is to disconnect the CDC flow from the planner's monitor (which is "txn" monitor of the connection that started the changefeed). This is needed since that connection can be closed _before_ the CDC flow is cleaned up which triggers the "short-living non-stopped monitor" assertion. An additional benefit of this change is improved observability since we can now easily track the memory usage across all changefeeds.

Release note: None