### PR TITLE
sql: add plan_cache_mode session setting

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3825,6 +3825,10 @@ func (m *sessionDataMutator) SetOptimizerPushOffsetIntoIndexJoin(val bool) {
 	m.data.OptimizerPushOffsetIntoIndexJoin = val
 }
 
+func (m *sessionDataMutator) SetPlanCacheMode(val sessiondatapb.PlanCacheMode) {
+	m.data.PlanCacheMode = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6190,6 +6190,7 @@ override_multi_region_zone_config                          off
 parallelize_multi_key_lookup_joins_enabled                 off
 password_encryption                                        scram-sha-256
 pg_trgm.similarity_threshold                               0.3
+plan_cache_mode                                            force_custom_plan
 plpgsql_use_strict_into                                    off
 prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2911,6 +2911,7 @@ override_multi_region_zone_config                          off                 N
 parallelize_multi_key_lookup_joins_enabled                 off                 NULL      NULL        NULL        string
 password_encryption                                        scram-sha-256       NULL      NULL        NULL        string
 pg_trgm.similarity_threshold                               0.3                 NULL      NULL        NULL        string
+plan_cache_mode                                            force_custom_plan   NULL      NULL        NULL        string
 plpgsql_use_strict_into                                    off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                                off                 NULL      NULL        NULL        string
 prepared_statements_cache_size                             0 B                 NULL      NULL        NULL        string
@@ -3096,6 +3097,7 @@ override_multi_region_zone_config                          off                 N
 parallelize_multi_key_lookup_joins_enabled                 off                 NULL  user     NULL      off                 off
 password_encryption                                        scram-sha-256       NULL  user     NULL      scram-sha-256       scram-sha-256
 pg_trgm.similarity_threshold                               0.3                 NULL  user     NULL      0.3                 0.3
+plan_cache_mode                                            force_custom_plan   NULL  user     NULL      force_custom_plan   force_custom_plan
 plpgsql_use_strict_into                                    off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                                off                 NULL  user     NULL      off                 off
 prepared_statements_cache_size                             0 B                 NULL  user     NULL      0 B                 0 B
@@ -3280,6 +3282,7 @@ override_multi_region_zone_config                          NULL    NULL     NULL
 parallelize_multi_key_lookup_joins_enabled                 NULL    NULL     NULL     NULL        NULL
 password_encryption                                        NULL    NULL     NULL     NULL        NULL
 pg_trgm.similarity_threshold                               NULL    NULL     NULL     NULL        NULL
+plan_cache_mode                                            NULL    NULL     NULL     NULL        NULL
 plpgsql_use_strict_into                                    NULL    NULL     NULL     NULL        NULL
 prefer_lookup_joins_for_fks                                NULL    NULL     NULL     NULL        NULL
 prepared_statements_cache_size                             NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -148,6 +148,7 @@ override_multi_region_zone_config                          off
 parallelize_multi_key_lookup_joins_enabled                 off
 password_encryption                                        scram-sha-256
 pg_trgm.similarity_threshold                               0.3
+plan_cache_mode                                            force_custom_plan
 plpgsql_use_strict_into                                    off
 prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -520,6 +520,9 @@ message LocalOnlySessionData {
   // OptimizerPushOffsetIntoIndexJoin, when true, indicates that the optimizer
   // should push offset expressions into index joins.
   bool optimizer_push_offset_into_index_join = 132;
+  // PlanCacheMode indicates the method that the optimizer should use to choose
+  // between a custom and generic query plan.
+  PlanCacheMode plan_cache_mode = 133;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
@@ -534,6 +537,23 @@ enum ReplicationMode {
   REPLICATION_MODE_DISABLED = 0;
   REPLICATION_MODE_ENABLED = 1;
   REPLICATION_MODE_DATABASE = 2;
+}
+
+// PlanCacheMode controls the optimizer's decision to use a custom or generic
+// query plan.
+enum PlanCacheMode {
+  option (gogoproto.goproto_enum_prefix) = false;
+  option (gogoproto.goproto_enum_stringer) = false;
+
+  // PlanCacheModeForceCustom forces the optimizer to use a custom query plan.
+  force_custom_plan = 0 [(gogoproto.enumvalue_customname) = "PlanCacheModeForceCustom"];
+
+  // PlanCacheModeForceCustom forces the optimizer to use a generic query plan.
+  force_generic_plan = 1 [(gogoproto.enumvalue_customname) = "PlanCacheModeForceGeneric"];
+
+  // PlanCacheModeAuto allows the optimizer to automatically choose between a
+  // custom and generic query plan.
+  auto = 2 [(gogoproto.enumvalue_customname) = "PlanCacheModeAuto"];
 }
 
 // SequenceCacheEntry is an entry in a SequenceCache.

--- a/pkg/sql/sessiondatapb/session_data.go
+++ b/pkg/sql/sessiondatapb/session_data.go
@@ -80,6 +80,25 @@ func VectorizeExecModeFromString(val string) (VectorizeExecMode, bool) {
 	return m, true
 }
 
+func (m PlanCacheMode) String() string {
+	name, ok := PlanCacheMode_name[int32(m)]
+	if !ok {
+		return fmt.Sprintf("invalid (%d)", m)
+	}
+	return name
+}
+
+// PlanCacheModeFromString converts a string into a PlanCacheMode. False is
+// returned if the conversion was unsuccessful.
+func PlanCacheModeFromString(val string) (PlanCacheMode, bool) {
+	lowerVal := strings.ToLower(val)
+	m, ok := PlanCacheMode_value[lowerVal]
+	if !ok {
+		return 0, false
+	}
+	return PlanCacheMode(m), true
+}
+
 // User retrieves the current user.
 func (s *SessionData) User() username.SQLUsername {
 	return s.UserProto.Decode()

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -162,7 +162,7 @@ message DataConversionConfig {
   util.timeutil.pgdate.DateStyle date_style = 4 [(gogoproto.nullable) = false];
 }
 
-// VectorizeExecMode controls if an when the Executor executes queries using
+// VectorizeExecMode controls if and when the Executor executes queries using
 // the columnar execution engine.
 enum VectorizeExecMode {
   option (gogoproto.goproto_enum_prefix) = false;

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3377,6 +3377,29 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	`plan_cache_mode`: {
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			mode, ok := sessiondatapb.PlanCacheModeFromString(s)
+			if !ok {
+				return newVarValueError(
+					`plan_cache_mode`,
+					s,
+					sessiondatapb.PlanCacheModeForceCustom.String(),
+					sessiondatapb.PlanCacheModeForceGeneric.String(),
+					sessiondatapb.PlanCacheModeAuto.String(),
+				)
+			}
+			m.SetPlanCacheMode(mode)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return evalCtx.SessionData().PlanCacheMode.String(), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return sessiondatapb.PlanCacheModeForceCustom.String()
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
The `plan_cache_mode` session setting has been added. It allows for
three options: `force_custom_plan`, `force_generic_plan`, and `auto`.
The session currently has no effect. In future commits it will control
how the system chooses between using a custom or generic query plan.

Epic: CRDB-37712

Release note: None
