### PR TITLE
sql/rowexec: reduce allocations in joinerBase

### DIFF
--- a/pkg/sql/catalog/descpb/join_type.go
+++ b/pkg/sql/catalog/descpb/join_type.go
@@ -105,7 +105,21 @@ func (j JoinType) IsLeftAntiOrExceptAll() bool {
 
 // MakeOutputTypes computes the output types for this join type.
 func (j JoinType) MakeOutputTypes(left, right []*types.T) []*types.T {
+	return j.makeOutputTypes(left, right, false /* continuationCol */)
+}
+
+// MakeOutputTypesWithContinuationColumn computes the output types for this join
+// type and includes a continuation column that is used for paired joiners.
+func (j JoinType) MakeOutputTypesWithContinuationColumn(left, right []*types.T) []*types.T {
+	return j.makeOutputTypes(left, right, true /* continuationCol */)
+}
+
+func (j JoinType) makeOutputTypes(left, right []*types.T, continuationCol bool) []*types.T {
 	numOutputTypes := 0
+	if continuationCol {
+		// Add 1 to account for the continuation column.
+		numOutputTypes++
+	}
 	if j.ShouldIncludeLeftColsInOutput() {
 		numOutputTypes += len(left)
 	}
@@ -118,6 +132,10 @@ func (j JoinType) MakeOutputTypes(left, right []*types.T) []*types.T {
 	}
 	if j.ShouldIncludeRightColsInOutput() {
 		outputTypes = append(outputTypes, right...)
+	}
+	if continuationCol {
+		// The continuation column is always the last column.
+		outputTypes = append(outputTypes, types.Bool)
 	}
 	return outputTypes
 }

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -78,9 +78,11 @@ func (jb *joinerBase) init(
 	onCondTypes = append(onCondTypes, leftTypes...)
 	onCondTypes = append(onCondTypes, rightTypes...)
 
-	outputTypes := jType.MakeOutputTypes(leftTypes, rightTypes)
+	var outputTypes []*types.T
 	if outputContinuationColumn {
-		outputTypes = append(outputTypes, types.Bool)
+		outputTypes = jType.MakeOutputTypesWithContinuationColumn(leftTypes, rightTypes)
+	} else {
+		outputTypes = jType.MakeOutputTypes(leftTypes, rightTypes)
 	}
 
 	if err := jb.ProcessorBase.Init(


### PR DESCRIPTION
#### sql/rowexec: batch allocations in joinerBase

Three allocations in `joinerBase.init` have been batched into a single
allocation.

Release note: None

#### sql/rowexec: avoid extra allocation and copy in joinerBase for paired joiners

Prior to this commit `joinerBase` would always reallocate and copy a
slice of output types if the join had a continuation column (which is
the case for paired joiners). This extra allocation has been eliminated
by initially allocating enough space in the output types for the
continuation column.

Epic: None

Release note: None
