### PR TITLE
release-24.1: log: use httptest for http sink tests

### DIFF
--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -175,7 +175,6 @@ go_test(
         "//pkg/util/log/logconfig",
         "//pkg/util/log/logpb",
         "//pkg/util/log/severity",
-        "//pkg/util/netutil/addr",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",


### PR DESCRIPTION
Backport 1/1 commits from #125873.

/cc @cockroachdb/release

---

Previously, we had a custom test server using a raw tcp connection. This server would cause occasional flakes and has been replaced with a standard test HTTP server to more reliably mimic an HTTP sink

The hung server test is also amended to use a waitGroup and also check
if we log too quickly since that would mean we didn't hang at all.

Resolves: https://github.com/cockroachdb/cockroach/issues/125753
Resolves: https://github.com/cockroachdb/cockroach/issues/125725
Resolves: https://github.com/cockroachdb/cockroach/issues/125540
Resolves: https://github.com/cockroachdb/cockroach/issues/125466
Resolves: https://github.com/cockroachdb/cockroach/issues/125389
Resolves: https://github.com/cockroachdb/cockroach/issues/125358
Resolves: https://github.com/cockroachdb/cockroach/issues/125005
Resolves: https://github.com/cockroachdb/cockroach/issues/124973
Resolves: https://github.com/cockroachdb/cockroach/issues/124642
Resolves: https://github.com/cockroachdb/cockroach/issues/124596

Release note: None

----

Release justification: test-only deflaking