### PR TITLE
oidc: Fix failing test on CI under stress

### DIFF
--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -133,7 +133,13 @@ func TestOIDCEnabled(t *testing.T) {
 	sqlDB.Exec(t, `set cluster setting server.oidc_authentication.claim_json_key = "email"`)
 	sqlDB.Exec(t, `set cluster setting server.oidc_authentication.principal_regex = '^([^@]+)@[^@]+$'`)
 	sqlDB.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING server.http.base_path = "%s"`, basePath))
-	sqlDB.Exec(t, `SET CLUSTER SETTING server.oidc_authentication.enabled = "true"`)
+	// Setting the `server.oidc_authentication.enabled` cluster setting through
+	// SQL command adds an overhead in updating the `OIDCEnabled` var.
+	// This fails the test under stress as the value of `OIDCEnabled` var
+	// determines the response to the `/oidc/v1/login` API handler.
+	// Hence, it is recommended to override the value directly.
+	// TODO(pritesh-lahoti): Refactor the above OIDC cluster setting statements.
+	OIDCEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	testCertsContext := s.NewClientRPCContext(ctx, username.TestUserName())
 	client, err := testCertsContext.GetHTTPClient()


### PR DESCRIPTION
The `TestOIDCEnabled` fails intermittently under stress, possibly due to the overhead of updating the cluster setting `server.oidc_authentication.enabled` through SQL. This is because the value of `OIDCEnabled` var determines the response to `oidc/v1/login` API handler.
Directly setting the value using `OIDCEnabled.Override` solves this issue.

Epic: CRDB-39652

Release note: None