### PR TITLE
kv: deflake TestWedgedReplicaDetection

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -18,6 +18,7 @@ package kvserver
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -407,6 +408,12 @@ func (r *Replica) NumPendingProposals() int64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.numPendingProposalsRLocked()
+}
+
+func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]time.Time {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return maps.Clone(r.mu.lastUpdateTimes)
 }
 
 func (r *Replica) IsFollowerActiveSince(


### PR DESCRIPTION
Closes #125826.

This commit deflakes `TestWedgedReplicaDetection` by waiting to ensure that the leader replica has three entries in its lastUpdateTimes map before wedging a follower replica. This should already be the case by the time we run the SucceedsSoon because the leader was able to replicate a log entry to its two followers, but we wait to be sure and to avoid flakiness. The logging from the first commit revealed that it is possible that the WaitForValues call returned as soon as one of the followers appended and applied a log entry, but before its response was delivered to the leader.

Release note: None