### PR TITLE
kvtenant: use manual replication mode for desc scan tests

### DIFF
--- a/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
@@ -30,13 +30,9 @@ func setup(
 	t *testing.T, ctx context.Context,
 ) (*testcluster.TestCluster, serverutils.ApplicationLayerInterface, rangedesc.IteratorFactory) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
 			DefaultTestTenant: base.TestControlsTenantsExplicitly,
-			Knobs: base.TestingKnobs{
-				Store: &kvserver.StoreTestingKnobs{
-					DisableMergeQueue: true,
-				},
-			},
 		},
 	})
 


### PR DESCRIPTION
`TestScanRangeDescriptors` expects that there are no splits interleaving the manual splits the test issues. This wasn't the case as the split queue was left enabled. Disable the split queue via `ReplicationManual` test cluster replication mode.

Fixes: #125780
Release note: None