### PR TITLE
roachtest: fix crash on cluster creation failure

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -749,7 +749,7 @@ func (r *testRunner) runWorker(
 		// If DebugKeepAlways is set, mark it as a saved cluster, so it isn't
 		// cleaned up. Do it now instead of at the end as the test may be interrupted
 		// with ctrl c before we get there.
-		if clustersOpt.debugMode == DebugKeepAlways {
+		if c != nil && clustersOpt.debugMode == DebugKeepAlways {
 			c.Save(ctx, "cluster saved since --debug-always set", l)
 		}
 


### PR DESCRIPTION
Before this patch, we'd segfault if cluster creation fails and we're running with --debug-always.

This patch is a small protection against the problem, but I don't think it's the right fix. The structure of the code makes similar bugs very likely to introduce -- I've made the same mistake myself. The issue is that, since #73706, the point where the cluster creation fails is disconnected from the point where that error is handled. It's very easy for code in between to assume that there is a cluster. Besides the bug being fixed here, there are some other awkward protections against a nil cluster around that seem surprising.

Epic: None
Release note: None