### PR TITLE
sql: add support for EXPLAIN ANALYZE in SQL shell and a builtin

### DIFF
--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -1062,3 +1062,12 @@ sql admin
  },
  "num_statements": 4
 }
+
+# Note that we don't verify the contents of the response because it's not
+# deterministic, so we only check that it didn't result in an error.
+sql admin expect-no-error
+{
+  "execute": true,
+  "statements": [{"sql": "EXPLAIN ANALYZE SELECT 1"}]
+}
+----

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -868,17 +868,17 @@ type RestrictedCommandResult interface {
 	// soon as AddBatch returns.
 	AddBatch(ctx context.Context, batch coldata.Batch) error
 
+	// SupportsAddBatch returns whether this command result supports AddBatch
+	// method of adding the data. If false is returned, then the behavior of
+	// AddBatch is undefined.
+	SupportsAddBatch() bool
+
 	// BufferedResultsLen returns the length of the results buffer.
 	BufferedResultsLen() int
 
 	// TruncateBufferedResults clears any results that have been buffered after
 	// given index, and returns true iff any results were actually truncated.
 	TruncateBufferedResults(idx int) bool
-
-	// SupportsAddBatch returns whether this command result supports AddBatch
-	// method of adding the data. If false is returned, then the behavior of
-	// AddBatch is undefined.
-	SupportsAddBatch() bool
 
 	// SetRowsAffected sets RowsAffected counter to n. This is used for all
 	// result types other than tree.Rows.
@@ -1120,7 +1120,8 @@ func (r *streamingCommandResult) SendNotice(ctx context.Context, notice pgnotice
 
 // ResetStmtType is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) ResetStmtType(stmt tree.Statement) {
-	panic("unimplemented")
+	// This command result doesn't care about the stmt type since it doesn't
+	// produce pgwire messages.
 }
 
 // GetFormatCode is part of the sql.RestrictedCommandResult interface.
@@ -1150,20 +1151,21 @@ func (r *streamingCommandResult) AddBatch(context.Context, coldata.Batch) error 
 	panic("unimplemented")
 }
 
+// SupportsAddBatch is part of the RestrictedCommandResult interface.
+func (r *streamingCommandResult) SupportsAddBatch() bool {
+	return false
+}
+
 // BufferedResultsLen is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) BufferedResultsLen() int {
-	// Since this implementation is streaming, there is no sensible return
-	// value here.
-	panic("unimplemented")
+	// Since this implementation is streaming, we cannot truncate some buffered
+	// results. This is achieved by unconditionally returning false in
+	// TruncateBufferedResults, so this return value doesn't actually matter.
+	return 0
 }
 
 // TruncateBufferedResults is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) TruncateBufferedResults(int) bool {
-	return false
-}
-
-// SupportsAddBatch is part of the RestrictedCommandResult interface.
-func (r *streamingCommandResult) SupportsAddBatch() bool {
 	return false
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -212,3 +212,6 @@ query T
 SELECT crdb_internal.execute_internally('SELECT session_user;', 'User=testuser');
 ----
 root
+
+statement ok
+SELECT crdb_internal.execute_internally('EXPLAIN ANALYZE SELECT 1;');

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -287,6 +287,11 @@ func (r *commandResult) AddBatch(ctx context.Context, batch coldata.Batch) error
 	return r.conn.bufferBatch(ctx, batch, r)
 }
 
+// SupportsAddBatch is part of the sql.RestrictedCommandResult interface.
+func (r *commandResult) SupportsAddBatch() bool {
+	return true
+}
+
 // BufferedResultsLen is part of the sql.RestrictedCommandResult interface.
 func (r *commandResult) BufferedResultsLen() int {
 	return r.conn.writerState.buf.Len()
@@ -305,11 +310,6 @@ func (r *commandResult) TruncateBufferedResults(idx int) bool {
 		return true
 	}
 	r.conn.writerState.buf.Truncate(idx)
-	return true
-}
-
-// SupportsAddBatch is part of the sql.RestrictedCommandResult interface.
-func (r *commandResult) SupportsAddBatch() bool {
 	return true
 }
 
@@ -560,16 +560,16 @@ func (r *limitedCommandResult) AddRow(ctx context.Context, row tree.Datums) erro
 	return nil
 }
 
-// RevokePortalPausability is part of the sql.RestrictedCommandResult interface.
-func (r *limitedCommandResult) RevokePortalPausability() error {
-	r.portalPausablity = sql.NotPausablePortalForUnsupportedStmt
-	return nil
-}
-
 // SupportsAddBatch is part of the sql.RestrictedCommandResult interface.
 // TODO(yuzefovich): implement limiting behavior for AddBatch.
 func (r *limitedCommandResult) SupportsAddBatch() bool {
 	return false
+}
+
+// RevokePortalPausability is part of the sql.RestrictedCommandResult interface.
+func (r *limitedCommandResult) RevokePortalPausability() error {
+	r.portalPausablity = sql.NotPausablePortalForUnsupportedStmt
+	return nil
 }
 
 // moreResultsNeeded is a restricted connection handler that waits for more


### PR DESCRIPTION
This commit fixes a possible crash that could happen whenever the internal executor is used to run EXPLAIN ANALYZE statement (the crash happened because we'd attempt to call `ResetStmtType` on `streamingCommandResult` which is unimplemented). This commit makes this method a no-op since we don't care about the stmt type. This affects the UI SQL shell as well as `crdb_internal.execute_internally` builtin.

It additionally audits all methods of `streamingCommandResult` that panic. `AddBatch` is ok to not be implemented given that we have `SupportsBatch` always return `false`. Another panic is removed in `BufferedResultsLen` (used under read committed) where it's ok to be a no-op. This commit also moves the code around a bit to have better layout.

Epic: None

Release note (sql change): EXPLAIN ANALYZE statements are now supported when executed via UI SQL shell.