### PR TITLE
colexec: use streaming mem account in columnarizer and materializer

### DIFF
--- a/pkg/sql/colexec/BUILD.bazel
+++ b/pkg/sql/colexec/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "//pkg/util/json",  # keep
         "//pkg/util/log",
         "//pkg/util/metamorphic",
+        "//pkg/util/mon",
         "//pkg/util/stringarena",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_apd_v3//:apd",  # keep

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -141,7 +141,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	defer r.TestCleanupNoError(t)
 
 	m := colexec.NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		flowCtx,
 		0, /* processorID */
 		r.OpWithMetaInfo,

--- a/pkg/sql/colexec/colexecbase/simple_project_test.go
+++ b/pkg/sql/colexec/colexecbase/simple_project_test.go
@@ -122,7 +122,7 @@ func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
 			for i := range parallelUnorderedSynchronizerInputs {
 				parallelUnorderedSynchronizerInputs[i].Root = inputs[i]
 			}
-			input = colexec.NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testAllocator, parallelUnorderedSynchronizerInputs, &wg)
+			input = colexec.NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testMemAcc, parallelUnorderedSynchronizerInputs, &wg)
 			input = colexecbase.NewSimpleProjectOp(input, len(inputTypes), []uint32{0})
 			return colexecbase.NewConstOp(testAllocator, input, types.Int, constVal, 1)
 		})

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -20,13 +20,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
-	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -71,8 +71,9 @@ type drainHelper struct {
 	// are noops.
 	ctx context.Context
 
-	// allocator can be nil in tests.
-	allocator *colmem.Allocator
+	// streamingMemAcc can be nil in tests.
+	streamingMemAcc      *mon.BoundAccount
+	metadataAccountedFor int64
 
 	statsCollectors []colexecop.VectorizedStatsCollector
 	sources         colexecop.MetadataSources
@@ -118,17 +119,18 @@ func (d *drainHelper) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata)
 	if !d.drained {
 		d.meta = d.sources.DrainMeta()
 		d.drained = true
-		if d.allocator != nil {
-			colexecutils.AccountForMetadata(d.allocator, d.meta)
+		if d.streamingMemAcc != nil {
+			d.metadataAccountedFor = colexecutils.AccountForMetadata(d.ctx, d.streamingMemAcc, d.meta)
 		}
 	}
 	if len(d.meta) == 0 {
 		// Eagerly lose the reference to the slice.
 		d.meta = nil
-		if d.allocator != nil {
-			// At this point, the caller took over all of the metadata, so we
-			// can release all of the allocations.
-			d.allocator.ReleaseAll()
+		if d.streamingMemAcc != nil {
+			// At this point, the caller took over the metadata, so we can
+			// release the allocations.
+			d.streamingMemAcc.Shrink(d.ctx, d.metadataAccountedFor)
+			d.metadataAccountedFor = 0
 		}
 		return nil, nil
 	}
@@ -152,13 +154,12 @@ var materializerPool = sync.Pool{
 // NewMaterializer creates a new Materializer processor which processes the
 // columnar data coming from input to return it as rows.
 // Arguments:
-// - allocator must use a memory account that is not shared with any other user,
-// can be nil in tests.
+// - streamingMemAcc can be nil in tests.
 // - typs is the output types schema. Typs are assumed to have been hydrated.
 // NOTE: the constructor does *not* take in an execinfrapb.PostProcessSpec
 // because we expect input to handle that for us.
 func NewMaterializer(
-	allocator *colmem.Allocator,
+	streamingMemAcc *mon.BoundAccount,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input colexecargs.OpWithMetaInfo,
@@ -179,7 +180,7 @@ func NewMaterializer(
 	} else {
 		m.row = make(rowenc.EncDatumRow, len(typs))
 	}
-	m.drainHelper.allocator = allocator
+	m.drainHelper.streamingMemAcc = streamingMemAcc
 	m.drainHelper.statsCollectors = input.StatsCollectors
 	m.drainHelper.sources = input.MetadataSources
 

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -61,7 +61,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 	c := NewBufferingColumnarizerForTests(testAllocator, flowCtx, 0, input)
 
 	m := NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: c},
@@ -174,7 +174,7 @@ func BenchmarkMaterializer(b *testing.B) {
 						b.SetBytes(int64(nRows * nCols * int(memsize.Int64)))
 						for i := 0; i < b.N; i++ {
 							m := NewMaterializer(
-								nil, /* allocator */
+								nil, /* streamingMemAcc */
 								flowCtx,
 								0, /* processorID */
 								colexecargs.OpWithMetaInfo{Root: input},
@@ -224,7 +224,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 	}
 
 	m := NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		flowCtx,
 		0, /* processorID */
 		colexecargs.OpWithMetaInfo{
@@ -269,7 +269,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 	b.SetBytes(int64(nRows * nCols * int(memsize.Int64)))
 	for i := 0; i < b.N; i++ {
 		m := NewMaterializer(
-			nil, /* allocator */
+			nil, /* streamingMemAcc */
 			flowCtx,
 			1, /* processorID */
 			colexecargs.OpWithMetaInfo{Root: c},

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -128,7 +128,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	var wg sync.WaitGroup
-	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testAllocator, inputs, &wg)
+	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testMemAcc, inputs, &wg)
 	s.Init(ctx)
 
 	t.Run(fmt.Sprintf("numInputs=%d/numBatches=%d/terminationScenario=%d", numInputs, numBatches, terminationScenario), func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testAllocator, inputs, &wg)
+	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testMemAcc, inputs, &wg)
 	s.Init(ctx)
 	for {
 		if err := colexecerror.CatchVectorizedRuntimeError(func() { _ = s.Next() }); err != nil {
@@ -261,7 +261,7 @@ func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
 	}
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
-	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testAllocator, inputs, &wg)
+	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testMemAcc, inputs, &wg)
 	s.Init(ctx)
 	b.SetBytes(8 * int64(coldata.BatchSize()))
 	b.ResetTimer()

--- a/pkg/sql/colexec/proj_utils_test.go
+++ b/pkg/sql/colexec/proj_utils_test.go
@@ -76,7 +76,7 @@ func assertProjOpAgainstRowByRow(
 	// column of the projection operator.
 	op := colexecbase.NewSimpleProjectOp(projOp, len(inputTypes)+1, []uint32{uint32(len(inputTypes))})
 	materializer := NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: op},

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -89,7 +89,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 			arrowOp := newArrowTestOperator(columnarizer, c, r, typs)
 
 			materializer := NewMaterializer(
-				nil, /* allocator */
+				nil, /* streamingMemAcc */
 				flowCtx,
 				1, /* processorID */
 				colexecargs.OpWithMetaInfo{Root: arrowOp},

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -378,7 +378,7 @@ func (i *Inbox) Next() coldata.Batch {
 					// to keep errors unchanged (e.g. kvpb.ErrPriority() will
 					// be called on each error in the DistSQLReceiver).
 					i.bufferedMeta = append(i.bufferedMeta, meta)
-					colexecutils.AccountForMetadata(i.allocator, i.bufferedMeta[len(i.bufferedMeta)-1:])
+					colexecutils.AccountForMetadata(i.Ctx, i.allocator.Acc(), i.bufferedMeta[len(i.bufferedMeta)-1:])
 				}
 			}
 			if receivedErr != nil {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -995,8 +995,8 @@ func (s *vectorizedFlowCreator) setupInput(
 			// Note that if we have opt == flowinfra.FuseAggressively, then we
 			// must use the serial unordered sync above in order to remove any
 			// concurrency.
-			allocator := colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory)
-			sync := colexec.NewParallelUnorderedSynchronizer(flowCtx, processorID, allocator, inputStreamOps, s.f.GetWaitGroup())
+			streamingMemAcc := s.monitorRegistry.NewStreamingMemAccount(flowCtx)
+			sync := colexec.NewParallelUnorderedSynchronizer(flowCtx, processorID, streamingMemAcc, inputStreamOps, s.f.GetWaitGroup())
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            sync,
 				MetadataSources: colexecop.MetadataSources{sync},
@@ -1042,6 +1042,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 	opWithMetaInfo colexecargs.OpWithMetaInfo,
 	opOutputTypes []*types.T,
 	factory coldata.ColumnFactory,
+	streamingMemAccount *mon.BoundAccount,
 ) error {
 	output := &pspec.Output[0]
 	if output.Type != execinfrapb.OutputRouterSpec_PASS_THROUGH {
@@ -1097,7 +1098,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			if input == nil {
 				// We couldn't remove the columnarizer.
 				input = colexec.NewMaterializer(
-					colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory),
+					streamingMemAccount,
 					flowCtx,
 					pspec.ProcessorID,
 					opWithMetaInfo,
@@ -1174,10 +1175,11 @@ func (s *vectorizedFlowCreator) setupFlow(
 				return
 			}
 
+			streamingMemAccount := s.monitorRegistry.NewStreamingMemAccount(flowCtx)
 			args := &colexecargs.NewColOperatorArgs{
 				Spec:                 pspec,
 				Inputs:               inputs,
-				StreamingMemAccount:  s.monitorRegistry.NewStreamingMemAccount(flowCtx),
+				StreamingMemAccount:  streamingMemAccount,
 				ProcessorConstructor: rowexec.NewProcessor,
 				LocalProcessors:      s.f.GetLocalProcessors(),
 				LocalVectorSources:   s.f.GetLocalVectorSources(),
@@ -1214,7 +1216,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 			}
 
 			if err = s.setupOutput(
-				ctx, flowCtx, pspec, result.OpWithMetaInfo, result.ColumnTypes, factory,
+				ctx, flowCtx, pspec, result.OpWithMetaInfo, result.ColumnTypes, factory, streamingMemAccount,
 			); err != nil {
 				return
 			}

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -54,7 +54,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 	col := colexec.NewBufferingColumnarizerForTests(testAllocator, &flowCtx, 0 /* processorID */, input)
 	vee := newTestVectorizedInternalPanicEmitter(col)
 	mat := colexec.NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		&flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: vee},
@@ -91,7 +91,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 	col := colexec.NewBufferingColumnarizerForTests(testAllocator, &flowCtx, 0 /* processorID */, input)
 	nvee := newTestNonVectorizedPanicEmitter(col)
 	mat := colexec.NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		&flowCtx,
 		1, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: nvee},

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -164,7 +164,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	defer result.TestCleanupNoError(t)
 
 	outColOp := colexec.NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		flowCtx,
 		int32(len(args.inputs))+2,
 		result.OpWithMetaInfo,

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -57,7 +57,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 	flow := colflow.NewVectorizedFlow(base)
 
 	mat := colexec.NewMaterializer(
-		nil, /* allocator */
+		nil, /* streamingMemAcc */
 		&flowCtx,
 		0, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: &colexecop.CallbackOperator{

--- a/pkg/sql/sem/eval/eval_test/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test/eval_test.go
@@ -204,7 +204,7 @@ func TestEval(t *testing.T) {
 			require.NoError(t, err)
 
 			mat := colexec.NewMaterializer(
-				nil, /* allocator */
+				nil, /* streamingMemAcc */
 				flowCtx,
 				0, /* processorID */
 				result.OpWithMetaInfo,


### PR DESCRIPTION
Previously, in order to account for the memory usage of the metadata we required an allocator that wasn't shared with any other user. This was an overkill on two fronts:
- we can easily track precisely how much memory was reserved for the metadata (meaning that we can use the "streaming" allocator)
- we don't actually need the allocator object in many cases since we don't allocate any vectors or batches.

This commit takes advantage of these observations and refactors the relevant code to work on the streaming memory account instead. In particular, columnarizers, materializers, and parallel unordered syncs will now use the streaming memory account, which reduces the number of allocations we make.

Epic: None

Release note: None