### PR TITLE
crosscluster/logical: improve the insert benchmark

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -83,8 +83,6 @@ go_test(
         "//pkg/ccl/storageccl",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
-        "//pkg/kv/kvpb",
-        "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
This commit improves the benchmark we have for the INSERT ingestion queries. Previously, we tried to mock out the KV layer by injecting an error during KV request evaluation, and it was helpful in finding spots with SQL overhead we could improve. However, most of the low-hanging fruit has been addressed, and the overhead of error-handling starts to skew the profiles significantly. Plus the mocked-out KV layer is not something we have in the production, so this commit removes the error injection in favor of simply evaluating the requests (which makes raft things show up noticeably in the profile). (Interestingly, the runtime of a single iteration with no conflict is _shorter_ than when we injected the error in the KV layer, which shows just how much overhead we have with error handling.) This commit additionally extends the existing configs to have "no conflict" and "with conflict" cases. The former required some trickery with the key adjustment. Also, in order to better represent what we have on the main code path we now treat a batch of 32 inserts as a single benchmark iteration.

Before introducing the current version of the benchmark, I tried a similar approach and saw lots of time spent in raft and Go runtime. By now many allocations have been removed, so Go runtime mostly went away, making this new version of the benchmark useful.

Epic: None

Release note: None