### PR TITLE
roachprod: handle insecure cluster in delete cluster config

### DIFF
--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -107,7 +107,7 @@ func TestDeleteClusterConfig(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("failed")),
 			}, nil
 		}
-		err := c.DeleteClusterConfig(ctx, "c1", false, l)
+		err := c.DeleteClusterConfig(ctx, "c1", false, false, l)
 		require.NotNil(t, err)
 		require.Equal(t, "request failed with status 400 and error failed", err.Error())
 	})
@@ -119,7 +119,18 @@ func TestDeleteClusterConfig(t *testing.T) {
 				StatusCode: 204,
 			}, nil
 		}
-		err := c.DeleteClusterConfig(ctx, "c1", false, l)
+		err := c.DeleteClusterConfig(ctx, "c1", false, false /* insecure */, l)
+		require.Nil(t, err)
+	})
+	t.Run("DeleteClusterConfig insecure succeeds", func(t *testing.T) {
+		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (
+			resp *http.Response, err error) {
+			require.Equal(t, fmt.Sprintf("%s?insecure=true", getUrl(promUrl, "c1")), url)
+			return &http.Response{
+				StatusCode: 204,
+			}, nil
+		}
+		err := c.DeleteClusterConfig(ctx, "c1", false, true /* insecure */, l)
 		require.Nil(t, err)
 	})
 }


### PR DESCRIPTION
If a insecure cluster is created, the corresponding config is created in prometheus. This config is created in a separate location that is different from the secure clusters. When this cluster is destroyed, the ?insecure=true flag has to be passed so that the specific config file gets deleted. This is not done today.

This change passes the ?insecure=true for insecure clusters

Fixes: #125616
Epic: None