### PR TITLE
crosscluster/producer: always repartition spec if able

### DIFF
--- a/pkg/ccl/crosscluster/producer/stream_lifetime.go
+++ b/pkg/ccl/crosscluster/producer/stream_lifetime.go
@@ -363,11 +363,7 @@ func buildReplicationStreamSpec(
 func repartitionSpans(partitions []sql.SpanPartition, parts int) []sql.SpanPartition {
 	result := make([]sql.SpanPartition, 0, parts*len(partitions))
 	for part := range partitions {
-		if len(partitions[part].Spans) < parts {
-			result = append(result, partitions[part])
-			continue
-		}
-		repartitioned := make([]sql.SpanPartition, parts)
+		repartitioned := make([]sql.SpanPartition, min(parts, len(partitions[part].Spans)))
 		for i := range repartitioned {
 			repartitioned[i].SQLInstanceID = partitions[part].SQLInstanceID
 		}

--- a/pkg/ccl/crosscluster/producer/stream_lifetime_test.go
+++ b/pkg/ccl/crosscluster/producer/stream_lifetime_test.go
@@ -42,11 +42,7 @@ func TestRepartition(t *testing.T) {
 			var expectedParts int
 			var expectedSpans, gotSpans roachpb.Spans
 			for _, part := range input {
-				if len(part.Spans) >= parts {
-					expectedParts += parts
-				} else {
-					expectedParts += 1
-				}
+				expectedParts += min(parts, len(part.Spans))
 				expectedSpans = append(expectedSpans, part.Spans...)
 			}
 			for _, part := range got {


### PR DESCRIPTION
If we have 5 or 6 spans, we still want to partition them up across more than one proc to get more parallelism since those spans could be large.

Release note: none.
Epic: none.