### PR TITLE
sql: reduce miscellaneous allocations

### DIFF
--- a/pkg/sql/colexec/colexecargs/BUILD.bazel
+++ b/pkg/sql/colexec/colexecargs/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/colcontainer",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
+        "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfra/execreleasable",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -60,9 +61,12 @@ type OpWithMetaInfo struct {
 // NewColOperatorArgs is a helper struct that encompasses all of the input
 // arguments to NewColOperator call.
 type NewColOperatorArgs struct {
-	Spec                 *execinfrapb.ProcessorSpec
-	Inputs               []OpWithMetaInfo
-	StreamingMemAccount  *mon.BoundAccount
+	Spec   *execinfrapb.ProcessorSpec
+	Inputs []OpWithMetaInfo
+	// StreamingMemAccount, if nil, is allocated lazily in NewColOperator.
+	StreamingMemAccount *mon.BoundAccount
+	// StreamingAllocator will be allocated lazily in NewColOperator.
+	StreamingAllocator   *colmem.Allocator
 	ProcessorConstructor execinfra.ProcessorConstructor
 	LocalProcessors      []execinfra.LocalProcessor
 	// any is actually a coldata.Batch, see physicalplan.PhysicalInfrastructure comments.

--- a/pkg/sql/colmem/reset_maybe_reallocate_test.go
+++ b/pkg/sql/colmem/reset_maybe_reallocate_test.go
@@ -50,13 +50,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 		typs := []*types.T{types.Bytes}
 
 		// Allocate a new batch and modify it.
-		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
 		b.SetSelection(true)
 		b.Selection()[0] = 1
 		b.ColVec(0).Bytes().Set(1, []byte("foo"))
 
 		oldBatch := b
-		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
 		// We should have used the same batch, and now it should be in a "reset"
 		// state.
 		require.Equal(t, oldBatch, b)
@@ -83,7 +83,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 		// Allocate a new batch attempting to use the batch with too small of a
 		// capacity - new batch should **not** be allocated because the memory
 		// limit is already exceeded.
-		b, _, _ = testAllocator.resetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, smallBatch, minDesiredCapacity, coldata.BatchSize(), smallMemSize, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
@@ -91,13 +91,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 
 		// Reset the batch asking for the same small desired capacity when it is
 		// sufficient - the same batch should be returned.
-		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */, false /* alwaysReallocate */)
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity/2, coldata.BatchSize(), smallMemSize, true /* desiredCapacitySufficient */, false /* alwaysReallocate */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
 		// Reset the batch and confirm that a new batch is allocated because we
 		// have given larger memory limit.
-		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, coldata.BatchSize(), largeMemSize, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
 		require.NotEqual(t, oldBatch, b)
 		require.Equal(t, minDesiredCapacity, b.Capacity())
 
@@ -108,7 +108,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 			// resetMaybeReallocate truncates the capacity at
 			// coldata.BatchSize(), so we run this part of the test only when
 			// doubled capacity will not be truncated.
-			b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
+			b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, coldata.BatchSize(), largeMemSize, false /* desiredCapacitySufficient */, false /* alwaysReallocate */)
 			require.NotEqual(t, oldBatch, b)
 			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
 		}

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -474,9 +474,9 @@ func (c *copyMachine) initVectorizedCopy(ctx context.Context, typs []*types.T) e
 	c.vectorized = true
 	factory := coldataext.NewExtendedColumnFactory(c.p.EvalContext())
 	alloc := colmem.NewLimitedAllocator(ctx, &c.rowsMemAcc, nil /*optional unlimited memory account*/, factory)
-	alloc.SetMaxBatchSize(c.copyBatchRowSize)
 	// TODO(cucaroach): Avoid allocating selection vector.
-	c.accHelper.Init(alloc, c.maxRowMem, typs, false /*alwaysReallocate*/)
+	c.accHelper.Init(alloc, c.maxRowMem, typs, false /* alwaysReallocate */)
+	c.accHelper.SetMaxBatchSize(c.copyBatchRowSize)
 	// Start with small number of rows, compromise between going too big and
 	// overallocating memory and avoiding some doubling growth batches.
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -272,6 +272,7 @@ func (ie *InternalExecutor) initConnEx(
 		mode: mode,
 		sync: syncCallback,
 	}
+	clientComm.results = clientComm.resultsScratch[:0]
 	clientComm.rowsAffectedState.rewind = func() {
 		var zero int
 		_ = w.addResult(ctx, ieIteratorResult{rowsAffected: &zero})
@@ -1431,6 +1432,8 @@ type internalClientComm struct {
 	// at any point in time (i.e. any command is created, evaluated, and then
 	// closed / discarded, and only after that a new command can be processed).
 	results []*streamingCommandResult
+	// resultsScratch is the underlying storage for results.
+	resultsScratch [4]*streamingCommandResult
 
 	// The results of the query execution will be written into w.
 	w ieResultWriter

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -209,6 +209,10 @@ var _ tree.Visitor = &ivarRemapper{}
 
 func (v *ivarRemapper) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	if ivar, ok := expr.(*tree.IndexedVar); ok {
+		if ivar.Idx == v.indexVarMap[ivar.Idx] {
+			// Avoid the identical remapping since it's redundant.
+			return false, expr
+		}
 		newIvar := v.allocIndexedVar()
 		*newIvar = *ivar
 		newIvar.Idx = v.indexVarMap[ivar.Idx]


### PR DESCRIPTION
See each commit for details.

Combined improvement:
```
name                   old time/op    new time/op    delta
LastWriteWinsInsert-8    1.42ms ±16%    1.44ms ±13%    ~     (p=0.820 n=20+20)

name                   old alloc/op   new alloc/op   delta
LastWriteWinsInsert-8     267kB ± 2%     265kB ± 2%    ~     (p=0.057 n=19+20)

name                   old allocs/op  new allocs/op  delta
LastWriteWinsInsert-8     1.95k ± 0%     1.91k ± 0%  -2.38%  (p=0.000 n=17+18)
```

Epic: CRDB-39063.