### PR TITLE
liveness: grant test an additional core under `race`

### DIFF
--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -49,6 +49,10 @@ go_test(
         "main_test.go",
     ],
     embed = [":liveness"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/gossip",


### PR DESCRIPTION
Closes #124124.

Epic: none
Release note: None