### PR TITLE
streamingccl/logical: dedup code in query construction

### DIFF
--- a/pkg/ccl/streamingccl/logical/lww_row_processor.go
+++ b/pkg/ccl/streamingccl/logical/lww_row_processor.go
@@ -194,77 +194,72 @@ func makeInsertQueries(
 		var onConflictUpdateClause strings.Builder
 		argIdx := 1
 		seenIds := make(map[catid.ColumnID]struct{})
-		addColumn := func(colName string, colID catid.ColumnID) {
-			// We will set crdb_internal_origin_timestamp ourselves from the MVCC timestamp of the incoming datum.
-			// We should never see this on the rangefeed as a non-null value as that would imply we've looped data around.
-			if colName == "crdb_internal_origin_timestamp" {
-				return
-			}
-			if _, seen := seenIds[colID]; seen {
-				return
-			}
-
-			if argIdx == 1 {
-				columnNames.WriteString(colName)
-				fmt.Fprintf(&valueStrings, "$%d", argIdx)
-				fmt.Fprintf(&onConflictUpdateClause, "%s = $%d", colName, argIdx)
-			} else {
-				fmt.Fprintf(&columnNames, ", %s", colName)
-				fmt.Fprintf(&valueStrings, ", $%d", argIdx)
-				fmt.Fprintf(&onConflictUpdateClause, ",\n%s = $%d", colName, argIdx)
-			}
-			seenIds[colID] = struct{}{}
-			argIdx++
-		}
 
 		publicColumns := td.PublicColumns()
 		colOrd := catalog.ColumnIDToOrdinalMap(publicColumns)
+		addColumnByNameNoCheck := func(colName string) {
+			if argIdx == 1 {
+				columnNames.WriteString(colName)
+				fmt.Fprintf(&valueStrings, "$%d", argIdx)
+				fmt.Fprintf(&onConflictUpdateClause, "%s = excluded.%[1]s", colName)
+			} else {
+				fmt.Fprintf(&columnNames, ", %s", colName)
+				fmt.Fprintf(&valueStrings, ", $%d", argIdx)
+				fmt.Fprintf(&onConflictUpdateClause, ",\n%s = excluded.%[1]s", colName)
+			}
+			argIdx++
+		}
+		addColumnByID := func(colID catid.ColumnID) error {
+			ord, ok := colOrd.Get(colID)
+			if !ok {
+				return errors.AssertionFailedf("expected to find column %d", colID)
+			}
+			col := publicColumns[ord]
+			if col.IsComputed() {
+				return nil
+			}
+			colName := col.GetName()
+			// We will set crdb_internal_origin_timestamp ourselves from the MVCC timestamp of the incoming datum.
+			// We should never see this on the rangefeed as a non-null value as that would imply we've looped data around.
+			if colName == "crdb_internal_origin_timestamp" {
+				return nil
+			}
+			if _, seen := seenIds[colID]; seen {
+				return nil
+			}
+			addColumnByNameNoCheck(colName)
+			seenIds[colID] = struct{}{}
+			return nil
+		}
+
 		primaryIndex := td.GetPrimaryIndex()
-
 		for i := 0; i < primaryIndex.NumKeyColumns(); i++ {
-			colID := primaryIndex.GetKeyColumnID(i)
-			ord, ok := colOrd.Get(colID)
-			if !ok {
-				return errors.AssertionFailedf("expected to find column %d", colID)
+			if err := addColumnByID(primaryIndex.GetKeyColumnID(i)); err != nil {
+				return err
 			}
-			col := publicColumns[ord]
-			if col.IsComputed() {
-				continue
-			}
-			addColumn(col.GetName(), col.GetID())
 		}
 
-		for i, colName := range family.ColumnNames {
-			colID := family.ColumnIDs[i]
-			ord, ok := colOrd.Get(colID)
-			if !ok {
-				return errors.AssertionFailedf("expected to find column %d", colID)
+		for i := range family.ColumnNames {
+			if err := addColumnByID(family.ColumnIDs[i]); err != nil {
+				return err
 			}
-			col := publicColumns[ord]
-			if col.IsComputed() {
-				continue
-			}
-			addColumn(colName, family.ColumnIDs[i])
 		}
-
+		addColumnByNameNoCheck("crdb_internal_origin_timestamp")
 		var err error
-		originTSIdx := argIdx
-		baseQuery := `
-INSERT INTO %s (%s, crdb_internal_origin_timestamp)
-VALUES (%s, $%d)
+		const baseQuery = `
+INSERT INTO %s AS t (%s)
+VALUES (%s)
 ON CONFLICT ON CONSTRAINT %s
 DO UPDATE SET
-%s,
-crdb_internal_origin_timestamp=$%[4]d
-WHERE (%[1]s.crdb_internal_mvcc_timestamp <= $%[4]d
-       AND %[1]s.crdb_internal_origin_timestamp IS NULL)
-   OR (%[1]s.crdb_internal_origin_timestamp <= $%[4]d
-       AND %[1]s.crdb_internal_origin_timestamp IS NOT NULL)`
+%s
+WHERE (t.crdb_internal_mvcc_timestamp <= excluded.crdb_internal_origin_timestamp
+       AND t.crdb_internal_origin_timestamp IS NULL)
+   OR (t.crdb_internal_origin_timestamp <= excluded.crdb_internal_origin_timestamp
+       AND t.crdb_internal_origin_timestamp IS NOT NULL)`
 		queries[family.ID], err = parser.ParseOne(fmt.Sprintf(baseQuery,
 			fqTableName,
 			columnNames.String(),
 			valueStrings.String(),
-			originTSIdx,
 			td.GetPrimaryIndex().GetName(),
 			onConflictUpdateClause.String(),
 		))


### PR DESCRIPTION
This dedups some code during insert query construction and makes use of the `excluded` table in the ON CONFLICT clause rather than referencing the positional arguments again.

I don't expect this to have much of an impact on query performance. Rather, I think this will simplify some other potential changes to query construction.

Interestingly, the microbenchmark does show a small reduction in allocs, but I haven't tested this at larger scales yet:

```
                    │   old.txt    │            new.txt            │
                    │    sec/op    │   sec/op     vs base          │
LastWriteWinsInsert   749.8µ ± 11%   718.4µ ± 5%  ~ (p=0.280 n=10)

                    │   old.txt    │               new.txt               │
                    │     B/op     │     B/op      vs base               │
LastWriteWinsInsert   251.3Ki ± 1%   244.5Ki ± 1%  -2.68% (p=0.000 n=10)

                    │   old.txt   │              new.txt               │
                    │  allocs/op  │  allocs/op   vs base               │
LastWriteWinsInsert   1.881k ± 0%   1.741k ± 0%  -7.42% (p=0.000 n=10)
```

Epic: none
Release note: None