### PR TITLE
acceptance: put CRDB logs in `outputs.zip` instead of `artifacts`

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -69,11 +69,6 @@ jobs:
         if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
-        with:
-          name: acceptance artifacts
-          path: artifacts
       - name: clean up
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()

--- a/build/github/acceptance-test.sh
+++ b/build/github/acceptance-test.sh
@@ -10,25 +10,15 @@ bazel build --config crosslinux //pkg/cmd/cockroach-short \
     --bes_keywords integration-test-artifact-build \
     --jobs 100 $(./build/github/engflow-args.sh)
 
-ARTIFACTSDIR=$PWD/artifacts
-mkdir -p $ARTIFACTSDIR
 COCKROACH=$(bazel info bazel-bin --config=crosslinux)/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short
 
 bazel test //pkg/acceptance:acceptance_test \
   --config crosslinux \
   --jobs 100 $(./build/github/engflow-args.sh) \
   --remote_download_minimal \
-  "--sandbox_writable_path=$ARTIFACTSDIR" \
-  "--test_tmpdir=$ARTIFACTSDIR" \
-  --test_arg=-l="$ARTIFACTSDIR" \
   --test_arg=-b=$COCKROACH \
   --test_env=COCKROACH_DEV_LICENSE \
   --test_env=COCKROACH_RUN_ACCEPTANCE=true \
   --test_env=TZ=America/New_York \
   --test_timeout=1800 \
   --build_event_binary_file=bes.bin
-
-# Some unit tests test automatic ballast creation. These ballasts can be
-# larger than the maximum artifact size. Remove any artifacts with the
-# EMERGENCY_BALLAST filename.
-find "$ARTIFACTSDIR" -name "EMERGENCY_BALLAST" -delete

--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -318,7 +318,15 @@ func (c *Container) WaitUntilNotRunning(ctx context.Context) error {
 		if exitCode := waitOKBody.StatusCode; exitCode != 0 {
 			err = errors.Errorf("non-zero exit code: %d", exitCode)
 			fmt.Fprintln(out, err.Error())
-			log.Shoutf(ctx, severity.INFO, "command left-over files in %s", c.cluster.volumesDir)
+			volumesDir := c.cluster.volumesDir
+			// NB: TEST_UNDECLARED_OUTPUTS_DIR is set for remote Bazel tests.
+			undeclaredOutsDir := os.Getenv("TEST_UNDECLARED_OUTPUTS_DIR")
+			if undeclaredOutsDir != "" {
+				log.Shoutf(ctx, severity.INFO, "command left-over files in %s",
+					strings.Replace(volumesDir, undeclaredOutsDir, "outputs.zip", 1))
+			} else {
+				log.Shoutf(ctx, severity.INFO, "command left-over files in %s", volumesDir)
+			}
 		}
 
 		return err

--- a/pkg/acceptance/util_cluster.go
+++ b/pkg/acceptance/util_cluster.go
@@ -12,6 +12,7 @@ package acceptance
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -73,7 +74,16 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 
 	switch runMode {
 	case dockerTest:
-		logDir := *flagLogDir
+		var logDir string
+		isRemote := os.Getenv("REMOTE_EXEC")
+		if len(isRemote) > 0 {
+			logDir = os.Getenv("TEST_UNDECLARED_OUTPUTS_DIR")
+			if logDir != "" {
+				logDir = filepath.Join(logDir, "logs")
+			}
+		} else {
+			logDir = *flagLogDir
+		}
 		if logDir != "" {
 			logDir = filepath.Join(logDir, filepath.Clean(t.Name()))
 		}


### PR DESCRIPTION
Today, the artifacts are split into `outputs.zip` and the `artifacts` zip file which is confusing. Instead, put everything in `outputs.zip`.

Part of: DEVINF-1199

Epic: CRDB-17171
Release note: None