### PR TITLE
util/duration: add a couple of special cases to MulFloat

### DIFF
--- a/pkg/util/duration/duration.go
+++ b/pkg/util/duration/duration.go
@@ -820,6 +820,16 @@ func (d Duration) Div(x int64) Duration {
 
 // MulFloat returns a Duration representing a time length of d*x.
 func (d Duration) MulFloat(x float64) Duration {
+	// Have a couple of special cases to avoid rounding errors with very large
+	// intervals.
+	// TODO(#26932): once we correctly error out on intervals out of range, this
+	// could be removed.
+	switch x {
+	case 1:
+		return d
+	case -1:
+		return MakeDuration(-d.nanos, -d.Days, -d.Months)
+	}
 	monthInt, monthFrac := math.Modf(float64(d.Months) * x)
 	dayInt, dayFrac := math.Modf((float64(d.Days) * x) + (monthFrac * DaysPerMonth))
 


### PR DESCRIPTION
We recently observed a test failure that happened due to rounding behavior of `MulFloat` with out-of-range intervals (which we incorrectly allow at the moment). In order to prevent this type of test failure from occurring again, this commit adds two special cases when multiplying by 1 and -1 to avoid float math.

Fixes: #125410.

Release note: None