### PR TITLE
roachtest: exclude .perf directories from artifacts.zip

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1859,8 +1859,11 @@ func zipArtifacts(t *testImpl) error {
 		// However, if the order is reversed, or 'stats.json' is created directly on the test runner node,
 		// it will be moved to the zip archive. The corresponding CI script (build/teamcity/util/roachtest_util.sh) will
 		// then fail to find 'stats.json' in the artifacts directory, and the roachperf dashboard will be looking rather sad.
-		if !entry.IsDir() && entry.Name() == "stats.json" {
-			// Skip any 'stats.json' files.
+		if (!entry.IsDir() && entry.Name() == "stats.json") ||
+			// N.B. performance artifacts are expected to be in a directory of the form "2.perf",
+			// where 2 is node id; see `getPerfArtifacts`.
+			(entry.IsDir() && strings.HasSuffix(entry.Name(), "."+t.PerfArtifactsDir())) {
+			// Skip 'stats.json' and directories ending in '.perf'.
 			return false
 		}
 		return true

--- a/pkg/cmd/roachtest/zip_util_test.go
+++ b/pkg/cmd/roachtest/zip_util_test.go
@@ -21,28 +21,25 @@ import (
 )
 
 func TestMoveToZipArchive(t *testing.T) {
-	dir := t.TempDir()
-	p := func(elems ...string) string {
-		return filepath.Join(append([]string{dir}, elems...)...)
-	}
-	require.NoError(t, os.WriteFile(p("a1"), []byte("foo"), 0777))
-	require.NoError(t, os.WriteFile(p("a2"), []byte("foo"), 0777))
-	require.NoError(t, os.WriteFile(p("a3"), []byte("foo"), 0777))
-	require.NoError(t, os.Mkdir(p("dir1"), 0777))
-	require.NoError(t, os.WriteFile(p("dir1", "file1"), []byte("foo"), 0777))
-	require.NoError(t, os.WriteFile(p("dir1", "file2"), []byte("foo"), 0777))
-	require.NoError(t, os.Mkdir(p("dir2"), 0777))
-	require.NoError(t, os.WriteFile(p("dir2", "file1"), []byte("foo"), 0777))
-	require.NoError(t, os.WriteFile(p("dir2", "file2"), []byte("foo"), 0777))
+	baseDir := t.TempDir()
+	require.NoError(t, os.WriteFile(p(baseDir, "a1"), []byte("foo"), 0777))
+	require.NoError(t, os.WriteFile(p(baseDir, "a2"), []byte("foo"), 0777))
+	require.NoError(t, os.WriteFile(p(baseDir, "a3"), []byte("foo"), 0777))
+	require.NoError(t, os.Mkdir(p(baseDir, "dir1"), 0777))
+	require.NoError(t, os.WriteFile(p(baseDir, "dir1", "file1"), []byte("foo"), 0777))
+	require.NoError(t, os.WriteFile(p(baseDir, "dir1", "file2"), []byte("foo"), 0777))
+	require.NoError(t, os.Mkdir(p(baseDir, "dir2"), 0777))
+	require.NoError(t, os.WriteFile(p(baseDir, "dir2", "file1"), []byte("foo"), 0777))
+	require.NoError(t, os.WriteFile(p(baseDir, "dir2", "file2"), []byte("foo"), 0777))
 
 	// expectLs checks the current directory listing of dir.
 	expectLs := func(expected ...string) {
 		t.Helper()
 		var actual []string
-		require.NoError(t, filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 			require.NoError(t, err)
 			if !info.IsDir() {
-				rel, err := filepath.Rel(dir, path)
+				rel, err := filepath.Rel(baseDir, path)
 				require.NoError(t, err)
 				actual = append(actual, rel)
 			}
@@ -50,35 +47,56 @@ func TestMoveToZipArchive(t *testing.T) {
 		}))
 		require.Equal(t, expected, actual)
 	}
-	// expectZip checks the files contained in the given archive; paths must use
-	// slashes.
-	expectZip := func(archiveName string, expected ...string) {
-		r, err := zip.OpenReader(p(archiveName))
-		require.NoError(t, err)
-		var actual []string
-		for _, f := range r.File {
-			actual = append(actual, f.Name)
-		}
-		require.Equal(t, expected, actual)
-		require.NoError(t, r.Close())
-	}
 	j := filepath.Join
 	expectLs("a1", "a2", "a3", j("dir1", "file1"), j("dir1", "file2"), j("dir2", "file1"), j("dir2", "file2"))
 
-	list, err := filterDirEntries(dir, func(entry os.DirEntry) bool {
+	list, err := filterDirEntries(baseDir, func(entry os.DirEntry) bool {
 		return entry.Name() != "a2" && entry.Name() != "dir2"
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"a1", "a3", "dir1"}, list)
-	require.NoError(t, moveToZipArchive("first.zip", dir, list...))
-	expectZip("first.zip", "a1", "a3", "dir1/file1", "dir1/file2")
+	require.NoError(t, moveToZipArchive("first.zip", baseDir, list...))
+	expectZip(t, baseDir, "first.zip", "a1", "a3", "dir1/file1", "dir1/file2")
 	expectLs("a2", j("dir2", "file1"), j("dir2", "file2"), "first.zip")
 
-	list, err = filterDirEntries(dir, func(entry os.DirEntry) bool {
+	list, err = filterDirEntries(baseDir, func(entry os.DirEntry) bool {
 		return !strings.HasSuffix(entry.Name(), ".zip")
 	})
 	require.NoError(t, err)
-	require.NoError(t, moveToZipArchive("second.zip", dir, list...))
-	expectZip("second.zip", "a2", "dir2/file1", "dir2/file2")
+	require.NoError(t, moveToZipArchive("second.zip", baseDir, list...))
+	expectZip(t, baseDir, "second.zip", "a2", "dir2/file1", "dir2/file2")
 	expectLs("first.zip", "second.zip")
+}
+
+func TestZipArtifacts(t *testing.T) {
+	tmp := t.TempDir()
+	artifactsDir := filepath.Join(tmp, "someTestRun")
+	require.NoError(t, os.Mkdir(artifactsDir, 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(artifactsDir, "test.log"), []byte("foobar"), 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(artifactsDir, "test-teardown.log"), []byte{}, 0777))
+	perfArtifactsDir := filepath.Join(artifactsDir, "1.perf")
+	require.NoError(t, os.Mkdir(perfArtifactsDir, 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(perfArtifactsDir, "stats.json"), []byte("{}"), 0777))
+	tt := testImpl{
+		artifactsDir: artifactsDir,
+	}
+	require.NoError(t, zipArtifacts(&tt))
+	expectZip(t, artifactsDir, "artifacts.zip", "test.log", "test-teardown.log")
+}
+
+// expectZip checks the files contained in the given archive; paths must use
+// slashes.
+func expectZip(t *testing.T, basedir string, archiveName string, expected ...string) {
+	r, err := zip.OpenReader(p(basedir, archiveName))
+	require.NoError(t, err)
+	var actual []string
+	for _, f := range r.File {
+		actual = append(actual, f.Name)
+	}
+	require.ElementsMatch(t, expected, actual)
+	require.NoError(t, r.Close())
+}
+
+func p(baseDir string, elems ...string) string {
+	return filepath.Join(append([]string{baseDir}, elems...)...)
 }


### PR DESCRIPTION
In #125022, we excluded stats.json files from being zipped. However, because the stats.json file lives in a .perf dir this dir is found first by filterDirEntries and zipped. This change instead excludes the .perf directory from being zipped.

Epic: none
Fixes: none

Release note: None