### PR TITLE
ui: wrong usage of string interpolation in React component

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/loading/loading.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/loading/loading.tsx
@@ -150,7 +150,7 @@ export const Loading = (props: React.PropsWithChildren<LoadingProps>) => {
     );
   }
   return (
-    (props.children && <>${props.children}</>) ||
+    (props.children && <>{props.children}</>) ||
     (props.render && props.render())
   );
 };


### PR DESCRIPTION
Removes unnecessary $ sign which was mistakenly used as a string interpolation `${}` instead of using curly braces only within react component.

Release note (ui change): Removes $ sign on Databases and Jobs pages.

<img width="560" alt="Screenshot 2024-06-08 at 18 51 51" src="https://github.com/cockroachdb/cockroach/assets/3106437/eef10793-640f-4632-8c92-50b1b3a7a3cf">
<img width="514" alt="Screenshot 2024-06-08 at 18 51 44" src="https://github.com/cockroachdb/cockroach/assets/3106437/91a7e3ab-46de-4094-9853-1181bf8554b3">

Epic: None