### PR TITLE
opt: add ConvertSelectWithPlaceholdersToJoin exploration rule

### DIFF
--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -154,6 +154,7 @@ define False {
 
 [Scalar]
 define Placeholder {
+    # Value is always a *tree.Placeholder.
     Value TypedExpr
 }
 

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cycle_funcs.go",
         "explorer.go",
         "general_funcs.go",
+        "generic_funcs.go",
         "groupby_funcs.go",
         "index_scan_builder.go",
         "insert_funcs.go",

--- a/pkg/sql/opt/xform/generic_funcs.go
+++ b/pkg/sql/opt/xform/generic_funcs.go
@@ -120,3 +120,12 @@ func (c *CustomFuncs) GeneratePlaceholderValuesAndJoinFilters(
 
 	return values, newFilters, true
 }
+
+// GenericJoinPrivate returns JoinPrivate that disabled join reordering and
+// merge join exploration.
+func (c *CustomFuncs) GenericJoinPrivate() *memo.JoinPrivate {
+	return &memo.JoinPrivate{
+		Flags:            memo.DisallowMergeJoin,
+		SkipReorderJoins: true,
+	}
+}

--- a/pkg/sql/opt/xform/generic_funcs.go
+++ b/pkg/sql/opt/xform/generic_funcs.go
@@ -1,0 +1,122 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package xform
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/errors"
+)
+
+// HasPlaceholders returns true if the given relational expression's subtree has
+// at least one placeholder.
+func (c *CustomFuncs) HasPlaceholders(e memo.RelExpr) bool {
+	return e.Relational().HasPlaceholder
+}
+
+// GeneratePlaceholderValuesAndJoinFilters returns a single-row Values
+// expression containing placeholders in the given filters. It also returns a
+// new set of filters where the placeholders have been replaced with variables
+// referencing the columns produced by the returned Values expression. If the
+// given filters have no placeholders, ok=false is returned.
+func (c *CustomFuncs) GeneratePlaceholderValuesAndJoinFilters(
+	filters memo.FiltersExpr,
+) (values memo.RelExpr, newFilters memo.FiltersExpr, ok bool) {
+	// Collect all the placeholders in the filters.
+	//
+	// collectPlaceholders recursively walks the scalar expression and collects
+	// placeholder expressions into the placeholders slice.
+	var placeholders []*memo.PlaceholderExpr
+	var seenIndexes intsets.Fast
+	var collectPlaceholders func(e opt.Expr)
+	collectPlaceholders = func(e opt.Expr) {
+		if p, ok := e.(*memo.PlaceholderExpr); ok {
+			idx := int(p.Value.(*tree.Placeholder).Idx)
+			// Don't include the same placeholder multiple times.
+			if !seenIndexes.Contains(idx) {
+				seenIndexes.Add(idx)
+				placeholders = append(placeholders, p)
+			}
+			return
+		}
+		for i, n := 0, e.ChildCount(); i < n; i++ {
+			collectPlaceholders(e.Child(i))
+		}
+	}
+
+	for i := range filters {
+		// Only traverse the scalar expression if it contains a placeholder.
+		if filters[i].ScalarProps().HasPlaceholder {
+			collectPlaceholders(filters[i].Condition)
+		}
+	}
+
+	// If there are no placeholders in the filters, there is nothing to do.
+	if len(placeholders) == 0 {
+		return nil, nil, false
+	}
+
+	// Create the Values expression with one row and one column for each
+	// placeholder.
+	cols := make(opt.ColList, len(placeholders))
+	colIDs := make(map[tree.PlaceholderIdx]opt.ColumnID, len(placeholders))
+	typs := make([]*types.T, len(placeholders))
+	exprs := make(memo.ScalarListExpr, len(placeholders))
+	for i, p := range placeholders {
+		idx := p.Value.(*tree.Placeholder).Idx
+		col := c.e.f.Metadata().AddColumn(fmt.Sprintf("$%d", idx+1), p.DataType())
+		cols[i] = col
+		colIDs[idx] = col
+		exprs[i] = p
+		typs[i] = p.DataType()
+	}
+
+	tupleTyp := types.MakeTuple(typs)
+	rows := memo.ScalarListExpr{c.e.f.ConstructTuple(exprs, tupleTyp)}
+	values = c.e.f.ConstructValues(rows, &memo.ValuesPrivate{
+		Cols: cols,
+		ID:   c.e.f.Metadata().NextUniqueID(),
+	})
+
+	// Create new filters by replacing the placeholders in the filters with
+	// variables.
+	var replace func(e opt.Expr) opt.Expr
+	replace = func(e opt.Expr) opt.Expr {
+		if p, ok := e.(*memo.PlaceholderExpr); ok {
+			idx := p.Value.(*tree.Placeholder).Idx
+			col, ok := colIDs[idx]
+			if !ok {
+				panic(errors.AssertionFailedf("unknown placeholder %d", idx))
+			}
+			return c.e.f.ConstructVariable(col)
+		}
+		return c.e.f.Replace(e, replace)
+	}
+
+	newFilters = make(memo.FiltersExpr, len(filters))
+	for i := range newFilters {
+		cond := filters[i].Condition
+		if newCond := replace(cond).(opt.ScalarExpr); newCond != cond {
+			// Construct a new filter if placeholders were replaced.
+			newFilters[i] = c.e.f.ConstructFiltersItem(newCond)
+		} else {
+			// Otherwise copy the filter.
+			newFilters[i] = filters[i]
+		}
+	}
+
+	return values, newFilters, true
+}

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -42,7 +42,7 @@
 )
 =>
 (Project
-    (InnerJoin $values $scan $newFilters (EmptyJoinPrivate))
+    (InnerJoin $values $scan $newFilters (GenericJoinPrivate))
     []
     (OutputCols (Root))
 )

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -1,0 +1,48 @@
+# =============================================================================
+# generic.opt contains exploration rules for optimizing generic query plans.
+# =============================================================================
+
+# ConvertSelectWithPlaceholdersToJoin is an exploration rule that converts a
+# Select expression with placeholders in the filters into an InnerJoin that
+# joins the Select's input with a Values expression that produces the
+# placeholder values.
+#
+# This rule allows generic query plans, in which placeholder values are not
+# known, to be optimized. By converting the Select into an InnerJoin, the
+# optimizer can plan a lookup join, in many cases, which has similar performance
+# characteristics to the constrained Scan that would be planned if the
+# placeholder values were known. For example, consider a schema and query like:
+#
+#   CREATE TABLE t (i INT PRIMARY KEY)
+#   SELECT * FROM t WHERE i = $1
+#
+# ConvertSelectWithPlaceholdersToJoin will perform the first conversion below,
+# from a Select into a Join. GenerateLookupJoins will perform the second
+# conversion from a (hash) Join into a LookupJoin.
+#
+#
+#   Select (i=$1)              Join (i=col_$1)         LookupJoin (t@t_pkey)
+# 	    |           ->            /   \           ->          |
+# 	    |                        /     \                      |
+# 	  Scan t             Values ($1)   Scan t              Values ($1)
+#
+[ConvertSelectWithPlaceholdersToJoin, Explore]
+(Select
+    $scan:(Scan $scanPrivate:*) & (IsCanonicalScan $scanPrivate)
+    $filters:* &
+        (HasPlaceholders (Root)) &
+        (Let
+            (
+                $values
+                $newFilters
+                $ok
+            ):(GeneratePlaceholderValuesAndJoinFilters $filters)
+            $ok
+        )
+)
+=>
+(Project
+    (InnerJoin $values $scan $newFilters (EmptyJoinPrivate))
+    []
+    (OutputCols (Root))
+)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -999,6 +999,7 @@ project
            │    ├── fd: ()-->(9,12)
            │    └── inner-join (lookup phone [as=phones1_])
            │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
+           │         ├── flags: disallow merge join
            │         ├── key columns: [17] = [9]
            │         ├── lookup columns are key
            │         ├── cardinality: [0 - 1]
@@ -1063,6 +1064,7 @@ project
            │    ├── fd: ()-->(9,12)
            │    └── inner-join (lookup phone [as=phones1_])
            │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
+           │         ├── flags: disallow merge join
            │         ├── key columns: [17] = [9]
            │         ├── lookup columns are key
            │         ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -991,18 +991,28 @@ project
            ├── has-placeholder
            ├── key: ()
            ├── fd: ()-->(1-6,9,12), (12)==(1), (1)==(12)
-           ├── select
+           ├── project
            │    ├── columns: phones1_.id:9!null person_id:12
            │    ├── cardinality: [0 - 1]
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(9,12)
-           │    ├── scan phone [as=phones1_]
-           │    │    ├── columns: phones1_.id:9!null person_id:12
-           │    │    ├── key: (9)
-           │    │    └── fd: (9)-->(12)
-           │    └── filters
-           │         └── phones1_.id:9 = $1 [outer=(9), constraints=(/9: (/NULL - ]), fd=()-->(9)]
+           │    └── inner-join (lookup phone [as=phones1_])
+           │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
+           │         ├── key columns: [17] = [9]
+           │         ├── lookup columns are key
+           │         ├── cardinality: [0 - 1]
+           │         ├── has-placeholder
+           │         ├── key: ()
+           │         ├── fd: ()-->(9,12,17), (17)==(9), (9)==(17)
+           │         ├── values
+           │         │    ├── columns: "$1":17
+           │         │    ├── cardinality: [1 - 1]
+           │         │    ├── has-placeholder
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(17)
+           │         │    └── ($1,)
+           │         └── filters (true)
            └── filters (true)
 
 opt
@@ -1045,18 +1055,28 @@ project
            ├── has-placeholder
            ├── key: ()
            ├── fd: ()-->(1-6,9,12), (12)==(1), (1)==(12)
-           ├── select
+           ├── project
            │    ├── columns: phones1_.id:9!null person_id:12
            │    ├── cardinality: [0 - 1]
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(9,12)
-           │    ├── scan phone [as=phones1_]
-           │    │    ├── columns: phones1_.id:9!null person_id:12
-           │    │    ├── key: (9)
-           │    │    └── fd: (9)-->(12)
-           │    └── filters
-           │         └── phones1_.id:9 = $1 [outer=(9), constraints=(/9: (/NULL - ]), fd=()-->(9)]
+           │    └── inner-join (lookup phone [as=phones1_])
+           │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
+           │         ├── key columns: [17] = [9]
+           │         ├── lookup columns are key
+           │         ├── cardinality: [0 - 1]
+           │         ├── has-placeholder
+           │         ├── key: ()
+           │         ├── fd: ()-->(9,12,17), (17)==(9), (9)==(17)
+           │         ├── values
+           │         │    ├── columns: "$1":17
+           │         │    ├── cardinality: [1 - 1]
+           │         │    ├── has-placeholder
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(17)
+           │         │    └── ($1,)
+           │         └── filters (true)
            └── filters (true)
 
 opt

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -222,6 +222,7 @@ project
       │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(7), (7)==(38)
       │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
       │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":38!null
+      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
       │    │    │    │    │    │    │         │    ├── key columns: [38] = [7]
       │    │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
@@ -831,6 +832,7 @@ project
       │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (2)==(44), (44)==(2), (13)==(43)
       │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_name_deleted_key)
       │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
       │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [2 13]
       │    │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
@@ -968,6 +970,7 @@ project
       │    │    │    │    │    │    ├── fd: ()-->(1-16)
       │    │    │    │    │    │    └── inner-join (lookup instance_types)
       │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$4":43!null "$1":44!null
+      │    │    │    │    │    │         ├── flags: disallow merge join
       │    │    │    │    │    │         ├── key columns: [43] = [1]
       │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │         ├── cardinality: [0 - 1]
@@ -997,6 +1000,7 @@ project
       │    │    │    │    │    │    │    ├── fd: ()-->(20-22)
       │    │    │    │    │    │    │    └── inner-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
       │    │    │    │    │    │    │         ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null "$2":45!null "$3":46!null "$4":47!null
+      │    │    │    │    │    │    │         ├── flags: disallow merge join
       │    │    │    │    │    │    │         ├── key columns: [47 46 45] = [20 21 22]
       │    │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
@@ -1135,6 +1139,7 @@ project
       │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(2), (2)==(38)
       │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_name_key)
       │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null name:2!null "$2":38!null
+      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
       │    │    │    │    │    │    │         │    ├── key columns: [38] = [2]
       │    │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
@@ -1274,6 +1279,7 @@ project
       │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(7), (7)==(38)
       │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
       │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":38!null
+      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
       │    │    │    │    │    │    │         │    ├── key columns: [38] = [7]
       │    │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
@@ -1725,6 +1731,7 @@ project
       │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (7)==(44), (44)==(7), (13)==(43)
       │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
       │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
       │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [7 13]
       │    │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
@@ -2475,6 +2482,7 @@ project
       │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (7)==(44), (44)==(7), (13)==(43)
       │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
       │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
       │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [7 13]
       │    │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
@@ -2603,6 +2611,7 @@ project
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
       │    │    │    │    │    │    └── inner-join (lookup flavors)
       │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+      │    │    │    │    │    │         ├── flags: disallow merge join
       │    │    │    │    │    │         ├── key columns: [38] = [1]
       │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │         ├── cardinality: [0 - 1]
@@ -2631,6 +2640,7 @@ project
       │    │    │    │    │    │    │    ├── fd: ()-->(19,20)
       │    │    │    │    │    │    │    └── inner-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
       │    │    │    │    │    │    │         ├── columns: flavor_projects.flavor_id:19!null project_id:20!null "$1":39!null "$2":40!null
+      │    │    │    │    │    │    │         ├── flags: disallow merge join
       │    │    │    │    │    │    │         ├── key columns: [40 39] = [19 20]
       │    │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │    │         ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -206,18 +206,37 @@ project
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(7), (7)==(38)
+      │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
+      │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":38!null
+      │    │    │    │    │    │    │         │    ├── key columns: [38] = [7]
+      │    │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,38), (38)==(7), (7)==(38)
+      │    │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │    │         │    │    ├── columns: "$2":38
+      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(38)
+      │    │    │    │    │    │    │         │    │    └── ($2,)
+      │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
@@ -796,26 +815,37 @@ project
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    └── select
-      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1,2,13)
-      │    │    │    │    │    │    │         ├── scan instance_types@instance_types_name_deleted_key
-      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13
-      │    │    │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
-      │    │    │    │    │    │    │         │    ├── key: (1)
-      │    │    │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
-      │    │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    │              └── name:2 = $4 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (2)==(44), (44)==(2), (13)==(43)
+      │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_name_deleted_key)
+      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [2 13]
+      │    │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,2,13,43,44), (44)==(2), (13)==(43), (43)==(13), (2)==(44)
+      │    │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │    │         │    │    ├── columns: "$1":43 "$4":44
+      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(43,44)
+      │    │    │    │    │    │    │         │    │    └── ($1, $4)
+      │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
       │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
@@ -922,38 +952,68 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
       │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$4":43!null "$1":44!null
+      │    │    │    │    │    │         ├── key columns: [43] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(1), (13)==(44), (44)==(13), (1)==(43)
+      │    │    │    │    │    │         ├── values
+      │    │    │    │    │    │         │    ├── columns: "$4":43 "$1":44
+      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(43,44)
+      │    │    │    │    │    │         │    └── ($4, $1)
+      │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │              └── instance_types.deleted:13 = "$1":44 [outer=(13,44), constraints=(/13: (/NULL - ]; /44: (/NULL - ]), fd=(13)==(44), (44)==(13)]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(20,30)
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_types.id:1 = $4 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
-      │    │    │    │    │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │         ├── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    │         └── instance_type_projects.instance_type_id:20 = $4 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
+      │    │    │    │    │    │    │    ├── fd: ()-->(20-22)
+      │    │    │    │    │    │    │    └── inner-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    │    │         ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null "$2":45!null "$3":46!null "$4":47!null
+      │    │    │    │    │    │    │         ├── key columns: [47 46 45] = [20 21 22]
+      │    │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(20-22,45-47), (45)==(22), (21)==(46), (46)==(21), (20)==(47), (47)==(20), (22)==(45)
+      │    │    │    │    │    │    │         ├── values
+      │    │    │    │    │    │    │         │    ├── columns: "$2":45 "$3":46 "$4":47
+      │    │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(45-47)
+      │    │    │    │    │    │    │         │    └── ($2, $3, $4)
+      │    │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [as=true:30]
+      │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
       │    │    │    └── $5
@@ -1059,18 +1119,37 @@ project
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── name:2 = $2 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      │    │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(2), (2)==(38)
+      │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_name_key)
+      │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null name:2!null "$2":38!null
+      │    │    │    │    │    │    │         │    ├── key columns: [38] = [2]
+      │    │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,2,38), (38)==(2), (2)==(38)
+      │    │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │    │         │    │    ├── columns: "$2":38
+      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(38)
+      │    │    │    │    │    │    │         │    │    └── ($2,)
+      │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
@@ -1179,18 +1258,37 @@ project
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(7), (7)==(38)
+      │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
+      │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":38!null
+      │    │    │    │    │    │    │         │    ├── key columns: [38] = [7]
+      │    │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,38), (38)==(7), (7)==(38)
+      │    │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │    │         │    │    ├── columns: "$2":38
+      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(38)
+      │    │    │    │    │    │    │         │    │    └── ($2,)
+      │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
@@ -1611,26 +1709,37 @@ project
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    └── select
-      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
-      │    │    │    │    │    │    │         ├── scan instance_types@instance_types_flavorid_deleted_key
-      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
-      │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
-      │    │    │    │    │    │    │         │    ├── key: (1)
-      │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
-      │    │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (7)==(44), (44)==(7), (13)==(43)
+      │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
+      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [7 13]
+      │    │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,43,44), (44)==(7), (13)==(43), (43)==(13), (7)==(44)
+      │    │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │    │         │    │    ├── columns: "$1":43 "$4":44
+      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(43,44)
+      │    │    │    │    │    │    │         │    │    └── ($1, $4)
+      │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
       │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
@@ -2350,26 +2459,37 @@ project
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    ├── project
       │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    └── select
-      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
-      │    │    │    │    │    │    │         ├── scan instance_types@instance_types_flavorid_deleted_key
-      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
-      │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
-      │    │    │    │    │    │    │         │    ├── key: (1)
-      │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
-      │    │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (7)==(44), (44)==(7), (13)==(43)
+      │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
+      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":43!null "$4":44!null
+      │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [7 13]
+      │    │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,43,44), (44)==(7), (13)==(43), (43)==(13), (7)==(44)
+      │    │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │    │         │    │    ├── columns: "$1":43 "$4":44
+      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(43,44)
+      │    │    │    │    │    │    │         │    │    └── ($1, $4)
+      │    │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
       │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
@@ -2467,36 +2587,67 @@ project
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
       │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    ├── left-join (merge)
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    │    │    ├── left ordering: +1
+      │    │    │    │    │    ├── right ordering: +19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
       │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+      │    │    │    │    │    │         ├── key columns: [38] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(1), (1)==(38)
+      │    │    │    │    │    │         ├── values
+      │    │    │    │    │    │         │    ├── columns: "$2":38
+      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(38)
+      │    │    │    │    │    │         │    └── ($2,)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
+      │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    ├── has-placeholder
+      │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    ├── fd: ()-->(19,27)
+      │    │    │    │    │    │    ├── project
+      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── flavors.id:1 = $2 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    │         └── flavor_projects.flavor_id:19 = $2 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    │    │    ├── fd: ()-->(19,20)
+      │    │    │    │    │    │    │    └── inner-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    │    │         ├── columns: flavor_projects.flavor_id:19!null project_id:20!null "$1":39!null "$2":40!null
+      │    │    │    │    │    │    │         ├── key columns: [40 39] = [19 20]
+      │    │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(19,20,39,40), (39)==(20), (19)==(40), (40)==(19), (20)==(39)
+      │    │    │    │    │    │    │         ├── values
+      │    │    │    │    │    │    │         │    ├── columns: "$1":39 "$2":40
+      │    │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │    │         │    ├── fd: ()-->(39,40)
+      │    │    │    │    │    │    │         │    └── ($1, $2)
+      │    │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── true [as=true:27]
+      │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
       │    │    │    └── $3

--- a/pkg/sql/opt/xform/testdata/rules/generic
+++ b/pkg/sql/opt/xform/testdata/rules/generic
@@ -24,6 +24,7 @@ project
  ├── fd: ()-->(1-5)
  └── inner-join (lookup t)
       ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
+      ├── flags: disallow merge join
       ├── key columns: [8] = [1]
       ├── lookup columns are key
       ├── cardinality: [0 - 1]
@@ -50,6 +51,7 @@ project
  ├── fd: ()-->(1-5)
  └── inner-join (lookup t)
       ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
+      ├── flags: disallow merge join
       ├── key columns: [8] = [1]
       ├── lookup columns are key
       ├── cardinality: [0 - 1]
@@ -82,6 +84,7 @@ project
       ├── fd: ()-->(2-4,8-10), (1)-->(5), (2)==(8), (8)==(2), (3)==(9), (9)==(3), (4)==(10), (10)==(4)
       ├── inner-join (lookup t@t_i_s_b_idx)
       │    ├── columns: k:1!null i:2!null s:3!null b:4!null "$1":8!null "$2":9!null "$3":10!null
+      │    ├── flags: disallow merge join
       │    ├── key columns: [8 9 10] = [2 3 4]
       │    ├── has-placeholder
       │    ├── key: (1)
@@ -109,6 +112,7 @@ project
  ├── fd: ()-->(1-5)
  └── inner-join (lookup t)
       ├── columns: k:1!null i:2!null s:3 b:4 t:5 "$1":8!null
+      ├── flags: disallow merge join
       ├── key columns: [8] = [1]
       ├── lookup columns are key
       ├── cardinality: [0 - 1]
@@ -124,6 +128,40 @@ project
       │    └── ($1,)
       └── filters
            └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+
+# The generated join should not be reordered and merge joins should not be
+# explored on it.
+opt expect=ConvertSelectWithPlaceholdersToJoin expect-not=(ReorderJoins,GenerateMergeJoins)
+SELECT * FROM t WHERE i = $1
+----
+project
+ ├── columns: k:1!null i:2!null s:3 b:4 t:5
+ ├── has-placeholder
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2!null s:3 b:4 t:5 "$1":8!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── has-placeholder
+      ├── key: (1)
+      ├── fd: ()-->(2,8), (1)-->(3-5), (2)==(8), (8)==(2)
+      ├── inner-join (lookup t@t_i_s_b_idx)
+      │    ├── columns: k:1!null i:2!null s:3 b:4 "$1":8!null
+      │    ├── flags: disallow merge join
+      │    ├── key columns: [8] = [2]
+      │    ├── has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,8), (1)-->(3,4), (2)==(8), (8)==(2)
+      │    ├── values
+      │    │    ├── columns: "$1":8
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(8)
+      │    │    └── ($1,)
+      │    └── filters (true)
+      └── filters (true)
 
 opt expect=ConvertSelectWithPlaceholdersToJoin
 SELECT * FROM t WHERE k = (SELECT i FROM t WHERE k = $1)
@@ -150,6 +188,7 @@ project
       │    ├── fd: ()-->(8,9)
       │    └── inner-join (lookup t)
       │         ├── columns: k:8!null i:9 "$1":15!null
+      │         ├── flags: disallow merge join
       │         ├── key columns: [15] = [8]
       │         ├── lookup columns are key
       │         ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/xform/testdata/rules/generic
+++ b/pkg/sql/opt/xform/testdata/rules/generic
@@ -1,0 +1,213 @@
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING,
+  b BOOL,
+  t TIMESTAMP,
+  INDEX (i, s, b)
+)
+----
+
+# --------------------------------------------------
+# ConvertSelectWithPlaceholdersToJoin
+# --------------------------------------------------
+
+opt expect=ConvertSelectWithPlaceholdersToJoin
+SELECT * FROM t WHERE k = $1
+----
+project
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
+      ├── key columns: [8] = [1]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-5,8), (8)==(1), (1)==(8)
+      ├── values
+      │    ├── columns: "$1":8
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(8)
+      │    └── ($1,)
+      └── filters (true)
+
+opt expect=ConvertSelectWithPlaceholdersToJoin
+SELECT * FROM t WHERE k = $1::INT
+----
+project
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
+      ├── key columns: [8] = [1]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-5,8), (8)==(1), (1)==(8)
+      ├── values
+      │    ├── columns: "$1":8
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(8)
+      │    └── ($1,)
+      └── filters (true)
+
+opt expect=ConvertSelectWithPlaceholdersToJoin
+SELECT * FROM t WHERE i = $1 AND s = $2 AND b = $3
+----
+project
+ ├── columns: k:1!null i:2!null s:3!null b:4!null t:5
+ ├── has-placeholder
+ ├── key: (1)
+ ├── fd: ()-->(2-4), (1)-->(5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2!null s:3!null b:4!null t:5 "$1":8!null "$2":9!null "$3":10!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── has-placeholder
+      ├── key: (1)
+      ├── fd: ()-->(2-4,8-10), (1)-->(5), (2)==(8), (8)==(2), (3)==(9), (9)==(3), (4)==(10), (10)==(4)
+      ├── inner-join (lookup t@t_i_s_b_idx)
+      │    ├── columns: k:1!null i:2!null s:3!null b:4!null "$1":8!null "$2":9!null "$3":10!null
+      │    ├── key columns: [8 9 10] = [2 3 4]
+      │    ├── has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2-4,8-10), (2)==(8), (8)==(2), (3)==(9), (9)==(3), (4)==(10), (10)==(4)
+      │    ├── values
+      │    │    ├── columns: "$1":8 "$2":9 "$3":10
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(8-10)
+      │    │    └── ($1, $2, $3)
+      │    └── filters (true)
+      └── filters (true)
+
+# A placeholder referenced multiple times in the filters should only appear once
+# in the Values expression.
+opt expect=ConvertSelectWithPlaceholdersToJoin
+SELECT * FROM t WHERE k = $1 AND i = $1
+----
+project
+ ├── columns: k:1!null i:2!null s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2!null s:3 b:4 t:5 "$1":8!null
+      ├── key columns: [8] = [1]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-5,8), (2)==(1,8), (8)==(1,2), (1)==(2,8)
+      ├── values
+      │    ├── columns: "$1":8
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(8)
+      │    └── ($1,)
+      └── filters
+           └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+
+opt expect=ConvertSelectWithPlaceholdersToJoin
+SELECT * FROM t WHERE k = (SELECT i FROM t WHERE k = $1)
+----
+project
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2 s:3 b:4 t:5 k:8!null i:9!null
+      ├── key columns: [9] = [1]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-5,8,9), (9)==(1), (1)==(9)
+      ├── project
+      │    ├── columns: k:8!null i:9
+      │    ├── cardinality: [0 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(8,9)
+      │    └── inner-join (lookup t)
+      │         ├── columns: k:8!null i:9 "$1":15!null
+      │         ├── key columns: [15] = [8]
+      │         ├── lookup columns are key
+      │         ├── cardinality: [0 - 1]
+      │         ├── has-placeholder
+      │         ├── key: ()
+      │         ├── fd: ()-->(8,9,15), (15)==(8), (8)==(15)
+      │         ├── values
+      │         │    ├── columns: "$1":15
+      │         │    ├── cardinality: [1 - 1]
+      │         │    ├── has-placeholder
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(15)
+      │         │    └── ($1,)
+      │         └── filters (true)
+      └── filters (true)
+
+# TODO(mgartner): The rule doesn't apply because the filters do not reference
+# the placeholder directly. Consider ways to handle cases like this.
+opt
+SELECT * FROM t WHERE k = (SELECT $1::INT)
+----
+project
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── select
+      ├── columns: k:1!null i:2 s:3 b:4 t:5 int8:8!null
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-5,8), (8)==(1), (1)==(8)
+      ├── project
+      │    ├── columns: int8:8 k:1!null i:2 s:3 b:4 t:5
+      │    ├── has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: ()-->(8), (1)-->(2-5)
+      │    ├── scan t
+      │    │    ├── columns: k:1!null i:2 s:3 b:4 t:5
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    └── projections
+      │         └── $1 [as=int8:8]
+      └── filters
+           └── k:1 = int8:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+
+# The rule does not match if there are no placeholders in the filters.
+opt expect-not=ConvertSelectWithPlaceholdersToJoin
+SELECT * FROM t WHERE i = 1 AND s = 'foo'
+----
+index-join t
+ ├── columns: k:1!null i:2!null s:3!null b:4 t:5
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4,5)
+ └── scan t@t_i_s_b_idx
+      ├── columns: k:1!null i:2!null s:3!null b:4
+      ├── constraint: /2/3/4/1: [/1/'foo' - /1/'foo']
+      ├── key: (1)
+      └── fd: ()-->(2,3), (1)-->(4)


### PR DESCRIPTION
#### opt: add ConvertSelectWithPlaceholdersToJoin exploration rule

The `ConvertSelectWithPlaceholdersToJoin` exploration rule has been
added which enables optimizations to apply to query plans where
placeholder values are not known. See the rule's comments for more
details. The rule does not currently apply to any query plans because it
only matches Select expressions with filters that have placeholders, and
we currently replaces all placeholders with constant values before
exploration. It will be used in the future when we enable exploration of
generic query plans.

Epic: CRDB-37712

Release note: None

#### opt: reduce exploration for joins created by ConvertSelectWithPlaceholdersToJoin

Join reordering and merge join exploration is now disabled for joins
created by the `ConvertSelectWithPlaceholdersToJoin` rule. The rule's
main goal is to assist in generating lookup joins. This changes reduces
unnecessary exploration.

Release note: None
