### PR TITLE
roachprod: add error when using --arch=arm64 but machine type is empty/wrong

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1294,6 +1294,10 @@ func (p *Provider) computeInstanceArgs(
 	image := providerOpts.Image
 	imageProject := defaultImageProject
 
+	if opts.Arch == string(vm.ArchARM64) && !providerOpts.useArmAMI() {
+		return nil, cleanUpFn, errors.Errorf("Requested arch is arm64, but machine type is %s. Do specify a t2a VM", providerOpts.MachineType)
+	}
+
 	if providerOpts.useArmAMI() && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
 		return nil, cleanUpFn, errors.Errorf("machine type %s is arm64, but requested arch is %s", providerOpts.MachineType, opts.Arch)
 	}


### PR DESCRIPTION
When trying to use `--arch` flag for arm64 without specifying the `--gce-machine-type` flag, the framework will spin up `amd64` based instances

This might create confusion in case someone is expecting the framework to start `arm64` based instances.

Added an error when we get this situation