### PR TITLE
roachtest: deflake disk-stall by moving monitor wait

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -108,7 +108,6 @@ func runDiskStalledWALFailover(
 			`{pgurl:1-3}`)
 		return nil
 	})
-	defer m.Wait()
 
 	const pauseBetweenStalls = 10 * time.Minute
 	t.Status("pausing ", pauseBetweenStalls, " before simulated disk stall on n1")
@@ -181,6 +180,8 @@ func runDiskStalledWALFailover(
 	if durInFailover < 60*time.Second {
 		t.Errorf("expected s1 to spend at least 60s writing to secondary, but spent %s", durInFailover)
 	}
+	// Wait for the workload to finish (if it hasn't already).
+	m.Wait()
 
 	// Shut down the nodes, allowing any devices to be unmounted during cleanup.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 3))
@@ -296,7 +297,6 @@ func runDiskStalledDetection(
 			`{pgurl:2-3}`)
 		return nil
 	})
-	defer m.Wait()
 
 	// Wait between [3m,6m) before stalling the disk.
 	pauseDur := 3*time.Minute + time.Duration(rand.Intn(3))*time.Minute
@@ -394,6 +394,8 @@ func runDiskStalledDetection(
 	} else if ok && exit > 0 {
 		t.Fatal("no stall induced, but process exited")
 	}
+	// Wait for the workload to finish (if it hasn't already).
+	m.Wait()
 
 	// Shut down the nodes, allowing any devices to be unmounted during cleanup.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 3))


### PR DESCRIPTION
Previously, we'd have the monitor wait for the workload(s) to complete _after_ we had stopped all the nodes. This resulted in flaky test behaviour if the workload ran for a bit longer than the stall/unstall part(s) of the test, as the monitor could catch the cockroach process terminating because we shut it down ourselves in the test. This change moves the monitor's wait method to be before the cluster.Stop call in the disk-stall/* roachtests, to avoid this failure case.

Fixes: #125292

Epic: none

Release note: None