### PR TITLE
roachprod: resize support for local clusters

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -156,12 +156,12 @@ var growCmd = &cobra.Command{
 	Short: `grow a cluster by adding nodes`,
 	Long: `grow a cluster by adding the specified number of nodes to it.
 
-The cluster has to be a managed cluster (i.e., a cluster created with the
-gce-managed flag). Only Google Cloud clusters currently support adding nodes.
-The new nodes will use the instance template that was used to create the cluster
-originally (Nodes will be created in the same zone as the existing nodes, or if
-the cluster is geographically distributed, the nodes will be fairly distributed
-across the zones of the cluster).
+Only Google Cloud and local clusters currently support adding nodes. The Google
+Cloud cluster has to be a managed cluster (i.e., a cluster created with the
+gce-managed flag). The new nodes will use the instance template that was used to
+create the cluster originally (Nodes will be created in the same zone as the
+existing nodes, or if the cluster is geographically distributed, the nodes will
+be fairly distributed across the zones of the cluster).
 `,
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
@@ -178,10 +178,10 @@ var shrinkCmd = &cobra.Command{
 	Short: `shrink a cluster by removing nodes`,
 	Long: `shrink a cluster by removing the specified number of nodes.
 
-The cluster has to be a managed cluster (i.e., a cluster created with the
-gce-managed flag). Only Google Cloud clusters currently support removing nodes.
-Nodes are removed from the tail end of the cluster. Removing nodes from the
-middle of the cluster is not supported yet.
+Only Google Cloud and local clusters currently support removing nodes. The
+Google Cloud cluster has to be a managed cluster (i.e., a cluster created with
+the gce-managed flag). Nodes are removed from the tail end of the cluster.
+Removing nodes from the middle of the cluster is not supported yet.
 `,
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -369,24 +369,26 @@ func GrowCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 		names = append(names, vmName)
 	}
 
-	providers := c.Clouds()
-	if len(providers) != 1 || providers[0] != gce.ProviderName {
-		return errors.Errorf("cannot grow cluster %s, growing a cluster is currently only supported on %s",
-			c.Name, gce.ProviderName)
+	if !c.IsLocal() {
+		providers := c.Clouds()
+		if len(providers) != 1 || providers[0] != gce.ProviderName {
+			return errors.Errorf("cannot grow cluster %s, growing a cluster is currently only supported on %s",
+				c.Name, gce.ProviderName)
+		}
 	}
-
-	// Only GCE supports expanding a cluster.
-	return vm.ForProvider(gce.ProviderName, func(p vm.Provider) error {
+	return vm.ForProvider(c.VMs[0].Provider, func(p vm.Provider) error {
 		return p.Grow(l, c.VMs, c.Name, names)
 	})
 }
 
 // ShrinkCluster removes tail nodes from an existing cluster.
 func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
-	providers := c.Clouds()
-	if len(providers) != 1 || providers[0] != gce.ProviderName {
-		return errors.Errorf("cannot shrink cluster %s, shrinking a cluster is currently only supported on %s",
-			c.Name, gce.ProviderName)
+	if !c.IsLocal() {
+		providers := c.Clouds()
+		if len(providers) != 1 || providers[0] != gce.ProviderName {
+			return errors.Errorf("cannot shrink cluster %s, shrinking a cluster is currently only supported on %s",
+				c.Name, gce.ProviderName)
+		}
 	}
 
 	if numNodes >= len(c.VMs) {
@@ -396,8 +398,7 @@ func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 	// Always delete from the tail.
 	vmsToDelete := c.VMs[len(c.VMs)-numNodes:]
 
-	// Only GCE supports shrinking a cluster.
-	return vm.ForProvider(gce.ProviderName, func(p vm.Provider) error {
+	return vm.ForProvider(c.VMs[0].Provider, func(p vm.Provider) error {
 		return p.Shrink(l, vmsToDelete, c.Name)
 	})
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1646,6 +1646,11 @@ func Grow(ctx context.Context, l *logger.Logger, clusterName string, numNodes in
 	if err != nil {
 		return err
 	}
+	if c.IsLocal() {
+		// If this is used externally with roachtest then we need to reload the
+		// clusters before returning.
+		return LoadClusters()
+	}
 	return SetupSSH(ctx, l, clusterName)
 }
 
@@ -1658,6 +1663,11 @@ func Shrink(ctx context.Context, l *logger.Logger, clusterName string, numNodes 
 	err = cloud.ShrinkCluster(l, &c.Cluster, numNodes)
 	if err != nil {
 		return err
+	}
+	if c.IsLocal() {
+		// If this is used externally with roachtest then we need to reload the
+		// clusters before returning.
+		return LoadClusters()
 	}
 	_, err = Sync(l, vm.ListOptions{})
 	return err


### PR DESCRIPTION
Previously, resizing (grow & shrink) was only supported with Google Cloud clusters. This adds the ability to grow and shrink local clusters, which is useful for testing purposes.

Release Note: None
Epic: None