### PR TITLE
crosscluster/logical: use fresh internal session data

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -99,7 +99,6 @@ go_test(
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondata",
         "//pkg/testutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -120,9 +120,9 @@ func newLogicalReplicationWriterProcessor(
 	for i := range bhPool {
 		rp, err := makeSQLLastWriteWinsHandler(
 			ctx, flowCtx.Cfg.Settings, spec.TableDescriptors,
-			// Initialize the executor with the copy of the current session's
-			// variables in order to avoid creating a fresh copy on each usage.
-			flowCtx.Cfg.DB.Executor(isql.WithSessionData(flowCtx.EvalCtx.SessionData().Clone())),
+			// Initialize the executor with a fresh session data - this will
+			// avoid creating a new copy on each executor usage.
+			flowCtx.Cfg.DB.Executor(isql.WithSessionData(sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */))),
 		)
 		if err != nil {
 			return nil, err
@@ -131,7 +131,7 @@ func newLogicalReplicationWriterProcessor(
 			db:       flowCtx.Cfg.DB,
 			rp:       rp,
 			settings: flowCtx.Cfg.Settings,
-			sd:       flowCtx.EvalCtx.SessionData().Clone(),
+			sd:       sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */),
 		}
 	}
 


### PR DESCRIPTION
This commit switches usage of the current session's data in favor of a fresh internal session data when instantiating the executor and the txn used by the LWW row processor. I didn't quite tracked down why, but it appears that current session's data (which comes from the JobExecCtx) is inconsistent (in some cases I observed it to use Go defaults, perhaps because it was being mutated (?)), so using the fresh internal session data would alleviate that. (This is also exactly what would happen if we didn't use the WithSessionData option, but this way avoid an allocation on each executor usage). Microbenchmark show no difference (which is a good thing).

Epic: None

Release note: None