### PR TITLE
sql: remove unnecessary `convertNodeOrdinalsToInts` function

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2291,7 +2291,7 @@ type aggregatorPlanningInfo struct {
 	aggregations             []execinfrapb.AggregatorSpec_Aggregation
 	argumentsColumnTypes     [][]*types.T
 	isScalar                 bool
-	groupCols                []int
+	groupCols                []exec.NodeColumnOrdinal
 	groupColOrdering         colinfo.ColumnOrdering
 	inputMergeOrdering       execinfrapb.Ordering
 	reqOrdering              ReqOrdering
@@ -2757,7 +2757,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 				intermediateTypes = append(intermediateTypes, inputTypes[groupColIdx])
 			}
 			finalGroupCols[i] = uint32(idx)
-			if orderedGroupColSet.Contains(info.groupCols[i]) {
+			if orderedGroupColSet.Contains(int(info.groupCols[i])) {
 				finalOrderedGroupCols = append(finalOrderedGroupCols, uint32(idx))
 			}
 		}
@@ -2769,7 +2769,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 			// Find the group column.
 			found := false
 			for j, col := range info.groupCols {
-				if col == o.ColIdx {
+				if int(col) == o.ColIdx {
 					ordCols[i].ColIdx = finalGroupCols[j]
 					found = true
 					break

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -546,7 +546,7 @@ func (e *distSQLSpecExecFactory) constructAggregators(
 			aggregations:         aggregationSpecs,
 			argumentsColumnTypes: argumentsColumnTypes,
 			isScalar:             isScalar,
-			groupCols:            convertNodeOrdinalsToInts(groupCols),
+			groupCols:            groupCols,
 			groupColOrdering:     groupColOrdering,
 			inputMergeOrdering:   physPlan.MergeOrdering,
 			reqOrdering:          ReqOrdering(reqOrdering),

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -233,16 +233,6 @@ func getResultColumnsForGroupBy(
 	return columns
 }
 
-// convertNodeOrdinalsToInts converts a slice of exec.NodeColumnOrdinals to a slice
-// of ints.
-func convertNodeOrdinalsToInts(ordinals []exec.NodeColumnOrdinal) []int {
-	ints := make([]int, len(ordinals))
-	for i := range ordinals {
-		ints[i] = int(ordinals[i])
-	}
-	return ints
-}
-
 func constructVirtualScan(
 	ef exec.Factory,
 	p *planner,

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -27,7 +28,7 @@ type groupNode struct {
 	plan planNode
 
 	// Indices of the group by columns in the source plan.
-	groupCols []int
+	groupCols []exec.NodeColumnOrdinal
 
 	// Set when we have an input ordering on (a subset of) grouping columns. Only
 	// column indices in groupCols can appear in this ordering.
@@ -68,7 +69,7 @@ type aggregateFuncHolder struct {
 	funcName string
 	// The argument of the function is a single value produced by the renderNode
 	// underneath. If the function has no argument (COUNT_ROWS), it is empty.
-	argRenderIdxs []int
+	argRenderIdxs []exec.NodeColumnOrdinal
 	// If there is a filter, the result is a single value produced by the
 	// renderNode underneath. If there is no filter, it is set to
 	// tree.NoColumnIdx.
@@ -92,7 +93,7 @@ type aggregateFuncHolder struct {
 // argRenderIdx is noRenderIdx.
 func newAggregateFuncHolder(
 	funcName string,
-	argRenderIdxs []int,
+	argRenderIdxs []exec.NodeColumnOrdinal,
 	arguments tree.Datums,
 	isDistinct bool,
 	distsqlBlocklist bool,

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -509,7 +509,7 @@ func (ef *execFactory) ConstructGroupBy(
 		plan:              inputPlan,
 		funcs:             make([]*aggregateFuncHolder, 0, len(groupCols)+len(aggregations)),
 		columns:           getResultColumnsForGroupBy(inputCols, groupCols, aggregations),
-		groupCols:         convertNodeOrdinalsToInts(groupCols),
+		groupCols:         groupCols,
 		groupColOrdering:  groupColOrdering,
 		isScalar:          false,
 		reqOrdering:       ReqOrdering(reqOrdering),
@@ -519,7 +519,7 @@ func (ef *execFactory) ConstructGroupBy(
 		// TODO(radu): only generate the grouping columns we actually need.
 		f := newAggregateFuncHolder(
 			builtins.AnyNotNull,
-			[]int{col},
+			[]exec.NodeColumnOrdinal{col},
 			nil,   /* arguments */
 			false, /* isDistinct */
 			false, /* distsqlBlocklist */
@@ -535,11 +535,10 @@ func (ef *execFactory) ConstructGroupBy(
 func (ef *execFactory) addAggregations(n *groupNode, aggregations []exec.AggInfo) error {
 	for i := range aggregations {
 		agg := &aggregations[i]
-		renderIdxs := convertNodeOrdinalsToInts(agg.ArgCols)
 
 		f := newAggregateFuncHolder(
 			agg.FuncName,
-			renderIdxs,
+			agg.ArgCols,
 			agg.ConstArgs,
 			agg.Distinct,
 			agg.DistsqlBlocklist,


### PR DESCRIPTION
This function converted a slice of `exec.NodeColumnOrdinal`s to a slice
of `int`s. There was no reason to make this conversion. Removing it
reduces allocations.

Epic: None

Release note: None
