### PR TITLE
sql: only compute histogram sample size once for all requested stats

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -205,6 +205,7 @@ func (dsp *DistSQLPlanner) createAndAttachSamplers(
 			// there are fewer rows than this in the table, there will be fewer
 			// samples of course, which is fine.)
 			sampler.MinSampleSize = s.histogramMaxBuckets
+			break
 		}
 	}
 


### PR DESCRIPTION
Previously, we computed the number of samples for histogram construction repeatedly for each stat request. This is unnecessary as this number doesn't change and pollutes logging with the computed sample size. We now compute and log the number of samples only once, if necessary.

See also: #123972

Release note: None