### PR TITLE
go.mod: bump version to 1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach
 
-go 1.22.0
+go 1.22.3
 
 // golang.org/x/* packages are maintained and curated by the go project, just
 // without the backwards compatibility promises the standard library, and thus


### PR DESCRIPTION
This was missed in #123779.

Epic: none
Release note: None
Release justification: Non-production code changes