### PR TITLE
release-23.2: pkg/cli: tsdump - fix custom SQL port behaviour

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -17,6 +17,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -78,10 +79,6 @@ will then convert it to the --format requested in the current invocation.
 			if convertFile != "" {
 				return errors.Errorf("input file is already in raw format")
 			}
-			err := createYAML(ctx)
-			if err != nil {
-				return err
-			}
 
 			// Special case, we don't go through the text output code.
 		case tsDumpCSV:
@@ -129,6 +126,23 @@ will then convert it to the --format requested in the current invocation.
 				// be writing potentially a lot of data to it.
 				w := bufio.NewWriter(os.Stdout)
 				if err := tsutil.DumpRawTo(stream, w); err != nil {
+					return err
+				}
+
+				// get the node details so that we can get the SQL port
+				resp, err := serverpb.NewStatusClient(conn).Details(ctx, &serverpb.DetailsRequest{NodeId: "local"})
+				if err != nil {
+					return err
+				}
+
+				// override the server port with the SQL port taken from the DetailsResponse
+				// this port should be used to make the SQL connection
+				cliCtx.clientOpts.ServerHost, cliCtx.clientOpts.ServerPort, err = net.SplitHostPort(resp.SQLAddress.String())
+				if err != nil {
+					return err
+				}
+
+				if err = createYAML(ctx); err != nil {
 					return err
 				}
 				return w.Flush()
@@ -210,7 +224,8 @@ type openMetricsWriter struct {
 	labels map[string]string
 }
 
-// createYAML generates and writes tsdump.yaml to default /tmp or to a specified path
+// createYAML generates and writes tsdump.yaml to default /tmp or to a specified path.
+// This file is used for staging the tsdump data into a local database for debugging
 func createYAML(ctx context.Context) (resErr error) {
 	file, err := os.OpenFile(debugTimeSeriesDumpOpts.yaml, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #125626.

/cc @cockroachdb/release

---

When CRDB is running with a custom gRPC and SQL port, users have the option to provide the gRPC address using the `--host` flag. An option for providing the custom SQL address is the `--url`. But, tsdump doesn't seem to be using the address provided as part of `--url`.

This commit fixes that. When the `--host` flag is provided, we can connect to the gRPC server and get the Node Details. This will give us the SQL address. So, there is no need for the user to specify the SQL port separately at all. This is how it's handled in the `debug zip` command. Since `debug zip` and `tsdump` are often used together, it's important to have a consistent behaviour across both of them.

<details>
<summary>Screenshot of old and new behaviour</summary>
<br>

![image](https://github.com/cockroachdb/cockroach/assets/11977524/053ad7df-425c-4302-9549-2a9bc98875b2)

</details>

---

Part of: CRDB-39382
Fixes: #125315
Release note (bug fix): Fix the bug in tsdump where the command fails when a custom SQL port is used and the `--format=raw` flag is provided

---

Release justification: This commit fixes the bug reported in #125315. This bug is seen in `23.2` and `24.1`. Hence this back port is required.
