### PR TITLE
sql: don't collect exec stats unconditionally for internal executors

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -590,6 +590,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			// txnState.mu.priority, so we don't need to get a mutex here.
 			ex.state.mu.priority,
 			ex.extraTxnState.shouldCollectTxnExecutionStats,
+			ex.executorType,
 		)
 	} else {
 		ctx = portal.pauseInfo.execStmtInOpenState.ihWrapper.ctx


### PR DESCRIPTION
This commit fixes a recent regression due to 630d77b939df2d138294c11d1d2a50de6012a7ef. Namely, after that change, whenever deciding whether to collect execution stats on an internal query we would always get "should sample first execution" which enables structured tracing, causing performance overhead. IIUC that change fixed a bug where previously we didn't consider the internal query to have its first execution (Internal Executors only execute a single query during its "session", so every execution is the "first" one). This commit disables this heuristic for internal executors.

Epic: None

Release note: None