### PR TITLE
roachtest: support custom workload node CPU sizes

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/cmd/roachprod/grafana",
         "//pkg/cmd/roachprod/update",
         "//pkg/roachprod",
+        "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
         "//pkg/roachprod/fluentbit",

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/update"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -145,7 +146,8 @@ Local Clusters
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 		createVMOpts.ClusterName = args[0]
-		return roachprod.Create(context.Background(), config.Logger, username, numNodes, createVMOpts, providerOptsContainer)
+		opts := cloud.ClusterCreateOpts{Nodes: numNodes, CreateOpts: createVMOpts, ProviderOptsContainer: providerOptsContainer}
+		return roachprod.Create(context.Background(), config.Logger, username, &opts)
 	}),
 }
 

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -106,6 +106,7 @@ go_test(
         "//pkg/cmd/roachtest/test",
         "//pkg/internal/team",
         "//pkg/roachprod",
+        "//pkg/roachprod/cloud",
         "//pkg/roachprod/errors",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1135,11 +1135,15 @@ func (c *clusterImpl) lister() option.NodeLister {
 	if c.f != nil { // accommodates poorly set up tests
 		fatalf = c.f.Fatalf
 	}
-	return option.NodeLister{NodeCount: c.spec.NodeCount, Fatalf: fatalf}
+	return option.NodeLister{NodeCount: c.spec.NodeCount, WorkloadNodeProvisioned: c.spec.WorkloadNode, Fatalf: fatalf}
 }
 
 func (c *clusterImpl) All() option.NodeListOption {
 	return c.lister().All()
+}
+
+func (c *clusterImpl) CRDBNodes() option.NodeListOption {
+	return c.lister().CRDBNodes()
 }
 
 func (c *clusterImpl) Range(begin, end int) option.NodeListOption {
@@ -1152,6 +1156,10 @@ func (c *clusterImpl) Nodes(ns ...int) option.NodeListOption {
 
 func (c *clusterImpl) Node(i int) option.NodeListOption {
 	return c.lister().Node(i)
+}
+
+func (c *clusterImpl) WorkloadNode() option.NodeListOption {
+	return c.lister().WorkloadNode()
 }
 
 // FetchLogs downloads the logs from the cluster using `roachprod get`.

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -885,9 +885,9 @@ func (f *clusterFactory) newCluster(
 
 	providerOptsContainer := vm.CreateProviderOptionsContainer()
 
-	cloud := roachtestflags.Cloud
+	clusterCloud := roachtestflags.Cloud
 	params := spec.RoachprodClusterConfig{
-		Cloud:                  cloud,
+		Cloud:                  clusterCloud,
 		UseIOBarrierOnLocalSSD: cfg.useIOBarrier,
 		PreferredArch:          cfg.arch,
 	}
@@ -902,8 +902,8 @@ func (f *clusterFactory) newCluster(
 	if err != nil {
 		return nil, nil, err
 	}
-	if cloud != spec.Local {
-		providerOptsContainer.SetProviderOpts(cloud, providerOpts)
+	if clusterCloud != spec.Local {
+		providerOptsContainer.SetProviderOpts(clusterCloud, providerOpts)
 	}
 
 	createFlagsOverride(&createVMOpts)
@@ -939,7 +939,7 @@ func (f *clusterFactory) newCluster(
 		}
 
 		c := &clusterImpl{
-			cloud:      cloud,
+			cloud:      clusterCloud,
 			name:       genName,
 			spec:       cfg.spec,
 			expiration: cfg.spec.Expiration(),
@@ -955,7 +955,8 @@ func (f *clusterFactory) newCluster(
 
 		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
 		createVMOpts.ClusterName = c.name
-		err = create(ctx, l, cfg.username, cfg.spec.NodeCount, createVMOpts, providerOptsContainer)
+		opts := cloud.ClusterCreateOpts{Nodes: cfg.spec.NodeCount, CreateOpts: createVMOpts, ProviderOptsContainer: providerOptsContainer}
+		err = create(ctx, l, cfg.username, &opts)
 		if err == nil {
 			if err := f.r.registerCluster(c); err != nil {
 				return nil, nil, err

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -34,9 +34,11 @@ type Cluster interface {
 	// Selecting nodes.
 
 	All() option.NodeListOption
+	CRDBNodes() option.NodeListOption
 	Range(begin, end int) option.NodeListOption
 	Nodes(ns ...int) option.NodeListOption
 	Node(i int) option.NodeListOption
+	WorkloadNode() option.NodeListOption
 
 	// Uploading and downloading from/to nodes.
 

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestClusterNodes(t *testing.T) {
-	c := &clusterImpl{spec: spec.MakeClusterSpec(10)}
+	c := &clusterImpl{spec: spec.MakeClusterSpec(10, spec.WorkloadNode())}
 	opts := func(opts ...option.Option) []option.Option {
 		return opts
 	}
@@ -49,6 +49,8 @@ func TestClusterNodes(t *testing.T) {
 		{opts(c.Range(2, 5), c.Range(6, 8)), ":2-8"},
 		{opts(c.Node(2), c.Node(4), c.Node(6)), ":2,4,6"},
 		{opts(c.Node(2), c.Node(3), c.Node(4)), ":2-4"},
+		{opts(c.CRDBNodes()), ":1-9"},
+		{opts(c.WorkloadNode()), ":10"},
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/option/node_lister.go
+++ b/pkg/cmd/roachtest/option/node_lister.go
@@ -12,12 +12,21 @@ package option
 
 // NodeLister is a helper to create `option.NodeListOption`s.
 type NodeLister struct {
-	NodeCount int
-	Fatalf    func(string, ...interface{})
+	NodeCount               int
+	WorkloadNodeProvisioned bool
+	Fatalf                  func(string, ...interface{})
 }
 
 // All returns a list of all nodes.
 func (l NodeLister) All() NodeListOption {
+	return l.Range(1, l.NodeCount)
+}
+
+// CRDBNodes returns a list of all CRDB nodes, i.e, non workload nodes.
+func (l NodeLister) CRDBNodes() NodeListOption {
+	if l.WorkloadNodeProvisioned {
+		return l.Range(1, l.NodeCount-1)
+	}
 	return l.Range(1, l.NodeCount)
 }
 
@@ -50,4 +59,10 @@ func (l NodeLister) Nodes(ns ...int) NodeListOption {
 // Node returns only the node at the provided (1-indexed) position.
 func (l NodeLister) Node(n int) NodeListOption {
 	return l.Nodes(n)
+}
+
+// WorkloadNode returns the workload node—it assumes that one has
+// been created through the cluster spec WorkloadNode option.
+func (l NodeLister) WorkloadNode() NodeListOption {
+	return l.Nodes(l.NodeCount)
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -99,6 +99,9 @@ const (
 type ClusterSpec struct {
 	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
 	NodeCount int
+	// WorkloadNode indicates that the last node of the cluster should be a
+	// workload node.
+	WorkloadNode bool
 	// CPUs is the number of CPUs per node.
 	CPUs                 int
 	Mem                  MemPerCPU

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -100,8 +100,10 @@ type ClusterSpec struct {
 	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
 	NodeCount int
 	// WorkloadNode indicates that the last node of the cluster should be a
-	// workload node.
-	WorkloadNode bool
+	// workload node. Defaults to a VM with 4 CPUs if not specified by
+	// WorkloadNodeCPUs.
+	WorkloadNode     bool
+	WorkloadNodeCPUs int
 	// CPUs is the number of CPUs per node.
 	CPUs                 int
 	Mem                  MemPerCPU
@@ -148,7 +150,7 @@ type ClusterSpec struct {
 // MakeClusterSpec makes a ClusterSpec.
 func MakeClusterSpec(nodeCount int, opts ...Option) ClusterSpec {
 	spec := ClusterSpec{NodeCount: nodeCount}
-	defaultOpts := []Option{CPU(4), nodeLifetime(12 * time.Hour), ReuseAny()}
+	defaultOpts := []Option{CPU(4), WorkloadNodeCPU(4), nodeLifetime(12 * time.Hour), ReuseAny()}
 	for _, o := range append(defaultOpts, opts...) {
 		o(&spec)
 	}
@@ -327,10 +329,9 @@ type RoachprodClusterConfig struct {
 
 // RoachprodOpts returns the opts to use when calling `roachprod.Create()`
 // in order to create the cluster described in the spec.
-// If
 func (s *ClusterSpec) RoachprodOpts(
 	params RoachprodClusterConfig,
-) (vm.CreateOpts, vm.ProviderOpts, vm.CPUArch, error) {
+) (vm.CreateOpts, vm.ProviderOpts, vm.ProviderOpts, vm.CPUArch, error) {
 	useIOBarrier := params.UseIOBarrierOnLocalSSD
 	requestedArch := params.PreferredArch
 
@@ -354,17 +355,17 @@ func (s *ClusterSpec) RoachprodOpts(
 	case Local:
 		createVMOpts.VMProviders = []string{cloud}
 		// remaining opts are not applicable to local clusters
-		return createVMOpts, nil, requestedArch, nil
+		return createVMOpts, nil, nil, requestedArch, nil
 	case AWS, GCE, Azure:
 		createVMOpts.VMProviders = []string{cloud}
 	default:
-		return vm.CreateOpts{}, nil, "", errors.Errorf("unsupported cloud %v", cloud)
+		return vm.CreateOpts{}, nil, nil, "", errors.Errorf("unsupported cloud %v", cloud)
 	}
 	if cloud != GCE {
 		// TODO(DarrylWong): support specifying SSD count on other providers, see: #123777.
 		// Once done, revisit all tests that set SSD count to see if they can run on non GCE.
 		if s.SSDs != 0 {
-			return vm.CreateOpts{}, nil, "", errors.Errorf("specifying SSD count is not yet supported on %s", cloud)
+			return vm.CreateOpts{}, nil, nil, "", errors.Errorf("specifying SSD count is not yet supported on %s", cloud)
 		}
 	}
 
@@ -404,7 +405,7 @@ func (s *ClusterSpec) RoachprodOpts(
 			}
 
 			if err != nil {
-				return vm.CreateOpts{}, nil, "", err
+				return vm.CreateOpts{}, nil, nil, "", err
 			}
 			if requestedArch != "" && selectedArch != requestedArch {
 				// TODO(srosenberg): we need a better way to monitor the rate of this mismatch, i.e.,
@@ -434,7 +435,7 @@ func (s *ClusterSpec) RoachprodOpts(
 
 	if s.FileSystem == Zfs {
 		if cloud != GCE {
-			return vm.CreateOpts{}, nil, "", errors.Errorf(
+			return vm.CreateOpts{}, nil, nil, "", errors.Errorf(
 				"node creation with zfs file system not yet supported on %s", cloud,
 			)
 		}
@@ -469,26 +470,48 @@ func (s *ClusterSpec) RoachprodOpts(
 		}
 	}
 
+	var workloadMachineType string
+	var err error
+	switch cloud {
+	case AWS:
+		workloadMachineType, _, err = SelectAWSMachineType(s.WorkloadNodeCPUs, s.Mem, preferLocalSSD && s.VolumeSize == 0, requestedArch)
+	case GCE:
+		workloadMachineType, _ = SelectGCEMachineType(s.WorkloadNodeCPUs, s.Mem, requestedArch)
+	case Azure:
+		workloadMachineType, _, err = SelectAzureMachineType(s.WorkloadNodeCPUs, s.Mem, requestedArch)
+	}
+	if err != nil {
+		return vm.CreateOpts{}, nil, nil, "", err
+	}
+
 	if createVMOpts.Arch == string(vm.ArchFIPS) && !(cloud == GCE || cloud == AWS) {
-		return vm.CreateOpts{}, nil, "", errors.Errorf(
+		return vm.CreateOpts{}, nil, nil, "", errors.Errorf(
 			"FIPS not yet supported on %s", cloud,
 		)
 	}
 	var providerOpts vm.ProviderOpts
+	var workloadProviderOpts vm.ProviderOpts
 	switch cloud {
 	case AWS:
 		providerOpts = getAWSOpts(machineType, zones, s.VolumeSize, s.AWS.VolumeThroughput,
+			createVMOpts.SSDOpts.UseLocalSSD)
+		workloadProviderOpts = getAWSOpts(workloadMachineType, zones, s.VolumeSize, s.AWS.VolumeThroughput,
 			createVMOpts.SSDOpts.UseLocalSSD)
 	case GCE:
 		providerOpts = getGCEOpts(machineType, zones, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
 			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpotVMs,
 		)
+		workloadProviderOpts = getGCEOpts(workloadMachineType, zones, s.VolumeSize, ssdCount,
+			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpotVMs,
+		)
 	case Azure:
 		providerOpts = getAzureOpts(machineType, zones, s.VolumeSize)
+		workloadProviderOpts = getAzureOpts(workloadMachineType, zones, s.VolumeSize)
 	}
 
-	return createVMOpts, providerOpts, selectedArch, nil
+	return createVMOpts, providerOpts, workloadProviderOpts, selectedArch, nil
 }
 
 // Expiration is the lifetime of the cluster. It may be destroyed after
@@ -499,4 +522,12 @@ func (s *ClusterSpec) Expiration() time.Time {
 		l = 12 * time.Hour
 	}
 	return timeutil.Now().Add(l)
+}
+
+// TotalCPUs is the total amount of CPUs allocated for a cluster.
+func (s *ClusterSpec) TotalCPUs() int {
+	if !s.WorkloadNode {
+		return s.NodeCount * s.CPUs
+	}
+	return (s.NodeCount-1)*s.CPUs + s.WorkloadNodeCPUs
 }

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -39,9 +39,16 @@ func CPU(n int) Option {
 }
 
 // WorkloadNode indicates that the last node is a workload node.
+// Defaults to a VM with 4 CPUs if not specified by WorkloadNodeCPUs.
 func WorkloadNode() Option {
 	return func(spec *ClusterSpec) {
 		spec.WorkloadNode = true
+	}
+}
+
+func WorkloadNodeCPU(n int) Option {
+	return func(spec *ClusterSpec) {
+		spec.WorkloadNodeCPUs = n
 	}
 }
 

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -38,6 +38,13 @@ func CPU(n int) Option {
 	}
 }
 
+// WorkloadNode indicates that the last node is a workload node.
+func WorkloadNode() Option {
+	return func(spec *ClusterSpec) {
+		spec.WorkloadNode = true
+	}
+}
+
 // Mem requests nodes with low/standard/high ratio of memory per CPU.
 func Mem(level MemPerCPU) Option {
 	return func(spec *ClusterSpec) {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -876,7 +876,6 @@ func (r *testRunner) runWorker(
 				}
 
 				c.goCoverDir = t.GoCoverArtifactsDir()
-
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")
 

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -449,12 +450,12 @@ func TestNewCluster(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		createMock          func(ctx context.Context, l *logger.Logger, username string, numNodes int, createVMOpts vm.CreateOpts, providerOptsContainer vm.ProviderOptionsContainer) (retErr error)
+		createMock          func(ctx context.Context, l *logger.Logger, username string, opts ...*cloud.ClusterCreateOpts) (retErr error)
 		expectedCreateCalls int
 	}{
 		{
 			"Malformed Cluster Name Error",
-			func(ctx context.Context, l *logger.Logger, username string, numNodes int, createVMOpts vm.CreateOpts, providerOptsContainer vm.ProviderOptionsContainer) (retErr error) {
+			func(ctx context.Context, l *logger.Logger, username string, opts ...*cloud.ClusterCreateOpts) (retErr error) {
 				createCallsCounter++
 				return &roachprod.MalformedClusterNameError{}
 			},
@@ -462,7 +463,7 @@ func TestNewCluster(t *testing.T) {
 		},
 		{
 			"Cluster Already Exists Error",
-			func(ctx context.Context, l *logger.Logger, username string, numNodes int, createVMOpts vm.CreateOpts, providerOptsContainer vm.ProviderOptionsContainer) (retErr error) {
+			func(ctx context.Context, l *logger.Logger, username string, opts ...*cloud.ClusterCreateOpts) (retErr error) {
 				createCallsCounter++
 				return &roachprod.ClusterAlreadyExistsError{}
 			},

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -85,7 +85,6 @@ func registerKV(r registry.Registry) {
 	}
 	runKV := func(ctx context.Context, t test.Test, c cluster.Cluster, opts kvOptions) {
 		nodes := c.Spec().NodeCount - 1
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 		// Don't start a scheduled backup on this perf sensitive roachtest that reports to roachperf.
 		startOpts := option.NewStartOpts(option.NoBackupSchedule)
@@ -97,7 +96,7 @@ func registerKV(r registry.Registry) {
 		if opts.globalMVCCRangeTombstone {
 			settings.Env = append(settings.Env, "COCKROACH_GLOBAL_MVCC_RANGE_TOMBSTONE=true")
 		}
-		c.Start(ctx, t.L(), startOpts, settings, c.Range(1, nodes))
+		c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
@@ -124,7 +123,7 @@ func registerKV(r registry.Registry) {
 		}
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx, c.Range(1, nodes))
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(computeConcurrency(opts)))
 			splits := ""
@@ -178,7 +177,7 @@ func registerKV(r registry.Registry) {
 			) +
 				histograms + concurrency + splits + duration + readPercent +
 				batchSize + blockSize + sequential + envFlags + url
-			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			return nil
 		})
 		m.Wait()
@@ -316,7 +315,7 @@ func registerKV(r registry.Registry) {
 		if opts.encryption {
 			encryption = registry.EncryptionAlwaysEnabled
 		}
-		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
+		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.WorkloadNode(), spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
 
 		var clouds registry.CloudSet
 		tags := make(map[string]struct{})
@@ -514,6 +513,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.WorkloadNode())
 
 			t.Status("starting cluster")
 			// If the test ever fails, the person who investigates the
@@ -959,7 +959,7 @@ func registerKVRestartImpact(r registry.Registry) {
 		Suites:           registry.Suites(registry.Weekly),
 		Owner:            registry.OwnerAdmissionControl,
 		Timeout:          4 * time.Hour,
-		Cluster:          r.MakeClusterSpec(13, spec.CPU(8), spec.DisableLocalSSD()),
+		Cluster:          r.MakeClusterSpec(13, spec.WorkloadNode(), spec.CPU(8), spec.DisableLocalSSD()),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -156,7 +156,7 @@ func (p *workPool) selectTest(
 		smallestTestCPU := math.MaxInt64
 		smallestTestIdx := -1
 		for i, t := range p.mu.tests {
-			cpu := t.spec.Cluster.NodeCount * t.spec.Cluster.CPUs
+			cpu := t.spec.Cluster.TotalCPUs()
 			if cpu < smallestTestCPU {
 				smallestTestCPU = cpu
 				smallestTestIdx = i
@@ -189,7 +189,7 @@ func (p *workPool) selectTest(
 			runNum:          runNum,
 			canReuseCluster: false,
 		}
-		cpu := tc.spec.Cluster.NodeCount * tc.spec.Cluster.CPUs
+		cpu := tc.spec.Cluster.TotalCPUs()
 		return uint64(cpu), nil
 	})
 

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -312,31 +312,51 @@ func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 	return cloud, providerErr
 }
 
+type ClusterCreateOpts struct {
+	// Nodes indicates how many nodes in the cluster should be created with the
+	// respective CreateOpts and ProviderOpts.
+	Nodes                 int
+	CreateOpts            vm.CreateOpts
+	ProviderOptsContainer vm.ProviderOptionsContainer
+}
+
 // CreateCluster TODO(peter): document
-func CreateCluster(
-	l *logger.Logger,
-	nodes int,
-	opts vm.CreateOpts,
-	providerOptsContainer vm.ProviderOptionsContainer,
-) error {
-	providerCount := len(opts.VMProviders)
-	if providerCount == 0 {
-		return errors.New("no VMProviders configured")
+// opts is a slice of all node VM specs to be provisioned for the cluster. Generally,
+// non uniform VM specs are not supported for a CRDB cluster, but we often want to provision
+// an additional "workload node". This node often times does not need the same CPU count as
+// the rest of the cluster. i.e. it is overkill for a 3 node 32 CPU cluster to have a 32 CPU
+// workload node, but a 50 node 8 CPU cluster might find a 8 CPU workload node inadequate.
+func CreateCluster(l *logger.Logger, opts []*ClusterCreateOpts) error {
+	// Keep track of the total number of nodes created, as we append all cluster names
+	// with the node count.
+	var nodesCreated int
+	vmName := func(name string) string {
+		nodesCreated++
+		return vm.Name(name, nodesCreated)
+	}
+	for _, o := range opts {
+		providerCount := len(o.CreateOpts.VMProviders)
+		if providerCount == 0 {
+			return errors.New("no VMProviders configured")
+		}
+
+		// Allocate vm names over the configured providers
+		// N.B., nodeIdx starts at 1 as nodes are one-based, i.e. n1, n2, ...
+		vmLocations := map[string][]string{}
+		for nodeIdx, p := 1, 0; nodeIdx <= o.Nodes; nodeIdx++ {
+			pName := o.CreateOpts.VMProviders[p]
+			vmLocations[pName] = append(vmLocations[pName], vmName(o.CreateOpts.ClusterName))
+			p = (p + 1) % providerCount
+		}
+
+		if err := vm.ProvidersParallel(o.CreateOpts.VMProviders, func(p vm.Provider) error {
+			return p.Create(l, vmLocations[p.Name()], o.CreateOpts, o.ProviderOptsContainer[p.Name()])
+		}); err != nil {
+			return err
+		}
 	}
 
-	// Allocate vm names over the configured providers
-	vmLocations := map[string][]string{}
-	for i, p := 1, 0; i <= nodes; i++ {
-		pName := opts.VMProviders[p]
-		vmName := vm.Name(opts.ClusterName, i)
-		vmLocations[pName] = append(vmLocations[pName], vmName)
-
-		p = (p + 1) % providerCount
-	}
-
-	return vm.ProvidersParallel(opts.VMProviders, func(p vm.Provider) error {
-		return p.Create(l, vmLocations[p.Name()], opts, providerOptsContainer[p.Name()])
-	})
+	return nil
 }
 
 // GrowCluster adds new nodes to an existing cluster.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1541,18 +1541,17 @@ func RemoveLabels(l *logger.Logger, clusterName string, labels []string) error {
 
 // Create TODO
 func Create(
-	ctx context.Context,
-	l *logger.Logger,
-	username string,
-	numNodes int,
-	createVMOpts vm.CreateOpts,
-	providerOptsContainer vm.ProviderOptionsContainer,
+	ctx context.Context, l *logger.Logger, username string, opts ...*cloud.ClusterCreateOpts,
 ) (retErr error) {
+	var numNodes int
+	for _, o := range opts {
+		numNodes = numNodes + o.Nodes
+	}
 	if numNodes <= 0 || numNodes >= 1000 {
 		// Upper limit is just for safety.
 		return fmt.Errorf("number of nodes must be in [1..999]")
 	}
-	clusterName := createVMOpts.ClusterName
+	clusterName := opts[0].CreateOpts.ClusterName
 	if err := verifyClusterName(l, clusterName, username); err != nil {
 		return err
 	}
@@ -1599,23 +1598,27 @@ func Create(
 		}
 
 		// If the local cluster is being created, force the local Provider to be used
-		createVMOpts.VMProviders = []string{local.ProviderName}
+		for _, o := range opts {
+			o.CreateOpts.VMProviders = []string{local.ProviderName}
+		}
 	}
 
-	if createVMOpts.SSDOpts.FileSystem == vm.Zfs {
-		for _, provider := range createVMOpts.VMProviders {
-			// TODO(DarrylWong): support zfs on other providers, see: #123775.
-			// Once done, revisit all tests that set zfs to see if they can run on non GCE.
-			if !(provider == gce.ProviderName || provider == aws.ProviderName) {
-				return fmt.Errorf(
-					"creating a node with --filesystem=zfs is currently not supported in %q", provider,
-				)
+	for _, o := range opts {
+		if o.CreateOpts.SSDOpts.FileSystem == vm.Zfs {
+			for _, provider := range o.CreateOpts.VMProviders {
+				// TODO(DarrylWong): support zfs on other providers, see: #123775.
+				// Once done, revisit all tests that set zfs to see if they can run on non GCE.
+				if !(provider == gce.ProviderName || provider == aws.ProviderName) {
+					return fmt.Errorf(
+						"creating a node with --filesystem=zfs is currently not supported in %q", provider,
+					)
+				}
 			}
 		}
 	}
 
 	l.Printf("Creating cluster %s with %d nodes...", clusterName, numNodes)
-	if createErr := cloud.CreateCluster(l, numNodes, createVMOpts, providerOptsContainer); createErr != nil {
+	if createErr := cloud.CreateCluster(l, opts); createErr != nil {
 		return createErr
 	}
 


### PR DESCRIPTION
A common roachtest pattern is to spin up an additional workload node alongside the CRDB cluster. This workload node is often not as stressed as the rest of the cluster, and potentially giving a workload node 32 CPUs can be a waste of money and quota. On the other end, a large scale 50 node cluster might find that a single 8 CPU workload node is not enough.

This change allows for roachtests to specify custom CPU sizes for the workload node through the `spec.WorkloadNode` and `spec.WorkloadNodeCPUs` cluster specs.

This change also adds a very simple approach for automatically assigning workload nodes less CPU if not explicitly specified in the cluster spec. It checks if a workload node is in use (specified by `spec.WorkloadNode`) and if the cluster is small enough that a smaller CPU should be okay (set very conservatively at 3 CRDB nodes), then sets the workload node to 4 CPUs if applicable.

Release note: none
Epic: none
Fixes: none
Informs: https://github.com/cockroachdb/cockroach/issues/62302

------------------------------

Follow up work would be to go through all the tests and switch them over to use `spec.Workload`, but I wanted to see if my approach was even reasonable first.