### PR TITLE
logical: fix double counting in metrics on txn retries

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -583,6 +583,8 @@ func (t *txnBatch) HandleBatch(
 		}
 	} else {
 		err = t.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			// Reset the counter in case the txn was retried transparently.
+			stats.byteSize = 0
 			for _, kv := range batch {
 				stats.byteSize += kv.Size()
 				if err := t.rp.ProcessRow(ctx, txn, kv.KeyValue, kv.PrevValue); err != nil {


### PR DESCRIPTION
Previously, we would keep on incrementing `stats.byteSize` field inside of the `Txn` closure which would result in double-counting this metric in case of transparent retries, significantly inflating some metrics. This commit fixes the problem by resetting the field on each txn iteration.

Epic: None

Release note: None