### PR TITLE
changefeedccl: add CompressionLevel option to kafka_sink_config

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -199,7 +199,8 @@ type saramaConfig struct {
 		MaxMessages int          `json:",omitempty"`
 	}
 
-	Compression compressionCodec `json:",omitempty"`
+	Compression      compressionCodec `json:",omitempty"`
+	CompressionLevel int              `json:",omitempty"`
 
 	RequiredAcks string `json:",omitempty"`
 
@@ -240,6 +241,7 @@ func defaultSaramaConfig() *saramaConfig {
 	// The default compression protocol is sarama.CompressionNone,
 	// which is 0.
 	config.Compression = 0
+	config.CompressionLevel = sarama.CompressionLevelDefault
 
 	// This works around what seems to be a bug in sarama where it isn't
 	// computing the right value to compare against `Producer.MaxMessageBytes`
@@ -831,6 +833,9 @@ func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 	kafka.Producer.Flush.MaxMessages = c.Flush.MaxMessages
 	kafka.ClientID = c.ClientID
 
+	kafka.Producer.Compression = sarama.CompressionCodec(c.Compression)
+	kafka.Producer.CompressionLevel = c.CompressionLevel
+
 	if c.Version != "" {
 		parsedVersion, err := sarama.ParseKafkaVersion(c.Version)
 		if err != nil {
@@ -845,7 +850,7 @@ func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 		}
 		kafka.Producer.RequiredAcks = parsedAcks
 	}
-	kafka.Producer.Compression = sarama.CompressionCodec(c.Compression)
+
 	return nil
 }
 


### PR DESCRIPTION
The Kafka client (sarama) supports compression level in addition to compression codecs. This option only works with `gzip` and `zstd` compression. This allows the user to choose the compression level in the Kafka integration.

Part of #113495

Release note (enterprise change): Added `CompressionLevel` option to `kafka_sink_config`. Changefeed will use this compression level when emitting events. The possible values depend on a compression codec. This option is useful for choosing between faster or better compression.