### PR TITLE
sql: fix pg_catalog formatting of BYTES[] expressions

### DIFF
--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -316,7 +316,7 @@ func deserializeExprForFormatting(
 	}
 
 	// In pg_catalog, we need to make sure we always display constants instead of
-	// expressions, when possible (e.g., turn Array expr into a DArrray). This is
+	// expressions, when possible (e.g., turn Array expr into a DArray). This is
 	// best-effort, so if there is any error, it is safe to fallback to the
 	// typedExpr.
 	if fmtFlags == tree.FmtPGCatalog {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3553,7 +3553,7 @@ PREPARE args_deduce_type_1(int) AS SELECT $1::int, $2::varchar(10), $3::varchar(
 query TTTB
 SELECT name, statement, parameter_types, from_sql FROM pg_prepared_statements WHERE name LIKE 'args_%' ORDER BY 1,2
 ----
-args_deduce_type    PREPARE args_deduce_type (int, varchar, int, int) AS INSERT INTO t_prepare VALUES ($1, $2, $3)                   {bigint,"'character varying'",bigint,bigint}          true
+args_deduce_type    PREPARE args_deduce_type (int, varchar, int, int) AS INSERT INTO t_prepare VALUES ($1, $2, $3)           {bigint,"'character varying'",bigint,bigint}          true
 args_deduce_type_1  PREPARE args_deduce_type_1 (int, varchar, varchar) AS SELECT $1::INT8, $2::VARCHAR(10), $3::VARCHAR(20)  {bigint,"'character varying'","'character varying'"}  true
 args_test_few       PREPARE args_test_few (int, int) AS SELECT $1, $2::INT8                                                  {bigint,bigint}                                       true
 args_test_many      PREPARE args_test_many (int, int) AS SELECT $1                                                           {bigint,bigint}                                       true
@@ -5153,5 +5153,26 @@ SELECT typname, typrelid, typarray FROM pg_catalog.pg_type WHERE oid = 'u[]'::re
 ----
 typname  typrelid  typarray
 _u       0         0
+
+subtest end
+
+subtest regression_126042
+
+statement ok
+CREATE TABLE t126042 (
+  id INT8 NOT NULL PRIMARY KEY,
+  bytes_array BYTES[] DEFAULT '{f}'::BYTES[]
+)
+
+# Regression test for #126042. Expressions of type BYTES[] should be parsable.
+query TT
+SELECT a.attname, pg_get_expr(d.adbin, d.adrelid)
+FROM pg_attribute a
+LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+WHERE a.attrelid = 't126042'::REGCLASS
+ORDER BY 1
+----
+bytes_array  '{"\\x66"}'::BYTES[]
+id           NULL
 
 subtest end

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1563,7 +1563,7 @@ func writeAsHexString(ctx *FmtCtx, b string) {
 // Format implements the NodeFormatter interface.
 func (d *DBytes) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if f.HasFlags(fmtPgwireFormat) {
+	if f.HasFlags(fmtPgwireFormat) || f.HasFlags(fmtPGCatalog) {
 		ctx.WriteString(`\x`)
 		writeAsHexString(ctx, string(*d))
 	} else if f.HasFlags(fmtFormatByteLiterals) {
@@ -4904,7 +4904,9 @@ func (d *DArray) AmbiguousFormat() bool {
 
 // Format implements the NodeFormatter interface.
 func (d *DArray) Format(ctx *FmtCtx) {
-	if ctx.flags.HasAnyFlags(fmtPgwireFormat | FmtPGCatalog) {
+	if ctx.flags.HasAnyFlags(fmtPgwireFormat | fmtPGCatalog) {
+		defer func(f FmtFlags) { ctx.flags = f }(ctx.flags)
+		ctx.flags = ctx.flags & ^fmtPGCatalogCasts
 		d.pgwireFormat(ctx)
 		return
 	}

--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -136,7 +136,7 @@ func (d *DArray) pgwireFormat(ctx *FmtCtx) {
 		return
 	}
 
-	if ctx.HasFlags(FmtPGCatalog) {
+	if ctx.HasFlags(fmtPGCatalog) {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteByte('{')
@@ -172,7 +172,7 @@ func (d *DArray) pgwireFormat(ctx *FmtCtx) {
 		delimiter = d.ParamTyp.Delimiter()
 	}
 	ctx.WriteByte('}')
-	if ctx.HasFlags(FmtPGCatalog) {
+	if ctx.HasFlags(fmtPGCatalog) {
 		ctx.WriteByte('\'')
 	}
 }
@@ -242,7 +242,7 @@ func pgwireFormatStringInArray(ctx *FmtCtx, in string) {
 			// Strings in arrays escape " and \.
 			buf.WriteByte('\\')
 			buf.WriteByte(byte(r))
-		} else if ctx.HasFlags(FmtPGCatalog) && r == '\'' {
+		} else if ctx.HasFlags(fmtPGCatalog) && r == '\'' {
 			buf.WriteByte('\'')
 			buf.WriteByte('\'')
 		} else {


### PR DESCRIPTION
This commit fixes the formatting of BYTES[] expression in pg_catalog so
that they are correct and can be parsed by the SQL parser. Prior to this
commit the expression:

    '{f}'::BYTES[]

Would be formatted as:

    '{"\'\x66'::BYTES"}'::BYTES[]

The inner-most single-quotes and the `::BYTES` cast have been removed. The
expression is now correctly formatted as:

    '{"\\x66"}'::BYTES[]

Fixes #126042

Release note (bug fix): Expressions of type `BYTES[]` are now correctly
formatted in `pg_catalog` tables.
