### PR TITLE
roachtest: remove settings related to handling 22.2

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -935,14 +935,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	ctx context.Context, t test.Test, c cluster.Cluster,
 ) {
 	topology := topologySpec{multiRegion: false}
-	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness,
-		// In 23.1, the `user_id` field was added to `system.web_sessions`.
-		// If the cluster is migrating to 23.1, auth-session login will not
-		// be aware of this new field and authentication will fail.
-		// TODO(DarrylWong): When 22.2 is no longer supported, we won't run
-		// into the above issue anymore and can enable secure clusters.
-		mixedversion.ClusterSettingOption(install.SecureOption(false)),
-	)
+	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness)
 }
 
 // runFollowerReadsMixedVersionGlobalTableTest runs a multi-region follower-read
@@ -962,12 +955,6 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		// Use a longer upgrade timeout to give the migrations enough time to finish
 		// considering the cross-region latency.
 		mixedversion.UpgradeTimeout(60*time.Minute),
-		// In 23.1, the `user_id` field was added to `system.web_sessions`.
-		// If the cluster is migrating to 23.1, auth-session login will not
-		// be aware of this new field and authentication will fail.
-		// TODO(DarrylWong): When 22.2 is no longer supported, we won't run
-		// into the above issue anymore and can enable secure clusters.
-		mixedversion.ClusterSettingOption(install.SecureOption(false)),
 	)
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -504,18 +504,7 @@ func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// NB: We rely on the testing framework to choose a random predecessor
 	// to upgrade from.
-	mvt := mixedversion.NewTest(
-		ctx, t, t.L(), c, tester.crdbNodes,
-		// For now, we perform at most 2 upgrades in this test so that the
-		// lowest version we start from is 22.2. The reason for this is
-		// that, in 22.1, node draining errors were common and led to
-		// changefeeds failing. See #106878.
-		//
-		// TODO(renato): remove this restriction by not failing the test
-		// if the changefeed failed due to "node draining" errors while
-		// still in 22.1 or older.
-		mixedversion.MaxUpgrades(2),
-	)
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, tester.crdbNodes)
 
 	cleanupKafka := tester.StartKafka(t, c)
 	defer cleanupKafka()

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -98,12 +98,6 @@ func registerRebalanceLoad(r registry.Registry) {
 			mvt := mixedversion.NewTest(ctx, t, t.L(), c, roachNodes, mixedversion.NeverUseFixtures,
 				mixedversion.ClusterSettingOption(
 					install.ClusterSettingsOption(settings.ClusterSettings),
-					// In 23.1, the `user_id` field was added to `system.web_sessions`.
-					// If the cluster is migrating to 23.1, auth-session login will not
-					// be aware of this new field and authentication will fail.
-					// TODO(DarrylWong): When 22.2 is no longer supported, we won't run
-					// into the above issue anymore and can enable secure clusters.
-					install.SecureOption(false),
 				),
 			)
 			mvt.InMixedVersion("rebalance load run",

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -76,9 +76,6 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
 		// Fixtures are generated on a version that's too old for this test.
 		mixedversion.NeverUseFixtures,
-		// We limit the number of upgrades since the test is not expected to work
-		// on versions older than 22.2.
-		mixedversion.MaxUpgrades(2),
 	)
 	mvt.AfterUpgradeFinalized(
 		"obtain system schema from the upgraded cluster",


### PR DESCRIPTION
There were a few mixedversion tests that had logic specific to handling 22.2 releases. Now that we bumped mixedversion's `OldestSupportedVersion` to 23.1 (#125952), we no longer need to handle these situations.

Epic: none

Release note: None