### PR TITLE
sql: improve fingerprinting runtime by increasing concurrency

### DIFF
--- a/pkg/sql/fingerprint_span.go
+++ b/pkg/sql/fingerprint_span.go
@@ -36,7 +36,7 @@ var maxFingerprintNumWorkers = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"sql.fingerprint.max_span_parallelism",
 	"the maximum number of workers used to issue fingerprint ExportRequests",
-	8,
+	64,
 	settings.PositiveInt,
 )
 
@@ -48,7 +48,6 @@ func (p *planner) FingerprintSpan(
 ) (uint64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "sql.FingerprintSpan")
 	defer sp.Finish()
-
 	evalCtx := p.EvalContext()
 	fingerprint, ssts, err := p.fingerprintSpanFanout(ctx, span, startTime, allRevisions, stripped)
 	if err != nil {
@@ -129,48 +128,66 @@ func (p *planner) fingerprintSpanFanout(
 		return 0, nil, err
 	}
 
-	var workerPartitions []SpanPartition
-	if len(spanPartitions) <= maxWorkerCount {
-		workerPartitions = spanPartitions
-	} else {
-		workerPartitions = make([]SpanPartition, maxWorkerCount)
-		for i, sp := range spanPartitions {
-			idx := i % maxWorkerCount
-			workerPartitions[idx].Spans = append(workerPartitions[idx].Spans, sp.Spans...)
+	maxLen := 0
+	count := 0
+	for _, partition := range spanPartitions {
+		length := len(partition.Spans)
+		maxLen = max(maxLen, length)
+		count += length
+	}
+	// Take as many workers as partitions to efficiently distribute work
+	maxWorkerCount = min(maxWorkerCount, count)
+
+	// Each span partition contains spans that are likely to be served by
+	// the same node. By round robin grabbing a span from each partition
+	// and pushing to the channel, ideally sequential workers won't attempt
+	// to read from the same node at the same time.
+	spanChannel := make(chan roachpb.Span, count)
+	for i := range maxLen {
+		for _, partition := range spanPartitions {
+			if i < len(partition.Spans) {
+				spanChannel <- partition.Spans[i]
+			}
 		}
 	}
+	close(spanChannel)
 
 	rv := struct {
 		syncutil.Mutex
 		ssts        [][]byte
 		fingerprint uint64
 	}{
-		ssts: make([][]byte, 0, len(workerPartitions)),
+		ssts: make([][]byte, 0, len(spanPartitions)),
 	}
 
 	grp := ctxgroup.WithContext(ctx)
-	for i := range workerPartitions {
-		workerIdx := i
+	for range maxWorkerCount {
 		grp.GoCtx(func(ctx context.Context) error {
-			spans := workerPartitions[workerIdx].Spans
-			for _, sp := range spans {
-				localFingerprint, localSSTs, err := fingerprintSpanImpl(ctx, evalCtx, sp, startTime, allRevisions, stripped)
-				if err != nil {
-					return err
+			// Run until channel is empty
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case sp, ok := <-spanChannel:
+					if !ok {
+						return nil
+					}
+					localFingerprint, localSSTs, err := fingerprintSpanImpl(ctx, evalCtx, sp, startTime, allRevisions, stripped)
+					if err != nil {
+						return err
+					}
+					rv.Lock()
+					rv.ssts = append(rv.ssts, localSSTs...) // nolint:deferunlockcheck
+					rv.fingerprint = rv.fingerprint ^ localFingerprint
+					rv.Unlock()
 				}
-				rv.Lock()
-				rv.ssts = append(rv.ssts, localSSTs...) // nolint:deferunlockcheck
-				rv.fingerprint = rv.fingerprint ^ localFingerprint
-				rv.Unlock()
 			}
-			return nil
 		})
 	}
+
 	if err := grp.Wait(); err != nil {
 		return 0, nil, err
 	}
-	rv.Lock()
-	defer rv.Unlock()
 	return rv.fingerprint, rv.ssts, nil
 }
 


### PR DESCRIPTION
The previous fingerprint algorithm was tied to 1 worker per node which led to slower performance. The current algorithm spins up as many workers as roach spans leading to quicker runtimes. The change alone leads to a speedup of 28%, but when paired with disabling admission control on CPU time for export requests, can lead to improvements as high as 64%. It's not possible to set cluster settings in code, so for now the admission control is untouched. More details found here: https://docs.google.com/spreadsheets/d/1VNZ_giEQWNagc6laAmYZYSdnR9Tb1vDAaBO-81ksJ8k/edit?usp=sharing

Fixes: #124725
Release note: none