### PR TITLE
sql: avoid fetching all descriptors in crdb_internal.ranges_no_leases

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4575,27 +4575,24 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		if err != nil {
 			return nil, nil, err
 		}
-		all, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
+		viewActOrViewActRedact, _, err := p.HasViewActivityOrViewActivityRedactedRole(ctx)
 		if err != nil {
 			return nil, nil, err
 		}
-		descs := all.OrderedDescriptors()
-
-		privCheckerFunc := func(desc catalog.Descriptor) (bool, error) {
-			if hasAdmin {
-				return true, nil
+		var descs catalog.Descriptors
+		// Admin or viewActivity roles have access to all information, so
+		// don't bother fetching all the descriptors unecessarily.
+		if !hasAdmin && !viewActOrViewActRedact {
+			all, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
+			if err != nil {
+				return nil, nil, err
 			}
-			viewActOrViewActRedact, _, err := p.HasViewActivityOrViewActivityRedactedRole(ctx)
-			// Return if we have permission or encountered an error.
-			if viewActOrViewActRedact || err != nil {
-				return viewActOrViewActRedact, err
-			}
-			return p.HasPrivilege(ctx, desc, privilege.ZONECONFIG, p.User())
+			descs = all.OrderedDescriptors()
 		}
 
-		hasPermission := false
+		hasPermission := hasAdmin || viewActOrViewActRedact
 		for _, desc := range descs {
-			if ok, err := privCheckerFunc(desc); err != nil {
+			if ok, err := p.HasPrivilege(ctx, desc, privilege.ZONECONFIG, p.User()); err != nil {
 				return nil, nil, err
 			} else if ok {
 				hasPermission = true


### PR DESCRIPTION
Previously, the builtin crdb_internal.ranges_no_leases would fetch all descriptors, even if the user had view activity or admin privilege. This was unnecessary and could end up fetching tons of descriptors on larger clusters. To address this, the logic no longer fetches any descriptors if it's known that the user already has privileges.

Fixes: #125878
Epic: CRDB-24134
Release note: None