### PR TITLE
kvccl: Propogate context through follower read validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ pkg/testutils/serverutils/*_generated.go
 
 # Temporary directories during gomock generate
 **/gomock_reflect_*
+
+.DS_Store
+.idea/

--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,26 @@
+export GOPATH=~/go
+export GOROOT="$(brew --prefix go)/libexec"
+autoload -Uz compinit && compinit
+alias repo='cd /Users/nasetlur/go/src/github.com/cockroachdb/cockroach'
+alias zshell='vim ~/.zshrc'
+alias create-cluster='roachprod create $CLUSTER; roachprod stage $CLUSTER workload'
+alias start-cluster='roachprod start $CLUSTER'
+alias stop-cluster='roachprod stop $CLUSTER'
+alias destroy-cluster='roachprod destroy $CLUSTER'
+alias put-build='roachprod put $CLUSTER artifacts/cockroach'
+alias refresh='source ~/.zshrc'
+
+# The next line updates PATH for the Google Cloud SDK.
+if [ -f '/opt/homebrew/share/google-cloud-sdk/path.zsh.inc' ]; then . '/opt/homebrew/share/google-cloud-sdk/path.zsh.inc'; fi
+
+# The next line enables shell command completion for gcloud.
+if [ -f '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc' ]; then . '/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc'; fi
+
+export PATH="/Users/nasetlur/go/src/github.com/cockroachdb/cockroach/bin:/Users/nasetlur/go/src/github.com/cockroachdb/cockroach:$PATH"
+export CLUSTER="naveensetlur-test"
+export CLUSTER2="naveensetlur-test2"
+export COCKROACH_DEV_LICENSE="crl-0-EI32gMgHGAEiI0NvY2tyb2FjaCBMYWJzIC0gUHJvZHVjdGlvbiBUZXN0aW5n"
+
+### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)
+export PATH="/Users/nasetlur/.rd/bin:$PATH"
+### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -482,7 +482,7 @@ func TestCanSendToFollower(t *testing.T) {
 				closedts.TargetDuration.Override(ctx, &st.SV, 0)
 			}
 
-			can := canSendToFollower(st, clock, c.ctPolicy, c.ba)
+			can := canSendToFollower(ctx, st, clock, c.ctPolicy, c.ba)
 			require.Equal(t, c.exp, can)
 		})
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -333,6 +333,7 @@ var metamorphicRouteToLeaseholderFirst = metamorphic.ConstantWithTestBool(
 // followerreadsccl code to inject logic to check if follower reads are enabled.
 // By default, without CCL code, this function returns false.
 var CanSendToFollower = func(
+	_ context.Context,
 	_ *cluster.Settings,
 	_ *hlc.Clock,
 	_ roachpb.RangeClosedTimestampPolicy,
@@ -2490,7 +2491,7 @@ func (ds *DistSender) sendToReplicas(
 	// otherwise, we may send a request to a remote region unnecessarily.
 	if ba.RoutingPolicy == kvpb.RoutingPolicy_LEASEHOLDER &&
 		CanSendToFollower(
-			ds.st, ds.clock,
+			ctx, ds.st, ds.clock,
 			routing.ClosedTimestampPolicy(defaultSendClosedTimestampPolicy), ba,
 		) {
 		ba = ba.ShallowCopy()

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -386,6 +386,7 @@ func TestSendRPCOrder(t *testing.T) {
 	old := CanSendToFollower
 	defer func() { CanSendToFollower = old }()
 	CanSendToFollower = func(
+		_ context.Context,
 		_ *cluster.Settings,
 		_ *hlc.Clock,
 		p roachpb.RangeClosedTimestampPolicy,
@@ -974,6 +975,7 @@ func TestNoBackoffOnNotLeaseHolderErrorFromFollowerRead(t *testing.T) {
 	old := CanSendToFollower
 	defer func() { CanSendToFollower = old }()
 	CanSendToFollower = func(
+		_ context.Context,
 		_ *cluster.Settings,
 		_ *hlc.Clock,
 		_ roachpb.RangeClosedTimestampPolicy,
@@ -3984,6 +3986,7 @@ func TestCanSendToFollower(t *testing.T) {
 	defer func() { CanSendToFollower = old }()
 	canSend := true
 	CanSendToFollower = func(
+		_ context.Context,
 		_ *cluster.Settings,
 		_ *hlc.Clock,
 		_ roachpb.RangeClosedTimestampPolicy,

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -39,7 +39,7 @@ var FollowerReadsEnabled = settings.RegisterBoolSetting(
 // BatchCanBeEvaluatedOnFollower determines if a batch consists exclusively of
 // requests that can be evaluated on a follower replica, given a sufficiently
 // advanced closed timestamp.
-func BatchCanBeEvaluatedOnFollower(ba *kvpb.BatchRequest) bool {
+func BatchCanBeEvaluatedOnFollower(ctx context.Context, ba *kvpb.BatchRequest) bool {
 	// Various restrictions apply to a batch for it to be successfully considered
 	// for evaluation on a follower replica, which are described inline.
 	//
@@ -87,7 +87,7 @@ func BatchCanBeEvaluatedOnFollower(ba *kvpb.BatchRequest) bool {
 // must be transactional and composed exclusively of this kind of request to be
 // accepted as a follower read.
 func (r *Replica) canServeFollowerReadRLocked(ctx context.Context, ba *kvpb.BatchRequest) bool {
-	eligible := BatchCanBeEvaluatedOnFollower(ba) && FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV)
+	eligible := BatchCanBeEvaluatedOnFollower(ctx, ba) && FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV)
 	if !eligible {
 		// We couldn't do anything with the error, propagate it.
 		return false


### PR DESCRIPTION
We currently don't propogate the context through the code that validates if a request can use a follower to read data. We need the context to log any debug messages, so updating this code to take in a context argument.

Epic: none
Release note: none