### PR TITLE
settings: code cleanup and improvements

### DIFF
--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -34,6 +34,11 @@ func (b *BoolSetting) String(sv *Values) string {
 	return EncodeBool(b.Get(sv))
 }
 
+// DefaultString returns the default value for the setting as a string.
+func (b *BoolSetting) DefaultString() string {
+	return EncodeBool(b.defaultValue)
+}
+
 // Encoded returns the encoded value of the current value of the setting.
 func (b *BoolSetting) Encoded(sv *Values) string {
 	return b.String(sv)
@@ -66,11 +71,6 @@ func (*BoolSetting) Typ() string {
 // Default returns default value for setting.
 func (b *BoolSetting) Default() bool {
 	return b.defaultValue
-}
-
-// DefaultString returns the default value for the setting as a string.
-func (b *BoolSetting) DefaultString() (string, error) {
-	return b.DecodeToString(b.EncodedDefault())
 }
 
 // Defeat the linter.

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -94,6 +94,26 @@ func (b *BoolSetting) set(ctx context.Context, sv *Values, v bool) {
 	sv.setInt64(ctx, b.slot, vInt)
 }
 
+func (b *BoolSetting) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	v, err := strconv.ParseBool(encoded)
+	if err != nil {
+		return err
+	}
+	b.set(ctx, sv, v)
+	return nil
+}
+
+func (b *BoolSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	v, err := strconv.ParseBool(encoded)
+	if err != nil {
+		return err
+	}
+	sv.setDefaultOverride(b.slot, v)
+	return nil
+}
+
 func (b *BoolSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
 	if val := sv.getDefaultOverride(b.slot); val != nil {

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -22,7 +22,7 @@ type ByteSizeSetting struct {
 	IntSetting
 }
 
-var _ numericSetting = &ByteSizeSetting{}
+var _ internalSetting = &ByteSizeSetting{}
 
 // Typ returns the short (1 char) string denoting the type of setting.
 func (*ByteSizeSetting) Typ() string {

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -33,6 +33,11 @@ func (b *ByteSizeSetting) String(sv *Values) string {
 	return string(humanizeutil.IBytes(b.Get(sv)))
 }
 
+// DefaultString returns the default value for the setting as a string.
+func (b *ByteSizeSetting) DefaultString() string {
+	return string(humanizeutil.IBytes(b.defaultValue))
+}
+
 // DecodeToString decodes and renders an encoded value.
 func (b *ByteSizeSetting) DecodeToString(encoded string) (string, error) {
 	iv, err := b.DecodeValue(encoded)
@@ -40,11 +45,6 @@ func (b *ByteSizeSetting) DecodeToString(encoded string) (string, error) {
 		return "", err
 	}
 	return string(humanizeutil.IBytes(iv)), nil
-}
-
-// DefaultString returns the default value for the setting as a string.
-func (b *ByteSizeSetting) DefaultString() (string, error) {
-	return b.DecodeToString(b.EncodedDefault())
 }
 
 // RegisterByteSizeSetting defines a new setting with type bytesize and any

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -156,8 +156,6 @@ type internalSetting interface {
 	init(class Class, key InternalKey, description string, slot slotIdx)
 	isRetired() bool
 	isSensitive() bool
-	setToDefault(ctx context.Context, sv *Values)
-
 	getSlot() slotIdx
 
 	// isReportable indicates whether the value of the setting can be
@@ -168,11 +166,14 @@ type internalSetting interface {
 	// it cannot be listed, but can be accessed with `SHOW CLUSTER
 	// SETTING enterprise.license` or SET CLUSTER SETTING.
 	isReportable() bool
-}
 
-// numericSetting is used for settings that can be set using an integer value.
-type numericSetting interface {
-	internalSetting
-	DecodeValue(value string) (int64, error)
-	set(ctx context.Context, sv *Values, value int64) error
+	setToDefault(ctx context.Context, sv *Values)
+
+	// decodeAndSet sets the setting after decoding the encoded value.
+	decodeAndSet(ctx context.Context, sv *Values, encoded string) error
+
+	// decodeAndOverrideDefault overrides the default value for the respective
+	// setting to newVal. It does not change the current value. Validation checks
+	// are not run against the decoded value.
+	decodeAndSetDefaultOverride(ctx context.Context, sv *Values, encoded string) error
 }

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -71,7 +71,7 @@ func (d *DurationSetting) DecodeToString(encoded string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return EncodeDuration(v), nil
+	return v.String(), nil
 }
 
 // DecodeValue decodes the value into a float.
@@ -117,6 +117,25 @@ func (d *DurationSetting) set(ctx context.Context, sv *Values, v time.Duration) 
 		return err
 	}
 	sv.setInt64(ctx, d.slot, int64(v))
+	return nil
+}
+
+func (d *DurationSetting) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	v, err := d.DecodeValue(encoded)
+	if err != nil {
+		return err
+	}
+	return d.set(ctx, sv, v)
+}
+
+func (d *DurationSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	v, err := d.DecodeValue(encoded)
+	if err != nil {
+		return err
+	}
+	sv.setDefaultOverride(d.slot, v)
 	return nil
 }
 

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -50,6 +50,11 @@ func (d *DurationSetting) String(sv *Values) string {
 	return EncodeDuration(d.Get(sv))
 }
 
+// DefaultString returns the default value for the setting as a string.
+func (d *DurationSetting) DefaultString() string {
+	return EncodeDuration(d.defaultValue)
+}
+
 // Encoded returns the encoded value of the current value of the setting.
 func (d *DurationSetting) Encoded(sv *Values) string {
 	return d.String(sv)
@@ -82,11 +87,6 @@ func (*DurationSetting) Typ() string {
 // Default returns default value for setting.
 func (d *DurationSetting) Default() time.Duration {
 	return d.defaultValue
-}
-
-// DefaultString returns the default value for the setting as a string.
-func (d *DurationSetting) DefaultString() (string, error) {
-	return d.DecodeToString(d.EncodedDefault())
 }
 
 // Defeat the linter.

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -44,8 +44,8 @@ func (e *EnumSetting) String(sv *Values) string {
 }
 
 // DefaultString returns the default value for the setting as a string.
-func (e *EnumSetting) DefaultString() (string, error) {
-	return e.DecodeToString(e.EncodedDefault())
+func (e *EnumSetting) DefaultString() string {
+	return e.enumValues[e.defaultValue]
 }
 
 // DecodeToString decodes and renders an encoded value.

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -12,13 +12,10 @@ package settings
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/cockroachdb/errors"
 )
 
 // EnumSetting is a StringSetting that restricts the values to be one of the `enumValues`
@@ -27,7 +24,7 @@ type EnumSetting struct {
 	enumValues map[int64]string
 }
 
-var _ numericSetting = &EnumSetting{}
+var _ internalSetting = &EnumSetting{}
 
 // Typ returns the short (1 char) string denoting the type of setting.
 func (e *EnumSetting) Typ() string {
@@ -111,13 +108,6 @@ func (e *EnumSetting) GetAvailableValues() []string {
 		vals = append(vals, e.enumValues[int64(enumIdx)])
 	}
 	return vals
-}
-
-func (e *EnumSetting) set(ctx context.Context, sv *Values, k int64) error {
-	if _, ok := e.enumValues[k]; !ok {
-		return errors.Errorf("unrecognized value %d", k)
-	}
-	return e.IntSetting.set(ctx, sv, k)
 }
 
 func enumValuesToDesc(enumValues map[int64]string) string {

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -38,6 +38,11 @@ func (f *FloatSetting) String(sv *Values) string {
 	return EncodeFloat(f.Get(sv))
 }
 
+// DefaultString returns the default value for the setting as a string.
+func (f *FloatSetting) DefaultString() string {
+	return EncodeFloat(f.defaultValue)
+}
+
 // Encoded returns the encoded value of the current value of the setting.
 func (f *FloatSetting) Encoded(sv *Values) string {
 	return f.String(sv)
@@ -70,11 +75,6 @@ func (*FloatSetting) Typ() string {
 // Default returns default value for setting.
 func (f *FloatSetting) Default() float64 {
 	return f.defaultValue
-}
-
-// DefaultString returns the default value for the setting as a string.
-func (f *FloatSetting) DefaultString() (string, error) {
-	return f.DecodeToString(f.EncodedDefault())
 }
 
 // Defeat the linter.

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -110,6 +110,25 @@ func (f *FloatSetting) set(ctx context.Context, sv *Values, v float64) error {
 	return nil
 }
 
+func (f *FloatSetting) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	v, err := f.DecodeValue(encoded)
+	if err != nil {
+		return err
+	}
+	return f.set(ctx, sv, v)
+}
+
+func (f *FloatSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	v, err := f.DecodeValue(encoded)
+	if err != nil {
+		return err
+	}
+	sv.setDefaultOverride(f.slot, v)
+	return nil
+}
+
 func (f *FloatSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
 	if val := sv.getDefaultOverride(f.slot); val != nil {

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -37,6 +37,11 @@ func (i *IntSetting) String(sv *Values) string {
 	return EncodeInt(i.Get(sv))
 }
 
+// DefaultString returns the default value for the setting as a string.
+func (i *IntSetting) DefaultString() string {
+	return EncodeInt(i.defaultValue)
+}
+
 // Encoded returns the encoded value of the current value of the setting.
 func (i *IntSetting) Encoded(sv *Values) string {
 	return i.String(sv)
@@ -69,11 +74,6 @@ func (*IntSetting) Typ() string {
 // Default returns default value for setting.
 func (i *IntSetting) Default() int64 {
 	return i.defaultValue
-}
-
-// DefaultString returns the default value for the setting as a string.
-func (i *IntSetting) DefaultString() (string, error) {
-	return i.DecodeToString(i.EncodedDefault())
 }
 
 // Defeat the linter.

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -26,7 +26,7 @@ type IntSetting struct {
 	validateFn   func(int64) error
 }
 
-var _ numericSetting = &IntSetting{}
+var _ internalSetting = &IntSetting{}
 
 // Get retrieves the int value in the setting.
 func (i *IntSetting) Get(sv *Values) int64 {
@@ -97,6 +97,29 @@ func (i *IntSetting) Override(ctx context.Context, sv *Values, v int64) {
 	sv.setValueOrigin(ctx, i.slot, OriginOverride)
 	sv.setInt64(ctx, i.slot, v)
 	sv.setDefaultOverride(i.slot, v)
+}
+
+func (i *IntSetting) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	v, err := strconv.ParseInt(encoded, 10, 64)
+	if err != nil {
+		return err
+	}
+	if err := i.Validate(v); err != nil {
+		return err
+	}
+	sv.setInt64(ctx, i.slot, v)
+	return nil
+}
+
+func (i *IntSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	v, err := strconv.ParseInt(encoded, 10, 64)
+	if err != nil {
+		return err
+	}
+	sv.setDefaultOverride(i.slot, v)
+	return nil
 }
 
 func (i *IntSetting) set(ctx context.Context, sv *Values, v int64) error {

--- a/pkg/settings/masked.go
+++ b/pkg/settings/masked.go
@@ -52,8 +52,8 @@ func (s *MaskedSetting) String(sv *Values) string {
 }
 
 // DefaultString returns the default value for the setting as a string.
-func (s *MaskedSetting) DefaultString() (string, error) {
-	return s.setting.DecodeToString(s.setting.EncodedDefault())
+func (s *MaskedSetting) DefaultString() string {
+	return s.setting.DefaultString()
 }
 
 // Visibility returns the visibility setting for the underlying setting.

--- a/pkg/settings/protobuf.go
+++ b/pkg/settings/protobuf.go
@@ -121,6 +121,25 @@ func (s *ProtobufSetting) Override(ctx context.Context, sv *Values, p protoutil.
 	sv.setDefaultOverride(s.slot, p)
 }
 
+func (s *ProtobufSetting) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	p, err := s.DecodeValue(encoded)
+	if err != nil {
+		return err
+	}
+	return s.set(ctx, sv, p)
+}
+
+func (s *ProtobufSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	p, err := s.DecodeValue(encoded)
+	if err != nil {
+		return err
+	}
+	sv.setDefaultOverride(s.slot, p)
+	return nil
+}
+
 func (s *ProtobufSetting) set(ctx context.Context, sv *Values, p protoutil.Message) error {
 	if err := s.Validate(sv, p); err != nil {
 		return err

--- a/pkg/settings/protobuf.go
+++ b/pkg/settings/protobuf.go
@@ -45,6 +45,15 @@ func (s *ProtobufSetting) String(sv *Values) string {
 	return json
 }
 
+// DefaultString returns the default value for the setting as a string.
+func (s *ProtobufSetting) DefaultString() string {
+	json, err := s.MarshalToJSON(s.defaultValue)
+	if err != nil {
+		panic(errors.Wrapf(err, "marshaling %s: %+v", proto.MessageName(s.defaultValue), s.defaultValue))
+	}
+	return json
+}
+
 // Encoded returns the encoded value of the current value of the setting.
 func (s *ProtobufSetting) Encoded(sv *Values) string {
 	p := s.Get(sv)
@@ -86,11 +95,6 @@ func (s *ProtobufSetting) DecodeValue(encoded string) (protoutil.Message, error)
 // Default returns default value for setting.
 func (s *ProtobufSetting) Default() protoutil.Message {
 	return s.defaultValue
-}
-
-// DefaultString returns the default value for the setting as a string.
-func (s *ProtobufSetting) DefaultString() (string, error) {
-	return s.DecodeToString(s.EncodedDefault())
 }
 
 // Get retrieves the protobuf value in the setting.

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -69,8 +69,9 @@ type Setting interface {
 	// reporting (see LookupForReportingByKey), String hides the actual value.
 	String(sv *Values) string
 
-	// DefaultString returns the default value for the setting as a string.
-	DefaultString() (string, error)
+	// DefaultString returns the default value for the setting as a string. This
+	// is the same as calling String on the setting when it was never set.
+	DefaultString() string
 
 	// Description contains a helpful text explaining what the specific cluster
 	// setting is for.

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -87,11 +87,11 @@ func (s *StringSetting) Validate(sv *Values, v string) error {
 // it passes validation.
 func (s *StringSetting) Override(ctx context.Context, sv *Values, v string) {
 	sv.setValueOrigin(ctx, s.slot, OriginOverride)
-	_ = s.set(ctx, sv, v)
+	_ = s.decodeAndSet(ctx, sv, v)
 	sv.setDefaultOverride(s.slot, v)
 }
 
-func (s *StringSetting) set(ctx context.Context, sv *Values, v string) error {
+func (s *StringSetting) decodeAndSet(ctx context.Context, sv *Values, v string) error {
 	if err := s.Validate(sv, v); err != nil {
 		return err
 	}
@@ -101,15 +101,22 @@ func (s *StringSetting) set(ctx context.Context, sv *Values, v string) error {
 	return nil
 }
 
+func (s *StringSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, v string,
+) error {
+	sv.setDefaultOverride(s.slot, v)
+	return nil
+}
+
 func (s *StringSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
 	if val := sv.getDefaultOverride(s.slot); val != nil {
 		// As per the semantics of override, these values don't go through
 		// validation.
-		_ = s.set(ctx, sv, val.(string))
+		_ = s.decodeAndSet(ctx, sv, val.(string))
 		return
 	}
-	if err := s.set(ctx, sv, s.defaultValue); err != nil {
+	if err := s.decodeAndSet(ctx, sv, s.defaultValue); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -57,8 +57,8 @@ func (s *StringSetting) Default() string {
 }
 
 // DefaultString returns the default value for the setting as a string.
-func (s *StringSetting) DefaultString() (string, error) {
-	return s.DecodeToString(s.EncodedDefault())
+func (s *StringSetting) DefaultString() string {
+	return s.defaultValue
 }
 
 // Defeat the linter.

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -33,7 +33,7 @@ type VersionSetting struct {
 	common
 }
 
-var _ Setting = &VersionSetting{}
+var _ internalSetting = &VersionSetting{}
 
 // VersionSettingImpl is the interface bridging pkg/settings and
 // pkg/clusterversion. See VersionSetting for additional commentary.
@@ -158,10 +158,32 @@ func (v *VersionSetting) SetInternal(ctx context.Context, sv *Values, newVal Clu
 	sv.setGeneric(ctx, v.slot, newVal)
 }
 
-// setToDefault is part of the extendingSetting interface. This is a no-op for
+// setToDefault is part of the internalSetting interface. This is a no-op for
 // VersionSetting. They don't have defaults that they can go back to at any
 // time.
 func (v *VersionSetting) setToDefault(ctx context.Context, sv *Values) {}
+
+// decodeAndSet is part of the internalSetting interface. We intentionally avoid
+//
+// We intentionally avoid updating the setting through this code path. The
+// specific setting backed by VersionSetting is the cluster version setting,
+// changes to which are propagated through direct RPCs to each node in the
+// cluster instead of gossip. This is done using the BumpClusterVersion RPC.
+func (v *VersionSetting) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	return nil
+}
+
+// decodeAndSetDefaultOverride is part of the internalSetting interface.
+//
+// We intentionally avoid updating the setting through this code path. The
+// specific setting backed by VersionSetting is the cluster version setting,
+// changes to which are propagated through direct RPCs to each node in the
+// cluster instead of gossip. This is done using the BumpClusterVersion RPC.
+func (v *VersionSetting) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	return nil
+}
 
 // RegisterVersionSetting adds the provided version setting to the global
 // registry.

--- a/pkg/settings/version.go
+++ b/pkg/settings/version.go
@@ -112,8 +112,8 @@ func (v *VersionSetting) String(sv *Values) string {
 }
 
 // DefaultString returns the default value for the setting as a string.
-func (v *VersionSetting) DefaultString() (string, error) {
-	return v.DecodeToString(v.EncodedDefault())
+func (v *VersionSetting) DefaultString() string {
+	return encodedDefaultVersion
 }
 
 // Encoded is part of the NonMaskedSetting interface.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2434,10 +2434,7 @@ CREATE TABLE crdb_internal.cluster_settings (
 			strVal := setting.String(&p.ExecCfg().Settings.SV)
 			isPublic := setting.Visibility() == settings.Public
 			desc := setting.Description()
-			defaultVal, err := setting.DefaultString()
-			if err != nil {
-				return err
-			}
+			defaultVal := setting.DefaultString()
 			origin := setting.ValueOrigin(ctx, &p.ExecCfg().Settings.SV).String()
 			if err := addRow(
 				tree.NewDString(string(setting.Name())),


### PR DESCRIPTION
#### setting: clean up DefaultString

It makes no sense for this method to return an error, especially when
the `String()` method doesn't. This was the consequence of a
round-about way of implementing it.

Epic: none
Release note: None

#### settings: add decodeAndSet/decodeAndSetDefaultOverride methods

Replace type switches with methods.

Epic: none
Release note: None