### PR TITLE
kv: move leaseStatus to leases package

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -330,7 +330,6 @@ go_test(
         "replica_raft_overload_test.go",
         "replica_raft_test.go",
         "replica_raft_truncation_test.go",
-        "replica_range_lease_test.go",
         "replica_rangefeed_test.go",
         "replica_rankings_test.go",
         "replica_sideload_test.go",

--- a/pkg/kv/kvserver/leases/BUILD.bazel
+++ b/pkg/kv/kvserver/leases/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "leases",
-    srcs = ["build.go"],
+    srcs = [
+        "build.go",
+        "status.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/leases",
     visibility = ["//visibility:public"],
     deps = [
@@ -12,15 +15,21 @@ go_library(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/util/hlc",
+        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
 go_test(
     name = "leases_test",
-    srcs = ["build_test.go"],
+    srcs = [
+        "build_test.go",
+        "status_test.go",
+    ],
     embed = [":leases"],
     deps = [
+        "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",

--- a/pkg/kv/kvserver/leases/status.go
+++ b/pkg/kv/kvserver/leases/status.go
@@ -1,0 +1,173 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package leases
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
+)
+
+// StatusInput is the input to the Status function.
+type StatusInput struct {
+	// Information about the local store and replica.
+	LocalStoreID       roachpb.StoreID
+	MaxOffset          time.Duration
+	MinProposedTs      hlc.ClockTimestamp
+	MinValidObservedTs hlc.ClockTimestamp
+
+	// The current time and the time of the request to evaluate the lease for.
+	Now       hlc.ClockTimestamp
+	RequestTs hlc.Timestamp
+
+	// The lease to evaluate.
+	Lease roachpb.Lease
+}
+
+// Status returns a lease status. The lease status is linked to the desire to
+// serve a request at a specific timestamp (which may be a future timestamp)
+// under the lease, as well as a notion of the current hlc time (now).
+//
+// # Explanation
+//
+// A status of ERROR indicates a failure to determine the correct lease status,
+// and should not occur under normal operations. The caller's only recourse is
+// to give up or to retry.
+//
+// If the lease is expired according to the now timestamp (and, in the case of
+// epoch-based leases, the liveness epoch), a status of EXPIRED is returned.
+// Note that this ignores the timestamp of the request, which may well
+// technically be eligible to be served under the lease. The key feature of an
+// EXPIRED status is that it reflects that a new lease with a start timestamp
+// greater than or equal to now can be acquired non-cooperatively.
+//
+// If the lease is not EXPIRED, the lease's start timestamp is checked against
+// the minProposedTimestamp. This timestamp indicates the oldest timestamp that
+// a lease can have as its start time and still be used by the node. It is set
+// both in cooperative lease transfers and to prevent reuse of leases across
+// node restarts (which would result in latching violations). Leases with start
+// times preceding this timestamp are assigned a status of PROSCRIBED and can
+// not be used. Instead, a new lease should be acquired by callers.
+//
+// If the lease is not EXPIRED or PROSCRIBED, the request timestamp is taken
+// into account. The expiration timestamp is adjusted for clock offset; if the
+// request timestamp falls into the so-called "stasis period" at the end of the
+// lifetime of the lease, or if the request timestamp is beyond the end of the
+// lifetime of the lease, the status is UNUSABLE. Callers typically want to
+// react to an UNUSABLE lease status by extending the lease, if they are in a
+// position to do so.
+//
+// Finally, for requests timestamps falling before the stasis period of a lease
+// that is not EXPIRED and also not PROSCRIBED, the status is VALID.
+//
+// # Implementation Note
+//
+// On the surface, it might seem like we could easily abandon the lease stasis
+// concept in favor of consulting a request's uncertainty interval. We would
+// then define a request's timestamp as the maximum of its read_timestamp and
+// its global_uncertainty_limit, and simply check whether this timestamp falls
+// below a lease's expiration. This could allow certain transactional requests
+// to operate more closely to a lease's expiration. But not all requests that
+// expect linearizability use an uncertainty interval (e.g. non-transactional
+// requests), and so the lease stasis period serves as a kind of catch-all
+// uncertainty interval for non-transactional and admin requests.
+//
+// Without that stasis period, the following linearizability violation could
+// occur for two non-transactional requests operating on a single register
+// during a lease change:
+//
+//   - a range lease gets committed on the new lease holder (but not the old).
+//   - client proposes and commits a write on new lease holder (with a timestamp
+//     just greater than the expiration of the old lease).
+//   - client tries to read what it wrote, but hits a slow coordinator (which
+//     assigns a timestamp covered by the old lease).
+//   - the read is served by the old lease holder (which has not processed the
+//     change in lease holdership).
+//   - the client fails to read their own write.
+func Status(ctx context.Context, nl NodeLiveness, i StatusInput) kvserverpb.LeaseStatus {
+	lease := i.Lease
+	status := kvserverpb.LeaseStatus{
+		Lease: lease,
+		// NOTE: it would not be correct to accept either only the request time
+		// or only the current time in this method, we need both. We need the
+		// request time to determine whether the current lease can serve a given
+		// request, even if that request has a timestamp in the future of
+		// present time. We need the current time to distinguish between an
+		// EXPIRED lease and an UNUSABLE lease. Only an EXPIRED lease can change
+		// hands through a lease acquisition.
+		Now:                       i.Now,
+		RequestTime:               i.RequestTs,
+		MinValidObservedTimestamp: i.MinValidObservedTs,
+	}
+	var expiration hlc.Timestamp
+	if lease.Type() == roachpb.LeaseExpiration {
+		expiration = lease.GetExpiration()
+	} else {
+		l, ok := nl.GetLiveness(lease.Replica.NodeID)
+		status.Liveness = l.Liveness
+		if !ok || status.Liveness.Epoch < lease.Epoch {
+			// If lease validity can't be determined (e.g. gossip is down
+			// and liveness info isn't available for owner), we can neither
+			// use the lease nor do we want to attempt to acquire it.
+			var msg redact.StringBuilder
+			if !ok {
+				msg.Printf("can't determine lease status of %s due to node liveness error: %v",
+					lease.Replica, liveness.ErrRecordCacheMiss)
+			} else {
+				msg.Printf("can't determine lease status of %s because node liveness info for n%d is stale. lease: %s, liveness: %s",
+					lease.Replica, lease.Replica.NodeID, lease, l.Liveness)
+			}
+			if leaseStatusLogLimiter.ShouldLog() {
+				log.Infof(ctx, "%s", msg)
+			}
+			status.State = kvserverpb.LeaseState_ERROR
+			status.ErrInfo = msg.String()
+			return status
+		}
+		if status.Liveness.Epoch > lease.Epoch {
+			status.State = kvserverpb.LeaseState_EXPIRED
+			return status
+		}
+		expiration = status.Liveness.Expiration.ToTimestamp()
+	}
+	maxOffset := i.MaxOffset
+	stasis := expiration.Add(-int64(maxOffset), 0)
+	ownedLocally := lease.OwnedBy(i.LocalStoreID)
+	// NB: the order of these checks is important, and goes from stronger to
+	// weaker reasons why the lease may be considered invalid. For example,
+	// EXPIRED or PROSCRIBED must take precedence over UNUSABLE, because some
+	// callers consider UNUSABLE as valid. For an example issue that this ordering
+	// may cause, see https://github.com/cockroachdb/cockroach/issues/100101.
+	if expiration.LessEq(i.Now.ToTimestamp()) {
+		status.State = kvserverpb.LeaseState_EXPIRED
+	} else if ownedLocally && lease.ProposedTS.Less(i.MinProposedTs) {
+		// If the replica owns the lease, additional verify that the lease's
+		// proposed timestamp is not earlier than the min proposed timestamp.
+		status.State = kvserverpb.LeaseState_PROSCRIBED
+	} else if stasis.LessEq(i.RequestTs) {
+		status.State = kvserverpb.LeaseState_UNUSABLE
+	} else {
+		status.State = kvserverpb.LeaseState_VALID
+	}
+	return status
+}
+
+var leaseStatusLogLimiter = func() *log.EveryN {
+	e := log.Every(15 * time.Second)
+	e.ShouldLog() // waste the first shot
+	return &e
+}()

--- a/pkg/kv/kvserver/leases/status_test.go
+++ b/pkg/kv/kvserver/leases/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cockroach Authors.
+// Copyright 2024 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,41 +8,23 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvserver
+package leases
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestReplicaLeaseStatus tests that Replica.leaseStatus returns a valid lease
-// status, both for expiration- and epoch-based leases.
-func TestReplicaLeaseStatus(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-
+func TestStatus(t *testing.T) {
 	const maxOffset = 100 * time.Nanosecond
-	clock := hlc.NewClock(hlc.NewHybridManualClock(), maxOffset, maxOffset)
-
 	r1 := roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1}
 	ts := []hlc.ClockTimestamp{
 		{WallTime: 500, Logical: 0},  // before lease start
@@ -123,34 +105,33 @@ func TestReplicaLeaseStatus(t *testing.T) {
 			wantErr: "node liveness info for n1 is stale"},
 	} {
 		t.Run("", func(t *testing.T) {
-			cache :=
-				liveness.NewCache(
-					gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry()),
-					clock,
-					cluster.MakeTestingClusterSettings(),
-					nil,
-				)
-			l := liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
-				Clock: clock,
-				Cache: cache,
-			})
-			r := Replica{store: &Store{
-				Ident: &roachpb.StoreIdent{StoreID: 1, NodeID: 1},
-				cfg:   StoreConfig{Clock: clock, NodeLiveness: l},
-			}}
-			var empty livenesspb.Liveness
-			if maybeLiveness := tc.liveness; maybeLiveness != empty {
-				l.TestingMaybeUpdate(ctx, liveness.Record{Liveness: maybeLiveness})
+			nl := &mockNodeLiveness{
+				record:  liveness.Record{Liveness: tc.liveness},
+				missing: tc.liveness == livenesspb.Liveness{},
+			}
+			in := StatusInput{
+				LocalStoreID:       r1.StoreID,
+				MaxOffset:          maxOffset,
+				Now:                tc.now,
+				MinProposedTs:      tc.minProposedTS,
+				MinValidObservedTs: hlc.ClockTimestamp{},
+				RequestTs:          tc.reqTS,
+				Lease:              tc.lease,
 			}
 
-			got := r.leaseStatus(ctx, tc.lease, tc.now, tc.minProposedTS, hlc.ClockTimestamp{}, tc.reqTS)
+			got := Status(context.Background(), nl, in)
 			if tc.wantErr != "" {
 				require.Contains(t, got.ErrInfo, tc.wantErr)
 				got.ErrInfo = ""
 			}
-			assert.Equal(t, kvserverpb.LeaseStatus{
-				Lease: tc.lease, Now: tc.now, RequestTime: tc.reqTS, State: tc.want, Liveness: tc.liveness,
-			}, got)
+			exp := kvserverpb.LeaseStatus{
+				Lease:       tc.lease,
+				Now:         tc.now,
+				RequestTime: tc.reqTS,
+				State:       tc.want,
+				Liveness:    tc.liveness,
+			}
+			require.Equal(t, exp, got)
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -296,7 +296,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		RangeLeaseDuration:       p.repl.store.cfg.RangeLeaseDuration,
 	}
 	nl := p.repl.store.cfg.NodeLiveness
-	in := leases.Input{
+	in := leases.BuildInput{
 		LocalStoreID:          p.repl.StoreID(),
 		Now:                   status.Now,
 		MinLeaseProposedTS:    p.repl.mu.minLeaseProposedTS,

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -73,7 +73,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
-	"github.com/cockroachdb/redact"
 )
 
 var TransferExpirationLeasesFirstEnabled = settings.RegisterBoolSetting(
@@ -157,12 +156,6 @@ var RejectLeaseOnLeaderUnknown = settings.RegisterBoolSetting(
 	"reject lease requests on a replica that does not know the raft leader",
 	false,
 )
-
-var leaseStatusLogLimiter = func() *log.EveryN {
-	e := log.Every(15 * time.Second)
-	e.ShouldLog() // waste the first shot
-	return &e
-}()
 
 // leaseRequestHandle is a handle to an asynchronous lease request.
 type leaseRequestHandle struct {
@@ -639,140 +632,6 @@ func (p *pendingLeaseRequest) newResolvedHandle(pErr *kvpb.Error) *leaseRequestH
 	return h
 }
 
-// leaseStatus returns a lease status. The lease status is linked to the desire
-// to serve a request at a specific timestamp (which may be a future timestamp)
-// under the lease, as well as a notion of the current hlc time (now).
-//
-// # Explanation
-//
-// A status of ERROR indicates a failure to determine the correct lease status,
-// and should not occur under normal operations. The caller's only recourse is
-// to give up or to retry.
-//
-// If the lease is expired according to the now timestamp (and, in the case of
-// epoch-based leases, the liveness epoch), a status of EXPIRED is returned.
-// Note that this ignores the timestamp of the request, which may well
-// technically be eligible to be served under the lease. The key feature of an
-// EXPIRED status is that it reflects that a new lease with a start timestamp
-// greater than or equal to now can be acquired non-cooperatively.
-//
-// If the lease is not EXPIRED, the lease's start timestamp is checked against
-// the minProposedTimestamp. This timestamp indicates the oldest timestamp that
-// a lease can have as its start time and still be used by the node. It is set
-// both in cooperative lease transfers and to prevent reuse of leases across
-// node restarts (which would result in latching violations). Leases with start
-// times preceding this timestamp are assigned a status of PROSCRIBED and can
-// not be used. Instead, a new lease should be acquired by callers.
-//
-// If the lease is not EXPIRED or PROSCRIBED, the request timestamp is taken
-// into account. The expiration timestamp is adjusted for clock offset; if the
-// request timestamp falls into the so-called "stasis period" at the end of the
-// lifetime of the lease, or if the request timestamp is beyond the end of the
-// lifetime of the lease, the status is UNUSABLE. Callers typically want to
-// react to an UNUSABLE lease status by extending the lease, if they are in a
-// position to do so.
-//
-// Finally, for requests timestamps falling before the stasis period of a lease
-// that is not EXPIRED and also not PROSCRIBED, the status is VALID.
-//
-// # Implementation Note
-//
-// On the surface, it might seem like we could easily abandon the lease stasis
-// concept in favor of consulting a request's uncertainty interval. We would
-// then define a request's timestamp as the maximum of its read_timestamp and
-// its global_uncertainty_limit, and simply check whether this timestamp falls
-// below a lease's expiration. This could allow certain transactional requests
-// to operate more closely to a lease's expiration. But not all requests that
-// expect linearizability use an uncertainty interval (e.g. non-transactional
-// requests), and so the lease stasis period serves as a kind of catch-all
-// uncertainty interval for non-transactional and admin requests.
-//
-// Without that stasis period, the following linearizability violation could
-// occur for two non-transactional requests operating on a single register
-// during a lease change:
-//
-//   - a range lease gets committed on the new lease holder (but not the old).
-//   - client proposes and commits a write on new lease holder (with a timestamp
-//     just greater than the expiration of the old lease).
-//   - client tries to read what it wrote, but hits a slow coordinator (which
-//     assigns a timestamp covered by the old lease).
-//   - the read is served by the old lease holder (which has not processed the
-//     change in lease holdership).
-//   - the client fails to read their own write.
-func (r *Replica) leaseStatus(
-	ctx context.Context,
-	lease roachpb.Lease,
-	now hlc.ClockTimestamp,
-	minProposedTS hlc.ClockTimestamp,
-	minValidObservedTS hlc.ClockTimestamp,
-	reqTS hlc.Timestamp,
-) kvserverpb.LeaseStatus {
-	status := kvserverpb.LeaseStatus{
-		Lease: lease,
-		// NOTE: it would not be correct to accept either only the request time
-		// or only the current time in this method, we need both. We need the
-		// request time to determine whether the current lease can serve a given
-		// request, even if that request has a timestamp in the future of
-		// present time. We need the current time to distinguish between an
-		// EXPIRED lease and an UNUSABLE lease. Only an EXPIRED lease can change
-		// hands through a lease acquisition.
-		Now:                       now,
-		RequestTime:               reqTS,
-		MinValidObservedTimestamp: minValidObservedTS,
-	}
-	var expiration hlc.Timestamp
-	if lease.Type() == roachpb.LeaseExpiration {
-		expiration = lease.GetExpiration()
-	} else {
-		l, ok := r.store.cfg.NodeLiveness.GetLiveness(lease.Replica.NodeID)
-		status.Liveness = l.Liveness
-		if !ok || status.Liveness.Epoch < lease.Epoch {
-			// If lease validity can't be determined (e.g. gossip is down
-			// and liveness info isn't available for owner), we can neither
-			// use the lease nor do we want to attempt to acquire it.
-			var msg redact.StringBuilder
-			if !ok {
-				msg.Printf("can't determine lease status of %s due to node liveness error: %v",
-					lease.Replica, liveness.ErrRecordCacheMiss)
-			} else {
-				msg.Printf("can't determine lease status of %s because node liveness info for n%d is stale. lease: %s, liveness: %s",
-					lease.Replica, lease.Replica.NodeID, lease, l.Liveness)
-			}
-			if leaseStatusLogLimiter.ShouldLog() {
-				log.Infof(ctx, "%s", msg)
-			}
-			status.State = kvserverpb.LeaseState_ERROR
-			status.ErrInfo = msg.String()
-			return status
-		}
-		if status.Liveness.Epoch > lease.Epoch {
-			status.State = kvserverpb.LeaseState_EXPIRED
-			return status
-		}
-		expiration = status.Liveness.Expiration.ToTimestamp()
-	}
-	maxOffset := r.store.Clock().MaxOffset()
-	stasis := expiration.Add(-int64(maxOffset), 0)
-	ownedLocally := lease.OwnedBy(r.store.StoreID())
-	// NB: the order of these checks is important, and goes from stronger to
-	// weaker reasons why the lease may be considered invalid. For example,
-	// EXPIRED or PROSCRIBED must take precedence over UNUSABLE, because some
-	// callers consider UNUSABLE as valid. For an example issue that this ordering
-	// may cause, see https://github.com/cockroachdb/cockroach/issues/100101.
-	if expiration.LessEq(now.ToTimestamp()) {
-		status.State = kvserverpb.LeaseState_EXPIRED
-	} else if ownedLocally && lease.ProposedTS.Less(minProposedTS) {
-		// If the replica owns the lease, additional verify that the lease's
-		// proposed timestamp is not earlier than the min proposed timestamp.
-		status.State = kvserverpb.LeaseState_PROSCRIBED
-	} else if stasis.LessEq(reqTS) {
-		status.State = kvserverpb.LeaseState_UNUSABLE
-	} else {
-		status.State = kvserverpb.LeaseState_VALID
-	}
-	return status
-}
-
 // CurrentLeaseStatus returns the status of the current lease for the
 // current time.
 //
@@ -810,8 +669,16 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		// would be given to a request with a timestamp of now.
 		reqTS = now.ToTimestamp()
 	}
-	return r.leaseStatus(ctx, *r.mu.state.Lease, now, r.mu.minLeaseProposedTS,
-		r.mu.minValidObservedTimestamp, reqTS)
+	in := leases.StatusInput{
+		LocalStoreID:       r.StoreID(),
+		MaxOffset:          r.Clock().MaxOffset(),
+		Now:                now,
+		MinProposedTs:      r.mu.minLeaseProposedTS,
+		MinValidObservedTs: r.mu.minValidObservedTimestamp,
+		RequestTs:          reqTS,
+		Lease:              *r.mu.state.Lease,
+	}
+	return leases.Status(ctx, r.store.cfg.NodeLiveness, in)
 }
 
 // OwnsValidLease returns whether this replica is the current valid


### PR DESCRIPTION
Informs #123498.

This commit moves the `leaseStatus` function to the leases package. This allows for easier unit testing and helps to further consolidate leasing logic in a single location.

Code movement only, not behavior changes.

Release note: None