### PR TITLE
roachprod: fix stopCmd defaults

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -68,6 +68,9 @@ var (
 	sig                   = 9
 	waitFlag              = false
 	maxWait               = 0
+	deploySig             = 15
+	deployWaitFlag        = true
+	deployMaxWait         = 300
 	pause                 = time.Duration(0)
 	createVMOpts          = vm.DefaultCreateOpts()
 	startOpts             = roachprod.DefaultStartOpts()
@@ -258,19 +261,23 @@ func initFlags() {
 
 	// Flags for processes that stop (kill) processes.
 	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd, deployCmd} {
-		defaultSig := sig
-		defaultWait := waitFlag
-		defaultMaxWait := maxWait
+		// Cobra does not support reusing flags across multiple commands, especially
+		// if the defaults differ, so we need to supply different flags for the case
+		// where the defaults are different.
+		// See: https://github.com/spf13/cobra/issues/1398
+		sigPtr := &sig
+		waitPtr := &waitFlag
+		maxWaitPtr := &maxWait
 		// deployCmd is a special case, because it is used to stop processes in a
 		// rolling restart, and we want to drain the nodes by default.
 		if stopProcessesCmd == deployCmd {
-			defaultSig = 15
-			defaultWait = true
-			defaultMaxWait = 300
+			sigPtr = &deploySig
+			waitPtr = &deployWaitFlag
+			maxWaitPtr = &deployMaxWait
 		}
-		stopProcessesCmd.Flags().IntVar(&sig, "sig", defaultSig, "signal to pass to kill")
-		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", defaultWait, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", defaultMaxWait, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(sigPtr, "sig", *sigPtr, "signal to pass to kill")
+		stopProcessesCmd.Flags().BoolVar(waitPtr, "wait", *waitPtr, "wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(maxWaitPtr, "max-wait", *maxWaitPtr, "approx number of seconds to wait for processes to exit")
 	}
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -784,7 +784,7 @@ Currently available application options are:
 			versionArg = args[2]
 		}
 		return roachprod.Deploy(context.Background(), config.Logger, args[0], args[1],
-			versionArg, pause, sig, waitFlag, maxWait, secure)
+			versionArg, pause, deploySig, deployWaitFlag, deployMaxWait, secure)
 	}),
 }
 


### PR DESCRIPTION
This change fixes a bug where all the stop command variants (stopCmd, stopInstanceCmd, deployCmd) ended up using the same flag defaults (sig, wait, maxWait).

The deployCmd had a special set of defaults (sig 15 to drain nodes by default), but it was re-using the same flag variables. This is not supported by Cobra (See: https://github.com/spf13/cobra/issues/1398 for more details) and ends up overriding the default for all the commands using the flag.

This change creates a separate set of flag variables for the deployCmd, but re-uses the wording for these flags as originally intended.

Informs: #123461

Epic: None
Release Note: None