### PR TITLE
schemachanger: fallback when zone config in prepared stmt

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1708,3 +1708,16 @@ statement error pgcode 42601 syntax error
 PREPARE bar AS CALL foo($1);
 
 subtest end
+
+# Regression test for #126288 to make sure that zone configurations in
+# prepared statements work as expected.
+subtest zone_config
+
+statement ok
+PREPARE p AS
+ALTER DATABASE test CONFIGURE ZONE USING gc.ttlseconds = $1
+
+statement ok
+EXECUTE p(120)
+
+subtest end


### PR DESCRIPTION
In order for zone configurations to be set in prepared statements, we will need to add support for prepared statements in the DSC (tracked by #126288). For now, fallback to the legacy schema changer when executing a prepared statement.

Fixes: #126053
Fixes: #126055

Release note: None