### PR TITLE
sqlstats: remove unnecessary lock acquisition

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -322,8 +322,6 @@ func NewTempContainerFromExistingTxnStats(
 // NewApplicationStatsWithInheritedOptions implements the
 // sqlstats.ApplicationStats interface.
 func (s *Container) NewApplicationStatsWithInheritedOptions() sqlstats.ApplicationStats {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	return New(
 		s.st,
 		// There is no need to constraint txn fingerprint limit since in temporary


### PR DESCRIPTION
This locking does not seem necessary as we don't access any fields guarded by the mutex.

Epic: none

Release note: None