### PR TITLE
insights: cache capacity using statement count

### DIFF
--- a/pkg/sql/sqlstats/insights/store_test.go
+++ b/pkg/sql/sqlstats/insights/store_test.go
@@ -26,26 +26,40 @@ func TestStore(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	store := newStore(st)
 
-	// With the ExecutionInsightsCapacity set to 5, we retain the 5 most recently-seen insights.
+	// With the ExecutionInsightsCapacity set to 5, we retain the 5 most recently-seen statement insights.
 	ExecutionInsightsCapacity.Override(ctx, &st.SV, 5)
 	for id := 0; id < 10; id++ {
-		addInsight(store, uint64(id))
+		addInsight(store, []uint64{uint64(id)})
 	}
 	assertInsightStatementIDs(t, store, []uint64{9, 8, 7, 6, 5})
 
 	// Lowering the ExecutionInsightsCapacity requires having a new insight to evict the others.
 	ExecutionInsightsCapacity.Override(ctx, &st.SV, 2)
 	assertInsightStatementIDs(t, store, []uint64{9, 8, 7, 6, 5})
-	addInsight(store, 10)
+	addInsight(store, []uint64{10})
 	assertInsightStatementIDs(t, store, []uint64{10, 9})
+
+	ExecutionInsightsCapacity.Override(ctx, &st.SV, 5)
+	// Insert a new insight with multiple statements to ensure the
+	// eviction policy is enforced using the statement count.
+	addInsight(store, []uint64{11, 12, 13, 14})
+	assertInsightStatementIDs(t, store, []uint64{14, 13, 12, 11, 10})
+
+	addInsight(store, []uint64{15, 16})
+	// The last insight should be evicted to make room for the new one.
+	assertInsightStatementIDs(t, store, []uint64{16, 15})
 }
 
-func addInsight(store *lockingStore, idBase uint64) {
+func addInsight(store *lockingStore, statementIDs []uint64) {
+	stmts := make([]*Statement, len(statementIDs))
+	for i, id := range statementIDs {
+		stmts[i] = &Statement{ID: clusterunique.ID{Uint128: uint128.FromInts(0, id)}}
+	}
 	store.AddInsight(&Insight{
 		Transaction: &Transaction{
 			ID: uuid.MakeV4(),
 		},
-		Statements: []*Statement{{ID: clusterunique.ID{Uint128: uint128.FromInts(0, idBase)}}},
+		Statements: stmts,
 	})
 }
 


### PR DESCRIPTION
The cluster setting `sql.insights.execution_insights_capacity`
was meant to limit the number of statement insights stored in
memory. This limit was being erroneously enforced since
the cache evicts based on the number of Insights objects, and
each insight stores  all statement insights for a transaction.

This commit fixes the cache sizing so that we are evicting
elements based on the number of statement insights in order
to adhere to the limit and have a predictable size for the
cache.

Epic: none
Fixes: #125339

Release note: None