### PR TITLE
sql,schemachanger: pause backfill job when disk space runs out

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2393,6 +2393,9 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 		uint64(columnBackfillUpdateChunkSizeThresholdBytes.Get(&sc.settings.SV)),
 		backfill.ColumnMutationFilter,
 	); err != nil {
+		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
+			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
+		}
 		return err
 	}
 	log.Info(ctx, "finished clearing and backfilling columns")

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprotectedts",
+        "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/security/username",


### PR DESCRIPTION
Previously, this error would cause the job to fail and begin reverting. If the cause of the error was insufficient disk space, then attempting to revert is just as likely to fail. Now we pause the job instead.

fixes https://github.com/cockroachdb/cockroach/issues/125513
Release note: None