### PR TITLE
cli: fix statement-bundle recreate for cluster settings

### DIFF
--- a/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
@@ -18,6 +18,16 @@ spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 
+# Set a couple of cluster settings to ensure recreation of the bundle with them
+# succeeds.
+send "SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing';\r"
+eexpect "SET CLUSTER SETTING"
+eexpect root@
+
+send "SET CLUSTER SETTING sql.distsql.use_streamer.enabled = false;\r"
+eexpect "SET CLUSTER SETTING"
+eexpect root@
+
 # Note: we need to use SELECT 1 (i.e. do not select a table)
 # so that the "recreate" test below is a proper regression test
 # for issue https://github.com/cockroachdb/cockroach/issues/86472.

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -555,7 +555,10 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	if err := c.PrintClusterSettings(&buf, false /* all */); err != nil {
 		b.printError(fmt.Sprintf("-- error getting cluster settings: %v", err), &buf)
 	}
-
+	// Note: ensure that cluster settings are added last to 'env.sql' - 'debug
+	// statement-bundle recreate' relies on SET CLUSTER SETTING stmts being
+	// last. In other words, any new additions to 'env.sql' should go above the
+	// PrintClusterSettings call.
 	b.z.AddFile("env.sql", buf.String())
 
 	mem := b.plan.mem


### PR DESCRIPTION
In the recently merged change we included `SET CLUSTER SETTING` statements into `env.sql` file for all cluster settings that have non-default values. However, this broke `debug sb recreate` command because SET CLUSTER SETTING stmts aren't allowed to be in the multi-stmt implicit txn. This commit fixes that oversight by splitting out the contents of `env.sql` file so that each SET CLUSTER SETTING would get its own implicit txn.

Epic: None

Release note: None