### PR TITLE
sql: avoid slow lock verification in TestSchemaChangeAfterCreateInTxn

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4319,8 +4319,8 @@ SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20s'
 	// A large enough value that the backfills run as part of the
 	// schema change run in many chunks.
 	var maxValue = 4001
-	if util.RaceEnabled {
-		// Race builds are a lot slower, so use a smaller number of rows.
+	if util.RaceEnabled || syncutil.DeadlockEnabled {
+		// Race and deadlock builds are a lot slower, so use a smaller number of rows.
 		maxValue = 200
 	}
 


### PR DESCRIPTION
The addition of test-only verification pushed this test over the timeout sometimes, such that running it under the deadlock detector would cause spurious failures. We avoid this by making the test smaller under deadlock, like we do for race builds.

fixes https://github.com/cockroachdb/cockroach/issues/126075
Release justification: test only change
Release note: None