### PR TITLE
kv: include ReplicaNeedsSnapshotStatus in allocator log

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -3033,13 +3033,14 @@ func excludeReplicasInNeedOfSnapshots(
 ) []roachpb.ReplicaDescriptor {
 	filled := 0
 	for _, repl := range replicas {
-		if raftutil.ReplicaMayNeedSnapshot(st, firstIndex, repl.ReplicaID) != raftutil.NoSnapshotNeeded {
+		snapStatus := raftutil.ReplicaMayNeedSnapshot(st, firstIndex, repl.ReplicaID)
+		if snapStatus != raftutil.NoSnapshotNeeded {
 			log.KvDistribution.VEventf(
 				ctx,
 				5,
-				"not considering [n%d, s%d] as a potential candidate for a lease transfer"+
-					" because the replica may be waiting for a snapshot",
-				repl.NodeID, repl.StoreID,
+				"not considering %s as a potential candidate for a lease transfer"+
+					" because the replica may be waiting for a snapshot: %s",
+				repl, snapStatus,
 			)
 			continue
 		}


### PR DESCRIPTION
Informs #125893.

This commit includes ReplicaNeedsSnapshotStatus in the allocator log in excludeReplicasInNeedOfSnapshots. This will help us understand why a replica is not considered for lease transfer.

It also adds information about the candidate replica ID and replica type by deferring to ReplicaDescriptor.String instead of re-implementing it.

Release note: None