### PR TITLE
raft: decouple commit index bumps from appends

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -105,7 +105,7 @@ func (l *raftLog) String() string {
 
 // maybeAppend returns (0, false) if the entries cannot be appended. Otherwise,
 // it returns (last index of new entries, true).
-func (l *raftLog) maybeAppend(a logSlice, committed uint64) (lastnewi uint64, ok bool) {
+func (l *raftLog) maybeAppend(a logSlice) (lastnewi uint64, ok bool) {
 	if !l.matchTerm(a.prev) {
 		return 0, false
 	}
@@ -125,7 +125,6 @@ func (l *raftLog) maybeAppend(a logSlice, committed uint64) (lastnewi uint64, ok
 		}
 		l.append(a.entries[ci-offset:]...)
 	}
-	l.commitTo(min(committed, lastnewi))
 	return lastnewi, true
 }
 

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -311,9 +311,12 @@ func TestLogMaybeAppend(t *testing.T) {
 					require.True(t, tt.wpanic)
 				}
 			}()
-			glasti, gappend := raftLog.maybeAppend(app, tt.committed)
+			glasti, gappend := raftLog.maybeAppend(app)
 			require.Equal(t, tt.wlasti, glasti)
 			require.Equal(t, tt.wappend, gappend)
+			if gappend {
+				raftLog.commitTo(min(glasti, tt.committed))
+			}
 			require.Equal(t, tt.wcommit, raftLog.committed)
 			if gappend && len(tt.ents) != 0 {
 				gents, err := raftLog.slice(raftLog.lastIndex()-uint64(len(tt.ents))+1, raftLog.lastIndex()+1, noLimit)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1682,8 +1682,13 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed})
 		return
 	}
-	if mlastIndex, ok := r.raftLog.maybeAppend(a, m.Commit); ok {
+	if mlastIndex, ok := r.raftLog.maybeAppend(a); ok {
 		r.accTerm = m.Term // our log is now consistent with the m.Term leader
+		// TODO(pav-kv): make it possible to commit even if the append did not
+		// succeed or is stale. If r.accTerm >= m.Term, then our log contains all
+		// committed entries at m.Term (by raft invariants), so it is safe to bump
+		// the commit index even if the MsgApp is stale.
+		r.raftLog.commitTo(min(m.Commit, mlastIndex))
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: mlastIndex})
 		return
 	}


### PR DESCRIPTION
This commit logically decouples appends and commit index bumps, by moving the `commitTo` call out of `maybeAppend`. Today, the commit index moves only within the bounds of the appended slice, but in the future, commit index advancement can be independent. In some cases (when our log is already consistent with the leader), the commit index can be bumped to higher values even if the `MsgApp` is stale.

Epic: CRDB-37516
Release note: none