### PR TITLE
roachprod: add default auth-mode env var

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -102,22 +102,6 @@ var (
 	grafanaDashboardUID string
 	grafanaTimeRange    []int64
 
-	pgAuthModes = map[string]install.PGAuthMode{
-		"root":          install.AuthRootCert,
-		"user-password": install.AuthUserPassword,
-		"user-cert":     install.AuthUserCert,
-	}
-
-	defaultAuthMode = func() string {
-		for modeStr, mode := range pgAuthModes {
-			if mode == install.DefaultAuthMode {
-				return modeStr
-			}
-		}
-
-		panic(fmt.Errorf("could not find string for default auth mode"))
-	}()
-
 	sshKeyUser string
 
 	fluentBitConfig fluentbit.Config
@@ -217,7 +201,7 @@ func initFlags() {
 
 	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, loadBalancerPGUrl} {
 		cmd.Flags().StringVar(&authMode,
-			"auth-mode", defaultAuthMode, fmt.Sprintf("form of authentication to use, valid auth-modes: %v", maps.Keys(pgAuthModes)))
+			"auth-mode", install.DefaultAuthMode().String(), fmt.Sprintf("form of authentication to use, valid auth-modes: %v", maps.Keys(install.PGAuthModes)))
 		cmd.Flags().StringVar(&database, "database", "", "database to use")
 	}
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -537,7 +537,7 @@ var loadBalancerPGUrl = &cobra.Command{
 %[1]s`, strings.TrimSpace(AuthModeHelp)),
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		auth, err := resolveAuthMode()
+		auth, err := install.ResolveAuthMode(authMode)
 		if err != nil {
 			return err
 		}
@@ -1140,9 +1140,9 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		auth, ok := pgAuthModes[authMode]
+		auth, ok := install.PGAuthModes[authMode]
 		if !ok {
-			return errors.Newf("unsupported auth-mode %s, valid auth-modes: %v", authMode, maps.Keys(pgAuthModes))
+			return errors.Newf("unsupported auth-mode %s, valid auth-modes: %v", authMode, maps.Keys(install.PGAuthModes))
 		}
 
 		return roachprod.SQL(context.Background(), config.Logger, args[0], isSecure, virtualClusterName, sqlInstance, auth, database, args[1:])
@@ -1158,7 +1158,7 @@ var pgurlCmd = &cobra.Command{
 `, strings.TrimSpace(AuthModeHelp)),
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		auth, err := resolveAuthMode()
+		auth, err := install.ResolveAuthMode(authMode)
 		if err != nil {
 			return err
 		}
@@ -1187,14 +1187,6 @@ Defaults to root if not passed. Available auth-modes are:
 	user-password: authenticates with the default roachprod user and password
 
 	user-cert: authenticates with the default roachprod user and certificates`
-
-func resolveAuthMode() (install.PGAuthMode, error) {
-	auth, ok := pgAuthModes[authMode]
-	if !ok {
-		return -1, errors.Newf("unsupported auth-mode %s, valid auth-modes: %v", authMode, maps.Keys(pgAuthModes))
-	}
-	return auth, nil
-}
 
 var pprofCmd = &cobra.Command{
 	Use:     "pprof <cluster>",

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/operations"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -180,6 +181,14 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	// could yield false positives; e.g., user-specified test teardown goroutines
 	// may still be running long after the test has completed.
 	defer leaktest.AfterTest(l)()
+
+	// We allow roachprod users to set a default auth-mode through the
+	// ROACHPROD_DEFAULT_AUTH_MODE env var. However, roachtests shouldn't
+	// use this feature in order to minimize confusion over which auth-mode
+	// is being used.
+	if err = os.Unsetenv(install.DefaultAuthModeEnv); err != nil {
+		return err
+	}
 
 	err = runner.Run(
 		ctx, specs, roachtestflags.Count, parallelism, opt,

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -445,7 +445,7 @@ func (c *SyncedCluster) Stop(
 		return c.kill(ctx, l, "stop", display, sig, wait, maxWait, virtualClusterLabel)
 	} else {
 		cmd := fmt.Sprintf("ALTER TENANT '%s' STOP SERVICE", virtualClusterName)
-		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, DefaultAuthMode, "", /* database */
+		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, DefaultAuthMode(), "", /* database */
 			[]string{"-e", cmd})
 		if err != nil || res[0].Err != nil {
 			if len(res) > 0 {
@@ -2563,7 +2563,7 @@ func (c *SyncedCluster) pgurls(
 		if err != nil {
 			return nil, err
 		}
-		m[node] = c.NodeURL(host, desc.Port, virtualClusterName, desc.ServiceMode, AuthUserCert, "" /* database */)
+		m[node] = c.NodeURL(host, desc.Port, virtualClusterName, desc.ServiceMode, DefaultAuthMode(), "" /* database */)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -175,7 +175,7 @@ func (e *expander) maybeExpandPgURL(
 	}
 	switch strings.ToLower(m[1]) {
 	case ":lb":
-		url, err := c.loadBalancerURL(ctx, l, virtualClusterName, sqlInstance, DefaultAuthMode)
+		url, err := c.loadBalancerURL(ctx, l, virtualClusterName, sqlInstance, DefaultAuthMode())
 		return url, url != "", err
 	default:
 		if e.pgURLs[virtualClusterName] == nil {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2226,7 +2226,7 @@ func StartJaeger(
 			return err
 		}
 		_, err = c.ExecSQL(
-			ctx, l, nodes, virtualClusterName, 0, install.DefaultAuthMode, "", /* database */
+			ctx, l, nodes, virtualClusterName, 0, install.DefaultAuthMode(), "", /* database */
 			[]string{"-e", setupStmt},
 		)
 		if err != nil {


### PR DESCRIPTION
This change adds a ROACHPROD_DEFAULT_AUTH_MODE env var which sets the default auth mode used by roachprod CLI and roachprod pgurl expander if not specified.

This env var is unset at the start of every roachtest run.

Release note: none
Fixes: none
Epic: none