### PR TITLE
sql/sem/tree: add type-specific allocation sizes for DatumAlloc

### DIFF
--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -171,8 +171,14 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 		// this batch is the longest we've seen so far.
 		c.da.DefaultAllocSize = batchLength
 	}
-	sel := batch.Selection()
 	vecs := batch.ColVecs()
+	c.da.ResetTypeAllocSizes()
+	for _, vecIdx := range c.vecIdxsToConvert {
+		// Provide the datum allocator with hints about the number of
+		// allocations for each type.
+		c.da.AddTypeAllocSize(batchLength, vecs[vecIdx].Type().Family())
+	}
+	sel := batch.Selection()
 	for _, vecIdx := range c.vecIdxsToConvert {
 		ColVecToDatumAndDeselect(
 			c.convertedVecs[vecIdx], vecs[vecIdx], batchLength, sel, &c.da,
@@ -229,6 +235,12 @@ func (c *VecToDatumConverter) ConvertVecs(vecs []*coldata.Vec, inputLen int, sel
 		// Adjust the datum alloc according to the length of the batch since
 		// this batch is the longest we've seen so far.
 		c.da.DefaultAllocSize = requiredLength
+	}
+	c.da.ResetTypeAllocSizes()
+	for _, vecIdx := range c.vecIdxsToConvert {
+		// Provide the datum allocator with hints about the number of
+		// allocations for each type.
+		c.da.AddTypeAllocSize(inputLen, vecs[vecIdx].Type().Family())
 	}
 	for _, vecIdx := range c.vecIdxsToConvert {
 		ColVecToDatum(

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -166,10 +166,10 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 			c.convertedVecs[vecIdx] = c.convertedVecs[vecIdx][:batchLength]
 		}
 	}
-	if c.da.AllocSize < batchLength {
+	if c.da.DefaultAllocSize < batchLength {
 		// Adjust the datum alloc according to the length of the batch since
 		// this batch is the longest we've seen so far.
-		c.da.AllocSize = batchLength
+		c.da.DefaultAllocSize = batchLength
 	}
 	sel := batch.Selection()
 	vecs := batch.ColVecs()
@@ -225,10 +225,10 @@ func (c *VecToDatumConverter) ConvertVecs(vecs []*coldata.Vec, inputLen int, sel
 			c.convertedVecs[vecIdx] = c.convertedVecs[vecIdx][:requiredLength]
 		}
 	}
-	if c.da.AllocSize < requiredLength {
+	if c.da.DefaultAllocSize < requiredLength {
 		// Adjust the datum alloc according to the length of the batch since
 		// this batch is the longest we've seen so far.
-		c.da.AllocSize = requiredLength
+		c.da.DefaultAllocSize = requiredLength
 	}
 	for _, vecIdx := range c.vecIdxsToConvert {
 		ColVecToDatum(

--- a/pkg/sql/colconv/vec_to_datum_tmpl.go
+++ b/pkg/sql/colconv/vec_to_datum_tmpl.go
@@ -176,10 +176,10 @@ func (c *VecToDatumConverter) ConvertBatchAndDeselect(batch coldata.Batch) {
 			c.convertedVecs[vecIdx] = c.convertedVecs[vecIdx][:batchLength]
 		}
 	}
-	if c.da.AllocSize < batchLength {
+	if c.da.DefaultAllocSize < batchLength {
 		// Adjust the datum alloc according to the length of the batch since
 		// this batch is the longest we've seen so far.
-		c.da.AllocSize = batchLength
+		c.da.DefaultAllocSize = batchLength
 	}
 	sel := batch.Selection()
 	vecs := batch.ColVecs()
@@ -235,10 +235,10 @@ func (c *VecToDatumConverter) ConvertVecs(vecs []*coldata.Vec, inputLen int, sel
 			c.convertedVecs[vecIdx] = c.convertedVecs[vecIdx][:requiredLength]
 		}
 	}
-	if c.da.AllocSize < requiredLength {
+	if c.da.DefaultAllocSize < requiredLength {
 		// Adjust the datum alloc according to the length of the batch since
 		// this batch is the longest we've seen so far.
-		c.da.AllocSize = requiredLength
+		c.da.DefaultAllocSize = requiredLength
 	}
 	for _, vecIdx := range c.vecIdxsToConvert {
 		ColVecToDatum(

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1346,8 +1346,8 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 	outputNulls := outputVec.Nulls()
 	toType := outputVec.Type()
 	c.allocator.PerformOperation([]*coldata.Vec{outputVec}, func() {
-		if n > c.da.AllocSize {
-			c.da.AllocSize = n
+		if n > c.da.DefaultAllocSize {
+			c.da.DefaultAllocSize = n
 		}
 		if cap(c.scratch) < n {
 			c.scratch = make([]tree.Datum, n)

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -414,8 +414,8 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 	outputNulls := outputVec.Nulls()
 	toType := outputVec.Type()
 	c.allocator.PerformOperation([]*coldata.Vec{outputVec}, func() {
-		if n > c.da.AllocSize {
-			c.da.AllocSize = n
+		if n > c.da.DefaultAllocSize {
+			c.da.DefaultAllocSize = n
 		}
 		if cap(c.scratch) < n {
 			c.scratch = make([]tree.Datum, n)

--- a/pkg/sql/colexec/colexechash/hash_utils.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.go
@@ -176,8 +176,8 @@ func (d *TupleHashDistributor) Distribute(b coldata.Batch, hashCols []uint32) []
 
 	// Check if we received a batch with more tuples than the current
 	// allocation size and increase it if so.
-	if n > d.datumAlloc.AllocSize {
-		d.datumAlloc.AllocSize = n
+	if n > d.datumAlloc.DefaultAllocSize {
+		d.datumAlloc.DefaultAllocSize = n
 	}
 
 	for _, i := range hashCols {

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -769,10 +769,10 @@ func (ht *HashTable) ComputeBuckets(buckets []uint32, keys []*coldata.Vec, nKeys
 
 	// Check if we received more tuples than the current allocation size and
 	// increase it if so (limiting it by coldata.BatchSize()).
-	if nKeys > ht.datumAlloc.AllocSize && ht.datumAlloc.AllocSize < coldata.BatchSize() {
-		ht.datumAlloc.AllocSize = nKeys
-		if ht.datumAlloc.AllocSize > coldata.BatchSize() {
-			ht.datumAlloc.AllocSize = coldata.BatchSize()
+	if nKeys > ht.datumAlloc.DefaultAllocSize && ht.datumAlloc.DefaultAllocSize < coldata.BatchSize() {
+		ht.datumAlloc.DefaultAllocSize = nKeys
+		if ht.datumAlloc.DefaultAllocSize > coldata.BatchSize() {
+			ht.datumAlloc.DefaultAllocSize = coldata.BatchSize()
 		}
 	}
 

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -236,7 +236,7 @@ func NewHashAggregator(
 	}
 	hashAgg.accountingHelper.Init(args.OutputUnlimitedAllocator, args.MaxOutputBatchMemSize, args.OutputTypes, false /* alwaysReallocate */)
 	hashAgg.bufferingState.tuples = colexecutils.NewAppendOnlyBufferedBatch(args.Allocator, args.InputTypes, nil /* colsToStore */)
-	hashAgg.datumAlloc.AllocSize = hashAggregatorAllocSize
+	hashAgg.datumAlloc.DefaultAllocSize = hashAggregatorAllocSize
 	hashAgg.aggHelper = newAggregatorHelper(args.NewAggregatorArgs, &hashAgg.datumAlloc, true /* isHashAgg */, hashAggregatorMaxBuffered)
 	if newSpillingQueueArgs != nil {
 		hashAgg.inputTrackingState.tuples = colexecutils.NewSpillingQueue(newSpillingQueueArgs)

--- a/pkg/sql/colexec/values.go
+++ b/pkg/sql/colexec/values.go
@@ -97,8 +97,8 @@ func (v *valuesOp) Next() coldata.Batch {
 	if len(v.data) < willBuffer {
 		willBuffer = len(v.data)
 	}
-	if v.dalloc.AllocSize < willBuffer {
-		v.dalloc.AllocSize = willBuffer
+	if v.dalloc.DefaultAllocSize < willBuffer {
+		v.dalloc.DefaultAllocSize = willBuffer
 	}
 
 	nRows := 0

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -346,7 +346,7 @@ func (cf *cFetcher) resetBatch() {
 		}
 		// Change the allocation size to be the same as the capacity of the
 		// batch we allocated above.
-		cf.table.da.AllocSize = cf.machine.batch.Capacity()
+		cf.table.da.DefaultAllocSize = cf.machine.batch.Capacity()
 	}
 }
 

--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -21,11 +21,11 @@ import (
 type DatumAlloc struct {
 	_ util.NoCopy
 
-	// AllocSize determines the number of objects allocated whenever we've used
+	// DefaultAllocSize determines the number of objects allocated whenever we've used
 	// up previously allocated ones. This field is exported so that the caller
 	// could adjust it dynamically. If it is left unchanged by the caller, then
 	// it will be set to defaultDatumAllocSize automatically.
-	AllocSize int
+	DefaultAllocSize int
 
 	datumAlloc        []Datum
 	dintAlloc         []DInt
@@ -67,12 +67,12 @@ const maxEWKBAllocSize = 16384    // Arbitrary, could be tuned.
 
 // NewDatums allocates Datums of the specified size.
 func (a *DatumAlloc) NewDatums(num int) Datums {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.datumAlloc
 	if len(*buf) < num {
-		extensionSize := a.AllocSize
+		extensionSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			extensionSize = a.DefaultAllocSize
+		}
 		if extTupleLen := num * datumAllocMultiplier; extensionSize < extTupleLen {
 			extensionSize = extTupleLen
 		}
@@ -85,12 +85,13 @@ func (a *DatumAlloc) NewDatums(num int) Datums {
 
 // NewDInt allocates a DInt.
 func (a *DatumAlloc) NewDInt(v DInt) *DInt {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dintAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DInt, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DInt, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -100,12 +101,13 @@ func (a *DatumAlloc) NewDInt(v DInt) *DInt {
 
 // NewDPGLSN allocates a DPGLSN.
 func (a *DatumAlloc) NewDPGLSN(v DPGLSN) *DPGLSN {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dpglsnAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DPGLSN, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DPGLSN, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -115,12 +117,13 @@ func (a *DatumAlloc) NewDPGLSN(v DPGLSN) *DPGLSN {
 
 // NewDFloat allocates a DFloat.
 func (a *DatumAlloc) NewDFloat(v DFloat) *DFloat {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dfloatAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DFloat, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DFloat, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -129,12 +132,13 @@ func (a *DatumAlloc) NewDFloat(v DFloat) *DFloat {
 }
 
 func (a *DatumAlloc) newString() *string {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.stringAlloc
 	if len(*buf) == 0 {
-		*buf = make([]string, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]string, allocSize)
 	}
 	r := &(*buf)[0]
 	*buf = (*buf)[1:]
@@ -179,12 +183,13 @@ func (a *DatumAlloc) NewDEncodedKey(v DEncodedKey) *DEncodedKey {
 
 // NewDBitArray allocates a DBitArray.
 func (a *DatumAlloc) NewDBitArray(v DBitArray) *DBitArray {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dbitArrayAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DBitArray, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DBitArray, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -194,12 +199,13 @@ func (a *DatumAlloc) NewDBitArray(v DBitArray) *DBitArray {
 
 // NewDDecimal allocates a DDecimal.
 func (a *DatumAlloc) NewDDecimal(v DDecimal) *DDecimal {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.ddecimalAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DDecimal, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DDecimal, allocSize)
 	}
 	r := &(*buf)[0]
 	r.Set(&v.Decimal)
@@ -209,12 +215,13 @@ func (a *DatumAlloc) NewDDecimal(v DDecimal) *DDecimal {
 
 // NewDDate allocates a DDate.
 func (a *DatumAlloc) NewDDate(v DDate) *DDate {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.ddateAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DDate, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DDate, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -224,12 +231,13 @@ func (a *DatumAlloc) NewDDate(v DDate) *DDate {
 
 // NewDEnum allocates a DEnum.
 func (a *DatumAlloc) NewDEnum(v DEnum) *DEnum {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.denumAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DEnum, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DEnum, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -239,12 +247,13 @@ func (a *DatumAlloc) NewDEnum(v DEnum) *DEnum {
 
 // NewDBox2D allocates a DBox2D.
 func (a *DatumAlloc) NewDBox2D(v DBox2D) *DBox2D {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dbox2dAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DBox2D, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DBox2D, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -254,12 +263,13 @@ func (a *DatumAlloc) NewDBox2D(v DBox2D) *DBox2D {
 
 // NewDGeography allocates a DGeography.
 func (a *DatumAlloc) NewDGeography(v DGeography) *DGeography {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dgeographyAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DGeography, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DGeography, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -269,12 +279,13 @@ func (a *DatumAlloc) NewDGeography(v DGeography) *DGeography {
 
 // NewDVoid allocates a new DVoid.
 func (a *DatumAlloc) NewDVoid() *DVoid {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dvoidAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DVoid, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DVoid, allocSize)
 	}
 	r := &(*buf)[0]
 	*buf = (*buf)[1:]
@@ -307,12 +318,13 @@ func (a *DatumAlloc) DoneInitNewDGeo(so *geopb.SpatialObject) {
 
 // NewDGeometry allocates a DGeometry.
 func (a *DatumAlloc) NewDGeometry(v DGeometry) *DGeometry {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dgeometryAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DGeometry, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DGeometry, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -345,12 +357,13 @@ func (a *DatumAlloc) giveBytesToEWKB(so *geopb.SpatialObject) {
 
 // NewDTime allocates a DTime.
 func (a *DatumAlloc) NewDTime(v DTime) *DTime {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dtimeAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DTime, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DTime, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -360,12 +373,13 @@ func (a *DatumAlloc) NewDTime(v DTime) *DTime {
 
 // NewDTimeTZ allocates a DTimeTZ.
 func (a *DatumAlloc) NewDTimeTZ(v DTimeTZ) *DTimeTZ {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dtimetzAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DTimeTZ, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DTimeTZ, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -375,12 +389,13 @@ func (a *DatumAlloc) NewDTimeTZ(v DTimeTZ) *DTimeTZ {
 
 // NewDTimestamp allocates a DTimestamp.
 func (a *DatumAlloc) NewDTimestamp(v DTimestamp) *DTimestamp {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dtimestampAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DTimestamp, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DTimestamp, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -390,12 +405,13 @@ func (a *DatumAlloc) NewDTimestamp(v DTimestamp) *DTimestamp {
 
 // NewDTimestampTZ allocates a DTimestampTZ.
 func (a *DatumAlloc) NewDTimestampTZ(v DTimestampTZ) *DTimestampTZ {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dtimestampTzAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DTimestampTZ, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DTimestampTZ, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -405,12 +421,13 @@ func (a *DatumAlloc) NewDTimestampTZ(v DTimestampTZ) *DTimestampTZ {
 
 // NewDInterval allocates a DInterval.
 func (a *DatumAlloc) NewDInterval(v DInterval) *DInterval {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dintervalAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DInterval, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DInterval, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -420,12 +437,13 @@ func (a *DatumAlloc) NewDInterval(v DInterval) *DInterval {
 
 // NewDUuid allocates a DUuid.
 func (a *DatumAlloc) NewDUuid(v DUuid) *DUuid {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.duuidAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DUuid, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DUuid, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -435,12 +453,13 @@ func (a *DatumAlloc) NewDUuid(v DUuid) *DUuid {
 
 // NewDIPAddr allocates a DIPAddr.
 func (a *DatumAlloc) NewDIPAddr(v DIPAddr) *DIPAddr {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dipnetAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DIPAddr, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DIPAddr, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -450,12 +469,13 @@ func (a *DatumAlloc) NewDIPAddr(v DIPAddr) *DIPAddr {
 
 // NewDJSON allocates a DJSON.
 func (a *DatumAlloc) NewDJSON(v DJSON) *DJSON {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.djsonAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DJSON, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DJSON, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -465,12 +485,13 @@ func (a *DatumAlloc) NewDJSON(v DJSON) *DJSON {
 
 // NewDTuple allocates a DTuple.
 func (a *DatumAlloc) NewDTuple(v DTuple) *DTuple {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.dtupleAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DTuple, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DTuple, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v
@@ -480,12 +501,13 @@ func (a *DatumAlloc) NewDTuple(v DTuple) *DTuple {
 
 // NewDOid allocates a DOid.
 func (a *DatumAlloc) NewDOid(v DOid) Datum {
-	if a.AllocSize == 0 {
-		a.AllocSize = defaultDatumAllocSize
-	}
 	buf := &a.doidAlloc
 	if len(*buf) == 0 {
-		*buf = make([]DOid, a.AllocSize)
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DOid, allocSize)
 	}
 	r := &(*buf)[0]
 	*r = v


### PR DESCRIPTION
#### sql/colexec: add more cases to BenchmarkMaterializer

Release note: None

#### sql/sem/tree: refactor DatumAlloc

This commit renames the `AllocSize` field of the `DatumAlloc` struct to
`DefaultAllocSize` in preparation of a future commit that will introduce
allocation sizes for individual datum types.

Release note: None

#### sql/sem/tree: add type-specific allocation sizes for DatumAlloc

`DatumAlloc` now allows for users to provide type-specific allocation
sizes. This is useful when the number of allocations of specific types
can be known before bulk allocating datums with `DatumAlloc`.

Type-specific allocation sizes are currently only used by
`VecToDatumConverter`. This can significantly reduce the number of
allocations made by `Materializer` when operating on a small batch of
wide rows that has many duplicate column types. For example, consider a
single-row batch with 100 string columns. Prior to this change, the
allocation size would be set to 1 (because the batch size is 1) and
`DatumAlloc` would allocate 100 individual string slices. After this
change, `DatumAlloc` allocates a single string slice with a length of
100.

Epic: None

Release note: None
