### PR TITLE
sql: fix panic with create logical replication stream

### DIFF
--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -421,6 +421,7 @@ func init() {
 		&tree.Import{},
 		&tree.ScheduledBackup{},
 		&tree.CreateTenantFromReplication{},
+		&tree.CreateLogicalReplicationStream{},
 	} {
 		typ := optbuilder.OpaqueReadOnly
 		if tree.CanModifySchema(stmt) {

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -182,7 +182,7 @@ func CanWriteData(stmt Statement) bool {
 	case *Split, *Unsplit, *Relocate, *RelocateRange, *Scatter:
 		return true
 	// Replication operations.
-	case *CreateTenantFromReplication, *AlterTenantReplication:
+	case *CreateTenantFromReplication, *AlterTenantReplication, *CreateLogicalReplicationStream:
 		return true
 	}
 	return false


### PR DESCRIPTION
This commit fixes the random schema generation test for the newly added create logical replication stream syntax in #126160.

Previously, the test would panic due to the new statement not being registered in opaque.go. This is now fixed and the statement type is now recognized. The change also is reflected in the SQL shell when executing the statement as a panic is no longer shown to the user.

Fixes: #126238
Release note: None