### PR TITLE
raft: document/test invariants in unstable

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -85,12 +85,8 @@ func newLogWithSize(
 		panic(err) // TODO(bdarnell)
 	}
 	return &raftLog{
-		storage: storage,
-		unstable: unstable{
-			offset:           lastIndex + 1,
-			offsetInProgress: lastIndex + 1,
-			logger:           logger,
-		},
+		storage:             storage,
+		unstable:            newUnstable(lastIndex+1, logger),
 		maxApplyingEntsSize: maxApplyingEntsSize,
 
 		// Initialize our committed and applied pointers to the time of the last compaction.

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -35,6 +35,8 @@ import pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 // might need to truncate the log before persisting unstable.entries.
 type unstable struct {
 	// the incoming unstable snapshot, if any.
+	//
+	// Invariant: snapshot == nil ==> !snapshotInProgress
 	snapshot *pb.Snapshot
 	// all entries that have not yet been written to storage.
 	entries []pb.Entry
@@ -42,14 +44,26 @@ type unstable struct {
 	offset uint64
 
 	// if true, snapshot is being written to storage.
+	//
+	// Invariant: snapshotInProgress ==> snapshot != nil
 	snapshotInProgress bool
 	// entries[:offsetInProgress-offset] are being written to storage.
 	// Like offset, offsetInProgress is exclusive, meaning that it
 	// contains the index following the largest in-progress entry.
+	//
 	// Invariant: offset <= offsetInProgress
+	// Invariant: offsetInProgress - offset <= len(entries)
 	offsetInProgress uint64
 
 	logger Logger
+}
+
+func newUnstable(offset uint64, logger Logger) unstable {
+	return unstable{
+		offset:           offset,
+		offsetInProgress: offset,
+		logger:           logger,
+	}
 }
 
 // maybeFirstIndex returns the index of the first possible entry in entries

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1110,19 +1110,17 @@ func (r *raft) Step(m pb.Message) error {
 				r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term)
 			r.send(pb.Message{To: m.From, Term: r.Term, Type: pb.MsgPreVoteResp, Reject: true})
 		} else if m.Type == pb.MsgStorageAppendResp {
+			if m.Snapshot != nil {
+				// Even if the snapshot applied under a different term, its application
+				// is still valid. Snapshots carry committed (term-independent) state.
+				r.appliedSnap(m.Snapshot)
+			}
 			if m.Index != 0 {
-				// Don't consider the appended log entries to be stable because
-				// they may have been overwritten in the unstable log during a
-				// later term. See the comment in newStorageAppendResp for more
-				// about this race.
+				// Don't consider the appended log entries to be stable because they may
+				// have been overwritten in the unstable log during a later term. See
+				// the comment in newStorageAppendResp for more about this race.
 				r.logger.Infof("%x [term: %d] ignored entry appends from a %s message with lower term [term: %d]",
 					r.id, r.Term, m.Type, m.Term)
-			}
-			if m.Snapshot != nil {
-				// Even if the snapshot applied under a different term, its
-				// application is still valid. Snapshots carry committed
-				// (term-independent) state.
-				r.appliedSnap(m.Snapshot)
 			}
 		} else {
 			// ignore other cases
@@ -1141,11 +1139,13 @@ func (r *raft) Step(m pb.Message) error {
 		}
 
 	case pb.MsgStorageAppendResp:
-		if m.Index != 0 {
-			r.raftLog.stableTo(entryID{term: m.LogTerm, index: m.Index})
-		}
+		// The snapshot precedes the entries. We acknowledge the snapshot first,
+		// then the entries, as required by the unstable structure.
 		if m.Snapshot != nil {
 			r.appliedSnap(m.Snapshot)
+		}
+		if m.Index != 0 {
+			r.raftLog.stableTo(entryID{term: m.LogTerm, index: m.Index})
 		}
 
 	case pb.MsgStorageApplyResp:


### PR DESCRIPTION
This PR documents and tests invariants in the `unstable` log structure. Most importantly, the clean-up straightens up the order of handling `snapshot` and `entries` when both are present.

When `unstable` contains both the `snapshot`, and the `entries`, entries start at `snapshot.index + 1`. Both are sent to storage as one `MsgStorageAppend`. When a `MsgStorageAppendResp` arrives, we should acknowledge the snapshot first. If we, instead, acknowledge entries first, it briefly introduces a gap between the `snapshot` and `entries`, and then it's hard to reason about what this means. Fortunately, the code was calling both `stableSnapTo` and `stableTo`, so the invariant was de facto maintained (but non-atomically).

Epic: none
Release note: none