### PR TITLE
builtins: grant test more memory under `race`

### DIFF
--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -174,6 +174,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":builtins"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/kv",


### PR DESCRIPTION
Closes #125899

Epic: none
Release note: None