### PR TITLE
perf: leverage insert-start flag in ycsb init

### DIFF
--- a/pkg/workload/ycsb/ycsb.go
+++ b/pkg/workload/ycsb/ycsb.go
@@ -388,7 +388,7 @@ func (g *ycsb) Tables() []workload.Table {
 				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
 					rowOffset := rowIdx - rowBegin
 
-					key.Set(rowOffset, []byte(w.buildKeyName(uint64(rowIdx))))
+					key.Set(rowOffset, []byte(w.buildKeyName(uint64(g.insertStart+rowIdx))))
 
 					for i := range fields {
 						randStringLetters(rng, tmpbuf[:])


### PR DESCRIPTION
The ycsb workload has the ability to bias key values based on a supplied --insert-start flag. When provided, all key indexes will be added after the insert-start point. Until now however, this flag wasn't properly plumbed into the init path and was only used during workload run.

This commit plumbs the flag into the init path, so that it can be used to seed databases with different row sets during database creation.

Epic: none
Release note: none