### PR TITLE
crosscluster: implement dlq client

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "logical",
     srcs = [
         "create_logical_replication_stmt.go",
+        "dead_letter_queue.go",
         "logical_replication_dist.go",
         "logical_replication_job.go",
         "logical_replication_writer_processor.go",
@@ -77,6 +78,7 @@ go_library(
 go_test(
     name = "logical_test",
     srcs = [
+        "dead_letter_queue_test.go",
         "logical_replication_job_test.go",
         "lww_row_processor_test.go",
         "main_test.go",
@@ -86,12 +88,15 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/ccl/changefeedccl/cdcevent",
+        "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/crosscluster/replicationtestutils",
         "//pkg/ccl/storageccl",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/ccl/crosscluster/logical/dead_letter_queue.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue.go
@@ -1,0 +1,112 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package logical
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// TODO(azhu): Use WriteType as built-in database enum.
+type WriteType int
+
+const (
+	Insert WriteType = iota
+	Delete
+)
+
+func (t WriteType) String() string {
+	switch t {
+	case Insert:
+		return "Insert"
+	case Delete:
+		return "Delete"
+	default:
+		return fmt.Sprintf("Unrecognized WriteType(%d)", int(t))
+	}
+}
+
+type ConflictResolutionType int
+
+const (
+	Unresolved ConflictResolutionType = iota
+	ManuallyResolved
+	Applied
+	Ignored
+)
+
+type DeadLetterQueueClient interface {
+	Create() error
+
+	Log(
+		ctx context.Context,
+		ingestionJobID int64,
+		kv streampb.StreamEvent_KV,
+		cdcEventRow cdcevent.Row,
+		writeTimestamp hlc.Timestamp,
+		conflictReason string,
+	) error
+}
+
+type loggingDeadLetterQueueClient struct {
+}
+
+// TODO(azhu): Implement after V0.
+// In future iterations Create() should create a DLQ table in the database.
+func (dlq *loggingDeadLetterQueueClient) Create() error {
+	return nil
+}
+
+// TODO(azhu): Append complete log as rows to DLQ table.
+func (dlq *loggingDeadLetterQueueClient) Log(
+	ctx context.Context,
+	ingestionJobID int64,
+	kv streampb.StreamEvent_KV,
+	cdcEventRow cdcevent.Row,
+	writeTimestamp hlc.Timestamp,
+	conflictReason string,
+) error {
+	if !dlq.exists() {
+		return errors.New("dead letter queue table needs to be created before logs can be appended")
+	}
+
+	if !cdcEventRow.IsInitialized() {
+		return errors.New("cdc event row not initialized")
+	}
+
+	tableID := cdcEventRow.TableID
+	var writeType WriteType
+
+	if cdcEventRow.IsDeleted() {
+		writeType = Delete
+	} else {
+		writeType = Insert
+	}
+
+	// TODO(azhu): once we have the actual conflictReason passed in, replace DebugString() with conflictReason
+	log.Infof(ctx,
+		`ingestion_job_id: %d, \ntable_id: %d, \nwrite_timestamp: %d, \nwrite_type: %s,\nconflict_reason: %s`,
+		ingestionJobID, tableID, writeTimestamp, writeType, cdcEventRow.DebugString())
+	return nil
+}
+
+// TODO(azhu): verify that DLQ table exists.
+func (dlq *loggingDeadLetterQueueClient) exists() bool {
+	return true
+}
+
+func InitDeadLetterQueueClient() DeadLetterQueueClient {
+	return &loggingDeadLetterQueueClient{}
+}

--- a/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package logical
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggingDLQClient(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.ApplicationLayer()
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT)`)
+
+	tableDesc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), "foo")
+	familyDesc := &descpb.ColumnFamilyDescriptor{
+		ID:   descpb.FamilyID(1),
+		Name: "",
+	}
+
+	ed, err := cdcevent.NewEventDescriptor(tableDesc, familyDesc, false, false, hlc.Timestamp{})
+	require.NoError(t, err)
+
+	dlqClient := InitDeadLetterQueueClient()
+	require.NoError(t, dlqClient.Create())
+
+	type testCase struct {
+		name           string
+		expectedErrMsg string
+
+		jobID          int64
+		kv             streampb.StreamEvent_KV
+		cdcEventRow    cdcevent.Row
+		writeTimestamp hlc.Timestamp
+		conflictReason string
+	}
+
+	testCases := []testCase{
+		{
+			name:        "log conflict for query",
+			cdcEventRow: cdcevent.Row{EventDescriptor: ed},
+		},
+		{
+			name:           "expect error when given nil cdcEventRow",
+			expectedErrMsg: "cdc event row not initialized",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := dlqClient.Log(ctx, tc.jobID, tc.kv, tc.cdcEventRow, tc.writeTimestamp, tc.conflictReason)
+			if tc.expectedErrMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErrMsg)
+			}
+		})
+	}
+}

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -129,6 +129,11 @@ func (r *logicalReplicationResumer) ingest(
 	}
 	defer func() { _ = client.Close(ctx) }()
 
+	dlqClient := InitDeadLetterQueueClient()
+	if err := dlqClient.Create(); err != nil {
+		return errors.Wrap(err, "failed to create dead letter queue client")
+	}
+
 	asOf := replicatedTimeAtStart
 	if asOf.IsEmpty() {
 		asOf = payload.ReplicationStartTime

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -90,6 +90,8 @@ type logicalReplicationWriterProcessor struct {
 	logBufferEvery log.EveryN
 
 	debug streampb.DebugLogicalConsumerStatus
+
+	dlqClient DeadLetterQueueClient
 }
 
 var (
@@ -147,6 +149,7 @@ func newLogicalReplicationWriterProcessor(
 			StreamID:    streampb.StreamID(spec.StreamID),
 			ProcessorID: processorID,
 		},
+		dlqClient: InitDeadLetterQueueClient(),
 	}
 	if err := lrw.Init(ctx, lrw, post, logicalReplicationWriterResultType, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{


### PR DESCRIPTION
In this PR, we define the DLQ client interface and implement
the MVP version of `DeadLetterQueueClient`. The client gets
initialized in `logical_replication_writer_processor` and logs
conflict when an insert/delete query errors out. Currently,
`DeadLetterQueueClient` does not create a DLQ table and is only
responsible for logging LWW conflict info. In later iterations,
we should be appending the LWW conflict logs as rows to the DLQ
table.

Part of: https://cockroachlabs.atlassian.net/browse/DOC-10483

Epic: [CRDB-38992](https://cockroachlabs.atlassian.net/browse/CRDB-38992)

Release note: None