### PR TITLE
ui: fix database index usage page error

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -177,6 +177,7 @@ type Statistics = {
   rowsWritten: NumericStat;
   runLat: NumericStat;
   svcLat: NumericStat;
+  regions: string[];
 };
 
 type ExecStats = {
@@ -262,6 +263,7 @@ export function convertStatementRawFormatToAggregatedStatistics(
       run_lat: s.statistics.statistics.runLat,
       service_lat: s.statistics.statistics.svcLat,
       sql_type: s.metadata.stmtType,
+      regions: s.statistics.statistics.regions,
     },
   };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/testUtils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/api/testUtils.tsx
@@ -121,6 +121,8 @@ const baseStmt: Partial<Stmt> = {
     plan_gists: ["AgFUBAAgAAAABgI="],
     indexes: ["123@456"],
     index_recommendations: [],
+    regions: ["gcp-us-east1", "gcp-us-west1"],
+    nodes: [Long.fromNumber(1)],
   },
 };
 


### PR DESCRIPTION
For serverless customers, the database index usage page was broken and wouldn't load. This was occuring due to the expectation of region data in the `AggregationStatistics.stats` field which wasn't properly being set.

Now, region data is correctly being set in `AggregationStatistics.stats`

Fixes: #126037
Release note: None