### PR TITLE
streamingccl: move to wrapped event by default

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
@@ -48,7 +48,7 @@ func KeyMatches(key roachpb.Key) FeedEventPredicate {
 			return false
 		}
 		for _, kv := range msg.GetKVs() {
-			if bytes.Equal(key, kv.Key) {
+			if bytes.Equal(key, kv.KeyValue.Key) {
 				return true
 			}
 		}
@@ -120,7 +120,7 @@ func (rf *ReplicationFeed) ObserveKey(ctx context.Context, key roachpb.Key) roac
 	rf.consumeUntil(ctx, KeyMatches(key), func(err error) bool {
 		return false
 	})
-	return rf.msg.GetKVs()[0]
+	return rf.msg.GetKVs()[0].KeyValue
 }
 
 // ObserveAnySpanConfigRecord consumes the feed until any span config record is observed.

--- a/pkg/ccl/streamingccl/streamclient/client_helpers.go
+++ b/pkg/ccl/streamingccl/streamclient/client_helpers.go
@@ -105,12 +105,12 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 		case len(streamEvent.Batch.Ssts) > 0:
 			event = streamingccl.MakeSSTableEvent(streamEvent.Batch.Ssts[0])
 			streamEvent.Batch.Ssts = streamEvent.Batch.Ssts[1:]
-		case len(streamEvent.Batch.KeyValues) > 0:
-			event = streamingccl.MakeKVEvent(streamEvent.Batch.KeyValues)
-			streamEvent.Batch.KeyValues = nil
-		case len(streamEvent.Batch.KeyValuesWithDiff) > 0:
-			event = streamingccl.MakeKVWithDiffEvent(streamEvent.Batch.KeyValuesWithDiff)
-			streamEvent.Batch.KeyValuesWithDiff = nil
+		case len(streamEvent.Batch.DeprecatedKeyValues) > 0:
+			event = streamingccl.MakeKVEventFromKVs(streamEvent.Batch.DeprecatedKeyValues)
+			streamEvent.Batch.DeprecatedKeyValues = nil
+		case len(streamEvent.Batch.KVs) > 0:
+			event = streamingccl.MakeKVEvent(streamEvent.Batch.KVs)
+			streamEvent.Batch.KVs = nil
 		case len(streamEvent.Batch.DelRanges) > 0:
 			event = streamingccl.MakeDeleteRangeEvent(streamEvent.Batch.DelRanges[0])
 			streamEvent.Batch.DelRanges = streamEvent.Batch.DelRanges[1:]
@@ -130,8 +130,8 @@ func parseEvent(streamEvent *streampb.StreamEvent) streamingccl.Event {
 }
 
 func isEmptyBatch(b *streampb.StreamEvent_Batch) bool {
-	return len(b.KeyValues) == 0 &&
-		len(b.KeyValuesWithDiff) == 0 &&
+	return len(b.KVs) == 0 &&
+		len(b.DeprecatedKeyValues) == 0 &&
 		len(b.Ssts) == 0 &&
 		len(b.DelRanges) == 0 &&
 		len(b.SpanConfigs) == 0 &&

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -105,7 +105,7 @@ func (sc testStreamClient) Subscribe(
 	}
 
 	events := make(chan streamingccl.Event, 2)
-	events <- streamingccl.MakeKVEvent([]roachpb.KeyValue{sampleKV})
+	events <- streamingccl.MakeKVEventFromKVs([]roachpb.KeyValue{sampleKV})
 	events <- streamingccl.MakeCheckpointEvent([]jobspb.ResolvedSpan{sampleResolvedSpan})
 	close(events)
 
@@ -308,7 +308,7 @@ func ExampleClient() {
 				case streamingccl.KVEvent:
 					kvs := event.GetKVs()
 					for _, kv := range kvs {
-						fmt.Printf("kv: %s->%s@%d\n", kv.Key.String(), string(kv.Value.RawBytes), kv.Value.Timestamp.WallTime)
+						fmt.Printf("kv: %s->%s@%d\n", kv.KeyValue.Key.String(), string(kv.KeyValue.Value.RawBytes), kv.KeyValue.Value.Timestamp.WallTime)
 					}
 				case streamingccl.SSTableEvent:
 					sst := event.GetSSTable()

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -238,6 +238,7 @@ func (p *partitionedStreamClient) Subscribe(
 	sps.ConsumerNode = consumerNode
 	sps.ConsumerProc = consumerProc
 	sps.Compressed = true
+	sps.WrappedEvents = true
 	sps.WithDiff = cfg.withDiff
 	sps.WithFiltering = cfg.withFiltering
 

--- a/pkg/ccl/streamingccl/streamingest/merged_subscription_test.go
+++ b/pkg/ccl/streamingccl/streamingest/merged_subscription_test.go
@@ -30,10 +30,10 @@ func TestMergeSubscriptionsRun(t *testing.T) {
 	ctx := context.Background()
 	events := func(partition string) []streamingccl.Event {
 		return []streamingccl.Event{
-			streamingccl.MakeKVEvent([]roachpb.KeyValue{{
+			streamingccl.MakeKVEventFromKVs([]roachpb.KeyValue{{
 				Key: []byte(partition + "_key1"),
 			}}),
-			streamingccl.MakeKVEvent([]roachpb.KeyValue{{
+			streamingccl.MakeKVEventFromKVs([]roachpb.KeyValue{{
 				Key: []byte(partition + "_key2"),
 			}}),
 		}
@@ -67,7 +67,7 @@ func TestMergeSubscriptionsRun(t *testing.T) {
 		events := []string{}
 		g.Go(func() error {
 			for ev := range merged.Events() {
-				events = append(events, string(ev.GetKVs()[0].Key))
+				events = append(events, string(ev.GetKVs()[0].KeyValue.Key))
 			}
 			return nil
 		})

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -559,5 +559,6 @@ func streamPartition(
 		spec:     spec,
 		execCfg:  execCfg,
 		mon:      evalCtx.Planner.Mon(),
+		seb:      streamEventBatcher{wrappedKVs: spec.WrappedEvents},
 	}, nil
 }

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -274,7 +274,7 @@ func (s *eventStream) onValues(ctx context.Context, values []kv.KeyValue) {
 		defer s.addMu.Unlock()
 	}
 	for _, i := range values {
-		s.seb.addKV(roachpb.KeyValue{Key: i.Key, Value: *i.Value})
+		s.seb.addKV(streampb.StreamEvent_KV{KeyValue: roachpb.KeyValue{Key: i.Key, Value: *i.Value}})
 	}
 	s.setErr(s.maybeFlushBatch(ctx))
 }
@@ -287,14 +287,9 @@ func (s *eventStream) onValue(ctx context.Context, value *kvpb.RangeFeedValue) {
 		s.addMu.Lock()
 		defer s.addMu.Unlock()
 	}
-	if s.spec.WithDiff {
-		s.seb.addKVWithDiff(
-			roachpb.KeyValue{Key: value.Key, Value: value.Value},
-			value.PrevValue,
-		)
-	} else {
-		s.seb.addKV(roachpb.KeyValue{Key: value.Key, Value: value.Value})
-	}
+	s.seb.addKV(streampb.StreamEvent_KV{
+		KeyValue: roachpb.KeyValue{Key: value.Key, Value: value.Value}, PrevValue: value.PrevValue,
+	})
 	s.setErr(s.maybeFlushBatch(ctx))
 }
 
@@ -478,7 +473,10 @@ func (s *eventStream) addSST(sst *kvpb.RangeFeedSSTable, registeredSpan roachpb.
 			if err != nil {
 				return err
 			}
-			s.seb.addKV(roachpb.KeyValue{Key: k.Key.Key, Value: roachpb.Value{RawBytes: v.RawBytes, Timestamp: k.Key.Timestamp}})
+			s.seb.addKV(
+				streampb.StreamEvent_KV{KeyValue: roachpb.KeyValue{
+					Key: k.Key.Key, Value: roachpb.Value{RawBytes: v.RawBytes, Timestamp: k.Key.Timestamp}},
+				})
 			return nil
 		}, func(rk storage.MVCCRangeKeyValue) error {
 			s.seb.addDelRange(kvpb.RangeFeedDeleteRange{

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -327,6 +327,7 @@ func encodeSpecForSpans(
 		PreviousReplicatedTimestamp: previousReplicatedTime,
 		Spans:                       spans,
 		Progress:                    progress,
+		WrappedEvents:               true,
 		Config: streampb.StreamPartitionSpec_ExecutionConfig{
 			MinCheckpointFrequency: 10 * time.Millisecond,
 		},

--- a/pkg/ccl/streamingccl/streamproducer/span_config_event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/span_config_event_stream.go
@@ -217,7 +217,7 @@ func (s *spanConfigEventStream) streamLoop(ctx context.Context) error {
 	// don't clog up the rangefeed. Consider using async flushing.
 	pacer := makeCheckpointPacer(s.spec.MinCheckpointFrequency)
 	bufferedEvents := make([]streampb.StreamedSpanConfigEntry, 0)
-	batcher := makeStreamEventBatcher()
+	batcher := makeStreamEventBatcher(s.spec.WrappedEvents)
 	frontier := makeSpanConfigFrontier(s.spec.Span)
 
 	for {

--- a/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_event_batcher.go
@@ -29,7 +29,7 @@ func makeStreamEventBatcher() *streamEventBatcher {
 
 func (seb *streamEventBatcher) reset() {
 	seb.size = 0
-	seb.batch.KeyValues = seb.batch.KeyValues[:0]
+	seb.batch.KVs = seb.batch.KVs[:0]
 	seb.batch.Ssts = seb.batch.Ssts[:0]
 	seb.batch.DelRanges = seb.batch.DelRanges[:0]
 	seb.batch.SpanConfigs = seb.batch.SpanConfigs[:0]
@@ -41,17 +41,9 @@ func (seb *streamEventBatcher) addSST(sst kvpb.RangeFeedSSTable) {
 	seb.size += sst.Size()
 }
 
-func (seb *streamEventBatcher) addKVWithDiff(kv roachpb.KeyValue, prev roachpb.Value) {
-	seb.batch.KeyValuesWithDiff = append(seb.batch.KeyValuesWithDiff, streampb.StreamEvent_KVWithDiff{
-		KeyValue:  kv,
-		PrevValue: prev,
-	})
-	seb.size += (kv.Size() + prev.Size())
-}
-
-func (seb *streamEventBatcher) addKV(kv roachpb.KeyValue) {
-	seb.batch.KeyValues = append(seb.batch.KeyValues, kv)
-	seb.size += kv.Size()
+func (seb *streamEventBatcher) addKV(kv streampb.StreamEvent_KV) {
+	seb.batch.KVs = append(seb.batch.KVs, kv)
+	seb.size += (kv.Size())
 }
 
 func (seb *streamEventBatcher) addDelRange(d kvpb.RangeFeedDeleteRange) {

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -459,6 +459,7 @@ func setupSpanConfigsStream(
 		Span:                   span,
 		TenantID:               tenantID,
 		MinCheckpointFrequency: streamingccl.StreamReplicationMinCheckpointFrequency.Get(&evalCtx.Settings.SV),
+		WrappedEvents:          true,
 	}
 	return streamSpanConfigs(evalCtx, spec)
 }

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -195,18 +195,18 @@ message StreamedSpanConfigEntry {
 // StreamEvent describes a replication stream event
 message StreamEvent {
 
-  message KVWithDiff {
+  message KV {
     roachpb.KeyValue key_value = 1 [(gogoproto.nullable) = false];
     roachpb.Value prev_value = 2 [(gogoproto.nullable) = false];
   }
 
   message Batch {
-    repeated roachpb.KeyValue key_values = 1 [(gogoproto.nullable) = false];
+    repeated roachpb.KeyValue deprecated_key_values = 1 [(gogoproto.nullable) = false];
     repeated roachpb.RangeFeedSSTable ssts = 2 [(gogoproto.nullable) = false];
     repeated roachpb.RangeFeedDeleteRange del_ranges = 3 [(gogoproto.nullable) = false];
     repeated StreamedSpanConfigEntry span_configs = 4 [(gogoproto.nullable) = false];
     repeated bytes split_points = 5 [(gogoproto.casttype) =  "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
-    repeated KVWithDiff key_values_with_diff = 6 [(gogoproto.nullable) = false];;
+    repeated KV kvs = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "KVs"];
   }
 
   // Checkpoint represents stream checkpoint.

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -144,6 +144,8 @@ message StreamPartitionSpec {
 
   bool with_diff = 10;
 
+  bool wrapped_events = 11;
+
   // NEXT ID: 11.
 }
 
@@ -156,7 +158,7 @@ message SpanConfigEventStreamSpec {
   // Controls how often checkpoint records are published.
   google.protobuf.Duration min_checkpoint_frequency = 3
   [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-
+  bool wrapped_events = 4;
 }
 
 message ReplicationStreamSpec {


### PR DESCRIPTION
Previously we had one event type that was just roachpb.KeyValues and a separate event type that was a wrapped KeyValue with additional previous value if diffs were requested. This, however, made a lot of code need to to handle one or the other. In the future we also expect to need to add more optional metadata to KVs, such as MVCC value headers, which would also require the use of a wrapper.

This change switches to use the wrapper by default all the time, even if a specific piece of added data like diffs isn't requested, and deprecates the old unwrapped field.

Release note: none.
Epic: none.