### PR TITLE
sqlccl: remove stale skip in a test

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -192,7 +192,6 @@ func TestExplainGist(t *testing.T) {
 			if err != nil && strings.Contains(err.Error(), "internal error") {
 				// Ignore all errors except the internal ones.
 				for _, knownErr := range []string{
-					"ALTER TABLE: failed to type check the cast of",     // #114316
 					"invalid datum type given: RECORD, expected RECORD", // #117101
 					"expected equivalence dependants to be its closure", // #119045
 				} {


### PR DESCRIPTION
The underlying issue was recently resolved.

Epic: None

Release note: None