### PR TITLE
pkg/obs/logstream: increase timeout used in TestBlockedFlush

### DIFF
--- a/pkg/obs/logstream/BUILD.bazel
+++ b/pkg/obs/logstream/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     embed = [":logstream"],
     deps = [
         "//pkg/roachpb",
-        "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",


### PR DESCRIPTION
Addresses: https://github.com/cockroachdb/cockroach/issues/125290

TestBlockedFlush only provided 100 milliseconds of tolerance for a goroutine to be created, make a call to
`(*asyncProcessorRouter).Process()`, and then signal on a channel. Under nightly stress, the test was timing out because the goroutine failed to signal on the channel within 100 milliseconds, which certainly feels possible if the test is running under nightly stress.

This patch simply updates the test with a longer timeout (10ms -> 10s) to make the timeout less likely when run under stress.

Release note: none

Epic: none