### PR TITLE
kvserver: deflake rebalance multi-store

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -249,6 +249,11 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 				st := server.ClusterSettings()
 				st.Manual.Store(true)
 				allocatorimpl.LeaseRebalanceThreshold.Override(ctx, &st.SV, leaseRebalanceThreshold)
+				// We speed up replicate queue processing (scan min/max idle) time,
+				// this causes actions to occur more frequently than in practice and
+				// ultimately this test will fail unless we correspondingly increase
+				// the max store gossip frequency.
+				kvserver.MaxStoreGossipFrequency.Override(ctx, &st.SV, 0)
 			}
 
 			// Add a few ranges per store.


### PR DESCRIPTION
After #125276, which reduced gossip frequency,
`TestReplicateQueueRebalanceMultiStore/multi-store` became flaky as the queue processing speed is artificially increased but gossip updates remain limited.

Increase the gossip frequency to deflake the test.

Fixes: #125360
Fixes: #125450
Release note: None