### PR TITLE
sql: improve bundle with plan-gist matching

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -302,6 +302,33 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		}
 	})
 
+	// getBundleThroughBuiltin is a helper function that returns an url to
+	// download a stmt bundle that was collected in response to a diagnostics
+	// request inserted by the builtin.
+	getBundleThroughBuiltin := func(fprint, query, planGist string, redacted bool) string {
+		// Delete all old diagnostics to make this test easier.
+		r.Exec(t, "DELETE FROM system.statement_diagnostics WHERE true")
+
+		// Insert the diagnostics request via the builtin function.
+		row := r.QueryRow(t, `SELECT crdb_internal.request_statement_bundle($1, $2, 0::FLOAT, 0::INTERVAL, 0::INTERVAL, $3);`, fprint, planGist, redacted)
+		var inserted bool
+		row.Scan(&inserted)
+		require.True(t, inserted)
+
+		// Now actually execute the query so that the bundle is collected.
+		r.Exec(t, query)
+
+		// Get ID of our bundle.
+		var id int
+		var bundleFingerprint string
+		row = r.QueryRow(t, "SELECT id, statement_fingerprint FROM system.statement_diagnostics LIMIT 1")
+		row.Scan(&id, &bundleFingerprint)
+		require.Equal(t, fprint, bundleFingerprint)
+
+		// We need to come up with the url to download the bundle from.
+		return findBundleDownloadURL(t, r, id)
+	}
+
 	t.Run("redact", func(t *testing.T) {
 		r.Exec(t, "CREATE TYPE plesiosaur AS ENUM ('pterodactyl', '5555555555554444');")
 		r.Exec(t, "CREATE TABLE pterosaur (cardholder STRING PRIMARY KEY, cardno INT, INDEX (cardno));")
@@ -312,30 +339,11 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			t.Run(fmt.Sprintf("viaBuiltin=%t", viaBuiltin), func(t *testing.T) {
 				var url string
 				if viaBuiltin {
-					// Delete all old diagnostics to make this test easier.
-					r.Exec(t, "DELETE FROM system.statement_diagnostics WHERE true")
-
-					// Insert the diagnostics request via the builtin function.
-					fingerprint := "SELECT max(cardno), test_redact() FROM pterosaur WHERE cardholder = _"
-					row := r.QueryRow(t, `SELECT crdb_internal.request_statement_bundle($1, 0::FLOAT, 0::INTERVAL, 0::INTERVAL, true);`, fingerprint)
-					var inserted bool
-					row.Scan(&inserted)
-					require.True(t, inserted)
-
-					// Now actually execute the query so that the bundle is
-					// collected.
-					r.Exec(t, "SELECT max(cardno), test_redact() FROM pterosaur WHERE cardholder = 'pterodactyl';")
-
-					// Get ID of our bundle.
-					var id int
-					var bundleFingerprint string
-					row = r.QueryRow(t, "SELECT id, statement_fingerprint FROM system.statement_diagnostics LIMIT 1")
-					row.Scan(&id, &bundleFingerprint)
-					require.Equal(t, fingerprint, bundleFingerprint)
-
-					// We need to come up with the url to download the bundle
-					// from.
-					url = findBundleDownloadURL(t, r, id)
+					fprint := "SELECT max(cardno), test_redact() FROM pterosaur WHERE cardholder = _"
+					query := "SELECT max(cardno), test_redact() FROM pterosaur WHERE cardholder = 'pterodactyl';"
+					// Collect a bundle in response to a diagnostics request
+					// inserted by the builtin.
+					url = getBundleThroughBuiltin(fprint, query, "" /* planGist */, true /* redacted */)
 				} else {
 					rows := r.QueryStr(t,
 						"EXPLAIN ANALYZE (DEBUG, REDACT) SELECT max(cardno), test_redact() FROM pterosaur WHERE cardholder = 'pterodactyl'",
@@ -487,6 +495,42 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		checkBundle(
 			t, fmt.Sprint(rows), "db2.s2.t2", nil, false, /* expectErrors */
 			base, plans, "distsql.html vec.txt vec-v.txt stats-db1.public.t1.sql stats-db2.s2.t2.sql",
+		)
+	})
+
+	t.Run("plan-gist matching", func(t *testing.T) {
+		r.Exec(t, "CREATE TABLE gist (k INT PRIMARY KEY);")
+		const fprint = `SELECT * FROM gist`
+
+		// Come up with a target gist.
+		row := r.QueryRow(t, "EXPLAIN (GIST) "+fprint)
+		var gist string
+		row.Scan(&gist)
+
+		url := getBundleThroughBuiltin(fprint, fprint, gist, false /* redacted */)
+		checkBundleContents(
+			t, url, "gist", func(name, contents string) error {
+				if name != "plan.txt" {
+					return nil
+				}
+				// Add a new line at the beginning for cleaner formatting in the
+				// test.
+				contents = "\n" + contents
+				// The gist appears to be somewhat non-deterministic (but its
+				// decoding stays the same), so we populate the expected
+				// contents based on the particular gist.
+				expected := fmt.Sprintf(`
+-- plan is incomplete due to gist matching: %s
+
+• scan
+  table: gist@gist_pkey
+  spans: FULL SCAN`, gist)
+				if contents != expected {
+					return errors.Newf("unexpected contents of plan.txn\nexpected:\n%s\ngot:\n%s", expected, contents)
+				}
+				return nil
+			}, false, /* expectErrors */
+			base, plans, "distsql.html vec.txt vec-v.txt stats-defaultdb.public.gist.sql",
 		)
 	})
 }

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -648,7 +649,7 @@ func (ih *instrumentationHelper) Finish(
 			ob := ih.emitExplainAnalyzePlanToOutputBuilder(ctx, ih.explainFlags, phaseTimes, queryLevelStats)
 			warnings = ob.GetWarnings()
 			var payloadErr error
-			if pwe, ok := retPayload.(payloadWithError); ok {
+			if pwe, ok2 := retPayload.(payloadWithError); ok2 {
 				payloadErr = pwe.errorCause()
 			}
 			bundleCtx := ctx
@@ -681,7 +682,42 @@ func (ih *instrumentationHelper) Finish(
 			if ih.planGistMatchingBundle {
 				// We don't have the plan string available since the stmt bundle
 				// collection was enabled _after_ the optimizer was done.
-				planString = "-- plan elided due to gist matching"
+				// Instead, we do have the gist available, so we'll decode it
+				// and use that as the plan string.
+				var sb strings.Builder
+				sb.WriteString("-- plan is incomplete due to gist matching: ")
+				sb.WriteString(ih.planGist.String())
+				// Perform best-effort decoding ignoring all errors.
+				if it, err := ie.QueryIterator(
+					bundleCtx, "plan-gist-decoding" /* opName */, nil, /* txn */
+					fmt.Sprintf("SELECT * FROM crdb_internal.decode_plan_gist('%s')", ih.planGist.String()),
+				); err == nil {
+					defer func() {
+						_ = it.Close()
+					}()
+					sb.WriteString("\n")
+					// Ignore the errors returned on Next call.
+					for ok, _ = it.Next(bundleCtx); ok; ok, _ = it.Next(bundleCtx) {
+						row := it.Cur()
+						var line string
+						// Be conservative in case the output format changes.
+						if len(row) == 1 {
+							var ds tree.DString
+							ds, ok = tree.AsDString(row[0])
+							line = string(ds)
+						} else {
+							ok = false
+						}
+						if !ok && buildutil.CrdbTestBuild {
+							return errors.AssertionFailedf("unexpected output format for decoding plan gist %s", ih.planGist.String())
+						}
+						if ok {
+							sb.WriteString("\n")
+							sb.WriteString(line)
+						}
+					}
+				}
+				planString = sb.String()
 			}
 			bundle = buildStatementBundle(
 				bundleCtx, ih.explainFlags, cfg.DB, p, ie.(*InternalExecutor),


### PR DESCRIPTION
Previously, if the bundle collection was triggered via the plan-gist matching, we would include "-- plan elided due to gist matching" string as `plan.txt` since we couldn't set up the optimizer for the complete bundle collection. However, this is suboptimal since it requires the user to copy the gist elsewhere. This commit improves the bundle collection a bit by explicitly including the gist into `plan.txt` as well as decoding it (on a best effort basis) in to the file.

Epic: None

Release note: None