### PR TITLE
   Revert "jobs: release registration before clearing claim"

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -481,7 +481,6 @@ func (r *Registry) maybeClearLease(job *Job, jobErr error) {
 	if jobErr == nil {
 		return
 	}
-	r.unregister(job.ID())
 	r.clearLeaseForJobID(job.ID(), r.db.Executor(), nil /* txn */)
 }
 

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -637,8 +637,6 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 125433)
-
 	const (
 		// Number of retries should be reasonably large such that they are sufficient
 		// to test long delays but not too many to increase the test time.


### PR DESCRIPTION
This reverts commit 187e7dfe849cf15ac36b0d348f981e0fb881a5c6.

Fixes: #125439 
Fixes: #125497
Fixes #125438
Fixes: #125514 

Epic: none

Release note: none