### PR TITLE
release-23.1: roachtest: add unparseable asyncpg test to ignore list

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
@@ -87,6 +87,7 @@ var asyncpgBlocklist = blocklist{
 
 var asyncpgIgnoreList = blocklist{
 	`test_pool.TestPool.test_pool_01`:                                   "can't parse output",
+	`test_codecs.TestCodecs.test_interval`:                              "can't parse output",
 	`test_copy.TestCopyFrom.test_copy_from_query_basics`:                "flaky; see #119291 and https://github.com/MagicStack/asyncpg/issues/240",
 	`test_copy.TestCopyFrom.test_copy_from_query_cancellation_explicit`: "flaky; see #119291 and https://github.com/MagicStack/asyncpg/issues/240",
 	`test_copy.TestCopyFrom.test_copy_from_query_timeout_1`:             "flaky; see #119291 and https://github.com/MagicStack/asyncpg/issues/240",


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/126188
Release justification: test only change
Release note: None