### PR TITLE
sql: fix stmt stats for internal executors with outer txns

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -295,8 +295,10 @@ func (ie *InternalExecutor) initConnEx(
 		// it's created.
 		if ie.syntheticDescriptors != nil {
 			postSetupFn = func(ex *connExecutor) {
+				// Note that we don't need to set shouldResetSyntheticDescriptors
+				// since ReleaseAll will be called on the descs.Collection which
+				// will also release synthetic descriptors.
 				ex.extraTxnState.descCollection.SetSyntheticDescriptors(ie.syntheticDescriptors)
-				ex.extraTxnState.shouldResetSyntheticDescriptors = true
 			}
 		}
 		srvMetrics := &ie.s.InternalMetrics
@@ -318,7 +320,7 @@ func (ie *InternalExecutor) initConnEx(
 			srvMetrics,
 			applicationStats,
 			ie.s.cfg.GenerateID(),
-			false, /* fromOuterTxn */
+			false, /* underOuterTxn */
 			postSetupFn,
 		)
 	} else {
@@ -376,11 +378,13 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 	shouldResetSyntheticDescriptors := len(ie.syntheticDescriptors) > 0
 
 	var postSetupFn func(*connExecutor)
-	// If an internal executor is run with a not-nil txn, we may want to
-	// let it inherit the descriptor collection, schema change job records
-	// and job collections from the caller.
+	// If an internal executor is run with a not-nil txn and has some extra txn
+	// state already set up, we may want to let it inherit the descriptor
+	// collection, schema change job records and job collections from the
+	// caller.
 	if ie.extraTxnState != nil {
 		postSetupFn = func(ex *connExecutor) {
+			ex.extraTxnState.skipResettingSchemaObjects = true
 			ex.extraTxnState.descCollection = ie.extraTxnState.descCollection
 			ex.extraTxnState.jobs = ie.extraTxnState.jobs
 			ex.extraTxnState.schemaChangerState = ie.extraTxnState.schemaChangerState
@@ -406,7 +410,7 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		srvMetrics,
 		applicationStats,
 		ie.s.cfg.GenerateID(),
-		ie.extraTxnState != nil, /* fromOuterTxn */
+		true, /* underOuterTxn */
 		postSetupFn,
 	)
 
@@ -1388,6 +1392,9 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 	rw := newAsyncIEResultChannel()
 	stmtBuf := NewStmtBuf()
 
+	// Create a fresh conn executor simply for the purpose of committing the
+	// txn.
+	// TODO(#124935): this probably will need to change.
 	ex, err := ie.initConnEx(
 		ctx, ie.extraTxnState.txn, rw, defaultIEExecutionMode, sd, stmtBuf,
 		nil /* syncCallback */, false, /* attributeToUser */
@@ -1397,6 +1404,8 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 	}
 	// TODO(janexing): is this correct?
 	ex.planner.txn = ie.extraTxnState.txn
+	// TODO(#124935): might need to set ex.extraTxnState.shouldExecuteOnTxnFinish
+	// to true.
 
 	defer ex.close(ctx, externalTxnClose)
 	if ie.extraTxnState.txn.IsCommitted() {

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -468,7 +468,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		insightsProvider.Writer(false /* internal */),
 		sessionphase.NewTimes(),
 		sqlStats.GetCounters(),
-		false, /* fromOuterTxn */
+		false, /* underOuterTxn */
 		nil,   /* knobs */
 	)
 
@@ -596,7 +596,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			insightsProvider.Writer(false /* internal */),
 			sessionphase.NewTimes(),
 			sqlStats.GetCounters(),
-			false, /* fromOuterTxn */
+			false, /* underOuterTxn */
 			nil,   /* knobs */
 		)
 
@@ -1867,12 +1867,7 @@ FROM crdb_internal.statement_statistics WHERE app_name = $1`, appName)
 	})
 
 	t.Run("internal multi-statement transaction", func(t *testing.T) {
-		// We don't associate internal statements from outer transactions
-		// with a transaction fingerprint ID. Thus we should have already
-		// seen this query in the "with-txn" application from the previous
-		// test. We should see that the execution counts increase but not
-		// the sampling count.
-		appName := "with-txn"
+		appName := "with-txn-multiple"
 		err := ts.InternalDB().(descs.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			for i := 0; i < 10; i++ {
 				if _, err := txn.Exec(ctx, appName, txn.KV(), "SELECT 1"); err != nil {
@@ -1886,7 +1881,34 @@ FROM crdb_internal.statement_statistics WHERE app_name = $1`, appName)
 		// Verify that the internal statement is captured.
 		query, cnt, sampledCnt := getStmtRow(appName, false /* attributedToUser */)
 		require.Equal(t, "SELECT _", query)
-		require.Equal(t, 20, cnt)
+		require.Equal(t, 10, cnt)
 		require.Equal(t, 1, sampledCnt)
+	})
+
+	// This test case differs from "internal statement with a transaction" since
+	// we use the internal executor without any extra txn state set up.
+	t.Run("internal statement with a transaction through executor", func(t *testing.T) {
+		appName := "with-txn-through-executor"
+		testutils.RunTrueAndFalse(t, "attributed to user", func(t *testing.T, attributedToUser bool) {
+			for i := 0; i < 10; i++ {
+				err := ts.InternalDB().(descs.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+					_, err := ts.InternalExecutor().(isql.Executor).ExecEx(
+						ctx,
+						appName,
+						txn.KV(),
+						sessiondata.InternalExecutorOverride{AttributeToUser: attributedToUser},
+						"SELECT 1",
+					)
+					return err
+				})
+				require.NoError(t, err)
+			}
+
+			// Verify that the internal statement is captured.
+			query, cnt, sampledCnt := getStmtRow(appName, attributedToUser)
+			require.Equal(t, "SELECT _", query)
+			require.Equal(t, 10, cnt)
+			require.Equal(t, 1, sampledCnt)
+		})
 	})
 }

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -81,10 +81,10 @@ func NewStatsCollector(
 	insights insights.Writer,
 	phaseTime *sessionphase.Times,
 	uniqueServerCounts *ssmemstorage.SQLStatsAtomicCounters,
-	fromOuterTxn bool,
+	underOuterTxn bool,
 	knobs *sqlstats.TestingKnobs,
 ) *StatsCollector {
-	// See #124935 for more details. If fromOuterTxn is true, the
+	// See #124935 for more details. If underOuterTxn is true, the
 	// executor owning the stats collector is not responsible for
 	// starting or committing the transaction. Since the statements
 	// are merged into flushTarget on EndTransaction, in this case the
@@ -92,7 +92,7 @@ func NewStatsCollector(
 	// we'll write directly to the flushTarget when we're collecting
 	// stats for a conn exec belonging to an outer transaction.
 	currentTransactionStatementStats := appStats
-	if !fromOuterTxn {
+	if !underOuterTxn {
 		currentTransactionStatementStats = appStats.NewApplicationStatsWithInheritedOptions()
 	}
 	return &StatsCollector{


### PR DESCRIPTION
This commit fixes an oversight where we previously incorrectly used `fromOuterTxn` boolean when instantiating the stats container. This field was originally introduced to indicate that some schema objects shouldn't be reset when resetting the conn executor, which is the case when we have an outer txn AND we injected the descs collection, etc. For the stats container we only care about whether there is an outer txn or not. This commit splits out the boolean into two to clarify things. Now, whenever we're `underOuterTxn` we'll do the right thing for the stats container, and the old boolean `fromOuterTxn` has been renamed to `skipResettingSchemaObjects` to avoid possible confusion.

I think the same problem was present with the usage of `fromOuterTxn` when ensuring that we step back the txn in the internal executor, and this is now fixed.

Additionally, it adds a few TODOs about code spots we might need to change to address an issue with txn stats of internal executors.

Epic: None

Release note: None