### PR TITLE
storage: use jemalloc size classes when intializing pebble

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -920,6 +920,21 @@ func DefaultPebbleOptions() *pebble.Options {
 		l.EnsureDefaults()
 	}
 
+	// These size classes are a subset of available size classes in jemalloc[1].
+	// The size classes are used by Pebble for determining target block sizes for
+	// flushes, with the goal of reducing internal fragmentation. There are many
+	// more size classes that could be included, however, sstable blocks have a
+	// target block size of 32KiB, a minimum size threshold of ~19.6KiB and are
+	// unlikely to exceed 128KiB.
+	//
+	// [1] https://jemalloc.net/jemalloc.3.html#size_classes
+	opts.AllocatorSizeClasses = []int{
+		16384,
+		20480, 24576, 28672, 32768,
+		40960, 49152, 57344, 65536,
+		81920, 98304, 114688, 131072,
+	}
+
 	return opts
 }
 


### PR DESCRIPTION
This patch makes use of the pebble size class aware flush heuristics introduced in https://github.com/cockroachdb/pebble/pull/3508. The experimentation there showed improvements in internal fragmentation.

Fixes #123090.

Release note: None