### PR TITLE
rangefeed: add option to invoke tasks via caller

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -149,6 +149,7 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 		rangefeed.WithFrontierQuantized(quantize.Get(&s.execCfg.Settings.SV)),
 		rangefeed.WithOnValues(s.onValues),
 		rangefeed.WithFiltering(s.spec.WithFiltering),
+		rangefeed.WithInvoker(func(fn func() error) error { return fn() }),
 	}
 	if emitMetadata.Get(&s.execCfg.Settings.SV) {
 		opts = append(opts, rangefeed.WithOnMetadata(s.onMetadata))

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -39,6 +39,8 @@ type config struct {
 	// be sane depending on your use case.
 	useRowTimestampInInitialScan bool
 
+	invoker func(func() error) error
+
 	withDiff             bool
 	withFiltering        bool
 	onUnrecoverableError OnUnrecoverableError
@@ -152,6 +154,16 @@ func WithDiff(withDiff bool) Option {
 func WithFiltering(withFiltering bool) Option {
 	return optionFunc(func(c *config) {
 		c.withFiltering = withFiltering
+	})
+}
+
+// WithInvoker makes an option to invoke the rangefeed tasks such as running the
+// the client and processing events emitted by the client with a caller-supplied
+// function, which can make it easier to introspect into work done by a given
+// caller as the stacks for these tasks will now include the caller's invoker.
+func WithInvoker(invoker func(func() error) error) Option {
+	return optionFunc(func(c *config) {
+		c.invoker = invoker
 	})
 }
 


### PR DESCRIPTION
The rangefeed client has a callback-based API where the caller sets up what it wants run in reaction to each type of event, then sits back and lets the rangefeed 'drive' the rest, running the loops required to get those events and then call the callbacks.

While this is easy to use, it has one downside which is that when the driver is _not_ processing an event, but is waiting for one, its stack is the just the generic rangefeed client stack, regardless of which caller it is working on behalf of.

This change allows the caller to pass an 'invoker' which if passed is used to invoke the rangefeed task functions, so that the stacks for those tasks reflect that they are being run not only behalf of but indeed by their caller.

This also has the property of ensuring a debugger inspecting a specific rangefeed stack can traverse up into the state of the caller that launched it.

Release note: none.
Epic: none.