### PR TITLE
roachtest/test-selector: capture infra flake information in query

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -460,7 +460,6 @@
 /pkg/cmd/roachprod-microbench/ @cockroachdb/test-eng
 /pkg/cmd/roachprod-stress/   @cockroachdb/test-eng
 /pkg/cmd/roachtest/          @cockroachdb/test-eng
-/pkg/cmd/roachtest-selector/              @cockroachdb/test-eng
 /pkg/cmd/roachtest/tests/activerecord.go  @cockroachdb/test-eng @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/asyncpg.go       @cockroachdb/test-eng @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/django.go        @cockroachdb/test-eng @cockroachdb/docs-infra-prs

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -67,7 +67,7 @@ build/teamcity-roachtest-invoke.sh \
   --cloud="${CLOUD}" \
   --count="${COUNT-1}" \
   --clear-cluster-cache="${CLEAR_CLUSTER_CACHE:-true}" \
-  --auto-kill-threshold="${AUTO_KILL_THRESHOLD:-0.05}" \
+  --auto-kill-threshold="${AUTO_KILL_THRESHOLD:-0.10}" \
   --parallelism="${PARALLELISM}" \
   --cpu-quota="${CPUQUOTA}" \
   --cluster-id="${TC_BUILD_ID}" \
@@ -75,5 +75,5 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
   --suite nightly \
-  --selective-tests="${SELECTIVE_TESTS:-false}" \
+  --selective-tests="${SELECTIVE_TESTS:-true}" \
   "${TESTS}"

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -320,6 +320,10 @@ func updateSpecForSelectiveTests(ctx context.Context, specs []registry.TestSpec)
 		} else {
 			selectedTestsCount++
 		}
+		if td, ok := tdMap[specs[i].Name]; ok {
+			// populate the stats as obtained from the test selector
+			specs[i].SetStats(td.AvgDurationInMillis, td.LastFailureIsPreempt)
+		}
 	}
 	fmt.Printf("%d out of %d tests selected for the run!\n", selectedTestsCount, len(specs))
 }

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -29,6 +29,18 @@ var LibGEOS = []string{"libgeos", "libgeos_c"}
 // endpoint should use.
 var PrometheusNameSpace = "roachtest"
 
+// testStats is internally populated based on its previous runs and used for
+// deciding on the current execution approach. This includes decisions like
+// executing the test on spot VM vs ondemand VM.
+// The stats are populated if selective-tests is enabled.
+type testStats struct {
+	// AvgDurationInMillis is the average duration that the test takes to run
+	AvgDurationInMillis int64
+	// LastFailureIsPreempt indicates that the last run of the test failed
+	// due to VM preemption
+	LastFailureIsPreempt bool
+}
+
 // TestSpec is a spec for a roachtest.
 type TestSpec struct {
 	Skip string // if non-empty, test will be skipped
@@ -146,6 +158,22 @@ type TestSpec struct {
 	// Note that this flag needs to be set with a specific reason in the comment
 	// explaining why the test has been chosen for opting out of test selection.
 	TestSelectionOptOutSuites SuiteSet
+
+	// stats are populated by test selector based on previous execution data
+	stats *testStats
+}
+
+// SetStats sets the stats for the test
+func (ts *TestSpec) SetStats(avgDurationInMillis int64, lastFailureIsPreempt bool) {
+	ts.stats = &testStats{
+		AvgDurationInMillis:  avgDurationInMillis,
+		LastFailureIsPreempt: lastFailureIsPreempt,
+	}
+}
+
+// IsLastFailurePreempt returns true is the last failure of the test was due to VM preemption.
+func (ts *TestSpec) IsLastFailurePreempt() bool {
+	return ts.stats != nil && ts.stats.LastFailureIsPreempt
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -338,7 +338,8 @@ func (r *testRunner) Run(
 			if roachtestflags.Cloud == spec.GCE &&
 				tests[i].Benchmark &&
 				!tests[i].Suites.Contains(registry.Weekly) &&
-				rand.Float64() <= 0.5 {
+				!tests[i].IsLastFailurePreempt() &&
+				rand.Float64() <= 0.8 {
 				lopt.l.PrintfCtx(ctx, "using spot VMs to run test %s", tests[i].Name)
 				tests[i].Cluster.UseSpotVMs = true
 			}

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -46,10 +46,11 @@ var suites = map[string]string{
 
 // TestDetails has the details of the test as fetched from snowflake
 type TestDetails struct {
-	Name                string // test name
-	Selected            bool   // whether a test is Selected or not
-	AvgDurationInMillis int64  // average duration of the test
-	TotalRuns           int    // total number of times the test has run successfully
+	Name                 string // test name
+	Selected             bool   // whether a test is Selected or not
+	AvgDurationInMillis  int64  // average duration of the test
+	TotalRuns            int    // total number of times the test has run successfully
+	LastFailureIsPreempt bool   // last failure is due to a VM preemption
 }
 
 // SelectTestsReq is the request for CategoriseTests
@@ -131,11 +132,13 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 		// 1. whether a test is Selected or not
 		// 2. average duration of the test
 		// 3. total number of times the test has run successfully
+		// 4. last failure is due to an infra flake
 		testDetails := &TestDetails{
-			Name:                testInfos[0],
-			Selected:            testInfos[1] != "no",
-			AvgDurationInMillis: getDuration(testInfos[2]),
-			TotalRuns:           getTotalRuns(testInfos[3]),
+			Name:                 testInfos[0],
+			Selected:             testInfos[1] != "no",
+			AvgDurationInMillis:  getDuration(testInfos[2]),
+			TotalRuns:            getTotalRuns(testInfos[3]),
+			LastFailureIsPreempt: testInfos[4] == "yes",
 		}
 		if testDetails.Selected {
 			// selected for running


### PR DESCRIPTION
In the current test selection categorization all the failures due to spot VM failures are ignored. But, we do not have that information if the test actually failure due to VM preemption. To avoid that test to fail again due to VM preemption, we can ensure that we do not run that test again in spot VMs.

This PR captures the information that the test has failed last time due to a VM preemption and uses the information to not run the same test in spot VM the next time. Also, the spot VM selection is increased to 80% as:
1. we have an extra condition to not run the same test on spot.
2. we are running lesser tests due to selective tests and hence, the spot VM usage is going down.

Informs: #119630
Epic: none