### PR TITLE
opt/optgen: document "Root" built-in and update syntax files

### DIFF
--- a/pkg/sql/opt/optgen/lang/doc.go
+++ b/pkg/sql/opt/optgen/lang/doc.go
@@ -455,6 +455,28 @@ refers to the name of the node bound to that variable:
 In this pattern, Join is a tag that refers to a group of nodes. The replace
 expression will construct a node having the same name as the matched join node.
 
+# Accessing Relational Properties of Root Expression
+
+The built-in "Root" function returns the root of the group that is currently
+being explored. This allows exploration rules to access the relational
+properties of the group during matching.
+
+	[AssociateJoin, Explore]
+	(InnerJoin
+	  $left:(InnerJoin
+	    $innerLeft:*
+	    $innerRight:*
+	    $innerOn:*
+	  )
+	  $right:* & (ShouldReorderJoins (Root))
+	  $on:*
+	)
+	=>
+	...
+
+The "Root" function cannot be used in
+normalization rules - Optgen will fail to compile such a rule.
+
 # Name Parameters
 
 The OpName built-in function can also be a parameter to a custom match or

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
@@ -243,6 +243,7 @@
                         UnionAll |
                         IntersectAll |
                         ExceptAll |
+                        Let |
                         Limit |
                         Offset |
                         Max1Row |
@@ -250,10 +251,12 @@
                         ExplainPrivate |
                         ShowTraceForSession |
                         ShowTracePrivate |
+                        Root |
                         RowNumber |
                         RowNumberPrivate |
                         ProjectSet |
                         Sort |
+                        TopK |
                         Insert |
                         Update |
                         Upsert |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -55,8 +55,8 @@ syn keyword operator SemiJoinApply AntiJoinApply
 syn keyword operator GroupBy GroupingPrivate ScalarGroupBy
 syn keyword operator DistinctOn EnsureDistinctOn UpsertDistinctOn EnsureUpsertDistinctOn
 syn keyword operator Union SetPrivate Intersect Except UnionAll IntersectAll ExceptAll
-syn keyword operator Limit Offset Max1Row Explain ExplainPrivate
-syn keyword operator ShowTraceForSession ShowTracePrivate RowNumber RowNumberPrivate ProjectSet
-syn keyword operator Sort Insert Update Upsert Delete CreateTable OpName
+syn keyword operator Let Limit Offset Max1Row Explain ExplainPrivate
+syn keyword operator ShowTraceForSession ShowTracePrivate Root RowNumber RowNumberPrivate ProjectSet
+syn keyword operator Sort TopK Insert Update Upsert Delete CreateTable OpName
 
 let b:current_syntax = "cropt"

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -243,6 +243,7 @@
                         UnionAll |
                         IntersectAll |
                         ExceptAll |
+                        Let |
                         Limit |
                         Offset |
                         Max1Row |
@@ -250,10 +251,12 @@
                         ExplainPrivate |
                         ShowTraceForSession |
                         ShowTracePrivate |
+                        Root |
                         RowNumber |
                         RowNumberPrivate |
                         ProjectSet |
                         Sort |
+                        TopK |
                         Insert |
                         Update |
                         Upsert |


### PR DESCRIPTION
#### opt/optgen: document built-in "Root" function

Epic: None

Release note: None

#### opt/optgen: add built-in functions and operators to syntax files

The `TopK` operator, and `Let` and `Root` built-in functions have been
added to the optgen syntax files.

Release note: None
