### PR TITLE
sql: add dynamic sample size max/min private settings and logging

### DIFF
--- a/pkg/sql/distsql_plan_stats_test.go
+++ b/pkg/sql/distsql_plan_stats_test.go
@@ -11,9 +11,11 @@
 package sql
 
 import (
+	"context"
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -21,6 +23,7 @@ import (
 func TestComputeNumberSamples(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 
 	testData := []struct {
 		numRows            int
@@ -43,7 +46,9 @@ func TestComputeNumberSamples(t *testing.T) {
 			t.Fatalf("expected %d samples, got %d", expectedNumSamples, computedNumSamples)
 		}
 	}
+
+	st := cluster.MakeTestingClusterSettings()
 	for _, td := range testData {
-		checkComputeNumberSamples(int(computeNumberSamples(uint64(td.numRows))), td.expectedNumSamples)
+		checkComputeNumberSamples(int(computeNumberSamples(ctx, uint64(td.numRows), st)), td.expectedNumSamples)
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -254,6 +254,72 @@ SELECT (count(*) // 10) * 10 FROM [SHOW HISTOGRAM $hist_id_injected]
 ----
 20000
 
+# Verify that we can configure the minimum and maximum automatically-determined
+# sample size.
+
+statement ok
+SET CLUSTER SETTING sql.stats.histogram_samples.min = 15000
+
+statement ok
+CREATE STATISTICS s_dynamic_min FROM big
+
+let $hist_id_dynamic_min
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE big] WHERE statistics_name = 's_dynamic_min';
+
+# Perform integer division by 10 because there may be 2 extra buckets added
+# on either end of the histogram to account for the 20000 distinct values.
+query I
+SELECT (count(*) // 10) * 10 FROM [SHOW HISTOGRAM $hist_id_dynamic_min]
+----
+15000
+
+statement ok
+RESET CLUSTER SETTING sql.stats.histogram_samples.min
+
+statement ok
+SET CLUSTER SETTING sql.stats.histogram_samples.max = 10500
+
+statement ok
+CREATE STATISTICS s_dynamic_max FROM big
+
+let $hist_id_dynamic_max
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE big] WHERE statistics_name = 's_dynamic_max';
+
+# Perform integer division by 10 because there may be 2 extra buckets added
+# on either end of the histogram to account for the 20000 distinct values.
+query I
+SELECT (count(*) // 10) * 10 FROM [SHOW HISTOGRAM $hist_id_dynamic_max]
+----
+10500
+
+# Verify that the default sample size bounds are used if the minimum is
+# greater than the maximum.
+
+statement ok
+SET CLUSTER SETTING sql.stats.histogram_samples.min = 11000
+
+statement ok
+CREATE STATISTICS s_dynamic_default_bounds FROM big
+
+let $hist_id_dynamic_default_bounds
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE big] WHERE statistics_name = 's_dynamic_default_bounds';
+
+# Perform integer division by 10 because there may be 2 extra buckets added
+# on either end of the histogram to account for the 20000 distinct values.
+query I
+SELECT (count(*) // 10) * 10 FROM [SHOW HISTOGRAM $hist_id_dynamic_default_bounds]
+----
+10840
+
+statement ok
+RESET CLUSTER SETTING sql.stats.histogram_samples.min
+
+statement ok
+RESET CLUSTER SETTING sql.stats.histogram_samples.max
+
+# Verify that specifying the number of samples in the cluster setting overrides
+# the dynamically determined number of samples.
+
 statement ok
 SET CLUSTER SETTING sql.stats.histogram_samples.count = 20000
 


### PR DESCRIPTION
Logs the histogram sample size when it is determined dynamically. Also makes the bounds on the dynamic sample size computation configurable with private cluster settings. These are private for now since users should modify the `sql_stats_histogram_samples_count` table setting or `sql.stats.histogram_samples.count` cluster setting if they want custom sample sizes.

See also: #123972

Release note: None