### PR TITLE
sql: remove a couple of allocations in connExecutor.resetPlanner

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3824,39 +3824,51 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 	p.datumAlloc = &tree.DatumAlloc{}
 }
 
+// maybeAdjustMaxTimestampBound checks
+func (ex *connExecutor) maybeAdjustMaxTimestampBound(p *planner, txn *kv.Txn) {
+	if autoRetryReason := ex.state.mu.autoRetryReason; autoRetryReason != nil {
+		// If we are retrying due to an unsatisfiable timestamp bound which is
+		// retriable, it means we were unable to serve the previous minimum
+		// timestamp as there was a schema update in between. When retrying, we
+		// want to keep the same minimum timestamp for the AOST read, but set
+		// the maximum timestamp to the point just before our failed read to
+		// ensure we don't try to read data which may be after the schema change
+		// when we retry.
+		var minTSErr *kvpb.MinTimestampBoundUnsatisfiableError
+		if errors.As(autoRetryReason, &minTSErr) {
+			nextMax := minTSErr.MinTimestampBound
+			ex.extraTxnState.descCollection.SetMaxTimestampBound(nextMax)
+			return
+		}
+	}
+	// Otherwise, only change the historical timestamps if this is a new txn.
+	// This is because resetPlanner can be called multiple times for the same
+	// txn during the extended protocol.
+	if newTxn := txn == nil || p.extendedEvalCtx.Txn != txn; newTxn {
+		ex.extraTxnState.descCollection.ResetMaxTimestampBound()
+	}
+}
+
 func (ex *connExecutor) resetPlanner(
 	ctx context.Context, p *planner, txn *kv.Txn, stmtTS time.Time,
 ) {
 	p.resetPlanner(ctx, txn, ex.sessionData(), ex.state.mon, ex.sessionMon)
-	autoRetryReason := ex.state.mu.autoRetryReason
-	// If we are retrying due to an unsatisfiable timestamp bound which is
-	// retriable, it means we were unable to serve the previous minimum timestamp
-	// as there was a schema update in between. When retrying, we want to keep the
-	// same minimum timestamp for the AOST read, but set the maximum timestamp
-	// to the point just before our failed read to ensure we don't try to read
-	// data which may be after the schema change when we retry.
-	var minTSErr *kvpb.MinTimestampBoundUnsatisfiableError
+	ex.maybeAdjustMaxTimestampBound(p, txn)
 	// Make sure the default locality specifies the actual gateway region at the
 	// start of query compilation. It could have been overridden to a remote
 	// region when the enforce_home_region session setting is true.
 	p.EvalContext().Locality = p.EvalContext().OriginalLocality
-	if err := autoRetryReason; err != nil && errors.As(err, &minTSErr) {
-		nextMax := minTSErr.MinTimestampBound
-		ex.extraTxnState.descCollection.SetMaxTimestampBound(nextMax)
-	} else if execinfra.IsDynamicQueryHasNoHomeRegionError(autoRetryReason) {
+	if execinfra.IsDynamicQueryHasNoHomeRegionError(ex.state.mu.autoRetryReason) {
 		if int(ex.state.mu.autoRetryCounter) <= len(p.EvalContext().RemoteRegions) {
 			// Set a fake gateway region for use by the optimizer to inform its
-			// decision on which region to access first in locality-optimized scan
-			// and join operations. This setting does not affect the distsql planner,
-			// and local plans will continue to be run from the actual gateway region.
-			p.EvalContext().Locality =
-				p.EvalContext().Locality.CopyReplaceKeyValue("region", string(p.EvalContext().RemoteRegions[ex.state.mu.autoRetryCounter-1]))
+			// decision on which region to access first in locality-optimized
+			// scan and join operations. This setting does not affect the
+			// distsql planner, and local plans will continue to be run from the
+			// actual gateway region.
+			p.EvalContext().Locality = p.EvalContext().Locality.CopyReplaceKeyValue(
+				"region" /* key */, string(p.EvalContext().RemoteRegions[ex.state.mu.autoRetryCounter-1]),
+			)
 		}
-	} else if newTxn := txn == nil || p.extendedEvalCtx.Txn != txn; newTxn {
-		// Otherwise, only change the historical timestamps if this is a new txn.
-		// This is because resetPlanner can be called multiple times for the same
-		// txn during the extended protocol.
-		ex.extraTxnState.descCollection.ResetMaxTimestampBound()
 	}
 	ex.resetEvalCtx(&p.extendedEvalCtx, txn, stmtTS)
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3827,7 +3827,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 func (ex *connExecutor) resetPlanner(
 	ctx context.Context, p *planner, txn *kv.Txn, stmtTS time.Time,
 ) {
-	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData(), ex.state.mon, ex.sessionMon)
+	p.resetPlanner(ctx, txn, ex.sessionData(), ex.state.mon, ex.sessionMon)
 	autoRetryReason := ex.state.mu.autoRetryReason
 	// If we are retrying due to an unsatisfiable timestamp bound which is
 	// retriable, it means we were unable to serve the previous minimum timestamp

--- a/pkg/sql/sem/eval/unsupported_types.go
+++ b/pkg/sql/sem/eval/unsupported_types.go
@@ -19,18 +19,24 @@ import (
 )
 
 type unsupportedTypeChecker struct {
-	version clusterversion.Handle
+	// Uncomment this when a new type is introduced.
+	// version clusterversion.Handle
 }
 
 // NewUnsupportedTypeChecker returns a new tree.UnsupportedTypeChecker that can
 // be used to check whether a type is allowed by the current cluster version.
-func NewUnsupportedTypeChecker(handle clusterversion.Handle) tree.UnsupportedTypeChecker {
-	return &unsupportedTypeChecker{version: handle}
+func NewUnsupportedTypeChecker(clusterversion.Handle) tree.UnsupportedTypeChecker {
+	// Right now we don't have any unsupported types, so there is no benefit in
+	// returning a type checker that never errors, so we just return nil. (The
+	// infrastructure is already set up to handle such case gracefully.)
+	return nil
 }
 
 var _ tree.UnsupportedTypeChecker = &unsupportedTypeChecker{}
 
 // CheckType implements the tree.UnsupportedTypeChecker interface.
 func (tc *unsupportedTypeChecker) CheckType(ctx context.Context, typ *types.T) error {
+	// NB: when adding an unsupported type here, change the constructor to not
+	// return nil.
 	return nil
 }


### PR DESCRIPTION
**sql: unify newInternalPlanner and resetPlanner a bit**

This should be a no-op change that removes some of the duplicated
initialization.

**sql: avoid an allocation in connExecutor.resetPlanner**

This commit avoids an allocation for `kvpb.MinTimestampBoundUnsatisfiableError` in `connExecutor.resetPlanner` in the happy path (meaning when there is not auto retry error). This allocation occurred because we're passing a reference to the pointer to the error into `errors.As`, and now we allocate only in the error path.

Additionally, this commit separates out handling of "max timestamp bound" (which is used by the descriptor collection) and locality handling (used by "query home region" feature of the optimizer). In other words, it's not exactly an equivalent change, but I think the previous version was incorrect.

**eval: avoid redundant allocation of UnsupportedTypeChecker**

Given that we currently don't have any types that should be rejected in mixed version clusters, returning `nil` instead of fully-initialized `unsupportedTypeChecker` is equivalent, which allows us to avoid an allocation in `connExecutor.resetPlanner`.

Epic: CRDB-39063.