### PR TITLE
opt: improve stats for filters with placeholder equalities

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -135,7 +135,7 @@ quality of service: regular
   KV bytes read: 8 B
   KV gRPC calls: 1
   estimated max memory allocated: 0 B
-  estimated row count: 0
+  estimated row count: 1
   table: ab@ab_pkey
   spans: [/1 - /1]
 
@@ -164,6 +164,6 @@ quality of service: regular
   KV bytes read: 0 B
   KV gRPC calls: 0
   estimated max memory allocated: 0 B
-  estimated row count: 0
+  estimated row count: 1
   table: ab@ab_pkey
   spans: [/2 - /2]

--- a/pkg/sql/opt/memo/testdata/stats/generic
+++ b/pkg/sql/opt/memo/testdata/stats/generic
@@ -1,0 +1,168 @@
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING
+)
+----
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 1000
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 100
+  }
+]'
+----
+
+norm
+SELECT * FROM t WHERE k = $1
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string)
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── k:1 = $1 [type=bool, outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+
+norm
+SELECT * FROM t WHERE i = $1
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=3333.333, distinct(2)=1000, null(2)=0]
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=1000, null(2)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 = $1 [type=bool, outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+
+norm
+SELECT * FROM t WHERE $1 = s
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string!null)
+ ├── has-placeholder
+ ├── stats: [rows=3333.333, distinct(3)=100, null(3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(3)=100, null(3)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── s:3 = $1 [type=bool, outer=(3), constraints=(/3: (/NULL - ]), fd=()-->(3)]
+
+norm
+SELECT * FROM t WHERE i = $1 AND s = $2
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── has-placeholder
+ ├── stats: [rows=1111.111, distinct(2)=1000, null(2)=0, distinct(3)=100, null(3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=1000, null(2)=0, distinct(3)=100, null(3)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      ├── i:2 = $1 [type=bool, outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      └── s:3 = $2 [type=bool, outer=(3), constraints=(/3: (/NULL - ]), fd=()-->(3)]
+
+norm
+SELECT * FROM t WHERE i > $1
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=3333.333, distinct(2)=1000, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=1000, null(2)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 > $1 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+
+norm
+SELECT * FROM t WHERE i = $1 OR i = $2
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=3333.333, distinct(2)=1000, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=1000, null(2)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── (i:2 = $1) OR (i:2 = $2) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+
+norm
+SELECT * FROM t WHERE i IN ($1, $2, $3)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=3333.333]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 IN ($1, $2, $3) [type=bool, outer=(2)]
+
+norm
+SELECT * FROM t WHERE i = $1 OR s = $2
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=3333.333]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── (i:2 = $1) OR (s:3 = $2) [type=bool, outer=(2,3)]

--- a/pkg/sql/opt/memo/testdata/stats/generic
+++ b/pkg/sql/opt/memo/testdata/stats/generic
@@ -53,7 +53,7 @@ SELECT * FROM t WHERE i = $1
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string)
  ├── has-placeholder
- ├── stats: [rows=3333.333, distinct(2)=1000, null(2)=0]
+ ├── stats: [rows=10, distinct(2)=1, null(2)=0]
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3)
  ├── scan t
@@ -70,7 +70,7 @@ SELECT * FROM t WHERE $1 = s
 select
  ├── columns: k:1(int!null) i:2(int) s:3(string!null)
  ├── has-placeholder
- ├── stats: [rows=3333.333, distinct(3)=100, null(3)=0]
+ ├── stats: [rows=100, distinct(3)=1, null(3)=0]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2)
  ├── scan t
@@ -87,12 +87,12 @@ SELECT * FROM t WHERE i = $1 AND s = $2
 select
  ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
  ├── has-placeholder
- ├── stats: [rows=1111.111, distinct(2)=1000, null(2)=0, distinct(3)=100, null(3)=0]
+ ├── stats: [rows=0.100001, distinct(2)=0.100001, null(2)=0, distinct(3)=0.100001, null(3)=0, distinct(2,3)=0.100001, null(2,3)=0]
  ├── key: (1)
  ├── fd: ()-->(2,3)
  ├── scan t
  │    ├── columns: k:1(int!null) i:2(int) s:3(string)
- │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=1000, null(2)=0, distinct(3)=100, null(3)=0]
+ │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0, distinct(2)=1000, null(2)=0, distinct(3)=100, null(3)=0, distinct(2,3)=10000, null(2,3)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1885,30 +1885,31 @@ project
  │    ├── has-placeholder
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2-4,16)
- │    ├── right-join (hash)
- │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10 true:15
+ │    ├── project
+ │    │    ├── columns: true:15 bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10
  │    │    ├── has-placeholder
  │    │    ├── fd: ()-->(4), (1)-->(2,3)
- │    │    ├── project
- │    │    │    ├── columns: true:15!null successfulbid:10
- │    │    │    ├── fd: ()-->(15)
+ │    │    ├── right-join (hash)
+ │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10
+ │    │    │    ├── has-placeholder
+ │    │    │    ├── fd: ()-->(4), (1)-->(2,3)
  │    │    │    ├── scan tauction2 [as=a]
  │    │    │    │    └── columns: successfulbid:10
- │    │    │    └── projections
- │    │    │         └── true [as=true:15]
- │    │    ├── select
- │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null
- │    │    │    ├── has-placeholder
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: ()-->(4), (1)-->(2,3)
- │    │    │    ├── scan tbid2 [as=bids0_]
- │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null
+ │    │    │    │    ├── has-placeholder
  │    │    │    │    ├── key: (1)
- │    │    │    │    └── fd: (1)-->(2-4)
+ │    │    │    │    ├── fd: ()-->(4), (1)-->(2,3)
+ │    │    │    │    ├── scan tbid2 [as=bids0_]
+ │    │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2-4)
+ │    │    │    │    └── filters
+ │    │    │    │         └── auctionid:4 = $1 [outer=(4), constraints=(/4: (/NULL - ]), fd=()-->(4)]
  │    │    │    └── filters
- │    │    │         └── auctionid:4 = $1 [outer=(4), constraints=(/4: (/NULL - ]), fd=()-->(4)]
- │    │    └── filters
- │    │         └── successfulbid:10 = bids0_.id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    │    │         └── successfulbid:10 = bids0_.id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
+ │    │    └── projections
+ │    │         └── CASE successfulbid:10 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:15, outer=(10)]
  │    └── aggregations
  │         ├── const-not-null-agg [as=true_agg:16, outer=(15)]
  │         │    └── true:15

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -95,6 +95,25 @@ SELECT v+1 FROM kv WHERE k = $1
 ----
 no fast path
 
+
+# Inject statistics so that the estimated row count is high.
+exec-ddl
+ALTER TABLE abcd INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 5
+  }
+]'
+----
+
 # The fast path should not kick in because the estimated row count is too high.
 placeholder-fast-path
 SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2
@@ -120,7 +139,7 @@ SELECT a, b, c FROM abcd WHERE a=$1 AND b=$2
 placeholder-scan abcd@abcd_a_b_idx
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=1.98, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── $1
@@ -132,7 +151,7 @@ SELECT a, b, c FROM abcd WHERE b=$1 AND a=$2
 placeholder-scan abcd@abcd_a_b_idx
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=1.1, distinct(1)=1.1, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=1.98, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── $2
@@ -145,7 +164,7 @@ SELECT a, b, c FROM abcd WHERE a=0 AND b=$1
 placeholder-scan abcd@abcd_a_b_idx
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=0.66, distinct(1)=0.66, null(1)=0, distinct(2)=0.66, null(2)=0, distinct(1,2)=0.66, null(1,2)=0]
+ ├── stats: [rows=1.98, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── 0
@@ -157,7 +176,7 @@ SELECT a, b, c FROM abcd WHERE a=$1 AND b=0
 placeholder-scan abcd@abcd_a_b_idx
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=3.3, distinct(1)=3.3, null(1)=0, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=1.98, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── $1
@@ -170,7 +189,7 @@ SELECT a, b, c FROM abcd WHERE a=1+2 AND b=$1
 placeholder-scan abcd@abcd_a_b_idx
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=0.66, distinct(1)=0.66, null(1)=0, distinct(2)=0.66, null(2)=0, distinct(1,2)=0.66, null(1,2)=0]
+ ├── stats: [rows=1.98, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── 3
@@ -182,7 +201,7 @@ SELECT a, b, c FROM abcd WHERE a=fnv32a('foo') AND b=$1
 placeholder-scan abcd@abcd_a_b_idx
  ├── columns: a:1!null b:2!null c:3
  ├── has-placeholder
- ├── stats: [rows=0.66, distinct(1)=0.66, null(1)=0, distinct(2)=0.66, null(2)=0, distinct(1,2)=0.66, null(1,2)=0]
+ ├── stats: [rows=1.98, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
  ├── fd: ()-->(1,2)
  └── span
       ├── 2851307223
@@ -230,7 +249,7 @@ SELECT a, d FROM abcd WHERE d=$1 AND c=$2
 placeholder-scan abcd@abcd_d_c_a_idx
  ├── columns: a:1 d:4!null
  ├── has-placeholder
- ├── stats: [rows=1.089]
+ ├── stats: [rows=9.801]
  ├── fd: ()-->(4)
  └── span
       ├── $1
@@ -290,7 +309,7 @@ SELECT a, b FROM partial1 WHERE a = $1
 placeholder-scan partial1@pseudo_ab,partial
  ├── columns: a:2!null b:3
  ├── has-placeholder
- ├── stats: [rows=3.3, distinct(2)=1, null(2)=0]
+ ├── stats: [rows=9.9, distinct(2)=1, null(2)=0]
  ├── fd: ()-->(2)
  └── span
       └── $1


### PR DESCRIPTION
#### opt: add stats tests for generic query plans

This commit adds some stats tests with queries containing placeholders.

Release note: None

#### opt: improve stats for filters with placeholder equalities

Stats estimates for filters of the form `col = $1` have been improved.
While histograms cannot be filtered without knowing the placeholder
value, we do know that `col` is limited to a one distinct value. This
improves the estimate over the simple 1/3 "unknown selectivity" that was
applied for these filters before this commit.

This changed required a modification to `TestCopyAndReplace` because it
made it such that a merge-join was no longer selected when optimizing
the query with placeholders. Now the test checks that `CopyAndReplace`
works correctly when copying a fully optimized memo with a parameterized
lookup-join. I've confirmed that the test still catches the bug
fixed in the original PR that added the test, #35020.

Epic: CRDB-37712

Release note: None
