### PR TITLE
kvserver: filter events with remote originID before rangefeed publishing

### DIFF
--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -111,7 +111,8 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 		streams[i] = &noopStream{ctx: ctx}
 		futures[i] = &future.ErrorFuture{}
 		ok, _ := p.Register(span, hlc.MinTimestamp, nil,
-			withDiff, withFiltering, streams[i], nil, futures[i])
+			withDiff, withFiltering, false, /* withOmitRemote */
+			streams[i], nil, futures[i])
 		require.True(b, ok)
 	}
 
@@ -148,7 +149,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 			binary.BigEndian.PutUint32(key[len(prefix):], uint32(i))
 			ts := hlc.Timestamp{WallTime: int64(i + 1)}
 			logicalOps[i] = writeIntentOpWithKey(txnID, key, isolation.Serializable, ts)
-			logicalOps[b.N+i] = commitIntentOpWithKV(txnID, key, ts, value, false /* omitInRangefeeds */)
+			logicalOps[b.N+i] = commitIntentOpWithKV(txnID, key, ts, value, false /* omitInRangefeeds */, 0 /* originID */)
 		}
 
 	case closedTSOpType:

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -59,7 +59,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 			err = iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
 				counter++
 				return nil
-			}, opts.withDiff, false /* withFiltering */)
+			}, opts.withDiff, false /* withFiltering */, false /* withOmitRemote */)
 			if err != nil {
 				b.Fatalf("failed catchUp scan: %+v", err)
 			}

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -207,6 +207,7 @@ type Processor interface {
 		catchUpIter *CatchUpIterator,
 		withDiff bool,
 		withFiltering bool,
+		withOmitRemote bool,
 		stream Stream,
 		disconnectFn func(),
 		done *future.ErrorFuture,
@@ -336,6 +337,12 @@ type syncEvent struct {
 type spanErr struct {
 	span roachpb.Span
 	pErr *kvpb.Error
+}
+
+// logicalOpMetadata is metadata associated with a logical Op.
+type logicalOpMetadata struct {
+	omitInRangefeeds bool
+	originID         uint32
 }
 
 func NewLegacyProcessor(cfg Config) *LegacyProcessor {
@@ -585,6 +592,7 @@ func (p *LegacyProcessor) Register(
 	catchUpIter *CatchUpIterator,
 	withDiff bool,
 	withFiltering bool,
+	withOmitRemote bool,
 	stream Stream,
 	disconnectFn func(),
 	done *future.ErrorFuture,
@@ -596,7 +604,7 @@ func (p *LegacyProcessor) Register(
 
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
 	r := newRegistration(
-		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering,
+		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn, done,
 	)
 	select {
@@ -821,7 +829,7 @@ func (p *LegacyProcessor) consumeLogicalOps(
 		// MVCCWriteValueOp (could be the result of a 1PC write).
 		case *enginepb.MVCCWriteValueOp:
 			// Publish the new value directly.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, t.OmitInRangefeeds, alloc)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, logicalOpMetadata{omitInRangefeeds: t.OmitInRangefeeds, originID: t.OriginID}, alloc)
 
 		case *enginepb.MVCCDeleteRangeOp:
 			// Publish the range deletion directly.
@@ -835,7 +843,7 @@ func (p *LegacyProcessor) consumeLogicalOps(
 
 		case *enginepb.MVCCCommitIntentOp:
 			// Publish the newly committed value.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, t.OmitInRangefeeds, alloc)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, logicalOpMetadata{omitInRangefeeds: t.OmitInRangefeeds, originID: t.OriginID}, alloc)
 
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
@@ -882,7 +890,7 @@ func (p *LegacyProcessor) publishValue(
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
 	value, prevValue []byte,
-	omitInRangefeeds bool,
+	valueMetadata logicalOpMetadata,
 	alloc *SharedBudgetAllocation,
 ) {
 	if !p.Span.ContainsKey(roachpb.RKey(key)) {
@@ -902,7 +910,7 @@ func (p *LegacyProcessor) publishValue(
 		},
 		PrevValue: prevVal,
 	})
-	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, omitInRangefeeds, alloc)
+	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, valueMetadata, alloc)
 }
 
 func (p *LegacyProcessor) publishDeleteRange(
@@ -921,7 +929,7 @@ func (p *LegacyProcessor) publishDeleteRange(
 		Span:      span,
 		Timestamp: timestamp,
 	})
-	p.reg.PublishToOverlapping(ctx, span, &event, false /* omitInRangefeeds */, alloc)
+	p.reg.PublishToOverlapping(ctx, span, &event, logicalOpMetadata{}, alloc)
 }
 
 func (p *LegacyProcessor) publishSSTable(
@@ -943,7 +951,7 @@ func (p *LegacyProcessor) publishSSTable(
 			Span:    sstSpan,
 			WriteTS: sstWTS,
 		},
-	}, false /* omitInRangefeeds */, alloc)
+	}, logicalOpMetadata{}, alloc)
 }
 
 func (p *LegacyProcessor) publishCheckpoint(ctx context.Context) {
@@ -951,7 +959,7 @@ func (p *LegacyProcessor) publishCheckpoint(ctx context.Context) {
 	// TODO(nvanbenschoten): rate limit these? send them periodically?
 
 	event := p.newCheckpointEvent()
-	p.reg.PublishToOverlapping(ctx, all, event, false /* omitInRangefeeds */, nil)
+	p.reg.PublishToOverlapping(ctx, all, event, logicalOpMetadata{}, nil)
 }
 
 func (p *LegacyProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -80,6 +80,7 @@ type registration struct {
 	catchUpTimestamp hlc.Timestamp // exclusive
 	withDiff         bool
 	withFiltering    bool
+	withOmitRemote   bool
 	metrics          *Metrics
 
 	// Output.
@@ -119,6 +120,7 @@ func newRegistration(
 	catchUpIter *CatchUpIterator,
 	withDiff bool,
 	withFiltering bool,
+	withOmitRemote bool,
 	bufferSz int,
 	blockWhenFull bool,
 	metrics *Metrics,
@@ -131,6 +133,7 @@ func newRegistration(
 		catchUpTimestamp: startTS,
 		withDiff:         withDiff,
 		withFiltering:    withFiltering,
+		withOmitRemote:   withOmitRemote,
 		metrics:          metrics,
 		stream:           stream,
 		done:             done,
@@ -405,7 +408,7 @@ func (r *registration) maybeRunCatchUpScan(ctx context.Context) error {
 		r.metrics.RangeFeedCatchUpScanNanos.Inc(timeutil.Since(start).Nanoseconds())
 	}()
 
-	return catchUpIter.CatchUpScan(ctx, r.stream.Send, r.withDiff, r.withFiltering)
+	return catchUpIter.CatchUpScan(ctx, r.stream.Send, r.withDiff, r.withFiltering, r.withOmitRemote)
 }
 
 // ID implements interval.Interface.
@@ -469,7 +472,7 @@ func (reg *registry) PublishToOverlapping(
 	ctx context.Context,
 	span roachpb.Span,
 	event *kvpb.RangeFeedEvent,
-	omitInRangefeeds bool,
+	valueMetadata logicalOpMetadata,
 	alloc *SharedBudgetAllocation,
 ) {
 	// Determine the earliest starting timestamp that a registration
@@ -496,8 +499,9 @@ func (reg *registry) PublishToOverlapping(
 	reg.forOverlappingRegs(ctx, span, func(r *registration) (bool, *kvpb.Error) {
 		// Don't publish events if they:
 		// 1. are equal to or less than the registration's starting timestamp, or
-		// 2. have OmitInRangefeeds = true and this registration has opted into filtering.
-		if r.catchUpTimestamp.Less(minTS) && !(r.withFiltering && omitInRangefeeds) {
+		// 2. have OmitInRangefeeds = true and this registration has opted into filtering, or
+		// 3. have OmitRemote = true and this value is from a remote cluster.
+		if r.catchUpTimestamp.Less(minTS) && !(r.withFiltering && valueMetadata.omitInRangefeeds) && (!r.withOmitRemote || valueMetadata.originID == 0) {
 			r.publish(ctx, event, alloc)
 		}
 		return false, nil

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -121,6 +121,7 @@ func newTestRegistration(
 	catchup storage.SimpleMVCCIterator,
 	withDiff bool,
 	withFiltering bool,
+	withOmitRemote bool,
 ) *testRegistration {
 	s := newTestStream()
 	r := newRegistration(
@@ -129,6 +130,7 @@ func newTestRegistration(
 		makeCatchUpIterator(catchup, span, ts),
 		withDiff,
 		withFiltering,
+		withOmitRemote,
 		5,
 		false, /* blockWhenFull */
 		NewMetrics(),
@@ -166,7 +168,7 @@ func TestRegistrationBasic(t *testing.T) {
 
 	// Registration with no catchup scan specified.
 	noCatchupReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	noCatchupReg.publish(ctx, ev1, nil /* alloc */)
 	noCatchupReg.publish(ctx, ev2, nil /* alloc */)
 	require.Equal(t, len(noCatchupReg.buf), 2)
@@ -182,7 +184,7 @@ func TestRegistrationBasic(t *testing.T) {
 			makeKV("bc", "val3", 11),
 			makeKV("bd", "val4", 9),
 		}, nil),
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	catchupReg.publish(ctx, ev1, nil /* alloc */)
 	catchupReg.publish(ctx, ev2, nil /* alloc */)
 	require.Equal(t, len(catchupReg.buf), 2)
@@ -196,7 +198,7 @@ func TestRegistrationBasic(t *testing.T) {
 	// EXIT CONDITIONS
 	// External Disconnect.
 	disconnectReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	disconnectReg.publish(ctx, ev1, nil /* alloc */)
 	disconnectReg.publish(ctx, ev2, nil /* alloc */)
 	go disconnectReg.runOutputLoop(ctx, 0)
@@ -208,7 +210,7 @@ func TestRegistrationBasic(t *testing.T) {
 
 	// External Disconnect before output loop.
 	disconnectEarlyReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	disconnectEarlyReg.publish(ctx, ev1, nil /* alloc */)
 	disconnectEarlyReg.publish(ctx, ev2, nil /* alloc */)
 	disconnectEarlyReg.disconnect(discErr)
@@ -218,7 +220,7 @@ func TestRegistrationBasic(t *testing.T) {
 
 	// Overflow.
 	overflowReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	for i := 0; i < cap(overflowReg.buf)+3; i++ {
 		overflowReg.publish(ctx, ev1, nil /* alloc */)
 	}
@@ -228,7 +230,7 @@ func TestRegistrationBasic(t *testing.T) {
 
 	// Stream Error.
 	streamErrReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	streamErr := fmt.Errorf("stream error")
 	streamErrReg.stream.SetSendErr(streamErr)
 	go streamErrReg.runOutputLoop(ctx, 0)
@@ -237,7 +239,8 @@ func TestRegistrationBasic(t *testing.T) {
 
 	// Stream Context Canceled.
 	streamCancelReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
+
 	streamCancelReg.stream.Cancel()
 	go streamCancelReg.runOutputLoop(ctx, 0)
 	require.NoError(t, streamCancelReg.waitForCaughtUp(ctx))
@@ -290,7 +293,7 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 		r := newTestRegistration(roachpb.Span{
 			Key:    roachpb.Key("d"),
 			EndKey: roachpb.Key("w"),
-		}, hlc.Timestamp{WallTime: 4}, iter, true /* withDiff */, withFiltering)
+		}, hlc.Timestamp{WallTime: 4}, iter, true /* withDiff */, withFiltering, false /* withOmitRemote */)
 
 		require.Zero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
 		require.NoError(t, r.maybeRunCatchUpScan(context.Background()))
@@ -366,6 +369,47 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 	})
 }
 
+// TestRegistryWithOmitOrigin verifies that when a registration is created with
+// withOmitRemote = true, it will not publish values with originID != 0.
+func TestRegistryWithOmitOrigin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	noPrev := func(ev *kvpb.RangeFeedEvent) *kvpb.RangeFeedEvent {
+		ev = ev.ShallowCopy()
+		ev.GetValue().(*kvpb.RangeFeedValue).PrevValue = roachpb.Value{}
+		return ev
+	}
+
+	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
+	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
+
+	reg := makeRegistry(NewMetrics())
+	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
+	originFiltering := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, true /* withOmitRemote */)
+
+	go rAC.runOutputLoop(ctx, 0)
+	go originFiltering.runOutputLoop(ctx, 0)
+
+	defer rAC.disconnect(nil)
+	defer originFiltering.disconnect(nil)
+
+	reg.Register(ctx, &rAC.registration)
+	reg.Register(ctx, &originFiltering.registration)
+
+	reg.PublishToOverlapping(ctx, spAC, ev1, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev2, logicalOpMetadata{originID: 1}, nil /* alloc */)
+
+	require.NoError(t, reg.waitForCaughtUp(ctx, all))
+
+	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2)}, rAC.Events())
+	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1)}, originFiltering.Events())
+	require.Nil(t, rAC.TryErr())
+	require.Nil(t, originFiltering.TryErr())
+}
+
 func TestRegistryBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
@@ -387,15 +431,15 @@ func TestRegistryBasic(t *testing.T) {
 
 	reg := makeRegistry(NewMetrics())
 	require.Equal(t, 0, reg.Len())
-	reg.PublishToOverlapping(ctx, spAB, ev1, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev1, logicalOpMetadata{}, nil /* alloc */)
 	reg.Disconnect(ctx, spAB)
 	reg.DisconnectWithErr(ctx, spAB, err1)
 
-	rAB := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */)
-	rBC := newTestRegistration(spBC, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */)
-	rCD := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */)
-	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */)
-	rACFiltering := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, true /* withFiltering */)
+	rAB := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
+	rBC := newTestRegistration(spBC, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
+	rCD := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
+	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
+	rACFiltering := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, true /* withFiltering */, false /* withOmitRemote */)
 	go rAB.runOutputLoop(ctx, 0)
 	go rBC.runOutputLoop(ctx, 0)
 	go rCD.runOutputLoop(ctx, 0)
@@ -407,7 +451,7 @@ func TestRegistryBasic(t *testing.T) {
 	defer rAC.disconnect(nil)
 	defer rACFiltering.disconnect(nil)
 
-	// Register 4 registrations.
+	// Register 6 registrations.
 	reg.Register(ctx, &rAB.registration)
 	require.Equal(t, 1, reg.Len())
 	reg.Register(ctx, &rBC.registration)
@@ -420,11 +464,12 @@ func TestRegistryBasic(t *testing.T) {
 	require.Equal(t, 5, reg.Len())
 
 	// Publish to different spans.
-	reg.PublishToOverlapping(ctx, spAB, ev1, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spBC, ev2, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spCD, ev3, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev4, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev5, true /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev1, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spBC, ev2, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spCD, ev3, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev4, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev5, logicalOpMetadata{omitInRangefeeds: true}, nil /* alloc */)
+
 	require.NoError(t, reg.waitForCaughtUp(ctx, all))
 	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev4), noPrev(ev5)}, rAB.Events())
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev2, ev4, ev5}, rBC.Events())
@@ -468,10 +513,10 @@ func TestRegistryBasic(t *testing.T) {
 	require.Equal(t, err1.GoError(), rCD.Err())
 
 	// Can still publish to rAB.
-	reg.PublishToOverlapping(ctx, spAB, ev4, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spBC, ev3, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spCD, ev2, false /* omitInRangefeeds */, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev1, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev4, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spBC, ev3, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spCD, ev2, logicalOpMetadata{}, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev1, logicalOpMetadata{}, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(ctx, all))
 	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev4), noPrev(ev1)}, rAB.Events())
 
@@ -515,7 +560,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	reg := makeRegistry(NewMetrics())
 
 	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	go r.runOutputLoop(ctx, 0)
 	reg.Register(ctx, &r.registration)
 
@@ -525,7 +570,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ev.MustSetValue(&kvpb.RangeFeedValue{
 		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 5}},
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(ctx, all))
 	require.Nil(t, r.Events())
 
@@ -534,7 +579,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ev.MustSetValue(&kvpb.RangeFeedValue{
 		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 10}},
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(ctx, all))
 	require.Nil(t, r.Events())
 
@@ -543,7 +588,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ev.MustSetValue(&kvpb.RangeFeedCheckpoint{
 		Span: spAB, ResolvedTS: hlc.Timestamp{WallTime: 5},
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(ctx, all))
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev}, r.Events())
 
@@ -597,7 +642,7 @@ func TestRegistryShutdownMetrics(t *testing.T) {
 
 	regDoneC := make(chan interface{})
 	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /*catchup */
-		false /* withDiff */, false /* withFiltering */)
+		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	go func() {
 		r.runOutputLoop(ctx, 0)
 		close(regDoneC)

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -307,6 +307,7 @@ func (p *ScheduledProcessor) Register(
 	catchUpIter *CatchUpIterator,
 	withDiff bool,
 	withFiltering bool,
+	withOmitRemote bool,
 	stream Stream,
 	disconnectFn func(),
 	done *future.ErrorFuture,
@@ -318,7 +319,7 @@ func (p *ScheduledProcessor) Register(
 
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
 	r := newRegistration(
-		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering,
+		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn, done,
 	)
 
@@ -668,10 +669,10 @@ func (p *ScheduledProcessor) consumeLogicalOps(
 		// OmitInRangefeeds is relevant only for transactional writes, so it's
 		// propagated only in the case of a MVCCCommitIntentOp and
 		// MVCCWriteValueOp (could be the result of a 1PC write).
+
 		case *enginepb.MVCCWriteValueOp:
 			// Publish the new value directly.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, t.OmitInRangefeeds, alloc)
-
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, logicalOpMetadata{omitInRangefeeds: t.OmitInRangefeeds, originID: t.OriginID}, alloc)
 		case *enginepb.MVCCDeleteRangeOp:
 			// Publish the range deletion directly.
 			p.publishDeleteRange(ctx, t.StartKey, t.EndKey, t.Timestamp, alloc)
@@ -684,7 +685,7 @@ func (p *ScheduledProcessor) consumeLogicalOps(
 
 		case *enginepb.MVCCCommitIntentOp:
 			// Publish the newly committed value.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, t.OmitInRangefeeds, alloc)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, logicalOpMetadata{omitInRangefeeds: t.OmitInRangefeeds, originID: t.OriginID}, alloc)
 
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
@@ -733,7 +734,7 @@ func (p *ScheduledProcessor) publishValue(
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
 	value, prevValue []byte,
-	omitInRangefeeds bool,
+	valueMetadata logicalOpMetadata,
 	alloc *SharedBudgetAllocation,
 ) {
 	if !p.Span.ContainsKey(roachpb.RKey(key)) {
@@ -753,7 +754,7 @@ func (p *ScheduledProcessor) publishValue(
 		},
 		PrevValue: prevVal,
 	})
-	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, omitInRangefeeds, alloc)
+	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, valueMetadata, alloc)
 }
 
 func (p *ScheduledProcessor) publishDeleteRange(
@@ -772,7 +773,7 @@ func (p *ScheduledProcessor) publishDeleteRange(
 		Span:      span,
 		Timestamp: timestamp,
 	})
-	p.reg.PublishToOverlapping(ctx, span, &event, false /* omitInRangefeeds */, alloc)
+	p.reg.PublishToOverlapping(ctx, span, &event, logicalOpMetadata{}, alloc)
 }
 
 func (p *ScheduledProcessor) publishSSTable(
@@ -794,7 +795,7 @@ func (p *ScheduledProcessor) publishSSTable(
 			Span:    sstSpan,
 			WriteTS: sstWTS,
 		},
-	}, false /* omitInRangefeeds */, alloc)
+	}, logicalOpMetadata{}, alloc)
 }
 
 func (p *ScheduledProcessor) publishCheckpoint(ctx context.Context, alloc *SharedBudgetAllocation) {
@@ -802,7 +803,7 @@ func (p *ScheduledProcessor) publishCheckpoint(ctx context.Context, alloc *Share
 	// TODO(nvanbenschoten): rate limit these? send them periodically?
 
 	event := p.newCheckpointEvent()
-	p.reg.PublishToOverlapping(ctx, all, event, false /* omitInRangefeeds */, alloc)
+	p.reg.PublishToOverlapping(ctx, all, event, logicalOpMetadata{}, alloc)
 }
 
 func (p *ScheduledProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -288,6 +288,11 @@ message MVCCWriteValueOp {
   // MVCCValueHeader of the corresponding write. It is only relevant for
   // transactional writes, which in the case of MVCCWriteValueOp are 1PC writes.
   bool omit_in_rangefeeds = 6;
+
+  // OriginID identifes the original cluster that wrote this key in Logical Data
+  // Replication. 0 identifies a local write, 1 identifies a remote write, and
+  // 2+ are reserved to identify remote clusters.
+  uint32 origin_id = 5  [(gogoproto.customname) = "OriginID"];
 }
 
 // MVCCUpdateIntentOp corresponds to an intent being written for a given
@@ -329,6 +334,11 @@ message MVCCCommitIntentOp {
   // MVCCValueHeader of the corresponding write. It is only relevant for
   // transactional writes.
   bool omit_in_rangefeeds = 6;
+  
+  // OriginID identifes the original cluster that wrote this key in Logical Data
+  // Replication. 0 identifies a local write, 1 identifies a remote write, and
+  // 2+ are reserved to identify remote clusters.
+  uint32 origin_id = 7  [(gogoproto.customname) = "OriginID"];
 }
 
 // MVCCAbortIntentOp corresponds to an intent being aborted for a given


### PR DESCRIPTION
This patch plumbs the same logic that OmitFromRangefeeds has to kv events
originally written by a remote cluster using the OriginID field in the
MVCCValueHeader. If a rangefeed registers with the new withOmitRemote flag,
the rangefeed processor will filter kvevents from a remote cluster.

Informs https://github.com/cockroachdb/cockroach/issues/126253

Release note: none