### PR TITLE
sql/colexecerror: implement `Unwrap` on `StorageError`, deflake `TestAdminDecommissionedOperations`

### DIFF
--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -889,7 +889,7 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 			})
 			return err
 		}},
-		{"Events", codes.Internal, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Events", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
 			_, err := c.Events(ctx, &serverpb.EventsRequest{})
 			return err
 		}},

--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -214,18 +214,17 @@ func shouldCatchPanic(panicEmittedFrom string) bool {
 // stack, such as the network or storage layers. A StorageError will be bubbled
 // up all the way past the SQL layer unchanged.
 type StorageError struct {
-	error
+	cause error
 }
 
-// Cause implements the Causer interface.
-func (s *StorageError) Cause() error {
-	return s.error
-}
+func (s *StorageError) Error() string { return s.cause.Error() }
+func (s *StorageError) Cause() error  { return s.cause }
+func (s *StorageError) Unwrap() error { return s.cause }
 
 // NewStorageError returns a new storage error. This can be used to propagate
 // an error through the exec subsystem unchanged.
 func NewStorageError(err error) *StorageError {
-	return &StorageError{error: err}
+	return &StorageError{cause: err}
 }
 
 // notInternalError is an error that occurs not because the vectorized engine


### PR DESCRIPTION
Fixes #125922.

In #125922, we saw flakiness in `TestAdminDecommissionedOperations` due to unreliable grpc error code propagation. This commit fixes the issue by implementing `Unwrap` on `colexecerror.StorageError` so that the grpc error code is propagated correctly.

This was broken before because `grpc/status.FromError` uses `errors.As` from the standard library, which only respects `Unwrap()` and does not respect `Cause()`. As a result, grpc codes of any error wrapped in a `colexecerror.StorageError` were being lost.

The test was flaky and not entirely broken because it would sometimes hit a code path that wrapped the grpc error in a `StorageError` and sometimes hit a code path that did not.

Release note: None