### PR TITLE
dev: add support for `--remote` mode to `dev doctor`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=96
+DEV_VERSION=97
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
This can be opted into with `dev doctor --remote`. You can switch back to local mode with `--remote=no`. If neither option is supplied, then we infer the appropriate mode from the `.bazelrc.user` contents.

Epic: CRDB-34137
Release note: None