### PR TITLE
syncutil: remove AtomicBool

### DIFF
--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -50,7 +50,6 @@ go_library(
         "//pkg/util/netutil/addr",
         "//pkg/util/retry",
         "//pkg/util/stop",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",

--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -59,7 +59,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -133,13 +133,13 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 	})
 
 	t.Run("all ranges are unavailable for Gets only", func(t *testing.T) {
-		var dbIsAvailable syncutil.AtomicBool
-		dbIsAvailable.Set(true)
+		var dbIsAvailable atomic.Bool
+		dbIsAvailable.Store(true)
 
 		s, _, p, cleanup := initTestServer(t, base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				TestingRequestFilter: func(i context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
-					if !dbIsAvailable.Get() {
+					if !dbIsAvailable.Load() {
 						for _, ru := range ba.Requests {
 							if ru.GetGet() != nil {
 								return kvpb.NewError(fmt.Errorf("boom"))
@@ -154,7 +154,7 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		defer cleanup()
 
 		// Want server to startup successfully then become unavailable.
-		dbIsAvailable.Set(false)
+		dbIsAvailable.Store(false)
 
 		kvprober.ReadEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.ReadInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)
@@ -180,13 +180,13 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
 	})
 	t.Run("all ranges are unavailable for Puts only", func(t *testing.T) {
-		var dbIsAvailable syncutil.AtomicBool
-		dbIsAvailable.Set(true)
+		var dbIsAvailable atomic.Bool
+		dbIsAvailable.Store(true)
 
 		s, _, p, cleanup := initTestServer(t, base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
 				TestingRequestFilter: func(i context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
-					if !dbIsAvailable.Get() {
+					if !dbIsAvailable.Load() {
 						for _, ru := range ba.Requests {
 							if ru.GetPut() != nil {
 								return kvpb.NewError(fmt.Errorf("boom"))
@@ -201,7 +201,7 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 		defer cleanup()
 
 		// Want server to startup successfully then become unavailable.
-		dbIsAvailable.Set(false)
+		dbIsAvailable.Store(false)
 
 		kvprober.ReadEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 		kvprober.ReadInterval.Override(ctx, &s.ClusterSettings().SV, 5*time.Millisecond)

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4344,18 +4344,17 @@ func TestStrictGCEnforcement(t *testing.T) {
 
 		// Block the KVSubscriber rangefeed from progressing.
 		blockKVSubscriberCh := make(chan struct{})
-		var isBlocked syncutil.AtomicBool
-		isBlocked.Set(false)
+		var isBlocked atomic.Bool
 		mu.Lock()
 		mu.blockOnTimestampUpdate = func() {
-			isBlocked.Set(true)
+			isBlocked.Store(true)
 			<-blockKVSubscriberCh
 		}
 		mu.Unlock()
 
 		// Ensure that the KVSubscriber has been blocked.
 		testutils.SucceedsSoon(t, func() error {
-			if !isBlocked.Get() {
+			if !isBlocked.Load() {
 				return errors.New("kvsubscriber not blocked yet")
 			}
 			return nil
@@ -4389,18 +4388,17 @@ func TestStrictGCEnforcement(t *testing.T) {
 	t.Run("protected timestamps are respected", func(t *testing.T) {
 		// Block the KVSubscriber rangefeed from progressing.
 		blockKVSubscriberCh := make(chan struct{})
-		var isBlocked syncutil.AtomicBool
-		isBlocked.Set(false)
+		var isBlocked atomic.Bool
 		mu.Lock()
 		mu.blockOnTimestampUpdate = func() {
-			isBlocked.Set(true)
+			isBlocked.Store(true)
 			<-blockKVSubscriberCh
 		}
 		mu.Unlock()
 
 		// Ensure that the KVSubscriber has been blocked.
 		testutils.SucceedsSoon(t, func() error {
-			if !isBlocked.Get() {
+			if !isBlocked.Load() {
 				return errors.New("kvsubscriber not blocked yet")
 			}
 			return nil

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -279,7 +280,7 @@ type NodeLiveness struct {
 
 	// Set to true once Start is called. RegisterCallback can not be called after
 	// Start is called.
-	started syncutil.AtomicBool
+	started atomic.Bool
 }
 
 // Record is a liveness record that has been read from the database, together
@@ -605,7 +606,7 @@ func (nl *NodeLiveness) setMembershipStatusInternal(
 // be possible.
 func (nl *NodeLiveness) Start(ctx context.Context) {
 	log.VEventf(ctx, 1, "starting node liveness instance")
-	if nl.started.Get() {
+	if nl.started.Load() {
 		// This is meant to prevent tests from calling start twice.
 		log.Fatal(ctx, "liveness already started")
 	}
@@ -613,7 +614,7 @@ func (nl *NodeLiveness) Start(ctx context.Context) {
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.Closer = nl.stopper.ShouldQuiesce()
 
-	nl.started.Set(true)
+	nl.started.Store(true)
 
 	_ = nl.stopper.RunAsyncTaskEx(ctx, stop.TaskOpts{TaskName: "liveness-hb", SpanOpt: stop.SterileRootSpan}, func(context.Context) {
 		ambient := nl.ambientCtx
@@ -713,7 +714,7 @@ var errNodeAlreadyLive = errors.New("node already live")
 // by the Start loop.
 // TODO(bdarnell): Should we just remove this synchronous heartbeat completely?
 func (nl *NodeLiveness) Heartbeat(ctx context.Context, liveness livenesspb.Liveness) error {
-	if buildutil.CrdbTestBuild && !nl.started.Get() {
+	if buildutil.CrdbTestBuild && !nl.started.Load() {
 		// This check was added as part of resolving #106706. We were previously
 		// accidentally relying on synchronous heartbeats to paper over problems,
 		// which only worked most of the time but could lead to hangs.

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -286,7 +286,7 @@ type Replica struct {
 	// incoming message but we are waiting for our initial snapshot.
 	// The field can be accessed atomically without needing to acquire the
 	// replica.mu lock. All updates to state.Desc should be duplicated here.
-	isInitialized syncutil.AtomicBool
+	isInitialized atomic.Bool
 
 	// connectionClass controls the ConnectionClass used to send raft messages.
 	connectionClass atomicConnectionClass

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -104,7 +104,7 @@ func TestStoreCheckpointSpans(t *testing.T) {
 		desc := makeDesc(rangeID, start, end)
 		r := &Replica{RangeID: rangeID, startKey: desc.StartKey}
 		r.mu.state.Desc = &desc
-		r.isInitialized.Set(desc.IsInitialized())
+		r.isInitialized.Store(desc.IsInitialized())
 		require.NoError(t, s.addToReplicasByRangeIDLocked(r))
 		if r.IsInitialized() {
 			require.NoError(t, s.addToReplicasByKeyLocked(r, r.Desc()))

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -325,7 +325,7 @@ func (r *Replica) initFromSnapshotLockedRaftMuLocked(
 // node. It is false when a replica has been created in response to an incoming
 // message but we are waiting for our initial snapshot.
 func (r *Replica) IsInitialized() bool {
-	return r.isInitialized.Get()
+	return r.isInitialized.Load()
 }
 
 // TenantID returns the associated tenant ID and a boolean to indicate that it
@@ -411,7 +411,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 	}
 
 	r.rangeStr.store(r.replicaID, desc)
-	r.isInitialized.Set(desc.IsInitialized())
+	r.isInitialized.Store(desc.IsInitialized())
 	r.connectionClass.set(rpc.ConnectionClassForKey(desc.StartKey, defRaftConnClass))
 	r.concMgr.OnRangeDescUpdated(desc)
 	r.mu.state.Desc = desc

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2116,7 +2116,7 @@ func (s *adminServer) checkReadinessForHealthCheck(ctx context.Context) error {
 		return err
 	}
 
-	if !s.sqlServer.isReady.Get() {
+	if !s.sqlServer.isReady.Load() {
 		return grpcstatus.Errorf(codes.Unavailable, "node is not accepting SQL clients")
 	}
 
@@ -2159,7 +2159,7 @@ func (s *systemAdminServer) checkReadinessForHealthCheck(ctx context.Context) er
 		return grpcstatus.Errorf(codes.Unavailable, "node is not healthy")
 	}
 
-	if !s.sqlServer.isReady.Get() {
+	if !s.sqlServer.isReady.Load() {
 		return grpcstatus.Errorf(codes.Unavailable, "node is not accepting SQL clients")
 	}
 

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -383,7 +383,7 @@ func (s *drainServer) drainClients(
 	// Set the gRPC mode of the node to "draining" and mark the node as "not ready".
 	// Probes to /health?ready=1 will now notice the change in the node's readiness.
 	s.grpc.setMode(modeDraining)
-	s.sqlServer.isReady.Set(false)
+	s.sqlServer.isReady.Store(false)
 
 	// Log the number of connections periodically.
 	if err := s.logOpenConns(ctx); err != nil {
@@ -475,7 +475,7 @@ func (s *drainServer) drainClients(
 	}
 
 	// Mark the node as fully drained.
-	s.sqlServer.gracefulDrainComplete.Set(true)
+	s.sqlServer.gracefulDrainComplete.Store(true)
 	// Mark this phase in the logs to clarify the context of any subsequent
 	// errors/warnings, if any.
 	log.Infof(ctx, "SQL server drained successfully; SQL queries cannot execute any more")

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -72,7 +72,7 @@ func maybeImportTS(ctx context.Context, s *topLevelServer) (returnErr error) {
 	// store statuses to map the store timeseries to the node under which they
 	// fall). An alternative to this is setting a FirstStoreID and FirstNodeID that
 	// is not in use in the data set to import.
-	s.node.suppressNodeStatus.Set(true)
+	s.node.suppressNodeStatus.Store(true)
 
 	// Disable raft log synchronization to make the server generally faster.
 	logstore.DisableSyncRaftLog.Override(ctx, &s.cfg.Settings.SV, true)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -398,7 +399,7 @@ type Node struct {
 
 	// Turns `Node.writeNodeStatus` into a no-op. This is a hack to enable the
 	// COCKROACH_DEBUG_TS_IMPORT_FILE env var.
-	suppressNodeStatus syncutil.AtomicBool
+	suppressNodeStatus atomic.Bool
 
 	diskStatsMap diskStatsMap
 
@@ -1289,7 +1290,7 @@ func (n *Node) startWriteNodeStatus(frequency time.Duration) error {
 // If mustExist is true the status key must already exist and must
 // not change during writing -- if false, the status is always written.
 func (n *Node) writeNodeStatus(ctx context.Context, alertTTL time.Duration, mustExist bool) error {
-	if n.suppressNodeStatus.Get() {
+	if n.suppressNodeStatus.Load() {
 		return nil
 	}
 	var err error

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2329,7 +2329,7 @@ func (s *topLevelServer) AcceptClients(ctx context.Context) error {
 		return err
 	}
 
-	s.sqlServer.isReady.Set(true)
+	s.sqlServer.isReady.Store(true)
 
 	log.Event(ctx, "server ready")
 	return nil

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -129,7 +130,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/collector"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/service"
@@ -193,12 +193,12 @@ type SQLServer struct {
 	// When false, the node is unhealthy or "not ready", with load balancers and
 	// connection management tools learning this status from health checks.
 	// This is set to true when the server has started accepting client conns.
-	isReady syncutil.AtomicBool
+	isReady atomic.Bool
 
 	// gracefulDrainComplete indicates when a graceful drain has
 	// completed successfully. We use this to document cases where a
 	// graceful drain did _not_ occur.
-	gracefulDrainComplete syncutil.AtomicBool
+	gracefulDrainComplete atomic.Bool
 
 	// internalDBMemMonitor is the memory monitor corresponding to the
 	// InternalDB singleton. It only gets closed when
@@ -1730,7 +1730,7 @@ func (s *SQLServer) preStart(
 			sk, _ = knobs.Server.(*TestingKnobs)
 		}
 
-		if !s.gracefulDrainComplete.Get() {
+		if !s.gracefulDrainComplete.Load() {
 			warnCtx := s.AnnotateCtx(context.Background())
 
 			if sk != nil && sk.RequireGracefulDrain {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -985,7 +985,7 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 		return err
 	}
 
-	s.sqlServer.isReady.Set(true)
+	s.sqlServer.isReady.Store(true)
 
 	log.Event(ctx, "server ready")
 	return nil

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1445,7 +1445,7 @@ func (t *testTenant) StatsForSpan(
 
 // SetReady is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) SetReady(ready bool) {
-	t.sql.isReady.Set(ready)
+	t.sql.isReady.Store(ready)
 }
 
 // SetAcceptSQLWithoutTLS is part of the serverutils.ApplicationLayerInterface.
@@ -2333,7 +2333,7 @@ func (ts *testServer) StatsForSpan(
 
 // SetReady is part of the serverutils.ApplicationLayerInterface.
 func (ts *testServer) SetReady(ready bool) {
-	ts.sqlServer.isReady.Set(ready)
+	ts.sqlServer.isReady.Store(ready)
 }
 
 // SetAcceptSQLWithoutTLS is part of the serverutils.ApplicationLayerInterface.

--- a/pkg/sql/pgwire/pre_serve_options.go
+++ b/pkg/sql/pgwire/pre_serve_options.go
@@ -293,14 +293,14 @@ var trustClientProvidedRemoteAddrOverride = envutil.EnvOrDefaultBool("COCKROACH_
 
 // TestingSetTrustClientProvidedRemoteAddr is used in tests.
 func (s *PreServeConnHandler) TestingSetTrustClientProvidedRemoteAddr(b bool) func() {
-	prev := s.trustClientProvidedRemoteAddr.Get()
-	s.trustClientProvidedRemoteAddr.Set(b)
-	return func() { s.trustClientProvidedRemoteAddr.Set(prev) }
+	prev := s.trustClientProvidedRemoteAddr.Load()
+	s.trustClientProvidedRemoteAddr.Store(b)
+	return func() { s.trustClientProvidedRemoteAddr.Store(prev) }
 }
 
 // TestingAcceptSystemIdentityOption is used in tests.
 func (s *PreServeConnHandler) TestingAcceptSystemIdentityOption(b bool) func() {
-	prev := s.acceptSystemIdentityOption.Get()
-	s.acceptSystemIdentityOption.Set(b)
-	return func() { s.acceptSystemIdentityOption.Set(prev) }
+	prev := s.acceptSystemIdentityOption.Load()
+	s.acceptSystemIdentityOption.Store(b)
+	return func() { s.acceptSystemIdentityOption.Store(prev) }
 }

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -3063,8 +3063,8 @@ func TestPrimaryKeyDropIndexNotCancelable(t *testing.T) {
 
 	ctx := context.Background()
 	var db *gosql.DB
-	var shouldAttemptCancel syncutil.AtomicBool
-	shouldAttemptCancel.Set(true)
+	var shouldAttemptCancel atomic.Bool
+	shouldAttemptCancel.Store(true)
 	hasAttemptedCancel := make(chan struct{})
 	params, _ := createTestServerParams()
 	params.Knobs = base.TestingKnobs{

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -140,7 +139,7 @@ func backupSuccess(t *testing.T, factory TestServerFactory, cs CumulativeTestCas
 	url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d",
 		cs.Phase, cs.StageOrdinal)
 	var dbForBackup atomic.Pointer[gosql.DB]
-	var isBackupPostBackfill syncutil.AtomicBool
+	var isBackupPostBackfill atomic.Bool
 	pe := MakePlanExplainer()
 	knobs := &scexec.TestingKnobs{
 		// Back up the database exactly once when reaching the stage prescribed
@@ -168,7 +167,7 @@ func backupSuccess(t *testing.T, factory TestServerFactory, cs CumulativeTestCas
 						// schema changer state.
 						for j := i + 1; j < stageIdx; j++ {
 							if p.Stages[j].Type() == scop.MutationType {
-								isBackupPostBackfill.Set(true)
+								isBackupPostBackfill.Store(true)
 								break OuterLoop
 							}
 						}
@@ -214,7 +213,7 @@ func backupSuccess(t *testing.T, factory TestServerFactory, cs CumulativeTestCas
 			mayRollback:             false,
 			expectedOnRollback:      before,
 		}
-		if isBackupPostBackfill.Get() {
+		if isBackupPostBackfill.Load() {
 			const countRowsQ = `
 				SELECT coalesce(sum(rows), 0)
 				FROM [SHOW BACKUP FROM LATEST IN $2]

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -145,7 +145,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/retry",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/log/file_api.go
+++ b/pkg/util/log/file_api.go
@@ -132,7 +132,7 @@ func ListLogFiles() (logFiles []logpb.FileInfo, err error) {
 		l.mu.Lock()
 		thisLogDir := l.mu.logDir
 		l.mu.Unlock()
-		if !l.enabled.Get() || thisLogDir == "" {
+		if !l.enabled.Load() || thisLogDir == "" {
 			// This file sink is detached from file storage.
 			return nil
 		}
@@ -209,7 +209,7 @@ func GetLogReader(filename string) (io.ReadCloser, error) {
 		return nil
 	})
 	// Check whether we found a sink and it has a log directory.
-	if fs == nil || !fs.enabled.Get() {
+	if fs == nil || !fs.enabled.Load() {
 		return nil, errors.Newf("no log directory found for %s", filename)
 	}
 	dir := func() string {

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -154,7 +154,7 @@ func signalFlusher() {
 // occurs are flushed to logs (in case the error degenerates
 // into a panic / segfault on the way out).
 func StartAlwaysFlush() {
-	logging.flushWrites.Set(true)
+	logging.flushWrites.Store(true)
 	// There may be something in the buffers already; flush it.
 	FlushFiles()
 }

--- a/pkg/util/log/stderr_sink.go
+++ b/pkg/util/log/stderr_sink.go
@@ -11,15 +11,16 @@
 package log
 
 import (
+	"sync/atomic"
+
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // Type of a stderr copy sink.
 type stderrSink struct {
 	// the --no-color flag. When set it disables escapes code on the
 	// stderr copy.
-	noColor syncutil.AtomicBool
+	noColor atomic.Bool
 }
 
 // activeAtSeverity implements the logSink interface.

--- a/pkg/util/quotapool/int_rate.go
+++ b/pkg/util/quotapool/int_rate.go
@@ -14,9 +14,9 @@ import (
 	"context"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/tokenbucket"
 )
 
@@ -33,7 +33,7 @@ func Inf() Limit {
 // in the case that they end up not getting used.
 type RateLimiter struct {
 	qp    *AbstractPool
-	isInf syncutil.AtomicBool
+	isInf atomic.Bool
 }
 
 // NewRateLimiter defines a new RateLimiter. The limiter is implemented as a
@@ -47,7 +47,7 @@ func NewRateLimiter(name string, rate Limit, burst int64, options ...Option) *Ra
 	tb := &tokenbucket.TokenBucket{}
 	rl.qp = New(name, tb, options...)
 	tb.InitWithNowFn(tokenbucket.TokensPerSecond(rate), tokenbucket.Tokens(burst), rl.qp.timeSource.Now)
-	rl.isInf.Set(math.IsInf(float64(rate), 1))
+	rl.isInf.Store(math.IsInf(float64(rate), 1))
 	return rl
 }
 
@@ -67,7 +67,7 @@ func (rl *RateLimiter) WaitN(ctx context.Context, n int64) error {
 		// Special case 0 acquisition.
 		return nil
 	}
-	if rl.isInf.Get() {
+	if rl.isInf.Load() {
 		return nil
 	}
 	r := rl.newRateRequest(n)
@@ -82,7 +82,7 @@ func (rl *RateLimiter) WaitN(ctx context.Context, n int64) error {
 // false and not block if there is currently insufficient quota or the pool is
 // closed.
 func (rl *RateLimiter) AdmitN(n int64) bool {
-	if rl.isInf.Get() {
+	if rl.isInf.Load() {
 		return true
 	}
 
@@ -99,7 +99,7 @@ func (rl *RateLimiter) AdmitN(n int64) bool {
 // putting the limiter into debt.
 func (rl *RateLimiter) UpdateLimit(rate Limit, burst int64) {
 	rl.qp.Update(func(res Resource) (shouldNotify bool) {
-		rl.isInf.Set(math.IsInf(float64(rate), 1))
+		rl.isInf.Store(math.IsInf(float64(rate), 1))
 		tb := res.(*tokenbucket.TokenBucket)
 		tb.UpdateConfig(tokenbucket.TokensPerSecond(rate), tokenbucket.Tokens(burst))
 		return true

--- a/pkg/util/syncutil/atomic.go
+++ b/pkg/util/syncutil/atomic.go
@@ -63,32 +63,6 @@ func (f *AtomicFloat64) StoreIfHigher(new float64) (val float64) {
 	}
 }
 
-// AtomicBool mimics an atomic boolean.
-type AtomicBool uint32
-
-// Set atomically sets the boolean.
-func (b *AtomicBool) Set(v bool) {
-	s := uint32(0)
-	if v {
-		s = 1
-	}
-	atomic.StoreUint32((*uint32)(b), s)
-}
-
-// Get atomically gets the boolean.
-func (b *AtomicBool) Get() bool {
-	return atomic.LoadUint32((*uint32)(b)) != 0
-}
-
-// Swap atomically swaps the value.
-func (b *AtomicBool) Swap(v bool) bool {
-	wanted := uint32(0)
-	if v {
-		wanted = 1
-	}
-	return atomic.SwapUint32((*uint32)(b), wanted) != 0
-}
-
 // AtomicString gives you atomic-style APIs for string.
 type AtomicString struct {
 	s atomic.Value

--- a/pkg/util/syncutil/atomic_test.go
+++ b/pkg/util/syncutil/atomic_test.go
@@ -13,8 +13,6 @@ package syncutil
 import (
 	"math"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 const magic64 = 0xdeddeadbeefbeef
@@ -99,12 +97,4 @@ func TestAtomicAddFloat64(t *testing.T) {
 	if x.before.val.Load() != magic64 || x.after.val.Load() != magic64 {
 		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before.val.Load(), x.after.val.Load(), uint64(magic64), uint64(magic64))
 	}
-}
-
-func TestAtomicBool(t *testing.T) {
-	var x AtomicBool
-	x.Set(true)
-	require.Equal(t, x.Get(), true)
-	require.Equal(t, x.Swap(false), true)
-	require.Equal(t, x.Get(), false)
 }


### PR DESCRIPTION
This type now duplicates `atomic.Bool`.

Epic: none
Release note: None