### PR TITLE
sql,logical: attribute ingestion queries to "external" things

### DIFF
--- a/pkg/ccl/streamingccl/logical/BUILD.bazel
+++ b/pkg/ccl/streamingccl/logical/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",

--- a/pkg/ccl/streamingccl/logical/lww_row_processor.go
+++ b/pkg/ccl/streamingccl/logical/lww_row_processor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -121,6 +122,10 @@ func (lww *sqlLastWriteWinsRowProcessor) ProcessRow(
 	}
 }
 
+var attributeToUser = sessiondata.InternalExecutorOverride{
+	AttributeToUser: true,
+}
+
 func (lww *sqlLastWriteWinsRowProcessor) insertRow(
 	ctx context.Context, txn isql.Txn, row cdcevent.Row,
 ) error {
@@ -155,7 +160,7 @@ func (lww *sqlLastWriteWinsRowProcessor) insertRow(
 	if !ok {
 		return errors.Errorf("no pre-generated insert query for table %d column family %d", row.TableID, row.FamilyID)
 	}
-	if _, err := txn.ExecParsed(ctx, "replicated-insert", txn.KV(), insertQuery, datums...); err != nil {
+	if _, err := txn.ExecParsed(ctx, "replicated-insert", txn.KV(), attributeToUser, insertQuery, datums...); err != nil {
 		log.Warningf(ctx, "replicated insert failed (query: %s): %s", insertQuery.SQL, err.Error())
 		return err
 	}
@@ -176,7 +181,7 @@ func (lww *sqlLastWriteWinsRowProcessor) deleteRow(
 	datums = append(datums, &lww.scratch.ts)
 	lww.scratch.datums = datums[:0]
 	deleteQuery := lww.queryBuffer.deleteQueries[row.TableID]
-	if _, err := txn.ExecParsed(ctx, "replicated-delete", txn.KV(), deleteQuery, datums...); err != nil {
+	if _, err := txn.ExecParsed(ctx, "replicated-delete", txn.KV(), attributeToUser, deleteQuery, datums...); err != nil {
 		log.Warningf(ctx, "replicated delete failed (query: %s): %s", deleteQuery.SQL, err.Error())
 		return err
 	}

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -864,6 +864,7 @@ func (txn *wrappedInternalTxn) ExecParsed(
 	ctx context.Context,
 	opName string,
 	_ *kv.Txn,
+	o sessiondata.InternalExecutorOverride,
 	parsedStmt statements.Statement[tree.Statement],
 	params ...interface{},
 ) (int, error) {

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -164,14 +164,11 @@ type SQLServer struct {
 	tenantConnect     kvtenant.Connector
 	// sessionRegistry can be queried for info on running SQL sessions. It is
 	// shared between the sql.Server and the statusServer.
-	sessionRegistry        *sql.SessionRegistry
-	closedSessionCache     *sql.ClosedSessionCache
-	jobRegistry            *jobs.Registry
-	statsRefresher         *stats.Refresher
-	temporaryObjectCleaner *sql.TemporaryObjectCleaner
-	internalMemMetrics     sql.MemoryMetrics
-	// sqlMemMetrics are used to track memory usage of sql sessions.
-	sqlMemMetrics                  sql.MemoryMetrics
+	sessionRegistry                *sql.SessionRegistry
+	closedSessionCache             *sql.ClosedSessionCache
+	jobRegistry                    *jobs.Registry
+	statsRefresher                 *stats.Refresher
+	temporaryObjectCleaner         *sql.TemporaryObjectCleaner
 	stmtDiagnosticsRegistry        *stmtdiagnostics.Registry
 	sqlLivenessSessionID           sqlliveness.SessionID
 	sqlLivenessProvider            sqlliveness.Provider
@@ -1408,8 +1405,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		sqlInstanceDialer:              cfg.sqlInstanceDialer,
 		statsRefresher:                 statsRefresher,
 		temporaryObjectCleaner:         temporaryObjectCleaner,
-		internalMemMetrics:             internalMemMetrics,
-		sqlMemMetrics:                  sqlMemMetrics,
 		stmtDiagnosticsRegistry:        stmtDiagnosticsRegistry,
 		sqlLivenessProvider:            cfg.sqlLivenessProvider,
 		sqlInstanceStorage:             cfg.sqlInstanceStorage,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -832,7 +832,7 @@ func (s *Server) SetupConn(
 		clientComm,
 		memMetrics,
 		&s.Metrics,
-		s.sqlStats.GetApplicationStats(sd.ApplicationName, false /* internal */),
+		s.sqlStats.GetApplicationStats(sd.ApplicationName),
 		sessionID,
 		false, /* fromOuterTxn */
 		nil,   /* postSetupFn */
@@ -1150,7 +1150,7 @@ func (s *Server) newConnExecutor(
 	)
 	ex.dataMutatorIterator.onApplicationNameChange = func(newName string) {
 		ex.applicationName.Store(newName)
-		ex.applicationStats = ex.server.sqlStats.GetApplicationStats(newName, false /* internal */)
+		ex.applicationStats = ex.server.sqlStats.GetApplicationStats(newName)
 	}
 
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionInit, timeutil.Now())

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -279,7 +279,7 @@ func (ie *InternalExecutor) initConnEx(
 	}
 	clientComm.rowsAffectedState.numRewindsLimit = ieRowsAffectedRetryLimit.Get(&ie.s.cfg.Settings.SV)
 
-	applicationStats := ie.s.sqlStats.GetApplicationStats(sd.ApplicationName, true /* internal */)
+	applicationStats := ie.s.sqlStats.GetApplicationStats(sd.ApplicationName)
 	sds := sessiondata.NewStack(sd)
 	defaults := SessionDefaults(map[string]string{
 		"application_name": sd.ApplicationName,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -220,8 +220,9 @@ func (ie *InternalExecutor) runWithEx(
 	wg *sync.WaitGroup,
 	syncCallback func([]*streamingCommandResult),
 	errCallback func(error),
+	attributeToUser bool,
 ) error {
-	ex, err := ie.initConnEx(ctx, txn, w, mode, sd, stmtBuf, syncCallback)
+	ex, err := ie.initConnEx(ctx, txn, w, mode, sd, stmtBuf, syncCallback, attributeToUser)
 	if err != nil {
 		return err
 	}
@@ -266,6 +267,7 @@ func (ie *InternalExecutor) initConnEx(
 	sd *sessiondata.SessionData,
 	stmtBuf *StmtBuf,
 	syncCallback func([]*streamingCommandResult),
+	attributeToUser bool,
 ) (*connExecutor, error) {
 	clientComm := &internalClientComm{
 		w:    w,
@@ -296,13 +298,23 @@ func (ie *InternalExecutor) initConnEx(
 				ex.extraTxnState.shouldResetSyntheticDescriptors = true
 			}
 		}
+		srvMetrics := &ie.s.InternalMetrics
+		if attributeToUser {
+			srvMetrics = &ie.s.Metrics
+		}
 		ex = ie.s.newConnExecutor(
 			ctx,
 			sdMutIterator,
 			stmtBuf,
 			clientComm,
+			// memMetrics is only about attributing memory monitoring to the
+			// right metric, so we choose to ignore the 'attributeToUser'
+			// boolean and use "internal memory metrics" unconditionally. (We
+			// will be using the internal sql executor as the parent during
+			// query execution, using different metrics here could lead to
+			// confusion.)
 			ie.memMetrics,
-			&ie.s.InternalMetrics,
+			srvMetrics,
 			applicationStats,
 			ie.s.cfg.GenerateID(),
 			false, /* fromOuterTxn */
@@ -315,6 +327,7 @@ func (ie *InternalExecutor) initConnEx(
 			stmtBuf,
 			clientComm,
 			applicationStats,
+			attributeToUser,
 		)
 		if err != nil {
 			return nil, err
@@ -346,6 +359,7 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 	stmtBuf *StmtBuf,
 	clientComm ClientComm,
 	applicationStats sqlstats.ApplicationStats,
+	attributeToUser bool,
 ) (ex *connExecutor, _ error) {
 
 	// If the internal executor has injected synthetic descriptors, we will
@@ -372,13 +386,22 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		}
 	}
 
+	srvMetrics := &ie.s.InternalMetrics
+	if attributeToUser {
+		srvMetrics = &ie.s.Metrics
+	}
 	ex = ie.s.newConnExecutor(
 		ctx,
 		sdMutIterator,
 		stmtBuf,
 		clientComm,
+		// memMetrics is only about attributing memory monitoring to the right
+		// metric, so we choose to ignore the 'attributeToUser' boolean and use
+		// "internal memory metrics" unconditionally. (We will be using the
+		// internal sql executor as the parent during query execution, using
+		// different metrics here could lead to confusion.)
 		ie.memMetrics,
-		&ie.s.InternalMetrics,
+		srvMetrics,
 		applicationStats,
 		ie.s.cfg.GenerateID(),
 		ie.extraTxnState != nil, /* fromOuterTxn */
@@ -780,10 +803,11 @@ func (ie *InternalExecutor) ExecParsed(
 	ctx context.Context,
 	opName string,
 	txn *kv.Txn,
+	o sessiondata.InternalExecutorOverride,
 	parsedStmt statements.Statement[tree.Statement],
 	qargs ...interface{},
 ) (int, error) {
-	return ie.execIEStmt(ctx, opName, txn, ie.maybeNodeSessionDataOverride(opName), ieStmt{parsed: parsedStmt}, qargs...)
+	return ie.execIEStmt(ctx, opName, txn, o, ieStmt{parsed: parsedStmt}, qargs...)
 }
 
 type ieStmt struct {
@@ -965,6 +989,14 @@ func GetInternalOpName(ctx context.Context) (opName string, ok bool) {
 	return tag.ValueStr(), true
 }
 
+var attributeToUserEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.internal_executor.attribute_to_user.enabled",
+	"controls whether internally-executed queries with the AttributeToUser "+
+		"override should actually be attributed to user or not",
+	true,
+)
+
 // execInternal is the main entry point for executing a statement via the
 // InternalExecutor. From the high level it does the following:
 // - parses the statement as well as its arguments
@@ -1100,6 +1132,7 @@ func (ie *InternalExecutor) execInternal(
 
 	applyInternalExecutorSessionExceptions(sd)
 	applyOverrides(sessionDataOverride, sd)
+	attributeToUser := sessionDataOverride.AttributeToUser && attributeToUserEnabled.Get(&ie.s.cfg.Settings.SV)
 	if !rw.async() && (txn != nil && txn.Type() == kv.RootTxn) {
 		// If the "outer" query uses the RootTxn and the sync result channel is
 		// requested, then we must disable both DistSQL and Streamer to ensure
@@ -1125,6 +1158,13 @@ func (ie *InternalExecutor) execInternal(
 	} else if !strings.HasPrefix(sd.ApplicationName, catconstants.InternalAppNamePrefix) {
 		// If this is already an "internal app", don't put more prefix.
 		sd.ApplicationName = catconstants.DelegatedAppNamePrefix + sd.ApplicationName
+	}
+	if attributeToUser {
+		// If this query should be attributable to user, then we discard
+		// previous app name heuristics and use a separate prefix. This is
+		// needed since we hard-code filters that exclude queries with '$
+		// internal' in their app names on the UI.
+		sd.ApplicationName = catconstants.AttributedToUserInternalAppNamePrefix + "-" + opName
 	}
 	// If the caller has injected a mapping to temp schemas, install it, and
 	// leave it installed for the rest of the transaction.
@@ -1207,7 +1247,7 @@ func (ie *InternalExecutor) execInternal(
 	errCallback := func(err error) {
 		_ = rw.addResult(ctx, ieIteratorResult{err: err})
 	}
-	err = ie.runWithEx(ctx, txn, rw, mode, sd, stmtBuf, &wg, syncCallback, errCallback)
+	err = ie.runWithEx(ctx, txn, rw, mode, sd, stmtBuf, &wg, syncCallback, errCallback, attributeToUser)
 	if err != nil {
 		return nil, err
 	}
@@ -1345,7 +1385,10 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 	rw := newAsyncIEResultChannel()
 	stmtBuf := NewStmtBuf()
 
-	ex, err := ie.initConnEx(ctx, ie.extraTxnState.txn, rw, defaultIEExecutionMode, sd, stmtBuf, nil /* syncCallback */)
+	ex, err := ie.initConnEx(
+		ctx, ie.extraTxnState.txn, rw, defaultIEExecutionMode, sd, stmtBuf,
+		nil /* syncCallback */, false, /* attributeToUser */
+	)
 	if err != nil {
 		return errors.Wrap(err, "cannot create conn executor to commit txn")
 	}

--- a/pkg/sql/isql/isql_db.go
+++ b/pkg/sql/isql/isql_db.go
@@ -98,6 +98,7 @@ type Executor interface {
 		ctx context.Context,
 		opName string,
 		txn *kv.Txn,
+		o sessiondata.InternalExecutorOverride,
 		parsedStmt statements.Statement[tree.Statement],
 		qargs ...interface{},
 	) (int, error)

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -23,6 +23,11 @@ const ReportableAppNamePrefix = "$ "
 // names are used to classify queries in different categories.
 const InternalAppNamePrefix = ReportableAppNamePrefix + "internal"
 
+// AttributedToUserInternalAppNamePrefix indicates that the application name
+// identifies an internally-executed query that should be attributed to the
+// user.
+const AttributedToUserInternalAppNamePrefix = ReportableAppNamePrefix + "public-internal"
+
 // DelegatedAppNamePrefix is added to a regular client application
 // name for SQL queries that are ran internally on behalf of other SQL
 // queries inside that application. This is not the same as

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -56,6 +56,15 @@ type InternalExecutorOverride struct {
 	// overrides are performed on the best-effort basis - see SessionData.Update
 	// for more details.
 	MultiOverride string
+	// AttributeToUser notifies the internal executor that the query is executed
+	// directly on the user's behalf, and as such it should be included into
+	// "external" / user-owned observability features (like SQL Activity page
+	// and number of statements executed).
+	//
+	// Note that unlike other fields in this struct, this boolean doesn't
+	// directly result in modification of the SessionData. Instead, it changes
+	// the construction of the connExecutor used for the query.
+	AttributeToUser bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -396,7 +396,7 @@ func BenchmarkSqlStatsMaxFlushTime(b *testing.B) {
 
 	// Fills the in-memory stats for the 'bench' application until the fingerprint limit is reached.
 	fillBenchAppMemStats := func() {
-		appContainer := sqlStats.SQLStats.GetApplicationStats("bench", false)
+		appContainer := sqlStats.SQLStats.GetApplicationStats("bench")
 		mockStmtValue := sqlstats.RecordedStmtStats{}
 		for i := int64(1); i <= stmtFingerprintLimit; i++ {
 			stmtKey := appstatspb.StatementStatisticsKey{

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -91,7 +91,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 	server := cluster.Server(0 /* idx */).ApplicationLayer()
 	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
 
-	appStats := sqlStats.GetApplicationStats("app1", false)
+	appStats := sqlStats.GetApplicationStats("app1")
 
 	// Open two connections so that we can run statements without messing up
 	// the SQL stats.

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -783,7 +783,7 @@ func TestSQLStatsPlanSampling(t *testing.T) {
 	sqlRun.Exec(t, "SET application_name = $1", appName)
 
 	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
-	appStats := sqlStats.GetApplicationStats(appName, false)
+	appStats := sqlStats.GetApplicationStats(appName)
 
 	sqlRun.Exec(t, `SET CLUSTER SETTING sql.metrics.statement_details.plan_collection.enabled = true;`)
 	sqlRun.Exec(t, `SET CLUSTER SETTING sql.txn_stats.sample_rate = 0;`)

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -278,10 +278,3 @@ func (s *PersistedSQLStats) jitterInterval(interval time.Duration) time.Duration
 	jitteredInterval := time.Duration(frac * float64(interval.Nanoseconds()))
 	return jitteredInterval
 }
-
-// GetApplicationStats implements sqlstats.Provider interface.
-func (s *PersistedSQLStats) GetApplicationStats(
-	appName string, internal bool,
-) sqlstats.ApplicationStats {
-	return s.SQLStats.GetApplicationStats(appName, internal)
-}

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -247,7 +247,7 @@ func verifyInMemoryStmtFingerprints(
 	foundTxns := make(map[string]struct{})
 	stmtFingerprintIDToQueries := make(map[appstatspb.StmtFingerprintID]string)
 	require.NoError(t,
-		sqlStats.GetApplicationStats(appName, false).IterateStatementStats(
+		sqlStats.GetApplicationStats(appName).IterateStatementStats(
 			context.Background(),
 			sqlstats.IteratorOptions{},
 			func(ctx context.Context, statistics *appstatspb.CollectedStatementStatistics) error {

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -121,7 +121,6 @@ func (s *SQLStats) getStatsForApplication(appName string) *ssmemstorage.Containe
 		s.mu.mon,
 		appName,
 		s.knobs,
-		s.insights(false /* internal */),
 		s.latencyInformation,
 	)
 	s.mu.apps[appName] = a

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -460,7 +460,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		insightsProvider.LatencyInformation(),
 	)
 
-	appStats := sqlStats.GetApplicationStats("" /* appName */, false /* internal */)
+	appStats := sqlStats.GetApplicationStats("" /* appName */)
 	statsCollector := sslocal.NewStatsCollector(
 		st,
 		appStats,
@@ -588,7 +588,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			nil,
 			insightsProvider.LatencyInformation(),
 		)
-		appStats := sqlStats.GetApplicationStats("" /* appName */, false /* internal */)
+		appStats := sqlStats.GetApplicationStats("" /* appName */)
 		statsCollector := sslocal.NewStatsCollector(
 			st,
 			appStats,

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -100,7 +100,7 @@ func (s *SQLStats) Start(ctx context.Context, stopper *stop.Stopper) {
 }
 
 // GetApplicationStats implements sqlstats.Provider interface.
-func (s *SQLStats) GetApplicationStats(appName string, internal bool) sqlstats.ApplicationStats {
+func (s *SQLStats) GetApplicationStats(appName string) sqlstats.ApplicationStats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if a, ok := s.mu.apps[appName]; ok {
@@ -112,7 +112,6 @@ func (s *SQLStats) GetApplicationStats(appName string, internal bool) sqlstats.A
 		s.mu.mon,
 		appName,
 		s.knobs,
-		s.insights(internal),
 		s.latencyInformation,
 	)
 	s.mu.apps[appName] = a
@@ -160,7 +159,7 @@ func (s *SQLStats) ConsumeStats(
 	}
 	apps := s.getAppNames(false)
 	for _, app := range apps {
-		container := s.GetApplicationStats(app, true).(*ssmemstorage.Container)
+		container := s.GetApplicationStats(app).(*ssmemstorage.Container)
 		if err := s.MaybeDumpStatsToLog(ctx, app, container, s.flushTarget); err != nil {
 			log.Warningf(ctx, "failed to dump stats to log, %s", err.Error())
 		}

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -97,7 +97,6 @@ type Container struct {
 	mon       *mon.BytesMonitor
 
 	knobs              *sqlstats.TestingKnobs
-	insights           insights.Writer
 	latencyInformation insights.LatencyInformation
 }
 
@@ -110,7 +109,6 @@ func New(
 	mon *mon.BytesMonitor,
 	appName string,
 	knobs *sqlstats.TestingKnobs,
-	insightsWriter insights.Writer,
 	latencyInformation insights.LatencyInformation,
 ) *Container {
 	s := &Container{
@@ -118,7 +116,6 @@ func New(
 		appName:            appName,
 		mon:                mon,
 		knobs:              knobs,
-		insights:           insightsWriter,
 		latencyInformation: latencyInformation,
 		uniqueServerCount:  uniqueServerCount,
 	}
@@ -220,7 +217,6 @@ func NewTempContainerFromExistingStmtStats(
 		nil, /* mon */
 		appName,
 		nil, /* knobs */
-		nil, /* insights */
 		nil, /*latencyInformation */
 	)
 
@@ -294,7 +290,6 @@ func NewTempContainerFromExistingTxnStats(
 		nil, /* mon */
 		appName,
 		nil, /* knobs */
-		nil, /* insights */
 		nil, /* latencyInformation */
 	)
 
@@ -330,7 +325,6 @@ func (s *Container) NewApplicationStatsWithInheritedOptions() sqlstats.Applicati
 		s.mon,
 		s.appName,
 		s.knobs,
-		s.insights,
 		s.latencyInformation,
 	)
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -48,7 +48,6 @@ func TestRecordStatement(t *testing.T) {
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			knobs,
-			nil, /* insightsWriter */
 			insights.New(settings, insights.NewMetrics()).LatencyInformation(),
 		)
 		// Record a statement, ensure no insights are generated.
@@ -83,7 +82,6 @@ func TestRecordTransaction(t *testing.T) {
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			knobs,
-			nil, /* insightsWriter */
 			insights.New(settings, insights.NewMetrics()).LatencyInformation(),
 		)
 		// Record a transaction, ensure no insights are generated.

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -142,7 +142,7 @@ type Storage interface {
 
 	// GetApplicationStats returns an ApplicationStats instance for the given
 	// application name.
-	GetApplicationStats(appName string, internal bool) ApplicationStats
+	GetApplicationStats(appName string) ApplicationStats
 
 	// Reset resets all the statistics stored in-memory in the current Storage.
 	Reset(context.Context) error


### PR DESCRIPTION
**sqlstats: remove unused insights writer field**

This allows us to remove redundant `internal` boolean parameter in GetApplicationStats constructor.

**sql,logical: attribute ingestion queries to "external" things**

This commit introduces a way for the internally executed queries to be attributed to the user which is needed so that "external" observability would pick it up. In particular, we now can specify an InternalExecutorOverride option so that when instantiating the connExecutor we set the application name prefix to `$ public-internal` as well as we use the "server" metrics. As a result, such attributed internal queries will show up on the SQL Activity page as well as will be included into metrics like number of queries executed whenever this option is used. Note that these queries will keep contributing to "internal" things for less important stuff (like memory monitor metrics as well as txn guardrail metrics). No changes to the underlying internal executor machinery are applied so this _should_ be a pretty safe change.

The only hiccup I can think of right now is whether the hard-coded app name prefix that doesn't start with `$ internal` (or `$$` for "delegated" internal queries) can break some assumptions elsewhere.

This option is now utilized to attribute INSERT and DELETE queries of the ingestion pipeline of the LDR to the user. Newly added cluster setting `sql.internal_executor.attribute_to_user.enabled` can be used to disable this option.

Epic: CRDB-38996

Release note: None