### PR TITLE
release-23.1: util/log: add more information when log call exceeds deadline

### DIFF
--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -121,7 +121,8 @@ func testBase(
 	// to accommodate for the overhead of the logging call compared to
 	// the timeout in the HTTP request.
 	if deadline > 0 && logDuration > deadline {
-		t.Error("Log call exceeded timeout")
+		require.LessOrEqualf(t, logDuration, deadline,
+			"Log call exceeded timeout, expected to be less than %s, got %s", deadline.String(), logDuration.String())
 	}
 
 	// If we don't properly hang in the handler when we want to test a
@@ -192,7 +193,7 @@ func TestHTTPSinkTimeout(t *testing.T) {
 		},
 	}
 
-	testBase(t, defaults, nil /* testFn */, true /* hangServer */, 500*time.Millisecond)
+	testBase(t, defaults, nil /* testFn */, true /* hangServer */, 1*time.Second)
 }
 
 // TestHTTPSinkContentTypeJSON verifies that the HTTP sink content type


### PR DESCRIPTION
Backport 1/1 commits from #123130.

/cc @cockroachdb/release

---

For tests like `TestHTTSinkTimeout`, we want to verify that calls to hanging servers don't last much longer than the timeout configured for the http logging sink. Although this deadline is given a small bit of slack time, we've seen this test seemingly flake a couple of times. We should add more logging for when the log time exceeds the expected deadline to gather more information on if this is an actual bug.

Epic: none
Fixes: #122527

Release justification: test fix