### PR TITLE
changefeedccl: clear the registry cache in TestAvroWithRegionalTable

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -1285,6 +1285,10 @@ func TestAvroWithRegionalTable(t *testing.T) {
 			// are used. With one worker, the cache is forced to be used during
 			// encoding for the second row.
 			testutils.RunTrueAndFalse(t, "overrideWithSingleWorker", func(t *testing.T, overrideWithSingleWorker bool) {
+				// Clear the singleton cache to avoid pollution from other tests.
+				// This needs to be done here since this test doesn't use the
+				// cdcTest helper function.
+				TestingClearSchemaRegistrySingleton()
 				cluster, db, cleanup := startTestCluster(t)
 				defer cleanup()
 				if overrideWithSingleWorker {


### PR DESCRIPTION
There is a registry cache shared between tests that needs to be cleared to avoid polluting the cache between tests. Tests that use the helper function `cdcTest` always call this, but this test, which exercises avro exclusively, does not due to the test set up. This change clears the cache at the start of every run of the test.

Epic: None
Fixes: #124692

Release note: None