### PR TITLE
sql/row: reduce allocated bytes in joinerbase

### DIFF
--- a/pkg/sql/catalog/descpb/join_type.go
+++ b/pkg/sql/catalog/descpb/join_type.go
@@ -116,15 +116,15 @@ func (j JoinType) MakeOutputTypesWithContinuationColumn(left, right []*types.T) 
 
 func (j JoinType) makeOutputTypes(left, right []*types.T, continuationCol bool) []*types.T {
 	numOutputTypes := 0
-	if continuationCol {
-		// Add 1 to account for the continuation column.
-		numOutputTypes++
-	}
 	if j.ShouldIncludeLeftColsInOutput() {
 		numOutputTypes += len(left)
 	}
 	if j.ShouldIncludeRightColsInOutput() {
 		numOutputTypes += len(right)
+	}
+	if continuationCol {
+		// Add 1 to account for the continuation column.
+		numOutputTypes++
 	}
 	outputTypes := make([]*types.T, 0, numOutputTypes)
 	if j.ShouldIncludeLeftColsInOutput() {


### PR DESCRIPTION
This commit removes the `emptyLeft` and `emptyRight` fields of
`joinerbase`. To render unmatched join rows, NULLs are copied into the
`combinedRow` field from a global array of length 16. The array is
copied into the slice multiple times if the number of output columns
exceeds 16. The size of 16 was chosen because it proved to perform well
compared to a single `copy` of a larger, pre-allocated slice (like how
`emptyLeft` and `emptyRight` were used before). See
https://gist.github.com/mgartner/84b68bf16ab46ea7c488eeba71eaa416.

Epic: None

Release note: None
