### PR TITLE
kv: deflake TestNodeLivenessRetryAmbiguousResultError

### DIFF
--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -994,19 +994,21 @@ func TestNodeLivenessRetryAmbiguousResultError(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		return verifyLivenessServer(s, 1)
 	})
-	nl := s.NodeLiveness().(*liveness.NodeLiveness)
-
-	l, ok := nl.Self()
-	assert.True(t, ok)
 
 	// And again on manual heartbeat.
+	// NOTE: we make sure to set pause the heartbeat loop before we grab the
+	// liveness record to ensure that we don't race with the heartbeat loop in
+	// a way that allows our manual heartbeat to short-circuit.
+	nl := s.NodeLiveness().(*liveness.NodeLiveness)
+	defer nl.PauseHeartbeatLoopForTest()
+
 	injectError.Store(true)
-	if err := nl.Heartbeat(context.Background(), l); err != nil {
-		t.Fatal(err)
-	}
-	if count := injectedErrorCount.Load(); count < 2 {
-		t.Errorf("expected injected error count of at least 2; got %d", count)
-	}
+	l, ok := nl.Self()
+	assert.True(t, ok)
+	require.NoError(t, nl.Heartbeat(context.Background(), l))
+
+	// Verify that the error was injected exactly twice.
+	require.Equal(t, int32(2), injectedErrorCount.Load())
 }
 
 // This tests the create code path for node liveness, for that we need to create

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -964,17 +964,16 @@ func TestNodeLivenessRetryAmbiguousResultError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var injectError atomic.Value
-	var injectedErrorCount int32
+	var injectError atomic.Bool
+	var injectedErrorCount atomic.Int32
 
 	injectError.Store(true)
 	testingEvalFilter := func(args kvserverbase.FilterArgs) *kvpb.Error {
 		if _, ok := args.Req.(*kvpb.ConditionalPutRequest); !ok {
 			return nil
 		}
-		if val := injectError.Load(); val != nil && val.(bool) {
-			atomic.AddInt32(&injectedErrorCount, 1)
-			injectError.Store(false)
+		if injectError.Swap(false) {
+			injectedErrorCount.Add(1)
 			return kvpb.NewError(kvpb.NewAmbiguousResultErrorf("test"))
 		}
 		return nil
@@ -1005,7 +1004,7 @@ func TestNodeLivenessRetryAmbiguousResultError(t *testing.T) {
 	if err := nl.Heartbeat(context.Background(), l); err != nil {
 		t.Fatal(err)
 	}
-	if count := atomic.LoadInt32(&injectedErrorCount); count < 2 {
+	if count := injectedErrorCount.Load(); count < 2 {
 		t.Errorf("expected injected error count of at least 2; got %d", count)
 	}
 }


### PR DESCRIPTION
Fixes #125947.

This commit fixes a flake in `TestNodeLivenessRetryAmbiguousResultError`, where the short-circuit path for a manual liveness heartbeat could break an assertion in the test. To avoid this flakiness, pause the heartbeat loop before we grab the liveness record to ensure that we don't race with the heartbeat loop in a way that allows our manual heartbeat to short-circuit and fail to hit an injected error.

Release note: None