### PR TITLE
kv: don't unquiesce on read-only requests

### DIFF
--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -141,9 +141,6 @@ func (r *Replica) SendWithWriteBytes(
 	startCPU := grunning.Time()
 	defer r.MeasureReqCPUNanos(startCPU)
 
-	// If the internal Raft group is quiesced, wake it and the leader.
-	r.maybeUnquiesce(ctx, true /* wakeLeader */, true /* mayCampaign */)
-
 	isReadOnly := ba.IsReadOnly()
 	if err := r.checkBatchRequest(ba, isReadOnly); err != nil {
 		return nil, nil, kvpb.NewError(err)


### PR DESCRIPTION
This commit fixes a mistake in #104657, where we switched a call on the request path from `maybeInitializeRaftGroup` to `maybeUnquiesce`. As a result, we were unquiescing ranges whenver they saw any read or write traffic. We need to unquiesce on writes, but not on reads.

This was probably not having much of an effect because the leader would usually evaluate this call and skip the "wake leader" and "may campaign" actions, but it would still start ticking until it decided to quiesce again, which is unnecessary.

Even though this was a regression, I don't intend to backport this patch because it feels risky and the regression seems mostly harmless in practice.

Epic: None
Release notes: None