### PR TITLE
roachprod: add --dynamic to enable service discovery

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -150,6 +150,9 @@ func initFlags() {
 			vm.AllProviderNames()))
 	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
 		"geo", false, "Create geo-distributed cluster")
+	createCmd.Flags().BoolVar(&createVMOpts.DynamicService,
+		"dynamic", false, "Enable use of SRV records to dynamically discover and allocate ports to services "+
+			"for running multiple listening processes per node (e.g. for serverless-style deployments)")
 	createCmd.Flags().StringVar(&createVMOpts.Arch, "arch", "",
 		"architecture override for VM [amd64, arm64, fips]; N.B. fips implies amd64 with openssl")
 

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -318,6 +318,12 @@ func (s *ClusterSpec) RoachprodOpts(
 	}
 
 	createVMOpts := vm.DefaultCreateOpts()
+	// We just always use dynamic port allocations and discovery in tests since:
+	// a) some tests start multiple processes per node and would need to do this
+	// on a test by test basis if we didn't and
+	// b) these are *automated* tests, so the benefit of predictable ports to a
+	// human interacting with the cluster is less significant.
+	createVMOpts.DynamicService = true
 	// N.B. We set "usage=roachtest" as the default, custom label for billing tracking.
 	createVMOpts.CustomLabels = map[string]string{"usage": "roachtest"}
 	createVMOpts.ClusterName = "" // Will be set later.

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -246,6 +246,10 @@ func (c *SyncedCluster) allowServiceRegistration() bool {
 func (c *SyncedCluster) maybeRegisterServices(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts, portFunc FindOpenPortsFunc,
 ) error {
+	if !c.supportsDiscovery() {
+		return nil
+	}
+
 	serviceMap, err := c.MapServices(ctx, startOpts.VirtualClusterName, startOpts.SQLInstance)
 	if err != nil {
 		return err

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -40,6 +40,8 @@ const (
 	// TagUsage indicates where a certain resource is used. "roachtest" is used
 	// as the key for roachtest created resources.
 	TagUsage = "usage"
+	// TagService indicates service is either "static" or "srv".
+	TagService = "svc"
 	// TagArch is the CPU architecture tag const.
 	TagArch = "arch"
 
@@ -88,6 +90,11 @@ func ParseArch(s string) CPUArch {
 
 // GetDefaultLabelMap returns a label map for a common set of labels.
 func GetDefaultLabelMap(opts CreateOpts) map[string]string {
+	svc := "static"
+	if opts.DynamicService {
+		svc = "srv"
+	}
+
 	// Add architecture override tag, only if it was specified.
 	if opts.Arch != "" {
 		return map[string]string{
@@ -95,12 +102,14 @@ func GetDefaultLabelMap(opts CreateOpts) map[string]string {
 			TagLifetime:  opts.Lifetime.String(),
 			TagRoachprod: "true",
 			TagArch:      opts.Arch,
+			TagService:   svc,
 		}
 	}
 	return map[string]string{
 		TagCluster:   opts.ClusterName,
 		TagLifetime:  opts.Lifetime.String(),
 		TagRoachprod: "true",
+		TagService:   svc,
 	}
 }
 
@@ -306,6 +315,8 @@ type CreateOpts struct {
 		FileSystem string
 	}
 	OsVolumeSize int
+
+	DynamicService bool
 }
 
 // DefaultCreateOpts returns a new vm.CreateOpts with default values set.
@@ -316,6 +327,7 @@ func DefaultCreateOpts() CreateOpts {
 		GeoDistributed: false,
 		VMProviders:    []string{},
 		OsVolumeSize:   10,
+		DynamicService: true,
 		// N.B. When roachprod is used via CLI, this will be overridden by {"roachprod":"true"}.
 		CustomLabels: map[string]string{"roachtest": "true"},
 	}


### PR DESCRIPTION
This adds an option to cluster creation that persists a label on the VMs to indicate if they should use query and SRV records to dynamically find and allocate port numbers for services. While this dynamic allocation is useful for serverless-style deployments where variable numbers of listening processes are started on each host, such as in serverless-style deployments, it can also add complexity, latency and unpredictability in simpler cases where an engineer just wants to setup a simple cluster and run some sort of test or experiment.

In such cases it can be tedious to interact with cockroach while SSH'ed into a node, not knowing what port it is listening on, or can be slow to run some commands like pgurl when on higher latency internet connections (e.g. on a train).

This change makes using dynamic service discovery optional, so that it can be enabled for clusters where it will be useful and skipped for those where it isn't.

It is always enabled in roachtests, which are primarily _automated_ tests where the predictability for a human engineer is a non-factor.

Release note: none.
Epic: none.