### PR TITLE
release-23.2: sql: CREATE TABLE can fail on txn retries

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1776,6 +1776,17 @@ func NewTableDesc(
 		return newColumns, nil
 	}
 
+	// Copies the index elements, and returns a closure to restore them back,
+	// so that any mutation to the AST is undone once this statement completes.
+	copyIndexElemListAndRestore := func(existingList *tree.IndexElemList) func() {
+		newList := make(tree.IndexElemList, len(*existingList))
+		copy(newList, *existingList)
+		restoreList := *existingList
+		*existingList = newList
+		return func() {
+			*existingList = restoreList
+		}
+	}
 	// Now that we have all the other columns set up, we can validate
 	// any computed columns.
 	for _, def := range n.Defs {
@@ -1814,6 +1825,11 @@ func NewTableDesc(
 			if err := validateColumnsAreAccessible(&desc, d.Columns); err != nil {
 				return nil, err
 			}
+			// We are going to modify the AST to replace any index expressions with
+			// virtual columns. If the txn ends up retrying, then this change is not
+			// syntactically valid, since the virtual column is only added in the descriptor
+			// and not in the AST.
+			defer copyIndexElemListAndRestore(&d.Columns)()
 			if err := replaceExpressionElemsWithVirtualCols(
 				ctx,
 				&desc,
@@ -1933,6 +1949,11 @@ func NewTableDesc(
 			if err := validateColumnsAreAccessible(&desc, d.Columns); err != nil {
 				return nil, err
 			}
+			// We are going to modify the AST to replace any index expressions with
+			// virtual columns. If the txn ends up retrying, then this change is not
+			// syntactically valid, since the virtual descriptor is only added in the descriptor
+			// and not in the AST.
+			defer copyIndexElemListAndRestore(&d.Columns)()
 			if err := replaceExpressionElemsWithVirtualCols(
 				ctx,
 				&desc,

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1039,3 +1039,19 @@ public  generated_by_default_t_notnull_b_seq     INT8
 public  generated_always_t_notnull_b_seq         INT8
 public  generated_by_default_t_b_seq             INT8
 public  generated_always_t_b_seq                 INT8
+
+subtest 125619
+
+statement ok
+SET inject_retry_errors_enabled=true
+
+statement ok
+CREATE TABLE t_125619 (i INT8, j INT8, INDEX ((i + j)));
+
+statement ok
+ALTER TABLE t_125619 ADD CONSTRAINT uni UNIQUE ((i + j + i))
+
+statement ok
+SET inject_retry_errors_enabled=false
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #125910.

/cc @cockroachdb/release

---

Previously, when a CREATE TABLE definition included an index expression,
we modified the original abstract syntax tree (AST) to have the index
reference a new virtual column for the expression. However, if a
transaction retry occurred, this AST modification was not handled
correctly because the new virtual column was not public. To resolve
this, this patch ensures that the index element nodes are copied before
any changes are made.

Fixes: #125619

Release note (bug fix): CREATE TABLE with index expressions could hit
undefined column errors on transaction retries
Release justification: low risk fix for an issue that can lead to intermittent failure of CREATE TABLE when txn retries occur.
