### PR TITLE
sql/stats: add TS type for `*HistogramData.TypeCheck`

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1509,7 +1509,7 @@ StatsLoop:
 			// Ignore dropped columns (they are handled below).
 			if col != nil {
 				if err := h.TypeCheck(
-					col.GetType(), desc.GetName(), s.Columns[0], s.CreatedAt, time.Time{}, /* createdAtTime */
+					col.GetType(), desc.GetName(), s.Columns[0], stats.TSFromString(s.CreatedAt),
 				); err != nil {
 					return pgerror.WithCandidateCode(err, pgcode.DatatypeMismatch)
 				}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1806,7 +1806,7 @@ func (os *optTableStat) init(
 	if len(os.columnOrdinals) == 1 {
 		col := tab.getCol(os.columnOrdinals[0])
 		if err := stat.HistogramData.TypeCheck(
-			col.GetType(), string(tab.Name()), col.GetName(), "" /* createdAt */, stat.CreatedAt,
+			col.GetType(), string(tab.Name()), col.GetName(), stats.TSFromTime(stat.CreatedAt),
 		); err != nil {
 			// Column type in the histogram differs from column type in the
 			// table. This is only possible if we somehow re-used the same column ID


### PR DESCRIPTION
This commit adds the `stats.TS` struct which is like a type union that
allows passing either a `time.Time` or `string` created-at time for
stats to the `*HistogramData.TypeCheck` method. Private fields of the
struct and the functions `TSFromTime` and `TSFromString` make for a more
clear API—passing both a created-at string and time is now impossible.
Additionally, the `TS.String` method cleans up the code within
`*HistogramData.TypeCheck` a bit.

Epic: None

Release note: None
