### PR TITLE
build: update per-run timeouts for pebble meta tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
@@ -34,6 +34,6 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- \
                                       --test_env TC_SERVER_URL=$TC_SERVER_URL \
                                       --test_timeout=25200 '--test_filter=TestMetaCrossVersion$' \
                                       --define gotags=bazel,invariants \
-                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -timeout 20m -stderr -p 1" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -timeout 60m -stderr -p 1" \
                                       $test_args \
                                       --test_output streamed

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -22,7 +22,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --c
                                       --test_timeout=14400 \
                                       --test_sharding_strategy=disabled \
                                       --define gotags=bazel,invariants \
-                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 40m -stderr -p 1" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 60m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \
                                       --test_arg -ops --test_arg "uniform:2000-5000" \
                                       --test_output streamed \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh
@@ -21,7 +21,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --c
                                       --test_env TC_SERVER_URL=$TC_SERVER_URL \
                                       --test_timeout=25200 '--test_filter=TestMetaTwoInstance$' \
                                       --define gotags=bazel,invariants \
-                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 20m -stderr -p 1" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 60m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \
                                       --test_arg -ops --test_arg "uniform:5000-10000" \
                                       --test_output streamed \


### PR DESCRIPTION
In #125892 the per-run timeout of the main meta test was bumped to
60m. This commit makes the same change on the other meta test
variants.

Fixes https://github.com/cockroachdb/pebble/issues/3686
Release note: None