### PR TITLE
sql/schemachanger: block data type alter of col used in computed cols

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -564,7 +564,7 @@ func TestEventColumnOrderingWithSchemaChanges(t *testing.T) {
 					a STRING,
 					b STRING,
 					c STRING,
-					d STRING AS (concat(e, c)) VIRTUAL,
+					d STRING AS (concat(e, '.')) VIRTUAL,
 					e STRING,
 					PRIMARY KEY(j,i),
 					FAMILY main (i,j,a,b),

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -81,6 +81,9 @@ func AlterColumnType(
 	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, tableDesc.GetRowLevelTTL(), col); err != nil {
 		return err
 	}
+	if err := schemaexpr.ValidateComputedColumnExpressionDoesNotDependOnColumn(tableDesc, col); err != nil {
+		return err
+	}
 
 	typ, err := tree.ResolveType(ctx, t.ToType, params.p.semaCtx.GetTypeResolver())
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -640,3 +640,38 @@ ALTER TABLE t31 ALTER COLUMN b TYPE INT;
 
 statement ok
 ALTER TABLE t31 ALTER COLUMN b TYPE INT USING b::INT8;
+
+subtest alter_type_used_in_computed
+
+statement ok
+CREATE TABLE tab_w_computed (real1 int, real2 int, comp1 bigint as (real1 + real2) stored, comp2 bigint as (real2 * 2) virtual, comp3 int as (real1 * 2) virtual);
+INSERT INTO tab_w_computed (real1, real2) VALUES (1, 2), (3, 4), (5, 6);
+
+statement error pq: cannot alter column "real1" because computed column "comp[0-9]" depends on it\nHINT: consider dropping "comp[0-9]" first.
+ALTER TABLE tab_w_computed ALTER COLUMN real1 TYPE bigint;
+
+statement ok
+ALTER TABLE tab_w_computed DROP COLUMN comp1;
+
+statement error pq: cannot alter column "real1" because computed column "comp[0-9]" depends on it\nHINT: consider dropping "comp[0-9]" first.
+ALTER TABLE tab_w_computed ALTER COLUMN real1 TYPE bigint;
+
+statement ok
+ALTER TABLE tab_w_computed DROP COLUMN comp3;
+
+statement ok
+ALTER TABLE tab_w_computed ALTER COLUMN real1 TYPE bigint;
+
+statement error pq: cannot alter column "real2" because computed column "comp[0-9]" depends on it\nHINT: consider dropping "comp[0-9]" first.
+ALTER TABLE tab_w_computed ALTER COLUMN real2 TYPE string;
+
+statement ok
+ALTER TABLE tab_w_computed DROP COLUMN comp2;
+
+statement ok
+ALTER TABLE tab_w_computed ALTER COLUMN real2 TYPE string;
+
+statement ok
+DROP TABLE tab_w_computed;
+
+subtest end


### PR DESCRIPTION
Previously, altering the data type of a column used in a generated column was allowed, causing downstream issues when querying the generated column.

To be consistent with postgres, we will now block any attempt to alter the data type of a column used in a computed column.

Epic: CRDB-25314
Closes: #72457
Release note (bug fix): Attempts to alter the data type of a column used in a computed column expression are now blocked.