### PR TITLE
release-23.1: sqlstats: specify UserLow qos for sql stats queries

### DIFF
--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -73,3 +73,11 @@ var NodeUserSessionDataOverride = InternalExecutorOverride{
 var RootUserSessionDataOverride = InternalExecutorOverride{
 	User: username.MakeSQLUsernameFromPreNormalizedString(username.RootUser),
 }
+
+// NodeUserWithLowUserPrioritySessionDataOverride is an InternalExecutorOverride
+// which overrides the user to the NodeUser and sets the quality of service to
+// sessiondatapb.UserLow.
+var NodeUserWithLowUserPrioritySessionDataOverride = InternalExecutorOverride{
+	User:             username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
+	QualityOfService: &sessiondatapb.UserLowQoS,
+}

--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -333,6 +333,14 @@ const (
 	LockingName = "locking"
 )
 
+// When providing SessionData overrides to the internal executor,
+// we need to use pointers to specify the QoSLevel. Since we can't
+// use pointers to constants, we define these variables to use in
+// those cases.
+var (
+	UserLowQoS = UserLow
+)
+
 var qosLevelsDict = map[QoSLevel]string{
 	SystemLow:  SystemLowName,
 	TTLLow:     TTLLowName,

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/sqlstats/ssmemstorage",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/mon",

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
@@ -113,7 +113,7 @@ func (c *StatsCompactor) getRowCountForShard(
 	row, err := c.db.Executor().QueryRowEx(ctx,
 		"scan-row-count",
 		nil,
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		stmt,
 		shardIdx,
 	)
@@ -210,7 +210,7 @@ func (c *StatsCompactor) executeDeleteStmt(
 	it, err := c.db.Executor().QueryIteratorEx(ctx,
 		"delete-old-sql-stats",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		delStmt,
 		qargs...,
 	)

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -220,7 +221,7 @@ func (s *PersistedSQLStats) doFlushSingleTxnStats(
 			return errors.Wrapf(err, "flushing transaction %d's statistics", stats.TransactionFingerprintID)
 		}
 		return nil
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 }
 
 func (s *PersistedSQLStats) doFlushSingleStmtStats(
@@ -293,7 +294,7 @@ func (s *PersistedSQLStats) doFlushSingleStmtStats(
 			return errors.Wrapf(err, "flush statement %d's statistics", scopedStats.ID)
 		}
 		return nil
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 }
 
 func (s *PersistedSQLStats) doInsertElseDoUpdate(

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -117,7 +117,7 @@ FROM
 		ctx,
 		"fetch-stmt-count",
 		nil,
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		readStmt,
 	)
 
@@ -382,7 +382,7 @@ DO NOTHING
 		ctx,
 		"insert-txn-stats",
 		txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		insertStmt,
 		aggregatedTs,            // aggregated_ts
 		serializedFingerprintID, // fingerprint_id
@@ -422,7 +422,7 @@ WHERE fingerprint_id = $2
 		ctx,
 		"update-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		updateStmt,
 		statistics,              // statistics
 		serializedFingerprintID, // fingerprint_id
@@ -480,7 +480,7 @@ WHERE fingerprint_id = $3
 		ctx,
 		"update-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		updateStmt,
 		statistics,                         // statistics
 		indexRecommendations,               // index_recommendations
@@ -572,7 +572,7 @@ DO NOTHING
 		ctx,
 		"insert-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		insertStmt,
 		args...,
 	)
@@ -607,7 +607,7 @@ FOR UPDATE
 		ctx,
 		"fetch-txn-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		readStmt,                // stmt
 		serializedFingerprintID, // fingerprint_id
 		appName,                 // app_name
@@ -663,7 +663,7 @@ FOR UPDATE
 		ctx,
 		"fetch-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		readStmt,                           // stmt
 		serializedFingerprintID,            // fingerprint_id
 		serializedTransactionFingerprintID, // transaction_fingerprint_id


### PR DESCRIPTION
Backport 1/1 commits from #125848.
Backport 1/1 commits from #126331.

/cc @cockroachdb/release

---

Queries in the sql stats system can be expensive as they perform periodic INSERT and DELETE operations into various system tables. We should specify their qos level as `UserLow` to ensure they don't interfere with foreground workloads.

Epic: CRDB-37544
Fixes: #125839

Release note: None

Release justification: low-risk stability/perf improvement
