### PR TITLE
pkg/cli: add new sub-command "upload" to "debug zip"

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "zip_helpers.go",
         "zip_per_node.go",
         "zip_table_registry.go",
+        "zip_upload.go",
         ":gen-keytype-stringer",  # keep
     ],
     # keep
@@ -353,6 +354,7 @@ go_test(
         "zip_table_registry_test.go",
         "zip_tenant_test.go",
         "zip_test.go",
+        "zip_upload_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":cli"],
@@ -434,6 +436,7 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_google_pprof//profile",
         "@com_github_pmezard_go_difflib//difflib",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1437,6 +1437,7 @@ func (m lockValueFormatter) Format(f fmt.State, c rune) {
 var pebbleToolFS = &autoDecryptFS{}
 
 func init() {
+	debugZipCmd.AddCommand(debugZipUploadCmd)
 	DebugCmd.AddCommand(debugCmds...)
 
 	// Note: we hook up FormatValue here in order to avoid a circular dependency
@@ -1575,6 +1576,17 @@ func init() {
 		"force use of TTY escape codes to colorize the output")
 	f.StringSliceVar(&debugMergeLogsOpts.tenantIDsFilter, "tenant-ids", nil,
 		"tenant IDs to filter logs by")
+
+	f = debugZipUploadCmd.Flags()
+	f.StringVar(&debugZipUploadOpts.ddAPIKey, "dd-api-key", "",
+		"Datadog API key to use to send debug.zip artifacts to datadog")
+	f.StringSliceVar(&debugZipUploadOpts.include, "include", nil,
+		"The debug zip artifacts to include. Possible values: "+strings.Join(zipArtifactTypes, ", "))
+	f.StringSliceVar(&debugZipUploadOpts.tags, "tags", nil,
+		"Tags to attach to the debug zip artifacts. This can be used to annotate the artifacts with details about the customer."+
+			"\nExample: --tags \"env:prod,customer:xyz\"")
+	f.StringVar(&debugZipUploadOpts.clusterName, "cluster", "",
+		"Name of the cluster to associate with the debug zip artifacts. This can be used to identify data in the upstream observability tool.")
 
 	f = debugDecodeKeyCmd.Flags()
 	f.Var(&decodeKeyOptions.encoding, "encoding", "key argument encoding")

--- a/pkg/cli/testdata/upload/profiles
+++ b/pkg/cli/testdata/upload/profiles
@@ -1,0 +1,104 @@
+# Single-node - both profiles
+upload-profiles
+{
+    "1": [
+        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
+        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
+    ]
+}
+----
+Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=uuid:123
+Upload ID: 123
+Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof)
+debug zip upload debugDir --dd-api-key=dd-api-key --cluster=ABC
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,uuid:123","family":"go","version":"4"}
+
+
+# Multi-node - both profiles
+upload-profiles tags=foo:bar
+{
+    "1": [
+        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
+        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
+    ],
+    "2": [
+        { "type": "cpu", "timestamp": 1718974543, "duration": 20 },
+        { "type": "heap", "timestamp": 1718974535, "duration": 20 }
+    ]
+}
+----
+Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=uuid:123
+Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=uuid:123
+Upload ID: 123
+Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof)
+Uploaded profiles of node 2 to datadog (debugDir/nodes/2/cpu.pprof, debugDir/nodes/2/heap.pprof)
+debug zip upload debugDir --dd-api-key=dd-api-key --tags=foo:bar --cluster=ABC
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:1,service:CRDB-SH,uuid:123","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:2,service:CRDB-SH,uuid:123","family":"go","version":"4"}
+
+
+# Single-node - only CPU profile
+upload-profiles tags=customer:user-given-name,cluster:XYZ
+{
+    "1": [
+        { "type": "cpu", "timestamp": 1718972610, "duration": 20 }
+    ]
+}
+----
+Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=uuid:123
+Upload ID: 123
+Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof)
+debug zip upload debugDir --dd-api-key=dd-api-key --tags=customer:user-given-name,cluster:XYZ --cluster=ABC
+{"start":"","end":"","attachments":["cpu.pprof"],"tags_profiler":"cluster:XYZ,customer:user-given-name,env:debug,foo:bar,node_id:1,service:CRDB-SH,uuid:123","family":"go","version":"4"}
+
+
+# Single-node - no profiles found
+upload-profiles
+{
+    "1": []
+}
+----
+Upload ID: 123
+debug zip upload debugDir --dd-api-key=dd-api-key --cluster=ABC
+
+
+# Colliding tags - env provided by the user should take precedence
+upload-profiles tags=env:SH
+{
+    "1": [
+        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
+        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
+    ]
+}
+----
+Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=uuid:123
+Upload ID: 123
+Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof)
+debug zip upload debugDir --dd-api-key=dd-api-key --tags=env:SH --cluster=ABC
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:SH,node_id:1,service:CRDB-SH,uuid:123","family":"go","version":"4"}
+
+
+# Single-node - both profiles
+upload-profiles tags=ERR
+{
+    "1": [
+        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
+        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
+    ]
+}
+----
+ERROR: Failed to upload profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof): 'runtime' is a required field
+debug zip upload debugDir --dd-api-key=dd-api-key --tags=ERR --cluster=ABC
+
+
+# Customer name not provided by the user
+upload-profiles tags=foo:bar skip-cluster-name=true
+{
+    "1": [
+        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
+        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
+    ]
+}
+----
+ERROR: cluster name is required for uploading profiles
+debug zip upload debugDir --dd-api-key=dd-api-key --tags=foo:bar

--- a/pkg/cli/zip_cmd.go
+++ b/pkg/cli/zip_cmd.go
@@ -31,3 +31,13 @@ requires the cluster to be live.
 	Args: cobra.ExactArgs(1),
 	RunE: clierrorplus.MaybeDecorateError(runDebugZip),
 }
+
+// debugZipUploadCmd is a hidden command that uploads the generated debug.zip
+// to datadog. This will not apprear in the help text of the zip command.
+var debugZipUploadCmd = &cobra.Command{
+	Use:    "upload <path to debug dir>",
+	Short:  "upload the contents of the debug.zip to an observability platform",
+	Args:   cobra.ExactArgs(1),
+	Hidden: true,
+	RunE:   clierrorplus.MaybeDecorateError(runDebugZipUpload),
+}

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -1,0 +1,321 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/spf13/cobra"
+)
+
+type profileUploadEvent struct {
+	Start       string   `json:"start"`
+	End         string   `json:"end"`
+	Attachments []string `json:"attachments"`
+	Tags        string   `json:"tags_profiler"`
+	Family      string   `json:"family"`
+	Version     string   `json:"version"`
+}
+
+type uploadZipArtifactFunc func(ctx context.Context, uuid string, debugDirPath string) error
+
+const (
+	datadogAPIKeyHeader  = "DD-API-KEY"
+	zippedProfilePattern = "nodes/*/*.pprof"
+	profileFamily        = "go"
+	profileFormat        = "pprof"
+
+	// this is not the pprof version, but the version of the profile upload format supported by datadog
+	profileVersion = "4"
+
+	// names of mandatory tag
+	nodeIDTag  = "node_id"
+	uuidTag    = "uuid"
+	clusterTag = "cluster"
+)
+
+var debugZipUploadOpts = struct {
+	include            []string
+	ddAPIKey           string
+	ddProfileUploadURL string
+	clusterName        string
+	tags               []string
+}{
+	ddProfileUploadURL: "https://intake.profile.datadoghq.com/v1/input",
+}
+
+// This is the list of all supported artifact types. The "possible values" part
+// in the help text is generated from this list. So, make sure to keep this updated
+var zipArtifactTypes = []string{"profiles"}
+
+// uploadZipArtifactFuncs is a registry of handler functions for each artifact type.
+// While adding/removing functions from here, make sure to update
+// the zipArtifactTypes list as well
+var uploadZipArtifactFuncs = map[string]uploadZipArtifactFunc{
+	"profiles": uploadZipProfiles,
+}
+
+// default tags
+var ddProfileTags = []string{"service:CRDB-SH", "env:debug"}
+
+func runDebugZipUpload(cmd *cobra.Command, args []string) error {
+	if err := validateZipUploadReadiness(); err != nil {
+		return err
+	}
+
+	// a unique ID for this upload session. This should be used to tag all the artifacts uploaded in this session
+	uploadID := newUploadID()
+
+	// override the list of artifacts to upload if the user has provided any
+	artifactsToUpload := zipArtifactTypes
+	if len(debugZipUploadOpts.include) > 0 {
+		artifactsToUpload = debugZipUploadOpts.include
+	}
+
+	// run the upload functions
+	// TODO(arjunmahishi): Make this concurrent once there are multiple artifacts to upload
+	for _, artType := range artifactsToUpload {
+		if err := uploadZipArtifactFuncs[artType](cmd.Context(), uploadID, args[0]); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Upload ID:", uploadID)
+	return nil
+}
+
+func validateZipUploadReadiness() error {
+	if debugZipUploadOpts.ddAPIKey == "" {
+		return fmt.Errorf("datadog API key is required for uploading profiles")
+	}
+
+	if debugZipUploadOpts.clusterName == "" {
+		return fmt.Errorf("cluster name is required for uploading profiles")
+	}
+
+	// validate the artifact types provided and fail early if any of them are not supported
+	for _, artType := range debugZipUploadOpts.include {
+		if _, ok := uploadZipArtifactFuncs[artType]; !ok {
+			return fmt.Errorf("unsupported artifact type '%s'", artType)
+		}
+	}
+
+	return nil
+}
+
+func uploadZipProfiles(ctx context.Context, uuid string, debugDirPath string) error {
+	paths, err := expandPatterns([]string{path.Join(debugDirPath, zippedProfilePattern)})
+	if err != nil {
+		return err
+	}
+
+	pathsByNode := make(map[string][]string)
+	for _, path := range paths {
+		nodeID := filepath.Base(filepath.Dir(path))
+		if _, ok := pathsByNode[nodeID]; !ok {
+			pathsByNode[nodeID] = []string{}
+		}
+
+		pathsByNode[nodeID] = append(pathsByNode[nodeID], path)
+	}
+
+	for nodeID, paths := range pathsByNode {
+		req, err := newProfileUploadReq(
+			ctx, paths, appendUserTags(
+				append(
+					ddProfileTags, makeDDTag(nodeIDTag, nodeID), makeDDTag(uuidTag, uuid),
+					makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
+				), // system generated tags
+				debugZipUploadOpts.tags..., // user provided tags
+			),
+		)
+		if err != nil {
+			return err
+		}
+
+		resp, err := doUploadProfileReq(req)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				fmt.Println("failed to close response body:", err)
+			}
+		}()
+
+		if resp.StatusCode != http.StatusOK {
+			errMsg := fmt.Sprintf(
+				"Failed to upload profiles of node %s to datadog (%s)",
+				nodeID, (strings.Join(paths, ", ")),
+			)
+			if resp.Body != nil {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return err
+				}
+
+				return fmt.Errorf("%s: %s", errMsg, string(body))
+			}
+
+			return fmt.Errorf("%s: %s", errMsg, resp.Status)
+		}
+
+		fmt.Printf("Uploaded profiles of node %s to datadog (%s)\n", nodeID, strings.Join(paths, ", "))
+		fmt.Printf("Explore this profile on datadog: "+
+			"https://{{ datadog domain }}/profiling/explorer?query=uuid:%s\n", uuid)
+	}
+
+	return nil
+}
+
+func newProfileUploadReq(
+	ctx context.Context, profilePaths []string, tags []string,
+) (*http.Request, error) {
+	var (
+		body  bytes.Buffer
+		mw    = multipart.NewWriter(&body)
+		now   = timeutil.Now()
+		event = &profileUploadEvent{
+			Version: profileVersion,
+			Family:  profileFamily,
+			Tags:    strings.Join(tags, ","),
+
+			// Ideally, we should be calculating the start and end times based on the
+			// timestamp encoded in the pprof file. But, datadog doesn't seem to
+			// support uploading profiles that are older than a certain period. So, we
+			// are using a 5-second window around the current time.
+			Start: now.Add(time.Second * -5).Format(time.RFC3339Nano),
+			End:   now.Format(time.RFC3339Nano),
+		}
+	)
+
+	for _, profilePath := range profilePaths {
+		fileName := filepath.Base(profilePath)
+		event.Attachments = append(event.Attachments, fileName)
+
+		f, err := mw.CreateFormFile(fileName, fileName)
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := os.ReadFile(profilePath)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := f.Write(data); err != nil {
+			return nil, err
+		}
+	}
+
+	f, err := mw.CreatePart(textproto.MIMEHeader{
+		httputil.ContentDispositionHeader: []string{`form-data; name="event"; filename="event.json"`},
+		httputil.ContentTypeHeader:        []string{httputil.JSONContentType},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.NewEncoder(f).Encode(event); err != nil {
+		return nil, err
+	}
+
+	if err := mw.Close(); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, debugZipUploadOpts.ddProfileUploadURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set(httputil.ContentTypeHeader, mw.FormDataContentType())
+	req.Header.Set(datadogAPIKeyHeader, debugZipUploadOpts.ddAPIKey)
+	return req, nil
+}
+
+// appendUserTags will make sure there are no duplicates in the final list of tags.
+// In case of duplicates, the user provided tags will take precedence.
+func appendUserTags(systemTags []string, tags ...string) []string {
+	tagsMap := make(map[string]string)
+	for _, tag := range systemTags {
+		split := strings.Split(tag, ":")
+		if len(split) != 2 {
+			tagsMap[tag] = ""
+			continue
+		}
+
+		tagsMap[split[0]] = split[1]
+	}
+
+	for _, tag := range tags {
+		split := strings.Split(tag, ":")
+		if len(split) != 2 {
+			tagsMap[tag] = ""
+			continue
+		}
+
+		tagsMap[split[0]] = split[1]
+	}
+
+	var finalList []string
+	for key, value := range tagsMap {
+		if value == "" {
+			finalList = append(finalList, key)
+			continue
+		}
+
+		finalList = append(finalList, fmt.Sprintf("%s:%s", key, value))
+	}
+
+	sort.Strings(finalList)
+	return finalList
+}
+
+// makeDDTag is a simple convenience function to make a tag string in the key:value format.
+// This is just to make the code more readable.
+func makeDDTag(key, value string) string {
+	return fmt.Sprintf("%s:%s", key, value)
+}
+
+// doUploadProfileReq is a variable that holds the function that literally just sends the request.
+// This is useful to mock the datadog API's response in tests.
+var doUploadProfileReq = func(req *http.Request) (*http.Response, error) {
+	return http.DefaultClient.Do(req)
+}
+
+// a wrapper around uuid.MakeV4().String() to make the tests more deterministic.
+// Everything is converted to lowercase and spaces are replaced with hyphens. Because,
+// datadog will do this anyway and we want to make sure the UUIDs match when we generate the
+// explore/dashboard links.
+var newUploadID = func() string {
+	return strings.ToLower(
+		strings.ReplaceAll(
+			fmt.Sprintf("%s-%s", debugZipUploadOpts.clusterName, uuid.NewV4().Short()), " ", "-",
+		),
+	)
+}

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -1,0 +1,239 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/datadriven"
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type uploadProfileReq struct {
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+	Duration  int64  `json:"duration"`
+}
+
+func setupZipDirWithProfiles(t *testing.T, inputs map[int][]uploadProfileReq) (string, func()) {
+	t.Helper()
+
+	// make sure that the debug directory name is unique. Or the tests will be flaky.
+	debugDir := path.Join(os.TempDir(), fmt.Sprintf("debug-%s/", uuid.MakeV4().String()))
+
+	for nodeID, nodeInputs := range inputs {
+		// create a subdirectory for each node
+		profDir := path.Join(debugDir, fmt.Sprintf("nodes/%d/", nodeID))
+		require.NoError(t, os.MkdirAll(profDir, 0755))
+
+		for _, i := range nodeInputs {
+			p := &profile.Profile{
+				TimeNanos:     time.Unix(i.Timestamp, 0).UnixNano(),
+				DurationNanos: i.Duration,
+				SampleType: []*profile.ValueType{
+					{Type: i.Type},
+				},
+			}
+
+			file, err := os.Create(
+				path.Join(profDir, fmt.Sprintf("%s.pprof", i.Type)),
+			)
+			require.NoError(t, err)
+			require.NoError(t, p.Write(file))
+		}
+	}
+
+	return debugDir, func() {
+		require.NoError(t, os.RemoveAll(debugDir))
+	}
+}
+
+func TestUploadZipProfiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer testutils.TestingHook(&newUploadID, func() string {
+		return "123"
+	})()
+
+	defer testutils.TestingHook(&doUploadProfileReq,
+		func(req *http.Request) (*http.Response, error) {
+			defer req.Body.Close()
+
+			_, params, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			reader := multipart.NewReader(req.Body, params["boundary"])
+
+			// find the "event" part in the multipart request and copy it to the final output
+			for {
+				part, err := reader.NextPart()
+				if err == io.EOF {
+					break
+				}
+
+				if part.FormName() == "event" {
+					var event profileUploadEvent
+					require.NoError(t, json.NewDecoder(part).Decode(&event))
+
+					if strings.Contains(event.Tags, "ERR") {
+						// this is a test to simulate a client error
+						return &http.Response{
+							StatusCode: 400,
+							Body:       io.NopCloser(strings.NewReader("'runtime' is a required field")),
+						}, nil
+					}
+
+					// validate the timestamps outside the data-driven test framework
+					// to keep the test deterministic.
+					start, err := time.Parse(time.RFC3339Nano, event.Start)
+					require.NoError(t, err)
+
+					end, err := time.Parse(time.RFC3339Nano, event.End)
+					require.NoError(t, err)
+
+					require.Equal(t, time.Second*5, end.Sub(start))
+					event.Start = ""
+					event.End = ""
+
+					// require.NoError(t, json.NewEncoder(&finaloutput).Encode(event))
+					rawEvent, err := json.Marshal(event)
+					require.NoError(t, err)
+
+					// print the event so that it gets captured as a part of RunWithCapture
+					fmt.Println(string(rawEvent))
+				}
+			}
+
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("200 OK")),
+			}, nil
+		},
+	)()
+
+	datadriven.RunTest(t, "testdata/upload/profiles", func(t *testing.T, d *datadriven.TestData) string {
+		c := NewCLITest(TestCLIParams{})
+		defer c.Cleanup()
+
+		var finaloutput bytes.Buffer
+
+		var testInput map[int][]uploadProfileReq
+		require.NoError(t, json.Unmarshal([]byte(d.Input), &testInput))
+
+		var tags string
+		if d.HasArg("tags") {
+			d.ScanArgs(t, "tags", &tags)
+			tags = fmt.Sprintf("--tags=%s", tags)
+		} else {
+			debugZipUploadOpts.tags = nil
+		}
+
+		clusterNameArg := "--cluster=ABC"
+		if d.HasArg("skip-cluster-name") {
+			debugZipUploadOpts.clusterName = ""
+			clusterNameArg = ""
+		}
+
+		debugDir, cleanup := setupZipDirWithProfiles(t, testInput)
+		defer cleanup()
+
+		stdout, err := c.RunWithCapture(
+			fmt.Sprintf("debug zip upload %s --dd-api-key=dd-api-key %s %s", debugDir, tags, clusterNameArg),
+		)
+		require.NoError(t, err)
+
+		// also write the STDOUT output to the finaloutput buffer. So, both the
+		// API request made to Datadog and the STDOUT output are validated.
+		_, err = finaloutput.WriteString(stdout)
+		require.NoError(t, err)
+
+		// sort the lines to avoid flakiness in the test
+		lines := strings.Split(finaloutput.String(), "\n")
+		sort.Strings(lines)
+
+		// replace the debugDir with a constant string to avoid flakiness in the test
+		return strings.ReplaceAll(strings.TrimSpace(strings.Join(lines, "\n")), debugDir, "debugDir")
+	})
+}
+
+func TestAppendUserTags(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tt := []struct {
+		name       string
+		systemTags []string
+		userTags   []string
+		expected   []string
+	}{
+		{
+			name:       "no user tags",
+			systemTags: []string{"tag1:val1", "tag2:val2"},
+			expected:   []string{"tag1:val1", "tag2:val2"},
+		},
+		{
+			name:     "no system tags",
+			userTags: []string{"tag1:val1", "tag2:val2"},
+			expected: []string{"tag1:val1", "tag2:val2"},
+		},
+		{
+			name:       "different sets of tags",
+			systemTags: []string{"A:1", "B:2"},
+			userTags:   []string{"C:3", "D:4"},
+			expected:   []string{"A:1", "B:2", "C:3", "D:4"},
+		},
+		{
+			name:       "colliding tags",
+			systemTags: []string{"A:1", "B:2"},
+			userTags:   []string{"C:3", "A:4"},
+			expected:   []string{"A:4", "B:2", "C:3"},
+		},
+		{
+			name:       "non-key-value tags given by the user",
+			systemTags: []string{"A:1", "B:2"},
+			userTags:   []string{"C:3", "ABC"},
+			expected:   []string{"A:1", "ABC", "B:2", "C:3"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, appendUserTags(tc.systemTags, tc.userTags...))
+		})
+	}
+}
+
+func TestZipUploadArtifactTypes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, artifactType := range zipArtifactTypes {
+		_, ok := uploadZipArtifactFuncs[artifactType]
+		assert.True(
+			t, ok, "Missing upload function for '%s'. Either add an upload function for this artifact type or remove it from the list.",
+			artifactType,
+		)
+	}
+}

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -27,6 +27,8 @@ const (
 	AcceptHeader = "Accept"
 	// AcceptEncodingHeader is the canonical header name for accept encoding.
 	AcceptEncodingHeader = "Accept-Encoding"
+	// ContentDispositionHeader is the canonical header name for content disposition.
+	ContentDispositionHeader = "Content-Disposition"
 	// ContentEncodingHeader is the canonical header name for content type.
 	ContentEncodingHeader = "Content-Encoding"
 	// ContentTypeHeader is the canonical header name for content type.


### PR DESCRIPTION
This commit adds a new sub-command to the "debug zip" command called "upload". This gives cockroach CLI the ability to upload the contents of debug.zip to datadog (or any other observability tool in the future). This is an important step in consolidating the tools used for debugging issues in self-hosted clusters.

As of this commit, the "upload" command is capable of uploading the .pprof files captured for each node. They are usually found in the path: `nodes/*/*.pprof`. This command takes the datadog API key and the path to the directory containing the unzipped contents of the debug.zip as mandatory args.

Future commit will incrementally add the capability to upload more artefacts from the debug.zip. Adding support for a new artefact should be as simple as adding a new handler function to the `uploadZipArtifactFuncs` registry. 

---

**Usage**

```
$ cockroach debug zip upload /tmp/debug --dd-api-key=XXXX --tags="customer:ABC,cluster:prod"
```

<details>
<summary>Screenshots</summary>
<br>

**Command output**

![image](https://github.com/cockroachdb/cockroach/assets/11977524/513e5d6e-8a0b-4f44-a020-5bf9c1bb31a6)

**Datadog**

![image](https://github.com/cockroachdb/cockroach/assets/11977524/19c699c7-c68d-41a2-aebf-247c632cdcce)

![image](https://github.com/cockroachdb/cockroach/assets/11977524/444a2227-9ffc-4983-b2a8-216312189661)

</details>

---

Epic: CC-27712
Part of: CC-28674
Release note: None