### PR TITLE
cli: redact remote address in stack trace

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -348,6 +348,7 @@ go_test(
         "userfiletable_test.go",
         "workload_test.go",
         "zip_helpers_test.go",
+        "zip_per_node_test.go",
         "zip_table_registry_test.go",
         "zip_tenant_test.go",
         "zip_test.go",

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -24,12 +25,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
+
+var redactedAddress = fmt.Sprintf("%s=%s", rpc.RemoteAddressTag, redact.RedactedMarker())
+
+const regexpOfRemoteAddress = "[[:alnum:].:-]+"
 
 // makePerNodeZipRequests defines the zipRequests (API requests) that are to be
 // performed once per node.
@@ -344,6 +351,9 @@ func (zc *debugZipContext) collectPerNodeData(
 				}
 				return err
 			})
+		if zipCtx.redact {
+			stacksDataWithLabels = redactStackTrace(stacksDataWithLabels)
+		}
 		if err := zc.z.createRawOrError(s, prefix+"/stacks_with_labels.txt", stacksDataWithLabels, requestErr); err != nil {
 			return err
 		}
@@ -520,6 +530,12 @@ func (zc *debugZipContext) collectPerNodeData(
 		}
 	}
 	return nil
+}
+
+func redactStackTrace(stacksDataWithLabels []byte) []byte {
+	re := regexp.MustCompile(fmt.Sprintf("%s=%s", rpc.RemoteAddressTag, regexpOfRemoteAddress))
+	data := re.ReplaceAll(stacksDataWithLabels, []byte(redactedAddress))
+	return data
 }
 
 func guessNodeURL(workingURL string, hostport string) clisqlclient.Conn {

--- a/pkg/cli/zip_per_node_test.go
+++ b/pkg/cli/zip_per_node_test.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactStackTrace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tests := []struct {
+		log                 string
+		expectedRedactedLog string
+	}{
+		{"labels: {\"tags\":\"n1,rnode=1,raddr=localhost:26257,class=default,rpc\"}", "labels: {\"tags\":\"n1,rnode=1,raddr=‹×›,class=default,rpc\"}"},
+		{"labels: {\"tags\":\"n1,rnode=1,raddr=248.123.55.1:26257,class=default,rpc\"}", "labels: {\"tags\":\"n1,rnode=1,raddr=‹×›,class=default,rpc\"}"},
+		{"labels: {\"tags\":\"n1,rnode=1,raddr=abc.def.com:78484,class=default,rpc\"}", "labels: {\"tags\":\"n1,rnode=1,raddr=‹×›,class=default,rpc\"}"},
+		{"labels: {\"tags\":\"n1,rnode=1,raddr=0.0.0:26257\"}", "labels: {\"tags\":\"n1,rnode=1,raddr=‹×›\"}"},
+		{"labels: {\"tags\":\"n1,rnode=1,raddr=2001:db8:3333:4444:5555:6666:7777:8888:78484,class=default,rpc\"}", "labels: {\"tags\":\"n1,rnode=1,raddr=‹×›,class=default,rpc\"}"},
+	}
+
+	for _, test := range tests {
+		redactedData := redactStackTrace([]byte(test.log))
+		redactedDataStr := bytes.NewBuffer(redactedData).String()
+		require.Equal(t, test.expectedRedactedLog, redactedDataStr)
+	}
+}

--- a/pkg/cli/zip_table_registry_test.go
+++ b/pkg/cli/zip_table_registry_test.go
@@ -217,6 +217,7 @@ func TestNonSensitiveColumns(t *testing.T) {
 			// in a system tenant. These would fail if pointed to a
 			// secondary tenant.
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			Insecure:          true,
 		},
 	})
 	defer cluster.Stopper().Stop(context.Background())

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2065,6 +2065,11 @@ func (rpcCtx *Context) makeDialCtx(
 	return rpcCtx.wrapCtx(rpcCtx.MasterCtx, target, remoteNodeID, class)
 }
 
+const RemoteNodeTag = "rnode"
+const RemoteAddressTag = "raddr"
+const Class = "class"
+const RpcTag = "rpc"
+
 func (rpcCtx *Context) wrapCtx(
 	ctx context.Context, target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
 ) context.Context {
@@ -2072,10 +2077,10 @@ func (rpcCtx *Context) wrapCtx(
 	if remoteNodeID == 0 {
 		rnodeID = redact.SafeString("?")
 	}
-	ctx = logtags.AddTag(ctx, "rnode", rnodeID)
-	ctx = logtags.AddTag(ctx, "raddr", target)
-	ctx = logtags.AddTag(ctx, "class", class)
-	ctx = logtags.AddTag(ctx, "rpc", nil)
+	ctx = logtags.AddTag(ctx, RemoteNodeTag, rnodeID)
+	ctx = logtags.AddTag(ctx, RemoteAddressTag, target)
+	ctx = logtags.AddTag(ctx, Class, class)
+	ctx = logtags.AddTag(ctx, RpcTag, nil)
 	return ctx
 }
 


### PR DESCRIPTION
Previously, nodes/*/stacks_with_labels.txt files have unredacted remote address. We have --redact flag which redacts sensitive information which was not getting honored. This change adds capability to redact remote address based on flag.

Epic: CRDB-37533
Resolves: #123678
Release note: None