### PR TITLE
sql: skip TestCreateStatsAfterSchemaChange under duress

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5071,7 +5071,8 @@ CREATE TABLE t.test (a INT, b INT, c JSON, d JSON);
 func TestCreateStatsAfterSchemaChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "sometimes the timer in stats.Refresher doesn't fire fast enough under race")
+
+	skip.UnderDuress(t, "sometimes the timer in stats.Refresher doesn't fire fast enough under custom configs")
 
 	defer func(oldRefreshInterval, oldAsOf time.Duration) {
 		stats.DefaultRefreshInterval = oldRefreshInterval


### PR DESCRIPTION
It was already skipped under race and we just saw a failure under deadlock.

Fixes: #125403.

Release note: None