### PR TITLE
workload: reset w_ytd and d_ytd periodically for long running workload

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -140,6 +140,7 @@ func init() {
 			var genFlags *pflag.FlagSet
 			if f, ok := gen.(workload.Flagser); ok {
 				genFlags = f.Flags().FlagSet
+				gen.(workload.Flagser).Flags().AddFlag(runFlags.Lookup("duration"))
 			}
 
 			genRunCmd := SetCmdDefaults(&cobra.Command{

--- a/pkg/workload/tpcc/checks.go
+++ b/pkg/workload/tpcc/checks.go
@@ -28,29 +28,31 @@ type Check struct {
 	// If true, the check is only valid immediately after loading the dataset.
 	// The check may fail if run after the workload.
 	LoadOnly bool
+	// If true, the check can be skipped for long duration workloads.
+	SkipForLongDuration bool
 }
 
 // AllChecks returns a slice of all of the checks.
 func AllChecks() []Check {
 	return []Check{
-		{"3.3.2.1", check3321, false, false},
-		{"3.3.2.2", check3322, false, false},
-		{"3.3.2.3", check3323, false, false},
-		{"3.3.2.4", check3324, false, false},
-		{"3.3.2.5", check3325, false, false},
-		{"3.3.2.6", check3326, true, false},
-		{"3.3.2.7", check3327, false, false},
-		{"3.3.2.8", check3328, false, false},
-		{"3.3.2.9", check3329, false, false},
-		{"3.3.2.10", check33210, true, false},
+		{Name: "3.3.2.1", Fn: check3321, SkipForLongDuration: true},
+		{Name: "3.3.2.2", Fn: check3322},
+		{Name: "3.3.2.3", Fn: check3323},
+		{Name: "3.3.2.4", Fn: check3324},
+		{Name: "3.3.2.5", Fn: check3325},
+		{Name: "3.3.2.6", Fn: check3326, Expensive: true},
+		{Name: "3.3.2.7", Fn: check3327},
+		{Name: "3.3.2.8", Fn: check3328, SkipForLongDuration: true},
+		{Name: "3.3.2.9", Fn: check3329, SkipForLongDuration: true},
+		{Name: "3.3.2.10", Fn: check33210, Expensive: true},
 		// 3.3.2.11 is LoadOnly. It asserts a relationship between the number of
 		// rows in the "order" table and rows in the "new_order" table. Rows are
 		// inserted into these tables transactional by the NewOrder transaction.
 		// However, only rows in the "new_order" table are deleted by the Delivery
 		// transaction. Consequently, the consistency condition will fail after the
 		// first Delivery transaction is run by the workload.
-		{"3.3.2.11", check33211, false, true},
-		{"3.3.2.12", check33212, true, false},
+		{Name: "3.3.2.11", Fn: check33211, LoadOnly: true},
+		{Name: "3.3.2.12", Fn: check33212, Expensive: true},
 	}
 }
 

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
@@ -80,6 +81,8 @@ type payment struct {
 	selectByLastName  workload.StmtHandle
 	updateWithPayment workload.StmtHandle
 	insertHistory     workload.StmtHandle
+	resetWarehouse    workload.StmtHandle
+	resetDistrict     workload.StmtHandle
 
 	a bufalloc.ByteAllocator
 }
@@ -140,11 +143,69 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 	)
 
+	if p.config.isLongDurationWorkload {
+		p.resetWarehouse = p.sr.Define(`
+		UPDATE warehouse
+		SET w_ytd = $1
+		WHERE w_id >= $2 AND w_id < $3`,
+		)
+
+		p.resetDistrict = p.sr.Define(`
+		UPDATE district
+		SET d_ytd = $1
+		WHERE d_w_id >= $2 AND d_w_id < $3`,
+		)
+
+		// Starting the background goroutine which will reset the w_ytd values periodically in warehouseWytdResetPeriod
+		go p.startResetValueWorker(ctx)
+	}
+
 	if err := p.sr.Init(ctx, "payment", mcp); err != nil {
 		return nil, err
 	}
 
 	return p, nil
+}
+
+func (p *payment) startResetValueWorker(ctx context.Context) {
+	ticker := time.NewTicker(warehouseWytdResetPeriod)
+	defer ticker.Stop()
+
+	p.config.resetTableWg.Add(1)
+	defer p.config.resetTableWg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+
+			// Creating batches of maxRowsToUpdateTxn to avoid long-running txns
+			for startRange := 0; startRange < p.config.warehouses; startRange += maxRowsToUpdateTxn {
+				endRange := min(p.config.warehouses, startRange+maxRowsToUpdateTxn)
+
+				if _, err := p.config.executeTx(
+					ctx, p.mcp.Get(),
+					func(tx pgx.Tx) error {
+						if _, err := p.resetWarehouse.ExecTx(
+							ctx, tx, wYtd, startRange, endRange,
+						); err != nil {
+							return errors.Wrap(err, "reset warehouse failed")
+						}
+
+						if _, err := p.resetDistrict.ExecTx(
+							ctx, tx, ytd, startRange, endRange,
+						); err != nil {
+							return errors.Wrap(err, "reset district failed")
+						}
+
+						return nil
+					}); err != nil {
+					log.Errorf(ctx, "%v", err)
+				}
+			}
+		}
+	}
 }
 
 func (p *payment) run(ctx context.Context, wID int) (interface{}, time.Duration, error) {
@@ -192,6 +253,7 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, time.Duration,
 		ctx, p.mcp.Get(),
 		func(tx pgx.Tx) error {
 			var wName, dName string
+
 			// Update warehouse with payment
 			if err := p.updateWarehouse.QueryRowTx(
 				ctx, tx, d.hAmount, wID,


### PR DESCRIPTION
Fixes: #124259

Release note: None

The tpc-c workload used to fail when ran for a long period of time with the following error:

```
 workload/cli/run.go:569  [-] 1622  error in payment: update warehouse failed: ERROR: type DECIMAL(12,2): value with precision 12, scale 2 must round to an absolute value less than 10^10 (SQLSTATE 22003)
```
The solution is to reset the `w-ytd` column in the `warehouse` table after every 24 hours period if we run the workload with `duration=0` or `duration>=4d`. Since `d_ytd` also has a similar schema, this PR also does the similar reset in `district` table. 

Due to resetting the column values periodically, this change also disables 3 consistency checks for a long duration workload which involves `w_ytd` and `d_ytd`
