### PR TITLE
roachtest: fix mixedversion context in startup functions

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -260,9 +260,14 @@ func (p *testPlanner) Plan() *TestPlan {
 		}
 	}
 
+	// Use first tested upgrade version in the context passed to startup
+	// functions; the setup upgrades that happened before should be
+	// invisible to them.
+	firstTestedUpgradeVersion := testUpgrades[0].from
+
 	testPlan := &TestPlan{
 		setup:          setup,
-		initSteps:      p.testStartSteps(),
+		initSteps:      p.testStartSteps(firstTestedUpgradeVersion),
 		upgrades:       testUpgrades,
 		deploymentMode: p.deploymentMode,
 		isLocal:        p.isLocal,
@@ -282,14 +287,14 @@ func (p *testPlanner) Plan() *TestPlan {
 	return testPlan
 }
 
-func (p *testPlanner) longRunningContext() *Context {
+func (p *testPlanner) longRunningContext(fromVersion *clusterupgrade.Version) *Context {
 	var tenantDescriptor *ServiceDescriptor
 	if p.currentContext.Tenant != nil {
 		tenantDescriptor = p.currentContext.Tenant.Descriptor
 	}
 
 	return newContext(
-		p.versions[0], p.versions[len(p.versions)-1],
+		fromVersion, p.versions[len(p.versions)-1],
 		p.currentContext.DefaultService().Stage,
 		p.currentContext.DefaultService().Descriptor.Nodes,
 		tenantDescriptor,
@@ -326,18 +331,20 @@ func (p *testPlanner) clusterSetupSteps() []testStep {
 
 // startupSteps returns the list of steps that should be executed once
 // the test (as defined by user-provided functions) is ready to start.
-func (p *testPlanner) startupSteps() []testStep {
+func (p *testPlanner) startupSteps(firstUpgradeVersion *clusterupgrade.Version) []testStep {
 	p.currentContext.System.Stage = OnStartupStage
-	return p.hooks.StartupSteps(p.longRunningContext(), p.prng, p.isLocal)
+	return p.hooks.StartupSteps(p.longRunningContext(firstUpgradeVersion), p.prng, p.isLocal)
 }
 
 // testStartSteps are the user-provided steps that should run when the
 // test is starting i.e., when the cluster is running and at a
 // supported version.
-func (p *testPlanner) testStartSteps() []testStep {
+func (p *testPlanner) testStartSteps(firstUpgradeVersion *clusterupgrade.Version) []testStep {
 	return append(
-		p.startupSteps(),
-		p.hooks.BackgroundSteps(p.longRunningContext(), p.bgChans, p.prng, p.isLocal)...,
+		p.startupSteps(firstUpgradeVersion),
+		p.hooks.BackgroundSteps(
+			p.longRunningContext(firstUpgradeVersion), p.bgChans, p.prng, p.isLocal,
+		)...,
 	)
 }
 


### PR DESCRIPTION
Previously, the context assigned to startup functions (`OnStartup`) always had the `FromVersion` and `ToVersion` fields assigned to the very first and last versions in the upgrade test, respectively. This is because the concept of "from" and "to" versions are less well defined for these functions -- they run *before* the upgrades being tested happen, not during.

However, this can have undesired consequences. Specifically, if:

- the test introduced "setup upgrades" (i.e., upgrades that happen using unsupported versions of cockroachdb where user hooks do not run); **and**
- a mutator decides to insert a step relative to a startup step

then, the step added by the mutator will have an inaccurate view of the binaries running on each node -- they would think every node is running the very first version in the upgrade path, when in reality the "setup upgrades" had already finished by that point.

This commit updates the context passed to startup functions so that they know the actual binary versions running on the nodes by the time they run (via `FromVersion`).

Fixes: #125749

Release note: None