### PR TITLE
streamClient: use seperate proto for SubscribtionToken encoding

### DIFF
--- a/pkg/ccl/crosscluster/producer/replication_stream_test.go
+++ b/pkg/ccl/crosscluster/producer/replication_stream_test.go
@@ -281,8 +281,8 @@ func TestReplicationStreamInitialization(t *testing.T) {
 
 		// Ensures the processor spec tracks the tenant span.
 		require.Equal(t, 1, len(spec.Partitions))
-		require.Equal(t, 1, len(spec.Partitions[0].PartitionSpec.Spans))
-		require.Equal(t, keys.MakeTenantSpan(srcTenant.ID), spec.Partitions[0].PartitionSpec.Spans[0])
+		require.Equal(t, 1, len(spec.Partitions[0].SourcePartition.Spans))
+		require.Equal(t, keys.MakeTenantSpan(srcTenant.ID), spec.Partitions[0].SourcePartition.Spans[0])
 	})
 
 	t.Run("nonexistent-replication-stream-has-inactive-status", func(t *testing.T) {

--- a/pkg/ccl/crosscluster/producer/stream_lifetime.go
+++ b/pkg/ccl/crosscluster/producer/stream_lifetime.go
@@ -339,7 +339,7 @@ func buildReplicationStreamSpec(
 			NodeID:     roachpb.NodeID(sp.SQLInstanceID),
 			SQLAddress: nodeInfo.SQLAddress,
 			Locality:   nodeInfo.Locality,
-			PartitionSpec: &streampb.StreamPartitionSpec{
+			SourcePartition: &streampb.SourcePartition{
 				Spans: sp.Spans,
 			},
 		})

--- a/pkg/ccl/crosscluster/producer/stream_lifetime.go
+++ b/pkg/ccl/crosscluster/producer/stream_lifetime.go
@@ -341,9 +341,6 @@ func buildReplicationStreamSpec(
 			Locality:   nodeInfo.Locality,
 			PartitionSpec: &streampb.StreamPartitionSpec{
 				Spans: sp.Spans,
-				Config: streampb.StreamPartitionSpec_ExecutionConfig{
-					MinCheckpointFrequency: crosscluster.StreamReplicationMinCheckpointFrequency.Get(&evalCtx.Settings.SV),
-				},
 			},
 		})
 	}

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -92,7 +92,8 @@ message ReplicationProducerRequest {
   repeated string table_names = 4;
 }
 
-// StreamPartitionSpec is the stream partition specification.
+// StreamPartitionSpec is the stream partition specification used to init an
+// eventStream.
 message StreamPartitionSpec {
   // PreviousReplicatedTimestamp specifies the timestamp from which spans will
   // start ingesting data in the replication job. This timestamp is empty unless
@@ -165,6 +166,15 @@ message LogicalReplicationPlanRequest {
     util.hlc.Timestamp plan_as_of = 2 [(gogoproto.nullable) = false];
 }
 
+// SourcePartition contains per partition information for a replication plan.
+message SourcePartition {
+  // To maintain compatibility with the StreamPartitionSpec proto, reserve all
+  // wire types it uses.
+  reserved 1, 3, 4, 5, 6, 7, 8, 9, 10, 11;
+  // List of spans to stream.
+  repeated roachpb.Span spans = 2 [(gogoproto.nullable) = false];
+}
+
 message ReplicationStreamSpec {
   message Partition {
     // ID of the node this partition resides
@@ -178,8 +188,7 @@ message ReplicationStreamSpec {
     // Locality of the node
     roachpb.Locality locality = 3 [(gogoproto.nullable) = false];
 
-    // The spec of the processor responsible for streaming this partition
-    StreamPartitionSpec partition_spec = 4 [(gogoproto.customname) = "PartitionSpec"];
+    SourcePartition source_partition = 4; 
   }
 
   repeated Partition partitions = 1 [(gogoproto.nullable) = false];


### PR DESCRIPTION
Previously, the streamClient would encode a StreamPartitionSpec into a
SubscriptionToken during PlanLogicalReplication and PlanPhysicalReplication.
This didn't make much sense since the Spans field in the StreamPartitionSpec
was the only field necessary to encode in the token, as all other
StreamPartitionSpec fields were set during streamClient.Subscribe.

This patch creates a new PlannedPartition proto that streamClient will use to
encode the subscriptionToken. During Subscribe() then, the client creates a new
partionSpec using the token.

Epic: none

Release note: none