### PR TITLE
opt: fix stats estimates when histograms disabled

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
@@ -233,7 +233,7 @@ vectorized: true
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-    │ estimated row count: 1,024
+    │ estimated row count: 0
     │ from: statement_statistics
     │ auto commit
     │
@@ -260,7 +260,7 @@ vectorized: true
             │
             └── • scan
                   columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, statistics, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
-                  estimated row count: 1,024 (0.10% of the table; stats collected <hidden> ago)
+                  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
                   table: statement_statistics@primary
                   spans: /0-/0/2022-05-04T15:59:59.999999001Z
                   limit: 1024
@@ -420,7 +420,7 @@ vectorized: true
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-    │ estimated row count: 1,024
+    │ estimated row count: 0
     │ from: transaction_statistics
     │ auto commit
     │
@@ -444,7 +444,7 @@ vectorized: true
             │
             └── • scan
                   columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
-                  estimated row count: 1,024 (0.10% of the table; stats collected <hidden> ago)
+                  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
                   table: transaction_statistics@primary
                   spans: /0-/0/2022-05-04T15:59:59.999999001Z
                   limit: 1024
@@ -476,7 +476,7 @@ vectorized: true
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-    │ estimated row count: 1,024
+    │ estimated row count: 0
     │ from: statement_statistics
     │ auto commit
     │
@@ -503,7 +503,7 @@ vectorized: true
             │
             └── • scan
                   columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, statistics, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
-                  estimated row count: 1,024 (0.10% of the table; stats collected <hidden> ago)
+                  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
                   table: statement_statistics@primary
                   spans: /0/2022-05-04T14:00:00Z/"123"/"234"/"345"/"test"/1-/0/2022-05-04T15:59:59.999999001Z
                   limit: 1024
@@ -533,7 +533,7 @@ vectorized: true
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-    │ estimated row count: 1,024
+    │ estimated row count: 0
     │ from: transaction_statistics
     │ auto commit
     │
@@ -557,7 +557,7 @@ vectorized: true
             │
             └── • scan
                   columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
-                  estimated row count: 1,024 (0.10% of the table; stats collected <hidden> ago)
+                  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
                   table: transaction_statistics@primary
                   spans: /0/2022-05-04T14:00:00Z/"123"/"test"/2-/0/2022-05-04T15:59:59.999999001Z
                   limit: 1024

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
@@ -472,113 +472,131 @@ vectorized: true
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
 │   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
-│   │   │   │   ├── • index join
+│   │   │   │   ├── • limit
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 500
-│   │   │   │   │   │ table: statement_statistics@primary
-│   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │   │   │   │   │ count: 500
 │   │   │   │   │   │
-│   │   │   │   │   └── • top-k
-│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │       │ estimated row count: 500
-│   │   │   │   │       │ order: -execution_count
-│   │   │   │   │       │ k: 500
+│   │   │   │   │   └── • filter
+│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │       │ ordering: -execution_count
+│   │   │   │   │       │ estimated row count: 111,111
+│   │   │   │   │       │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │   │       │
-│   │   │   │   │       └── • scan
-│   │   │   │   │             columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │   │             table: statement_statistics@execution_count_idx (partial index)
-│   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │   │       └── • sort
+│   │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │           │ estimated row count: 3
+│   │   │   │   │           │ order: -execution_count
+│   │   │   │   │           │
+│   │   │   │   │           └── • scan
+│   │   │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │                 estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │   │                 table: statement_statistics@primary
+│   │   │   │   │                 spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │   │
-│   │   │   │   └── • index join
+│   │   │   │   └── • limit
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 500
-│   │   │   │       │ table: statement_statistics@primary
-│   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │   │   │       │ count: 500
 │   │   │   │       │
-│   │   │   │       └── • top-k
-│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │           │ estimated row count: 500
-│   │   │   │           │ order: -service_latency
-│   │   │   │           │ k: 500
+│   │   │   │       └── • filter
+│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │           │ ordering: -service_latency
+│   │   │   │           │ estimated row count: 111,111
+│   │   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │           │
-│   │   │   │           └── • scan
-│   │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │                 table: statement_statistics@service_latency_idx (partial index)
-│   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │           └── • sort
+│   │   │   │               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │               │ estimated row count: 3
+│   │   │   │               │ order: -service_latency
+│   │   │   │               │
+│   │   │   │               └── • scan
+│   │   │   │                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │                     table: statement_statistics@primary
+│   │   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │
-│   │   │   └── • index join
+│   │   │   └── • limit
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 500
-│   │   │       │ table: statement_statistics@primary
-│   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │   │       │ count: 500
 │   │   │       │
-│   │   │       └── • top-k
-│   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │           │ estimated row count: 500
-│   │   │           │ order: -cpu_sql_nanos
-│   │   │           │ k: 500
+│   │   │       └── • filter
+│   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │           │ ordering: -cpu_sql_nanos
+│   │   │           │ estimated row count: 111,111
+│   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │           │
-│   │   │           └── • scan
-│   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │                 table: statement_statistics@cpu_sql_nanos_idx (partial index)
-│   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │           └── • sort
+│   │   │               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │               │ estimated row count: 3
+│   │   │               │ order: -cpu_sql_nanos
+│   │   │               │
+│   │   │               └── • scan
+│   │   │                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │                     table: statement_statistics@primary
+│   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │
-│   │   └── • index join
+│   │   └── • limit
 │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 500
-│   │       │ table: statement_statistics@primary
-│   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │       │ count: 500
 │   │       │
-│   │       └── • top-k
-│   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │           │ estimated row count: 500
-│   │           │ order: -contention_time
-│   │           │ k: 500
+│   │       └── • filter
+│   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │           │ ordering: -contention_time
+│   │           │ estimated row count: 111,111
+│   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │           │
-│   │           └── • scan
-│   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │                 table: statement_statistics@contention_time_idx (partial index)
-│   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │           └── • sort
+│   │               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │               │ estimated row count: 3
+│   │               │ order: -contention_time
+│   │               │
+│   │               └── • scan
+│   │                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │                     table: statement_statistics@primary
+│   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │
-│   └── • index join
+│   └── • limit
 │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 500
-│       │ table: statement_statistics@primary
-│       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│       │ count: 500
 │       │
-│       └── • top-k
-│           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│           │ estimated row count: 500
-│           │ order: -total_estimated_execution_time
-│           │ k: 500
+│       └── • filter
+│           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│           │ ordering: -total_estimated_execution_time
+│           │ estimated row count: 111,111
+│           │ filter: app_name NOT LIKE '$ internal%'
 │           │
-│           └── • scan
-│                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│                 table: statement_statistics@total_estimated_execution_time_idx (partial index)
-│                 spans: /2023-03-21T14:05:00.000001Z-
+│           └── • sort
+│               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│               │ estimated row count: 3
+│               │ order: -total_estimated_execution_time
+│               │
+│               └── • scan
+│                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│                     table: statement_statistics@primary
+│                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │
-└── • index join
+└── • limit
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 500
-    │ table: statement_statistics@primary
-    │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+    │ count: 500
     │
-    └── • top-k
-        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-        │ estimated row count: 500
-        │ order: -p99_latency
-        │ k: 500
+    └── • filter
+        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+        │ ordering: -p99_latency
+        │ estimated row count: 111,111
+        │ filter: app_name NOT LIKE '$ internal%'
         │
-        └── • scan
-              columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-              table: statement_statistics@p99_latency_idx (partial index)
-              spans: /2023-03-21T14:05:00.000001Z-
+        └── • sort
+            │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+            │ estimated row count: 3
+            │ order: -p99_latency
+            │
+            └── • scan
+                  columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+                  estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                  table: statement_statistics@primary
+                  spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 
 query T
 EXPLAIN (VERBOSE)
@@ -702,113 +720,131 @@ vectorized: true
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
 │   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
-│   │   │   │   ├── • index join
+│   │   │   │   ├── • limit
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 500
-│   │   │   │   │   │ table: statement_statistics@primary
-│   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │   │   │   │   │ count: 500
 │   │   │   │   │   │
-│   │   │   │   │   └── • top-k
-│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │       │ estimated row count: 500
-│   │   │   │   │       │ order: -execution_count
-│   │   │   │   │       │ k: 500
+│   │   │   │   │   └── • filter
+│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │       │ ordering: -execution_count
+│   │   │   │   │       │ estimated row count: 111,111
+│   │   │   │   │       │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │   │       │
-│   │   │   │   │       └── • scan
-│   │   │   │   │             columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │   │             table: statement_statistics@execution_count_idx (partial index)
-│   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │   │       └── • sort
+│   │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │           │ estimated row count: 3
+│   │   │   │   │           │ order: -execution_count
+│   │   │   │   │           │
+│   │   │   │   │           └── • scan
+│   │   │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │                 estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │   │                 table: statement_statistics@primary
+│   │   │   │   │                 spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │   │
-│   │   │   │   └── • index join
+│   │   │   │   └── • limit
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 500
-│   │   │   │       │ table: statement_statistics@primary
-│   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │   │   │       │ count: 500
 │   │   │   │       │
-│   │   │   │       └── • top-k
-│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │           │ estimated row count: 500
-│   │   │   │           │ order: -service_latency
-│   │   │   │           │ k: 500
+│   │   │   │       └── • filter
+│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │           │ ordering: -service_latency
+│   │   │   │           │ estimated row count: 111,111
+│   │   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │           │
-│   │   │   │           └── • scan
-│   │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │                 table: statement_statistics@service_latency_idx (partial index)
-│   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │           └── • sort
+│   │   │   │               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │               │ estimated row count: 3
+│   │   │   │               │ order: -service_latency
+│   │   │   │               │
+│   │   │   │               └── • scan
+│   │   │   │                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │                     table: statement_statistics@primary
+│   │   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │
-│   │   │   └── • index join
+│   │   │   └── • limit
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 500
-│   │   │       │ table: statement_statistics@primary
-│   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │   │       │ count: 500
 │   │   │       │
-│   │   │       └── • top-k
-│   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │           │ estimated row count: 500
-│   │   │           │ order: -cpu_sql_nanos
-│   │   │           │ k: 500
+│   │   │       └── • filter
+│   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │           │ ordering: -cpu_sql_nanos
+│   │   │           │ estimated row count: 111,111
+│   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │           │
-│   │   │           └── • scan
-│   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │                 table: statement_statistics@cpu_sql_nanos_idx (partial index)
-│   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │           └── • sort
+│   │   │               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │               │ estimated row count: 3
+│   │   │               │ order: -cpu_sql_nanos
+│   │   │               │
+│   │   │               └── • scan
+│   │   │                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │                     table: statement_statistics@primary
+│   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │
-│   │   └── • index join
+│   │   └── • limit
 │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 500
-│   │       │ table: statement_statistics@primary
-│   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│   │       │ count: 500
 │   │       │
-│   │       └── • top-k
-│   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │           │ estimated row count: 500
-│   │           │ order: -contention_time
-│   │           │ k: 500
+│   │       └── • filter
+│   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │           │ ordering: -contention_time
+│   │           │ estimated row count: 111,111
+│   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │           │
-│   │           └── • scan
-│   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │                 table: statement_statistics@contention_time_idx (partial index)
-│   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │           └── • sort
+│   │               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │               │ estimated row count: 3
+│   │               │ order: -contention_time
+│   │               │
+│   │               └── • scan
+│   │                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │                     table: statement_statistics@primary
+│   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │
-│   └── • index join
+│   └── • limit
 │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 500
-│       │ table: statement_statistics@primary
-│       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+│       │ count: 500
 │       │
-│       └── • top-k
-│           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│           │ estimated row count: 500
-│           │ order: -total_estimated_execution_time
-│           │ k: 500
+│       └── • filter
+│           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│           │ ordering: -total_estimated_execution_time
+│           │ estimated row count: 111,111
+│           │ filter: app_name NOT LIKE '$ internal%'
 │           │
-│           └── • scan
-│                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│                 table: statement_statistics@total_estimated_execution_time_idx (partial index)
-│                 spans: /2023-03-21T14:05:00.000001Z-
+│           └── • sort
+│               │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│               │ estimated row count: 3
+│               │ order: -total_estimated_execution_time
+│               │
+│               └── • scan
+│                     columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│                     table: statement_statistics@primary
+│                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │
-└── • index join
+└── • limit
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 500
-    │ table: statement_statistics@primary
-    │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
+    │ count: 500
     │
-    └── • top-k
-        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-        │ estimated row count: 500
-        │ order: -p99_latency
-        │ k: 500
+    └── • filter
+        │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+        │ ordering: -p99_latency
+        │ estimated row count: 111,111
+        │ filter: app_name NOT LIKE '$ internal%'
         │
-        └── • scan
-              columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-              table: statement_statistics@p99_latency_idx (partial index)
-              spans: /2023-03-21T14:05:00.000001Z-
+        └── • sort
+            │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+            │ estimated row count: 3
+            │ order: -p99_latency
+            │
+            └── • scan
+                  columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+                  estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                  table: statement_statistics@primary
+                  spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 
 statement ok
 ALTER TABLE system.transaction_statistics INJECT STATISTICS '[
@@ -1190,113 +1226,131 @@ vectorized: true
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
 │   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
-│   │   │   │   ├── • index join
+│   │   │   │   ├── • limit
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 500
-│   │   │   │   │   │ table: transaction_statistics@primary
-│   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │   │   │   │   │ count: 500
 │   │   │   │   │   │
-│   │   │   │   │   └── • top-k
-│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │       │ estimated row count: 500
-│   │   │   │   │       │ order: -execution_count
-│   │   │   │   │       │ k: 500
+│   │   │   │   │   └── • filter
+│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │       │ ordering: -execution_count
+│   │   │   │   │       │ estimated row count: 111,111
+│   │   │   │   │       │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │   │       │
-│   │   │   │   │       └── • scan
-│   │   │   │   │             columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │   │             table: transaction_statistics@execution_count_idx (partial index)
-│   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │   │       └── • sort
+│   │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │           │ estimated row count: 3
+│   │   │   │   │           │ order: -execution_count
+│   │   │   │   │           │
+│   │   │   │   │           └── • scan
+│   │   │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │                 estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │   │                 table: transaction_statistics@primary
+│   │   │   │   │                 spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │   │
-│   │   │   │   └── • index join
+│   │   │   │   └── • limit
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 500
-│   │   │   │       │ table: transaction_statistics@primary
-│   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │   │   │       │ count: 500
 │   │   │   │       │
-│   │   │   │       └── • top-k
-│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │           │ estimated row count: 500
-│   │   │   │           │ order: -service_latency
-│   │   │   │           │ k: 500
+│   │   │   │       └── • filter
+│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │           │ ordering: -service_latency
+│   │   │   │           │ estimated row count: 111,111
+│   │   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │           │
-│   │   │   │           └── • scan
-│   │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │                 table: transaction_statistics@service_latency_idx (partial index)
-│   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │           └── • sort
+│   │   │   │               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │               │ estimated row count: 3
+│   │   │   │               │ order: -service_latency
+│   │   │   │               │
+│   │   │   │               └── • scan
+│   │   │   │                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │                     table: transaction_statistics@primary
+│   │   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │
-│   │   │   └── • index join
+│   │   │   └── • limit
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 500
-│   │   │       │ table: transaction_statistics@primary
-│   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │   │       │ count: 500
 │   │   │       │
-│   │   │       └── • top-k
-│   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │           │ estimated row count: 500
-│   │   │           │ order: -cpu_sql_nanos
-│   │   │           │ k: 500
+│   │   │       └── • filter
+│   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │           │ ordering: -cpu_sql_nanos
+│   │   │           │ estimated row count: 111,111
+│   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │           │
-│   │   │           └── • scan
-│   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │                 table: transaction_statistics@cpu_sql_nanos_idx (partial index)
-│   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │           └── • sort
+│   │   │               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │               │ estimated row count: 3
+│   │   │               │ order: -cpu_sql_nanos
+│   │   │               │
+│   │   │               └── • scan
+│   │   │                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │                     table: transaction_statistics@primary
+│   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │
-│   │   └── • index join
+│   │   └── • limit
 │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 500
-│   │       │ table: transaction_statistics@primary
-│   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │       │ count: 500
 │   │       │
-│   │       └── • top-k
-│   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │           │ estimated row count: 500
-│   │           │ order: -contention_time
-│   │           │ k: 500
+│   │       └── • filter
+│   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │           │ ordering: -contention_time
+│   │           │ estimated row count: 111,111
+│   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │           │
-│   │           └── • scan
-│   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │                 table: transaction_statistics@contention_time_idx (partial index)
-│   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │           └── • sort
+│   │               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │               │ estimated row count: 3
+│   │               │ order: -contention_time
+│   │               │
+│   │               └── • scan
+│   │                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │                     table: transaction_statistics@primary
+│   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │
-│   └── • index join
+│   └── • limit
 │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 500
-│       │ table: transaction_statistics@primary
-│       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│       │ count: 500
 │       │
-│       └── • top-k
-│           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│           │ estimated row count: 500
-│           │ order: -total_estimated_execution_time
-│           │ k: 500
+│       └── • filter
+│           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│           │ ordering: -total_estimated_execution_time
+│           │ estimated row count: 111,111
+│           │ filter: app_name NOT LIKE '$ internal%'
 │           │
-│           └── • scan
-│                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│                 table: transaction_statistics@total_estimated_execution_time_idx (partial index)
-│                 spans: /2023-03-21T14:05:00.000001Z-
+│           └── • sort
+│               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│               │ estimated row count: 3
+│               │ order: -total_estimated_execution_time
+│               │
+│               └── • scan
+│                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│                     table: transaction_statistics@primary
+│                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │
-└── • index join
+└── • limit
     │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 500
-    │ table: transaction_statistics@primary
-    │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+    │ count: 500
     │
-    └── • top-k
-        │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-        │ estimated row count: 500
-        │ order: -p99_latency
-        │ k: 500
+    └── • filter
+        │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+        │ ordering: -p99_latency
+        │ estimated row count: 111,111
+        │ filter: app_name NOT LIKE '$ internal%'
         │
-        └── • scan
-              columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-              table: transaction_statistics@p99_latency_idx (partial index)
-              spans: /2023-03-21T14:05:00.000001Z-
+        └── • sort
+            │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+            │ estimated row count: 3
+            │ order: -p99_latency
+            │
+            └── • scan
+                  columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+                  estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                  table: transaction_statistics@primary
+                  spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 
 query T
 EXPLAIN (VERBOSE)
@@ -1414,110 +1468,128 @@ vectorized: true
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
 │   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
-│   │   │   │   ├── • index join
+│   │   │   │   ├── • limit
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 500
-│   │   │   │   │   │ table: transaction_statistics@primary
-│   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │   │   │   │   │ count: 500
 │   │   │   │   │   │
-│   │   │   │   │   └── • top-k
-│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │       │ estimated row count: 500
-│   │   │   │   │       │ order: -execution_count
-│   │   │   │   │       │ k: 500
+│   │   │   │   │   └── • filter
+│   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │       │ ordering: -execution_count
+│   │   │   │   │       │ estimated row count: 111,111
+│   │   │   │   │       │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │   │       │
-│   │   │   │   │       └── • scan
-│   │   │   │   │             columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │   │             table: transaction_statistics@execution_count_idx (partial index)
-│   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │   │       └── • sort
+│   │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │           │ estimated row count: 3
+│   │   │   │   │           │ order: -execution_count
+│   │   │   │   │           │
+│   │   │   │   │           └── • scan
+│   │   │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │   │                 estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │   │                 table: transaction_statistics@primary
+│   │   │   │   │                 spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │   │
-│   │   │   │   └── • index join
+│   │   │   │   └── • limit
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 500
-│   │   │   │       │ table: transaction_statistics@primary
-│   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │   │   │       │ count: 500
 │   │   │   │       │
-│   │   │   │       └── • top-k
-│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │           │ estimated row count: 500
-│   │   │   │           │ order: -service_latency
-│   │   │   │           │ k: 500
+│   │   │   │       └── • filter
+│   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │           │ ordering: -service_latency
+│   │   │   │           │ estimated row count: 111,111
+│   │   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │   │           │
-│   │   │   │           └── • scan
-│   │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │   │                 table: transaction_statistics@service_latency_idx (partial index)
-│   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │   │           └── • sort
+│   │   │   │               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │               │ estimated row count: 3
+│   │   │   │               │ order: -service_latency
+│   │   │   │               │
+│   │   │   │               └── • scan
+│   │   │   │                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │   │                     table: transaction_statistics@primary
+│   │   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │   │
-│   │   │   └── • index join
+│   │   │   └── • limit
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 500
-│   │   │       │ table: transaction_statistics@primary
-│   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │   │       │ count: 500
 │   │   │       │
-│   │   │       └── • top-k
-│   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │           │ estimated row count: 500
-│   │   │           │ order: -cpu_sql_nanos
-│   │   │           │ k: 500
+│   │   │       └── • filter
+│   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │           │ ordering: -cpu_sql_nanos
+│   │   │           │ estimated row count: 111,111
+│   │   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │   │           │
-│   │   │           └── • scan
-│   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │   │                 table: transaction_statistics@cpu_sql_nanos_idx (partial index)
-│   │   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │   │           └── • sort
+│   │   │               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │               │ estimated row count: 3
+│   │   │               │ order: -cpu_sql_nanos
+│   │   │               │
+│   │   │               └── • scan
+│   │   │                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │   │                     table: transaction_statistics@primary
+│   │   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │   │
-│   │   └── • index join
+│   │   └── • limit
 │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 500
-│   │       │ table: transaction_statistics@primary
-│   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│   │       │ count: 500
 │   │       │
-│   │       └── • top-k
-│   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │           │ estimated row count: 500
-│   │           │ order: -contention_time
-│   │           │ k: 500
+│   │       └── • filter
+│   │           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │           │ ordering: -contention_time
+│   │           │ estimated row count: 111,111
+│   │           │ filter: app_name NOT LIKE '$ internal%'
 │   │           │
-│   │           └── • scan
-│   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│   │                 table: transaction_statistics@contention_time_idx (partial index)
-│   │                 spans: /2023-03-21T14:05:00.000001Z-
+│   │           └── • sort
+│   │               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │               │ estimated row count: 3
+│   │               │ order: -contention_time
+│   │               │
+│   │               └── • scan
+│   │                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│   │                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│   │                     table: transaction_statistics@primary
+│   │                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │   │
-│   └── • index join
+│   └── • limit
 │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 500
-│       │ table: transaction_statistics@primary
-│       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+│       │ count: 500
 │       │
-│       └── • top-k
-│           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│           │ estimated row count: 500
-│           │ order: -total_estimated_execution_time
-│           │ k: 500
+│       └── • filter
+│           │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│           │ ordering: -total_estimated_execution_time
+│           │ estimated row count: 111,111
+│           │ filter: app_name NOT LIKE '$ internal%'
 │           │
-│           └── • scan
-│                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-│                 table: transaction_statistics@total_estimated_execution_time_idx (partial index)
-│                 spans: /2023-03-21T14:05:00.000001Z-
+│           └── • sort
+│               │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│               │ estimated row count: 3
+│               │ order: -total_estimated_execution_time
+│               │
+│               └── • scan
+│                     columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+│                     estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+│                     table: transaction_statistics@primary
+│                     spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8
 │
-└── • index join
+└── • limit
     │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 500
-    │ table: transaction_statistics@primary
-    │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
+    │ count: 500
     │
-    └── • top-k
-        │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-        │ estimated row count: 500
-        │ order: -p99_latency
-        │ k: 500
+    └── • filter
+        │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+        │ ordering: -p99_latency
+        │ estimated row count: 111,111
+        │ filter: app_name NOT LIKE '$ internal%'
         │
-        └── • scan
-              columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
-              table: transaction_statistics@p99_latency_idx (partial index)
-              spans: /2023-03-21T14:05:00.000001Z-
+        └── • sort
+            │ columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+            │ estimated row count: 3
+            │ order: -p99_latency
+            │
+            └── • scan
+                  columns: (aggregated_ts, fingerprint_id, app_name, metadata, statistics, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency)
+                  estimated row count: 3 (<0.01% of the table; stats collected <hidden> ago)
+                  table: transaction_statistics@primary
+                  spans: /0/2023-03-21T14:05:00.000001Z-/1 /1/2023-03-21T14:05:00.000001Z-/2 /2/2023-03-21T14:05:00.000001Z-/3 /3/2023-03-21T14:05:00.000001Z-/4 /4/2023-03-21T14:05:00.000001Z-/5 /5/2023-03-21T14:05:00.000001Z-/6 /6/2023-03-21T14:05:00.000001Z-/7 /7/2023-03-21T14:05:00.000001Z-/8

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -409,3 +409,244 @@ scan jobs
  ├── fd: (1)-->(2,3,6-12)
  ├── distribution: test
  └── prune: (1-3,6-12)
+
+# Regression test for #125963. Ensure that we get reasonable stats estimates if
+# histograms are empty. (The test is here since the bug in #125963 doesn't
+# reproduce with optimizer tests.)
+
+statement ok
+CREATE TABLE tab (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  a STRING,
+  b STRING,
+  c STRING,
+  d STRING,
+  INDEX tab_a_b_c_idx (a ASC, b ASC, c ASC)
+);
+
+statement ok
+ALTER TABLE tab INJECT STATISTICS '[
+    {
+        "columns": [
+            "id"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 10000000,
+        "histo_col_type": "UUID",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 10000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "a",
+            "b"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 501000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "a",
+            "b",
+            "c"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1001000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 500000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "c"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "d"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    }
+]';
+
+query T
+EXPLAIN SELECT
+  id,
+  a,
+  b,
+  c,
+  d
+FROM
+  tab@{FORCE_INDEX=tab_a_b_c_idx,NO_FULL_SCAN}
+WHERE
+  a = 'a' AND b = 'b' AND c = 'c'
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ estimated row count: 9
+│ table: tab@tab_pkey
+│
+└── • scan
+      estimated row count: 9 (<0.01% of the table; stats collected <hidden> ago)
+      table: tab@tab_a_b_c_idx
+      spans: [/'a'/'b'/'c' - /'a'/'b'/'c']
+
+# Same stats as above but with some null values.
+statement ok
+ALTER TABLE tab INJECT STATISTICS '[
+    {
+        "columns": [
+            "id"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 10000000,
+        "histo_col_type": "UUID",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 10000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 10,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "a",
+            "b"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 501000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 10,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "a",
+            "b",
+            "c"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1001000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 10,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 500000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 10,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "c"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 10,
+        "row_count": 10000000
+    },
+    {
+        "columns": [
+            "d"
+        ],
+        "created_at": "2024-01-01 00:00:00",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "name": "__auto__",
+        "null_count": 10,
+        "row_count": 10000000
+    }
+]';
+
+query T
+EXPLAIN SELECT
+  id,
+  a,
+  b,
+  c,
+  d
+FROM
+  tab@{FORCE_INDEX=tab_a_b_c_idx,NO_FULL_SCAN}
+WHERE
+  a = 'a' AND b = 'b' AND c = 'c'
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ estimated row count: 9
+│ table: tab@tab_pkey
+│
+└── • scan
+      estimated row count: 9 (<0.01% of the table; stats collected <hidden> ago)
+      table: tab@tab_a_b_c_idx
+      spans: [/'a'/'b'/'c' - /'a'/'b'/'c']

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -706,7 +706,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 				stats.AvgColSizes[colOrd] = stat.AvgSize()
 			}
 
-			needHistogram := cols.Len() == 1 && stat.Histogram() != nil &&
+			needHistogram := cols.Len() == 1 && len(stat.Histogram()) > 0 &&
 				sb.evalCtx.SessionData().OptimizerUseHistograms
 			seenInvertedStat := false
 			invertedStatistic := false

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -646,7 +646,7 @@ func (sc *TableStatisticsCache) parseStats(
 	}
 	res := &TableStatistic{TableStatisticProto: *tsp}
 	var udt *types.T
-	if res.HistogramData != nil {
+	if res.HistogramData != nil && (len(res.HistogramData.Buckets) > 0 || res.RowCount == res.NullCount) {
 		// hydrate the type in case any user defined types are present.
 		// There are cases where typ is nil, so don't do anything if so.
 		if typ := res.HistogramData.ColumnType; typ != nil && typ.UserDefined() {


### PR DESCRIPTION
If the database detects excessive memory utilization during stats collection, it may disable histogram collection. Prior to this commit, the optimizer was using the resulting empty histograms for statistics estimation, resulting in bad plans. This commit fixes the stats cache and the statistics builder in the optimizer so they do not use histograms if they are empty (or the row count equals the null count).

Fixes #125963

Release note (bug fix): Fixed the statistics estimation code in the optimizer so it does not use the empty histograms produced if histogram collection has been disabled during stats collection due to excessive memory utilization. Now the optimizer will rely on distinct counts instead of the empty histograms and should produce better plans as a result. This bug has existed since CockroachDB v22.1.