### PR TITLE
roachprod: selective service registration

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -44,14 +44,6 @@ var startScript string
 //go:embed files/cockroachdb-logging.yaml
 var loggingConfig string
 
-// sharedProcessVirtualClusterNode is a constant node that is used
-// whenever we register a service descriptor for a shared-process
-// virtual cluster. Since these virtual clusters use the system
-// interface process, the service descriptor just represents the
-// existence of the virtual cluster; at service discovery time, ports
-// are resolved based on existing services for the system interface.
-var sharedProcessVirtualClusterNode = Node(1)
-
 func cockroachNodeBinary(c *SyncedCluster, node Node) string {
 	if filepath.IsAbs(c.Binary) {
 		return c.Binary
@@ -262,29 +254,13 @@ func (c *SyncedCluster) maybeRegisterServices(
 		servicesToRegister, err = c.servicesWithOpenPortSelection(
 			ctx, l, startOpts, ServiceModeExternal, serviceMap, portFunc,
 		)
-	case StartSharedProcessForVirtualCluster:
-		// Specifying a sql instance for shared process virtual clusters
-		// doesn't make sense, so return an error in that case to make it
-		// explicit.
-		if startOpts.SQLInstance != 0 {
-			err = fmt.Errorf("sql instance must be unset for shared process deployments")
-			break
-		}
-
-		for _, serviceType := range []ServiceType{ServiceTypeSQL, ServiceTypeUI} {
-			if _, ok := serviceMap[sharedProcessVirtualClusterNode][serviceType]; !ok {
-				servicesToRegister = append(servicesToRegister, ServiceDesc{
-					VirtualClusterName: startOpts.VirtualClusterName,
-					ServiceType:        serviceType,
-					ServiceMode:        ServiceModeShared,
-					Node:               sharedProcessVirtualClusterNode,
-				})
-			}
-		}
 	case StartServiceForVirtualCluster:
 		servicesToRegister, err = c.servicesWithOpenPortSelection(
 			ctx, l, startOpts, ServiceModeExternal, serviceMap, portFunc,
 		)
+	default:
+		// For shared-process virtual clusters, we don't need to register
+		// services as these will be resolved to the system interface process.
 	}
 
 	if err != nil {
@@ -406,9 +382,15 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 	}
 
 	if c.allowServiceRegistration() {
-		err := c.maybeRegisterServices(ctx, l, startOpts, c.FindOpenPorts)
-		if err != nil {
-			return err
+		// Only register services when starting a virtual cluster, or using custom
+		// ports, or for local cluster port management to avoid collisions. The
+		// lookup logic will automatically fall back to the default ports if the
+		// service is not found (or has not been registered).
+		if customPortsSpecified() || c.IsLocal() || startOpts.Target != StartDefault {
+			err := c.maybeRegisterServices(ctx, l, startOpts, c.FindOpenPorts)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		if customPortsSpecified() {

--- a/pkg/roachprod/install/services.go
+++ b/pkg/roachprod/install/services.go
@@ -220,9 +220,16 @@ func (c *SyncedCluster) DiscoverService(
 
 	// Finally, fall back to the default ports if no services are found. This is
 	// required for scenarios where the services were not registered with a DNS
-	// provider (Google DNS). Currently, services will not be registered with DNS
-	// for clusters not on GCP, and it will also not be registered for GCP
-	// clusters that specify a custom project. The fall back is also useful for
+	// provider (Google DNS). Currently, services will not be registered in the
+	// following scenarios:
+	//
+	// 1. A system interface started with default ports. This is an optimisation
+	// to avoid the overhead of registering services when starting a storage
+	// cluster with default ports.
+	// 2. Clusters not on GCP
+	// 3. Clusters that specify a custom project.
+	//
+	// The fall back is also useful for
 	// backwards compatibility with clusters that were created before the
 	// introduction of service discovery, or without a DNS provider.
 	// TODO(Herko): Remove this once DNS support is fully


### PR DESCRIPTION
Previously, DNS and service registration would be done for all services. In hindsight this may have been unnecessary when deploying a simplistic single process cockroach cluster. This change opts to start the system / storage cockroach service on default ports if no custom ports have been specified and skip registration of the service in this case. When a lookup is performed to find a service in this scenario we will assume if no service is found it has been started in this form.

Services will now only be registered for external process virtual clusters or when custom ports are passed to be able to keep track of the ports. For local clusters service will always be registered as there is a definite chance of port collision if the default ports are used.

Epic: None
Release Note: None