### PR TITLE
jobsprofiler: bump size of test under `race`

### DIFF
--- a/pkg/jobs/jobsprofiler/BUILD.bazel
+++ b/pkg/jobs/jobsprofiler/BUILD.bazel
@@ -24,6 +24,10 @@ go_test(
         "main_test.go",
         "profiler_test.go",
     ],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         ":jobsprofiler",
         "//pkg/base",


### PR DESCRIPTION
Closes #126093.

Epic: none
Release note: None