### PR TITLE
release-23.1: sql: CREATE TABLE can fail on txn retries

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -268,11 +268,17 @@ func (n *alterTableNode) startExec(params runParams) error {
 					return err
 				}
 
+				// We are going to modify the AST to replace any index expressions with
+				// virtual columns. If the txn ends up retrying, then this change is not
+				// syntactically valid, since the virtual column is only added in the descriptor
+				// and not in the AST.
+				columns := make(tree.IndexElemList, len(d.Columns))
+				copy(columns, d.Columns)
 				if err := replaceExpressionElemsWithVirtualCols(
 					params.ctx,
 					n.tableDesc,
 					tableName,
-					d.Columns,
+					columns,
 					false, /* isInverted */
 					false, /* isNewTable */
 					params.p.SemaCtx(),
@@ -282,7 +288,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 				// Check if the columns exist on the table.
-				for _, column := range d.Columns {
+				for _, column := range columns {
 					if column.Expr != nil {
 						return pgerror.New(
 							pgcode.InvalidTableDefinition,
@@ -301,7 +307,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					StoreColumnNames: d.Storing.ToStrings(),
 					CreatedAtNanos:   params.EvalContext().GetTxnTimestamp(time.Microsecond).UnixNano(),
 				}
-				if err := idx.FillColumns(d.Columns); err != nil {
+				if err := idx.FillColumns(columns); err != nil {
 					return err
 				}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1760,6 +1760,17 @@ func NewTableDesc(
 		return newColumns, nil
 	}
 
+	// Copies the index elements, and returns a closure to restore them back,
+	// so that any mutation to the AST is undone once this statement completes.
+	copyIndexElemListAndRestore := func(existingList *tree.IndexElemList) func() {
+		newList := make(tree.IndexElemList, len(*existingList))
+		copy(newList, *existingList)
+		restoreList := *existingList
+		*existingList = newList
+		return func() {
+			*existingList = restoreList
+		}
+	}
 	// Now that we have all the other columns set up, we can validate
 	// any computed columns.
 	for _, def := range n.Defs {
@@ -1798,6 +1809,11 @@ func NewTableDesc(
 			if err := validateColumnsAreAccessible(&desc, d.Columns); err != nil {
 				return nil, err
 			}
+			// We are going to modify the AST to replace any index expressions with
+			// virtual columns. If the txn ends up retrying, then this change is not
+			// syntactically valid, since the virtual column is only added in the descriptor
+			// and not in the AST.
+			defer copyIndexElemListAndRestore(&d.Columns)()
 			if err := replaceExpressionElemsWithVirtualCols(
 				ctx,
 				&desc,
@@ -1912,6 +1928,11 @@ func NewTableDesc(
 			if err := validateColumnsAreAccessible(&desc, d.Columns); err != nil {
 				return nil, err
 			}
+			// We are going to modify the AST to replace any index expressions with
+			// virtual columns. If the txn ends up retrying, then this change is not
+			// syntactically valid, since the virtual descriptor is only added in the descriptor
+			// and not in the AST.
+			defer copyIndexElemListAndRestore(&d.Columns)()
 			if err := replaceExpressionElemsWithVirtualCols(
 				ctx,
 				&desc,

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1039,3 +1039,19 @@ public  generated_by_default_t_notnull_b_seq     INT8
 public  generated_always_t_notnull_b_seq         INT8
 public  generated_by_default_t_b_seq             INT8
 public  generated_always_t_b_seq                 INT8
+
+subtest 125619
+
+statement ok
+SET inject_retry_errors_enabled=true
+
+statement ok
+CREATE TABLE t_125619 (i INT8, j INT8, INDEX ((i + j)));
+
+statement ok
+ALTER TABLE t_125619 ADD CONSTRAINT uni UNIQUE ((i + j + i))
+
+statement ok
+SET inject_retry_errors_enabled=false
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #125910.

/cc @cockroachdb/release

---

Previously, when a CREATE TABLE definition included an index expression,
we modified the original abstract syntax tree (AST) to have the index
reference a new virtual column for the expression. However, if a
transaction retry occurred, this AST modification was not handled
correctly because the new virtual column was not public. To resolve
this, this patch ensures that the index element nodes are copied before
any changes are made.

Fixes: #125619

Release note (bug fix): CREATE TABLE with index expressions could hit
undefined column errors on transaction retries
Release justification: low risk fix for an issue that can lead to intermittent failure of CREATE TABLE when txn retries occur.
