### PR TITLE
pkg/cli: tsdump - fix custom SQL port behaviour

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"regexp"
@@ -87,10 +88,6 @@ will then convert it to the --format requested in the current invocation.
 		case tsDumpRaw:
 			if convertFile != "" {
 				return errors.Errorf("input file is already in raw format")
-			}
-			err := createYAML(ctx)
-			if err != nil {
-				return err
 			}
 
 			// Special case, we don't go through the text output code.
@@ -169,6 +166,23 @@ will then convert it to the --format requested in the current invocation.
 				// be writing potentially a lot of data to it.
 				w := bufio.NewWriterSize(os.Stdout, 1024*1024)
 				if err := tsutil.DumpRawTo(stream, w); err != nil {
+					return err
+				}
+
+				// get the node details so that we can get the SQL port
+				resp, err := serverpb.NewStatusClient(conn).Details(ctx, &serverpb.DetailsRequest{NodeId: "local"})
+				if err != nil {
+					return err
+				}
+
+				// override the server port with the SQL port taken from the DetailsResponse
+				// this port should be used to make the SQL connection
+				cliCtx.clientOpts.ServerHost, cliCtx.clientOpts.ServerPort, err = net.SplitHostPort(resp.SQLAddress.String())
+				if err != nil {
+					return err
+				}
+
+				if err = createYAML(ctx); err != nil {
 					return err
 				}
 				return w.Flush()
@@ -638,7 +652,8 @@ type openMetricsWriter struct {
 	labels map[string]string
 }
 
-// createYAML generates and writes tsdump.yaml to default /tmp or to a specified path
+// createYAML generates and writes tsdump.yaml to default /tmp or to a specified path.
+// This file is used for staging the tsdump data into a local database for debugging
 func createYAML(ctx context.Context) (resErr error) {
 	file, err := os.OpenFile(debugTimeSeriesDumpOpts.yaml, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {

--- a/pkg/cli/tsdump_test.go
+++ b/pkg/cli/tsdump_test.go
@@ -17,7 +17,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,9 +35,9 @@ import (
 func TestDebugTimeSeriesDumpCmd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
 	c := NewCLITest(TestCLIParams{})
 	defer c.Cleanup()
+
 	t.Run("debug tsdump --format=openmetrics", func(t *testing.T) {
 		out, err := c.RunWithCapture("debug tsdump --format=openmetrics --cluster-name=test-cluster-1 --disable-cluster-name-verification")
 		require.NoError(t, err)
@@ -44,6 +46,35 @@ func TestDebugTimeSeriesDumpCmd(t *testing.T) {
 		require.Equal(t, results[len(results)-2], "# EOF")
 		require.Greater(t, len(results), 0)
 		require.Greater(t, len(results[:len(results)-2]), 0, "expected to have at least one metric")
+	})
+
+	t.Run("debug tsdump --format=raw with custom SQL and gRPC ports", func(t *testing.T) {
+		//  The `NewCLITest` function we call above to setup the test, already uses custom
+		//  ports to avoid conflict between concurrently running tests.
+
+		// Make sure that the yamlFileName is unique for each concurrently running test
+		_, port, err := net.SplitHostPort(c.Server.SQLAddr())
+		require.NoError(t, err)
+		yamlFileName := fmt.Sprintf("/tmp/tsdump_test_%s.yaml", port)
+
+		// The `--host` flag is automatically added by the `RunWithCapture` function based on the assigned port.
+		out, err := c.RunWithCapture(
+			"debug tsdump --yaml=" + yamlFileName +
+				" --format=raw --cluster-name=test-cluster-1 --disable-cluster-name-verification",
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, out)
+
+		yaml, err := os.Open(yamlFileName)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, yaml.Close())
+			require.NoError(t, os.Remove(yamlFileName)) // cleanup
+		}()
+
+		yamlContents, err := io.ReadAll(yaml)
+		require.NoError(t, err)
+		require.NotEmpty(t, yamlContents)
 	})
 }
 


### PR DESCRIPTION
When CRDB is running with a custom gRPC and SQL port, users have the option to provide the gRPC address using the `--host` flag. An option for providing the custom SQL address is the `--url`. But, tsdump doesn't seem to be using the address provided as part of `--url`.

This commit fixes that. When the `--host` flag is provided, we can connect to the gRPC server and get the Node Details. This will give us the SQL address. So, there is no need for the user to specify the SQL port separately at all. This is how it's handled in the `debug zip` command. Since `debug zip` and `tsdump` are often used together, it's important to have a consistent behaviour across both of them.

<details>
<summary>Screenshot of old and new behaviour</summary>
<br>

![image](https://github.com/cockroachdb/cockroach/assets/11977524/053ad7df-425c-4302-9549-2a9bc98875b2)

</details>

---

Part of: CRDB-39382
Fixes: #125315
Release note (bug fix): Fix the bug in tsdump where the command fails when a custom SQL port is used and the `--format=raw` flag is provided