### PR TITLE
release-23.1: execinfrapb: truncate ChangeAggregator spans in diagram

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",
         "//pkg/sql",

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -574,9 +574,23 @@ func (w *WindowerSpec) summary() (string, []string) {
 
 // summary implements the diagramCellType interface.
 func (s *ChangeAggregatorSpec) summary() (string, []string) {
-	var details []string
-	for _, watch := range s.Watches {
-		details = append(details, watch.Span.String())
+	var spanStr strings.Builder
+	if len(s.Watches) > 0 {
+		spanStr.WriteString(fmt.Sprintf("Watches [%d]: ", len(s.Watches)))
+		const limit = 3
+		for i := 0; i < len(s.Watches) && i < limit; i++ {
+			if i > 0 {
+				spanStr.WriteString(", ")
+			}
+			spanStr.WriteString(s.Watches[i].Span.String())
+		}
+		if len(s.Watches) > limit {
+			spanStr.WriteString("...")
+		}
+	}
+
+	details := []string{
+		spanStr.String(),
 	}
 	return "ChangeAggregator", details
 }

--- a/pkg/sql/plpgsql/parser/BUILD.bazel
+++ b/pkg/sql/plpgsql/parser/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/sql/parser",
         "//pkg/sql/parser/statements",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
Backport 1/1 commits from #114263.

/cc @cockroachdb/release

---

This change truncates the spans printined in the DistSQL diagram of a ChangeAggregator. This ensures that the encoded diagrams don't grow linearly with the number of spans that are being watched by a changefeed.

Fixes: #114248
Release note: None

---
Release justification: low risk change to prevent blow up of row size in the job_info table
