### PR TITLE
sql/schemachanger: preserve some column attributes during data type alter

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -376,11 +376,15 @@ func alterColumnTypeGeneral(
 		}
 	}
 
+	// Set up the new column's descriptor. Since it is a computed column,
+	// we need to omit the default and onUpdate expressions, as computed columns
+	// cannot have them. These expressions are set during the computed column swap
+	// later.
 	newCol := descpb.ColumnDescriptor{
 		Name:            shadowColName,
 		Type:            toType,
 		Nullable:        col.IsNullable(),
-		DefaultExpr:     col.ColumnDesc().DefaultExpr,
+		Hidden:          col.IsHidden(),
 		UsesSequenceIds: col.ColumnDesc().UsesSequenceIds,
 		OwnsSequenceIds: col.ColumnDesc().OwnsSequenceIds,
 		ComputeExpr:     newColComputeExpr,

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1679,6 +1679,17 @@ func (desc *Mutable) performComputedColumnSwap(swap *descpb.ComputedColumnSwap) 
 	// Make the oldCol a computed column by setting its computed expression.
 	oldCol.ColumnDesc().ComputeExpr = &swap.InverseExpr
 
+	// Swap the onUpdate/default expressions. These expressions can only be stored
+	// for non-computed columns, so they need to be swapped at the same time as
+	// the computed expression. Additionally, we have already validated in
+	// AlterColumnType that these expressions can be applied to the new column
+	// type with an automatic cast. Therefore, there is no need to validate the
+	// cast here.
+	newCol.ColumnDesc().OnUpdateExpr = oldCol.ColumnDesc().OnUpdateExpr
+	oldCol.ColumnDesc().OnUpdateExpr = nil
+	newCol.ColumnDesc().DefaultExpr = oldCol.ColumnDesc().DefaultExpr
+	oldCol.ColumnDesc().DefaultExpr = nil
+
 	// Generate unique name for old column.
 	nameExists := func(name string) bool {
 		return catalog.FindColumnByName(desc, name) != nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -674,4 +674,158 @@ ALTER TABLE tab_w_computed ALTER COLUMN real2 TYPE string;
 statement ok
 DROP TABLE tab_w_computed;
 
+subtest preserve_hidden_and_default_expr
+
+statement ok
+CREATE TABLE t_with_hidden (vis1 int, hid1 int2 default 1 not visible, FAMILY f1 (vis1,hid1,rowid));
+
+statement ok
+INSERT INTO t_with_hidden VALUES (0),(1),(2);
+
+query I
+SELECT * FROM t_with_hidden ORDER BY vis1
+----
+0
+1
+2
+
+statement ok
+ALTER TABLE t_with_hidden alter column hid1 type string using '1'::string;
+
+statement ok
+INSERT INTO t_with_hidden VALUES (3);
+
+query I
+SELECT * FROM t_with_hidden ORDER BY vis1
+----
+0
+1
+2
+3
+
+query IT
+SELECT vis1, hid1 FROM t_with_hidden ORDER BY vis1
+----
+0 1
+1 1
+2 1
+3 1
+
+query TT
+SHOW CREATE TABLE t_with_hidden
+----
+t_with_hidden  CREATE TABLE public.t_with_hidden (
+                 vis1 INT8 NULL,
+                 hid1 STRING NOT VISIBLE NULL DEFAULT 1:::INT8,
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT t_with_hidden_pkey PRIMARY KEY (rowid ASC),
+                 FAMILY f1 (vis1, hid1, rowid)
+               )
+
+statement ok
+DROP TABLE t_with_hidden;
+
+subtest preserve_on_update
+
+statement ok
+CREATE TABLE t_with_on_update(a int primary key, b int on update 3, FAMILY f1 (a,b));
+
+statement ok
+INSERT INTO t_with_on_update VALUES (1);
+
+query II
+SELECT a, b FROM t_with_on_update
+----
+1 NULL
+
+statement ok
+UPDATE t_with_on_update SET a=a+1 WHERE a > 0;
+
+query II
+SELECT a, b FROM t_with_on_update ORDER BY a
+----
+2 3
+
+statement ok
+ALTER TABLE t_with_on_update ALTER COLUMN b SET DATA TYPE INT4;
+
+statement ok
+INSERT INTO t_with_on_update VALUES (10);
+UPDATE t_with_on_update SET a=a+1 WHERE a=10;
+INSERT INTO t_with_on_update VALUES (100);
+
+query II
+SELECT a, b FROM t_with_on_update ORDER BY a
+----
+2 3
+11 3
+100 NULL
+
+statement ok
+ALTER TABLE t_with_on_update ALTER COLUMN b SET DATA TYPE STRING;
+
+statement ok
+INSERT INTO t_with_on_update VALUES (1000);
+UPDATE t_with_on_update SET a=a+1 WHERE a=1000;
+INSERT INTO t_with_on_update VALUES (10000);
+
+query IT
+SELECT a, b FROM t_with_on_update ORDER BY a
+----
+2 3
+11 3
+100 NULL
+1001 3
+10000 NULL
+
+query TT
+SHOW CREATE TABLE t_with_on_update
+----
+t_with_on_update  CREATE TABLE public.t_with_on_update (
+                    a INT8 NOT NULL,
+                    b STRING NULL ON UPDATE 3:::INT8,
+                    CONSTRAINT t_with_on_update_pkey PRIMARY KEY (a ASC),
+                    FAMILY f1 (a, b)
+                  )
+
+statement ok
+DROP TABLE t_with_on_update;
+
+subtest preserve_default
+
+statement ok
+CREATE TABLE t_with_default(c1 int4 default 2147483647, FAMILY f1 (rowid,c1));
+
+# Even though c1 has a default value out of range, we allow this. This is
+# consistent with postgres.
+statement ok
+ALTER TABLE t_with_default ALTER COLUMN c1 SET DATA TYPE INT2;
+
+statement error integer out of range for type int2
+INSERT INTO t_with_default VALUES (default);
+
+statement ok
+ALTER TABLE t_with_default ALTER COLUMN c1 SET DEFAULT 32767;
+
+statement ok
+INSERT INTO t_with_default VALUES (default);
+
+query I
+SELECT * FROM t_with_default ORDER BY c1
+----
+32767
+
+query TT
+SHOW CREATE TABLE t_with_default
+----
+t_with_default  CREATE TABLE public.t_with_default (
+                  c1 INT2 NULL DEFAULT 32767:::INT8,
+                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                  CONSTRAINT t_with_default_pkey PRIMARY KEY (rowid ASC),
+                  FAMILY f1 (rowid, c1)
+                )
+
+statement ok
+DROP TABLE t_with_default;
+
 subtest end


### PR DESCRIPTION
Previously, altering a data type on a column with the hidden attribute would succeed, but the column would lose the hidden attribute. Additionally, if a column had a DEFAULT or ON UPDATE expression, the ALTER would fail.

To address this:

- ON UPDATE and DEFAULT expressions are now deferred until we swap the computed property of the column with the shadow column. These expressions can't be set when the shadow column is created because it starts as a computed column, which can't have these expressions.
- The hidden attribute is now copied over when creating the shadow column, preserving it properly.

Epic: CRDB-25314
Closes: #71571
Release note (bug fix): When altering the data type of columns with the hidden attribute, we now preserve that in the alter column. Also, we now allow type alterations for columns with ON UPDATE/DEFAULT expressions.