### PR TITLE
stmtdiagnostics: fix the test in an edge case

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -163,15 +163,16 @@ func TestDiagnosticsRequest(t *testing.T) {
 		require.NoError(t, err)
 		checkNotCompleted(reqID)
 
-		// Set the statement timeout (as well as clean it up in a defer).
+		// Set the statement timeout.
 		runner.Exec(t, "SET statement_timeout = '100ms';")
-		defer func() {
-			runner.Exec(t, "RESET statement_timeout;")
-		}()
 
 		// Run the query that times out.
 		_, err = db.Exec("SELECT pg_sleep(999999)")
 		require.True(t, strings.Contains(err.Error(), sqlerrors.QueryTimeoutError.Error()))
+
+		// Reset the stmt timeout so that it doesn't affect the query in
+		// checkCompleted.
+		runner.Exec(t, "RESET statement_timeout;")
 		checkCompleted(reqID)
 	})
 


### PR DESCRIPTION
We previously reset the stmt timeout after executing the query that checks that the request is completed, so in an edge case that query could've timed out producing a test flake.

Fixes: #126132.

Release note: None