### PR TITLE
acceptance/compose: add docker health check

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -17,11 +17,17 @@ services:
       - ${CERTS_DIR:-../../.localcluster.certs}:/certs
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
+    healthcheck:
+      test: "bash -c 'echo -n > /dev/tcp/cockroach/26257'"
+      interval: 0.5s
+      timeout: 10s
+      retries: 25
   python:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20221214-141947
     user: "${UID}:${GID}"
     depends_on:
-      - cockroach
+      cockroach:
+        condition: service_healthy
     environment:
       - PGHOST=cockroach
       - PGPORT=26257

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   kdc:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000
@@ -17,11 +18,17 @@ services:
       - ${CERTS_DIR:-../../.localcluster.certs}:/certs
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
+    healthcheck:
+      test: "bash -c 'echo -n > /dev/tcp/cockroach/26257'"
+      interval: 0.5s
+      timeout: 10s
+      retries: 25
   psql:
     image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20230907-113902
     user: "${UID}:${GID}"
     depends_on:
-      - cockroach
+      cockroach:
+        condition: service_healthy
     environment:
       - PGHOST=cockroach
       - PGPORT=26257


### PR DESCRIPTION
Previously, docker compose based GSS tests sometimes failed, because the cockroach container took some time to bring the server up. This doesn't happen with `--insecure` tests, such as `flyway`.

This PR adds a health check in order to ensure the cockroach container is healthy before running any tests.

Fixes: #125003
Fixes: #125089
Fixes: #125413
Release note: None