### PR TITLE
cli: fix non determinism of TestTenantZip

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -620,6 +620,8 @@ func eraseNonDeterministicZipOutput(out string) string {
 	out = re.ReplaceAllString(out, `[node ?] ? goroutine dumps found`)
 	re = regexp.MustCompile(`(?m)^\[node \d+\] \d+ cpu profiles found$`)
 	out = re.ReplaceAllString(out, `[node ?] ? cpu profiles found`)
+	re = regexp.MustCompile(`(?m)^\[node \d+\] retrieving cpuprof.*$` + "\n")
+	out = re.ReplaceAllString(out, ``)
 	re = regexp.MustCompile(`(?m)^\[node \d+\] \d+ log files found$`)
 	out = re.ReplaceAllString(out, `[node ?] ? log files found`)
 	re = regexp.MustCompile(`(?m)^\[node \d+\] retrieving (memprof|memstats|memmonitoring).*$` + "\n")


### PR DESCRIPTION
Previously, TestTenantZip was generating non deterministic output due to cpu profile files retrieval logs.To address this, we are removing cpu profile file retrieval logs file during comparison with golden data.

Epic: none
Fixes: #125036
Release note: None