### PR TITLE
roachtest: don't fail `sysbench` tests on assertion failure

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -154,8 +154,11 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 		if result.RemoteExitStatus == roachprodErrors.SegmentationFaultExitCode {
 			t.L().Printf("sysbench segfaulted; passing test anyway")
 			return nil
-		} else if result.RemoteExitStatus == roachprodErrors.IllegalInstruction {
+		} else if result.RemoteExitStatus == roachprodErrors.IllegalInstructionExitCode {
 			t.L().Printf("sysbench crashed with illegal instruction; passing test anyway")
+			return nil
+		} else if result.RemoteExitStatus == roachprodErrors.AssertionFailureExitCode {
+			t.L().Printf("sysbench crashed with an assertion failure; passing test anyway")
 			return nil
 		}
 

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -37,8 +37,9 @@ const (
 )
 
 const (
-	IllegalInstruction        = 132
-	SegmentationFaultExitCode = 139
+	IllegalInstructionExitCode = 132
+	AssertionFailureExitCode   = 134
+	SegmentationFaultExitCode  = 139
 )
 
 // Cmd wraps errors that result from a command run against the cluster.


### PR DESCRIPTION
We've seen internal assertion failures when running the `sysbench` workload, especially on Azure. In this patch, we add exit code 134 to the list of exit codes that don't cause the test to fail to avoid unnecessary noise.

Fixes: #124961

Release note: None