### PR TITLE
release-23.2: logictestccl: deflake TestTenantLogic_jobs

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -153,16 +153,19 @@ func init() {
 // Status represents the status of a job in the system.jobs table.
 type Status string
 
-// SafeFormat implements redact.SafeFormatter.
-func (s Status) SafeFormat(sp redact.SafePrinter, verb rune) {
-	sp.SafeString(redact.SafeString(s))
-}
+// SafeValue implements redact.SafeValue.
+func (s Status) SafeValue() {}
 
-var _ redact.SafeFormatter = Status("")
+var _ redact.SafeValue = Status("")
 
 // RunningStatus represents the more detailed status of a running job in
 // the system.jobs table.
 type RunningStatus string
+
+// SafeValue implements redact.SafeValue.
+func (s RunningStatus) SafeValue() {}
+
+var _ redact.SafeValue = RunningStatus("")
 
 const (
 	// StatusPending is `for jobs that have been created but on which work has

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -279,7 +279,14 @@ subtest control_job_priv
 user testuser
 
 statement ok
-CREATE TABLE t_control_job_priv(x INT);
+CREATE TABLE t_control_job_priv(x INT)
+
+# Add a row into the table so that the GC job does not complete immediately;
+# it must wait for the table data gc.ttl before removing the descriptor.
+statement ok
+INSERT INTO t_control_job_priv VALUES (1)
+
+statement ok
 DROP TABLE t_control_job_priv
 
 let $job_id
@@ -310,7 +317,14 @@ subtest control_job_priv_inherited
 user testuser
 
 statement ok
-CREATE TABLE t_control_job_priv_inherited(x INT);
+CREATE TABLE t_control_job_priv_inherited(x INT)
+
+# Add a row into the table so that the GC job does not complete immediately;
+# it must wait for the table data gc.ttl before removing the descriptor.
+statement ok
+INSERT INTO t_control_job_priv_inherited VALUES (1)
+
+statement ok
 DROP TABLE t_control_job_priv_inherited
 
 let $job_id

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -75,6 +75,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"sz":     {},
 						"timing": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/jobs": {
+						"RunningStatus": {},
+						"Status":        {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/jobs/jobspb": {
 						"Type": {},
 					},


### PR DESCRIPTION
Backport 1/1 commits from #125324.

/cc @cockroachdb/release

Release justification: test change and redaction change

---

By adding a row into the table before dropping it, we can ensure that the schema change GC job will not complete immediately. It needs to wait for the table data to be removed according to the gc.ttl.

While we're here, mark a status string as safe for non-redaction.

fixes https://github.com/cockroachdb/cockroach/issues/125212
Release note: None
