### PR TITLE
sql: start internal executor goroutine via stopper

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -956,7 +956,11 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 
 	storageEngineClient := kvserver.NewStorageEngineClient(cfg.kvNodeDialer)
 	*execCfg = sql.ExecutorConfig{
-		Settings:                cfg.Settings,
+		Settings: cfg.Settings,
+		// TODO(yuzefovich): I think cfg.stopper doesn't use the Tracer option.
+		// Investigate whether it's important (it's probably created in
+		// setupAndInitializeLoggingAndProfiling).
+		Stopper:                 cfg.stopper,
 		NodeInfo:                nodeInfo,
 		Codec:                   codec,
 		DefaultZoneConfig:       &cfg.DefaultZoneConfig,

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -254,8 +254,8 @@ func constructVirtualScan(
 	}
 	idx := index.(*optVirtualIndex).idx
 	columns, constructor := virtual.getPlanInfo(
-		table.(*optVirtualTable).desc,
-		idx, params.IndexConstraint, p.execCfg.DistSQLPlanner.stopper)
+		table.(*optVirtualTable).desc, idx, params.IndexConstraint, p.execCfg.Stopper,
+	)
 
 	n, err := delayedNodeCallback(&delayedNode{
 		name:            fmt.Sprintf("%s@%s", table.Name(), index.Name()),

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -119,6 +119,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -1241,6 +1242,7 @@ func EmptySystemTenantOnly[T any]() SystemTenantOnly[T] {
 // an Executor; the rest will have sane defaults set if omitted.
 type ExecutorConfig struct {
 	Settings          *cluster.Settings
+	Stopper           *stop.Stopper
 	NodeInfo          NodeInfo
 	Codec             keys.SQLCodec
 	DefaultZoneConfig *zonepb.ZoneConfig

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -46,8 +46,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -212,6 +212,7 @@ var ieRowsAffectedRetryLimit = settings.RegisterIntSetting(
 
 func (ie *InternalExecutor) runWithEx(
 	ctx context.Context,
+	opName string,
 	txn *kv.Txn,
 	w ieResultWriter,
 	mode ieExecutionMode,
@@ -227,24 +228,39 @@ func (ie *InternalExecutor) runWithEx(
 		return err
 	}
 	wg.Add(1)
-	go func() {
-		if err := ex.run(
-			ctx,
-			ie.mon,
-			&mon.BoundAccount{}, /*reserved*/
-			nil,                 /* cancel */
-		); err != nil {
-			sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
-			errCallback(err)
-		}
-		w.finish()
+	cleanup := func() {
 		closeMode := normalClose
 		if txn != nil {
 			closeMode = externalTxnClose
 		}
 		ex.close(ctx, closeMode)
 		wg.Done()
-	}()
+	}
+	if err = ie.s.cfg.Stopper.RunAsyncTaskEx(
+		ctx,
+		stop.TaskOpts{
+			TaskName: opName,
+			SpanOpt:  stop.ChildSpan,
+		},
+		func(ctx context.Context) {
+			defer cleanup()
+			if err := ex.run(
+				ctx,
+				ie.mon,
+				&mon.BoundAccount{}, /*reserved*/
+				nil,                 /* cancel */
+			); err != nil {
+				sqltelemetry.RecordError(ctx, err, &ex.server.cfg.Settings.SV)
+				errCallback(err)
+			}
+			w.finish()
+		},
+	); err != nil {
+		// The goroutine wasn't started, so we need to perform the cleanup
+		// ourselves.
+		cleanup()
+		return err
+	}
 	return nil
 }
 
@@ -507,9 +523,6 @@ type rowsIterator struct {
 
 	// wg can be used to wait for the connExecutor's goroutine to exit.
 	wg *sync.WaitGroup
-
-	// sp will finished on Close().
-	sp *tracing.Span
 }
 
 var _ isql.Rows = &rowsIterator{}
@@ -614,18 +627,11 @@ func (r *rowsIterator) RowsAffected() int {
 }
 
 func (r *rowsIterator) Close() error {
+	// Ensure that we wait for the connExecutor goroutine to exit.
+	defer r.wg.Wait()
 	// Closing the stmtBuf will tell the connExecutor to stop executing commands
 	// (if it hasn't exited yet).
 	r.stmtBuf.Close()
-	// We need to finish the span but only after the connExecutor goroutine is
-	// done.
-	defer func() {
-		if r.sp != nil {
-			r.wg.Wait()
-			r.sp.Finish()
-			r.sp = nil
-		}
-	}()
 	// Close the ieResultReader to tell the writer that we're done.
 	if err := r.r.close(); err != nil && r.lastErr == nil {
 		r.lastErr = err
@@ -1183,11 +1189,6 @@ func (ie *InternalExecutor) execInternal(
 		ie.extraTxnState.descCollection.SetDescriptorSessionDataProvider(p)
 	}
 
-	// The returned span is finished by this function in all error paths, but if
-	// an iterator is returned, then we transfer the responsibility of closing
-	// the span to the iterator. This is necessary so that the connExecutor
-	// exits before the span is finished.
-	ctx, sp := tracing.EnsureChildSpan(ctx, ie.s.cfg.AmbientCtx.Tracer, opName)
 	numCommands := 2 // ExecStmt -> Sync
 	if len(qargs) > 0 {
 		numCommands = 4 // PrepareStmt -> BindStmt -> ExecPortal -> Sync
@@ -1209,7 +1210,6 @@ func (ie *InternalExecutor) execInternal(
 			}
 			stmtBuf.Close()
 			wg.Wait()
-			sp.Finish()
 		} else {
 			r.errCallback = func(err error) error {
 				if err != nil && !errIsRetriable(err) {
@@ -1217,7 +1217,6 @@ func (ie *InternalExecutor) execInternal(
 				}
 				return err
 			}
-			r.sp = sp
 		}
 	}()
 
@@ -1261,7 +1260,7 @@ func (ie *InternalExecutor) execInternal(
 	errCallback := func(err error) {
 		_ = rw.addResult(ctx, ieIteratorResult{err: err})
 	}
-	err = ie.runWithEx(ctx, txn, rw, mode, sd, stmtBuf, &wg, syncCallback, errCallback, attributeToUser)
+	err = ie.runWithEx(ctx, opName, txn, rw, mode, sd, stmtBuf, &wg, syncCallback, errCallback, attributeToUser)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -546,7 +546,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 					"cannot execute prepared %v statement",
 					planHook.name,
 				)
-			}, header, nil /* subplans */, p.execCfg.DistSQLPlanner.stopper), nil
+			}, header, nil /* subplans */, p.execCfg.Stopper), nil
 		}
 
 		if fn, header, subplans, avoidBuffering, err := planHook.fn(ctx, stmt, p); err != nil {
@@ -555,7 +555,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 			if avoidBuffering {
 				p.curPlan.avoidBuffering = true
 			}
-			return newHookFnNode(planHook.name, fn, header, subplans, p.execCfg.DistSQLPlanner.stopper), nil
+			return newHookFnNode(planHook.name, fn, header, subplans, p.execCfg.Stopper), nil
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
This commit is similar in spirit to 1883e36738d2db7f634c8c853efaf62a47e9476e but applies the fix to the goroutine started for the connExecutor used by the internal executor. We just saw a failure where we hit the "short-living non-stopped monitors" assertion on the server shutdown. It additionally explicitly stores the stopper reference in the ExecutorConfig and removes some references to it that were done via the DistSQLPlanner.

Now that we start the goroutine via the stopper we no longer need to explicitly create a tracing span (it is done implicitly by the stopper), so we can remove some of the tracing logic from the internal executor code. There is a caveat though that IIUC we won't use the tracer from the `AmbientCtx` like we used to - I'm not sure what the impact of that is (we do use the same stopper all over the place, so I'm guessing it's ok).

Fixes: #126002.

Release note: None