### PR TITLE
kvfollowerreadsccl: bump pool of test under heavyweight configs

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -43,6 +43,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvfollowerreadsccl"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Closes #126242.

Epic: none
Release note: None