### PR TITLE
release-23.2: kvserver: bump max range size in TestStoreRangeSplitBackpressureWrites

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1239,7 +1239,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 			// size without adding 2x64MB of data.
 			defer zonepb.TestingSetMinRangeMaxBytes(1 << 16)()
 			const minBytes = 1 << 12
-			const maxBytes = 1 << 17
+			const maxBytes = 1 << 18
 			zoneConfig := zonepb.DefaultZoneConfig()
 			zoneConfig.RangeMinBytes = proto.Int64(minBytes)
 			zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)


### PR DESCRIPTION
Similar to #124818, this test assumes that no other ranges will ever split but the max range size was very close to the size of an existing system range.

Epic: none
Release note: None

Release justification: testing only