### PR TITLE
settings: make RegisterEnumSetting generic

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -359,9 +359,9 @@ var RangeDistributionStrategy = settings.RegisterEnumSetting(
 		"will not override locality restrictions",
 	metamorphic.ConstantWithTestChoice("default_range_distribution_strategy",
 		"default", "balanced_simple").(string),
-	map[int64]string{
-		int64(defaultDistribution):        "default",
-		int64(balancedSimpleDistribution): "balanced_simple",
+	map[rangeDistributionType]string{
+		defaultDistribution:        "default",
+		balancedSimpleDistribution: "balanced_simple",
 	},
 	settings.WithPublic)
 
@@ -415,8 +415,8 @@ func makePlan(
 			log.Infof(ctx, "spans returned by DistSQL: %v", spanPartitions)
 		}
 		switch {
-		case distMode == sql.LocalDistribution || rangeDistribution == int64(defaultDistribution):
-		case rangeDistribution == int64(balancedSimpleDistribution):
+		case distMode == sql.LocalDistribution || rangeDistribution == defaultDistribution:
+		case rangeDistribution == balancedSimpleDistribution:
 			log.Infof(ctx, "rebalancing ranges using balanced simple distribution")
 			sender := execCtx.ExecCfg().DB.NonTransactionalSender()
 			distSender := sender.(*kv.CrossRangeTxnWrapperSender).Wrapped().(*kvcoord.DistSender)

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -81,7 +81,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 		stats.AutomaticStatisticsClusterMode.Override(ctx, &s.SV, false)
 		stats.UseStatisticsOnSystemTables.Override(ctx, &s.SV, false)
 		stats.AutomaticStatisticsOnSystemTables.Override(ctx, &s.SV, false)
-		sql.DistSQLClusterExecMode.Override(ctx, &s.SV, int64(sessiondatapb.DistSQLOff))
+		sql.DistSQLClusterExecMode.Override(ctx, &s.SV, sessiondatapb.DistSQLOff)
 	}
 
 	reduceLeaseDurationAndReclaimLoopInterval := func(s *cluster.Settings) {

--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -310,7 +310,7 @@ func reloadConfigLocked(
 		successPath:    server.ServerHTTPBasePath.Get(&st.SV),
 
 		generateJWTAuthTokenEnabled:  OIDCGenerateClusterSSOTokenEnabled.Get(&st.SV),
-		generateJWTAuthTokenUseToken: tokenToUse(OIDCGenerateClusterSSOTokenUseToken.Get(&st.SV)),
+		generateJWTAuthTokenUseToken: OIDCGenerateClusterSSOTokenUseToken.Get(&st.SV),
 		generateJWTAuthTokenSQLHost:  OIDCGenerateClusterSSOTokenSQLHost.Get(&st.SV),
 		generateJWTAuthTokenSQLPort:  OIDCGenerateClusterSSOTokenSQLPort.Get(&st.SV),
 	}

--- a/pkg/ccl/oidcccl/settings.go
+++ b/pkg/ccl/oidcccl/settings.go
@@ -292,9 +292,9 @@ var OIDCGenerateClusterSSOTokenUseToken = settings.RegisterEnumSetting(
 	OIDCGenerateClusterSSOTokenUseTokenSettingName,
 	"selects which OIDC callback token to use for cluster SSO",
 	"id_token",
-	map[int64]string{
-		int64(useIdToken):     "id_token",
-		int64(useAccessToken): "access_token",
+	map[tokenToUse]string{
+		useIdToken:     "id_token",
+		useAccessToken: "access_token",
 	},
 )
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
@@ -71,10 +71,10 @@ var (
 		"kv.dist_sender.circuit_breakers.mode",
 		"set of ranges to trip circuit breakers for failing or stalled replicas",
 		"liveness range only",
-		map[int64]string{
-			int64(DistSenderCircuitBreakersNoRanges):          "no ranges",
-			int64(DistSenderCircuitBreakersLivenessRangeOnly): "liveness range only",
-			int64(DistSenderCircuitBreakersAllRanges):         "all ranges",
+		map[DistSenderCircuitBreakersMode]string{
+			DistSenderCircuitBreakersNoRanges:          "no ranges",
+			DistSenderCircuitBreakersLivenessRangeOnly: "liveness range only",
+			DistSenderCircuitBreakersAllRanges:         "all ranges",
 		},
 		settings.WithPublic,
 	)
@@ -433,7 +433,7 @@ func (d *DistSenderCircuitBreakers) ForReplica(
 }
 
 func (d *DistSenderCircuitBreakers) Mode() DistSenderCircuitBreakersMode {
-	return DistSenderCircuitBreakersMode(CircuitBreakersMode.Get(&d.settings.SV))
+	return CircuitBreakersMode.Get(&d.settings.SV)
 }
 
 // ReplicaCircuitBreaker is a circuit breaker for an individual replica.

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -51,7 +51,7 @@ func TestDistSenderReplicaStall(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, true)
 		kvcoord.CircuitBreakersMode.Override(
-			ctx, &st.SV, int64(kvcoord.DistSenderCircuitBreakersAllRanges),
+			ctx, &st.SV, kvcoord.DistSenderCircuitBreakersAllRanges,
 		)
 		kvcoord.CircuitBreakerCancellation.Override(ctx, &st.SV, true)
 		kvcoord.CircuitBreakerProbeThreshold.Override(ctx, &st.SV, time.Second)
@@ -146,7 +146,7 @@ func TestDistSenderCircuitBreakerModes(t *testing.T) {
 				// speed up the test by reducing various intervals and timeouts.
 				st := cluster.MakeTestingClusterSettings()
 				kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, true)
-				kvcoord.CircuitBreakersMode.Override(ctx, &st.SV, int64(mode))
+				kvcoord.CircuitBreakersMode.Override(ctx, &st.SV, mode)
 				kvcoord.CircuitBreakerCancellation.Override(ctx, &st.SV, true)
 				kvcoord.CircuitBreakerProbeThreshold.Override(ctx, &st.SV, time.Second)
 				kvcoord.CircuitBreakerProbeInterval.Override(ctx, &st.SV, time.Second)
@@ -278,7 +278,7 @@ func BenchmarkDistSenderCircuitBreakersForReplica(b *testing.B) {
 	ambientCtx := log.MakeTestingAmbientCtxWithNewTracer()
 	st := cluster.MakeTestingClusterSettings()
 	kvcoord.CircuitBreakersMode.Override(
-		ctx, &st.SV, int64(kvcoord.DistSenderCircuitBreakersAllRanges),
+		ctx, &st.SV, kvcoord.DistSenderCircuitBreakersAllRanges,
 	)
 
 	cbs := kvcoord.NewDistSenderCircuitBreakers(
@@ -346,13 +346,9 @@ func benchmarkCircuitBreakersTrack(
 	ambientCtx := log.MakeTestingAmbientCtxWithNewTracer()
 	st := cluster.MakeTestingClusterSettings()
 	if enable {
-		kvcoord.CircuitBreakersMode.Override(
-			ctx, &st.SV, int64(kvcoord.DistSenderCircuitBreakersAllRanges),
-		)
+		kvcoord.CircuitBreakersMode.Override(ctx, &st.SV, kvcoord.DistSenderCircuitBreakersAllRanges)
 	} else {
-		kvcoord.CircuitBreakersMode.Override(
-			ctx, &st.SV, int64(kvcoord.DistSenderCircuitBreakersNoRanges),
-		)
+		kvcoord.CircuitBreakersMode.Override(ctx, &st.SV, kvcoord.DistSenderCircuitBreakersNoRanges)
 	}
 	kvcoord.CircuitBreakerCancellation.Override(ctx, &st.SV, cancel)
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2246,8 +2246,8 @@ func (a *Allocator) DiskOptions() DiskCapacityOptions {
 // enforcement level.
 func (a *Allocator) IOOverloadOptions() IOOverloadOptions {
 	return IOOverloadOptions{
-		ReplicaEnforcementLevel:      IOOverloadEnforcementLevel(ReplicaIOOverloadThresholdEnforcement.Get(&a.st.SV)),
-		LeaseEnforcementLevel:        IOOverloadEnforcementLevel(LeaseIOOverloadThresholdEnforcement.Get(&a.st.SV)),
+		ReplicaEnforcementLevel:      ReplicaIOOverloadThresholdEnforcement.Get(&a.st.SV),
+		LeaseEnforcementLevel:        LeaseIOOverloadThresholdEnforcement.Get(&a.st.SV),
 		UseIOThresholdMax:            a.st.Version.IsActive(context.Background(), clusterversion.V24_1_GossipMaximumIOOverload),
 		ReplicaIOOverloadThreshold:   ReplicaIOOverloadThreshold.Get(&a.st.SV),
 		LeaseIOOverloadThreshold:     LeaseIOOverloadThreshold.Get(&a.st.SV),

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -180,10 +180,10 @@ var ReplicaIOOverloadThresholdEnforcement = settings.RegisterEnumSetting(
 		"targets of rebalance actions, `block_all` will exclude candidate stores "+
 		"from being targets of both allocation and rebalancing",
 	"block_rebalance_to",
-	map[int64]string{
-		int64(IOOverloadThresholdIgnore):         "ignore",
-		int64(IOOverloadThresholdBlockTransfers): "block_rebalance_to",
-		int64(IOOverloadThresholdBlockAll):       "block_all",
+	map[IOOverloadEnforcementLevel]string{
+		IOOverloadThresholdIgnore:         "ignore",
+		IOOverloadThresholdBlockTransfers: "block_rebalance_to",
+		IOOverloadThresholdBlockAll:       "block_all",
 	},
 )
 
@@ -227,10 +227,10 @@ var LeaseIOOverloadThresholdEnforcement = settings.RegisterEnumSetting(
 		"`shed`: a store will receive no new leases and shed existing leases to "+
 		"non io-overloaded stores, this is a superset of block_transfer_to",
 	"shed",
-	map[int64]string{
-		int64(IOOverloadThresholdIgnore):         "ignore",
-		int64(IOOverloadThresholdBlockTransfers): "block_transfer_to",
-		int64(IOOverloadThresholdShed):           "shed",
+	map[IOOverloadEnforcementLevel]string{
+		IOOverloadThresholdIgnore:         "ignore",
+		IOOverloadThresholdBlockTransfers: "block_transfer_to",
+		IOOverloadThresholdShed:           "shed",
 	},
 )
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -715,7 +715,7 @@ func TestAllocatorAllocateVoterIOOverloadCheck(t *testing.T) {
 			defer stopper.Stop(ctx)
 			sg := gossiputil.NewStoreGossiper(g)
 			sg.GossipStores(test.stores, t)
-			ReplicaIOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, int64(test.enforcement))
+			ReplicaIOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, test.enforcement)
 
 			// Allocate a voter where all replicas are alive (e.g. up-replicating a valid range).
 			add, _, err := a.AllocateVoter(
@@ -2126,7 +2126,7 @@ func TestAllocatorTransferLeaseTargetIOOverloadCheck(t *testing.T) {
 
 			sg := gossiputil.NewStoreGossiper(g)
 			sg.GossipStores(stores, t)
-			LeaseIOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, int64(tc.enforcement))
+			LeaseIOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, tc.enforcement)
 			LeaseIOOverloadThreshold.Override(ctx, &a.st.SV, threshold)
 			LeaseIOOverloadShedThreshold.Override(ctx, &a.st.SV, shedThreshold)
 
@@ -2959,7 +2959,7 @@ func TestAllocatorShouldTransferLeaseIOOverload(t *testing.T) {
 
 			sg := gossiputil.NewStoreGossiper(g)
 			sg.GossipStores(stores, t)
-			LeaseIOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, int64(tc.enforcement))
+			LeaseIOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, tc.enforcement)
 			LeaseIOOverloadThreshold.Override(ctx, &a.st.SV, threshold)
 			LeaseIOOverloadShedThreshold.Override(ctx, &a.st.SV, shedThreshold)
 

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4498,7 +4498,7 @@ func TestMergeQueue(t *testing.T) {
 
 		setSplitObjective := func(dim kvserver.LBRebalancingObjective) {
 			for _, s := range tc.Servers {
-				kvserver.LoadBasedRebalancingObjective.Override(ctx, &s.ClusterSettings().SV, int64(dim))
+				kvserver.LoadBasedRebalancingObjective.Override(ctx, &s.ClusterSettings().SV, dim)
 			}
 		}
 

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -775,7 +775,7 @@ func TestFlowControlRaftSnapshot(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
-	kvflowcontrol.Mode.Override(ctx, &st.SV, int64(kvflowcontrol.ApplyToAll))
+	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 
 	for i := 0; i < numServers; i++ {
 		stickyServerArgs[i] = base.TestServerArgs{
@@ -2338,7 +2338,7 @@ func (h *flowControlTestHelper) init() {
 	// SETTING`) interferes with the later activities in these tests.
 	for _, s := range h.tc.Servers {
 		kvflowcontrol.Enabled.Override(context.Background(), &s.ClusterSettings().SV, true)
-		kvflowcontrol.Mode.Override(context.Background(), &s.ClusterSettings().SV, int64(kvflowcontrol.ApplyToAll))
+		kvflowcontrol.Mode.Override(context.Background(), &s.ClusterSettings().SV, kvflowcontrol.ApplyToAll)
 	}
 }
 

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -148,10 +148,10 @@ var AdmissionPriority = settings.RegisterEnumSetting(
 	"kv.gc.admission_priority",
 	"the admission priority to use for mvcc gc work",
 	"bulk_normal_pri",
-	map[int64]string{
-		int64(admissionpb.BulkNormalPri): "bulk_normal_pri",
-		int64(admissionpb.NormalPri):     "normal_pri",
-		int64(admissionpb.UserHighPri):   "user_high_pri",
+	map[admissionpb.WorkPriority]string{
+		admissionpb.BulkNormalPri: "bulk_normal_pri",
+		admissionpb.NormalPri:     "normal_pri",
+		admissionpb.UserHighPri:   "user_high_pri",
 	},
 )
 

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
@@ -45,10 +45,7 @@ var Mode = settings.RegisterEnumSetting(
 		modeDict[ApplyToElastic], /* default value */
 		modeDict[ApplyToAll],     /* other value */
 	).(string),
-	map[int64]string{
-		int64(ApplyToElastic): modeDict[ApplyToElastic],
-		int64(ApplyToAll):     modeDict[ApplyToAll],
-	},
+	modeDict,
 )
 
 var modeDict = map[ModeT]string{

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
@@ -146,7 +146,7 @@ func New(registry *metric.Registry, settings *cluster.Settings, clock *hlc.Clock
 }
 
 func (c *Controller) mode() kvflowcontrol.ModeT {
-	return kvflowcontrol.ModeT(kvflowcontrol.Mode.Get(&c.settings.SV))
+	return kvflowcontrol.Mode.Get(&c.settings.SV)
 }
 
 // Admit is part of the kvflowcontrol.Controller interface. It blocks until

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_test.go
@@ -304,7 +304,7 @@ func TestBucketSignalingBug(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	regularTokensPerStream.Override(ctx, &st.SV, 10)
 	elasticTokensPerStream.Override(ctx, &st.SV, 5)
-	kvflowcontrol.Mode.Override(ctx, &st.SV, int64(kvflowcontrol.ApplyToAll))
+	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 	controller := New(
 		metric.NewRegistry(),
 		st,
@@ -413,7 +413,7 @@ func TestInspectController(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	elasticTokensPerStream.Override(ctx, &st.SV, 8<<20 /* 8 MiB */)
 	regularTokensPerStream.Override(ctx, &st.SV, 16<<20 /* 16 MiB */)
-	kvflowcontrol.Mode.Override(ctx, &st.SV, int64(kvflowcontrol.ApplyToAll))
+	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 	controller := New(metric.NewRegistry(), st, hlc.NewClockForTesting(nil))
 
 	// No streams connected -- inspect state should be empty.
@@ -474,7 +474,7 @@ func TestControllerLogging(t *testing.T) {
 	const numTokens = 1 << 20 /* 1 MiB */
 	elasticTokensPerStream.Override(ctx, &st.SV, numTokens)
 	regularTokensPerStream.Override(ctx, &st.SV, numTokens)
-	kvflowcontrol.Mode.Override(ctx, &st.SV, int64(kvflowcontrol.ApplyToAll))
+	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 	controller := New(metric.NewRegistry(), st, hlc.NewClockForTesting(nil))
 
 	numBlocked := 0

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle_test.go
@@ -89,7 +89,7 @@ func TestHandleAdmit(t *testing.T) {
 			clock := hlc.NewClockForTesting(nil)
 			st := cluster.MakeTestingClusterSettings()
 			kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
-			kvflowcontrol.Mode.Override(ctx, &st.SV, int64(kvflowcontrol.ApplyToAll))
+			kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 
 			controller := kvflowcontroller.New(registry, st, clock)
 			handle := kvflowhandle.New(
@@ -173,7 +173,7 @@ func TestFlowControlMode(t *testing.T) {
 			clock := hlc.NewClockForTesting(nil)
 			st := cluster.MakeTestingClusterSettings()
 			kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
-			kvflowcontrol.Mode.Override(ctx, &st.SV, int64(tc.mode))
+			kvflowcontrol.Mode.Override(ctx, &st.SV, tc.mode)
 
 			controller := kvflowcontroller.New(registry, st, clock)
 			handle := kvflowhandle.New(
@@ -253,7 +253,7 @@ func TestInspectHandle(t *testing.T) {
 	clock := hlc.NewClockForTesting(nil)
 	st := cluster.MakeTestingClusterSettings()
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
-	kvflowcontrol.Mode.Override(ctx, &st.SV, int64(kvflowcontrol.ApplyToAll))
+	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 
 	pos := func(d uint64) kvflowcontrolpb.RaftLogPosition {
 		return kvflowcontrolpb.RaftLogPosition{Term: 1, Index: d}

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -945,7 +944,7 @@ func (*mvccGCQueue) updateChan() <-chan time.Time {
 }
 
 func gcAdmissionHeader(st *cluster.Settings) kvpb.AdmissionHeader {
-	pri := admissionpb.WorkPriority(gc.AdmissionPriority.Get(&st.SV))
+	pri := gc.AdmissionPriority.Get(&st.SV)
 	return kvpb.AdmissionHeader{
 		// TODO(irfansharif): GC could be expected to be BulkNormalPri, so
 		// that it does not impact user-facing traffic when resources (e.g.

--- a/pkg/kv/kvserver/rebalance_objective.go
+++ b/pkg/kv/kvserver/rebalance_objective.go
@@ -94,13 +94,13 @@ const (
 
 // LoadBasedRebalancingObjectiveMap maps the LoadBasedRebalancingObjective enum
 // value to a string.
-var LoadBasedRebalancingObjectiveMap map[int64]string = map[int64]string{
-	int64(LBRebalancingQueries): "qps",
-	int64(LBRebalancingCPU):     "cpu",
+var LoadBasedRebalancingObjectiveMap = map[LBRebalancingObjective]string{
+	LBRebalancingQueries: "qps",
+	LBRebalancingCPU:     "cpu",
 }
 
 func (lbro LBRebalancingObjective) String() string {
-	return LoadBasedRebalancingObjectiveMap[int64(lbro)]
+	return LoadBasedRebalancingObjectiveMap[lbro]
 }
 
 // LoadBasedRebalancingObjective is a cluster setting that defines the load
@@ -263,7 +263,7 @@ func ResolveLBRebalancingObjective(
 ) LBRebalancingObjective {
 	set := LoadBasedRebalancingObjective.Get(&st.SV)
 	// Queries should always be supported, return early if set.
-	if set == int64(LBRebalancingQueries) {
+	if set == LBRebalancingQueries {
 		return LBRebalancingQueries
 	}
 	// When the cpu timekeeping utility is unsupported on this aarch, the cpu
@@ -290,5 +290,5 @@ func ResolveLBRebalancingObjective(
 	// The cluster is on a supported version and this local store is on aarch
 	// which supported the cpu timekeeping utility, return the cluster setting
 	// as is.
-	return LBRebalancingObjective(set)
+	return set
 }

--- a/pkg/kv/kvserver/rebalance_objective_test.go
+++ b/pkg/kv/kvserver/rebalance_objective_test.go
@@ -89,7 +89,7 @@ func TestLoadBasedRebalancingObjective(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 
 		gossipStoreDescProvider := testMakeProviderNotifier(allPositiveCPUMap)
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
@@ -97,7 +97,7 @@ func TestLoadBasedRebalancingObjective(t *testing.T) {
 
 		// Despite setting to CPU, only QPS should be returned since this aarch
 		// doesn't support grunning.
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
@@ -108,19 +108,19 @@ func TestLoadBasedRebalancingObjective(t *testing.T) {
 	t.Run("latest version supports all rebalance objectives", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		gossipStoreDescProvider := testMakeProviderNotifier(allPositiveCPUMap)
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
 		)
 
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		require.Equal(t,
 			LBRebalancingCPU,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
 		)
 
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
@@ -134,19 +134,19 @@ func TestLoadBasedRebalancingObjective(t *testing.T) {
 		// LBRebalancingQueries if the cluster setting is set to
 		// LBRebalancingCPU.
 		gossipStoreDescProvider := testMakeProviderNotifier(oneNegativeCPUMap)
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
 		)
 
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
 		)
 
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		require.Equal(t,
 			LBRebalancingQueries,
 			ResolveLBRebalancingObjective(ctx, st, gossipStoreDescProvider.GetStores()),
@@ -179,7 +179,7 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 	// one of these unsupported aarch, test this behavior only.
 	if !grunning.Supported() {
 		st := cluster.MakeTestingClusterSettings()
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		providerNotifier := testMakeProviderNotifier(allPositiveCPUMap)
 		manager, callbacks := makeTestManager(st, providerNotifier)
 
@@ -187,7 +187,7 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 
 		// Changing the objective to CPU should not work since it isn't
 		// supported on this aarch.
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		require.Equal(t, LBRebalancingQueries, manager.Objective())
 		require.Len(t, *callbacks, 0)
 
@@ -196,7 +196,7 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 
 	t.Run("latest version", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		providerNotifier := testMakeProviderNotifier(allPositiveCPUMap)
 		manager, callbacks := makeTestManager(st, providerNotifier)
 
@@ -206,14 +206,14 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 		require.Len(t, *callbacks, 0)
 
 		// Override the setting to be QPS, which will trigger a callback.
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingQueries))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingQueries)
 		require.Equal(t, LBRebalancingQueries, manager.Objective())
 		require.Len(t, *callbacks, 1)
 		require.Equal(t, LBRebalancingQueries, (*callbacks)[0])
 
 		// Override the setting again back to CPU, which will trigger a
 		// callback.
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		require.Equal(t, LBRebalancingCPU, manager.Objective())
 		require.Len(t, *callbacks, 2)
 		require.Equal(t, LBRebalancingCPU, (*callbacks)[1])
@@ -221,7 +221,7 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 
 	t.Run("latest version, remote node no cpu support", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
-		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
+		LoadBasedRebalancingObjective.Override(ctx, &st.SV, LBRebalancingCPU)
 		providerNotifier := testMakeProviderNotifier(allPositiveCPUMap)
 		manager, callbacks := makeTestManager(st, providerNotifier)
 

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -86,7 +86,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	for _, server := range tc.Servers {
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
-		kvserver.LoadBasedRebalancingMode.Override(ctx, &st.SV, int64(kvserver.LBRebalancingOff))
+		kvserver.LoadBasedRebalancingMode.Override(ctx, &st.SV, kvserver.LBRebalancingOff)
 	}
 
 	const newRanges = 10

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -76,10 +76,10 @@ var LoadBasedRebalancingMode = settings.RegisterEnumSetting(
 	"kv.allocator.load_based_rebalancing",
 	"whether to rebalance based on the distribution of load across stores",
 	"leases and replicas",
-	map[int64]string{
-		int64(LBRebalancingOff):               "off",
-		int64(LBRebalancingLeasesOnly):        "leases",
-		int64(LBRebalancingLeasesAndReplicas): "leases and replicas",
+	map[LBRebalancingMode]string{
+		LBRebalancingOff:               "off",
+		LBRebalancingLeasesOnly:        "leases",
+		LBRebalancingLeasesAndReplicas: "leases and replicas",
 	},
 	settings.WithPublic)
 
@@ -240,7 +240,7 @@ type RebalanceContext struct {
 // RebalanceMode returns the mode of the store rebalancer. See
 // LoadBasedRebalancingMode.
 func (sr *StoreRebalancer) RebalanceMode() LBRebalancingMode {
-	return LBRebalancingMode(LoadBasedRebalancingMode.Get(&sr.st.SV))
+	return LoadBasedRebalancingMode.Get(&sr.st.SV)
 }
 
 // RebalanceDimension returns the dimension the store rebalancer is balancing.

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -37,10 +37,10 @@ var authorizerMode = settings.RegisterEnumSetting(
 	"server.secondary_tenants.authorization.mode",
 	"configures how requests are authorized for secondary tenants",
 	"on",
-	map[int64]string{
-		int64(authorizerModeOn):       "on",
-		int64(authorizerModeAllowAll): "allow-all",
-		int64(authorizerModeV222):     "v222",
+	map[authorizerModeType]string{
+		authorizerModeOn:       "on",
+		authorizerModeAllowAll: "allow-all",
+		authorizerModeV222:     "v222",
 	},
 	settings.WithName("server.virtual_cluster_authorization.mode"),
 )
@@ -420,7 +420,7 @@ func (a *Authorizer) getMode(
 	ctx context.Context, tid roachpb.TenantID,
 ) (entry tenantcapabilities.Entry, selectedMode authorizerModeType) {
 	// We prioritize what the cluster setting tells us.
-	selectedMode = authorizerModeType(authorizerMode.Get(&a.settings.SV))
+	selectedMode = authorizerMode.Get(&a.settings.SV)
 
 	// If the mode is "on", we need to check the capabilities. Are they
 	// available?

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer_test.go
@@ -128,7 +128,7 @@ func TestDataDriven(t *testing.T) {
 				if !ok {
 					t.Fatalf("unknown authorizer mode %s", valStr)
 				}
-				authorizerMode.Override(ctx, &clusterSettings.SV, val)
+				authorizerMode.Override(ctx, &clusterSettings.SV, authorizerModeType(val))
 			case "is-exempt-from-rate-limiting":
 				return fmt.Sprintf("%t", authorizer.IsExemptFromRateLimiting(context.Background(), tenID))
 			default:

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -104,9 +104,9 @@ var PasswordHashMethod = settings.RegisterEnumSetting(
 	// previous-version nodes do not know anything about SCRAM. This is handled
 	// in the GetConfiguredPasswordHashMethod() function.
 	"scram-sha-256",
-	map[int64]string{
-		int64(password.HashBCrypt):      password.HashBCrypt.String(),
-		int64(password.HashSCRAMSHA256): password.HashSCRAMSHA256.String(),
+	map[password.HashMethod]string{
+		password.HashBCrypt:      password.HashBCrypt.String(),
+		password.HashSCRAMSHA256: password.HashSCRAMSHA256.String(),
 	},
 	settings.WithPublic)
 
@@ -130,7 +130,7 @@ func GetConfiguredPasswordCost(
 // GetConfiguredPasswordHashMethod returns the configured hash method
 // to use before storing passwords provided in cleartext from clients.
 func GetConfiguredPasswordHashMethod(sv *settings.Values) (method password.HashMethod) {
-	return password.HashMethod(PasswordHashMethod.Get(sv))
+	return PasswordHashMethod.Get(sv)
 }
 
 // AutoDetectPasswordHashes is the cluster setting that configures whether

--- a/pkg/security/password/password_test.go
+++ b/pkg/security/password/password_test.go
@@ -117,7 +117,7 @@ func TestSCRAMToBCryptConversion(t *testing.T) {
 	const cleartext = "hello"
 
 	ourDefault := int(security.BcryptCost.Get(&s.SV))
-	security.PasswordHashMethod.Override(ctx, &s.SV, int64(password.HashBCrypt))
+	security.PasswordHashMethod.Override(ctx, &s.SV, password.HashBCrypt)
 
 	// Start at MinCost+3, since the first 3 bcrypt costs all map to 4096.
 	// Don't iterate all the way to the max cost: the larger values

--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "@com_github_cockroachdb_redact//interfaces",
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//proto",
+        "@org_golang_x_exp//constraints",
     ],
 )
 

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -40,7 +40,7 @@ func (b *ByteSizeSetting) DefaultString() string {
 
 // DecodeToString decodes and renders an encoded value.
 func (b *ByteSizeSetting) DecodeToString(encoded string) (string, error) {
-	iv, err := b.DecodeValue(encoded)
+	iv, err := b.DecodeNumericValue(encoded)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -12,27 +12,60 @@ package settings
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+
+	"golang.org/x/exp/constraints"
 )
 
 // EnumSetting is a StringSetting that restricts the values to be one of the `enumValues`
-type EnumSetting struct {
-	IntSetting
-	enumValues map[int64]string
+type EnumSetting[T constraints.Integer] struct {
+	common
+	defaultValue T
+	// enumValues maps each valid value of T to a lowercase string.
+	enumValues map[T]string
 }
 
-var _ internalSetting = &EnumSetting{}
+// AnyEnumSetting is an interface that is used when the specific enum type T is
+// not known.
+type AnyEnumSetting interface {
+	internalSetting
+
+	// ParseEnum parses a string that is either a string in enumValues or an
+	// integer and returns the enum value as an int64 (and a boolean that
+	// indicates if it was parseable).
+	ParseEnum(raw string) (int64, bool)
+
+	// GetAvailableValuesAsHint returns the possible enum settings as a string that
+	// can be provided as an error hint to a user.
+	GetAvailableValuesAsHint() string
+}
+
+var _ AnyEnumSetting = &EnumSetting[int]{}
 
 // Typ returns the short (1 char) string denoting the type of setting.
-func (e *EnumSetting) Typ() string {
+func (e *EnumSetting[T]) Typ() string {
 	return "e"
 }
 
+// Get retrieves the int value in the setting.
+func (e *EnumSetting[T]) Get(sv *Values) T {
+	return T(sv.container.getInt64(e.slot))
+}
+
+// Override changes the setting without validation and also overrides the
+// default value.
+func (e *EnumSetting[T]) Override(ctx context.Context, sv *Values, v T) {
+	sv.setValueOrigin(ctx, e.slot, OriginOverride)
+	sv.setInt64(ctx, e.slot, int64(v))
+	sv.setDefaultOverride(e.slot, int64(v))
+}
+
 // String returns the enum's string value.
-func (e *EnumSetting) String(sv *Values) string {
+func (e *EnumSetting[T]) String(sv *Values) string {
 	enumID := e.Get(sv)
 	if str, ok := e.enumValues[enumID]; ok {
 		return str
@@ -41,28 +74,69 @@ func (e *EnumSetting) String(sv *Values) string {
 }
 
 // DefaultString returns the default value for the setting as a string.
-func (e *EnumSetting) DefaultString() string {
+func (e *EnumSetting[T]) DefaultString() string {
 	return e.enumValues[e.defaultValue]
 }
 
+func (e *EnumSetting[T]) Encoded(sv *Values) string {
+	return EncodeInt(int64(e.Get(sv)))
+}
+
+func (e *EnumSetting[T]) EncodedDefault() string {
+	return EncodeInt(int64(e.defaultValue))
+}
+
+func (e *EnumSetting[T]) setToDefault(ctx context.Context, sv *Values) {
+	// See if the default value was overridden.
+	if val := sv.getDefaultOverride(e.slot); val != nil {
+		// As per the semantics of override, these values don't go through
+		// validation.
+		sv.setInt64(ctx, e.slot, val.(int64))
+		return
+	}
+	sv.setInt64(ctx, e.slot, int64(e.defaultValue))
+}
+
+func (e *EnumSetting[T]) decodeAndSet(ctx context.Context, sv *Values, encoded string) error {
+	v, err := strconv.ParseInt(encoded, 10, 64)
+	if err != nil {
+		return err
+	}
+	sv.setInt64(ctx, e.slot, v)
+	return nil
+}
+
+func (e *EnumSetting[T]) decodeAndSetDefaultOverride(
+	ctx context.Context, sv *Values, encoded string,
+) error {
+	v, err := strconv.ParseInt(encoded, 10, 64)
+	if err != nil {
+		return err
+	}
+	sv.setDefaultOverride(e.slot, v)
+	return nil
+}
+
 // DecodeToString decodes and renders an encoded value.
-func (e *EnumSetting) DecodeToString(encoded string) (string, error) {
-	v, err := e.DecodeValue(encoded)
+func (e *EnumSetting[T]) DecodeToString(encoded string) (string, error) {
+	v, err := strconv.ParseInt(encoded, 10, 64)
 	if err != nil {
 		return "", err
 	}
-	if str, ok := e.enumValues[v]; ok {
+	if str, ok := e.enumValues[T(v)]; ok {
 		return str, nil
 	}
 	return encoded, nil
 }
 
-// ParseEnum returns the enum value, and a boolean that indicates if it was parseable.
-func (e *EnumSetting) ParseEnum(raw string) (int64, bool) {
+// ParseEnum parses a string that is either a string in enumValues or an integer
+// and returns the enum value as an int64 (and a boolean that indicates if it
+// was parseable).
+func (e *EnumSetting[T]) ParseEnum(raw string) (int64, bool) {
 	rawLower := strings.ToLower(raw)
 	for k, v := range e.enumValues {
 		if v == rawLower {
-			return k, true
+			return int64(k), true
 		}
 	}
 	// Attempt to parse the string as an integer since it isn't a valid enum string.
@@ -70,13 +144,13 @@ func (e *EnumSetting) ParseEnum(raw string) (int64, bool) {
 	if err != nil {
 		return 0, false
 	}
-	_, ok := e.enumValues[v]
+	_, ok := e.enumValues[T(v)]
 	return v, ok
 }
 
 // GetAvailableValuesAsHint returns the possible enum settings as a string that
 // can be provided as an error hint to a user.
-func (e *EnumSetting) GetAvailableValuesAsHint() string {
+func (e *EnumSetting[T]) GetAvailableValuesAsHint() string {
 	// First stabilize output by sorting by key.
 	valIdxs := make([]int, 0, len(e.enumValues))
 	for i := range e.enumValues {
@@ -87,14 +161,14 @@ func (e *EnumSetting) GetAvailableValuesAsHint() string {
 	// Now use those indices
 	vals := make([]string, 0, len(e.enumValues))
 	for _, enumIdx := range valIdxs {
-		vals = append(vals, fmt.Sprintf("%d: %s", enumIdx, e.enumValues[int64(enumIdx)]))
+		vals = append(vals, fmt.Sprintf("%d: %s", enumIdx, e.enumValues[T(enumIdx)]))
 	}
 	return "Available values: " + strings.Join(vals, ", ")
 }
 
 // GetAvailableValues returns the possible enum settings as a string
 // slice.
-func (e *EnumSetting) GetAvailableValues() []string {
+func (e *EnumSetting[T]) GetAvailableValues() []string {
 	// First stabilize output by sorting by key.
 	valIdxs := make([]int, 0, len(e.enumValues))
 	for i := range e.enumValues {
@@ -105,14 +179,14 @@ func (e *EnumSetting) GetAvailableValues() []string {
 	// Now use those indices
 	vals := make([]string, 0, len(e.enumValues))
 	for _, enumIdx := range valIdxs {
-		vals = append(vals, e.enumValues[int64(enumIdx)])
+		vals = append(vals, e.enumValues[T(enumIdx)])
 	}
 	return vals
 }
 
-func enumValuesToDesc(enumValues map[int64]string) string {
+func enumValuesToDesc[T constraints.Integer](enumValues map[T]string) string {
 	var buffer bytes.Buffer
-	values := make([]int64, 0, len(enumValues))
+	values := make([]T, 0, len(enumValues))
 	for k := range enumValues {
 		values = append(values, k)
 	}
@@ -130,32 +204,31 @@ func enumValuesToDesc(enumValues map[int64]string) string {
 }
 
 // RegisterEnumSetting defines a new setting with type int.
-func RegisterEnumSetting(
+func RegisterEnumSetting[T constraints.Integer](
 	class Class,
 	key InternalKey,
 	desc string,
 	defaultValue string,
-	enumValues map[int64]string,
+	enumValues map[T]string,
 	opts ...SettingOption,
-) *EnumSetting {
-	enumValuesLower := make(map[int64]string)
-	var i int64
-	var found bool
+) *EnumSetting[T] {
+	enumValuesLower := make(map[T]string, len(enumValues))
 	for k, v := range enumValues {
 		enumValuesLower[k] = strings.ToLower(v)
-		if v == defaultValue {
-			i = k
-			found = true
+	}
+
+	defaultVal := func() T {
+		for k, v := range enumValues {
+			if v == defaultValue {
+				return k
+			}
 		}
-	}
-
-	if !found {
 		panic(fmt.Sprintf("enum registered with default value %s not in map %s", defaultValue, enumValuesToDesc(enumValuesLower)))
-	}
+	}()
 
-	setting := &EnumSetting{
-		IntSetting: IntSetting{defaultValue: i},
-		enumValues: enumValuesLower,
+	setting := &EnumSetting[T]{
+		defaultValue: defaultVal,
+		enumValues:   enumValuesLower,
 	}
 
 	register(class, key, fmt.Sprintf("%s %s", desc, enumValuesToDesc(enumValues)), setting)

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -54,7 +54,7 @@ func (i *IntSetting) EncodedDefault() string {
 
 // DecodeToString decodes and renders an encoded value.
 func (i *IntSetting) DecodeToString(encoded string) (string, error) {
-	iv, err := i.DecodeValue(encoded)
+	iv, err := i.DecodeNumericValue(encoded)
 	if err != nil {
 		return "", err
 	}
@@ -62,7 +62,7 @@ func (i *IntSetting) DecodeToString(encoded string) (string, error) {
 }
 
 // DecodeValue decodes the value into an integer.
-func (i *IntSetting) DecodeValue(value string) (int64, error) {
+func (i *IntSetting) DecodeNumericValue(value string) (int64, error) {
 	return strconv.ParseInt(value, 10, 64)
 }
 

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -156,7 +156,7 @@ func TestAmbiguousCommit(t *testing.T) {
 		for _, server := range tc.Servers {
 			st := server.ClusterSettings()
 			st.Manual.Store(true)
-			sql.DistSQLClusterExecMode.Override(ctx, &st.SV, int64(sessiondatapb.DistSQLOff))
+			sql.DistSQLClusterExecMode.Override(ctx, &st.SV, sessiondatapb.DistSQLOff)
 		}
 
 		sqlDB := tc.Conns[0]

--- a/pkg/sql/catalog/lease/kv_writer_test.go
+++ b/pkg/sql/catalog/lease/kv_writer_test.go
@@ -82,7 +82,7 @@ func TestKVWriterMatchesIEWriter(t *testing.T) {
 			srv, sqlDB, kvDB := serverutils.StartServer(t, serverArgs)
 			defer srv.Stopper().Stop(ctx)
 			s := srv.ApplicationLayer()
-			LeaseEnableSessionBasedLeasing.Override(ctx, &s.ClusterSettings().SV, int64(mode))
+			LeaseEnableSessionBasedLeasing.Override(ctx, &s.ClusterSettings().SV, mode)
 
 			// Otherwise, we wouldn't get complete SSTs in our export under stress.
 			sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t)).Exec(

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -118,12 +118,12 @@ var LeaseEnableSessionBasedLeasing = settings.RegisterEnumSetting(
 	"sql.catalog.experimental_use_session_based_leasing",
 	"enables session based leasing for internal testing.",
 	"auto",
-	map[int64]string{
-		int64(SessionBasedLeasingAuto): "auto",
-		int64(SessionBasedLeasingOff):  "off",
-		int64(SessionBasedDualWrite):   "dual_write",
-		int64(SessionBasedDrain):       "drain",
-		int64(SessionBasedOnly):        "session",
+	map[SessionBasedLeasingMode]string{
+		SessionBasedLeasingAuto: "auto",
+		SessionBasedLeasingOff:  "off",
+		SessionBasedDualWrite:   "dual_write",
+		SessionBasedDrain:       "drain",
+		SessionBasedOnly:        "session",
 	},
 )
 
@@ -140,7 +140,7 @@ func readSessionBasedLeasingMode(
 ) SessionBasedLeasingMode {
 	// When leasing mode is set to OFF we will use the version to determine what
 	// mode we are executing in.
-	settingMode := SessionBasedLeasingMode(LeaseEnableSessionBasedLeasing.Get(&settings.SV))
+	settingMode := LeaseEnableSessionBasedLeasing.Get(&settings.SV)
 	if settingMode == SessionBasedLeasingAuto {
 		if settings.Version.IsActive(ctx, clusterversion.V24_1_SessionBasedLeasingOnly) {
 			return SessionBasedOnly

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1627,7 +1627,7 @@ func TestLeaseCountDetailCrossNode(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	// We are going to disable session based leasing as its easier to add a lot of
 	// fake leases into system.leases.
-	LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, int64(SessionBasedLeasingOff))
+	LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, SessionBasedLeasingOff)
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Settings:          st,
 		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -109,7 +109,7 @@ func newLeaseTest(tb testing.TB, params base.TestClusterArgs) *leaseTest {
 	if params.ServerArgs.Settings == nil {
 		params.ServerArgs.Settings = cluster.MakeTestingClusterSettings()
 	}
-	lease.LeaseEnableSessionBasedLeasing.Override(context.Background(), &params.ServerArgs.Settings.SV, int64(lease.SessionBasedDualWrite))
+	lease.LeaseEnableSessionBasedLeasing.Override(context.Background(), &params.ServerArgs.Settings.SV, lease.SessionBasedDualWrite)
 	c := serverutils.StartCluster(tb, 3, params)
 	s := c.Server(0).ApplicationLayer()
 	lt := &leaseTest{
@@ -2119,7 +2119,7 @@ func TestDeleteOrphanedLeases(testingT *testing.T) {
 	t := newLeaseTest(testingT, params)
 	// Force dual writing, so that entries exist within both versions of the
 	// leasing table to clean up.
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &t.server.ClusterSettings().SV, int64(lease.SessionBasedDualWrite))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &t.server.ClusterSettings().SV, lease.SessionBasedDualWrite)
 	defer t.cleanup()
 
 	if _, err := t.db.Exec(`
@@ -3009,7 +3009,7 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 	params.PartOfCluster = true
 	// Disable session based leasing, since a zero duration only
 	// applies to the expiry, and not the acquisition length.
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &params.Settings.SV, int64(lease.SessionBasedLeasingOff))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &params.Settings.SV, lease.SessionBasedLeasingOff)
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: func(ctx context.Context, req *kvpb.BatchRequest) *kvpb.Error {
 			filterMu.Lock()
@@ -3210,7 +3210,7 @@ func TestLeaseTxnDeadlineExtensionWithSession(t *testing.T) {
 	params.PartOfCluster = true
 	// Disable session based leasing, since a zero duration only
 	// applies to the expiry, and not the acquisition length.
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &params.Settings.SV, int64(lease.SessionBasedOnly))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &params.Settings.SV, lease.SessionBasedOnly)
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: func(ctx context.Context, req *kvpb.BatchRequest) *kvpb.Error {
 			filterMu.Lock()
@@ -3566,7 +3566,7 @@ func TestAmbiguousResultIsRetried(t *testing.T) {
 	})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &s.ClusterSettings().SV, int64(lease.SessionBasedLeasingOff))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &s.ClusterSettings().SV, lease.SessionBasedLeasingOff)
 	codec := s.Codec()
 
 	sqlutils.MakeSQLRunner(sqlDB).Exec(t, "SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
@@ -3819,7 +3819,7 @@ func TestDescriptorRemovedFromCacheWhenLeaseRenewalForThisDescriptorFails(t *tes
 	// Set lease duration to something small so that the periodical lease refresh is kicked off often where the testing
 	// knob will be invoked, and eventually the logic to remove unfound descriptor from cache will be triggered.
 	lease.LeaseDuration.Override(ctx, &s.ClusterSettings().SV, time.Second)
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &s.ClusterSettings().SV, int64(lease.SessionBasedLeasingOff))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &s.ClusterSettings().SV, lease.SessionBasedLeasingOff)
 	tdb = sqlutils.MakeSQLRunner(sqlDB)
 
 	sql := `
@@ -3867,7 +3867,7 @@ func TestSessionLeasingTable(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.Latest.Version(), clusterversion.MinSupported.Version(), false)
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, int64(lease.SessionBasedDualWrite))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, lease.SessionBasedDualWrite)
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Settings:          st,
 		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
@@ -3943,7 +3943,7 @@ func TestLongLeaseWaitMetrics(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.Latest.Version(), clusterversion.MinSupported.Version(), false)
 	// Force dual writes and instantly expire any leases.
-	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, int64(lease.SessionBasedDualWrite))
+	lease.LeaseEnableSessionBasedLeasing.Override(ctx, &st.SV, lease.SessionBasedDualWrite)
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Settings:          st,
 		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -510,11 +510,11 @@ var experimentalUseNewSchemaChanger = settings.RegisterEnumSetting(
 	"default value for use_declarative_schema_changer session setting;"+
 		"disables new schema changer by default",
 	"on",
-	map[int64]string{
-		int64(sessiondatapb.UseNewSchemaChangerOff):          "off",
-		int64(sessiondatapb.UseNewSchemaChangerOn):           "on",
-		int64(sessiondatapb.UseNewSchemaChangerUnsafe):       "unsafe",
-		int64(sessiondatapb.UseNewSchemaChangerUnsafeAlways): "unsafe_always",
+	map[sessiondatapb.NewSchemaChangerMode]string{
+		sessiondatapb.UseNewSchemaChangerOff:          "off",
+		sessiondatapb.UseNewSchemaChangerOn:           "on",
+		sessiondatapb.UseNewSchemaChangerUnsafe:       "unsafe",
+		sessiondatapb.UseNewSchemaChangerUnsafeAlways: "unsafe_always",
 	},
 	settings.WithPublic)
 
@@ -567,9 +567,9 @@ var experimentalDistSQLPlanningClusterMode = settings.RegisterEnumSetting(
 	ExperimentalDistSQLPlanningClusterSettingName,
 	"default experimental_distsql_planning mode; enables experimental opt-driven DistSQL planning",
 	"off",
-	map[int64]string{
-		int64(sessiondatapb.ExperimentalDistSQLPlanningOff): "off",
-		int64(sessiondatapb.ExperimentalDistSQLPlanningOn):  "on",
+	map[sessiondatapb.ExperimentalDistSQLPlanningMode]string{
+		sessiondatapb.ExperimentalDistSQLPlanningOff: "off",
+		sessiondatapb.ExperimentalDistSQLPlanningOn:  "on",
 	},
 	settings.WithPublic)
 
@@ -584,10 +584,11 @@ var VectorizeClusterMode = settings.RegisterEnumSetting(
 	VectorizeClusterSettingName,
 	"default vectorize mode",
 	"on",
-	func() map[int64]string {
-		m := make(map[int64]string, len(sessiondatapb.VectorizeExecMode_name))
+	func() map[sessiondatapb.VectorizeExecMode]string {
+		m := make(map[sessiondatapb.VectorizeExecMode]string, len(sessiondatapb.VectorizeExecMode_name))
 		for k := range sessiondatapb.VectorizeExecMode_name {
-			m[int64(k)] = sessiondatapb.VectorizeExecMode(k).String()
+			// Note that VectorizeExecMode.String() remaps "unset" to "on".
+			m[sessiondatapb.VectorizeExecMode(k)] = sessiondatapb.VectorizeExecMode(k).String()
 		}
 		return m
 	}(),
@@ -599,11 +600,11 @@ var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 	"sql.defaults.distsql",
 	"default distributed SQL execution mode",
 	"auto",
-	map[int64]string{
-		int64(sessiondatapb.DistSQLOff):    "off",
-		int64(sessiondatapb.DistSQLAuto):   "auto",
-		int64(sessiondatapb.DistSQLOn):     "on",
-		int64(sessiondatapb.DistSQLAlways): "always",
+	map[sessiondatapb.DistSQLExecMode]string{
+		sessiondatapb.DistSQLOff:    "off",
+		sessiondatapb.DistSQLAuto:   "auto",
+		sessiondatapb.DistSQLOn:     "on",
+		sessiondatapb.DistSQLAlways: "always",
 	},
 	settings.WithPublic)
 
@@ -614,13 +615,13 @@ var SerialNormalizationMode = settings.RegisterEnumSetting(
 	"sql.defaults.serial_normalization",
 	"default handling of SERIAL in table definitions",
 	"rowid",
-	map[int64]string{
-		int64(sessiondatapb.SerialUsesRowID):                  "rowid",
-		int64(sessiondatapb.SerialUsesUnorderedRowID):         "unordered_rowid",
-		int64(sessiondatapb.SerialUsesVirtualSequences):       "virtual_sequence",
-		int64(sessiondatapb.SerialUsesSQLSequences):           "sql_sequence",
-		int64(sessiondatapb.SerialUsesCachedSQLSequences):     "sql_sequence_cached",
-		int64(sessiondatapb.SerialUsesCachedNodeSQLSequences): "sql_sequence_cached_node",
+	map[sessiondatapb.SerialNormalizationMode]string{
+		sessiondatapb.SerialUsesRowID:                  "rowid",
+		sessiondatapb.SerialUsesUnorderedRowID:         "unordered_rowid",
+		sessiondatapb.SerialUsesVirtualSequences:       "virtual_sequence",
+		sessiondatapb.SerialUsesSQLSequences:           "sql_sequence",
+		sessiondatapb.SerialUsesCachedSQLSequences:     "sql_sequence_cached",
+		sessiondatapb.SerialUsesCachedNodeSQLSequences: "sql_sequence_cached_node",
 	},
 	settings.WithPublic)
 
@@ -636,14 +637,8 @@ var intervalStyle = settings.RegisterEnumSetting(
 	settings.ApplicationLevel,
 	"sql.defaults.intervalstyle",
 	"default value for IntervalStyle session setting",
-	strings.ToLower(duration.IntervalStyle_POSTGRES.String()),
-	func() map[int64]string {
-		ret := make(map[int64]string, len(duration.IntervalStyle_name))
-		for k, v := range duration.IntervalStyle_name {
-			ret[int64(k)] = strings.ToLower(v)
-		}
-		return ret
-	}(),
+	duration.IntervalStyle_POSTGRES.String(),
+	duration.IntervalStyle_name,
 	settings.WithPublic)
 
 // dateStyleEnumMap is not inlined in the RegisterEnumSetting call below because

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1404,7 +1404,7 @@ func (t *logicTest) newCluster(
 			// DistSQL if it's not disabled, and we have to disable it before
 			// the cluster started (so that we don't have any internal queries
 			// using DistSQL concurrently with updating the span resolver).
-			sql.DistSQLClusterExecMode.Override(context.Background(), &st.SV, int64(sessiondatapb.DistSQLOff))
+			sql.DistSQLClusterExecMode.Override(context.Background(), &st.SV, sessiondatapb.DistSQLOff)
 		}
 		return st
 	}

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -177,7 +177,7 @@ func (t *parallelTest) setup(ctx context.Context, spec *parTestSpec) {
 		mode := sessiondatapb.DistSQLOff
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
-		sql.DistSQLClusterExecMode.Override(ctx, &st.SV, int64(mode))
+		sql.DistSQLClusterExecMode.Override(ctx, &st.SV, mode)
 		// Disable automatic stats - they can interfere with the test shutdown.
 		stats.AutomaticStatisticsClusterMode.Override(ctx, &st.SV, false)
 		stats.UseStatisticsOnSystemTables.Override(ctx, &st.SV, false)

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -60,7 +60,7 @@ func createTestClusterArgs(ctx context.Context, numReplicas, numVoters int32) ba
 	zoneCfg.NumVoters = proto.Int32(numVoters)
 
 	clusterSettings := cluster.MakeTestingClusterSettings()
-	kvserver.LoadBasedRebalancingMode.Override(ctx, &clusterSettings.SV, int64(kvserver.LBRebalancingOff))
+	kvserver.LoadBasedRebalancingMode.Override(ctx, &clusterSettings.SV, kvserver.LBRebalancingOff)
 	return base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Settings: clusterSettings,

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -267,7 +267,8 @@ func (p *planner) getAndValidateTypedClusterSetting(
 				requiredType = types.Int
 			case *settings.FloatSetting:
 				requiredType = types.Float
-			case *settings.EnumSetting:
+			case settings.AnyEnumSetting:
+				// EnumSettings can be set with either strings or integers.
 				requiredType = types.Any
 			case *settings.DurationSetting:
 				requiredType = types.Interval
@@ -800,7 +801,7 @@ func toSettingString(
 			return settings.EncodeFloat(float64(*f)), nil
 		}
 		return "", errors.Errorf("cannot use %s %T value for float setting", d.ResolvedType(), d)
-	case *settings.EnumSetting:
+	case settings.AnyEnumSetting:
 		if i, intOK := d.(*tree.DInt); intOK {
 			v, ok := setting.ParseEnum(settings.EncodeInt(int64(*i)))
 			if ok {

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -218,7 +218,7 @@ func getShowClusterSettingPlanColumns(
 	switch val.(type) {
 	case *settings.IntSetting:
 		dType = types.Int
-	case *settings.StringSetting, *settings.ByteSizeSetting, *settings.VersionSetting, *settings.EnumSetting, *settings.ProtobufSetting:
+	case *settings.StringSetting, *settings.ByteSizeSetting, *settings.VersionSetting, settings.AnyEnumSetting, *settings.ProtobufSetting:
 		dType = types.String
 	case *settings.BoolSetting:
 		dType = types.Bool
@@ -256,7 +256,7 @@ func planShowClusterSetting(
 			if isNotNull {
 				switch s := val.(type) {
 				case *settings.IntSetting:
-					v, err := s.DecodeValue(encoded)
+					v, err := s.DecodeNumericValue(encoded)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -110,7 +110,7 @@ func testMonotonicInserts(t *testing.T, distSQLMode sessiondatapb.DistSQLExecMod
 	for _, server := range tc.Servers {
 		st := server.ApplicationLayer().ClusterSettings()
 		st.Manual.Store(true)
-		sql.DistSQLClusterExecMode.Override(ctx, &st.SV, int64(distSQLMode))
+		sql.DistSQLClusterExecMode.Override(ctx, &st.SV, distSQLMode)
 		// Let transactions push immediately to detect deadlocks. The test creates a
 		// large amount of contention and dependency cycles, and could take a long
 		// time to complete without this.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -159,10 +159,10 @@ var readaheadModeInformed = settings.RegisterEnumSetting(
 		"sys-readahead performs explicit prefetching via the readahead syscall; "+
 		"fadv-sequential lets the OS perform prefetching via fadvise(FADV_SEQUENTIAL)",
 	"fadv-sequential",
-	map[int64]string{
-		int64(objstorageprovider.NoReadahead):       "off",
-		int64(objstorageprovider.SysReadahead):      "sys-readahead",
-		int64(objstorageprovider.FadviseSequential): "fadv-sequential",
+	map[objstorageprovider.ReadaheadMode]string{
+		objstorageprovider.NoReadahead:       "off",
+		objstorageprovider.SysReadahead:      "sys-readahead",
+		objstorageprovider.FadviseSequential: "fadv-sequential",
 	},
 )
 
@@ -178,10 +178,10 @@ var readaheadModeSpeculative = settings.RegisterEnumSetting(
 		"fadv-sequential starts with explicit prefetching via the readahead syscall then automatically "+
 		"switches to OS-driven prefetching via fadvise(FADV_SEQUENTIAL)",
 	"fadv-sequential",
-	map[int64]string{
-		int64(objstorageprovider.NoReadahead):       "off",
-		int64(objstorageprovider.SysReadahead):      "sys-readahead",
-		int64(objstorageprovider.FadviseSequential): "fadv-sequential",
+	map[objstorageprovider.ReadaheadMode]string{
+		objstorageprovider.NoReadahead:       "off",
+		objstorageprovider.SysReadahead:      "sys-readahead",
+		objstorageprovider.FadviseSequential: "fadv-sequential",
 	},
 )
 
@@ -210,7 +210,7 @@ func (c compressionAlgorithm) String() string {
 // cluster setting with the given name, description and default value.
 func RegisterCompressionAlgorithmClusterSetting(
 	name settings.InternalKey, desc string, defaultValue compressionAlgorithm,
-) *settings.EnumSetting {
+) *settings.EnumSetting[compressionAlgorithm] {
 	return settings.RegisterEnumSetting(
 		// NB: We can't use settings.SystemOnly today because we may need to read the
 		// value from within a tenant building an sstable for AddSSTable.
@@ -219,9 +219,9 @@ func RegisterCompressionAlgorithmClusterSetting(
 		// will need to override it because they depend on a deterministic sstable
 		// size.
 		defaultValue.String(),
-		map[int64]string{
-			int64(compressionAlgorithmSnappy): compressionAlgorithmSnappy.String(),
-			int64(compressionAlgorithmZstd):   compressionAlgorithmZstd.String(),
+		map[compressionAlgorithm]string{
+			compressionAlgorithmSnappy: compressionAlgorithmSnappy.String(),
+			compressionAlgorithmZstd:   compressionAlgorithmZstd.String(),
 		},
 		settings.WithPublic,
 	)
@@ -265,12 +265,14 @@ var CompressionAlgorithmBackupTransport = RegisterCompressionAlgorithmClusterSet
 )
 
 func getCompressionAlgorithm(
-	ctx context.Context, settings *cluster.Settings, setting *settings.EnumSetting,
+	ctx context.Context,
+	settings *cluster.Settings,
+	setting *settings.EnumSetting[compressionAlgorithm],
 ) pebble.Compression {
 	switch setting.Get(&settings.SV) {
-	case int64(compressionAlgorithmSnappy):
+	case compressionAlgorithmSnappy:
 		return pebble.SnappyCompression
-	case int64(compressionAlgorithmZstd):
+	case compressionAlgorithmZstd:
 		// Pre-24.1 Pebble's implementation of zstd had bugs that could cause
 		// in-memory corruption. We require that the cluster version is 24.1 which
 		// implies that all nodes are running 24.1 code and will never run code
@@ -1251,8 +1253,8 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 
 	cfg.opts.Local.ReadaheadConfigFn = func() pebble.ReadaheadConfig {
 		return pebble.ReadaheadConfig{
-			Informed:    objstorageprovider.ReadaheadMode(readaheadModeInformed.Get(&cfg.settings.SV)),
-			Speculative: objstorageprovider.ReadaheadMode(readaheadModeSpeculative.Get(&cfg.settings.SV)),
+			Informed:    readaheadModeInformed.Get(&cfg.settings.SV),
+			Speculative: readaheadModeSpeculative.Get(&cfg.settings.SV),
 		}
 	}
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -145,7 +145,7 @@ var WithValueBlocksDisabled SSTWriterOption = func(opts *sstable.WriterOptions) 
 // WithCompressionFromClusterSetting sets the compression algorithm for an
 // SSTable based on the value of the given cluster setting.
 func WithCompressionFromClusterSetting(
-	ctx context.Context, cs *cluster.Settings, setting *settings.EnumSetting,
+	ctx context.Context, cs *cluster.Settings, setting *settings.EnumSetting[compressionAlgorithm],
 ) SSTWriterOption {
 	return func(opts *sstable.WriterOptions) {
 		opts.Compression = getCompressionAlgorithm(ctx, cs, setting)

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -150,7 +150,7 @@ func TestSSTWriterOption(t *testing.T) {
 	makeCompressionWriterOpt := func(alg compressionAlgorithm) SSTWriterOption {
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()
-		CompressionAlgorithmStorage.Override(ctx, &st.SV, int64(alg))
+		CompressionAlgorithmStorage.Override(ctx, &st.SV, alg)
 		return WithCompressionFromClusterSetting(ctx, st, CompressionAlgorithmStorage)
 	}
 


### PR DESCRIPTION
We change `RegisterEnumSetting` to use any integer type instead of always `int64`. This makes the code safer and cleaner (we no longer need to/from `int64` casts).

Fixes #125486
Release note: None