### PR TITLE
roachtest: disable mutators in backup-restore/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2565,6 +2565,20 @@ func registerBackupMixedVersion(r registry.Registry) {
 				// attempted.
 				mixedversion.UpgradeTimeout(30*time.Minute),
 				mixedversion.AlwaysUseLatestPredecessors,
+				// We disable cluster setting mutators because this test
+				// resets the cluster to older versions when verifying cluster
+				// backups. This makes the mixed-version context inaccurate
+				// and leads to flakes.
+				//
+				// TODO(renato): don't disable these mutators when the
+				// framework exposes some utility to provide mutual exclusion
+				// of concurrent steps.
+				mixedversion.DisableMutators(
+					mixedversion.ClusterSettingMutator("kv.expiration_leases_only.enabled"),
+					mixedversion.ClusterSettingMutator("kv.snapshot_receiver.excise.enabled"),
+					mixedversion.ClusterSettingMutator("storage.ingest_split.enabled"),
+					mixedversion.ClusterSettingMutator("storage.sstable.compression_algorithm"),
+				),
 			)
 			testRNG := mvt.RNG()
 


### PR DESCRIPTION
It should eventually be re-enabled if/when we add support for mutual exclusion in the mixed-version framework.

Fixes: #126189

Release note: None