### PR TITLE
sql: cleanup making copies of the eval context

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -331,7 +331,7 @@ func runBackupProcessor(
 
 	totalSpans := len(spec.Spans) + len(spec.IntroducedSpans)
 	requestSpans := make([]spanAndTime, 0, totalSpans)
-	rangeSizedSpans := preSplitExports.Get(&flowCtx.EvalCtx.Settings.SV)
+	rangeSizedSpans := preSplitExports.Get(&flowCtx.Cfg.Settings.SV)
 
 	splitSpans := func(spans []roachpb.Span, start, end hlc.Timestamp) error {
 		for _, fullSpan := range spans {

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -57,8 +57,7 @@ var generativeSplitAndScatterOutputTypes = []*types.T{
 type generativeSplitAndScatterProcessor struct {
 	execinfra.ProcessorBase
 
-	flowCtx *execinfra.FlowCtx
-	spec    execinfrapb.GenerativeSplitAndScatterSpec
+	spec execinfrapb.GenerativeSplitAndScatterSpec
 
 	// chunkSplitAndScatterers contain the splitAndScatterers for the group of
 	// split and scatter workers that's responsible for splitting and scattering
@@ -291,7 +290,6 @@ func newGenerativeSplitAndScatterProcessor(
 	}
 
 	ssp := &generativeSplitAndScatterProcessor{
-		flowCtx:                      flowCtx,
 		spec:                         spec,
 		chunkSplitAndScatterers:      chunkSplitAndScatterers,
 		chunkEntrySplitAndScatterers: chunkEntrySplitAndScatterers,
@@ -328,11 +326,11 @@ func (gssp *generativeSplitAndScatterProcessor) Start(ctx context.Context) {
 		cancel()
 		<-workerDone
 	}
-	if err := gssp.flowCtx.Stopper().RunAsyncTaskEx(scatterCtx, stop.TaskOpts{
+	if err := gssp.FlowCtx.Stopper().RunAsyncTaskEx(scatterCtx, stop.TaskOpts{
 		TaskName: "generativeSplitAndScatter-worker",
 		SpanOpt:  stop.ChildSpan,
 	}, func(ctx context.Context) {
-		gssp.scatterErr = runGenerativeSplitAndScatter(scatterCtx, gssp.flowCtx, &gssp.spec, gssp.chunkSplitAndScatterers, gssp.chunkEntrySplitAndScatterers, gssp.doneScatterCh,
+		gssp.scatterErr = runGenerativeSplitAndScatter(scatterCtx, gssp.FlowCtx, &gssp.spec, gssp.chunkSplitAndScatterers, gssp.chunkEntrySplitAndScatterers, gssp.doneScatterCh,
 			&gssp.routingDatumCache)
 		cancel()
 		close(gssp.doneScatterCh)

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -446,7 +446,6 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	ctx context.Context, kr *KeyRewriter, sst mergedSST,
 ) (kvpb.BulkOpSummary, error) {
 	db := rd.FlowCtx.Cfg.DB
-	evalCtx := rd.EvalCtx
 	var summary kvpb.BulkOpSummary
 
 	entry := sst.entry
@@ -492,7 +491,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		batcher, err = bulk.MakeSSTBatcher(ctx,
 			"restore",
 			db.KV(),
-			evalCtx.Settings,
+			rd.FlowCtx.Cfg.Settings,
 			disallowShadowingBelow,
 			writeAtBatchTS,
 			false, /* scatterSplitRanges */

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -52,9 +52,8 @@ var restoreDataOutputTypes = []*types.T{}
 type restoreDataProcessor struct {
 	execinfra.ProcessorBase
 
-	flowCtx *execinfra.FlowCtx
-	spec    execinfrapb.RestoreDataSpec
-	input   execinfra.RowSource
+	spec  execinfrapb.RestoreDataSpec
+	input execinfra.RowSource
 
 	// numWorkers is the number of workers this processor should use. This
 	// number is determined by the cluster setting and the amount of memory
@@ -148,10 +147,9 @@ func newRestoreDataProcessor(
 	input execinfra.RowSource,
 ) (execinfra.Processor, error) {
 	rd := &restoreDataProcessor{
-		flowCtx: flowCtx,
-		input:   input,
-		spec:    spec,
-		progCh:  make(chan backuppb.RestoreProgress, maxConcurrentRestoreWorkers),
+		input:  input,
+		spec:   spec,
+		progCh: make(chan backuppb.RestoreProgress, maxConcurrentRestoreWorkers),
 	}
 
 	rd.qp = backuputils.NewMemoryBackedQuotaPool(ctx, flowCtx.Cfg.BackupMonitor, "restore-mon", 0)
@@ -162,7 +160,7 @@ func newRestoreDataProcessor(
 				rd.ConsumerClosed()
 				if rd.agg != nil {
 					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
-						rd.flowCtx.NodeID.SQLInstanceID(), rd.flowCtx.ID, rd.agg)
+						rd.FlowCtx.NodeID.SQLInstanceID(), rd.FlowCtx.ID, rd.agg)
 					return []execinfrapb.ProducerMetadata{*meta}
 				}
 				return nil
@@ -196,7 +194,7 @@ func (rd *restoreDataProcessor) Start(ctx context.Context) {
 	// maximum number of workers is based on the cluster setting. If the cluster
 	// setting is updated, the job should be PAUSEd and RESUMEd for the new
 	// setting to take effect.
-	numWorkers, err := reserveRestoreWorkerMemory(ctx, rd.flowCtx.Cfg.Settings, rd.qp)
+	numWorkers, err := reserveRestoreWorkerMemory(ctx, rd.FlowCtx.Cfg.Settings, rd.qp)
 	if err != nil {
 		log.Warningf(ctx, "cannot reserve restore worker memory: %v", err)
 		rd.MoveToDraining(err)
@@ -354,7 +352,7 @@ func (rd *restoreDataProcessor) openSSTs(
 		file := entry.Files[idx]
 
 		log.VEventf(ctx, 2, "import file %s which starts at %s", file.Path, entry.Span.Key)
-		dir, err := rd.flowCtx.Cfg.ExternalStorage(ctx, file.Dir)
+		dir, err := rd.FlowCtx.Cfg.ExternalStorage(ctx, file.Dir)
 		if err != nil {
 			return mergedSST{}, nil, err
 		}
@@ -447,7 +445,7 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	ctx context.Context, kr *KeyRewriter, sst mergedSST,
 ) (kvpb.BulkOpSummary, error) {
-	db := rd.flowCtx.Cfg.DB
+	db := rd.FlowCtx.Cfg.DB
 	evalCtx := rd.EvalCtx
 	var summary kvpb.BulkOpSummary
 
@@ -501,8 +499,8 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 			// TODO(rui): we can change this to the processor's bound account, but
 			// currently there seems to be some accounting errors that will cause
 			// tests to fail.
-			rd.flowCtx.Cfg.BackupMonitor.MakeConcurrentBoundAccount(),
-			rd.flowCtx.Cfg.BulkSenderLimiter,
+			rd.FlowCtx.Cfg.BackupMonitor.MakeConcurrentBoundAccount(),
+			rd.FlowCtx.Cfg.BulkSenderLimiter,
 		)
 		if err != nil {
 			return summary, err
@@ -599,7 +597,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		return summary, err
 	}
 
-	if restoreKnobs, ok := rd.flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+	if restoreKnobs, ok := rd.FlowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
 		if restoreKnobs.RunAfterProcessingRestoreSpanEntry != nil {
 			if err := restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx, &entry); err != nil {
 				return summary, err
@@ -656,7 +654,7 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 		rd.aggTimer.Read = true
 		rd.aggTimer.Reset(15 * time.Second)
 		return nil, bulkutil.ConstructTracingAggregatorProducerMeta(rd.Ctx(),
-			rd.flowCtx.NodeID.SQLInstanceID(), rd.flowCtx.ID, rd.agg)
+			rd.FlowCtx.NodeID.SQLInstanceID(), rd.FlowCtx.ID, rd.agg)
 	case meta := <-rd.metaCh:
 		return nil, meta
 	case <-rd.Ctx().Done():

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -259,7 +259,6 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 
 	init(s.ClusterSettings())
 
-	evalCtx := eval.Context{Settings: s.ClusterSettings(), Tracer: s.AmbientCtx().Tracer}
 	flowCtx := execinfra.FlowCtx{
 		Cfg: &execinfra.ServerConfig{
 			DB: s.InternalDB().(descs.DB),
@@ -409,11 +408,10 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 				ProcessorBase: execinfra.ProcessorBase{
 					ProcessorBaseNoHelper: execinfra.ProcessorBaseNoHelper{
 						FlowCtx: &flowCtx,
-						EvalCtx: &evalCtx,
 					},
 				},
 				spec: mockRestoreDataSpec,
-				qp:   backuputils.NewMemoryBackedQuotaPool(ctx, nil, "restore-mon", 0),
+				qp:   backuputils.NewMemoryBackedQuotaPool(ctx, nil /* m */, "restore-mon", 0 /* limit */),
 			}
 			sst, res, err := mockRestoreDataProcessor.openSSTs(ctx, restoreSpanEntry, nil)
 			require.NoError(t, err)

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -59,8 +59,7 @@ var flushBatchSize = settings.RegisterIntSetting(
 type logicalReplicationWriterProcessor struct {
 	execinfra.ProcessorBase
 
-	flowCtx *execinfra.FlowCtx
-	spec    execinfrapb.LogicalReplicationWriterSpec
+	spec execinfrapb.LogicalReplicationWriterSpec
 
 	bh []BatchHandler
 
@@ -136,7 +135,6 @@ func newLogicalReplicationWriterProcessor(
 	}
 
 	lrw := &logicalReplicationWriterProcessor{
-		flowCtx:        flowCtx,
 		spec:           spec,
 		bh:             bhPool,
 		frontier:       frontier,
@@ -185,7 +183,7 @@ func (lrw *logicalReplicationWriterProcessor) Start(ctx context.Context) {
 
 	ctx = lrw.StartInternal(ctx, logicalReplicationWriterProcessorName)
 
-	lrw.metrics = lrw.flowCtx.Cfg.JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeLogicalReplication].(*Metrics)
+	lrw.metrics = lrw.FlowCtx.Cfg.JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeLogicalReplication].(*Metrics)
 	for _, bh := range lrw.bh {
 		bh.SetMetrics(lrw.metrics)
 	}
@@ -219,7 +217,7 @@ func (lrw *logicalReplicationWriterProcessor) Start(ctx context.Context) {
 	}
 	sub, err := streamClient.Subscribe(ctx,
 		streampb.StreamID(lrw.spec.StreamID),
-		int32(lrw.flowCtx.NodeID.SQLInstanceID()), lrw.ProcessorID,
+		int32(lrw.FlowCtx.NodeID.SQLInstanceID()), lrw.ProcessorID,
 		token,
 		lrw.spec.InitialScanTimestamp, lrw.frontier,
 		streamclient.WithFiltering(true),

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -425,7 +425,8 @@ func (lrw *logicalReplicationWriterProcessor) checkpoint(
 
 const maxWriterWorkers = 32
 
-// flushBuffer flushes the given flusableBufferand returns the underlying streamIngestionBuffer to the pool.
+// flushBuffer flushes the given flusableBuffer and returns the underlying
+// streamIngestionBuffer to the pool.
 func (lrw *logicalReplicationWriterProcessor) flushBuffer(
 	ctx context.Context, kvs []streampb.StreamEvent_KV,
 ) error {
@@ -436,7 +437,7 @@ func (lrw *logicalReplicationWriterProcessor) flushBuffer(
 		return nil
 	}
 
-	batchSize := int(flushBatchSize.Get(&lrw.EvalCtx.Settings.SV))
+	batchSize := int(flushBatchSize.Get(&lrw.FlowCtx.Cfg.Settings.SV))
 
 	// Ensure the batcher is always reset, even on early error returns.
 	preFlushTime := timeutil.Now()

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -124,7 +124,7 @@ func newStreamIngestionFrontierProcessor(
 		metrics:               flowCtx.Cfg.JobRegistry.MetricsStruct().StreamIngest.(*Metrics),
 		client:                streamClient,
 		heartbeatSender: streamclient.NewHeartbeatSender(ctx, streamClient, streamID, func() time.Duration {
-			return crosscluster.StreamReplicationConsumerHeartbeatFrequency.Get(&flowCtx.EvalCtx.Settings.SV)
+			return crosscluster.StreamReplicationConsumerHeartbeatFrequency.Get(&flowCtx.Cfg.Settings.SV)
 		}),
 		persistedReplicatedTime: spec.ReplicatedTimeAtStart,
 	}

--- a/pkg/cloud/cloudcheck/cloudcheck_processor.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_processor.go
@@ -238,8 +238,8 @@ func (p *proc) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 			return nil, p.DrainHelper()
 		}
 		return rowenc.EncDatumRow{
-			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(p.EvalCtx.NodeID.SQLInstanceID()))),
-			rowenc.DatumToEncDatum(types.String, tree.NewDString(p.EvalCtx.Locality.String())),
+			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(p.FlowCtx.EvalCtx.NodeID.SQLInstanceID()))),
+			rowenc.DatumToEncDatum(types.String, tree.NewDString(p.FlowCtx.EvalCtx.Locality.String())),
 			rowenc.DatumToEncDatum(types.Bool, tree.MakeDBool(tree.DBool(res.ok))),
 			rowenc.DatumToEncDatum(types.String, tree.NewDString(res.error)),
 			rowenc.DatumToEncDatum(types.Int, tree.NewDInt(tree.DInt(res.readBytes))),

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -223,6 +223,8 @@ func (cb *ColumnBackfiller) InitForDistributedUse(
 	mon *mon.BytesMonitor,
 ) error {
 	cb.initCols(desc)
+	// We'll be modifying the eval.Context in RunColumnBackfillChunk, so we need
+	// to make a copy.
 	evalCtx := flowCtx.NewEvalCtx()
 	var defaultExprs, computedExprs []tree.TypedExpr
 	// Install type metadata in the target descriptors, as well as resolve any
@@ -654,6 +656,8 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 		return err
 	}
 
+	// We'll be modifying the eval.Context in BuildIndexEntriesChunk, so we need
+	// to make a copy.
 	evalCtx := flowCtx.NewEvalCtx()
 	var predicates map[descpb.IndexID]tree.TypedExpr
 	var colExprs map[descpb.ColumnID]tree.TypedExpr

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -155,10 +155,6 @@ func newColumnarizer(
 	c.ProcessorBaseNoHelper.Init(
 		nil, /* self */
 		flowCtx,
-		// The columnarizer will update the eval context when closed, so we give
-		// it a copy of the eval context to preserve the "global" eval context
-		// from being mutated.
-		flowCtx.NewEvalCtx(),
 		processorID,
 		execinfra.ProcStateOpts{
 			// We append input to inputs to drain below in order to reuse the same

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -186,10 +186,6 @@ func NewMaterializer(
 	m.Init(
 		m,
 		flowCtx,
-		// The materializer will update the eval context when closed, so we give
-		// it a copy of the eval context to preserve the "global" eval context
-		// from being mutated.
-		flowCtx.NewEvalCtx(),
 		processorID,
 		execinfra.ProcStateOpts{
 			// We append drainHelper to inputs to drain below in order to reuse

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -551,7 +551,7 @@ func NewColIndexJoin(
 			flowCtx.Cfg.DistSender,
 			flowCtx.Stopper(),
 			txn,
-			flowCtx.EvalCtx.Settings,
+			flowCtx.Cfg.Settings,
 			flowCtx.EvalCtx.SessionData(),
 			spec.LockingWaitPolicy,
 			spec.LockingStrength,

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -66,10 +66,6 @@ func NewFlowCoordinator(
 	f.Init(
 		f,
 		flowCtx,
-		// The FlowCoordinator will update the eval context when closed, so we
-		// give it a copy of the eval context to preserve the "global" eval
-		// context from being mutated.
-		flowCtx.NewEvalCtx(),
 		processorID,
 		execinfra.ProcStateOpts{
 			// We append input to inputs to drain below in order to reuse

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -245,7 +245,7 @@ func (f *vectorizedFlow) Setup(
 	}
 	flowCtx := f.GetFlowCtx()
 	f.countingSemaphore = newFDCountingSemaphore(
-		f.Cfg.VecFDSemaphore, f.Cfg.Metrics.VecOpenFDs, &flowCtx.EvalCtx.Settings.SV,
+		f.Cfg.VecFDSemaphore, f.Cfg.Metrics.VecOpenFDs, &flowCtx.Cfg.Settings.SV,
 	)
 	f.creator = newVectorizedFlowCreator(
 		f.FlowBase,

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -286,6 +286,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 			&flowinfra.FlowBase{
 				FlowCtx: execinfra.FlowCtx{
 					Cfg: &execinfra.ServerConfig{
+						Settings:        st,
 						TempFS:          env,
 						TempStoragePath: tempPath,
 						VecFDSemaphore:  &colexecop.TestingSemaphore{},

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -42,13 +42,10 @@ type FlowCtx struct {
 	// ID is a unique identifier for a flow.
 	ID execinfrapb.FlowID
 
-	// EvalCtx is used by all the processors in the flow to evaluate expressions.
-	// Processors that intend to evaluate expressions with this EvalCtx should
-	// get a copy with NewEvalCtx instead of storing a pointer to this one
-	// directly (since some processor mutate the EvalContext they use).
-	//
-	// TODO(andrei): Get rid of this field and pass a non-shared EvalContext to
-	// cores of the processors that need it.
+	// EvalCtx is used by all the processors in the flow to access immutable
+	// state of the execution context. Processors that intend to evaluate
+	// expressions with this EvalCtx should get a copy with NewEvalCtx instead
+	// of using this field.
 	EvalCtx *eval.Context
 
 	Mon *mon.BytesMonitor
@@ -107,19 +104,11 @@ type FlowCtx struct {
 	TenantCPUMonitor multitenantcpu.CPUUsageHelper
 }
 
-// NewEvalCtx returns a modifiable copy of the FlowCtx's EvalContext.
-// Processors should use this method any time they need to store a pointer to
-// the EvalContext, since processors may mutate the EvalContext. Specifically,
-// every processor that runs ProcOutputHelper.Init must pass in a modifiable
-// EvalContext, since it stores that EvalContext in its exprHelpers and mutates
-// them at runtime to ensure expressions are evaluated with the correct indexed
-// var context.
-// TODO(yuzefovich): once we remove eval.Context.deprecatedContext, re-evaluate
-// this since many processors don't modify the eval context except for that
-// field.
+// NewEvalCtx returns a modifiable copy of the FlowCtx's eval.Context.
+// Processors should use this method whenever they explicitly modify the
+// eval.Context.
 func (flowCtx *FlowCtx) NewEvalCtx() *eval.Context {
-	evalCopy := flowCtx.EvalCtx.Copy()
-	return evalCopy
+	return flowCtx.EvalCtx.Copy()
 }
 
 // TestingKnobs returns the distsql testing knobs for this flow context.

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -182,7 +182,7 @@ func (eh *MultiExprHelper) Reset() {
 	eh.exprs = eh.exprs[:0]
 }
 
-// exprHelper is a base implementation of an expressoin helper used by both
+// exprHelper is a base implementation of an expression helper used by both
 // ExprHelper and MultiExprHelper.
 type exprHelper struct {
 	evalCtx    *eval.Context

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -145,7 +145,7 @@ func newCSVWriterProcessor(
 		input:       input,
 	}
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
-	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.EvalCtx, flowCtx); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -170,7 +170,7 @@ func (sp *parquetWriterProcessor) Run(ctx context.Context, output execinfra.RowR
 					// Make a best-effort attempt to capture the memory used by the parquet writer
 					// when encoding datums to write to files. In many cases, the datum will be
 					// encoded to bytes and these bytes will be buffered until the file is closed.
-					datumAllocSize := int64(float64(ed.Size()) * eventMemoryMultipier.Get(&sp.flowCtx.EvalCtx.Settings.SV))
+					datumAllocSize := int64(float64(ed.Size()) * eventMemoryMultipier.Get(&sp.flowCtx.Cfg.Settings.SV))
 					cummulativeAllocSize += datumAllocSize
 					if err := memAcc.Grow(ctx, datumAllocSize); err != nil {
 						return err

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -68,7 +68,7 @@ func newParquetWriterProcessor(
 		input:       input,
 	}
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
-	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.EvalCtx, flowCtx); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -119,11 +119,7 @@ func (p *planNodeToRowSource) Init(
 		post,
 		p.outputTypes,
 		flowCtx,
-		// Note that we have already created a copy of the extendedEvalContext
-		// (which made a copy of the EvalContext) right before calling
-		// newPlanNodeToRowSource, so we can just use the eval context from the
-		// params.
-		p.params.EvalContext(),
+		flowCtx.EvalCtx,
 		processorID,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -321,8 +321,10 @@ func NewDatumRowConverter(
 	c := &DatumRowConverter{
 		tableDesc: tableDesc,
 		KvCh:      kvCh,
-		EvalCtx:   evalCtx.Copy(),
-		db:        db,
+		// TODO(yuzefovich): audit all callers of NewDatumRowConverter to ensure
+		// that they don't make a redundant copy of the eval context.
+		EvalCtx: evalCtx.Copy(),
+		db:      db,
 	}
 
 	var targetCols []catalog.Column

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -838,6 +838,8 @@ type HashDiskBackedRowContainer struct {
 var _ HashRowContainer = &HashDiskBackedRowContainer{}
 
 // NewHashDiskBackedRowContainer makes a HashDiskBackedRowContainer.
+//
+// Note that eval context will **not** be mutated.
 func NewHashDiskBackedRowContainer(
 	evalCtx *eval.Context,
 	memoryMonitor *mon.BytesMonitor,

--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -54,7 +54,7 @@ type DiskBackedNumberedRowContainer struct {
 // Arguments:
 //   - deDup is true if it should de-duplicate.
 //   - types is the schema of rows that will be added to this container.
-//   - evalCtx defines the context.
+//   - evalCtx defines the context. It will **not** be mutated.
 //   - engine is the underlying store that rows are stored on when the container
 //     spills to disk.
 //   - memoryMonitor is used to monitor this container's memory usage.

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -179,6 +179,8 @@ var _ IndexedRowContainer = &MemRowContainer{}
 
 // Init initializes the MemRowContainer. The MemRowContainer uses the planner's
 // monitor to track memory usage.
+//
+// Note that eval context will **not** be mutated.
 func (mc *MemRowContainer) Init(
 	ordering colinfo.ColumnOrdering, types []*types.T, evalCtx *eval.Context,
 ) {
@@ -187,6 +189,8 @@ func (mc *MemRowContainer) Init(
 
 // InitWithMon initializes the MemRowContainer with an explicit monitor. Only
 // use this if the default MemRowContainer.Init() function is insufficient.
+//
+// Note that eval context will **not** be mutated.
 func (mc *MemRowContainer) InitWithMon(
 	ordering colinfo.ColumnOrdering, types []*types.T, evalCtx *eval.Context, mon *mon.BytesMonitor,
 ) {
@@ -431,7 +435,7 @@ var _ DeDupingRowContainer = &DiskBackedRowContainer{}
 //   - ordering is the output ordering; the order in which rows should be sorted.
 //   - types is the schema of rows that will be added to this container.
 //   - evalCtx defines the context in which to evaluate comparisons, only used
-//     when storing rows in memory.
+//     when storing rows in memory. It will **not** be mutated.
 //   - engine is the store used for rows when spilling to disk.
 //   - memoryMonitor is used to monitor the DiskBackedRowContainer's memory usage.
 //     If this monitor denies an allocation, the DiskBackedRowContainer will

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -102,8 +102,8 @@ func (sp *bulkRowWriter) work(ctx context.Context) error {
 
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	conv, err := row.NewDatumRowConverter(
-		ctx, &semaCtx, sp.tableDesc, nil /* targetColNames */, sp.EvalCtx, kvCh, nil,
-		/* seqChunkProvider */ sp.FlowCtx.GetRowMetrics(), sp.FlowCtx.Cfg.DB.KV(),
+		ctx, &semaCtx, sp.tableDesc, nil /* targetColNames */, sp.FlowCtx.EvalCtx,
+		kvCh, nil /* seqChunkProvider */, sp.FlowCtx.GetRowMetrics(), sp.FlowCtx.Cfg.DB.KV(),
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -159,7 +159,7 @@ func (d *distinct) matchLastGroupKey(row rowenc.EncDatumRow) (bool, error) {
 		return false, nil
 	}
 	for _, colIdx := range d.distinctCols.ordered {
-		res, err := d.lastGroupKey[colIdx].Compare(d.Ctx(), d.types[colIdx], &d.datumAlloc, d.EvalCtx, &row[colIdx])
+		res, err := d.lastGroupKey[colIdx].Compare(d.Ctx(), d.types[colIdx], &d.datumAlloc, d.FlowCtx.EvalCtx, &row[colIdx])
 		if res != 0 || err != nil {
 			return false, err
 		}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -127,7 +127,7 @@ func newHashJoiner(
 		h.leftEqColTypes[i] = leftTypes[eqCol]
 	}
 
-	if err := h.joinerBase.init(
+	if _, err := h.joinerBase.init(
 		ctx,
 		h,
 		flowCtx,
@@ -154,7 +154,7 @@ func newHashJoiner(
 	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "hashjoiner-limited")
 	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "hashjoiner-disk")
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
-		h.EvalCtx, h.MemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
+		h.FlowCtx.EvalCtx, h.MemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
 	)
 
 	// If the trace is recording, instrument the hashJoiner to collect stats.

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -48,12 +49,12 @@ func (jb *joinerBase) init(
 	outputContinuationColumn bool,
 	post *execinfrapb.PostProcessSpec,
 	opts execinfra.ProcStateOpts,
-) error {
+) (*eval.Context, error) {
 	jb.joinType = jType
 
 	if jb.joinType.IsSetOpJoin() {
 		if !onExpr.Empty() {
-			return errors.Errorf("expected empty onExpr, got %v", onExpr)
+			return nil, errors.Errorf("expected empty onExpr, got %v", onExpr)
 		}
 	}
 
@@ -85,13 +86,18 @@ func (jb *joinerBase) init(
 		outputTypes = jType.MakeOutputTypes(leftTypes, rightTypes)
 	}
 
-	if err := jb.ProcessorBase.Init(
-		ctx, self, post, outputTypes, flowCtx, processorID, nil /* memMonitor */, opts,
+	evalCtx := flowCtx.EvalCtx
+	if !onExpr.Empty() {
+		// Only make a copy if we need to evaluate ON expression.
+		evalCtx = flowCtx.NewEvalCtx()
+	}
+	if err := jb.ProcessorBase.InitWithEvalCtx(
+		ctx, self, post, outputTypes, flowCtx, evalCtx, processorID, nil /* memMonitor */, opts,
 	); err != nil {
-		return err
+		return nil, err
 	}
 	semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
-	return jb.onCond.Init(ctx, onExpr, onCondTypes, semaCtx, jb.EvalCtx)
+	return evalCtx, jb.onCond.Init(ctx, onExpr, onCondTypes, semaCtx, evalCtx)
 }
 
 // joinSide is the utility type to distinguish between two sides of the join.

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -555,7 +555,7 @@ func newJoinReader(
 			flowCtx.Cfg.DistSender,
 			flowCtx.Stopper(),
 			jr.txn,
-			flowCtx.EvalCtx.Settings,
+			flowCtx.Cfg.Settings,
 			flowCtx.EvalCtx.SessionData(),
 			spec.LockingWaitPolicy,
 			spec.LockingStrength,
@@ -857,7 +857,7 @@ func (jr *joinReader) getBatchBytesLimit() rowinfra.BytesLimit {
 	}
 	bytesLimit := jr.lookupBatchBytesLimit
 	if bytesLimit == 0 {
-		bytesLimit = rowinfra.GetDefaultBatchBytesLimit(jr.EvalCtx.TestingKnobs.ForceProductionValues)
+		bytesLimit = rowinfra.GetDefaultBatchBytesLimit(jr.FlowCtx.EvalCtx.TestingKnobs.ForceProductionValues)
 	}
 	return bytesLimit
 }

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -187,9 +187,9 @@ func (s *joinReaderNoOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []i
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
 	}
 
-	if s.EvalCtx.Planner.EnforceHomeRegion() {
+	if s.FlowCtx.EvalCtx.Planner.EnforceHomeRegion() {
 		err := noHomeRegionError
-		if s.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
+		if s.FlowCtx.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
 			err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
 		}
 		return nil, nil, err
@@ -599,9 +599,9 @@ func (s *joinReaderOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []int
 	if !ok {
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
 	}
-	if s.EvalCtx.Planner.EnforceHomeRegion() {
+	if s.FlowCtx.EvalCtx.Planner.EnforceHomeRegion() {
 		err := noHomeRegionError
-		if s.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
+		if s.FlowCtx.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
 			err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
 		}
 		return nil, nil, err

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -73,7 +73,7 @@ func newMergeJoiner(
 		m.ExecStatsForTrace = m.execStatsForTrace
 	}
 
-	if err := m.joinerBase.init(
+	if _, err := m.joinerBase.init(
 		ctx, m /* self */, flowCtx, processorID, leftSource.OutputTypes(), rightSource.OutputTypes(),
 		spec.Type, spec.OnExpr, false /* outputContinuationColumn */, post,
 		execinfra.ProcStateOpts{

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -232,7 +232,7 @@ func (m *mergeJoiner) nextRow() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 		// TODO(paul): Investigate (with benchmarks) whether or not it's
 		// worthwhile to only buffer one row from the right stream per batch
 		// for semi-joins.
-		m.leftRows, m.rightRows, meta = m.streamMerger.NextBatch(m.Ctx(), m.EvalCtx)
+		m.leftRows, m.rightRows, meta = m.streamMerger.NextBatch(m.Ctx(), m.FlowCtx.EvalCtx)
 		if meta != nil {
 			return nil, meta
 		}

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -184,6 +184,8 @@ func TestPostProcess(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+	flowCtx := &execinfra.FlowCtx{}
 	for tcIdx, tc := range testCases {
 		t.Run(strconv.Itoa(tcIdx), func(t *testing.T) {
 			inBuf := distsqlutils.NewRowBuffer(types.ThreeIntCols, input, distsqlutils.RowBufferArgs{})
@@ -192,14 +194,14 @@ func TestPostProcess(t *testing.T) {
 			var out execinfra.ProcOutputHelper
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			defer evalCtx.Stop(context.Background())
-			if err := out.Init(context.Background(), &tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx); err != nil {
+			defer evalCtx.Stop(ctx)
+			if err := out.Init(ctx, &tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx, flowCtx); err != nil {
 				t.Fatal(err)
 			}
 
 			// Run the rows through the helper.
 			for i := range input {
-				status, err := out.EmitRow(context.Background(), input[i], outBuf)
+				status, err := out.EmitRow(ctx, input[i], outBuf)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -461,7 +461,7 @@ func (s *samplerProcessor) sampleRow(
 	// Use Int63 so we don't have headaches converting to DInt.
 	rank := uint64(rng.Int63())
 	prevCapacity := sr.Cap()
-	if err := sr.SampleRow(ctx, s.EvalCtx, row, rank); err != nil {
+	if err := sr.SampleRow(ctx, s.FlowCtx.EvalCtx, row, rank); err != nil {
 		if !sqlerrors.IsOutOfMemoryError(err) {
 			return false, err
 		}

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -433,7 +433,7 @@ func (s *sortChunksProcessor) chunkCompleted(
 	types := s.input.OutputTypes()
 	for _, ord := range s.ordering[:s.matchLen] {
 		col := ord.ColIdx
-		cmp, err := nextChunkRow[col].Compare(s.Ctx(), types[col], &s.alloc, s.EvalCtx, &prefix[col])
+		cmp, err := nextChunkRow[col].Compare(s.Ctx(), types[col], &s.alloc, s.FlowCtx.EvalCtx, &prefix[col])
 		if cmp != 0 || err != nil {
 			return true, err
 		}

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -73,7 +73,7 @@ func (s *sorterBase) init(
 	rc.Init(
 		ordering,
 		input.OutputTypes(),
-		s.EvalCtx,
+		s.FlowCtx.EvalCtx,
 		flowCtx.Cfg.TempStorage,
 		memMonitor,
 		s.diskMonitor,

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -223,7 +223,7 @@ func (tr *tableReader) startScan(ctx context.Context) error {
 		initialTS := tr.FlowCtx.Txn.ReadTimestamp()
 		err = tr.fetcher.StartInconsistentScan(
 			ctx, tr.FlowCtx.Cfg.DB.KV(), initialTS, tr.maxTimestampAge, tr.Spans,
-			bytesLimit, tr.limitHint, tr.EvalCtx.QualityOfService(),
+			bytesLimit, tr.limitHint, tr.FlowCtx.EvalCtx.QualityOfService(),
 		)
 	}
 	tr.scanStarted = true

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -660,7 +660,7 @@ func (z *zigzagJoiner) nextRow(ctx context.Context) (rowenc.EncDatumRow, error) 
 			ctx,
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
 			nil, /* spanIDs */
-			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
+			rowinfra.GetDefaultBatchBytesLimit(z.FlowCtx.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
 		)
 		if err != nil {
@@ -800,7 +800,7 @@ func (z *zigzagJoiner) maybeFetchInitialRow() error {
 			z.Ctx(),
 			roachpb.Spans{roachpb.Span{Key: curInfo.key, EndKey: curInfo.endKey}},
 			nil, /* spanIDs */
-			rowinfra.GetDefaultBatchBytesLimit(z.EvalCtx.TestingKnobs.ForceProductionValues),
+			rowinfra.GetDefaultBatchBytesLimit(z.FlowCtx.EvalCtx.TestingKnobs.ForceProductionValues),
 			zigzagJoinerBatchSize,
 		)
 		if err != nil {

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -305,7 +305,7 @@ func newZigzagJoiner(
 
 	leftColumnTypes := spec.Sides[0].FetchSpec.FetchedColumnTypes()
 	rightColumnTypes := spec.Sides[1].FetchSpec.FetchedColumnTypes()
-	err := z.joinerBase.init(
+	_, err := z.joinerBase.init(
 		ctx,
 		z, /* self */
 		flowCtx,

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -293,7 +293,9 @@ func (rb *routerBase) init(
 		rb.outputs[i].mu.rowContainer.Init(
 			nil, /* ordering */
 			types,
-			flowCtx.NewEvalCtx(),
+			// Eval context will not be mutated, so it's ok to use the shared
+			// one.
+			flowCtx.EvalCtx,
 			flowCtx.Cfg.TempStorage,
 			rb.outputs[i].memoryMonitor,
 			rb.outputs[i].diskMonitor,


### PR DESCRIPTION
This PR audits all processors to avoid now-redundant (as of #125715) copies of the `eval.Context` as well as performs some miscellaneous cleanup along the way.

Some microbenchmarks:
```
name                   old time/op    new time/op    delta
LastWriteWinsInsert-8    1.37ms ±13%    1.41ms ±16%    ~     (p=0.265 n=20+20)

name                   old alloc/op   new alloc/op   delta
LastWriteWinsInsert-8     253kB ± 2%     247kB ± 2%  -2.65%  (p=0.000 n=19+20)

name                   old allocs/op  new allocs/op  delta
LastWriteWinsInsert-8     1.67k ± 0%     1.67k ± 0%  -0.18%  (p=0.033 n=18+19)
```
```
FlowSetup/vectorize=true/distribute=true-8       144µs ± 3%     142µs ± 3%   -1.25%  (p=0.005 n=25+25)
FlowSetup/vectorize=true/distribute=false-8      139µs ± 6%     138µs ± 3%     ~     (p=0.260 n=24+22)
FlowSetup/vectorize=false/distribute=true-8      137µs ± 2%     138µs ± 4%     ~     (p=0.158 n=22+25)
FlowSetup/vectorize=false/distribute=false-8     132µs ± 2%     133µs ± 3%   +1.21%  (p=0.001 n=24+25)

name                                          old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-8      22.9kB ± 9%    18.9kB ± 5%  -17.18%  (p=0.000 n=24+21)
FlowSetup/vectorize=true/distribute=false-8     21.3kB ±10%    17.7kB ±12%  -17.04%  (p=0.000 n=22+22)
FlowSetup/vectorize=false/distribute=true-8     27.1kB ± 0%    25.3kB ± 0%   -6.62%  (p=0.000 n=20+20)
FlowSetup/vectorize=false/distribute=false-8    25.6kB ± 0%    23.8kB ± 0%   -6.99%  (p=0.000 n=20+20)

name                                          old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-8         234 ± 2%       231 ± 1%   -1.01%  (p=0.000 n=20+21)
FlowSetup/vectorize=true/distribute=false-8        219 ± 8%       217 ± 7%   -0.93%  (p=0.016 n=22+22)
FlowSetup/vectorize=false/distribute=true-8        229 ± 0%       228 ± 0%   -0.44%  (p=0.000 n=21+21)
FlowSetup/vectorize=false/distribute=false-8       212 ± 0%       211 ± 0%   -0.47%  (p=0.000 n=20+20)
```

Epic: CRDB-39063.