### PR TITLE
roachtest: create tpcc backup fixture on azure

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -368,6 +368,19 @@ func registerBackupFixtures(r registry.Registry) {
 			suites:  registry.Suites(registry.Nightly),
 			skip:    "only for fixture generation",
 		},
+		{
+			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{
+				backupSpecs: backupSpecs{
+					cloud:              spec.Azure,
+					workload:           tpccRestore{opts: tpccRestoreOptions{warehouses: 5000}},
+					nonRevisionHistory: true,
+				},
+			}),
+			timeout: 1 * time.Hour,
+			suites:  registry.Suites(registry.Nightly),
+			skip:    "only for fixture generation",
+		},
 	} {
 		bf := bf
 		bf.initTestName()

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -689,6 +689,9 @@ func (bs backupSpecs) backupCollection() string {
 	case "gs":
 		return fmt.Sprintf(`'gs://cockroach-fixtures-us-east1/backups/%s/%s/inc-count=%d%s?AUTH=implicit'`,
 			bs.workload.fixtureDir(), bs.version, bs.numBackupsInChain, properties)
+	case "azure":
+		return fmt.Sprintf(`'https://roachtest.blob.core.windows.net/fixtures/backups/%s/%s/inc-count=%d%s'`,
+			bs.workload.fixtureDir(), bs.version, bs.numBackupsInChain, properties)
 	default:
 		panic(fmt.Sprintf("unknown storage prefix: %s", bs.storagePrefix()))
 	}


### PR DESCRIPTION
Currently do not support Azure based backup fixtures. This commit teaches roachtest to support fixtures being backed up to Azure storage.