### PR TITLE
streamingccl/logical: target descriptor IDs rather than names

### DIFF
--- a/pkg/ccl/streamingccl/logical/BUILD.bazel
+++ b/pkg/ccl/streamingccl/logical/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler",
         "//pkg/keys",
+        "//pkg/repstream",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/ccl/streamingccl/logical/logical_replication_dist.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_dist.go
@@ -33,7 +33,7 @@ func constructLogicalReplicationWriterSpecs(
 	initialScanTimestamp hlc.Timestamp,
 	previousReplicatedTimestamp hlc.Timestamp,
 	checkpoint jobspb.StreamIngestionCheckpoint,
-	tableDescs map[string]descpb.TableDescriptor,
+	tableDescs map[int32]descpb.TableDescriptor,
 	jobID jobspb.JobID,
 	streamID streampb.StreamID,
 ) (map[base.SQLInstanceID][]execinfrapb.LogicalReplicationWriterSpec, error) {

--- a/pkg/ccl/streamingccl/logical/logical_replication_job.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_job.go
@@ -161,7 +161,13 @@ func (r *logicalReplicationResumer) ingest(
 	}
 	defer func() { _ = client.Close(ctx) }()
 
-	req := streampb.LogicalReplicationPlanRequest{}
+	asOf := replicatedTimeAtStart
+	if asOf.IsEmpty() {
+		asOf = payload.ReplicationStartTime
+	}
+	req := streampb.LogicalReplicationPlanRequest{
+		PlanAsOf: asOf,
+	}
 	for _, pair := range payload.ReplicationPairs {
 		req.TableIDs = append(req.TableIDs, pair.SrcDescriptorID)
 	}

--- a/pkg/ccl/streamingccl/logical/logical_replication_job.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_job.go
@@ -21,11 +21,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler"
+	"github.com/cockroachdb/cockroach/pkg/repstream"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -69,54 +71,40 @@ type logicalReplicationResumer struct {
 
 var _ jobs.Resumer = (*logicalReplicationResumer)(nil)
 
+func init() {
+	repstream.CreateRemoteProduceJobForLogicalReplicationHook = createRemoteProduceJobForLogicalReplication
+}
+
+func createRemoteProduceJobForLogicalReplication(
+	ctx context.Context, srcAddr string, tableNames []string,
+) (*streampb.ReplicationProducerSpec, error) {
+	// TODO(ssd): Copy over our GetFirstActiveClient logic
+	// so that we can connect to any node that we've seen
+	// in a previous Topology.
+	streamAddr, err := url.Parse(srcAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = client.Close(ctx) }()
+
+	spec, err := client.CreateForTables(ctx, &streampb.ReplicationProducerRequest{
+		TableNames: tableNames,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return spec, err
+}
+
 // Resume is part of the jobs.Resumer interface.
 func (r *logicalReplicationResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	jobExecCtx := execCtx.(sql.JobExecContext)
-
-	progress := r.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
-	payload := r.job.Details().(jobspb.LogicalReplicationDetails)
-
-	if len(progress.SourceSpans) == 0 {
-		// TODO(ssd): Move this out to the when we create the job.
-		//
-		// TODO(ssd): Copy over our GetFirstActiveClient logic
-		// so that we can connect to any node that we've seen
-		// in a previous Topology.
-		streamAddr, err := url.Parse(payload.TargetClusterConnStr)
-		if err != nil {
-			return err
-		}
-
-		client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = client.Close(ctx) }()
-
-		spec, err := client.CreateForTables(ctx, &streampb.ReplicationProducerRequest{
-			TableNames: payload.TableNames,
-		})
-		if err != nil {
-			return err
-		}
-		log.Infof(ctx, "replication producer spec: %#+v", spec)
-		if err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-			prog := md.Progress.GetLogicalReplication()
-			prog.StreamID = uint64(spec.StreamID)
-			prog.SourceClusterID = spec.SourceClusterID
-			prog.SourceSpans = spec.TableSpans
-			prog.ReplicationStartTime = spec.ReplicationStartTime
-			prog.TableDescriptors = spec.TableDescriptors
-			ju.UpdateProgress(md.Progress)
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := client.Close(ctx); err != nil {
-			return err
-		}
-
-	}
 	return r.handleResumeError(ctx, jobExecCtx, r.ingestWithRetries(ctx, jobExecCtx))
 }
 
@@ -124,6 +112,9 @@ func (r *logicalReplicationResumer) Resume(ctx context.Context, execCtx interfac
 func (r *logicalReplicationResumer) handleResumeError(
 	ctx context.Context, execCtx sql.JobExecContext, err error,
 ) error {
+	if err == nil {
+		return nil
+	}
 	r.updateRunningStatus(ctx, redact.Sprintf("pausing after error: %s", err.Error()))
 	return jobs.MarkPauseRequestError(err)
 }
@@ -154,13 +145,38 @@ func (r *logicalReplicationResumer) ingest(
 		progress = r.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
 		payload  = r.job.Details().(jobspb.LogicalReplicationDetails)
 
+		streamID              = payload.StreamID
 		jobID                 = r.job.ID()
 		replicatedTimeAtStart = progress.ReplicatedTime
-		sourceSpans           = progress.SourceSpans
-		streamID              = progress.StreamID
 	)
 
-	frontier, err := span.MakeFrontierAt(replicatedTimeAtStart, sourceSpans...)
+	streamAddr, err := url.Parse(payload.TargetClusterConnStr)
+	if err != nil {
+		return err
+	}
+
+	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr, streamclient.WithStreamID(streampb.StreamID(streamID)))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close(ctx) }()
+
+	req := streampb.LogicalReplicationPlanRequest{}
+	for _, pair := range payload.ReplicationPairs {
+		req.TableIDs = append(req.TableIDs, pair.SrcDescriptorID)
+	}
+
+	plan, err := client.PlanLogicalReplication(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	dstToSrcDescMap := make(map[int32]descpb.TableDescriptor)
+	for _, pair := range payload.ReplicationPairs {
+		dstToSrcDescMap[pair.DstDescriptorID] = plan.DescriptorMap[pair.SrcDescriptorID]
+	}
+
+	frontier, err := span.MakeFrontierAt(replicatedTimeAtStart, plan.SourceSpans...)
 	if err != nil {
 		return err
 	}
@@ -178,30 +194,14 @@ func (r *logicalReplicationResumer) ingest(
 		return err
 	}
 
-	streamAddr, err := url.Parse(payload.TargetClusterConnStr)
-	if err != nil {
-		return err
-	}
-
-	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr, streamclient.WithStreamID(streampb.StreamID(streamID)))
-	if err != nil {
-		return err
-	}
-	defer func() { _ = client.Close(ctx) }()
-
-	topology, err := client.PlanLogicalReplication(ctx, sourceSpans)
-	if err != nil {
-		return err
-	}
-
 	specs, err := constructLogicalReplicationWriterSpecs(ctx,
 		streamingccl.StreamAddress(payload.TargetClusterConnStr),
-		topology,
+		plan.Topology,
 		destNodeLocalities,
-		progress.ReplicationStartTime,
+		payload.ReplicationStartTime,
 		progress.ReplicatedTime,
 		progress.Checkpoint,
-		progress.TableDescriptors,
+		dstToSrcDescMap,
 		jobID,
 		streampb.StreamID(streamID))
 	if err != nil {
@@ -218,7 +218,7 @@ func (r *logicalReplicationResumer) ingest(
 	// TODO(ssd): Now that we have more than one processor per
 	// node, we might actually want a tree of frontier processors
 	// spread out CPU load.
-	processorCorePlacements := make([]physicalplan.ProcessorCorePlacement, 0, len(topology.Partitions))
+	processorCorePlacements := make([]physicalplan.ProcessorCorePlacement, 0, len(plan.Topology.Partitions))
 	for nodeID, parts := range specs {
 		for _, part := range parts {
 			sp := part

--- a/pkg/ccl/streamingccl/logical/logical_replication_job_test.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_job_test.go
@@ -20,12 +20,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -58,63 +60,66 @@ func TestLogicalStreamIngestionJob(t *testing.T) {
 		},
 	}
 
-	serverA := testcluster.StartTestCluster(t, 1, clusterArgs)
-	defer serverA.Stopper().Stop(ctx)
+	server := testcluster.StartTestCluster(t, 1, clusterArgs)
+	defer server.Stopper().Stop(ctx)
 
-	serverB := testcluster.StartTestCluster(t, 1, clusterArgs)
-	defer serverB.Stopper().Stop(ctx)
+	_, err := server.Conns[0].Exec("CREATE DATABASE a")
+	require.NoError(t, err)
+	_, err = server.Conns[0].Exec("CREATE DATABASE B")
+	require.NoError(t, err)
 
-	serverASQL := sqlutils.MakeSQLRunner(serverA.Server(0).ApplicationLayer().SQLConn(t))
-	serverBSQL := sqlutils.MakeSQLRunner(serverB.Server(0).ApplicationLayer().SQLConn(t))
+	dbA := sqlutils.MakeSQLRunner(server.Server(0).ApplicationLayer().SQLConn(t, serverutils.DBName("a")))
+	dbB := sqlutils.MakeSQLRunner(server.Server(0).ApplicationLayer().SQLConn(t, serverutils.DBName("b")))
 
 	for _, s := range testClusterSettings {
-		serverASQL.Exec(t, s)
-		serverBSQL.Exec(t, s)
+		dbA.Exec(t, s)
 	}
 
 	createStmt := "CREATE TABLE tab (pk int primary key, payload string)"
-	serverASQL.Exec(t, createStmt)
-	serverBSQL.Exec(t, createStmt)
-	serverASQL.Exec(t, lwwColumnAdd)
-	serverBSQL.Exec(t, lwwColumnAdd)
+	dbA.Exec(t, createStmt)
+	dbB.Exec(t, createStmt)
+	dbA.Exec(t, lwwColumnAdd)
+	dbB.Exec(t, lwwColumnAdd)
 
-	serverASQL.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
-	serverBSQL.Exec(t, "INSERT INTO tab VALUES (1, 'goodbye')")
+	dbA.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
+	dbB.Exec(t, "INSERT INTO tab VALUES (1, 'goodbye')")
 
-	serverAURL, cleanup := sqlutils.PGUrl(t, serverA.Server(0).ApplicationLayer().SQLAddr(), t.Name(), url.User(username.RootUser))
+	dbAURL, cleanup := sqlutils.PGUrl(t, server.Server(0).ApplicationLayer().SQLAddr(), t.Name(), url.User(username.RootUser))
+	dbAURL.Path = "a"
 	defer cleanup()
-	serverBURL, cleanupB := sqlutils.PGUrl(t, serverB.Server(0).ApplicationLayer().SQLAddr(), t.Name(), url.User(username.RootUser))
+	dbBURL, cleanupB := sqlutils.PGUrl(t, server.Server(0).ApplicationLayer().SQLAddr(), t.Name(), url.User(username.RootUser))
 	defer cleanupB()
+	dbBURL.Path = "b"
 
 	var (
 		jobAID jobspb.JobID
 		jobBID jobspb.JobID
 	)
-	serverASQL.QueryRow(t, fmt.Sprintf("SELECT crdb_internal.start_logical_replication_job('%s', %s)", serverBURL.String(), `ARRAY['tab']`)).Scan(&jobAID)
-	serverBSQL.QueryRow(t, fmt.Sprintf("SELECT crdb_internal.start_logical_replication_job('%s', %s)", serverAURL.String(), `ARRAY['tab']`)).Scan(&jobBID)
+	dbA.QueryRow(t, fmt.Sprintf("SELECT crdb_internal.start_logical_replication_job('%s', %s)", dbBURL.String(), `ARRAY['tab']`)).Scan(&jobAID)
+	dbB.QueryRow(t, fmt.Sprintf("SELECT crdb_internal.start_logical_replication_job('%s', %s)", dbAURL.String(), `ARRAY['tab']`)).Scan(&jobBID)
 
-	now := serverA.Server(0).Clock().Now()
+	now := server.Server(0).Clock().Now()
 	t.Logf("waiting for replication job %d", jobAID)
-	WaitUntilReplicatedTime(t, now, serverASQL, jobAID)
+	WaitUntilReplicatedTime(t, now, dbA, jobAID)
 	t.Logf("waiting for replication job %d", jobBID)
-	WaitUntilReplicatedTime(t, now, serverBSQL, jobBID)
+	WaitUntilReplicatedTime(t, now, dbB, jobBID)
 
-	serverASQL.Exec(t, "INSERT INTO tab VALUES (2, 'potato')")
-	serverBSQL.Exec(t, "INSERT INTO tab VALUES (3, 'celeriac')")
-	serverASQL.Exec(t, "UPSERT INTO tab VALUES (1, 'hello, again')")
-	serverBSQL.Exec(t, "UPSERT INTO tab VALUES (1, 'goodbye, again')")
+	dbA.Exec(t, "INSERT INTO tab VALUES (2, 'potato')")
+	dbB.Exec(t, "INSERT INTO tab VALUES (3, 'celeriac')")
+	dbA.Exec(t, "UPSERT INTO tab VALUES (1, 'hello, again')")
+	dbB.Exec(t, "UPSERT INTO tab VALUES (1, 'goodbye, again')")
 
-	now = serverA.Server(0).Clock().Now()
-	WaitUntilReplicatedTime(t, now, serverASQL, jobAID)
-	WaitUntilReplicatedTime(t, now, serverBSQL, jobBID)
+	now = server.Server(0).Clock().Now()
+	WaitUntilReplicatedTime(t, now, dbA, jobAID)
+	WaitUntilReplicatedTime(t, now, dbB, jobBID)
 
 	expectedRows := [][]string{
 		{"1", "goodbye, again"},
 		{"2", "potato"},
 		{"3", "celeriac"},
 	}
-	serverBSQL.CheckQueryResults(t, "SELECT * from tab", expectedRows)
-	serverASQL.CheckQueryResults(t, "SELECT * from tab", expectedRows)
+	dbA.CheckQueryResults(t, "SELECT * from a.tab", expectedRows)
+	dbB.CheckQueryResults(t, "SELECT * from b.tab", expectedRows)
 }
 
 func TestLogicalStreamIngestionJobWithColumnFamilies(t *testing.T) {

--- a/pkg/ccl/streamingccl/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_writer_processor.go
@@ -344,7 +344,7 @@ func (lrw *logicalReplicationWriterProcessor) consumeEvents(ctx context.Context)
 			return err
 		}
 	}
-	return nil
+	return lrw.subscription.Err()
 }
 
 func (lrw *logicalReplicationWriterProcessor) handleEvent(

--- a/pkg/ccl/streamingccl/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/streamingccl/logical/logical_replication_writer_processor.go
@@ -113,9 +113,10 @@ func newLogicalReplicationWriterProcessor(
 			return nil, err
 		}
 	}
+
 	bhPool := make([]BatchHandler, maxWriterWorkers)
 	for i := range bhPool {
-		rp, err := makeSQLLastWriteWinsHandler(ctx, flowCtx.Codec(), flowCtx.Cfg.Settings, spec.TableDescriptors)
+		rp, err := makeSQLLastWriteWinsHandler(ctx, flowCtx.Cfg.Settings, spec.TableDescriptors)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/streamingccl/logical/lww_row_processor_test.go
+++ b/pkg/ccl/streamingccl/logical/lww_row_processor_test.go
@@ -81,7 +81,7 @@ func BenchmarkLastWriteWinsInsert(b *testing.B) {
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
 	tableDescs := make(map[string]descpb.TableDescriptor, 1)
 	tableDescs["defaultdb.public."+tableName] = *desc.TableDesc()
-	rp, err := makeSQLLastWriteWinsHandler(ctx, s.Codec(), s.ClusterSettings(), tableDescs)
+	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), tableDescs)
 	require.NoError(b, err)
 
 	// We'll be simulating processing the same INSERT over and over in the loop.

--- a/pkg/ccl/streamingccl/logical/lww_row_processor_test.go
+++ b/pkg/ccl/streamingccl/logical/lww_row_processor_test.go
@@ -79,9 +79,9 @@ func BenchmarkLastWriteWinsInsert(b *testing.B) {
 	runner.Exec(b, "ALTER TABLE tab ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL")
 
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
-	tableDescs := make(map[string]descpb.TableDescriptor, 1)
-	tableDescs["defaultdb.public."+tableName] = *desc.TableDesc()
-	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), tableDescs)
+	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]descpb.TableDescriptor{
+		int32(desc.GetID()): *desc.TableDesc(),
+	})
 	require.NoError(b, err)
 
 	// We'll be simulating processing the same INSERT over and over in the loop.

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -118,7 +118,7 @@ type Client interface {
 type LogicalReplicationClient interface {
 	Client
 
-	PlanLogicalReplication(ctx context.Context, spans []roachpb.Span) (Topology, error)
+	PlanLogicalReplication(ctx context.Context, req streampb.LogicalReplicationPlanRequest) (LogicalReplicationPlan, error)
 	CreateForTables(ctx context.Context, req *streampb.ReplicationProducerRequest) (*streampb.ReplicationProducerSpec, error)
 }
 

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -11,6 +11,7 @@ package streamclient
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"net"
 	"net/url"
 
@@ -299,7 +300,9 @@ func (p *partitionedStreamClient) PlanLogicalReplication(
 		return LogicalReplicationPlan{}, err
 	}
 
-	row := p.mu.srcConn.QueryRow(ctx, "SELECT crdb_internal.plan_logical_replication($1)", encodedReq)
+	row := p.mu.srcConn.QueryRow(ctx,
+		fmt.Sprintf("SELECT * FROM crdb_internal.plan_logical_replication($1) AS OF SYSTEM TIME %s", req.PlanAsOf.AsOfSystemTime()),
+		encodedReq)
 
 	streamSpecBytes := []byte{}
 	if err := row.Scan(&streamSpecBytes); err != nil {

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -278,37 +279,53 @@ func (p *partitionedStreamClient) Complete(
 	return nil
 }
 
+type LogicalReplicationPlan struct {
+	Topology      Topology
+	SourceSpans   []roachpb.Span
+	DescriptorMap map[int32]descpb.TableDescriptor
+}
+
 func (p *partitionedStreamClient) PlanLogicalReplication(
-	ctx context.Context, spans []roachpb.Span,
-) (Topology, error) {
+	ctx context.Context, req streampb.LogicalReplicationPlanRequest,
+) (LogicalReplicationPlan, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.PlanLogicalReplication")
 	defer sp.Finish()
-
-	encodedSpans := [][]byte{}
-	for _, sourceSpan := range spans {
-		spanBytes, err := protoutil.Marshal(&sourceSpan)
-		if err != nil {
-			return Topology{}, err
-		}
-		encodedSpans = append(encodedSpans, spanBytes)
-	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	row := p.mu.srcConn.QueryRow(ctx, "SELECT crdb_internal.plan_logical_replication($1)", encodedSpans)
+	encodedReq, err := protoutil.Marshal(&req)
+	if err != nil {
+		return LogicalReplicationPlan{}, err
+	}
+
+	row := p.mu.srcConn.QueryRow(ctx, "SELECT crdb_internal.plan_logical_replication($1)", encodedReq)
 
 	streamSpecBytes := []byte{}
 	if err := row.Scan(&streamSpecBytes); err != nil {
-		return Topology{}, err
+		return LogicalReplicationPlan{}, err
 	}
 
 	streamSpec := streampb.ReplicationStreamSpec{}
 	if err := protoutil.Unmarshal(streamSpecBytes, &streamSpec); err != nil {
-		return Topology{}, err
+		return LogicalReplicationPlan{}, err
+	}
+	topology, err := p.createTopology(streamSpec)
+	if err != nil {
+		return LogicalReplicationPlan{}, err
 	}
 
-	return p.createTopology(streamSpec)
+	descMap := make(map[int32]descpb.TableDescriptor)
+	for _, desc := range streamSpec.TableDescriptors {
+		desc := desc
+		descMap[int32(desc.ID)] = desc
+	}
+
+	return LogicalReplicationPlan{
+		Topology:      topology,
+		SourceSpans:   streamSpec.TableSpans,
+		DescriptorMap: descMap,
+	}, nil
 }
 
 func (p *partitionedStreamClient) CreateForTables(

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -212,31 +212,38 @@ message LogicalReplicationDetails {
   string target_cluster_conn_str = 1 [
     (gogoproto.customname) = "TargetClusterConnStr"
   ];
-  // TableNames is a list of fully qualified table names that
+
+  // TableNames is the original list of source table names given by the user.
+  repeated string table_names = 2;
+
+  // DescriptorIDMap is a map from the source descriptor ID
   // are being replicated by this job.
   //
-  // TODO(ssd): We need to change this into some more generic form of
-  // "target" to account for full-database replication.
-  repeated string table_names = 2;
+  // TODO(ssd): We need to decode how to account for full-database replication.
+  message ReplicationPair {
+    int32 src_descriptor_id = 1 [(gogoproto.customname) = "SrcDescriptorID"];
+    int32 dst_descriptor_id = 2 [(gogoproto.customname) = "DstDescriptorID"];
+  }
+  repeated ReplicationPair replication_pairs = 3 [(gogoproto.nullable) = false];
+
+  uint64 stream_id = 4 [(gogoproto.customname) = "StreamID"];
+
+  // ReplicationStartTime is the initial timestamp from which the replication
+  // producer job will begin streaming MVCC revisions. This timestamp is picked
+  // once when the replication producer job is created, and is never updated
+  // through the lifetime of a replication stream. This will be the timestamp as
+  // of which each partition will perform its initial rangefeed scan on the
+  // source cluster.
+  util.hlc.Timestamp replication_start_time = 5 [(gogoproto.nullable) = false];
+
+  bytes source_cluster_id = 6 [
+      (gogoproto.nullable) = false,
+      (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
+      (gogoproto.customname) = "SourceClusterID"];
 }
 
 message LogicalReplicationProgress {
-   uint64 stream_id = 1 [(gogoproto.customname) = "StreamID"];
-
-    repeated roachpb.Span source_spans = 2 [(gogoproto.nullable) = false];
-
-    // ReplicationStartTime is the initial timestamp from which the replication
-    // producer job will begin streaming MVCC revisions. This timestamp is picked
-    // once when the replication producer job is created, and is never updated
-    // through the lifetime of a replication stream. This will be the timestamp as
-    // of which each partition will perform its initial rangefeed scan on the
-    // source cluster.
-    util.hlc.Timestamp replication_start_time = 3 [(gogoproto.nullable) = false];
-
-    bytes source_cluster_id = 4 [
-        (gogoproto.nullable) = false,
-        (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
-        (gogoproto.customname) = "SourceClusterID"];
+    reserved 1, 2, 3, 4, 7;
 
     // ReplicatedTime is the ingestion frontier. This is the canonical
     // value of the frontier. The HighWater in the job progress is for
@@ -245,12 +252,6 @@ message LogicalReplicationProgress {
 
     // Checkpoint stores a set of resolved spans denoting completed ingestion progress
     StreamIngestionCheckpoint checkpoint = 6 [(gogoproto.nullable) = false];
-
-    // TableDescriptors is a map from table names to table descriptors.
-    // TODO(ssd): This should eventually be replaces with a rangefeed drive
-    // descriptor cache of some sort.
-    map<string, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 7 [(gogoproto.nullable) = false];
-
 }
 
 message StreamReplicationDetails {

--- a/pkg/repstream/BUILD.bazel
+++ b/pkg/repstream/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/repstream",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/repstream/streampb",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/resolver",
         "//pkg/sql/clusterunique",
         "//pkg/sql/isql",

--- a/pkg/repstream/api.go
+++ b/pkg/repstream/api.go
@@ -13,6 +13,8 @@ package repstream
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -22,18 +24,20 @@ import (
 
 // GetReplicationStreamManagerHook is the hook to get access to the producer side replication APIs.
 // Used by builtin functions to trigger streaming replication.
-var GetReplicationStreamManagerHook func(ctx context.Context, evalCtx *eval.Context, sc resolver.SchemaResolver, txn isql.Txn, sessionID clusterunique.ID) (eval.ReplicationStreamManager, error)
+var GetReplicationStreamManagerHook func(ctx context.Context, evalCtx *eval.Context, sc resolver.SchemaResolver, txn descs.Txn, sessionID clusterunique.ID) (eval.ReplicationStreamManager, error)
 
 // GetStreamIngestManagerHook is the hook to get access to the ingestion side replication APIs.
 // Used by builtin functions to trigger streaming replication.
 var GetStreamIngestManagerHook func(ctx context.Context, evalCtx *eval.Context, txn isql.Txn, sessionID clusterunique.ID) (eval.StreamIngestManager, error)
+
+var CreateRemoteProduceJobForLogicalReplicationHook func(ctx context.Context, srcAddr string, tableNames []string) (*streampb.ReplicationProducerSpec, error)
 
 // GetReplicationStreamManager returns a ReplicationStreamManager if a CCL binary is loaded.
 func GetReplicationStreamManager(
 	ctx context.Context,
 	evalCtx *eval.Context,
 	sc resolver.SchemaResolver,
-	txn isql.Txn,
+	txn descs.Txn,
 	sessionID clusterunique.ID,
 ) (eval.ReplicationStreamManager, error) {
 	if GetReplicationStreamManagerHook == nil {
@@ -50,4 +54,13 @@ func GetStreamIngestManager(
 		return nil, errors.New("replication streaming requires a CCL binary")
 	}
 	return GetStreamIngestManagerHook(ctx, evalCtx, txn, sessionID)
+}
+
+func CreateRemoteProduceJobForLogicalReplication(
+	ctx context.Context, srcAddr string, tableNames []string,
+) (*streampb.ReplicationProducerSpec, error) {
+	if CreateRemoteProduceJobForLogicalReplicationHook == nil {
+		return nil, errors.New("replication streaming requires a CCL binary")
+	}
+	return CreateRemoteProduceJobForLogicalReplicationHook(ctx, srcAddr, tableNames)
 }

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -161,6 +161,8 @@ message SpanConfigEventStreamSpec {
 message LogicalReplicationPlanRequest {
     // TableIDs are the destination table IDs that the caller would like a plan for.
     repeated int32 table_ids = 1 [(gogoproto.customname) = "TableIDs"];
+    // PlanAsOf is the time as of which the plan should be produced.
+    util.hlc.Timestamp plan_as_of = 2 [(gogoproto.nullable) = false];
 }
 
 message ReplicationStreamSpec {

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -28,6 +28,8 @@ import "sql/catalog/descpb/structured.proto";
 // ReplicationProducerSpec is the specification returned by the replication
 // producer job when it is created.
 message ReplicationProducerSpec {
+  reserved 5, 6;
+
   int64 stream_id = 1 [(gogoproto.customname) = "StreamID", (gogoproto.casttype) = "StreamID"];
 
   // ReplicationStartTime is the initial timestamp from which the replication
@@ -47,11 +49,6 @@ message ReplicationProducerSpec {
     (gogoproto.nullable) = false,
     (gogoproto.customname) = "SourceTenantID"
   ];
-
-  // TableSpans is the set of spans that cover the requested tables if
-  // this is in response to a ReplicationProducerRequest that
-  // specified individual tables.
-  repeated roachpb.Span table_spans = 5 [(gogoproto.nullable) = false];
 
   // TableDescriptors are the descriptors for the tables in the
   // ReplicationProducerRequest.
@@ -161,6 +158,11 @@ message SpanConfigEventStreamSpec {
   bool wrapped_events = 4;
 }
 
+message LogicalReplicationPlanRequest {
+    // TableIDs are the destination table IDs that the caller would like a plan for.
+    repeated int32 table_ids = 1 [(gogoproto.customname) = "TableIDs"];
+}
+
 message ReplicationStreamSpec {
   message Partition {
     // ID of the node this partition resides
@@ -185,6 +187,10 @@ message ReplicationStreamSpec {
   int64 span_config_stream_id = 3 [(gogoproto.customname) = "SpanConfigStreamID", (gogoproto
     .casttype) = "StreamID"];
 
+  // TableSpans is the set of spans that cover the requested tables if
+  // this is in response to a LogicalReplicationPlanRequest.
+  repeated roachpb.Span table_spans = 4 [(gogoproto.nullable) = false];
+  repeated cockroach.sql.sqlbase.TableDescriptor table_descriptors = 5 [(gogoproto.nullable) = false];
 }
 
 // StreamedSpanConfigEntry holds a span config update and its source side commit timestamp

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -511,5 +511,6 @@ message LogicalReplicationWriterSpec {
     // Checkpoint stores a set of resolved spans denoting completed progress.
     optional jobs.jobspb.StreamIngestionCheckpoint checkpoint = 7 [(gogoproto.nullable) = false];
 
-    map<string, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 8 [(gogoproto.nullable) = false];
+    // TableDescriptors is a map between from destination table IDs to the source table descriptor.
+    map<int32, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 8 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -1013,8 +1013,18 @@ func (p *planner) StartLogicalReplicationJob(
 
 	// TODO(ssd): Name resolution needs to be thought through for
 	// the final syntax.
+	//
+	// Currently, the user passes some name and that name is
+	// resolved by both the source and the destination. The
+	// destination-side resolution is below and happens in the
+	// context of the session calling the built-in. The
+	// source-side resolution happens when creating the remote
+	// producer job and happens in the context of the session we
+	// get when connecting to the source using the user-provided
+	// URL.
 	fullyQualifiedTableNames := make([]string, 0, len(tableNames))
-	for _, t := range tableNames {
+	repPairs := make([]jobspb.LogicalReplicationDetails_ReplicationPair, len(tableNames))
+	for i, t := range tableNames {
 		un := tree.MakeUnresolvedName(t)
 		uon, err := un.ToUnresolvedObjectName(tree.NoAnnotation)
 		if err != nil {
@@ -1032,14 +1042,28 @@ func (p *planner) StartLogicalReplicationJob(
 			tree.Name(td.GetName()),
 		)
 		fullyQualifiedTableNames = append(fullyQualifiedTableNames, tbNameWithSchema.FQString())
+		repPairs[i].DstDescriptorID = int32(td.GetID())
 	}
+
+	spec, err := repstream.CreateRemoteProduceJobForLogicalReplication(ctx, targetConnStr, tableNames)
+	if err != nil {
+		return 0, err
+	}
+	for i, name := range tableNames {
+		repPairs[i].SrcDescriptorID = int32(spec.TableDescriptors[name].ID)
+	}
+
 	jr := jobs.Record{
 		Description: fmt.Sprintf("logical replication ingestion for %s",
 			strings.Join(fullyQualifiedTableNames, ",")),
 		Username: evalCtx.SessionData().User(),
 		Details: jobspb.LogicalReplicationDetails{
+			StreamID:             uint64(spec.StreamID),
+			SourceClusterID:      spec.SourceClusterID,
+			ReplicationStartTime: spec.ReplicationStartTime,
 			TargetClusterConnStr: targetConnStr,
-			TableNames:           fullyQualifiedTableNames},
+			ReplicationPairs:     repPairs,
+			TableNames:           tableNames},
 		Progress: jobspb.LogicalReplicationProgress{},
 		JobID:    registry.MakeJobID(),
 	}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2582,7 +2582,7 @@ var builtinOidsArray = []string{
 	2614: `crdb_internal.scatter(key: bytes) -> void`,
 	2615: `crdb_internal.scatter(key: bytes, end_key: bytes) -> void`,
 	2616: `crdb_internal.start_logical_replication_job(conn_str: string, table_names: string[]) -> int`,
-	2617: `crdb_internal.plan_logical_replication(spans: bytes[]) -> bytes`,
+	2617: `crdb_internal.plan_logical_replication(req: bytes) -> bytes`,
 	2618: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
 }
 

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -916,7 +916,7 @@ type ReplicationStreamManager interface {
 
 	PlanLogicalReplication(
 		ctx context.Context,
-		spans []roachpb.Span,
+		req streampb.LogicalReplicationPlanRequest,
 	) (*streampb.ReplicationStreamSpec, error)
 
 	StartReplicationStreamForTables(

--- a/scripts/ldr
+++ b/scripts/ldr
@@ -83,8 +83,8 @@ case $1 in
     "start")
       roachprod sql $A:1 -- -e "SET CLUSTER SETTING kv.rangefeed.enabled = true"
       roachprod sql $B:1 -- -e "SET CLUSTER SETTING kv.rangefeed.enabled = true"
-      roachprod sql $A:1 -- -e "USE ycsb; SELECT crdb_internal.start_logical_replication_job($(roachprod pgurl --insecure $B:1), ARRAY['usertable']);"
-      roachprod sql $B:1 -- -e "USE ycsb; SELECT crdb_internal.start_logical_replication_job($(roachprod pgurl --insecure $A:1), ARRAY['usertable']);"
+      roachprod sql $A:1 -- -e "USE ycsb; SELECT crdb_internal.start_logical_replication_job($(roachprod pgurl --database ycsb --insecure $B:1), ARRAY['usertable']);"
+      roachprod sql $B:1 -- -e "USE ycsb; SELECT crdb_internal.start_logical_replication_job($(roachprod pgurl --database ycsb --insecure $A:1), ARRAY['usertable']);"
       ;;
     "pause")
       roachprod sql $A:1 -- -e "PAUSE JOBS (WITH x AS (SHOW JOBS) SELECT job_id FROM x WHERE job_type = 'LOGICAL REPLICATION' AND status = 'running');"
@@ -196,7 +196,7 @@ case $1 in
     # exited non-zero. So we capture the result in an `||` so we keep going to
     # the second one, then if we're still running, exit with the first's result.
     ret=0
-    
+
     echo "${A}:"
     roachprod "${cmd}" $A "$@" || ret=$?
     echo "${B}:"


### PR DESCRIPTION
This makes a number of changes with the end goal of being able to
stream from a table in one database to a table in another database.

Towards that end it:

  1. Resolves the bare table names to descriptor IDs on both the
  source and destination and stores a descpb.DescID->descpb.DescID map
  in the job details.

  2. Moves initial producer job creation into the initial replication
  start statement, storing the stream ID, initial replicated time, and
  other metadata in the payload rather than the progress.

  3. The followed spans and source descriptor IDs are now returned
  during planning.

  4. The SQL row processor was changed to use descriptor IDs rather
  than names.

Epic: none
Release note: None