### PR TITLE
keys: define TenantOne and SystemTenantID separately

### DIFF
--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -21,15 +21,17 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// SystemTenantID is the ID associated with the system's internal tenant in a
-// multi-tenant cluster and the only tenant in a single-tenant cluster.
+// SystemTenantID is the ID associated with the tenant that manages a cluster.
 //
-// The system tenant differs from all other tenants in four important ways:
-// 1. the system tenant's keyspace is not prefixed with a tenant specifier.
-// 2. the system tenant is created by default during cluster initialization.
-// 3. the system tenant is always present and can never be destroyed.
-// 4. the system tenant has the ability to create and destroy other tenants.
-var SystemTenantID = MustMakeTenantID(1)
+// The system tenant must exist and must use shared service, to be available to
+// node-internal processes. Additionally it is given special treatment in any
+// authorization decisions, bypassing typical restrictions that tenants act only
+// on their own key spans.
+var SystemTenantID = TenantOne
+
+// TenantOne is a special tenant ID, associated the numeric ID 1, which for
+// legacy compatibility reasons stores its tables without a tenant prefix.
+var TenantOne = MustMakeTenantID(1)
 
 // MinTenantID is the minimum ID of a (non-system) tenant in a multi-tenant
 // cluster.


### PR DESCRIPTION
Eventually the system tenant might not be tenant 1, but tenant 1 will always be special due to its lack of a tenant prefix, so code will need to refer to tenant one explicitly in some cases, i.e. those relating to the key prefix, even when not referencing the system tenant. Providing separate identifiers (for what is currently the same thing) allows us to start explicitly using the appropriate one in such cases now ahead of a future where they stop being the same.

Release note: none.
Epic: none.