### PR TITLE
release-23.2: compose: TestComposeCompare improvements and fixes

### DIFF
--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     tags = ["integration"],
     deps = [
         "//pkg/build/bazel",
+        "//pkg/testutils/datapathutils",
         "//pkg/util/envutil",
     ],
 )

--- a/pkg/compose/compare/compare/BUILD.bazel
+++ b/pkg/compose/compare/compare/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     visibility = ["//pkg/compose:__subpackages__"],
     deps = [
         "//pkg/cmd/cmpconn",
+        "//pkg/geo/geos",
         "//pkg/internal/sqlsmith",
         "//pkg/sql/randgen",
         "//pkg/testutils",

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -21,11 +21,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/cmpconn"
+	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -44,6 +46,16 @@ func TestCompare(t *testing.T) {
 	// N.B. randomized SQL workload performed by this test may require CCL
 	var license = envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")
 	require.NotEmptyf(t, license, "COCKROACH_DEV_LICENSE must be set")
+
+	// Initialize GEOS libraries so that the test can use geospatial types.
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = geos.EnsureInit(geos.EnsureInitErrorDisplayPrivate, path.Join(workingDir, "lib"))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	uris := map[string]struct {
 		addr string

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,16 +1,18 @@
 services:
   cockroach1:
     image: ubuntu:xenial-20170214
-    command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach1
+    command: /cockroach/cockroach start-single-node --insecure --log-dir=/cockroach/logs --spatial-libs=/cockroach/lib --listen-addr cockroach1
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
       - "${LIBGEOS_DIR_PATH}:/cockroach/lib"
+      - "${COMPARE_DIR_PATH}/logs1:/cockroach/logs"
   cockroach2:
     image: ubuntu:xenial-20170214
-    command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach2
+    command: /cockroach/cockroach start-single-node --insecure --log-dir=/cockroach/logs --spatial-libs=/cockroach/lib --listen-addr cockroach2
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
       - "${LIBGEOS_DIR_PATH}:/cockroach/lib"
+      - "${COMPARE_DIR_PATH}/logs2:/cockroach/logs"
   test:
     image: ubuntu:xenial-20170214
     environment:

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,18 +1,24 @@
 services:
   cockroach1:
     image: ubuntu:xenial-20170214
-    command: /cockroach/cockroach start-single-node --insecure --log-dir=/cockroach/logs --spatial-libs=/cockroach/lib --listen-addr cockroach1
+    user: ${UID}:${GID}
+    command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach1
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
       - "${LIBGEOS_DIR_PATH}:/cockroach/lib"
-      - "${COMPARE_DIR_PATH}/logs1:/cockroach/logs"
+      - "${COMPARE_DIR_PATH}/store1:/cockroach/store"
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
   cockroach2:
     image: ubuntu:xenial-20170214
-    command: /cockroach/cockroach start-single-node --insecure --log-dir=/cockroach/logs --spatial-libs=/cockroach/lib --listen-addr cockroach2
+    user: ${UID}:${GID}
+    command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach2
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
       - "${LIBGEOS_DIR_PATH}:/cockroach/lib"
-      - "${COMPARE_DIR_PATH}/logs2:/cockroach/logs"
+      - "${COMPARE_DIR_PATH}/store2:/cockroach/store"
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
   test:
     image: ubuntu:xenial-20170214
     environment:

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
@@ -78,10 +79,18 @@ func TestComposeCompare(t *testing.T) {
 		// start up docker-compose, but the files themselves will be
 		// Bazel-built symlinks. We want to copy these files to a
 		// different temporary location.
-		composeBinsDir := t.TempDir()
-		compareDir = composeBinsDir
-		cockroachBin = filepath.Join(composeBinsDir, "cockroach")
-		libGeosDir = filepath.Join(composeBinsDir, "lib")
+		compareDir, err = os.MkdirTemp(datapathutils.DebuggableTempDir(), "TestComposeCompare")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if t.Failed() {
+				return
+			}
+			_ = os.RemoveAll(compareDir)
+		})
+		cockroachBin = filepath.Join(compareDir, "cockroach")
+		libGeosDir = filepath.Join(compareDir, "lib")
 		if err = os.MkdirAll(libGeosDir, 0755); err != nil {
 			t.Fatal(err)
 		}
@@ -95,7 +104,7 @@ func TestComposeCompare(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err = copyBin(*flagCompare, filepath.Join(composeBinsDir, "compare.test")); err != nil {
+		if err = copyBin(*flagCompare, filepath.Join(compareDir, "compare.test")); err != nil {
 			t.Fatal(err)
 		}
 		if *flagArtifacts == "" {
@@ -138,6 +147,7 @@ func TestComposeCompare(t *testing.T) {
 		fmt.Sprintf("COCKROACH_DEV_LICENSE=%s", envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")),
 		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 	}
+	t.Logf("running: %s", cmd)
 	out, err := cmd.CombinedOutput()
 	t.Log(string(out))
 	if err != nil {

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"testing"
 	"time"
@@ -89,6 +90,12 @@ func TestComposeCompare(t *testing.T) {
 			}
 			_ = os.RemoveAll(compareDir)
 		})
+		if err = os.MkdirAll(filepath.Join(compareDir, "store1"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err = os.MkdirAll(filepath.Join(compareDir, "store2"), 0755); err != nil {
+			t.Fatal(err)
+		}
 		cockroachBin = filepath.Join(compareDir, "cockroach")
 		libGeosDir = filepath.Join(compareDir, "lib")
 		if err = os.MkdirAll(libGeosDir, 0755); err != nil {
@@ -137,7 +144,13 @@ func TestComposeCompare(t *testing.T) {
 		"--force-recreate",
 		"--exit-code-from", "test",
 	)
+	userInfo, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
 	cmd.Env = []string{
+		fmt.Sprintf("UID=%s", userInfo.Uid),
+		fmt.Sprintf("GID=%s", userInfo.Gid),
 		fmt.Sprintf("EACH=%s", *flagEach),
 		fmt.Sprintf("TESTS=%s", *flagTests),
 		fmt.Sprintf("COCKROACH_PATH=%s", cockroachBin),


### PR DESCRIPTION
Backport 2/2 commits from #125694.

/cc @cockroachdb/release

Release justification: test only change

---

This PR accomplishes:
- properly link libgeos
- preserve logs on failure
- run tests as current user 

fixes https://github.com/cockroachdb/cockroach/issues/125286
fixes https://github.com/cockroachdb/cockroach/issues/125027
fixes https://github.com/cockroachdb/cockroach/issues/125392
fixes https://github.com/cockroachdb/cockroach/issues/124379

Release note: None
