### PR TITLE
roachtest: wait for unmount in disk-stall/dmsetup

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/disk_stall.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_stall.go
@@ -190,7 +190,8 @@ func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 	// /dev/dm-0 is created. This possibly interferes with the dmsetup create
 	// reload, so uninstall snapd.
 	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get purge -y snapd`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount -f /mnt/data1 || true`)
+	// NB: We suppress errors in case the directory isn't mounted already.
+	_ = s.c.RunE(ctx, option.WithNodes(s.c.All()), `sudo umount -f /mnt/data1`)
 	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
 	err := s.c.RunE(ctx, option.WithNodes(s.c.All()), `echo "0 $(sudo blockdev --getsz `+dev+`) linear `+dev+` 0" | `+
 		`sudo dmsetup create data1`)


### PR DESCRIPTION
Previously, we wouldn't wait for the forced unmount of /mnt/data1 to complete in the dmsetup disk stalled roachtest. This change updates that command to wait for that command to return before calling dmsetup volume creation commands.

Fixes #125681.

Epic: none

Release note: None