### PR TITLE
release-23.2: sql: eliminate some possible races in connExecutor.serialize

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1461,7 +1461,7 @@ type connExecutor struct {
 		// Note that a single SQL txn can use multiple KV txns under the
 		// hood with multiple KV txn UUIDs, so the KV UUID is not a good
 		// txn identifier for SQL logging.
-		txnCounter int
+		txnCounter atomic.Int32
 
 		// txnRewindPos is the position within stmtBuf to which we'll rewind when
 		// performing automatic retries. This is more or less the position where the
@@ -2836,7 +2836,7 @@ func (ex *connExecutor) execCopyOut(
 			ctx,
 			ex.executorType,
 			int(ex.state.mu.autoRetryCounter),
-			ex.extraTxnState.txnCounter,
+			int(ex.extraTxnState.txnCounter.Load()),
 			numOutputRows,
 			ex.state.mu.stmtCount,
 			0, /* bulkJobId */
@@ -3098,7 +3098,7 @@ func (ex *connExecutor) execCopyIn(
 		)
 		var stats topLevelQueryStats
 		ex.planner.maybeLogStatement(ctx, ex.executorType,
-			int(ex.state.mu.autoRetryCounter), ex.extraTxnState.txnCounter,
+			int(ex.state.mu.autoRetryCounter), int(ex.extraTxnState.txnCounter.Load()),
 			numInsertedRows, ex.state.mu.stmtCount,
 			0, /* bulkJobId */
 			copyErr,
@@ -3692,10 +3692,14 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, stmtTS time.Time) {
 	newTxn := txn == nil || evalCtx.Txn != txn
 	evalCtx.TxnState = ex.getTransactionState()
-	evalCtx.TxnReadOnly = ex.state.readOnly
+	evalCtx.TxnReadOnly = ex.state.readOnly.Load()
 	evalCtx.TxnImplicit = ex.implicitTxn()
 	evalCtx.TxnIsSingleStmt = false
-	evalCtx.TxnIsoLevel = ex.state.isolationLevel
+	func() {
+		ex.state.mu.Lock()
+		defer ex.state.mu.Unlock()
+		evalCtx.TxnIsoLevel = ex.state.mu.isolationLevel
+	}()
 	if newTxn || !ex.implicitTxn() {
 		// Only update the stmt timestamp if in a new txn or an explicit txn. This is because this gets
 		// called multiple times during an extended protocol implicit txn, but we
@@ -4116,15 +4120,16 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			NumRetries:            int32(txn.Epoch()),
 			NumAutoRetries:        ex.state.mu.autoRetryCounter,
 			TxnDescription:        txn.String(),
-			Implicit:              ex.implicitTxn(),
-			AllocBytes:            ex.state.mon.AllocBytes(),
-			MaxAllocBytes:         ex.state.mon.MaximumBytes(),
-			IsHistorical:          ex.state.isHistorical,
-			ReadOnly:              ex.state.readOnly,
-			Priority:              ex.state.priority.String(),
-			QualityOfService:      sessiondatapb.ToQoSLevelString(txn.AdmissionHeader().Priority),
-			LastAutoRetryReason:   autoRetryReasonStr,
-			IsolationLevel:        tree.IsolationLevelFromKVTxnIsolationLevel(ex.state.isolationLevel).String(),
+			// TODO(yuzefovich): this seems like not a concurrency safe call.
+			Implicit:            ex.implicitTxn(),
+			AllocBytes:          ex.state.mon.AllocBytes(),
+			MaxAllocBytes:       ex.state.mon.MaximumBytes(),
+			IsHistorical:        ex.state.isHistorical.Load(),
+			ReadOnly:            ex.state.readOnly.Load(),
+			Priority:            ex.state.mu.priority.String(),
+			QualityOfService:    sessiondatapb.ToQoSLevelString(txn.AdmissionHeader().Priority),
+			LastAutoRetryReason: autoRetryReasonStr,
+			IsolationLevel:      tree.IsolationLevelFromKVTxnIsolationLevel(ex.state.mu.isolationLevel).String(),
 		}
 	}
 
@@ -4219,15 +4224,17 @@ func (ex *connExecutor) serialize() serverpb.Session {
 	}
 
 	return serverpb.Session{
-		Username:                   sd.SessionUser().Normalized(),
-		ClientAddress:              remoteStr,
-		ApplicationName:            ex.applicationName.Load().(string),
-		Start:                      ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionInit).UTC(),
-		ActiveQueries:              activeQueries,
-		ActiveTxn:                  activeTxnInfo,
-		NumTxnsExecuted:            int32(ex.extraTxnState.txnCounter),
-		TxnFingerprintIDs:          txnFingerprintIDs,
-		LastActiveQuery:            lastActiveQuery,
+		Username:        sd.SessionUser().Normalized(),
+		ClientAddress:   remoteStr,
+		ApplicationName: ex.applicationName.Load().(string),
+		// TODO(yuzefovich): this seems like not a concurrency safe call.
+		Start:             ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionInit).UTC(),
+		ActiveQueries:     activeQueries,
+		ActiveTxn:         activeTxnInfo,
+		NumTxnsExecuted:   ex.extraTxnState.txnCounter.Load(),
+		TxnFingerprintIDs: txnFingerprintIDs,
+		LastActiveQuery:   lastActiveQuery,
+		// TODO(yuzefovich): this seems like not a concurrency safe call.
 		ID:                         ex.planner.extendedEvalCtx.SessionID.GetBytes(),
 		AllocBytes:                 ex.mon.AllocBytes(),
 		MaxAllocBytes:              ex.mon.MaximumBytes(),

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -58,6 +59,12 @@ type txnState struct {
 		// txnStart records the time that txn started.
 		txnStart time.Time
 
+		// The transaction's priority.
+		priority roachpb.UserPriority
+
+		// The transaction's isolation level.
+		isolationLevel isolation.Level
+
 		// stmtCount keeps track of the number of statements that the transaction
 		// has executed.
 		stmtCount int
@@ -94,18 +101,12 @@ type txnState struct {
 	// This must be constant for the lifetime of a SQL transaction.
 	sqlTimestamp time.Time
 
-	// The transaction's priority.
-	priority roachpb.UserPriority
-
-	// The transaction's isolation level.
-	isolationLevel isolation.Level
-
 	// The transaction's read only state.
-	readOnly bool
+	readOnly atomic.Bool
 
 	// Set to true when the current transaction is using a historical timestamp
 	// through the use of AS OF SYSTEM TIME.
-	isHistorical bool
+	isHistorical atomic.Bool
 
 	// injectedTxnRetryCounter keeps track of how many errors have been
 	// injected in this transaction with the inject_retry_errors_enabled
@@ -192,7 +193,7 @@ func (ts *txnState) resetForNewSQLTxn(
 ) (txnID uuid.UUID) {
 	// Reset state vars to defaults.
 	ts.sqlTimestamp = sqlTimestamp
-	ts.isHistorical = false
+	ts.isHistorical.Swap(false)
 	ts.injectedTxnRetryCounter = 0
 
 	// Create a context for this transaction. It will include a root span that
@@ -339,7 +340,7 @@ func (ts *txnState) setHistoricalTimestamp(
 		return err
 	}
 	ts.sqlTimestamp = historicalTimestamp.GoTime()
-	ts.isHistorical = true
+	ts.isHistorical.Swap(true)
 	return nil
 }
 
@@ -360,7 +361,7 @@ func (ts *txnState) setPriorityLocked(userPriority roachpb.UserPriority) error {
 	if err := ts.mu.txn.SetUserPriority(userPriority); err != nil {
 		return err
 	}
-	ts.priority = userPriority
+	ts.mu.priority = userPriority
 	return nil
 }
 
@@ -374,7 +375,7 @@ func (ts *txnState) setIsolationLevelLocked(level isolation.Level) error {
 	if err := ts.mu.txn.SetIsoLevel(level); err != nil {
 		return err
 	}
-	ts.isolationLevel = level
+	ts.mu.isolationLevel = level
 	return nil
 }
 
@@ -383,12 +384,12 @@ func (ts *txnState) setReadOnlyMode(mode tree.ReadWriteMode) error {
 	case tree.UnspecifiedReadWriteMode:
 		return nil
 	case tree.ReadOnly:
-		ts.readOnly = true
+		ts.readOnly.Swap(true)
 	case tree.ReadWrite:
-		if ts.isHistorical {
+		if ts.isHistorical.Load() {
 			return tree.ErrAsOfSpecifiedWithReadWrite
 		}
-		ts.readOnly = false
+		ts.readOnly.Swap(false)
 	default:
 		return errors.AssertionFailedf("unknown read mode: %s", errors.Safe(mode))
 	}

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -98,11 +98,11 @@ func (tc *testContext) createOpenState(typ txnType) (fsm.State, *txnState) {
 		Ctx:           ctx,
 		connCtx:       tc.ctx,
 		sqlTimestamp:  timeutil.Now(),
-		priority:      roachpb.NormalUserPriority,
 		mon:           txnStateMon,
 		txnAbortCount: metric.NewCounter(MetaTxnAbort),
 	}
 	ts.mu.txn = kv.NewTxn(ctx, tc.mockDB, roachpb.NodeID(1) /* gatewayNodeID */)
+	ts.mu.priority = roachpb.NormalUserPriority
 
 	state := stateOpen{
 		ImplicitTxn: fsm.FromBool(typ == implicitTxn),


### PR DESCRIPTION
Backport 1/1 commits from #114783.

/cc @cockroachdb/release

Fixes: #125825 

---

`connExecutor.serialize` serializes the session in the connExecutor. It accesses many fields, with most being protected by one of the two mutexes. However, there is some state in the connExecutor that isn't protected and can be modified by the main goroutine concurrently with `serialize` goroutine reading that state, creating a data race. This commit audits the method, fixes several possible racy accesses, and adds TODOs to investigate / fix remaining (those that didn't seem immediately trivial to fix). Given that `serialize` is only used for SHOW SESSIONS and active query profiler, it seems ok to not fix it properly right away.

Fixes: #113911.

Release note: None
