### PR TITLE
opt: improve partial index implication for IS NOT NULL predicates

### DIFF
--- a/pkg/sql/opt/partialidx/implicator.go
+++ b/pkg/sql/opt/partialidx/implicator.go
@@ -591,48 +591,48 @@ func (im *Implicator) atomContainsAtom(
 		return false
 	}
 
-	// If either set has more than one constraint, then constraints cannot be
-	// used to prove containment. This happens when an expression has more than
-	// one variable. For example:
+	// Containment cannot be proven if the predicate constraint set is not tight
+	// or has multiple constraints.
 	//
-	//   @1 > @2
+	// TODO(mgartner): It may be possible to lift this restriction. Because
+	// constraint sets are conjunctions of constraints, we can use the rules:
 	//
-	// Produces the constraint set:
+	//   AND-expr A => atom B iff:      any of A's children => B
+	//   AND-expr A => AND-expr B iff:  A => each of B's children
 	//
-	//   /1: (/NULL - ]; /2: (/NULL - ]
-	//
-	if eSet.Length() > 1 || predSet.Length() > 1 {
+	// which translate here to: eSet implies predSet if every constraint in
+	// predSet contains any of eSet's constraints. This should be valid if
+	// predSet is not tight.
+	if !predTight || predSet.Length() > 1 {
 		return false
 	}
 
-	// Containment cannot be proven if either constraint is not tight, because
-	// the constraint does not fully represent the expression.
-	if !eTight || !predTight {
-		return false
-	}
-
-	eConstraint := eSet.Constraint(0)
-	predConstraint := predSet.Constraint(0)
-
-	// If predConstraint contains eConstraint, then eConstraint implies
+	// If predConstraint contains any constraints in eSet, then eSet implies
 	// predConstraint.
-	if predConstraint.Contains(im.evalCtx, eConstraint) {
-		// If the constraints contain each other, then they are semantically
-		// equivalent and the filter atom can be removed from the remaining filters.
-		// For example:
-		//
-		//   (a::INT > 17)
-		//   =>
-		//   (a::INT >= 18)
-		//
-		// (a > 17) is not the same expression as (a >= 18) syntactically, but
-		// they are semantically equivalent because there are no integers
-		// between 17 and 18. Therefore, there is no need to apply (a > 17) as a
-		// filter after the partial index scan.
-		exactMatches.addIf(e, func() bool {
-			return eConstraint.Contains(im.evalCtx, predConstraint)
-		})
-		return true
+	predConstraint := predSet.Constraint(0)
+	for i := 0; i < eSet.Length(); i++ {
+		eConstraint := eSet.Constraint(i)
+		if predConstraint.Contains(im.evalCtx, eConstraint) {
+			// If the constraint sets have a single, tight constraint that
+			// contain one another, then they are semantically equivalent and
+			// the filter atom can be removed from the remaining filters. For
+			// example:
+			//
+			//   (a::INT > 17)
+			//   =>
+			//   (a::INT >= 18)
+			//
+			// (a > 17) is not the same expression as (a >= 18) syntactically,
+			// but they are semantically equivalent because there are no
+			// integers between 17 and 18. Therefore, there is no need to apply
+			// (a > 17) as a filter after the partial index scan.
+			if eTight && predTight && eSet.Length() == 1 && predSet.Length() == 1 {
+				exactMatches.addIf(e, func() bool {
+					return eConstraint.Contains(im.evalCtx, predConstraint)
+				})
+			}
+			return true
+		}
 	}
 
 	return false

--- a/pkg/sql/opt/partialidx/testdata/implicator/and-expr
+++ b/pkg/sql/opt/partialidx/testdata/implicator/and-expr
@@ -24,6 +24,13 @@ a AND b
 ----
 false
 
+predtest vars=(a int, b int, c int)
+a = b
+=>
+a IS NOT NULL AND c > 0
+----
+false
+
 # Conjunction filters
 
 predtest vars=(a bool)
@@ -105,6 +112,14 @@ a AND b
 a AND c
 ----
 false
+
+predtest vars=(a int, b int, c int)
+c > 0 AND a = b
+=>
+a IS NOT NULL AND c > 0
+----
+true
+└── remaining filters: a = b
 
 # Range filters
 
@@ -206,6 +221,13 @@ predtest vars=(a bool, b bool)
 a OR b
 =>
 b AND a
+----
+false
+
+predtest vars=(a int, b int, c int)
+c > 0 OR a = b
+=>
+a IS NOT NULL AND c > 0
 ----
 false
 

--- a/pkg/sql/opt/partialidx/testdata/implicator/atom
+++ b/pkg/sql/opt/partialidx/testdata/implicator/atom
@@ -454,6 +454,46 @@ a IS NOT NULL
 ----
 false
 
+predtest vars=(a int, b int)
+a = b
+=>
+a IS NOT NULL
+----
+true
+└── remaining filters: a = b
+
+predtest vars=(a int, b int)
+a > b
+=>
+a IS NOT NULL
+----
+true
+└── remaining filters: a > b
+
+predtest vars=(a int, b int)
+a > b
+=>
+b IS NOT NULL
+----
+true
+└── remaining filters: a > b
+
+# TODO(mgartner): We could prove implication in this case if we constructed a
+# (/NULL - ] constraint for a.
+predtest vars=(a int, b int, c int)
+a IN (b, c)
+=>
+a IS NOT NULL
+----
+false
+
+predtest vars=(a int, b int, c int)
+a IN (b, c)
+=>
+b IS NOT NULL
+----
+false
+
 # Functions
 
 predtest vars=(a string)

--- a/pkg/sql/opt/partialidx/testdata/implicator/or-expr
+++ b/pkg/sql/opt/partialidx/testdata/implicator/or-expr
@@ -82,6 +82,14 @@ a
 ----
 false
 
+predtest vars=(a int, b int, c int)
+a = b
+=>
+a IS NOT NULL OR c > 0
+----
+true
+└── remaining filters: a = b
+
 # Conjunction filters
 
 predtest vars=(a bool, b bool)
@@ -176,6 +184,14 @@ a > 10 AND b < 20
 a > 11 OR b < 19
 ----
 false
+
+predtest vars=(a int, b int, c int)
+c > 0 AND a = b
+=>
+a IS NOT NULL OR c > 0
+----
+true
+└── remaining filters: (c > 0) AND (a = b)
 
 # Range filters
 
@@ -294,6 +310,14 @@ b < a OR d < c
 ----
 true
 └── remaining filters: (a > b) OR (c > d)
+
+predtest vars=(a int, b int, c int)
+c > 0 OR a = b
+=>
+a IS NOT NULL OR c > 0
+----
+true
+└── remaining filters: (c > 0) OR (a = b)
 
 # Combination conjunction and disjunction filters
 

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4601,6 +4601,49 @@ exec-ddl
 DROP INDEX i_partial
 ----
 
+# Regression test for #125422. An equality between with two variables implies
+# that either variable is not null, allowing a lookup join into a partial index
+# with an IS NOT NULL predicate.
+exec-ddl
+CREATE TABLE t125422 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  INDEX idx125422 (a, b) WHERE a IS NOT NULL
+)
+----
+
+opt
+SELECT * FROM t125422 AS t1
+LEFT LOOKUP JOIN t125422@idx125422 AS t2
+ON t1.a = t2.a AND t1.b = t2.b AND t2.c = 10
+----
+left-join (lookup t125422 [as=t2])
+ ├── columns: k:1!null a:2 b:3 c:4 k:7 a:8 b:9 c:10
+ ├── key columns: [13] = [7]
+ ├── lookup columns are key
+ ├── second join in paired joiner
+ ├── key: (1,7)
+ ├── fd: (1)-->(2-4), (7)-->(8,9), (1,7)-->(10)
+ ├── left-join (lookup t125422@idx125422,partial [as=t2])
+ │    ├── columns: t1.k:1!null t1.a:2 t1.b:3 t1.c:4 t2.k:13 t2.a:14 t2.b:15 continuation:19
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [2 3] = [14 15]
+ │    ├── first join in paired joiner; continuation column: continuation:19
+ │    ├── key: (1,13)
+ │    ├── fd: (1)-->(2-4), (13)-->(14,15,19)
+ │    ├── scan t125422 [as=t1]
+ │    │    ├── columns: t1.k:1!null t1.a:2 t1.b:3 t1.c:4
+ │    │    ├── partial index predicates
+ │    │    │    └── idx125422: filters
+ │    │    │         └── t1.a:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-4)
+ │    └── filters (true)
+ └── filters
+      └── t2.c:10 = 10 [outer=(10), constraints=(/10: [/10 - /10]; tight), fd=()-->(10)]
+
 # Regression test for #63735. Ensure that the constant filter which maximally
 # constrains the lookup table is chosen when there is more than one option.
 # Here, the CHECK constraint establishes an implicit filter that constrains the

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2772,6 +2772,40 @@ scan singleton_check
  ├── key: ()
  └── fd: ()-->(1,2)
 
+# Regression test for #125422. An equality between with two variables implies
+# that either variable is not null, allowing a scan over a partial index with an
+# IS NOT NULL predicate.
+exec-ddl
+CREATE TABLE t125422 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX t125422_a_idx (a) WHERE a IS NOT NULL
+)
+----
+
+opt
+SELECT k FROM t125422@t125422_a_idx WHERE a = b
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (2)==(3), (3)==(2)
+      ├── index-join t125422
+      │    ├── columns: k:1!null a:2 b:3
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3)
+      │    └── scan t125422@t125422_a_idx,partial
+      │         ├── columns: k:1!null a:2!null
+      │         ├── flags: force-index=t125422_a_idx
+      │         ├── key: (1)
+      │         └── fd: (1)-->(2)
+      └── filters
+           └── a:2 = b:3 [outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------


### PR DESCRIPTION
The partial index implicator can now prove that (in)equalities of two
variables implies that either variable `IS NOT NULL`. This allows the
optimizer to plan scans and lookup joins on partial indexes in more
cases.

I believe this makes the push-down of null-rejecting filters added
in #58204 unnecessary. However, I'm leaving that rule as-is for now. If
we want to remove it, we should first disable those changes by default
for a release or two so that a customer can re-enable it if it is found
to be necessary.

Fixes #125422

Release note (sql change): The optimizer will now generate plans
utilizing partial indexes with `IS NOT NULL` predicates in more cases.
