### PR TITLE
kvstreamer: disable tenants in TestStreamerVaryingResponseSizes

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -563,6 +563,9 @@ func TestStreamerVaryingResponseSizes(t *testing.T) {
 				ForceProductionValues: true,
 			},
 		},
+		// Disable tenant randomization since this test is quite heavy and could
+		// result in a timeout under shared-process tenant.
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 	})
 	defer s.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
This test is quite heavy and could result in a timeout under shared-process tenant. We already disabled other randomizations and skipped it under duress.

Epic: None

Release note: None