### PR TITLE
streamingccl: rename Create and Plan in client interface

### DIFF
--- a/pkg/ccl/cmdccl/clusterrepl/main.go
+++ b/pkg/ccl/cmdccl/clusterrepl/main.go
@@ -97,7 +97,7 @@ func streamPartition(ctx context.Context, streamAddr *url.URL) error {
 		return err
 	}
 
-	replicationProducerSpec, err := client.Create(ctx, roachpb.TenantName(*tenant), streampb.ReplicationProducerRequest{})
+	replicationProducerSpec, err := client.CreateForTenant(ctx, roachpb.TenantName(*tenant), streampb.ReplicationProducerRequest{})
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func streamPartition(ctx context.Context, streamAddr *url.URL) error {
 	}()
 
 	// We ignore most of this plan. But, it gives us the tenant ID.
-	plan, err := client.Plan(ctx, replicationProducerSpec.StreamID)
+	plan, err := client.PlanPhysicalReplication(ctx, replicationProducerSpec.StreamID)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/logical/logical_replication_job.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_job.go
@@ -189,7 +189,7 @@ func (r *logicalReplicationResumer) ingest(
 	}
 	defer func() { _ = client.Close(ctx) }()
 
-	topology, err := client.PartitionSpans(ctx, sourceSpans)
+	topology, err := client.PlanLogicalReplication(ctx, sourceSpans)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -59,10 +59,10 @@ type Dialer interface {
 type Client interface {
 	Dialer
 
-	// Create initializes a stream with the source, potentially reserving any
+	// CreateForTenant initializes a stream with the source, potentially reserving any
 	// required resources, such as protected timestamps, and returns an ID which
 	// can be used to interact with this stream in the future.
-	Create(ctx context.Context, tenant roachpb.TenantName, req streampb.ReplicationProducerRequest) (streampb.ReplicationProducerSpec, error)
+	CreateForTenant(ctx context.Context, tenant roachpb.TenantName, req streampb.ReplicationProducerRequest) (streampb.ReplicationProducerSpec, error)
 
 	// Destroy informs the source of the stream that it may terminate production
 	// and release resources such as protected timestamps.
@@ -78,9 +78,9 @@ type Client interface {
 		consumed hlc.Timestamp,
 	) (streampb.StreamReplicationStatus, error)
 
-	// Plan returns a Topology for this stream.
+	// PlanPhysicalReplication returns a Topology for this stream.
 	// TODO(dt): separate target argument from address argument.
-	Plan(ctx context.Context, streamID streampb.StreamID) (Topology, error)
+	PlanPhysicalReplication(ctx context.Context, streamID streampb.StreamID) (Topology, error)
 
 	// Subscribe opens and returns a subscription for the specified partition from
 	// the specified remote address. This is used by each consumer processor to
@@ -118,8 +118,8 @@ type Client interface {
 type LogicalReplicationClient interface {
 	Client
 
-	PartitionSpans([]roachpb.Span) (Topology, error)
-	CreateForTables(ctx context.Context, req streampb.ReplicationProducerRequest) (streampb.ReplicationProducerSpec, error)
+	PlanLogicalReplication(ctx context.Context, spans []roachpb.Span) (Topology, error)
+	CreateForTables(ctx context.Context, req *streampb.ReplicationProducerRequest) (*streampb.ReplicationProducerSpec, error)
 }
 
 type subscribeConfig struct {

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -43,8 +43,8 @@ func (sc testStreamClient) Dial(_ context.Context) error {
 	return nil
 }
 
-// Create implements the Client interface.
-func (sc testStreamClient) Create(
+// CreateForTenant implements the Client interface.
+func (sc testStreamClient) CreateForTenant(
 	_ context.Context, _ roachpb.TenantName, _ streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
 	return streampb.ReplicationProducerSpec{
@@ -53,8 +53,10 @@ func (sc testStreamClient) Create(
 	}, nil
 }
 
-// Plan implements the Client interface.
-func (sc testStreamClient) Plan(_ context.Context, _ streampb.StreamID) (Topology, error) {
+// PlanForPhysicalReplication implements the Client interface.
+func (sc testStreamClient) PlanPhysicalReplication(
+	_ context.Context, _ streampb.StreamID,
+) (Topology, error) {
 	return Topology{
 		Partitions: []PartitionInfo{
 			{
@@ -255,7 +257,7 @@ func ExampleClient() {
 		_ = client.Close(ctx)
 	}()
 
-	prs, err := client.Create(ctx, "system", streampb.ReplicationProducerRequest{})
+	prs, err := client.CreateForTenant(ctx, "system", streampb.ReplicationProducerRequest{})
 	if err != nil {
 		panic(err)
 	}
@@ -286,7 +288,7 @@ func ExampleClient() {
 	grp.GoCtx(func(ctx context.Context) error {
 		defer close(done)
 
-		topology, err := client.Plan(ctx, id)
+		topology, err := client.PlanPhysicalReplication(ctx, id)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/ccl/streamingccl/streamclient/mock_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/mock_stream_client.go
@@ -33,8 +33,8 @@ type MockStreamClient struct {
 
 var _ Client = &MockStreamClient{}
 
-// Create implements the Client interface.
-func (m *MockStreamClient) Create(
+// CreateForTenant implements the Client interface.
+func (m *MockStreamClient) CreateForTenant(
 	_ context.Context, _ roachpb.TenantName, _ streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
 	panic("unimplemented")
@@ -55,8 +55,10 @@ func (m *MockStreamClient) Heartbeat(
 	return m.HeartbeatStatus, m.HeartbeatErr
 }
 
-// Plan implements the Client interface.
-func (m *MockStreamClient) Plan(_ context.Context, _ streampb.StreamID) (Topology, error) {
+// PlanPhysicalReplication implements the Client interface.
+func (m *MockStreamClient) PlanPhysicalReplication(
+	_ context.Context, _ streampb.StreamID,
+) (Topology, error) {
 	panic("unimplemented mock method")
 }
 

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -294,7 +294,7 @@ func (p *partitionedStreamClient) PlanLogicalReplication(
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	row := p.mu.srcConn.QueryRow(ctx, "SELECT crdb_internal.partition_spans($1)", encodedSpans)
+	row := p.mu.srcConn.QueryRow(ctx, "SELECT crdb_internal.plan_logical_replication($1)", encodedSpans)
 
 	streamSpecBytes := []byte{}
 	if err := row.Scan(&streamSpecBytes); err != nil {

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -62,12 +62,13 @@ func NewPartitionedStreamClient(
 }
 
 var _ Client = &partitionedStreamClient{}
+var _ LogicalReplicationClient = &partitionedStreamClient{}
 
-// Create implements Client interface.
-func (p *partitionedStreamClient) Create(
+// CreateForTenant implements Client interface.
+func (p *partitionedStreamClient) CreateForTenant(
 	ctx context.Context, tenantName roachpb.TenantName, req streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
-	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.Create")
+	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.CreateForTenant")
 	defer sp.Finish()
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -138,8 +139,8 @@ func (p *partitionedStreamClient) postgresURL(servingAddr string) (url.URL, erro
 	return res, nil
 }
 
-// Plan implements Client interface.
-func (p *partitionedStreamClient) Plan(
+// PlanPhysicalReplication implements Client interface.
+func (p *partitionedStreamClient) PlanPhysicalReplication(
 	ctx context.Context, streamID streampb.StreamID,
 ) (Topology, error) {
 	var spec streampb.ReplicationStreamSpec
@@ -275,10 +276,10 @@ func (p *partitionedStreamClient) Complete(
 	return nil
 }
 
-func (p *partitionedStreamClient) PartitionSpans(
+func (p *partitionedStreamClient) PlanLogicalReplication(
 	ctx context.Context, spans []roachpb.Span,
 ) (Topology, error) {
-	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.PartitionSpans")
+	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.PlanLogicalReplication")
 	defer sp.Finish()
 
 	encodedSpans := [][]byte{}

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -387,7 +387,9 @@ func (m *RandomStreamClient) Dial(ctx context.Context) error {
 }
 
 // Plan implements the Client interface.
-func (m *RandomStreamClient) Plan(ctx context.Context, _ streampb.StreamID) (Topology, error) {
+func (m *RandomStreamClient) PlanPhysicalReplication(
+	ctx context.Context, _ streampb.StreamID,
+) (Topology, error) {
 	topology := Topology{
 		Partitions:     make([]PartitionInfo, 0, m.config.numPartitions),
 		SourceTenantID: m.config.tenantID,
@@ -422,7 +424,7 @@ func (m *RandomStreamClient) Plan(ctx context.Context, _ streampb.StreamID) (Top
 }
 
 // Create implements the Client interface.
-func (m *RandomStreamClient) Create(
+func (m *RandomStreamClient) CreateForTenant(
 	ctx context.Context, tenantName roachpb.TenantName, _ streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
 	log.Infof(ctx, "creating random stream for tenant %s", tenantName)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -510,7 +510,7 @@ func (p *replicationFlowPlanner) constructPlanGenerator(
 	return func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 		log.Infof(ctx, "generating DistSQL plan candidate")
 		streamID := streampb.StreamID(details.StreamID)
-		topology, err := client.Plan(ctx, streamID)
+		topology, err := client.PlanPhysicalReplication(ctx, streamID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -266,7 +266,7 @@ func createReplicationJob(
 		}
 	}
 
-	replicationProducerSpec, err := client.Create(ctx, roachpb.TenantName(sourceTenant), req)
+	replicationProducerSpec, err := client.CreateForTenant(ctx, roachpb.TenantName(sourceTenant), req)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -537,10 +537,10 @@ func TestRandomClientGeneration(t *testing.T) {
 
 	randomStreamClient, ok := streamClient.(*streamclient.RandomStreamClient)
 	require.True(t, ok)
-	rps, err := randomStreamClient.Create(ctx, tenantName, streampb.ReplicationProducerRequest{})
+	rps, err := randomStreamClient.CreateForTenant(ctx, tenantName, streampb.ReplicationProducerRequest{})
 	require.NoError(t, err)
 
-	topo, err := randomStreamClient.Plan(ctx, rps.StreamID)
+	topo, err := randomStreamClient.PlanPhysicalReplication(ctx, rps.StreamID)
 	require.NoError(t, err)
 	require.Equal(t, 2 /* numPartitions */, len(topo.Partitions))
 

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -126,10 +126,7 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 	}, nil
 }
 
-// TODO(ssd): This should probably just be an overload of
-// getReplicationStreamSpec once we are re-using the producer job rather than
-// the start history retention job.
-func (r *replicationStreamManagerImpl) PartitionSpans(
+func (r *replicationStreamManagerImpl) PlanLogicalReplication(
 	ctx context.Context, spans []roachpb.Span,
 ) (*streampb.ReplicationStreamSpec, error) {
 	_, tenID, err := keys.DecodeTenantPrefix(r.evalCtx.Codec.TenantPrefix())
@@ -159,14 +156,14 @@ func (r *replicationStreamManagerImpl) StreamPartition(
 	return streamPartition(r.evalCtx, streamID, opaqueSpec)
 }
 
-// GetReplicationStreamSpec implements streaming.ReplicationStreamManager interface.
-func (r *replicationStreamManagerImpl) GetReplicationStreamSpec(
+// GetPhysicalReplicationStreamSpec implements streaming.ReplicationStreamManager interface.
+func (r *replicationStreamManagerImpl) GetPhysicalReplicationStreamSpec(
 	ctx context.Context, streamID streampb.StreamID,
 ) (*streampb.ReplicationStreamSpec, error) {
 	if err := r.checkLicense(); err != nil {
 		return nil, err
 	}
-	return getReplicationStreamSpec(ctx, r.evalCtx, r.txn, streamID)
+	return getPhysicalReplicationStreamSpec(ctx, r.evalCtx, r.txn, streamID)
 }
 
 // CompleteReplicationStream implements ReplicationStreamManager interface.

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -272,8 +272,8 @@ func heartbeatReplicationStream(
 		streamID, frontier, txn)
 }
 
-// getReplicationStreamSpec gets a replication stream specification for the specified stream.
-func getReplicationStreamSpec(
+// getPhysicalReplicationStreamSpec gets a replication stream specification for the specified stream.
+func getPhysicalReplicationStreamSpec(
 	ctx context.Context, evalCtx *eval.Context, txn isql.Txn, streamID streampb.StreamID,
 ) (*streampb.ReplicationStreamSpec, error) {
 	jobExecCtx := evalCtx.JobExecContext.(sql.JobExecContext)

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2582,7 +2582,7 @@ var builtinOidsArray = []string{
 	2614: `crdb_internal.scatter(key: bytes) -> void`,
 	2615: `crdb_internal.scatter(key: bytes, end_key: bytes) -> void`,
 	2616: `crdb_internal.start_logical_replication_job(conn_str: string, table_names: string[]) -> int`,
-	2617: `crdb_internal.partition_spans(spans: bytes[]) -> bytes`,
+	2617: `crdb_internal.plan_logical_replication(spans: bytes[]) -> bytes`,
 	2618: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
 }
 

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -270,7 +270,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				}
 
 				streamID := int64(tree.MustBeDInt(args[0]))
-				spec, err := mgr.GetReplicationStreamSpec(ctx, streampb.StreamID(streamID))
+				spec, err := mgr.GetPhysicalReplicationStreamSpec(ctx, streampb.StreamID(streamID))
 				if err != nil {
 					return nil, err
 				}
@@ -472,7 +472,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	// TODO(ssd): These functions likely aren't the final API we
 	// want.  Namely, boths should perhaps just be overloads of
 	// existing functions.
-	"crdb_internal.partition_spans": makeBuiltin(
+	"crdb_internal.plan_logical_replication": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryClusterReplication,
 			Undocumented:     true,
@@ -497,7 +497,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 					}
 				}
 
-				spec, err := mgr.PartitionSpans(ctx, spans)
+				spec, err := mgr.PlanLogicalReplication(ctx, spans)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -920,8 +920,8 @@ type ReplicationStreamManager interface {
 		opaqueSpec []byte,
 	) (ValueGenerator, error)
 
-	// GetReplicationStreamSpec gets a stream replication spec on the producer side.
-	GetReplicationStreamSpec(
+	// GetPhysicalReplicationStreamSpec gets a physical stream replication spec on the producer side.
+	GetPhysicalReplicationStreamSpec(
 		ctx context.Context,
 		streamID streampb.StreamID,
 	) (*streampb.ReplicationStreamSpec, error)
@@ -938,7 +938,7 @@ type ReplicationStreamManager interface {
 	DebugGetProducerStatuses(ctx context.Context) []*streampb.DebugProducerStatus
 	DebugGetLogicalConsumerStatuses(ctx context.Context) []*streampb.DebugLogicalConsumerStatus
 
-	PartitionSpans(
+	PlanLogicalReplication(
 		ctx context.Context,
 		spans []roachpb.Span,
 	) (*streampb.ReplicationStreamSpec, error)


### PR DESCRIPTION
This patch renames Create to CreateForTenant and Plan to PlanPhysicalReplication to better destinguish which api calls relate to PCR vs LDR.

Follow up work will move CreateForTenant and PlanPhysicalReplication into its own client interface wrapper for PCR.

Epic: none

Release note: none