### PR TITLE
streamingccl: support column families in logical ingestor

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -200,6 +200,7 @@ func (r Row) forEachColumn(fn ColumnFn, colIndexes []int) error {
 // such column expected to be found.
 type ResultColumn struct {
 	colinfo.ResultColumn
+	Computed  bool
 	ord       int
 	sqlString string
 }
@@ -265,6 +266,7 @@ func NewEventDescriptor(
 				TableID:        desc.GetID(),
 				PGAttributeNum: uint32(col.GetPGAttributeNum()),
 			},
+			Computed:  col.IsComputed(),
 			ord:       ord,
 			sqlString: col.ColumnDesc().SQLStringNotHumanReadable(),
 		}

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -47,10 +47,10 @@ func TestEventDescriptor(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 	sqlDB.Exec(t, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
-  d STRING AS (concat(b, c)) VIRTUAL, 
+  d STRING AS (concat(b, c)) VIRTUAL,
   e status,
   PRIMARY KEY (b, a),
   FAMILY main (a, b, e),
@@ -153,10 +153,10 @@ func TestEventDecoder(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 	sqlDB.Exec(t, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
-  d STRING AS (concat(b, c)) VIRTUAL, 
+  d STRING AS (concat(b, c)) VIRTUAL,
   e status DEFAULT 'inactive',
   PRIMARY KEY (b, a),
   FAMILY main (a, b, e),
@@ -682,6 +682,7 @@ func expectResultColumns(
 				TableID:        desc.GetID(),
 				PGAttributeNum: uint32(col.GetPGAttributeNum()),
 			},
+			Computed:  col.IsComputed(),
 			ord:       colNamesSet[colName],
 			sqlString: col.ColumnDesc().SQLStringNotHumanReadable(),
 		})
@@ -780,8 +781,8 @@ func BenchmarkEventDecoder(b *testing.B) {
 	sqlDB.Exec(b, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 	sqlDB.Exec(b, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
   PRIMARY KEY (b, a)
 )`)

--- a/pkg/ccl/streamingccl/logical/lww_row_processor.go
+++ b/pkg/ccl/streamingccl/logical/lww_row_processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // sqlLastWriteWinsRowProcessor is a row processor that implements partial
@@ -52,7 +53,7 @@ type sqlLastWriteWinsRowProcessor struct {
 
 type queryBuffer struct {
 	deleteQueries map[catid.DescID]string
-	insertQueries map[catid.DescID]string
+	insertQueries map[catid.DescID]map[catid.FamilyID]string
 }
 
 func makeSQLLastWriteWinsHandler(
@@ -64,14 +65,18 @@ func makeSQLLastWriteWinsHandler(
 	descs := make(map[catid.DescID]catalog.TableDescriptor)
 	qb := queryBuffer{
 		deleteQueries: make(map[catid.DescID]string, len(tableDescs)),
-		insertQueries: make(map[catid.DescID]string, len(tableDescs)),
+		insertQueries: make(map[catid.DescID]map[catid.FamilyID]string, len(tableDescs)),
 	}
 	cdcEventTargets := changefeedbase.Targets{}
 	for name, desc := range tableDescs {
 		td := tabledesc.NewBuilder(&desc).BuildImmutableTable()
 		descs[desc.ID] = td
 		qb.deleteQueries[desc.ID] = makeDeleteQuery(name, td)
-		qb.insertQueries[desc.ID] = makeInsertQuery(name, td)
+		var err error
+		qb.insertQueries[desc.ID], err = makeInsertQueries(name, td)
+		if err != nil {
+			return nil, err
+		}
 		cdcEventTargets.Add(changefeedbase.Target{
 			Type:              jobspb.ChangefeedTargetSpecification_EACH_FAMILY,
 			TableID:           td.GetID(),
@@ -108,7 +113,7 @@ func (lww *sqlLastWriteWinsRowProcessor) insertRow(
 	ctx context.Context, txn isql.Txn, row cdcevent.Row,
 ) error {
 	datums := make([]interface{}, 0, len(row.EncDatums()))
-	err := row.ForEachColumn().Datum(func(d tree.Datum, col cdcevent.ResultColumn) error {
+	err := row.ForAllColumns().Datum(func(d tree.Datum, col cdcevent.ResultColumn) error {
 		// Ignore crdb_internal_origin_timestamp
 		if col.Name == "crdb_internal_origin_timestamp" {
 			if d != tree.DNull {
@@ -125,7 +130,14 @@ func (lww *sqlLastWriteWinsRowProcessor) insertRow(
 		return err
 	}
 	datums = append(datums, eval.TimestampToDecimalDatum(row.MvccTimestamp))
-	insertQuery := lww.queryBuffer.insertQueries[row.TableID]
+	insertQueriesForTable, ok := lww.queryBuffer.insertQueries[row.TableID]
+	if !ok {
+		return errors.Errorf("no pre-generated insert query for table %d", row.TableID)
+	}
+	insertQuery, ok := insertQueriesForTable[row.FamilyID]
+	if !ok {
+		return errors.Errorf("no pre-generated insert query for table %d column family %d", row.TableID, row.FamilyID)
+	}
 	if _, err := txn.Exec(ctx, "replicated-insert", txn.KV(), insertQuery, datums...); err != nil {
 		log.Warningf(ctx, "replicated insert failed (query: %s): %s", insertQuery, err.Error())
 		return err
@@ -151,54 +163,85 @@ func (lww *sqlLastWriteWinsRowProcessor) deleteRow(
 	return nil
 }
 
-func makeInsertQuery(fqTableName string, td catalog.TableDescriptor) string {
-	// TODO(ssd): Column families
-	var columnNames strings.Builder
-	var valueStrings strings.Builder
-	var onConflictUpdateClause strings.Builder
-	argIdx := 1
-	for _, col := range td.PublicColumns() {
-		// Virtual columns are not present in the data written to disk and
-		// thus not part of the rangefeed datum.
-		if col.IsVirtual() {
-			continue
+func makeInsertQueries(
+	fqTableName string, td catalog.TableDescriptor,
+) (map[catid.FamilyID]string, error) {
+	queries := make(map[catid.FamilyID]string, td.NumFamilies())
+
+	if err := td.ForeachFamily(func(family *descpb.ColumnFamilyDescriptor) error {
+		var columnNames strings.Builder
+		var valueStrings strings.Builder
+		var onConflictUpdateClause strings.Builder
+		argIdx := 1
+		seenIds := make(map[catid.ColumnID]struct{})
+		addColumn := func(colName string, colID catid.ColumnID) {
+			// We will set crdb_internal_origin_timestamp ourselves from the MVCC timestamp of the incoming datum.
+			// We should never see this on the rangefeed as a non-null value as that would imply we've looped data around.
+			if colName == "crdb_internal_origin_timestamp" {
+				return
+			}
+			if _, seen := seenIds[colID]; seen {
+				return
+			}
+
+			if argIdx == 1 {
+				columnNames.WriteString(colName)
+				fmt.Fprintf(&valueStrings, "$%d", argIdx)
+				fmt.Fprintf(&onConflictUpdateClause, "%s = $%d", colName, argIdx)
+			} else {
+				fmt.Fprintf(&columnNames, ", %s", colName)
+				fmt.Fprintf(&valueStrings, ", $%d", argIdx)
+				fmt.Fprintf(&onConflictUpdateClause, ",\n%s = $%d", colName, argIdx)
+			}
+			seenIds[colID] = struct{}{}
+			argIdx++
 		}
-		// We will set crdb_internal_origin_timestamp ourselves from the MVCC timestamp of the incoming datum.
-		// We should never see this on the rangefeed as a non-null value as that would imply we've looped data around.
-		if col.GetName() == "crdb_internal_origin_timestamp" {
-			continue
+
+		publicColumns := td.PublicColumns()
+		colOrd := catalog.ColumnIDToOrdinalMap(publicColumns)
+		primaryIndex := td.GetPrimaryIndex()
+
+		for i := 0; i < primaryIndex.NumKeyColumns(); i++ {
+			for i := 0; i < primaryIndex.NumKeyColumns(); i++ {
+				ord, ok := colOrd.Get(primaryIndex.GetKeyColumnID(i))
+				if !ok {
+					return errors.AssertionFailedf("expected to find column %d", ord)
+				}
+				col := publicColumns[ord]
+				addColumn(col.GetName(), col.GetID())
+
+			}
 		}
-		if argIdx == 1 {
-			columnNames.WriteString(col.GetName())
-			fmt.Fprintf(&valueStrings, "$%d", argIdx)
-			fmt.Fprintf(&onConflictUpdateClause, "%s = $%d", col.GetName(), argIdx)
-		} else {
-			fmt.Fprintf(&columnNames, ", %s", col.GetName())
-			fmt.Fprintf(&valueStrings, ", $%d", argIdx)
-			fmt.Fprintf(&onConflictUpdateClause, ",\n%s = $%d", col.GetName(), argIdx)
+
+		for i, colName := range family.ColumnNames {
+			addColumn(colName, family.ColumnIDs[i])
 		}
-		argIdx++
-	}
-	originTSIdx := argIdx
-	baseQuery := `
+
+		originTSIdx := argIdx
+		baseQuery := `
 INSERT INTO %s (%s, crdb_internal_origin_timestamp)
 VALUES (%s, $%d)
 ON CONFLICT ON CONSTRAINT %s
 DO UPDATE SET
 %s,
 crdb_internal_origin_timestamp=$%[4]d
-WHERE (%[1]s.crdb_internal_mvcc_timestamp < $%[4]d
+WHERE (%[1]s.crdb_internal_mvcc_timestamp <= $%[4]d
        AND %[1]s.crdb_internal_origin_timestamp IS NULL)
-   OR (%[1]s.crdb_internal_origin_timestamp < $%[4]d
+   OR (%[1]s.crdb_internal_origin_timestamp <= $%[4]d
        AND %[1]s.crdb_internal_origin_timestamp IS NOT NULL)`
-	return fmt.Sprintf(baseQuery,
-		fqTableName,
-		columnNames.String(),
-		valueStrings.String(),
-		originTSIdx,
-		td.GetPrimaryIndex().GetName(),
-		onConflictUpdateClause.String(),
-	)
+		queries[family.ID] = fmt.Sprintf(baseQuery,
+			fqTableName,
+			columnNames.String(),
+			valueStrings.String(),
+			originTSIdx,
+			td.GetPrimaryIndex().GetName(),
+			onConflictUpdateClause.String(),
+		)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return queries, nil
 }
 
 func makeDeleteQuery(fqTableName string, td catalog.TableDescriptor) string {


### PR DESCRIPTION
This adds basic support for column families in the logical ingestor.

Epic: none
Release note: None