### PR TITLE
sql: CREATE TABLE can fail on txn retries

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -268,11 +268,17 @@ func (n *alterTableNode) startExec(params runParams) error {
 					return err
 				}
 
+				// We are going to modify the AST to replace any index expressions with
+				// virtual columns. If the txn ends up retrying, then this change is not
+				// syntactically valid, since the virtual column is only added in the descriptor
+				// and not in the AST.
+				columns := make(tree.IndexElemList, len(d.Columns))
+				copy(columns, d.Columns)
 				if err := replaceExpressionElemsWithVirtualCols(
 					params.ctx,
 					n.tableDesc,
 					tableName,
-					d.Columns,
+					columns,
 					false, /* isInverted */
 					false, /* isNewTable */
 					params.p.SemaCtx(),
@@ -282,7 +288,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 				// Check if the columns exist on the table.
-				for _, column := range d.Columns {
+				for _, column := range columns {
 					if column.Expr != nil {
 						return pgerror.New(
 							pgcode.InvalidTableDefinition,
@@ -303,7 +309,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					StoreColumnNames: d.Storing.ToStrings(),
 					CreatedAtNanos:   params.EvalContext().GetTxnTimestamp(time.Microsecond).UnixNano(),
 				}
-				if err := idx.FillColumns(d.Columns); err != nil {
+				if err := idx.FillColumns(columns); err != nil {
 					return err
 				}
 

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1068,3 +1068,22 @@ CREATE TABLE public.t_115352 (
 )
 
 subtest end
+
+
+statement ok
+
+subtest 125619
+
+statement ok
+SET inject_retry_errors_enabled=true
+
+statement ok
+CREATE TABLE t_125619 (i INT8, j INT8, INDEX ((i + j)));
+
+statement ok
+ALTER TABLE t_125619 ADD CONSTRAINT uni UNIQUE ((i + j + i))
+
+statement ok
+SET inject_retry_errors_enabled=false
+
+subtest end


### PR DESCRIPTION
Previously, when a CREATE TABLE definition included an index expression,
we modified the original abstract syntax tree (AST) to have the index
reference a new virtual column for the expression. However, if a
transaction retry occurred, this AST modification was not handled
correctly because the new virtual column was not public. To resolve
this, this patch ensures that the index element nodes are copied before
any changes are made.

Fixes: #125619

Release note (bug fix): CREATE TABLE with index expressions could hit
undefined column errors on transaction retries