### PR TITLE
roachtest/test-selector: omit test failure due to preempted VMs

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -251,7 +251,9 @@ func testsToRun(
 		return nil, errors.Newf("%s", msg)
 	}
 
-	if roachtestflags.SelectiveTests {
+	// selective-tests is considered only if the select-probability is 1.0. This is because select probability already
+	// takes care of running limited tests.
+	if roachtestflags.SelectiveTests && roachtestflags.SelectProbability == 1.0 {
 		fmt.Printf("selective Test enabled\n")
 		// the test categorization must be complete in 30 seconds
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -91,7 +91,7 @@ var (
 	SelectiveTests = false
 	_              = registerRunFlag(&SelectiveTests, FlagInfo{
 		Name:  "selective-tests",
-		Usage: `Use selective tests to run based on previous test execution`,
+		Usage: `Use selective tests to run based on previous test execution. this is considered only if the select-probability is 1.0`,
 	})
 
 	Username string = os.Getenv("ROACHPROD_USER")

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1095,6 +1095,8 @@ func (r *testRunner) runTest(
 				failureMsg := t.failureMsg()
 				preemptedVMNames := getPreemptedVMNames(ctx, c, l)
 				if preemptedVMNames != "" {
+					// Note that this error message is referred for test selection in
+					// pkg/cmd/roachtest/testselector/snowflake_query.sql.
 					failureMsg = fmt.Sprintf("VMs preempted during the test run: %s\n\n**Other Failures:**\n%s", preemptedVMNames, failureMsg)
 					// Reset failures in the test so that the VM preemption
 					// error is the one that is taken into account when

--- a/pkg/cmd/roachtest/testselector/snowflake_query.sql
+++ b/pkg/cmd/roachtest/testselector/snowflake_query.sql
@@ -8,20 +8,19 @@ with builds as (
   where
     start_date > dateadd(DAY, ?, current_date()) -- last "forPastDays" days
     and lower(status) = 'success' -- consider only successful builds
-    and branch_name = 'master' -- consider only builds from master branch
+    and branch_name = ? -- consider the builds from target branch
     and lower(name) like ? -- name is based on the suite and cloud e.g. '%roachtest nightly - gce%'
   group by 1
 ), test_stats as (
   -- for all the build IDs select do a inner join on all the tests
   select test_name, -- distinct test names
-         count(case when duration>0 then test_name end) as total_runs, -- all runs with duration>0 (excluding all ignored test runs)
-         -- count by status
-         count(case when status='SUCCESS' then test_name end) as success_count,
-         count(case when status='FAILURE' then test_name end) as failure_count,
+         count(case when status='SUCCESS' then test_name end) as total_successful_runs, -- all successful runs
+         -- count the number of failed tests. tests failed due to preempted VMs are ignored.
+         count(case when status='FAILURE' and details not like '%VMs preempted during the test run%' then test_name end) as failure_count,
          -- get the first_run and last_run only if the status is not UNKNOWN. This returns nil for runs that have never run
          min(case when status!='UNKNOWN' then b.first_run end) as first_run,
          max(case when status!='UNKNOWN' then b.last_run end) as last_run,
-         sum(duration) as total_duration -- the total duration of the test
+         sum(case when status='SUCCESS' then duration end) as total_duration -- the total duration of the tests that are successful
   from DATAMART_PROD.TEAMCITY.TESTS t
          -- inner join as explained in the beginning
          inner join builds b on
@@ -38,8 +37,8 @@ select
          last_run < dateadd(DAY, ?, current_date()) or -- the test has not been run for last "lastRunOn" days
          last_run is null -- the test is always ignored till now or have never been run
          then 'yes' else 'no' end as selected,
-  -- average duration - this is set to 0 if the test is never run (total_runs=0)
-  case when total_runs > 0 then total_duration/total_runs else 0 end as avg_duration,
-  total_runs,
+  -- average duration - this is set to 0 if the test is never run (total_successful_runs=0)
+  case when total_successful_runs > 0 then total_duration/total_successful_runs else 0 end as avg_duration,
+  total_successful_runs,
 from test_stats
-order by selected desc, total_runs
+order by selected desc, total_successful_runs


### PR DESCRIPTION
This change is possible due to a recent addition of a column
capturing the failure details in snowflake.
In the test selection criteria, we consider all tests that
have failed. This includes the tests that are failed due to
infra as well. But, these tests can be considered success as
the actual test has not failed.
So, this change ignores the tests that have failed due
to preempted VMs (one type of infra flake).
 
Also, the query was considering the test results only from
the master branch. This change reads the branch from the env
as TC_BUILD_BRANCH.

Informs: #119630
Epic: none