### PR TITLE
workload: fix description of `seed` flag

### DIFF
--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -35,6 +35,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// NOTE: the caller is expected to pass the same seed on `init` and
+// `run` when using this workload.
 var RandomSeed = workload.NewInt64RandomSeed()
 
 type random struct {

--- a/pkg/workload/random.go
+++ b/pkg/workload/random.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	flagName        = "seed"
-	flagDescription = "Random seed. Must be the same in 'init' and 'run'. Default changes in each run"
+	flagDescription = "Random seed. Default changes in each run"
 )
 
 // RandomSeed is the interface used by the workload runner to print


### PR DESCRIPTION
The description previously stated that the `seed` command line flag needed to be the same for the `init` and `run` commands. However, that is inaccurate, as it is only true for some workloads (such as `rand`). For most workloads, there is no coupling between `init` and `run`, so they are allowed to use different seeds.

Epic: none

Release note: None