### PR TITLE
server: err handling, replace deprecated call in `disableReplication`

### DIFF
--- a/pkg/server/initial_sql.go
+++ b/pkg/server/initial_sql.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -102,7 +103,7 @@ func (s *topLevelServer) createAdminUser(
 func (s *topLevelServer) disableReplication(ctx context.Context) (retErr error) {
 	ie := s.sqlServer.internalExecutor
 
-	it, err := ie.QueryIterator(ctx, "get-zones", nil,
+	it, err := ie.QueryIteratorEx(ctx, "get-zones", nil, sessiondata.NodeUserSessionDataOverride,
 		"SELECT target FROM crdb_internal.zones")
 	if err != nil {
 		return err
@@ -122,6 +123,9 @@ func (s *topLevelServer) disableReplication(ctx context.Context) (retErr error) 
 		zone := string(*it.Cur()[0].(*tree.DString))
 		zones = append(zones, zone)
 	}
+	if err != nil {
+		return err
+	}
 
 	for _, zone := range zones {
 		if _, err := ie.Exec(ctx, "set-zone", nil,
@@ -130,5 +134,5 @@ func (s *topLevelServer) disableReplication(ctx context.Context) (retErr error) 
 		}
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
This patch ensures that we do not ignore the potential error we get when exiting out of our `get-zones` caching loop. Additionally, we replace the deprecated `QueryIterator` call with `QueryIteratorEx` -- which will allow us to specify that our queries issued during demo/start-single-node setup are executed by `node`.

Epic: none

Release note: None