### PR TITLE
raft: clean-up log conflict search

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -110,9 +110,6 @@ func (l *raftLog) maybeAppend(a logSlice) (lastnewi uint64, ok bool) {
 	if !ok {
 		return 0, false
 	}
-	if match.index < a.lastIndex() && match.index < l.committed {
-		l.logger.Panicf("entry %d is already committed [committed(%d)]", match.index+1, l.committed)
-	}
 
 	// Fast-forward to the first mismatching or missing entry.
 	// NB: prev.index <= match.index <= a.lastIndex(), so the sub-slicing is safe.
@@ -129,8 +126,8 @@ func (l *raftLog) append(ents ...pb.Entry) {
 	if len(ents) == 0 {
 		return
 	}
-	if after := ents[0].Index - 1; after < l.committed {
-		l.logger.Panicf("after(%d) is out of range [committed(%d)]", after, l.committed)
+	if first := ents[0].Index; first <= l.committed {
+		l.logger.Panicf("entry %d is already committed [committed(%d)]", first, l.committed)
 	}
 	l.unstable.truncateAndAppend(ents)
 }

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -27,32 +27,30 @@ import (
 
 func TestFindConflict(t *testing.T) {
 	previousEnts := index(1).terms(1, 2, 3)
-	tests := []struct {
-		ents      []pb.Entry
-		wconflict uint64
+	for _, tt := range []struct {
+		ents []pb.Entry
+		want uint64
 	}{
-		// no conflict, empty ent
-		{nil, 0},
+		// no conflict, empty entries
+		{ents: nil, want: 0},
 		// no conflict
-		{index(1).terms(1, 2, 3), 0},
-		{index(2).terms(2, 3), 0},
-		{index(3).terms(3), 0},
+		{ents: index(1).terms(1, 2, 3), want: 0},
+		{ents: index(2).terms(2, 3), want: 0},
+		{ents: index(3).terms(3), want: 0},
 		// no conflict, but has new entries
-		{index(1).terms(1, 2, 3, 4, 4), 4},
-		{index(2).terms(2, 3, 4, 5), 4},
-		{index(3).terms(3, 4, 4), 4},
-		{index(4).terms(4, 4), 4},
+		{ents: index(1).terms(1, 2, 3, 4, 4), want: 4},
+		{ents: index(2).terms(2, 3, 4, 5), want: 4},
+		{ents: index(3).terms(3, 4, 4), want: 4},
+		{ents: index(4).terms(4, 4), want: 4},
 		// conflicts with existing entries
-		{index(1).terms(4, 4), 1},
-		{index(2).terms(1, 4, 4), 2},
-		{index(3).terms(1, 2, 4, 4), 3},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			raftLog := newLog(NewMemoryStorage(), raftLogger)
-			raftLog.append(previousEnts...)
-			require.Equal(t, tt.wconflict, raftLog.findConflict(tt.ents))
+		{ents: index(1).terms(4, 4), want: 1},
+		{ents: index(2).terms(1, 4, 4), want: 2},
+		{ents: index(3).terms(1, 2, 4, 4), want: 3},
+	} {
+		t.Run("", func(t *testing.T) {
+			log := newLog(NewMemoryStorage(), discardLogger)
+			log.append(previousEnts...)
+			require.Equal(t, tt.want, log.findConflict(tt.ents))
 		})
 	}
 }


### PR DESCRIPTION
Use the new `entryID` and `logSlice` types. Move the preceding entry check into the conflict search method rather than do it outside. Add a bunch of TODOs for optimization: most log append requests can skip the term check scanning or do it more efficiently.

Epic: CRDB-37516
Release note: none