### PR TITLE
ptstorage: increase test timeout

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
 
 go_test(
     name = "ptstorage_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "main_test.go",
         "storage_test.go",


### PR DESCRIPTION
Fixes #125875.

This commit increases the test timeout for the package from 5m to 15m, which should prevent `TestStorage` from flaking when CI is slow.

Release note: None