### PR TITLE
rpc: grant test an additional core under `race`

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -120,6 +120,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":rpc"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",


### PR DESCRIPTION
Closes #126092.

Epic: none
Release note: None