### PR TITLE
release-23.1: changefeedccl: disable physical plan debug persistence

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -325,7 +325,9 @@ func startDistChangefeed(
 			finishedSetupFn = func(flowinfra.Flow) { resultsCh <- tree.Datums(nil) }
 		}
 
-		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID, execCfg.Settings.Version)
+		if log.V(1) {
+			jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID, execCfg.Settings.Version)
+		}
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx

--- a/pkg/jobs/jobsprofiler/profiler_test.go
+++ b/pkg/jobs/jobsprofiler/profiler_test.go
@@ -63,11 +63,14 @@ func TestProfilerStorePlanDiagram(t *testing.T) {
 			sql:  "RESTORE TABLE foo FROM LATEST IN 'userfile:///foo' WITH into_db='test'",
 			typ:  jobspb.TypeRestore,
 		},
-		{
-			name: "changefeed",
-			sql:  "CREATE CHANGEFEED FOR foo INTO 'null://sink'",
-			typ:  jobspb.TypeChangefeed,
-		},
+		/*
+			TODO(dt): re-enable this once #126083 is fixed.
+			 {
+				name: "changefeed",
+				sql:  "CREATE CHANGEFEED FOR foo INTO 'null://sink'",
+				typ:  jobspb.TypeChangefeed,
+			},
+		*/
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := sqlDB.Exec(tc.sql)


### PR DESCRIPTION
Backport 1/1 commits from #126085.

/cc @cockroachdb/release

---

Mitigation for #126083.

Release note (ops change): Some debugging-only information about physcial plans is no longer collected in the system.job_info table for changefeeds due to it having the potential to grow very large.

Epic: none.

Release justification: bug fix that disables collection of some debug-only info as its collection could render the jobs system unavailable over time. 
