### PR TITLE
release-23.1: scbuild: use proper checks when creating a virtual computed column 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3351,3 +3351,14 @@ CREATE TABLE public.t_114316 (
 )
 
 subtest end
+
+subtest regression_test_alter_table_add_constraint_unique
+
+statement ok
+create table t_124546(a int);
+
+# Regression Test for https://github.com/cockroachdb/cockroach/issues/124546
+statement error pgcode 42601 variable sub-expressions are not allowed in EXPRESSION INDEX ELEMENT
+ALTER TABLE t_124546 ADD CONSTRAINT ident UNIQUE ( ( EXISTS ( TABLE error FOR READ ONLY ) ) DESC ) STORING ( ident , ident );
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -272,7 +272,7 @@ SELECT * FROM (
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
 ) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_2"'
 ----
-{"computeExpr": "a + 10:::INT8", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "pgAttributeNum": 9, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "a + 10:::INT8", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
 
 statement ok
 DROP INDEX t_lower_c_a_plus_b_idx
@@ -288,8 +288,8 @@ SELECT * FROM (
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
 ) AS cols WHERE cols.desc->>'name' IN ('crdb_internal_idx_expr', 'crdb_internal_idx_expr_1')
 ----
-{"computeExpr": "a + b", "id": 7, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "pgAttributeNum": 7, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
-{"computeExpr": "lower(c)", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "pgAttributeNum": 8, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
+{"computeExpr": "a + b", "id": 7, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "lower(c)", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
 
 onlyif config local-legacy-schema-changer
 query T

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -877,32 +877,7 @@ func maybeCreateVirtualColumnForIndex(
 	d.Nullable.Nullability = tree.Null
 	// Infer column type from expression.
 	{
-		colLookupFn := func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-			scpb.ForEachColumnName(elts, func(_ scpb.Status, target scpb.TargetStatus, cn *scpb.ColumnName) {
-				if target == scpb.ToPublic && tree.Name(cn.Name) == columnName {
-					id = cn.ColumnID
-				}
-			})
-			if id == 0 {
-				return false, false, 0, nil
-			}
-			scpb.ForEachColumn(elts, func(_ scpb.Status, target scpb.TargetStatus, col *scpb.Column) {
-				if target == scpb.ToPublic && col.ColumnID == id {
-					exists = true
-					accessible = !col.IsInaccessible
-				}
-			})
-			scpb.ForEachColumnType(elts, func(_ scpb.Status, target scpb.TargetStatus, col *scpb.ColumnType) {
-				if target == scpb.ToPublic && col.ColumnID == id {
-					typ = col.Type
-				}
-			})
-			return exists, accessible, id, typ
-		}
-		replacedExpr, _, err := schemaexpr.ReplaceColumnVars(expr, colLookupFn)
-		if err != nil {
-			panic(err)
-		}
+		replacedExpr := b.ComputedColumnExpression(tbl, d)
 		typedExpr, err := tree.TypeCheck(b, replacedExpr, b.SemaCtx(), types.Any)
 		if err != nil {
 			panic(err)

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
@@ -36,7 +36,6 @@ upsert descriptor #104
   -    inaccessible: true
   -    name: crdb_internal_idx_expr
   -    nullable: true
-  -    pgAttributeNum: 3
   -    type:
   -      family: StringFamily
   -      oid: 25
@@ -65,7 +64,7 @@ upsert descriptor #104
   -    partitioning: {}
   -    predicate: i > 0:::INT8
   -    sharded: {}
-  -    version: 4
+  -    version: 3
   +  indexes: []
      modificationTime: {}
   +  mutations:
@@ -89,8 +88,8 @@ upsert descriptor #104
   +      partitioning: {}
   +      predicate: i > 0:::INT8
   +      sharded: {}
-  +      version: 4
-  +    mutationId: 1
+  +      version: 3
+  +    mutationId: 2
   +    state: WRITE_ONLY
   +  - column:
   +      computeExpr: lower(j)
@@ -98,21 +97,20 @@ upsert descriptor #104
   +      inaccessible: true
   +      name: crdb_internal_column_3_name_placeholder
   +      nullable: true
-  +      pgAttributeNum: 3
   +      type:
   +        family: StringFamily
   +        oid: 25
   +      virtual: true
   +    direction: DROP
-  +    mutationId: 1
+  +    mutationId: 2
   +    state: WRITE_ONLY
      name: t
      nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "8"
-  +  version: "9"
+  -  version: "7"
+  +  version: "8"
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
@@ -128,7 +126,6 @@ upsert descriptor #104
   -    inaccessible: true
   -    name: crdb_internal_idx_expr
   -    nullable: true
-  -    pgAttributeNum: 3
   -    type:
   -      family: StringFamily
   -      oid: 25
@@ -171,7 +168,7 @@ upsert descriptor #104
   -    partitioning: {}
   -    predicate: i > 0:::INT8
   -    sharded: {}
-  -    version: 4
+  -    version: 3
   +  indexes: []
      modificationTime: {}
   +  mutations:
@@ -195,8 +192,8 @@ upsert descriptor #104
   +      partitioning: {}
   +      predicate: i > 0:::INT8
   +      sharded: {}
-  +      version: 4
-  +    mutationId: 1
+  +      version: 3
+  +    mutationId: 2
   +    state: WRITE_ONLY
   +  - column:
   +      computeExpr: lower(j)
@@ -204,21 +201,20 @@ upsert descriptor #104
   +      inaccessible: true
   +      name: crdb_internal_column_3_name_placeholder
   +      nullable: true
-  +      pgAttributeNum: 3
   +      type:
   +        family: StringFamily
   +        oid: 25
   +      virtual: true
   +    direction: DROP
-  +    mutationId: 1
+  +    mutationId: 2
   +    state: WRITE_ONLY
      name: t
      nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "8"
-  +  version: "9"
+  -  version: "7"
+  +  version: "8"
 persist all catalog changes to storage
 create job #1 (non-cancelable: true): "DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
@@ -239,15 +235,15 @@ upsert descriptor #104
          partitioning: {}
   -      predicate: i > 0:::INT8
          sharded: {}
-         version: 4
-       mutationId: 1
+         version: 3
+       mutationId: 2
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      - column:
          computeExpr: lower(j)
   ...
        direction: DROP
-       mutationId: 1
+       mutationId: 2
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: t
@@ -255,8 +251,8 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "9"
-  +  version: "10"
+  -  version: "8"
+  +  version: "9"
 persist all catalog changes to storage
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 3 MutationType ops pending"
 commit transaction #3
@@ -303,8 +299,8 @@ upsert descriptor #104
   -      name: crdb_internal_index_2_name_placeholder
   -      partitioning: {}
   -      sharded: {}
-  -      version: 4
-  -    mutationId: 1
+  -      version: 3
+  -    mutationId: 2
   -    state: DELETE_ONLY
   -  - column:
   -      computeExpr: lower(j)
@@ -312,13 +308,12 @@ upsert descriptor #104
   -      inaccessible: true
   -      name: crdb_internal_column_3_name_placeholder
   -      nullable: true
-  -      pgAttributeNum: 3
   -      type:
   -        family: StringFamily
   -        oid: 25
   -      virtual: true
   -    direction: DROP
-  -    mutationId: 1
+  -    mutationId: 2
   -    state: DELETE_ONLY
   +  mutations: []
      name: t
@@ -326,8 +321,8 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "10"
-  +  version: "11"
+  -  version: "9"
+  +  version: "10"
 persist all catalog changes to storage
 create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]


### PR DESCRIPTION
Backport 1/1 commits from #125282.

/cc @cockroachdb/release

---

This bug only existed in the declarative schema changer due to the declarative schema changer code not running checks with ReplaceColumnVars() and SanitizeVarFreeExp() like in the legacy schema changer.  The fix was to add a call to b.ComputedColumnExpression() which calls
schemaexpr.ValidateComputedColumnExpression which calls DequalifyAndValidateExpr which calls DequalifyAndValidateExprImpl, and that calls both ReplaceColumnVars and SanitizeVarFreeExpr.

Fixes: #124546
Release note (bug fix): ALTER TABLE ... ADD CONSTRAINT UNIQUE will
now fail with a well-formed error message and code 42601 if a
statement tries to add a unique constraint on an expression.

Release justification: Bug fix.