### PR TITLE
roachtest: fix node kill drain variant

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -21,7 +21,7 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",
         "//pkg/cmd/roachtest/roachtestutil",
-        "//pkg/roachprod",
+        "//pkg/roachprod/install",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
     ],


### PR DESCRIPTION
Previously, if the drain variant of the node kill operation ran it would fail by not being able to find the binary since the remote run command required a `./` prefix to the binary.

But even if it did find the binary the constructed `pgurl` fails, because it passes the incorrect certificate required by drain. This code has been updated to rather use the readily available `certs` directory, or `insecure` if the cluster is not secure. And instead passes a `host:port` versus a postgres URL.

Epic: None
Release Note: None