### PR TITLE
operations: improve node-kill error formatting

### DIFF
--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -33,14 +33,22 @@ func (cl *cleanupNodeKill) Cleanup(ctx context.Context, o operation.Operation, c
 	db, err := c.ConnE(ctx, o.L(), cl.nodes[0])
 	if err != nil {
 		err = c.RunE(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
-		o.Status(fmt.Sprintf("restarted node with error %s", err))
+		if err != nil {
+			o.Status(fmt.Sprintf("restarted node with error %s", err))
+		} else {
+			o.Status("restarted node with no error")
+		}
 		return
 	}
 	defer db.Close()
 	_, err = db.Query("SELECT 1")
 	if err != nil {
 		err = c.RunE(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
-		o.Status(fmt.Sprintf("restarted node with error %s", err))
+		if err != nil {
+			o.Status(fmt.Sprintf("restarted node with error %s", err))
+		} else {
+			o.Status("restarted node with no error")
+		}
 	}
 }
 


### PR DESCRIPTION
Previously, if the error was nil, we'd try to %s format an error of type nil, which would look worse (`%s<nil>`) . This change manually prints out nil if the error value is nil from restarting the node in the node-kill operation.

Epic: none

Release note: None