### PR TITLE
kvserver: release transport factory

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1349,6 +1349,7 @@ func (ds *DistSender) sendProxyRequest(
 	// We construct a replica slice containing only the leaseholder, since we're
 	// only going to contact this replica and try once.
 	transport := ds.transportFactory(opts, ReplicaSlice{{ReplicaDescriptor: ba.ProxyRangeInfo.Lease.Replica}})
+	defer transport.Release()
 
 	requestToSend := ba.ShallowCopy()
 	requestToSend.ProxyRangeInfo = nil


### PR DESCRIPTION
This change correctly releases the Transport created by the transport factory on proxy requests.

Release note: none