### PR TITLE
sql: declare sessiondatapb.QoSLevel variables in one place

### DIFF
--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -350,7 +350,9 @@ const (
 // use pointers to constants, we define these variables to use in
 // those cases.
 var (
-	UserLowQoS = UserLow
+	SystemLowQoS = SystemLow
+	TTLLowQoS    = TTLLow
+	UserLowQoS   = UserLow
 )
 
 var qosLevelsDict = map[QoSLevel]string{

--- a/pkg/sql/ttl/ttljob/ttljob_metrics.go
+++ b/pkg/sql/ttl/ttljob/ttljob_metrics.go
@@ -235,12 +235,11 @@ func (m *rowLevelTTLMetrics) fetchStatistics(
 		// User a super low quality of service (lower than TTL low), as we don't
 		// really care if statistics gets left behind and prefer the TTL job to
 		// have priority.
-		qosLevel := sessiondatapb.SystemLow
 		datums, err := execCfg.InternalDB.Executor().QueryRowEx(
 			ctx,
 			c.opName,
 			nil,
-			getInternalExecutorOverride(qosLevel),
+			getInternalExecutorOverride(sessiondatapb.SystemLowQoS),
 			c.query,
 			c.args...,
 		)

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -118,8 +118,6 @@ func (b *SelectQueryBuilder) buildQuery() string {
 	)
 }
 
-var qosLevel = sessiondatapb.TTLLow
-
 func getInternalExecutorOverride(
 	qosLevel sessiondatapb.QoSLevel,
 ) sessiondata.InternalExecutorOverride {
@@ -158,7 +156,7 @@ func (b *SelectQueryBuilder) Run(
 		ctx,
 		b.selectOpName,
 		nil, /* txn */
-		getInternalExecutorOverride(qosLevel),
+		getInternalExecutorOverride(sessiondatapb.TTLLowQoS),
 		query,
 		b.cachedArgs...,
 	)
@@ -261,7 +259,7 @@ func (b *DeleteQueryBuilder) Run(
 		ctx,
 		b.deleteOpName,
 		txn.KV(),
-		getInternalExecutorOverride(qosLevel),
+		getInternalExecutorOverride(sessiondatapb.TTLLowQoS),
 		query,
 		deleteArgs...,
 	)


### PR DESCRIPTION
When we set the QualityOfService in the session data for an internal executor, we must provide a pointer to a
sessiondatapb.QoSLevel. Since the QoS levels are defined as constants, we can't take their address. This commit does a little cleanup by defining the variables versions of these consts in a singular place.

Epic: none
Release note: None