### PR TITLE
changefeedccl: add more logging around checkpointing

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -456,6 +456,9 @@ func makePlan(
 			aggregatorCheckpoint.Spans = checkpoint.Spans
 			aggregatorCheckpoint.Timestamp = checkpoint.Timestamp
 		}
+		if log.V(2) {
+			log.Infof(ctx, "aggregator checkpoint: %s", aggregatorCheckpoint)
+		}
 
 		aggregatorSpecs := make([]*execinfrapb.ChangeAggregatorSpec, len(spanPartitions))
 		for i, sp := range spanPartitions {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1682,7 +1682,7 @@ func (cf *changeFrontier) checkpointJobProgress(
 			}
 
 			if updateRunStatus {
-				md.Progress.RunningStatus = fmt.Sprintf("running: resolved=%s", frontier)
+				progress.RunningStatus = fmt.Sprintf("running: resolved=%s", frontier)
 			}
 
 			ju.UpdateProgress(progress)
@@ -1698,6 +1698,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 			return nil
 		}); err != nil {
 			return false, err
+		}
+		if log.V(2) {
+			log.Infof(cf.Ctx(), "change frontier persisted highwater=%s and checkpoint=%s", frontier, checkpoint)
 		}
 	}
 


### PR DESCRIPTION
This patch adds a log message that will log checkpoints that are
persisted to a changefeed job's progress during normal operation.
It also adds a log message to log the checkpoint that is read during
planning, which will be sent to aggregators to restore their progress.
These messages are useful for debugging checkpointing-related problems.

Epic: CRDB-37337

Release note: None