### PR TITLE
sql: sort overload functions according to search_path

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -610,3 +610,35 @@ SELECT nextval('s108297')
 2
 
 subtest end
+
+# Regression test for #124538. User should be able to override built-in functions
+# by moving "pg_catalog" to the back of the search path.
+subtest regression_124538
+
+statement ok
+CREATE FUNCTION now() RETURNS TIMESTAMP STABLE LANGUAGE SQL AS $$ SELECT TIMESTAMP '1999-12-31 23:59:59.999999'; $$;
+
+query B
+SELECT now() > '2024-06-21 19:04:25.625514+00'
+----
+true
+
+statement ok
+SET search_path = public, pg_catalog
+
+query T
+SELECT public.now()
+----
+1999-12-31 23:59:59.999999 +0000 +0000
+
+query T
+SELECT now()
+----
+1999-12-31 23:59:59.999999 +0000 +0000
+
+query B
+SELECT now() > '2024-06-21 19:04:25.625514+00'
+----
+false
+
+subtest end

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -473,7 +473,7 @@ func (sr *schemaResolver) ResolveFunction(
 
 	switch {
 	case builtinDef != nil && routine != nil:
-		return builtinDef.MergeWith(routine)
+		return builtinDef.MergeWith(routine, path)
 	case builtinDef != nil:
 		props, _ := builtinsregistry.GetBuiltinProperties(builtinDef.Name)
 		if props.UnsupportedWithIssue != 0 {
@@ -596,7 +596,7 @@ func maybeLookupRoutine(
 		if !found {
 			continue
 		}
-		udfDef, err = udfDef.MergeWith(curUdfDef)
+		udfDef, err = udfDef.MergeWith(curUdfDef, path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -234,7 +234,7 @@ func (fd *ResolvedFunctionDefinition) String() string { return AsString(fd) }
 
 // MergeWith is used to merge two UDF definitions with same name.
 func (fd *ResolvedFunctionDefinition) MergeWith(
-	another *ResolvedFunctionDefinition,
+	another *ResolvedFunctionDefinition, path SearchPath,
 ) (*ResolvedFunctionDefinition, error) {
 	if fd == nil {
 		return another, nil
@@ -249,7 +249,7 @@ func (fd *ResolvedFunctionDefinition) MergeWith(
 
 	return &ResolvedFunctionDefinition{
 		Name:      fd.Name,
-		Overloads: combineOverloads(fd.Overloads, another.Overloads),
+		Overloads: combineOverloads(fd.Overloads, another.Overloads, path),
 	}, nil
 }
 
@@ -437,8 +437,61 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 	return ret[0], nil
 }
 
-func combineOverloads(a, b []QualifiedOverload) []QualifiedOverload {
-	return append(append(make([]QualifiedOverload, 0, len(a)+len(b)), a...), b...)
+func combineOverloads(a, b []QualifiedOverload, path SearchPath) []QualifiedOverload {
+	// Corner case: if the path is empty, we can just append a and b.
+	if path == nil || path.NumElements() == 0 {
+		return append(append(make([]QualifiedOverload, 0, len(a)+len(b)), a...), b...)
+	}
+
+	result := make([]QualifiedOverload, 0, len(a)+len(b))
+
+	// Append overloads to the result according to the schema order in the path.
+	isSchemaInSearchPath := make(map[string]bool, path.NumElements())
+	for i := range path.NumElements() {
+		schema := path.GetSchema(i)
+		isSchemaInSearchPath[schema] = true
+
+		for _, overload := range a {
+			if overload.Schema == schema {
+				result = append(result, overload)
+			}
+		}
+
+		for _, overload := range b {
+			if overload.Schema == schema {
+				result = append(result, overload)
+			}
+		}
+	}
+
+	// Append any remaining overloads that are not in the path.
+	for _, overload := range a {
+		if _, ok := isSchemaInSearchPath[overload.Schema]; !ok {
+			result = append(result, overload)
+		}
+	}
+
+	for _, overload := range b {
+		if _, ok := isSchemaInSearchPath[overload.Schema]; !ok {
+			result = append(result, overload)
+		}
+	}
+
+	foundUDFOverload := false
+	for _, overload := range result {
+		if overload.Type == UDFRoutine {
+			foundUDFOverload = true
+		}
+	}
+	// When a UDF overload is found, reset the "prefered" attribute.
+	if foundUDFOverload {
+		for i, overload := range result {
+			overload.PreferredOverload = false
+			result[i] = overload
+		}
+	}
+
+	return result
 }
 
 // GetClass returns function class by checking each overload's Class and returns

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -3593,7 +3593,8 @@ func getMostSignificantOverload(
 		schema := searchPath.GetSchema(i)
 		for _, idx := range filter {
 			if r := qualifiedOverloads[idx]; r.Schema == schema {
-				if found {
+				// Only throw "ambiguous function" error for user-defined functions.
+				if found && r.Type == UDFRoutine {
 					return QualifiedOverload{}, ambiguousError()
 				}
 				found = true


### PR DESCRIPTION
Previously, overload functions were not sorted based on the "search_path", and the "PreferredOverload" attribute makes the sorting doesn't make sense, causing issue #124538.

This commit addresses these issues by:

- Introducing sorting logic in the "combineOverloads" function and including a search_path argument to ensure overloaded functions are returned in the correct order.

- Resetting the "PreferredOverload" attribute of overloaded functions to "false" when user-defined functions are present, so the type-checking routine selects overloaded functions based on their order.

- Only throw "ambiguous error" for user-defined functions.

Users can now override built-in functions using "search_path".

Replaces: https://github.com/cockroachdb/cockroach/pull/126048
Fixes: #124538

Release note (bug fix): Fixed a bug where a user-defined function that shared a name with a builtin function would not be resolved, even if it had higher precedence from the search_path variable.