### PR TITLE
cli: check cluster setting before crashing in log stall

### DIFF
--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -173,7 +173,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 		if err := cfg.Validate(&dir); err != nil {
 			t.Fatal(err)
 		}
-		cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{})
+		cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/log_flags.go
+++ b/pkg/cli/log_flags.go
@@ -191,7 +191,10 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 
 	logBytesWritten := serverCfg.DiskWriteStatsCollector.CreateStat(fs.CRDBLogWriteCategory)
 	// Configuration ready and directories exist; apply it.
-	logShutdownFn, err := log.ApplyConfig(h.Config, log.FileSinkMetrics{LogBytesWritten: logBytesWritten})
+	fatalOnLogStall := func() bool {
+		return fs.MaxSyncDurationFatalOnExceeded.Get(&serverCfg.Settings.SV)
+	}
+	logShutdownFn, err := log.ApplyConfig(h.Config, log.FileSinkMetrics{LogBytesWritten: logBytesWritten}, fatalOnLogStall)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -218,7 +218,7 @@ func setLogConfig(baseDir string) {
 	if err := logConf.Validate(&baseDir); err != nil {
 		panic(err)
 	}
-	if _, err := log.ApplyConfig(logConf, log.FileSinkMetrics{}); err != nil {
+	if _, err := log.ApplyConfig(logConf, log.FileSinkMetrics{}, nil /* fatalOnLogStall */); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -44,7 +44,7 @@ func installSensitiveAccessLogFileSink(sc *log.TestLogScope, t *testing.T) func(
 	if err := cfg.Validate(&dir); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{})
+	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -686,7 +686,7 @@ func TestPerfLogging(t *testing.T) {
 	if err := cfg.Validate(&dir); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{})
+	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -210,7 +210,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		if err := cfg.Validate(&dir); err != nil {
 			t.Fatal(err)
 		}
-		cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{})
+		cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -410,7 +410,7 @@ func TestGetLogReader(t *testing.T) {
 	// Validate and apply the config.
 	require.NoError(t, config.Validate(&sc.logDir))
 	TestingResetActive()
-	cleanupFn, err := ApplyConfig(config, FileSinkMetrics{})
+	cleanupFn, err := ApplyConfig(config, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanupFn()
 
@@ -622,7 +622,7 @@ func TestFd2Capture(t *testing.T) {
 		t.Fatal(err)
 	}
 	TestingResetActive()
-	cleanupFn, err := ApplyConfig(cfg, FileSinkMetrics{})
+	cleanupFn, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -66,7 +66,7 @@ func TestSecondaryGC(t *testing.T) {
 	// Validate and apply the config.
 	require.NoError(t, config.Validate(&s.logDir))
 	TestingResetActive()
-	cleanupFn, err := ApplyConfig(config, FileSinkMetrics{})
+	cleanupFn, err := ApplyConfig(config, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanupFn()
 

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -72,7 +72,7 @@ func init() {
 	// using TestLogScope.
 	cfg := getTestConfig(nil /* output to files disabled */, true /* mostly inline */)
 
-	if _, err := ApplyConfig(cfg, FileSinkMetrics{}); err != nil {
+	if _, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */); err != nil {
 		panic(err)
 	}
 
@@ -97,7 +97,7 @@ func IsActive() (active bool, firstUse string) {
 //
 // The returned logShutdownFn can be used to gracefully shut down logging facilities.
 func ApplyConfig(
-	config logconfig.Config, metrics FileSinkMetrics,
+	config logconfig.Config, metrics FileSinkMetrics, fatalOnLogStall func() bool,
 ) (logShutdownFn func(), err error) {
 	// Sanity check.
 	if active, firstUse := IsActive(); active {
@@ -319,6 +319,7 @@ func ApplyConfig(
 		if err != nil {
 			return nil, err
 		}
+		fileSink.fatalOnLogStall = fatalOnLogStall
 		attachBufferWrapper(fileSinkInfo, fc.CommonSinkConfig.Buffering, closer)
 		attachSinkInfo(fileSinkInfo, &fc.Channels)
 

--- a/pkg/util/log/flags_test.go
+++ b/pkg/util/log/flags_test.go
@@ -68,7 +68,7 @@ func TestAppliedConfig(t *testing.T) {
 			}
 
 			TestingResetActive()
-			cleanup, err := ApplyConfig(h.Config, FileSinkMetrics{})
+			cleanup, err := ApplyConfig(h.Config, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/log/fluent_client_test.go
+++ b/pkg/util/log/fluent_client_test.go
@@ -69,7 +69,7 @@ func TestFluentClient(t *testing.T) {
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{})
+	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/formats_test.go
+++ b/pkg/util/log/formats_test.go
@@ -66,7 +66,7 @@ func TestFormatRedaction(t *testing.T) {
 							// Validate and apply the config.
 							require.NoError(t, config.Validate(&sc.logDir))
 							TestingResetActive()
-							cleanupFn, err := ApplyConfig(config, FileSinkMetrics{})
+							cleanupFn, err := ApplyConfig(config, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 							require.NoError(t, err)
 							defer cleanupFn()
 

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -148,7 +148,7 @@ func testBase(
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{})
+	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -90,10 +90,21 @@ const flushInterval = time.Second
 // syncInterval is the multiple of flushInterval where the log is also synced to disk.
 const syncInterval = 30
 
-// maxSyncDuration is set to a conservative value since this is a new mechanism.
-// In practice, even a fraction of that would indicate a problem. This metric's
-// default should ideally match its sister metric in the storage engine, set by
-// COCKROACH_ENGINE_MAX_SYNC_DURATION.
+// maxSyncDuration is the maximum duration the file sink is allowed to take to
+// write a log entry before we fatal the process for a disk stall. Note that
+// this fataling behaviour can be disabled by the cluster setting
+// storage.max_sync_duration.fatal.enabled for most uses of the logger.
+//
+// This setting may sound similar to `ExitTimeoutForFatalLog`, however that
+// parameter configures how long we wait to write a *fatal* log entry to _any_
+// log sink before we exit the process. This one configures how long we wait
+// to write any log entry to a _file_ sink before we write a fatal log entry
+// instead (that could then take up to `ExitTimeoutForFatalLog` before crashing
+// the process).
+//
+// This metric's default should ideally match its sister metrics: one in the
+// storage engine, set by COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT and the
+// storage.max_sync_duration cluster setting, and another in `ExitTimeoutForFatalLog`.
 var maxSyncDuration = envutil.EnvOrDefaultDuration("COCKROACH_LOG_MAX_SYNC_DURATION", 20*time.Second)
 
 // syncWarnDuration is the threshold after which a slow disk warning is written

--- a/pkg/util/log/logtestutils/log_test_utils.go
+++ b/pkg/util/log/logtestutils/log_test_utils.go
@@ -40,7 +40,7 @@ func InstallLogFileSink(sc *log.TestLogScope, t *testing.T, channel logpb.Channe
 	if err := cfg.Validate(&dir); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{})
+	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -136,7 +136,7 @@ func TestSafeManaged(t *testing.T) {
 			if err := cfg.Validate(&s.logDir); err != nil {
 				t.Fatal(err)
 			}
-			cleanupFn, err := ApplyConfig(cfg, FileSinkMetrics{})
+			cleanupFn, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/log/registry_test.go
+++ b/pkg/util/log/registry_test.go
@@ -66,7 +66,7 @@ func TestIterHTTPSinks(t *testing.T) {
 
 	// Apply the configuration
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{})
+	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -48,7 +48,7 @@ func installSessionsFileSink(sc *TestLogScope, t *testing.T) func() {
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{})
+	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -162,7 +162,7 @@ func newLogScope(t tShim, mostlyInline bool) (sc *TestLogScope) {
 
 		// Switch to the new configuration.
 		TestingResetActive()
-		sc.cleanupFn, err = ApplyConfig(cfg, FileSinkMetrics{})
+		sc.cleanupFn, err = ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 		if err != nil {
 			return err
 		}
@@ -355,7 +355,7 @@ func (l *TestLogScope) SetupSingleFileLogging() (cleanup func()) {
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{})
+	cleanup, err := ApplyConfig(cfg, FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error in predefined log config"))
 	}

--- a/pkg/util/log/testshout/shout_test.go
+++ b/pkg/util/log/testshout/shout_test.go
@@ -33,7 +33,7 @@ func Example_shout_before_log() {
 		panic(err)
 	}
 	cfg.Sinks.Stderr.Filter = severity.WARNING
-	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{})
+	cleanup, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -181,7 +181,7 @@ func CmdHelper(
 			if err := cfg.Validate(nil /* no default log directory */); err != nil {
 				return err
 			}
-			if _, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}); err != nil {
+			if _, err := log.ApplyConfig(cfg, log.FileSinkMetrics{}, nil /* fatalOnLogStall */); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Previously, we'd unconditionally crash the process if the logger stalled, even if the cluster setting for not crashing the cockroach process on disk stalls was set. This change has the file logger respect that cluster setting,
storage.max_sync_duration.fatal.enabled, as well.

Fixes #124474.

Epic: none

Release note: None