### PR TITLE
sqlstats: fix stats recording for internal executors with txns

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -834,7 +834,8 @@ func (s *Server) SetupConn(
 		&s.Metrics,
 		s.sqlStats.GetApplicationStats(sd.ApplicationName, false /* internal */),
 		sessionID,
-		nil, /* postSetupFn */
+		false, /* fromOuterTxn */
+		nil,   /* postSetupFn */
 	)
 	return ConnectionHandler{ex}, nil
 }
@@ -1020,6 +1021,7 @@ func (s *Server) newConnExecutor(
 	srvMetrics *Metrics,
 	applicationStats sqlstats.ApplicationStats,
 	sessionID clusterunique.ID,
+	fromOuterTxn bool,
 	// postSetupFn is to override certain field of a conn executor.
 	// It is set when conn executor is init under an internal executor
 	// with a not-nil txn.
@@ -1143,7 +1145,7 @@ func (s *Server) newConnExecutor(
 		ex.server.insights.Writer(ex.sessionData().Internal),
 		ex.phaseTimes,
 		s.sqlStats.GetCounters(),
-		ex.extraTxnState.fromOuterTxn,
+		fromOuterTxn,
 		s.cfg.SQLStatsTestingKnobs,
 	)
 	ex.dataMutatorIterator.onApplicationNameChange = func(newName string) {
@@ -1153,6 +1155,7 @@ func (s *Server) newConnExecutor(
 
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionInit, timeutil.Now())
 
+	ex.extraTxnState.fromOuterTxn = fromOuterTxn
 	ex.extraTxnState.prepStmtsNamespace = prepStmtNamespace{
 		prepStmts:    make(map[string]*PreparedStatement),
 		prepStmtsLRU: make(map[string]struct{ prev, next string }),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -303,8 +303,8 @@ func (ie *InternalExecutor) initConnEx(
 			&ie.s.InternalMetrics,
 			applicationStats,
 			ie.s.cfg.GenerateID(),
-			postSetupFn,
-		)
+			false, /* fromOuterTxn */
+			postSetupFn)
 	} else {
 		ex, err = ie.newConnExecutorWithTxn(
 			ctx,
@@ -363,7 +363,6 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 	postSetupFn := func(ex *connExecutor) {
 		if ie.extraTxnState != nil {
 			ex.extraTxnState.descCollection = ie.extraTxnState.descCollection
-			ex.extraTxnState.fromOuterTxn = true
 			ex.extraTxnState.jobs = ie.extraTxnState.jobs
 			ex.extraTxnState.schemaChangerState = ie.extraTxnState.schemaChangerState
 			ex.extraTxnState.shouldResetSyntheticDescriptors = shouldResetSyntheticDescriptors
@@ -380,8 +379,8 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		&ie.s.InternalMetrics,
 		applicationStats,
 		ie.s.cfg.GenerateID(),
-		postSetupFn,
-	)
+		ie.extraTxnState != nil, /* fromOuterTxn */
+		postSetupFn)
 
 	if txn.Type() == kv.LeafTxn {
 		// If the txn is a leaf txn it is not allowed to perform mutations. For

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -60,6 +60,8 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/catalog/descs",
+        "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -464,8 +466,8 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		insightsProvider.Writer(false /* internal */),
 		sessionphase.NewTimes(),
 		sqlStats.GetCounters(),
-		false,
-		nil, /* knobs */
+		false, /* fromOuterTxn */
+		nil,   /* knobs */
 	)
 
 	recordStats := func(testCase *tc) {
@@ -592,8 +594,8 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			insightsProvider.Writer(false /* internal */),
 			sessionphase.NewTimes(),
 			sqlStats.GetCounters(),
-			false,
-			nil, /* knobs */
+			false, /* fromOuterTxn */
+			nil,   /* knobs */
 		)
 
 		for _, txn := range simulatedTxns {
@@ -1774,4 +1776,94 @@ func TestSQLStats_ConsumeStats(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// TestSQLStatsInternalStatements verifies SQL stats are captured
+// for internal statements.
+func TestSQLStatsInternalStatements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				// Disable to make the test deterministic.
+				// We'll be checking to ensure that the internal
+				// statements are only sampled once.
+				DisableProbabilisticSampling: true,
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+	ts := s.ApplicationLayer()
+	conn := sqlutils.MakeSQLRunner(ts.SQLConn(t))
+
+	getStmtRow := func(appName string) (query string, cnt, sampledCnt int) {
+		row := conn.QueryRow(t, `
+SELECT
+  metadata ->> 'query',
+  statistics -> 'statistics' ->> 'cnt',
+  statistics -> 'execution_statistics' ->> 'cnt'
+FROM crdb_internal.statement_statistics WHERE app_name = $1`, "$ internal-"+appName)
+		row.Scan(&query, &cnt, &sampledCnt)
+		return
+	}
+
+	// Within each distinct application, we should only sample the
+	// statement if it's the first time we've seen it.
+	t.Run("internal statement without a transaction", func(t *testing.T) {
+		appName := "without-txn"
+		for i := 0; i < 10; i++ {
+			_, err := ts.InternalExecutor().(*sql.InternalExecutor).Exec(ctx, appName, nil /* txn */, "SELECT 1")
+			require.NoError(t, err)
+		}
+
+		// Verify that the internal statement is captured.
+		query, cnt, sampledCnt := getStmtRow(appName)
+		require.Equal(t, "SELECT _", query)
+		require.Equal(t, 10, cnt)
+		require.Equal(t, 1, sampledCnt)
+	})
+
+	t.Run("internal statement with a transaction", func(t *testing.T) {
+		appName := "with-txn"
+		for i := 0; i < 10; i++ {
+			err := ts.InternalDB().(descs.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				_, err := txn.Exec(ctx, appName, txn.KV(), "SELECT 1")
+				return err
+			})
+			require.NoError(t, err)
+		}
+
+		// Verify that the internal statement is captured.
+		query, cnt, sampledCnt := getStmtRow(appName)
+		require.Equal(t, "SELECT _", query)
+		require.Equal(t, 10, cnt)
+		require.Equal(t, 1, sampledCnt)
+	})
+
+	t.Run("internal multi-statement transaction", func(t *testing.T) {
+		// We don't associate internal statements from outer transactions
+		// with a transaction fingerprint ID. Thus we should have already
+		// seen this query in the "with-txn" application from the previous
+		// test. We should see that the execution counts increase but not
+		// the sampling count.
+		appName := "with-txn"
+		err := ts.InternalDB().(descs.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			for i := 0; i < 10; i++ {
+				if _, err := txn.Exec(ctx, appName, txn.KV(), "SELECT 1"); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Verify that the internal statement is captured.
+		query, cnt, sampledCnt := getStmtRow(appName)
+		require.Equal(t, "SELECT _", query)
+		require.Equal(t, 20, cnt)
+		require.Equal(t, 1, sampledCnt)
+	})
 }


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/cockroachdb/cockroach/pull/123698. The stats collector was changed so that it needs to be informed whether it is collecting stats for a transaction outside the conn executor. In that patch, the field `fromOuterTxn` was being used before it was set leading to stats being discarded for all statements run by conn execs with outer txns. This in turn caused all of those statements to be unconditionally sammpled as the 'first' of its kind we have seen, causing a performance regression.

Epic: none
Release note: None