### PR TITLE
schemachanger: plumb semactx and placeholders to schemachanger

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1708,3 +1708,16 @@ statement error pgcode 42601 syntax error
 PREPARE bar AS CALL foo($1);
 
 subtest end
+
+# Regression test for #126288 to make sure that zone configurations in
+# prepared statements work as expected.
+subtest zone_config
+
+statement ok
+PREPARE p AS
+ALTER DATABASE test CONFIGURE ZONE USING gc.ttlseconds = $1
+
+statement ok
+EXECUTE p(120)
+
+subtest end

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -116,6 +116,7 @@ func (p *planner) newSchemaChangeBuilderDependencies(statements []string) scbuil
 		p, /* temporarySchemaProvider */
 		p, /* nodesStatusInfo */
 		p, /* regionProvider */
+		p.SemaCtx(),
 	)
 }
 

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -277,7 +277,7 @@ func newBuilderState(
 		ctx:                      ctx,
 		clusterSettings:          d.ClusterSettings(),
 		evalCtx:                  newEvalCtx(d),
-		semaCtx:                  newSemaCtx(d),
+		semaCtx:                  d.SemaCtx(),
 		cr:                       d.CatalogReader(),
 		tr:                       d.TableReader(),
 		auth:                     d.AuthorizationAccessor(),

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -61,6 +61,9 @@ type Dependencies interface {
 	// Statements returns the statements behind this schema change.
 	Statements() []string
 
+	// SemaCtx returns the tree.SemaContext for the schema change statement.
+	SemaCtx() *tree.SemaContext
+
 	// AstFormatter returns something that can format AST nodes.
 	AstFormatter() AstFormatter
 

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -22,17 +22,7 @@ var _ scbuildstmt.TreeContextBuilder = buildCtx{}
 
 // SemaCtx implements the scbuildstmt.TreeContextBuilder interface.
 func (b buildCtx) SemaCtx() *tree.SemaContext {
-	return newSemaCtx(b.Dependencies)
-}
-
-func newSemaCtx(d Dependencies) *tree.SemaContext {
-	semaCtx := tree.MakeSemaContext(d.CatalogReader())
-	semaCtx.Annotations = nil
-	semaCtx.SearchPath = &d.SessionData().SearchPath
-	semaCtx.DateStyle = d.SessionData().GetDateStyle()
-	semaCtx.IntervalStyle = d.SessionData().GetIntervalStyle()
-	semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(d.ClusterSettings().Version)
-	return &semaCtx
+	return b.Dependencies.SemaCtx()
 }
 
 // EvalCtx implements the scbuildstmt.TreeContextBuilder interface.
@@ -55,5 +45,6 @@ func newEvalCtx(d Dependencies) *eval.Context {
 		Settings:             d.ClusterSettings(),
 		Codec:                d.Codec(),
 		DescIDGenerator:      d.DescIDGenerator(),
+		Placeholders:         &d.SemaCtx().Placeholders,
 	}
 }

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -59,6 +59,7 @@ func NewBuilderDependencies(
 	temporarySchemaProvider scbuild.TemporarySchemaProvider,
 	nodesStatusInfo scbuild.NodesStatusInfo,
 	regionProvider scbuild.RegionProvider,
+	semaCtx *tree.SemaContext,
 ) scbuild.Dependencies {
 	return &buildDeps{
 		clusterID:       clusterID,
@@ -81,6 +82,7 @@ func NewBuilderDependencies(
 		temporarySchemaProvider:  temporarySchemaProvider,
 		nodesStatusInfo:          nodesStatusInfo,
 		regionProvider:           regionProvider,
+		semaCtx:                  semaCtx,
 	}
 }
 
@@ -103,6 +105,7 @@ type buildDeps struct {
 	temporarySchemaProvider  scbuild.TemporarySchemaProvider
 	nodesStatusInfo          scbuild.NodesStatusInfo
 	regionProvider           scbuild.RegionProvider
+	semaCtx                  *tree.SemaContext
 }
 
 var _ scbuild.CatalogReader = (*buildDeps)(nil)
@@ -370,6 +373,11 @@ func (d *buildDeps) ClusterSettings() *cluster.Settings {
 // Statements implements the scbuild.Dependencies interface.
 func (d *buildDeps) Statements() []string {
 	return d.statements
+}
+
+// SemaCtx implements the scbuild.Dependencies interface.
+func (d *buildDeps) SemaCtx() *tree.SemaContext {
+	return d.semaCtx
 }
 
 // AstFormatter implements the scbuild.Dependencies interface.

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -187,5 +188,9 @@ var defaultOptions = []Option{
 		state.merger = &testBackfiller{s: state}
 		state.indexSpanSplitter = &indexSpanSplitter{}
 		state.approximateTimestamp = defaultCreatedAt
+
+		semaCtx := tree.MakeSemaContext(state)
+		semaCtx.SearchPath = &state.SessionData().SearchPath
+		state.semaCtx = &semaCtx
 	}),
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -99,6 +99,11 @@ func (s *TestState) Statements() []string {
 	return s.statements
 }
 
+// SemaCtx implements the scbuild.Dependencies interface.
+func (s *TestState) SemaCtx() *tree.SemaContext {
+	return s.semaCtx
+}
+
 // IncrementSchemaChangeAlterCounter implements the scbuild.Dependencies
 // interface.
 func (s *TestState) IncrementSchemaChangeAlterCounter(counterType string, extra ...string) {

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -61,6 +61,7 @@ type TestState struct {
 	phase                   scop.Phase
 	sessionData             sessiondata.SessionData
 	statements              []string
+	semaCtx                 *tree.SemaContext
 	testingKnobs            *scexec.TestingKnobs
 	jobs                    []jobs.Record
 	createdJobsInCurrentTxn []jobspb.JobID

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -68,6 +68,7 @@ func WithBuilderDependenciesFromTestServer(
 		InternalSQLTxn() descs.Txn
 		Descriptors() *descs.Collection
 		SessionData() *sessiondata.SessionData
+		SemaCtx() *tree.SemaContext
 		resolver.SchemaResolver
 		scbuild.AuthorizationAccessor
 		scbuild.AstFormatter
@@ -106,6 +107,7 @@ func WithBuilderDependenciesFromTestServer(
 		planner, /* temporarySchemaProvider */
 		planner, /* nodesStatusInfo */
 		planner, /* regionProvider */
+		planner.SemaCtx(),
 	))
 }
 


### PR DESCRIPTION
This allows the declarative schema changer to execute statements that use placeholders.

Fixes: #126288
Fixes: https://github.com/cockroachdb/cockroach/issues/126053
Fixes: https://github.com/cockroachdb/cockroach/issues/126055
Release note: None