### PR TITLE
release-23.1: changefeedccl: add more logging around checkpointing

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -428,6 +428,9 @@ func makePlan(
 			Spans:     checkpoint.Spans,
 			Timestamp: checkpoint.Timestamp,
 		}
+		if log.V(2) {
+			log.Infof(ctx, "aggregator checkpoint: %s", aggregatorCheckpoint)
+		}
 
 		var checkpointSpanGroup roachpb.SpanGroup
 		checkpointSpanGroup.Add(checkpoint.Spans...)

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1424,7 +1424,7 @@ func (cf *changeFrontier) checkpointJobProgress(
 			}
 
 			if updateRunStatus {
-				md.Progress.RunningStatus = fmt.Sprintf("running: resolved=%s", frontier)
+				progress.RunningStatus = fmt.Sprintf("running: resolved=%s", frontier)
 			}
 
 			ju.UpdateProgress(progress)
@@ -1440,6 +1440,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 			return nil
 		}); err != nil {
 			return false, err
+		}
+		if log.V(2) {
+			log.Infof(cf.Ctx(), "change frontier persisted highwater=%s and checkpoint=%s", frontier, checkpoint)
 		}
 	} else {
 		cf.js.coreProgress.SetHighwater(&frontier)


### PR DESCRIPTION
Backport 1/1 commits from #125721.

/cc @cockroachdb/release

---

This patch adds a log message that will log checkpoints that are
persisted to a changefeed job's progress during normal operation.
It also adds a log message to log the checkpoint that is read during
planning, which will be sent to aggregators to restore their progress.
These messages are useful for debugging checkpointing-related problems.

Epic: CRDB-37337

Release note: None

----

Release justification: logging-only change