### PR TITLE
release-23.1: compose: don't use DebuggableTempDir helper

### DIFF
--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
     tags = ["integration"],
     deps = [
         "//pkg/build/bazel",
-        "//pkg/testutils/datapathutils",
         "//pkg/util/envutil",
     ],
 )

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
-	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
@@ -80,7 +79,7 @@ func TestComposeCompare(t *testing.T) {
 		// start up docker-compose, but the files themselves will be
 		// Bazel-built symlinks. We want to copy these files to a
 		// different temporary location.
-		compareDir, err = os.MkdirTemp(datapathutils.DebuggableTempDir(), "TestComposeCompare")
+		compareDir, err = os.MkdirTemp("", "TestComposeCompare")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #126014.

/cc @cockroachdb/release

Release justification: test only change

---

The helper is not needed since this test is never executed remotely. Also, the usage of it in older branches broke the test.

fixes https://github.com/cockroachdb/cockroach/issues/125981
Release note: None
