### PR TITLE
build: bump pebble TestMeta nightly per-run timeout

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -21,7 +21,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --c
                                       --test_env TC_SERVER_URL=$TC_SERVER_URL \
                                       --test_timeout=25200 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \
-                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -timeout 20m -stderr -p 1" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -timeout 60m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \
                                       --test_arg -ops --test_arg "uniform:5000-10000" \
                                       --test_output streamed \


### PR DESCRIPTION
Currently, we end up in cases where we don't hit the per-op timeout in a nightly pebble metamorphic test run, but the test run as a whole is slow enough that we get a timeout of an individual run under stress. This results in really unhelpful failure output, with no seeds to help reproduce this either (see cockroachdb/pebble#3635).

This change bumps up the per-run timeout to make it more likely for us to hit the per-op timeout if we really are having slow operations in a run. This should make future failures far easier to investigate.

Epic: none

Release note: None