### PR TITLE
build: replace `BinaryVersionPrefix` with `VersionForURLs`

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -107,13 +107,17 @@ func BinaryVersion() string {
 	return binaryVersion
 }
 
-// BinaryVersionPrefix returns the version prefix of the current build.
-func BinaryVersionPrefix() string {
-	v, err := version.Parse(BinaryVersion())
-	if err != nil {
-		return "dev"
+// VersionForURLs is used to determine the version to use in public-facing doc URLs.
+// It returns "vX.Y" for all release versions, and all prerelease versions >= "alpha.1".
+// X and Y are the major and minor, respectively, of the version specified in version.txt.
+// For all other prerelease versions, it returns "dev".
+// N.B. new public-facing doc URLs are expected to be up beginning with the "alpha.1" prerelease. Otherwise, "dev" will
+// cause the url mapper to redirect to the latest stable release.
+func VersionForURLs() string {
+	if parsedVersionTxt.PreRelease() >= "alpha.1" {
+		return fmt.Sprintf("v%d.%d", parsedVersionTxt.Major(), parsedVersionTxt.Minor())
 	}
-	return fmt.Sprintf("v%d.%d", v.Major(), v.Minor())
+	return "dev"
 }
 
 // BranchReleaseSeries returns tha major and minor in version.txt, without
@@ -211,5 +215,5 @@ func TestingOverrideVersion(v string) func() {
 
 // MakeIssueURL produces a URL to a CockroachDB issue.
 func MakeIssueURL(issue int) string {
-	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, BinaryVersionPrefix())
+	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, VersionForURLs())
 }

--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -169,7 +169,8 @@ func TestReleaseSeries(t *testing.T) {
 	}
 
 	// Verify the latest version.
-	require.Equal(t, fmt.Sprintf("v%s", Latest.ReleaseSeries()), build.BinaryVersionPrefix())
+	major, minor := build.BranchReleaseSeries()
+	require.Equal(t, fmt.Sprintf("v%s", Latest.ReleaseSeries()), fmt.Sprintf("v%d.%d", major, minor))
 
 	// Verify the ReleaseSeries results down to MinSupported.
 	expected := Latest.ReleaseSeries()

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -18,12 +18,12 @@ import (
 
 // URLBase is the root URL for the version of the docs associated with this
 // binary.
-var URLBase = "https://www.cockroachlabs.com/docs/" + build.BinaryVersionPrefix()
+var URLBase = "https://www.cockroachlabs.com/docs/" + build.VersionForURLs()
 
 // URLReleaseNotesBase is the root URL for the release notes for the .0 patch
 // release associated with this binary.
 var URLReleaseNotesBase = fmt.Sprintf("https://www.cockroachlabs.com/docs/releases/%s.0.html",
-	build.BinaryVersionPrefix())
+	build.VersionForURLs())
 
 // URL generates the URL to pageName in the version of the docs associated
 // with this binary.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -700,6 +700,8 @@ func TestServeIndexHTML(t *testing.T) {
 	unlinkFakeUI := func() {
 		ui.HaveUI = false
 	}
+	major, minor := build.BranchReleaseSeries()
+	version := fmt.Sprintf("v%d.%d", major, minor)
 
 	t.Run("Insecure mode", func(t *testing.T) {
 		srv := serverutils.StartServerOnly(t, base.TestServerArgs{
@@ -759,7 +761,7 @@ Binary built without web UI.
 			expected := fmt.Sprintf(
 				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0,"IsManaged":false}`,
 				build.GetInfo().Tag,
-				build.BinaryVersionPrefix(),
+				version,
 				1,
 			)
 			require.Equal(t, expected, string(respBytes))
@@ -787,7 +789,7 @@ Binary built without web UI.
 				fmt.Sprintf(
 					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0,"IsManaged":false}`,
 					build.GetInfo().Tag,
-					build.BinaryVersionPrefix(),
+					version,
 					1,
 				),
 			},
@@ -796,7 +798,7 @@ Binary built without web UI.
 				fmt.Sprintf(
 					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0,"IsManaged":false}`,
 					build.GetInfo().Tag,
-					build.BinaryVersionPrefix(),
+					version,
 					1,
 				),
 			},

--- a/pkg/sql/logictest/testdata/logic_test/notice
+++ b/pkg/sql/logictest/testdata/logic_test/notice
@@ -63,5 +63,5 @@ UNLISTEN temp
 ----
 NOTICE: unimplemented: CRDB does not support LISTEN, making UNLISTEN a no-op
 HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/41522/v24.2
+See: https://go.crdb.dev/issue-v/41522/dev
 SQLSTATE: 0A000

--- a/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
+++ b/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
@@ -457,7 +457,7 @@ ReadyForQuery
 {"Type":"PortalSuspended"}
 {"Type":"DataRow","Values":[{"text":"2"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/v24.2"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -504,7 +504,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"f"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/v24.2"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -553,7 +553,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"10"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/v24.2"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -602,7 +602,7 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"1"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/v24.2"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send crdb_only
@@ -946,7 +946,7 @@ ReadyForQuery
 {"Type":"PortalSuspended"}
 {"Type":"DataRow","Values":[{"text":"10"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/v24.2"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
 {"Type":"ReadyForQuery","TxStatus":"E"}
 
 send

--- a/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
+++ b/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
@@ -367,6 +367,6 @@ ErrorResponse
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"text":"(1,1)"}]}
 {"Type":"PortalSuspended"}
-{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/v24.2"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
 
 subtest end

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -170,11 +170,12 @@ func Handler(cfg Config) http.Handler {
 		}
 		licenseTTL := base.LicenseTTL.Value()
 		oidcConf := cfg.OIDC.GetOIDCConf()
+		major, minor := build.BranchReleaseSeries()
 		args := indexHTMLArgs{
 			Insecure:         cfg.Insecure,
 			LoggedInUser:     cfg.GetUser(r.Context()),
 			Tag:              buildInfo.Tag,
-			Version:          build.BinaryVersionPrefix(),
+			Version:          fmt.Sprintf("v%d.%d", major, minor),
 			OIDCAutoLogin:    oidcConf.AutoLogin,
 			OIDCLoginEnabled: oidcConf.Enabled,
 			OIDCButtonText:   oidcConf.ButtonText,


### PR DESCRIPTION
Historically, `BinaryVersionPrefix` was used to derive major.minor version of the corresponding Cockroach binary. All non-release versions, including prerelease versions would yield `dev`, instead. Although it's not clear, this helper function was intended primarily for
doc URLs. In [1], the behavior changed, resulting in major.minor for all prerelease versions. This breaks `TestHelpURLs` which attempts to verify that the
public-facing doc URLs are live.

To remove the ambiguity, we replace `BinaryVersionPrefix` with `VersionForURLs`. The latter always returns `dev` for prereleases strictly below `alpha.1`. Thus, any prerelease >= `alpha.1` is expected to have a corresponding doc URL base.
E.g., `https://www.cockroachlabs.com/docs/v24.2/show-create.html` for `v24.2.0-alpha.1` or greater. Otherwise, `dev` in the URL, e.g., `https://www.cockroachlabs.com/docs/dev/show-create.html`, always redirects to the current stable release, i.e., `v24.1`.

[1] https://github.com/cockroachdb/cockroach/pull/113827

Epic: none
Fixes: #123925

Release note: None