### PR TITLE
sql: presize stmt buf in internal executor

### DIFF
--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -348,7 +348,7 @@ func startConnExecutor(
 	}
 
 	s := NewServer(cfg, pool)
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	syncResults := make(chan []*streamingCommandResult, 1)
 	resultChannel := newAsyncIEResultChannel()
 	var cc ClientComm = &internalClientComm{
@@ -401,7 +401,7 @@ func TestSessionCloseWithPendingTempTableInTxn(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	srv := s.SQLServer().(*Server)
-	stmtBuf := NewStmtBuf()
+	stmtBuf := NewStmtBuf(0 /* toReserve */)
 	flushed := make(chan []*streamingCommandResult)
 	clientComm := &internalClientComm{
 		sync: func(res []*streamingCommandResult) {

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -473,9 +473,14 @@ func (s SendError) String() string {
 var _ Command = SendError{}
 
 // NewStmtBuf creates a StmtBuf.
-func NewStmtBuf() *StmtBuf {
+// - toReserve, if positive, indicates the initial capacity of the command
+// buffer.
+func NewStmtBuf(toReserve int) *StmtBuf {
 	var buf StmtBuf
 	buf.Init()
+	if toReserve > 0 {
+		buf.mu.data.Reserve(toReserve)
+	}
 	return &buf
 }
 

--- a/pkg/sql/conn_io_test.go
+++ b/pkg/sql/conn_io_test.go
@@ -71,7 +71,7 @@ func TestStmtBuf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	mustPush(ctx, t, buf, ExecStmt{Statement: s1})
 	mustPush(ctx, t, buf, ExecStmt{Statement: s2})
 	mustPush(ctx, t, buf, ExecStmt{Statement: s3})
@@ -144,7 +144,7 @@ func TestStmtBufSignal(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	s1, err := parser.ParseOne("SELECT 1")
 	if err != nil {
 		t.Fatal(err)
@@ -169,7 +169,7 @@ func TestStmtBufLtrim(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	for i := 0; i < 5; i++ {
 		stmt, err := parser.ParseOne(
 			fmt.Sprintf("SELECT %d", i))
@@ -198,7 +198,7 @@ func TestStmtBufClose(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	stmt, err := parser.ParseOne("SELECT 1")
 	if err != nil {
 		t.Fatal(err)
@@ -217,7 +217,7 @@ func TestStmtBufCloseUnblocksReader(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 
 	go func() {
 		buf.Close()
@@ -235,7 +235,7 @@ func TestStmtBufPreparedStmt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	ctx := context.Background()
 
 	s1, err := parser.ParseOne("SELECT 1")
@@ -279,7 +279,7 @@ func TestStmtBufBatching(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	buf := NewStmtBuf()
+	buf := NewStmtBuf(0 /* toReserve */)
 	ctx := context.Background()
 
 	s1, err := parser.ParseOne("SELECT 1")

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1181,7 +1181,11 @@ func (ie *InternalExecutor) execInternal(
 	// the span to the iterator. This is necessary so that the connExecutor
 	// exits before the span is finished.
 	ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.AmbientCtx.Tracer, opName)
-	stmtBuf := NewStmtBuf()
+	numCommands := 2 // ExecStmt -> Sync
+	if len(qargs) > 0 {
+		numCommands = 4 // PrepareStmt -> BindStmt -> ExecPortal -> Sync
+	}
+	stmtBuf := NewStmtBuf(numCommands)
 	var wg sync.WaitGroup
 
 	defer func() {
@@ -1260,10 +1264,6 @@ func (ie *InternalExecutor) execInternal(
 	if parsed.NumPlaceholders > numParams {
 		numParams = parsed.NumPlaceholders
 	}
-	typeHints := make(tree.PlaceholderTypes, numParams)
-	for i, d := range datums {
-		typeHints[tree.PlaceholderIdx(i)] = d.ResolvedType()
-	}
 	if len(qargs) == 0 {
 		if err := stmtBuf.Push(
 			ctx,
@@ -1285,6 +1285,10 @@ func (ie *InternalExecutor) execInternal(
 			return nil, err
 		}
 	} else {
+		typeHints := make(tree.PlaceholderTypes, numParams)
+		for i, d := range datums {
+			typeHints[tree.PlaceholderIdx(i)] = d.ResolvedType()
+		}
 		if err := stmtBuf.Push(
 			ctx,
 			PrepareStmt{
@@ -1386,7 +1390,7 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 	}
 
 	rw := newAsyncIEResultChannel()
-	stmtBuf := NewStmtBuf()
+	stmtBuf := NewStmtBuf(0 /* toReserve */)
 
 	ex, err := ie.initConnEx(
 		ctx, ie.extraTxnState.txn, rw, defaultIEExecutionMode, sd, stmtBuf,


### PR DESCRIPTION
We always execute either 2 or 4 commands in the internal executor, so we can precisely reserve the necessary capacity, avoiding some allocations.

Epic: None

Release note: None