### PR TITLE
release-23.1: roachtest: unpin ubuntu version for asyncpg test

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 )
 
 const asyncpgRunTestCmd = `
@@ -171,7 +170,7 @@ func registerAsyncpg(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "asyncpg",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1, spec.CPU(16), spec.UbuntuVersion(vm.FocalFossa)),
+		Cluster:          r.MakeClusterSpec(1, spec.CPU(16)),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Leases:           registry.MetamorphicLeases,


### PR DESCRIPTION
This is needed so that the newer version of python can be installed.

fixes https://github.com/cockroachdb/cockroach/issues/126058
Release justification: test only change
Release note: None