### PR TITLE
sqlstats: revert turning off sql activity tables

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -37,7 +37,7 @@ var sqlStatsActivityFlushEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.stats.activity.flush.enabled",
 	"enable the flush to the system statement and transaction activity tables",
-	false)
+	true)
 
 // sqlStatsActivityTopCount is the cluster setting that controls the number of
 // rows selected to be inserted into the activity tables


### PR DESCRIPTION
This commit reverts PR #123381 which turned off the sql activity update job by default. We'll punt disabling this flush job to the next major release. The justification for this is we changed some cluster settings for sql stats for 24.1.2 that will cap the number of rows per aggregation interval. We'll wait for existing clusters to stabilize with this cap before disabling the cache entirely.

Epic: none
Part of: #123081

Release note: None