### PR TITLE
kv: add hlc clock propagation to RaftTransport

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2472,10 +2472,11 @@ func TestStoreReplicaGCAfterMerge(t *testing.T) {
 	transport := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
+		tc.Servers[0].Stopper(),
+		tc.Servers[0].Clock(),
 		nodedialer.New(tc.Servers[0].RPCContext(),
 			gossip.AddressResolver(tc.Servers[0].GossipI().(*gossip.Gossip))),
 		nil, /* grpcServer */
-		tc.Servers[0].Stopper(),
 		kvflowdispatch.NewDummyDispatch(),
 		kvserver.NoopStoresFlowControlIntegration{},
 		kvserver.NoopRaftTransportDisconnectListener{},

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3403,9 +3403,10 @@ func TestReplicaGCRace(t *testing.T) {
 	fromTransport := kvserver.NewRaftTransport(
 		ambient,
 		cluster.MakeTestingClusterSettings(),
+		tc.Servers[0].Stopper(),
+		tc.Servers[0].Clock(),
 		nodedialer.New(tc.Servers[0].RPCContext(), gossip.AddressResolver(fromStore.Gossip())),
 		nil, /* grpcServer */
-		tc.Servers[0].Stopper(),
 		kvflowdispatch.NewDummyDispatch(),
 		kvserver.NoopStoresFlowControlIntegration{},
 		kvserver.NoopRaftTransportDisconnectListener{},
@@ -3794,10 +3795,11 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	transport0 := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
+		tc.Servers[0].Stopper(),
+		tc.Servers[0].Clock(),
 		nodedialer.New(tc.Servers[0].RPCContext(),
 			gossip.AddressResolver(tc.GetFirstStoreFromServer(t, 0).Gossip())),
 		nil, /* grpcServer */
-		tc.Servers[0].Stopper(),
 		kvflowdispatch.NewDummyDispatch(),
 		kvserver.NoopStoresFlowControlIntegration{},
 		kvserver.NoopRaftTransportDisconnectListener{},
@@ -6902,7 +6904,7 @@ func TestStoreMetricsOnIncomingOutgoingMsg(t *testing.T) {
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
-	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+	cfg.Transport = kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Clock)
 	store := kvserver.NewStore(ctx, cfg, eng, &node)
 	store.Ident = &roachpb.StoreIdent{
 		ClusterID: uuid.Nil,

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -19,8 +19,9 @@ import "kv/kvserver/liveness/livenesspb/liveness.proto";
 import "kv/kvserver/kvserverpb/state.proto";
 import "kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.proto";
 import "raft/raftpb/raft.proto";
-import "gogoproto/gogo.proto";
+import "util/hlc/timestamp.proto";
 import "util/tracing/tracingpb/recorded_span.proto";
+import "gogoproto/gogo.proto";
 
 // RaftHeartbeat is a request that contains the barebones information for a
 // raftpb.MsgHeartbeat raftpb.Message. RaftHeartbeats are coalesced and sent
@@ -129,6 +130,15 @@ message RaftMessageRequestBatch {
   //       RaftMessageRequest.
   // [^3]: See I1 from kvflowcontrol/doc.go.
   repeated uint64 store_ids = 2 [(gogoproto.customname) = "StoreIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"];
+
+  // now is a clock reading from the sender of the batch. It must be used by
+  // the receiver to update its local HLC, which provides causality tracking.
+  //
+  // One way in which this is used is to update the clock of a raft candidate
+  // to the clock of all followers that have voted for it, which is used to
+  // provide a disjointness guarantee to leader leases.
+  util.hlc.Timestamp now = 3 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
 }
 
 message RaftMessageResponseUnion {

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -109,10 +110,18 @@ func (s channelServer) HandleDelegatedSnapshot(
 type raftTransportTestContext struct {
 	t              testing.TB
 	stopper        *stop.Stopper
+	clocks         map[roachpb.NodeID]clockWithManualSource
 	transports     map[roachpb.NodeID]*kvserver.RaftTransport
 	nodeRPCContext *rpc.Context
 	gossip         *gossip.Gossip
 	st             *cluster.Settings
+}
+
+// clockWithManualSource is a pair of clocks: a manual clock and a clock that
+// uses the manual clock as a source.
+type clockWithManualSource struct {
+	manual *hlc.HybridManualClock
+	clock  *hlc.Clock
 }
 
 func newRaftTransportTestContext(t testing.TB, st *cluster.Settings) *raftTransportTestContext {
@@ -121,6 +130,7 @@ func newRaftTransportTestContext(t testing.TB, st *cluster.Settings) *raftTransp
 	rttc := &raftTransportTestContext{
 		t:          t,
 		stopper:    stop.NewStopper(stop.WithTracer(tr)),
+		clocks:     map[roachpb.NodeID]clockWithManualSource{},
 		transports: map[roachpb.NodeID]*kvserver.RaftTransport{},
 		st:         st,
 	}
@@ -173,14 +183,18 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	disconnectListener kvserver.RaftTransportDisconnectListener,
 	knobs *kvserver.RaftTransportTestingKnobs,
 ) (*kvserver.RaftTransport, net.Addr) {
+	manual := hlc.NewHybridManualClock()
+	clock := hlc.NewClockForTesting(manual)
+	rttc.clocks[nodeID] = clockWithManualSource{manual: manual, clock: clock}
 	grpcServer, err := rpc.NewServer(context.Background(), rttc.nodeRPCContext)
 	require.NoError(rttc.t, err)
 	transport := kvserver.NewRaftTransport(
 		log.MakeTestingAmbientCtxWithNewTracer(),
 		rttc.st,
+		rttc.stopper,
+		clock,
 		nodedialer.New(rttc.nodeRPCContext, gossip.AddressResolver(rttc.gossip)),
 		grpcServer,
-		rttc.stopper,
 		kvflowTokenDispatch,
 		kvflowHandles,
 		disconnectListener,
@@ -696,4 +710,49 @@ func TestSendFailureToConnectDoesNotHangRaft(t *testing.T) {
 		},
 		Message: raftpb.Message{To: to, From: from},
 	}, rpc.DefaultClass)
+}
+
+// TestRaftTransportClockPropagation verifies that hlc clock timestamps are
+// propagated across the RaftTransport.
+func TestRaftTransportClockPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	rttc := newRaftTransportTestContext(t, cluster.MakeTestingClusterSettings())
+	defer rttc.Stop()
+
+	serverReplica := roachpb.ReplicaDescriptor{
+		NodeID:    2,
+		StoreID:   2,
+		ReplicaID: 2,
+	}
+	rttc.AddNode(serverReplica.NodeID)
+	serverChannel := rttc.ListenStore(serverReplica.NodeID, serverReplica.StoreID)
+
+	clientReplica := roachpb.ReplicaDescriptor{
+		NodeID:    1,
+		StoreID:   1,
+		ReplicaID: 1,
+	}
+	rttc.AddNode(clientReplica.NodeID)
+
+	// Pause all clocks.
+	for _, c := range rttc.clocks {
+		c.manual.Pause()
+	}
+
+	// Advance the client's clock beyond the server's.
+	rttc.clocks[clientReplica.NodeID].manual.Increment(1000)
+	clientNow := rttc.clocks[clientReplica.NodeID].clock.Now()
+	serverNow := rttc.clocks[serverReplica.NodeID].clock.Now()
+	require.True(t, serverNow.Less(clientNow))
+
+	// Send a message from the client to the server.
+	sent := rttc.Send(clientReplica, serverReplica, 1 /* rangeID */, raftpb.Message{Commit: 10})
+	require.True(t, sent, "failed to send message")
+	req := <-serverChannel.ch
+	require.Equal(t, uint64(10), req.Message.Commit)
+
+	// The server's clock should have been updated to the client's time.
+	serverNow = rttc.clocks[serverReplica.NodeID].clock.Now()
+	require.False(t, serverNow.Less(clientNow))
 }

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
@@ -70,9 +71,10 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 	tp := NewRaftTransport(
 		log.MakeTestingAmbientCtxWithNewTracer(),
 		cluster.MakeTestingClusterSettings(),
+		stopper,
+		hlc.NewClockForTesting(nil),
 		nodedialer.New(rpcC, resolver),
 		grpcServer,
-		stopper,
 		kvflowdispatch.NewDummyDispatch(),
 		NoopStoresFlowControlIntegration{},
 		NoopRaftTransportDisconnectListener{},

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -247,7 +247,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 
-	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Clock)
 	store := NewStore(ctx, cfg, eng, &node)
 	// Fake an ident because this test doesn't want to start the store
 	// but without an Ident there will be NPEs.

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -156,7 +156,7 @@ func TestRaftCrossLocalityMetrics(t *testing.T) {
 	node := roachpb.NodeDescriptor{NodeID: roachpb.NodeID(1)}
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
-	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Clock)
 	store := NewStore(ctx, cfg, eng, &node)
 	store.Ident = &roachpb.StoreIdent{
 		ClusterID: uuid.Nil,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -236,9 +236,10 @@ func createTestStoreWithoutStart(
 	cfg.Transport = NewRaftTransport(
 		cfg.AmbientCtx,
 		cfg.Settings,
+		stopper,
+		cfg.Clock,
 		cfg.NodeDialer,
 		server,
-		stopper,
 		kvflowdispatch.NewDummyDispatch(),
 		NoopStoresFlowControlIntegration{},
 		NoopRaftTransportDisconnectListener{},
@@ -545,7 +546,7 @@ func TestInitializeEngineErrors(t *testing.T) {
 	require.NoError(t, eng.PutUnversioned(roachpb.Key("foo"), []byte("bar")))
 
 	cfg := TestStoreConfig(nil)
-	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+	cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Clock)
 	store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -138,7 +138,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 		stopper.AddCloser(memEngine)
 
 		cfg := TestStoreConfig(clock)
-		cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+		cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Clock)
 
 		store := NewStore(ctx, cfg, memEngine, &roachpb.NodeDescriptor{NodeID: 1})
 		// Fake-set an ident. This is usually read from the engine on store.Start()
@@ -231,7 +231,7 @@ func createStores(count int) (*timeutil.ManualTime, []*Store, *Stores, *stop.Sto
 	// Create two stores with ranges we care about.
 	stores := []*Store{}
 	for i := 0; i < count; i++ {
-		cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+		cfg.Transport = NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Clock)
 		eng := storage.NewDefaultInMemForTesting()
 		stopper.AddCloser(eng)
 		s := NewStore(context.Background(), cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -630,9 +630,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	raftTransport := kvserver.NewRaftTransport(
 		cfg.AmbientCtx,
 		st,
+		stopper,
+		clock,
 		kvNodeDialer,
 		grpcServer.Server,
-		stopper,
 		admissionControl.kvflowTokenDispatch,
 		admissionControl.storesFlowControl,
 		admissionControl.storesFlowControl,

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -182,7 +182,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		Stopper:      ltc.stopper,
 	}
 	ltc.DB = kv.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.dbContext)
-	transport := kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings)
+	transport := kvserver.NewDummyRaftTransport(cfg.AmbientCtx, cfg.Settings, ltc.Clock)
 	// By default, disable the replica scanner and split queue, which
 	// confuse tests using LocalTestCluster.
 	if ltc.StoreTestingKnobs == nil {


### PR DESCRIPTION
Fixes #125234.

This commit adds HLC clock propagation to the RaftTransport by passing ClockTimestamps on RaftMessageRequestBatch. It is necessary for the correctness of leader leases and the Raft fortification protocols for MsgPreVoteResp and MsgVoteResp messages to carry these timestamps. Doing so ensures that any future leader has an HLC clock that leads the timestamps used by the replicas that voted for it to evaluate store liveness support for the previous leader.

Release note: None