### PR TITLE
revert "reapply "flowinfra: fix incomplete shutdown in some cases""

### DIFF
--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -626,9 +626,8 @@ func (f *FlowBase) MemUsage() int64 {
 func (f *FlowBase) Cancel() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.mu.status == flowFinished || f.mu.ctxCancel == nil {
-		// The Flow is already done, nothing to cancel. ctxCancel can be nil in
-		// some tests.
+	if f.mu.status == flowFinished {
+		// The Flow is already done, nothing to cancel.
 		return
 	}
 	f.mu.ctxCancel()

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -314,16 +314,6 @@ func (fr *FlowRegistry) RegisterFlow(
 			// drain all the processors.
 			numTimedOutReceivers := fr.cancelPendingStreams(id, errNoInboundStreamConnection)
 			if numTimedOutReceivers != 0 {
-				// The whole plan will error out. So far we only pushed the
-				// error to the timed out receivers, and eventually it'll make
-				// its way to the DistSQLReceiver which will transition the plan
-				// into draining state. However, non-timed out streams will only
-				// learn about the error and the draining state the next time
-				// the producer sends something on the stream which might not
-				// happen for a while. To speed up the shutdown of the whole
-				// plan we cancel the flow on this node which will trigger quick
-				// ungraceful shutdown of the whole plan.
-				f.Cancel()
 				// The span in the context might be finished by the time this runs. In
 				// principle, we could ForkSpan() beforehand, but we don't want to
 				// create the extra span every time.

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"math"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -216,10 +215,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 	// to connect a stream, but it'll be too late.
 	id1 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 	f1 := &FlowBase{}
-	var canceled atomic.Bool
-	f1.mu.ctxCancel = func() {
-		canceled.Store(true)
-	}
+	f1.mu.ctxCancel = func() {}
 	streamID1 := execinfrapb.StreamID(1)
 	consumer := &distsqlutils.RowBuffer{}
 	wg := &sync.WaitGroup{}
@@ -242,9 +238,6 @@ func TestStreamConnectionTimeout(t *testing.T) {
 		defer si.mu.Unlock()
 		if !si.mu.canceled {
 			return errors.Errorf("not timed out yet")
-		}
-		if !canceled.Load() {
-			return errors.New("expected ctxCancel to have been called")
 		}
 		return nil
 	})
@@ -746,10 +739,10 @@ func (s *delayedErrorServerStream) Send(*execinfrapb.ConsumerSignal) error {
 //     inbound stream timeout is reached
 //   - that timeout "cancels" the single pending flow; this cancellation results
 //     in the flow being marked as "canceled" and the wait group being
-//     decremented (as well as calling Timeout() on the receiver). It also
-//     results in the flow cancellation.
+//     decremented (as well as calling Timeout() on the receiver)
 //   - after the flow cancellation is performed, the "handshake" RPC results in
-//     an error too, which doesn't actually matter at this point.
+//     an error which results in flow being properly canceled (by calling
+//     FlowBase.ctxCancel).
 //
 // Before #94113 was fixed, the flow would be incorrectly marked as "connected"
 // before the "handshake" RPC was issued, so the inbound stream timeout would
@@ -821,9 +814,7 @@ func TestErrorOnSlowHandshake(t *testing.T) {
 	// Make sure that the wait group is properly decremented (this must have
 	// been done by flowEntry.streamTimer too).
 	wg.Wait()
-	// We expect that Flow.Cancel is called twice - once when the inbound stream
-	// timed out, and again when the RPC results in an error.
-	<-cancelCh
+	// Since the RPC resulted in an error, we expect that the flow is canceled.
 	<-cancelCh
 	err := <-errCh
 	if err == nil {


### PR DESCRIPTION
This reverts commit dace3c5ad47cfc38aaae5984d536fa0da3e5b464.

Reapplying the logically sound fix exposed an issue around restarting servers in demo. It's possible that there is some pre-existing sequencing bug in the SQL server startup, but I couldn't easily reproduce the problem, so let's just revert the change that likely made the test fail. I'll give up on an attempt to apply this change going forward (which is the status quo we've had for many years).

Fixes: #125432.

Release note: None