### PR TITLE
changefeedccl: re-enable diagram storage

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -313,9 +313,7 @@ func startDistChangefeed(
 			finishedSetupFn = func(flowinfra.Flow) { resultsCh <- tree.Datums(nil) }
 		}
 
-		if log.V(1) {
-			jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID)
-		}
+		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID)
 
 		// Make sure to use special changefeed monitor going forward as the
 		// parent monitor for the DistSQL infrastructure. This is needed to

--- a/pkg/jobs/jobsprofiler/profiler_test.go
+++ b/pkg/jobs/jobsprofiler/profiler_test.go
@@ -101,14 +101,11 @@ func TestProfilerStorePlanDiagram(t *testing.T) {
 			sql:  "RESTORE TABLE foo FROM LATEST IN 'userfile:///foo' WITH into_db='test'",
 			typ:  jobspb.TypeRestore,
 		},
-		/*
-			TODO(dt): re-enable this once #126083 is fixed.
-			 {
-				name: "changefeed",
-				sql:  "CREATE CHANGEFEED FOR foo INTO 'null://sink'",
-				typ:  jobspb.TypeChangefeed,
-			},
-		*/
+		{
+			name: "changefeed",
+			sql:  "CREATE CHANGEFEED FOR foo INTO 'null://sink'",
+			typ:  jobspb.TypeChangefeed,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := sqlDB.Exec(tc.sql)


### PR DESCRIPTION
Now that these are capped by #126084 it is safe to capture new ones unconditionally.

Release note: none.
Epic: none.