### PR TITLE
 pkg/cli: only flush logs during startup when running under systemd 

### DIFF
--- a/pkg/util/sdnotify/sdnotify.go
+++ b/pkg/util/sdnotify/sdnotify.go
@@ -19,9 +19,10 @@ import "os/exec"
 // Ready sends a readiness signal using the systemd notification
 // protocol. It should be called (once) by a server after it has
 // completed its initialization (including but not necessarily limited
-// to binding ports) and is ready to receive traffic.
-func Ready() error {
-	return ready()
+// to binding ports) and is ready to receive traffic. If preNotify is
+// specified, it will be called before the readiness signal is sent.
+func Ready(preNotify func()) error {
+	return ready(preNotify)
 }
 
 // Exec the given command in the background using the systemd

--- a/pkg/util/sdnotify/sdnotify_unix.go
+++ b/pkg/util/sdnotify/sdnotify_unix.go
@@ -28,12 +28,16 @@ const (
 	netType  = "unixgram"
 )
 
-func ready() error {
-	return notifyEnv(readyMsg)
+func ready(preNotify func()) error {
+	return notifyEnv(preNotify, readyMsg)
 }
 
-func notifyEnv(msg string) error {
+func notifyEnv(preNotify func(), msg string) error {
 	if path, ok := os.LookupEnv(envName); ok {
+		// Only run preNotify if we need to notify.
+		if preNotify != nil {
+			preNotify()
+		}
 		return notify(path, msg)
 	}
 	return nil

--- a/pkg/util/sdnotify/sdnotify_windows.go
+++ b/pkg/util/sdnotify/sdnotify_windows.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func ready() error {
+func ready(preNotify func()) error {
 	return nil
 }
 


### PR DESCRIPTION
Previously, `log.FlushAllSync()` was called before sending the signal
readiness to systemd to ensure that the configuration logging is written to
disk in case a process is waiting for the sdnotify readiness to read
information from there. However, that gets invoked even if the process isn't
running under systemd, and process start ups would take an unnecessary hit on
performance. This commit addresses that by running `FlushAllSync`
conditionally, i.e. only when the process is running under systemd.

Epic: none

Release note (performance improvement): Starting a cockroach process will no
longer flush buffered logs to configured logging sinks unless the process is
running under systemd, where cockroach runs with the `NOTIFY_SOCKET`
environment variable.