### PR TITLE
roachtest: skip backup and restore tests that flake due to network error

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -347,7 +347,7 @@ func registerBackup(r registry.Registry) {
 					return err
 				}
 				if err := AssertReasonableFractionCompleted(ctx, t.L(), c, jobID, 2); err != nil {
-					return err
+					return errors.CombineErrors(err, skipIfNetworkFlake(ctx, t, c, int(jobID)))
 				}
 				tick()
 


### PR DESCRIPTION
As of 24.1, backup and restore are more resilient to network flakes due to
 #116957 and #119804. These patches were not backported to 23.2. To reduce test
flake noise in 23.2 and earlier branches, this patch skips a roachtest where backup/restore paused or failed due to a network flake.

Epic: none

Release note: none