### PR TITLE
ui: add transaction deadlocks graph to the SQL dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -232,6 +232,27 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Transaction Deadlocks"
+      isKvGraph={false}
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`The total number of transaction per second; typically, should be 0 ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis label="transaction deadlocks per second">
+        {map(nodeIDs, node => (
+          <Metric
+            key={node}
+            name="cr.store.txnwaitqueue.deadlocks_total"
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
+            sources={[node]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Active Flows for Distributed SQL Statements"
       isKvGraph={false}
       tenantSource={tenantSource}


### PR DESCRIPTION
Any time these are non-zero should be a cause for concern, just like full table scans. Show these on a graph in the DB console.

Epic: none

Release note: None