### PR TITLE
roachprod: update roachprod GC docker

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:ece9cc18904
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:2a6193bba6b
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
The gc dockerfile is updated with the new image.
This image has the change to delete the config for insecure clusters

Fixes: #125616
Epic: none