### PR TITLE
release-23.2: codeowners: add upgrade-prs team to pkg/upgrade

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -375,7 +375,7 @@
 /pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
 #!/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/server-prs
-#!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng
+#!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng-prs @cockroachdb/upgrade-prs
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/sql-foundations
@@ -496,7 +496,7 @@
 /pkg/keysbase/               @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
 #!/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
-/pkg/upgrade/                @cockroachdb/release-eng
+/pkg/upgrade/                @cockroachdb/release-eng-prs @cockroachdb/upgrade-prs
 /pkg/keyvisualizer/          @cockroachdb/obs-prs
 /pkg/multitenant/            @cockroachdb/server-prs
 /pkg/release/                @cockroachdb/dev-inf

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -102,6 +102,9 @@ cockroachdb/migrations:
   label: T-migrations
   triage_column_id: 18330909
 cockroachdb/release-eng:
+  aliases:
+    cockroachdb/release-eng-prs: other
+    cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
 cockroachdb/obs-prs:

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -33,6 +33,7 @@ const (
 	OwnerServer           Owner = `server` // not currently staffed
 	OwnerSQLFoundations   Owner = `sql-foundations`
 	OwnerMigrations       Owner = `migrations`
+	OwnerReleaseEng       Owner = `release-eng`
 	OwnerSQLQueries       Owner = `sql-queries`
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -29,6 +29,7 @@ func registerAcceptance(r registry.Registry) {
 		encryptionSupport registry.EncryptionSupport
 		defaultLeases     bool
 	}{
+		registry.OwnerReleaseEng: {},
 		registry.OwnerKV: {
 			{name: "decommission-self", fn: runDecommissionSelf},
 			{name: "event-log", fn: runEventLog},


### PR DESCRIPTION
Backport 1/1 commits from #123920.

/cc @cockroachdb/release

---

Add `upgrade-prs` team as reviewers to`pkg/upgrade`.

Epic: None
Release note: None
Release justification: non-production change (updating codeowners).
