### PR TITLE
sql: deflake TestCopyFromRandom 

### DIFF
--- a/pkg/sql/copy/BUILD.bazel
+++ b/pkg/sql/copy/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//pkg/base",
         "//pkg/cli/clisqlclient",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/security/securityassets",

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1143,19 +1143,33 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 			// for the next batch.
 			return c.doneWithRows(ctx)
 		} else {
-			// It is currently only safe to retry if we are not in atomic copy
-			// mode & we are in an implicit transaction.
-			// NOTE: we cannot re-use the connExecutor retry scheme here as COPY
-			// consumes directly from the read buffer, and the data would no
-			// longer be available during the retry.
-			if c.implicitTxn && !c.p.SessionData().CopyFromAtomicEnabled && c.p.SessionData().CopyFromRetriesEnabled && errIsRetriable(err) {
-				log.SqlExec.Infof(ctx, "%s failed on attempt %d and is retrying, error %+v", c.copyFromAST.String(), r.CurrentAttempt(), err)
-				if c.p.ExecCfg().TestingKnobs.CopyFromInsertRetry != nil {
-					if err := c.p.ExecCfg().TestingKnobs.CopyFromInsertRetry(); err != nil {
-						return err
+			if errIsRetriable(err) {
+				log.SqlExec.Infof(ctx, "%s failed on attempt %d and with retriable error %+v", c.copyFromAST.String(), r.CurrentAttempt(), err)
+				// It is currently only safe to retry if we are not in atomic copy
+				// mode & we are in an implicit transaction.
+				//
+				// NOTE: we cannot re-use the connExecutor retry scheme here as COPY
+				// consumes directly from the read buffer, and the data would no
+				// longer be available during the retry.
+				if c.implicitTxn && !c.p.SessionData().CopyFromAtomicEnabled && c.p.SessionData().CopyFromRetriesEnabled {
+					log.SqlExec.Infof(ctx, "%s is retrying", c.copyFromAST.String())
+					if c.p.ExecCfg().TestingKnobs.CopyFromInsertRetry != nil {
+						if err := c.p.ExecCfg().TestingKnobs.CopyFromInsertRetry(); err != nil {
+							return err
+						}
 					}
+					continue
+				} else {
+					log.SqlExec.Infof(
+						ctx,
+						"%s is not retrying; "+
+							"implicit: %v; copy_from_atomic_enabled: %v; copy_from_retriable_enabled %v",
+						c.copyFromAST.String(), c.implicitTxn,
+						c.p.SessionData().CopyFromAtomicEnabled, c.p.SessionData().CopyFromRetriesEnabled,
+					)
 				}
-				continue
+			} else {
+				log.SqlExec.Infof(ctx, "%s failed on attempt %d and with non-retriable error %+v", c.copyFromAST.String(), r.CurrentAttempt(), err)
 			}
 			return err
 		}


### PR DESCRIPTION
This test runs COPY using an explicit transaction, which doesn't retry
retriable errors automatically. Write pipelines are one form of such
errors that this test would occasionally run into and flake on. Turn off
write pipelining for this test.

Closes https://github.com/cockroachdb/cockroach/issues/122330

Release note: None