### PR TITLE
streamingccl: add WithDiff option to event stream 

### DIFF
--- a/pkg/ccl/streamingccl/event.go
+++ b/pkg/ccl/streamingccl/event.go
@@ -75,6 +75,7 @@ type Event interface {
 
 // kvEvent is a key value pair that needs to be ingested.
 type kvEvent struct {
+	emptyEvent
 	kv []roachpb.KeyValue
 }
 
@@ -90,38 +91,9 @@ func (kve kvEvent) GetKVs() []roachpb.KeyValue {
 	return kve.kv
 }
 
-// GetSSTable implements the Event interface.
-func (kve kvEvent) GetSSTable() *kvpb.RangeFeedSSTable {
-	return nil
-}
-
-// GetDeleteRange implements the Event interface.
-func (kve kvEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
-	return nil
-}
-
-// GetResolvedSpans implements the Event interface.
-func (kve kvEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
-	return nil
-}
-
-// GetSpanConfigEvent implements the Event interface.
-func (kve kvEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
-	return nil
-}
-
-// GetSplitEvent implements the Event interface.
-func (kve kvEvent) GetSplitEvent() *roachpb.Key {
-	return nil
-}
-
-// GetKVWithDiff implements the Event interface.
-func (kve kvEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
-	return nil
-}
-
 // sstableEvent is a sstable that needs to be ingested.
 type sstableEvent struct {
+	emptyEvent
 	sst kvpb.RangeFeedSSTable
 }
 
@@ -130,44 +102,16 @@ func (sste sstableEvent) Type() EventType {
 	return SSTableEvent
 }
 
-// GetKVs implements the Event interface.
-func (sste sstableEvent) GetKVs() []roachpb.KeyValue {
-	return nil
-}
-
 // GetSSTable implements the Event interface.
 func (sste sstableEvent) GetSSTable() *kvpb.RangeFeedSSTable {
 	return &sste.sst
-}
-
-// GetDeleteRange implements the Event interface.
-func (sste sstableEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
-	return nil
-}
-
-// GetResolvedSpans implements the Event interface.
-func (sste sstableEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
-	return nil
-}
-
-// GetSpanConfigEvent implements the Event interface.
-func (sste sstableEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
-	return nil
-}
-
-// GetSplitEvent implements the Event interface.
-func (sste sstableEvent) GetSplitEvent() *roachpb.Key {
-	return nil
-}
-
-func (sste sstableEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
-	return nil
 }
 
 var _ Event = sstableEvent{}
 
 // delRangeEvent is a DeleteRange event that needs to be ingested.
 type delRangeEvent struct {
+	emptyEvent
 	delRange kvpb.RangeFeedDeleteRange
 }
 
@@ -176,39 +120,9 @@ func (dre delRangeEvent) Type() EventType {
 	return DeleteRangeEvent
 }
 
-// GetKVs implements the Event interface.
-func (dre delRangeEvent) GetKVs() []roachpb.KeyValue {
-	return nil
-}
-
-// GetSSTable implements the Event interface.
-func (dre delRangeEvent) GetSSTable() *kvpb.RangeFeedSSTable {
-	return nil
-}
-
 // GetDeleteRange implements the Event interface.
 func (dre delRangeEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
 	return &dre.delRange
-}
-
-// GetResolvedSpans implements the Event interface.
-func (dre delRangeEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
-	return nil
-}
-
-// GetSpanConfigEvent implements the Event interface.
-func (dre delRangeEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
-	return nil
-}
-
-// GetSplitEvent implements the Event interface.
-func (dre delRangeEvent) GetSplitEvent() *roachpb.Key {
-	return nil
-}
-
-// GetKVWithDiff implements the Event interface.
-func (dre delRangeEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
-	return nil
 }
 
 var _ Event = delRangeEvent{}
@@ -216,6 +130,7 @@ var _ Event = delRangeEvent{}
 // checkpointEvent indicates that the stream has emitted every change for all
 // keys in the span it is responsible for up until this timestamp.
 type checkpointEvent struct {
+	emptyEvent
 	resolvedSpans []jobspb.ResolvedSpan
 }
 
@@ -226,42 +141,13 @@ func (ce checkpointEvent) Type() EventType {
 	return CheckpointEvent
 }
 
-// GetKVs implements the Event interface.
-func (ce checkpointEvent) GetKVs() []roachpb.KeyValue {
-	return nil
-}
-
-// GetSSTable implements the Event interface.
-func (ce checkpointEvent) GetSSTable() *kvpb.RangeFeedSSTable {
-	return nil
-}
-
-// GetDeleteRange implements the Event interface.
-func (ce checkpointEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
-	return nil
-}
-
 // GetResolvedSpans implements the Event interface.
 func (ce checkpointEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
 	return ce.resolvedSpans
 }
 
-// GetSpanConfigEvent implements the Event interface.
-func (ce checkpointEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
-	return nil
-}
-
-// GetSplitEvent implements the Event interface.
-func (ce checkpointEvent) GetSplitEvent() *roachpb.Key {
-	return nil
-}
-
-// GetKVWithDiff implements the Event interface.
-func (ce checkpointEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
-	return nil
-}
-
 type spanConfigEvent struct {
+	emptyEvent
 	spanConfig streampb.StreamedSpanConfigEntry
 }
 
@@ -272,42 +158,13 @@ func (spe spanConfigEvent) Type() EventType {
 	return SpanConfigEvent
 }
 
-// GetKVs implements the Event interface.
-func (spe spanConfigEvent) GetKVs() []roachpb.KeyValue {
-	return nil
-}
-
-// GetSSTable implements the Event interface.
-func (spe spanConfigEvent) GetSSTable() *kvpb.RangeFeedSSTable {
-	return nil
-}
-
-// GetDeleteRange implements the Event interface.
-func (spe spanConfigEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
-	return nil
-}
-
-// GetResolvedSpans implements the Event interface.
-func (spe spanConfigEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
-	return nil
-}
-
 // GetSpanConfigEvent implements the Event interface.
 func (spe spanConfigEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
 	return &spe.spanConfig
 }
 
-// GetSplitEvent implements the Event interface.
-func (spe spanConfigEvent) GetSplitEvent() *roachpb.Key {
-	return nil
-}
-
-// GetKVWithDiff implements the Event interface.
-func (spe spanConfigEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
-	return nil
-}
-
 type splitEvent struct {
+	emptyEvent
 	splitKey roachpb.Key
 }
 
@@ -318,43 +175,14 @@ func (se splitEvent) Type() EventType {
 	return SplitEvent
 }
 
-// GetKV implements the Event interface.
-func (se splitEvent) GetKVs() []roachpb.KeyValue {
-	return nil
-}
-
-// GetSSTable implements the Event interface.
-func (se splitEvent) GetSSTable() *kvpb.RangeFeedSSTable {
-	return nil
-}
-
-// GetDeleteRange implements the Event interface.
-func (se splitEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
-	return nil
-}
-
-// GetResolvedSpans implements the Event interface.
-func (se splitEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
-	return nil
-}
-
-// GetSpanConfigEvent implements the Event interface.
-func (se splitEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
-	return nil
-}
-
 // GetSplitEvent implements the Event interface.
 func (se splitEvent) GetSplitEvent() *roachpb.Key {
 	return &se.splitKey
 }
 
-// GetKVWithDiff implements the Event interface.
-func (se splitEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
-	return nil
-}
-
 // kvEvent is a key value pair that needs to be ingested.
 type kvEventWithDiff struct {
+	emptyEvent
 	kvsWithDiff []streampb.StreamEvent_KVWithDiff
 }
 
@@ -363,36 +191,6 @@ var _ Event = kvEventWithDiff{}
 // Type implements the Event interface.
 func (kve kvEventWithDiff) Type() EventType {
 	return KVWithDiffEvent
-}
-
-// GetKVs implements the Event interface.
-func (kve kvEventWithDiff) GetKVs() []roachpb.KeyValue {
-	return nil
-}
-
-// GetSSTable implements the Event interface.
-func (kve kvEventWithDiff) GetSSTable() *kvpb.RangeFeedSSTable {
-	return nil
-}
-
-// GetDeleteRange implements the Event interface.
-func (kve kvEventWithDiff) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
-	return nil
-}
-
-// GetResolvedSpans implements the Event interface.
-func (kve kvEventWithDiff) GetResolvedSpans() []jobspb.ResolvedSpan {
-	return nil
-}
-
-// GetSpanConfigEvent implements the Event interface.
-func (kve kvEventWithDiff) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
-	return nil
-}
-
-// GetSplitEvent implements the Event interface.
-func (kve kvEventWithDiff) GetSplitEvent() *roachpb.Key {
-	return nil
 }
 
 // GetKVWithDiff implements the Event interface.
@@ -430,4 +228,43 @@ func MakeSplitEvent(splitKey roachpb.Key) Event {
 
 func MakeKVWithDiffEvent(kvsWithDiff []streampb.StreamEvent_KVWithDiff) Event {
 	return kvEventWithDiff{kvsWithDiff: kvsWithDiff}
+}
+
+// emptyEvent is not an event (no Type method) but it is used to
+// reduce the boilerplate above.
+type emptyEvent struct{}
+
+// GetKVs implements the Event interface.
+func (ee emptyEvent) GetKVs() []roachpb.KeyValue {
+	return nil
+}
+
+// GetSSTable implements the Event interface.
+func (ee emptyEvent) GetSSTable() *kvpb.RangeFeedSSTable {
+	return nil
+}
+
+// GetDeleteRange implements the Event interface.
+func (ee emptyEvent) GetDeleteRange() *kvpb.RangeFeedDeleteRange {
+	return nil
+}
+
+// GetResolvedSpans implements the Event interface.
+func (ee emptyEvent) GetResolvedSpans() []jobspb.ResolvedSpan {
+	return nil
+}
+
+// GetSpanConfigEvent implements the Event interface.
+func (ee emptyEvent) GetSpanConfigEvent() *streampb.StreamedSpanConfigEntry {
+	return nil
+}
+
+// GetSplitEvent implements the Event interface.
+func (ee emptyEvent) GetSplitEvent() *roachpb.Key {
+	return nil
+}
+
+// GetKVWithDiff implements the Event interface.
+func (ee emptyEvent) GetKVWithDiff() []streampb.StreamEvent_KVWithDiff {
+	return nil
 }

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -127,6 +127,13 @@ type subscribeConfig struct {
 	// should be started with the WithFiltering option which
 	// elides rangefeed events.
 	withFiltering bool
+
+	// withDiff controls wiether the producer-side rangefeeds
+	// should be started with the WithDiff option
+	//
+	// NB: Callers should note that initial scan results will not
+	// contain a diff.
+	withDiff bool
 }
 
 type SubscribeOption func(*subscribeConfig)
@@ -137,6 +144,17 @@ type SubscribeOption func(*subscribeConfig)
 func WithFiltering(filteringEnabled bool) SubscribeOption {
 	return func(cfg *subscribeConfig) {
 		cfg.withFiltering = filteringEnabled
+	}
+}
+
+// WithDiff controls whether the producer-side rangefeeds
+// should be started with the WithDiff option
+//
+// NB: Callers should note that initial scan results will not
+// contain a diff.
+func WithDiff(enableDiff bool) SubscribeOption {
+	return func(cfg *subscribeConfig) {
+		cfg.withDiff = enableDiff
 	}
 }
 

--- a/pkg/ccl/streamingccl/streamclient/client_helpers.go
+++ b/pkg/ccl/streamingccl/streamclient/client_helpers.go
@@ -105,6 +105,9 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 		case len(streamEvent.Batch.KeyValues) > 0:
 			event = streamingccl.MakeKVEvent(streamEvent.Batch.KeyValues)
 			streamEvent.Batch.KeyValues = nil
+		case len(streamEvent.Batch.KeyValuesWithDiff) > 0:
+			event = streamingccl.MakeKVWithDiffEvent(streamEvent.Batch.KeyValuesWithDiff)
+			streamEvent.Batch.KeyValuesWithDiff = nil
 		case len(streamEvent.Batch.DelRanges) > 0:
 			event = streamingccl.MakeDeleteRangeEvent(streamEvent.Batch.DelRanges[0])
 			streamEvent.Batch.DelRanges = streamEvent.Batch.DelRanges[1:]

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -238,6 +238,7 @@ func (p *partitionedStreamClient) Subscribe(
 	sps.ConsumerNode = consumerNode
 	sps.ConsumerProc = consumerProc
 	sps.Compressed = true
+	sps.WithDiff = cfg.withDiff
 	sps.WithFiltering = cfg.withFiltering
 
 	specBytes, err := protoutil.Marshal(&sps)

--- a/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
@@ -41,6 +41,14 @@ func (seb *streamEventBatcher) addSST(sst kvpb.RangeFeedSSTable) {
 	seb.size += sst.Size()
 }
 
+func (seb *streamEventBatcher) addKVWithDiff(kv roachpb.KeyValue, prev roachpb.Value) {
+	seb.batch.KeyValuesWithDiff = append(seb.batch.KeyValuesWithDiff, streampb.StreamEvent_KVWithDiff{
+		KeyValue:  kv,
+		PrevValue: prev,
+	})
+	seb.size += (kv.Size() + prev.Size())
+}
+
 func (seb *streamEventBatcher) addKV(kv roachpb.KeyValue) {
 	seb.batch.KeyValues = append(seb.batch.KeyValues, kv)
 	seb.size += kv.Size()

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -142,7 +142,9 @@ message StreamPartitionSpec {
   // set.
   bool with_filtering = 8;
 
-  // NEXT ID: 10.
+  bool with_diff = 10;
+
+  // NEXT ID: 11.
 }
 
 // SpanConfigEventStreamSpec is the span config event stream specification.
@@ -193,12 +195,18 @@ message StreamedSpanConfigEntry {
 // StreamEvent describes a replication stream event
 message StreamEvent {
 
+  message KVWithDiff {
+    roachpb.KeyValue key_value = 1 [(gogoproto.nullable) = false];
+    roachpb.Value prev_value = 2 [(gogoproto.nullable) = false];
+  }
+
   message Batch {
     repeated roachpb.KeyValue key_values = 1 [(gogoproto.nullable) = false];
     repeated roachpb.RangeFeedSSTable ssts = 2 [(gogoproto.nullable) = false];
     repeated roachpb.RangeFeedDeleteRange del_ranges = 3 [(gogoproto.nullable) = false];
     repeated StreamedSpanConfigEntry span_configs = 4 [(gogoproto.nullable) = false];
     repeated bytes split_points = 5 [(gogoproto.casttype) =  "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+    repeated KVWithDiff key_values_with_diff = 6 [(gogoproto.nullable) = false];;
   }
 
   // Checkpoint represents stream checkpoint.


### PR DESCRIPTION
We believe that we'll eventually want access to the previous row for
custom conflict resolution.

This adds a WithDiff option to the event stream so that all LDR
streams start receiving the previous value, even though we aren't
doing anything with it yet.

Epic: None
Release note: None