### PR TITLE
opt: build constrained scans for LIKE patterns with escaped escapes

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -299,9 +299,8 @@ func (c *indexConstraintCtx) makeSpansForSingleColumnDatum(
 					// If pattern is simply prefix + .* the span is tight. Also pattern
 					// will have regexp special chars escaped and so prefix needs to be
 					// escaped too.
-					if prefixEscape, err := eval.LikeEscape(prefix); err == nil {
-						return strings.HasSuffix(pattern, ".*") && strings.TrimSuffix(pattern, ".*") == prefixEscape
-					}
+					prefixEscape := regexp.QuoteMeta(prefix)
+					return strings.HasSuffix(pattern, ".*") && strings.TrimSuffix(pattern, ".*") == prefixEscape
 				}
 			}
 		}

--- a/pkg/sql/opt/idxconstraint/testdata/strings
+++ b/pkg/sql/opt/idxconstraint/testdata/strings
@@ -15,6 +15,18 @@ a LIKE 'A\BC%'
 ----
 [/'ABC' - /'ABD')
 
+# A backslash escaping a backslash just becomes a backslash.
+index-constraints vars=(a string) index=a
+a LIKE '\\ABC%'
+----
+[/e'\\ABC' - /e'\\ABD')
+
+# A backslash escaping a backslash just becomes a backslash.
+index-constraints vars=(a string) index=a
+a LIKE '\\ABC\\%'
+----
+[/e'\\ABC\\' - /e'\\ABC]')
+
 # Currently we punt on custom ESCAPE clauses.
 index-constraints vars=(a string) index=a
 a LIKE '\aABC%' ESCAPE '|'
@@ -67,6 +79,24 @@ index-constraints vars=(a string) index=a
 a LIKE 'ABC\_Z'
 ----
 [/'ABC_Z' - /'ABC_Z']
+
+# A backslash that is escaping a wildcard becomes equality.
+index-constraints vars=(a string) index=a
+a LIKE '\%ABC'
+----
+[/'%ABC' - /'%ABC']
+
+# A backslash that is escaping a wildcard becomes equality.
+index-constraints vars=(a string) index=a
+a LIKE '\_ABC'
+----
+[/'_ABC' - /'_ABC']
+
+# A backslash that is escaping a backslash becomes equality.
+index-constraints vars=(a string) index=a
+a LIKE '\\ABC'
+----
+[/e'\\ABC' - /e'\\ABC']
 
 # Invalid pattern does not generate index constraints.
 index-constraints vars=(a string) index=a

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -186,7 +186,7 @@ func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
 
 	case opt.LikeOp:
 		if s, ok := tree.AsDString(datum); ok {
-			// Normalize the like pattern to a RE
+			// Normalize the like pattern to a RE.
 			if pattern, err := eval.LikeEscape(string(s)); err == nil {
 				if re, err := regexp.Compile(pattern); err == nil {
 					prefix, complete := re.LiteralPrefix()
@@ -200,10 +200,9 @@ func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
 					c := cb.makeStringPrefixSpan(col, prefix)
 					// If pattern is simply prefix + .* the span is tight. Also pattern
 					// will have regexp special chars escaped and so prefix needs to be
-					// escaped too. The original string may have superfluous escape
-					if prefixEscape, err := eval.LikeEscape(prefix); err == nil {
-						return c, strings.HasSuffix(pattern, ".*") && strings.TrimSuffix(pattern, ".*") == prefixEscape
-					}
+					// escaped too.
+					prefixEscape := regexp.QuoteMeta(prefix)
+					return c, strings.HasSuffix(pattern, ".*") && strings.TrimSuffix(pattern, ".*") == prefixEscape
 				}
 			}
 		}

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -13017,3 +13017,18 @@ select
  │    └── columns: c0:1 c1:2
  └── filters
       └── c0:1 = '2001-12-01 00:00:00' [outer=(1), constraints=(/1: [/'2001-12-01 00:00:00' - /'2001-12-01 00:00:00']; tight), fd=()-->(1)]
+
+# Regression test for 124455: LIKE expressions with an escaped backslash before
+# the wildcard should still become constrained scans.
+
+exec-ddl
+CREATE TABLE t124455 (s STRING PRIMARY KEY)
+----
+
+opt expect=GenerateConstrainedScans
+SELECT * FROM t124455 WHERE s LIKE e'\\\\%'
+----
+scan t124455
+ ├── columns: s:1!null
+ ├── constraint: /1: [/e'\\' - /']')
+ └── key: (1)


### PR DESCRIPTION
To build a tight constraint out of a constant LIKE pattern, we follow these steps:

1. call LikeEscape to convert the LIKE pattern to a regular expression
2. call LiteralPrefix to get a constant prefix from the regex
3. check if the regex consists solely of the prefix + ".*"

Before step 3, we need to escape any special regex characters in the constant prefix so that we can compare the prefix with the regex. We were incorrectly using LikeEscape to do this, which was throwing an error when the constant prefix contained special like pattern characters. Instead, use QuoteMeta which does exactly what we need.

Fixes: #124455

Release note (bug fix): Fix a bug in which constant LIKE patterns containing certain sequences of backslashes did not become constrained scans. This bug has been present since v21.1.13 when support for building constrained scans from LIKE patterns containing backslashes was added.