### PR TITLE
roachtest: wait for job to pause before resuming

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1853,6 +1853,19 @@ func (d *BackupRestoreTestDriver) runBackup(
 				continue
 			}
 
+			if err := testutils.SucceedsSoonError(func() error {
+				var status string
+				if err := pauseResumeDB.QueryRow(`SELECT status FROM [SHOW JOB $1]`, jobID).Scan(&status); err != nil {
+					return err
+				}
+				if status != "paused" {
+					return errors.Newf("expected status `paused` but found %s", status)
+				}
+				return nil
+			}); err != nil {
+				return backupCollection{}, "", err
+			}
+
 			time.Sleep(pauseDur)
 
 			l.Printf("resuming job %d", jobID)


### PR DESCRIPTION
Fixes #125921

Release note: none