### PR TITLE
kvserver: skip TestGossipHandlesReplacedNode under deadlock

### DIFF
--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -146,6 +146,7 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 
 	// As of Nov 2018 it takes 3.6s.
 	skip.UnderShort(t)
+	skip.UnderDeadlock(t)
 	ctx := context.Background()
 
 	// Shorten the raft tick interval and election timeout to make range leases


### PR DESCRIPTION
We've seen this test flake under deadlock for some time now. Skip it.

Closes https://github.com/cockroachdb/cockroach/issues/125215

Release note: None