### PR TITLE
kv: deflake TestRaftTransportClockPropagation

### DIFF
--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -741,10 +741,12 @@ func TestRaftTransportClockPropagation(t *testing.T) {
 	}
 
 	// Advance the client's clock beyond the server's.
-	rttc.clocks[clientReplica.NodeID].manual.Increment(1000)
-	clientNow := rttc.clocks[clientReplica.NodeID].clock.Now()
 	serverNow := rttc.clocks[serverReplica.NodeID].clock.Now()
-	require.True(t, serverNow.Less(clientNow))
+	var clientNow hlc.Timestamp
+	for clientNow.LessEq(serverNow) {
+		rttc.clocks[clientReplica.NodeID].manual.Increment(1000000)
+		clientNow = rttc.clocks[clientReplica.NodeID].clock.Now()
+	}
 
 	// Send a message from the client to the server.
 	sent := rttc.Send(clientReplica, serverReplica, 1 /* rangeID */, raftpb.Message{Commit: 10})


### PR DESCRIPTION
Fixes #125624.

Incrementing the manual clock by 1000 nanos, once, was not enough to ensure that the client clock was later than the server clock. We now increment in a loop to ensure desired clock skew.

Release notes: None