### PR TITLE
roachprod, roachtest: add resize operation

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -450,7 +450,7 @@ func initFlags() {
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, createLoadBalancerCmd, sqlCmd, pgurlCmd, loadBalancerPGUrl, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd, updateTargetsCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, createLoadBalancerCmd, sqlCmd, pgurlCmd, loadBalancerPGUrl, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd, updateTargetsCmd, growCmd} {
 		// TODO(renato): remove --secure once the default of secure
 		// clusters has existed in roachprod long enough.
 		cmd.Flags().BoolVar(&secure,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -169,7 +169,7 @@ be fairly distributed across the zones of the cluster).
 		if err != nil || count < 1 {
 			return errors.Wrapf(err, "invalid num-nodes argument")
 		}
-		return roachprod.Grow(context.Background(), config.Logger, args[0], int(count))
+		return roachprod.Grow(context.Background(), config.Logger, args[0], isSecure, int(count))
 	}),
 }
 

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     testonly = 1,
     srcs = [
         "cluster.go",
+        "dynamic_cluster.go",
         "github.go",
         "main.go",
         "monitor.go",

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -72,6 +72,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_slack_go_slack//:slack",
         "@com_github_spf13_cobra//:cobra",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/cmd/roachtest/cluster/BUILD.bazel
+++ b/pkg/cmd/roachtest/cluster/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cluster",
     srcs = [
         "cluster_interface.go",
+        "dynamic_cluster_interface.go",
         "err_command_details.go",
         "monitor_interface.go",
     ],

--- a/pkg/cmd/roachtest/cluster/dynamic_cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/dynamic_cluster_interface.go
@@ -1,0 +1,25 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+// DynamicCluster is a cluster that can be resized. This is only for use by
+// operations that mutate the underlying cluster topology.
+type DynamicCluster interface {
+	Cluster
+	Grow(ctx context.Context, l *logger.Logger, nodeCount int) error
+	Shrink(ctx context.Context, l *logger.Logger, nodeCount int) error
+}

--- a/pkg/cmd/roachtest/dynamic_cluster.go
+++ b/pkg/cmd/roachtest/dynamic_cluster.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
+
+type dynamicClusterImpl struct {
+	*clusterImpl
+}
+
+// Grow adds nodes to the cluster.
+func (c *clusterImpl) Grow(ctx context.Context, l *logger.Logger, nodeCount int) error {
+	err := roachprod.Grow(ctx, l, c.name, c.IsSecure(), nodeCount)
+	if err != nil {
+		return err
+	}
+	c.spec.NodeCount += nodeCount
+	return nil
+}
+
+// Shrink removes nodes from the cluster.
+func (c *clusterImpl) Shrink(ctx context.Context, l *logger.Logger, nodeCount int) error {
+	err := roachprod.Shrink(ctx, l, c.name, nodeCount)
+	if err != nil {
+		return err
+	}
+	c.spec.NodeCount -= nodeCount
+	return nil
+}

--- a/pkg/cmd/roachtest/operation/BUILD.bazel
+++ b/pkg/cmd/roachtest/operation/BUILD.bazel
@@ -5,5 +5,9 @@ go_library(
     srcs = ["operation_interface.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/roachprod/logger"],
+    deps = [
+        "//pkg/cmd/roachtest/option",
+        "//pkg/roachprod/install",
+        "//pkg/roachprod/logger",
+    ],
 )

--- a/pkg/cmd/roachtest/operation/operation_interface.go
+++ b/pkg/cmd/roachtest/operation/operation_interface.go
@@ -10,12 +10,19 @@
 
 package operation
 
-import "github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+import (
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
 
 type Operation interface {
 	// ClusterCockroach returns the path to the Cockroach binary on the target
 	// cluster.
 	ClusterCockroach() string
+	ClusterSettings() install.ClusterSettings
+	StartOpts() option.StartOpts
+
 	Name() string
 	Error(args ...interface{})
 	Errorf(string, ...interface{})

--- a/pkg/cmd/roachtest/operation_impl.go
+++ b/pkg/cmd/roachtest/operation_impl.go
@@ -16,7 +16,9 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -25,8 +27,9 @@ import (
 var errOperationFatal = errors.New("o.Fatal() was called")
 
 type operationImpl struct {
-	spec      *registry.OperationSpec
-	cockroach string // path to main cockroach binary on the cluster.
+	spec            *registry.OperationSpec
+	clusterSettings install.ClusterSettings
+	startOpts       option.StartOpts
 
 	// l is the logger that the operation will use for its output.
 	l *logger.Logger
@@ -50,7 +53,15 @@ type operationImpl struct {
 }
 
 func (o *operationImpl) ClusterCockroach() string {
-	return o.cockroach
+	return o.clusterSettings.Binary
+}
+
+func (o *operationImpl) ClusterSettings() install.ClusterSettings {
+	return o.clusterSettings
+}
+
+func (o *operationImpl) StartOpts() option.StartOpts {
+	return o.startOpts
 }
 
 func (o *operationImpl) Name() string {

--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "network_partition.go",
         "node_kill.go",
         "register.go",
+        "resize.go",
         "utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations",
@@ -26,6 +27,7 @@ go_library(
         "//pkg/testutils",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",
         "//pkg/cmd/roachtest/roachtestutil",
-        "//pkg/roachprod/install",
         "//pkg/testutils",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",

--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -64,38 +63,19 @@ func runNodeKill(
 	ctx context.Context, o operation.Operation, c cluster.Cluster, signal int, drain bool,
 ) registry.OperationCleanup {
 	rng, _ := randutil.NewPseudoRand()
-
 	node := c.All().SeededRandNode(rng)
 
 	if drain {
-		o.Status(fmt.Sprintf("draining node %s", node.NodeIDsString()))
-		addr, err := c.ExternalAddr(ctx, o.L(), node)
-		if err != nil {
-			o.Fatal(err)
-		}
-		args := []string{
-			fmt.Sprintf("./%s", o.ClusterCockroach()),
-			"node", "drain", "--logtostderr=INFO", "--self",
-			fmt.Sprintf("--host=%s", addr[0]),
-		}
-		if c.IsSecure() {
-			args = append(args, "--certs-dir", install.CockroachNodeCertsDir)
-		} else {
-			args = append(args, "--insecure")
-		}
-		err = c.RunE(ctx, option.WithNodes(node), args...)
-		if err != nil {
-			o.Fatal(err)
-		}
+		drainNode(ctx, o, c, node)
 	}
-	o.Status(fmt.Sprintf("killing node %s with signal %d", node.NodeIDsString(), signal))
 
+	o.Status(fmt.Sprintf("killing node %s with signal %d", node.NodeIDsString(), signal))
 	err := c.RunE(ctx, option.WithNodes(node), "pkill", fmt.Sprintf("-%d", signal), "-f", "cockroach\\ start")
 	if err != nil {
 		o.Fatal(err)
 	}
-	o.Status(fmt.Sprintf("sent signal %d to node %s, waiting for process to exit", signal, node.NodeIDsString()))
 
+	o.Status(fmt.Sprintf("sent signal %d to node %s, waiting for process to exit", signal, node.NodeIDsString()))
 	for {
 		if err := ctx.Err(); err != nil {
 			o.Fatal(err)
@@ -104,15 +84,13 @@ func runNodeKill(
 		if err != nil {
 			if strings.Contains(err.Error(), "status 1") {
 				// pgrep returns error code 1 if no processes are found.
+				o.Status(fmt.Sprintf("killed node %s with signal %d", node.NodeIDsString(), signal))
 				break
 			}
 			o.Fatal(err)
 		}
-
 		time.Sleep(1 * time.Second)
 	}
-
-	o.Status(fmt.Sprintf("killed node %s with signal %d", node.NodeIDsString(), signal))
 
 	return &cleanupNodeKill{
 		nodes: node,

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -22,4 +22,5 @@ func RegisterOperations(r registry.Registry) {
 	registerClusterSettings(r)
 	registerBackupRestore(r)
 	registerManualCompaction(r)
+	registerResize(r)
 }

--- a/pkg/cmd/roachtest/operations/resize.go
+++ b/pkg/cmd/roachtest/operations/resize.go
@@ -1,0 +1,105 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/errors"
+)
+
+type cleanupResize struct {
+	origClusterSize int
+	growCount       int
+}
+
+// Cleanup shrinks the cluster back to its original size.
+func (cl *cleanupResize) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	dynamicCluster := c.(cluster.DynamicCluster)
+	defer func() {
+		err := dynamicCluster.Shrink(ctx, o.L(), cl.growCount)
+		if err != nil {
+			o.Status(fmt.Sprintf("error shrinking cluster: %s", err))
+		} else {
+			o.Status("shrunk cluster back to original size")
+		}
+	}()
+	for i := 0; i < cl.growCount; i++ {
+		drainNode(ctx, o, c, c.Node(cl.origClusterSize+i+1))
+		decommissionNode(ctx, o, c, c.Node(cl.origClusterSize+i+1))
+	}
+}
+
+// resizeCluster grows the cluster by the specified count, waits for a specified
+// duration, then drains and decommissions the new nodes.
+func resizeCluster(
+	ctx context.Context, o operation.Operation, c cluster.Cluster, growCount int,
+) *cleanupResize {
+	// Create a temporary directory to store the required files for this operation.
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		o.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	dynamicCluster, ok := c.(cluster.DynamicCluster)
+	if !ok {
+		o.Fatal("cluster does not implement the DynamicCluster interface")
+	}
+
+	// Grab required files from the first node.
+	err = c.Get(ctx, o.L(), "cockroach", path.Join(tmpDir, "cockroach"), c.Node(1))
+	if err != nil {
+		o.Fatal(errors.Wrap(err, "failed to get cockroach, please ensure cockroach is running on this cluster"))
+	}
+	err = c.Get(ctx, o.L(), "lib", path.Join(tmpDir, "lib"), c.Node(1))
+	if err != nil {
+		o.Fatal(errors.Wrap(err, "failed to get cockroach libs"))
+	}
+
+	// Grow the cluster, but keep track of the original cluster size.
+	origClusterSize := c.Spec().NodeCount
+	err = dynamicCluster.Grow(ctx, o.L(), growCount)
+	if err != nil {
+		o.Fatal(err)
+	}
+	newNodes := c.Range(origClusterSize+1, origClusterSize+growCount)
+
+	// Copy the required files to the new nodes.
+	c.Put(ctx, path.Join(tmpDir, "cockroach"), "cockroach", newNodes)
+	c.Put(ctx, path.Join(tmpDir, "lib"), "lib", newNodes)
+
+	// Start the new nodes.
+	startOpts := o.StartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, o.L(), startOpts, o.ClusterSettings(), newNodes)
+
+	return &cleanupResize{growCount: growCount, origClusterSize: origClusterSize}
+}
+
+func registerResize(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "resize/grow=3",
+		Owner:            registry.OwnerStorage,
+		Timeout:          30 * time.Minute,
+		CompatibleClouds: registry.OnlyGCE,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresNodes},
+		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+			return resizeCluster(ctx, o, c, 3)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -109,10 +109,12 @@ var (
 		Usage: `Absolute path to cockroach binary to use`,
 	})
 
-	CockroachBinaryPath string = "cockroach"
-	_                          = registerRunOpsFlag(&CockroachBinaryPath, FlagInfo{
-		Name:  "cockroach-binary",
-		Usage: `Relative path to cockroach binary to use, on the cluster specified in --cluster`,
+	ConfigPath string
+	_          = registerRunOpsFlag(&ConfigPath, FlagInfo{
+		Name: "config",
+		Usage: `Path to a YAML config file containing the state of the cluster.
+						Used by operations to determine cluster settings, start options,
+						and the cluster spec.`,
 	})
 
 	CertsDir string

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -618,17 +618,19 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 		cockroach: roachtestflags.CockroachBinaryPath,
 		l:         l,
 	}
-	c := &clusterImpl{
-		name:       clusterName,
-		cloud:      roachtestflags.Cloud,
-		spec:       cSpec,
-		f:          op,
-		l:          l,
-		expiration: cSpec.Expiration(),
-		destroyState: destroyState{
-			owned: false,
+	c := &dynamicClusterImpl{
+		&clusterImpl{
+			name:       clusterName,
+			cloud:      roachtestflags.Cloud,
+			spec:       cSpec,
+			f:          op,
+			l:          l,
+			expiration: cSpec.Expiration(),
+			destroyState: destroyState{
+				owned: false,
+			},
+			localCertsDir: roachtestflags.CertsDir,
 		},
-		localCertsDir: roachtestflags.CertsDir,
 	}
 
 	specs, err := opsToRun(r, filter)

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_dataexmachina_dev_side_eye_go//sideeyeclient",
-        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -369,23 +369,27 @@ func GrowCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 		names = append(names, vmName)
 	}
 
+	provider := c.VMs[0].Provider
 	if !c.IsLocal() {
 		providers := c.Clouds()
-		if len(providers) != 1 || providers[0] != gce.ProviderName {
+		// Only GCE supports expanding a cluster.
+		if len(providers) != 1 || provider != gce.ProviderName {
 			return errors.Errorf("cannot grow cluster %s, growing a cluster is currently only supported on %s",
 				c.Name, gce.ProviderName)
 		}
 	}
-	return vm.ForProvider(c.VMs[0].Provider, func(p vm.Provider) error {
+	return vm.ForProvider(provider, func(p vm.Provider) error {
 		return p.Grow(l, c.VMs, c.Name, names)
 	})
 }
 
 // ShrinkCluster removes tail nodes from an existing cluster.
 func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
+	provider := c.VMs[0].Provider
 	if !c.IsLocal() {
 		providers := c.Clouds()
-		if len(providers) != 1 || providers[0] != gce.ProviderName {
+		// Only GCE supports shrinking a cluster.
+		if len(providers) != 1 || provider != gce.ProviderName {
 			return errors.Errorf("cannot shrink cluster %s, shrinking a cluster is currently only supported on %s",
 				c.Name, gce.ProviderName)
 		}
@@ -398,7 +402,7 @@ func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 	// Always delete from the tail.
 	vmsToDelete := c.VMs[len(c.VMs)-numNodes:]
 
-	return vm.ForProvider(c.VMs[0].Provider, func(p vm.Provider) error {
+	return vm.ForProvider(provider, func(p vm.Provider) error {
 		return p.Shrink(l, vmsToDelete, c.Name)
 	})
 }

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1390,7 +1390,7 @@ func (c *SyncedCluster) distributeCerts(ctx context.Context, l *logger.Logger) e
 	}
 	for _, node := range c.TargetNodes() {
 		if node == 1 {
-			return c.DistributeCerts(ctx, l)
+			return c.DistributeCerts(ctx, l, false)
 		}
 	}
 	return nil

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -58,7 +58,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
-	"golang.org/x/sys/unix"
 )
 
 // MalformedClusterNameError is returned when the cluster name passed to Create is invalid.
@@ -1008,7 +1007,7 @@ func DistributeCerts(ctx context.Context, l *logger.Logger, clusterName string) 
 	if err != nil {
 		return err
 	}
-	return c.DistributeCerts(ctx, l)
+	return c.DistributeCerts(ctx, l, false)
 }
 
 // Put copies a local file to the nodes in a cluster.
@@ -1667,7 +1666,7 @@ func Grow(
 		if err != nil {
 			return err
 		}
-		err = c.RedistributeNodeCert(ctx, l)
+		err = c.DistributeCerts(ctx, l, true)
 		if err != nil {
 			return err
 		}
@@ -2716,11 +2715,6 @@ func CreateLoadBalancer(
 	// cluster's certificate.
 	if secure {
 		err = c.RedistributeNodeCert(ctx, l)
-		if err != nil {
-			return err
-		}
-		// Send a SIGHUP to the nodes to reload the certificates.
-		err = c.Signal(ctx, l, int(unix.SIGHUP))
 		if err != nil {
 			return err
 		}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1705,6 +1705,10 @@ func (p *Provider) Shrink(l *logger.Logger, vmsToDelete vm.List, clusterName str
 }
 
 func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
+	if !isManaged(vms) {
+		return errors.New("growing is only supported for managed instance groups")
+	}
+
 	project := vms[0].Project
 	groupName := instanceGroupName(clusterName)
 	groups, err := listManagedInstanceGroups(project, groupName)


### PR DESCRIPTION
This change adds a new resize operation that will grow clusters and start
cockroach on the new nodes. It copies the current binary and libraries from the
first node, and uses the provided operation config to supply start options and
cluster settings when starting cockroach on the new nodes.

In the new state the operation will pause for a duration before draining and
then decommissioning the new nodes.

If the operation succeeded the cleanup function will shrink the cluster back to
its original size. But if the operation fails, the cleanup function is not
invoked and the cluster will remain at its new size. This is useful for
investigating the new nodes for issues, but also should be monitored since if
the operation is run again it will keep increasing the cluster in size.

Release Note: None
Epic: None