### PR TITLE
ui: add dashboard graphs for L0 sstable metrics

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -231,6 +231,50 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="L0 SSTable Count"
+      sources={storeSources}
+      isKvGraph={true}
+      tenantSource={tenantSource}
+      tooltip={`The number of L0 SSTables in use for each store ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis label="sstables">
+        {nodeIDs.flatMap(nid => (
+          storeIDsForNode(storeIDsByNodeID, nid).map(sid => (
+            <Metric
+              key={`${nid}-${sid}`}
+              name="cr.store.storage.l0-num-files"
+              title={`${getNodeNameById(nid)},s${sid}`}
+              sources={[sid]}
+            />
+          ))
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="L0 SSTable Size"
+      sources={storeSources}
+      isKvGraph={true}
+      tenantSource={tenantSource}
+      tooltip={`The size of all L0 SSTables in use for each store ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis label="Size" units={AxisUnits.Bytes}>
+        {nodeIDs.flatMap(nid => (
+          storeIDsForNode(storeIDsByNodeID, nid).map(sid => (
+            <Metric
+              key={`${nid}-${sid}`}
+              name="cr.store.storage.l0-level-size"
+              title={`${getNodeNameById(nid)},s${sid}`}
+              sources={[sid]}
+            />
+          ))
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="File Descriptors"
       sources={nodeSources}
       isKvGraph={true}


### PR DESCRIPTION
The storage metrics dashboard already contains a graph for SSTable count, but there was no visibility into per-level LSM statistics. This change adds graphs for L0 SStable count and size which should help to indicate when a large number of L0 SStables aren't properly being compacted out to lower levels. These metrics are displayed on a per-store basis rather than being aggregated for each node in order to provide more granular observability of any compaction issues.

Epic: none
Fixes: #79531
Release note (ui change): Added two graphs to the storage metrics dashboard which display count and size of L0 SStables in Pebble. This provides increased visibility into L0 compaction issues.