### PR TITLE
release-24.1: streamingccl: keep up with bulk ops

### DIFF
--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -78,11 +78,19 @@ var ReplanFrequency = settings.RegisterDurationSetting(
 	settings.WithName("physical_replication.consumer.replan_flow_frequency"),
 )
 
+var LagCheckFrequency = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"stream_replication.lag_check_frequency",
+	"frequency at which the consumer job checks for lagging nodes",
+	3*time.Minute,
+	settings.PositiveDuration,
+)
+
 var InterNodeLag = settings.RegisterDurationSetting(
 	settings.SystemOnly,
 	"physical_replication.consumer.node_lag_replanning_threshold",
 	"the maximum difference in lag tolerated across two destination nodes; if 0, disabled",
-	0,
+	5*time.Minute,
 	settings.NonNegativeDuration,
 )
 

--- a/pkg/ccl/streamingccl/streamingest/node_lag_detector.go
+++ b/pkg/ccl/streamingccl/streamingest/node_lag_detector.go
@@ -15,13 +15,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
 var ErrNodeLagging = errors.New("node frontier too far behind other nodes")
 
 // checkLaggingNode returns an error if there exists a destination node lagging
-// more than maxAllowable lag behind any other destination node. This function
+// more than maxAllowable lag behind the mean frontier of all destination nodes. This function
 // assumes that all nodes have finished their initial scan (i.e. have a nonzero hwm).
 func checkLaggingNodes(
 	ctx context.Context, executionDetails []frontierExecutionDetails, maxAllowableLag time.Duration,
@@ -29,18 +30,22 @@ func checkLaggingNodes(
 	if maxAllowableLag == 0 {
 		return nil
 	}
-	laggingNode, minLagDifference := computeMinLagDifference(executionDetails)
-	log.VEventf(ctx, 2, "computed min lag diff: %d lagging node, difference %.2f", laggingNode, minLagDifference.Minutes())
-	if maxAllowableLag < minLagDifference {
-		return errors.Wrapf(ErrNodeLagging, "node %d is %.2f minutes behind the next node. Try replanning", laggingNode, minLagDifference.Minutes())
+	laggingNode, meanLagDifference := computeMeanLagDifference(ctx, executionDetails)
+	log.VEventf(ctx, 2, "computed mean lag diff: %d lagging node, difference %.2f", laggingNode, meanLagDifference.Minutes())
+	if maxAllowableLag < meanLagDifference {
+		return errors.Wrapf(ErrNodeLagging, "node %d is %.2f minutes behind the average frontier. Try replanning", laggingNode, meanLagDifference.Minutes())
 	}
 	return nil
 }
 
-func computeMinLagDifference(
-	executionDetails []frontierExecutionDetails,
+// computeMeanLagDifference computes the difference between the mean frontier by
+// node and the node with the lowest frontier.
+func computeMeanLagDifference(
+	ctx context.Context, executionDetails []frontierExecutionDetails,
 ) (base.SQLInstanceID, time.Duration) {
-	oldestHWM := hlc.MaxTimestamp.GoTime()
+	lowestFrontier := hlc.MaxTimestamp.GoTime()
+
+	// First find the frontier for each node.
 	var laggingNode base.SQLInstanceID
 	destNodeFrontier := make(map[base.SQLInstanceID]time.Time)
 	for _, detail := range executionDetails {
@@ -50,8 +55,8 @@ func computeMinLagDifference(
 		} else if destNodeFrontier[detail.destInstanceID].After(frontier) {
 			destNodeFrontier[detail.destInstanceID] = frontier
 		}
-		if oldestHWM.After(frontier) {
-			oldestHWM = frontier
+		if lowestFrontier.After(frontier) {
+			lowestFrontier = frontier
 			laggingNode = detail.destInstanceID
 		}
 	}
@@ -59,16 +64,17 @@ func computeMinLagDifference(
 		// If there are fewer than 2 nodes in the frontier, we can't compare relative lag.
 		return base.SQLInstanceID(0), 0
 	}
+	meanFrontier := getMeanFrontier(destNodeFrontier)
+	log.VEventf(ctx, 2, "mean frontier: %s, lowest frontier %s", meanFrontier, lowestFrontier)
 
-	minlagDifference := hlc.MaxTimestamp.GoTime().Sub(hlc.MinTimestamp.GoTime())
-	for id, frontier := range destNodeFrontier {
-		if id == laggingNode {
-			continue
-		}
+	return laggingNode, meanFrontier.Sub(lowestFrontier)
+}
 
-		if diff := frontier.Sub(oldestHWM); diff < minlagDifference {
-			minlagDifference = diff
-		}
+func getMeanFrontier(destNodeFrontier map[base.SQLInstanceID]time.Time) time.Time {
+	var sum int64
+	for _, frontier := range destNodeFrontier {
+		sum += frontier.Unix()
 	}
-	return laggingNode, minlagDifference
+	frontierMean := timeutil.Unix(sum/int64(len(destNodeFrontier)), 0)
+	return frontierMean
 }

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -918,14 +918,14 @@ func TestStreamingReplanOnLag(t *testing.T) {
 
 	// Configure the ingestion job to replan eagerly based on node lagging.
 	serverutils.SetClusterSetting(t, c.DestCluster, "physical_replication.consumer.node_lag_replanning_threshold", time.Second)
-	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_frequency", time.Millisecond*500)
+	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.lag_check_frequency", time.Millisecond*500)
 
 	// The ingestion job should eventually retry because it detects a lagging node.
 	require.ErrorContains(t, <-retryErrorChan, ErrNodeLagging.Error())
 
 	// Prevent continuous replanning to reduce test runtime.
 	serverutils.SetClusterSetting(t, c.DestCluster, "physical_replication.consumer.node_lag_replanning_threshold", time.Minute*10)
-	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_frequency", time.Minute*10)
+	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.lag_check_frequency", time.Minute*10)
 	close(turnOffReplanning)
 
 	cutoverTime := c.DestSysServer.Clock().Now()

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -549,11 +549,6 @@ func (sf *streamIngestionFrontier) maybeCheckForLaggingNodes() error {
 			maxLag, checkFreq.Minutes(), sf.lastNodeLagCheck, timeutil.Since(sf.lastNodeLagCheck).Minutes())
 		return nil
 	}
-	// Don't check for lagging nodes if the hwm has yet to advance.
-	if sf.replicatedTimeAtStart.Equal(sf.persistedReplicatedTime) {
-		log.VEventf(ctx, 2, "skipping lag replanning check: hwm has yet to advance past %s", sf.replicatedTimeAtStart)
-		return nil
-	}
 	defer func() {
 		sf.lastNodeLagCheck = timeutil.Now()
 	}()
@@ -580,7 +575,7 @@ func (sf *streamIngestionFrontier) handleLaggingNodeError(ctx context.Context, e
 		sf.replicatedTimeAtLastPositiveLagNodeCheck = sf.persistedReplicatedTime
 		return nil
 	case sf.replicatedTimeAtLastPositiveLagNodeCheck.Equal(sf.persistedReplicatedTime):
-		return errors.Wrapf(err, "hwm has not advanced from %s", sf.persistedReplicatedTime)
+		return errors.Wrapf(err, "replicated time has not advanced from %s", sf.persistedReplicatedTime)
 	default:
 		return errors.Wrapf(err, "unable to handle replanning error with replicated time %s and last node lag check replicated time %s", sf.persistedReplicatedTime, sf.replicatedTimeAtLastPositiveLagNodeCheck)
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -544,6 +544,10 @@ func (sf *streamIngestionFrontier) maybeCheckForLaggingNodes() error {
 	// distSQL plan if a node is lagging for 2 checks in a row.
 	checkFreq := streamingccl.ReplanFrequency.Get(&sf.FlowCtx.Cfg.Settings.SV) / 2
 	maxLag := streamingccl.InterNodeLag.Get(&sf.FlowCtx.Cfg.Settings.SV)
+	if sf.persistedReplicatedTime.IsEmpty() {
+		log.VEvent(ctx, 2, "skipping lag replanning check: no persisted replicated time")
+		return nil
+	}
 	if checkFreq == 0 || maxLag == 0 || timeutil.Since(sf.lastNodeLagCheck) < checkFreq {
 		log.VEventf(ctx, 2, "skipping lag replanning check: maxLag %d; checkFreq %.2f; last node check %s; time since last check %.2f",
 			maxLag, checkFreq.Minutes(), sf.lastNodeLagCheck, timeutil.Since(sf.lastNodeLagCheck).Minutes())

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1239,19 +1239,19 @@ func registerClusterToCluster(r registry.Registry) {
 			suites:                    registry.Suites(registry.Nightly),
 		},
 		{
-			name:               "c2c/BulkOps/short",
+			name:               "c2c/BulkOps",
 			srcNodes:           4,
 			dstNodes:           4,
 			cpus:               8,
 			pdSize:             100,
-			workload:           replicateBulkOps{short: true},
+			workload:           replicateBulkOps{},
 			timeout:            2 * time.Hour,
 			additionalDuration: 0,
 			// Cutover currently takes around 4 minutes, perhaps because we need to
 			// revert 10 GB of replicated data.
 			//
 			// TODO(msbutler): investigate further if cutover can be sped up.
-			cutoverTimeout: 10 * time.Minute,
+			cutoverTimeout: 20 * time.Minute,
 			cutover:        5 * time.Minute,
 			// In a few ad hoc runs, the max latency hikes up to 27 minutes before lag
 			// replanning and distributed catch up scans fix the poor initial plan. If

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -235,6 +235,30 @@ func (tpcc replicateTPCC) runDriver(
 	return defaultWorkloadDriver(workloadCtx, setup, c, tpcc)
 }
 
+// replicateImportKV is a kv workload that runs the kv init step after the
+// replication stream has started, inducing a bulk import catchup scan workload.
+type replicateImportKV struct {
+	replicateKV
+	replicateSplits bool
+}
+
+func (ikv replicateImportKV) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
+	return ""
+}
+
+func (ikv replicateImportKV) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
+	return ikv.replicateKV.sourceInitCmd(tenantName, nodes)
+}
+
+func (ikv replicateImportKV) runDriver(
+	workloadCtx context.Context, c cluster.Cluster, t test.Test, setup *c2cSetup,
+) error {
+	if ikv.replicateSplits {
+		setup.dst.sysSQL.Exec(t, "SET CLUSTER SETTING physical_replication.consumer.ingest_split_event.enabled = true")
+	}
+	return defaultWorkloadDriver(workloadCtx, setup, c, ikv)
+}
+
 type replicateKV struct {
 	readPercent int
 
@@ -1167,6 +1191,65 @@ func registerClusterToCluster(r registry.Registry) {
 			suites:             registry.Suites(registry.Nightly),
 		},
 		{
+			// Catchup scan perf test on 7tb bulk import.
+			name:      "c2c/import/7tb/kv0",
+			benchmark: true,
+			srcNodes:  10,
+			dstNodes:  10,
+			cpus:      8,
+			pdSize:    1100,
+			// Write ~7TB data to disk via Import -- takes a little over 1 hour.
+			workload: replicateImportKV{
+				replicateSplits: true,
+				replicateKV:     replicateKV{readPercent: 0, initRows: 5000000000, maxBlockBytes: 1024}},
+			timeout: 3 * time.Hour,
+			// While replicating a bulk op, expect the max latency to be the runtime
+			// of the bulk op.
+			maxAcceptedLatency: 2 * time.Hour,
+			// Cutover to one second after the import completes.
+			cutover: -1 * time.Second,
+			// After the cutover command begins, the destination cluster still needs
+			// to catch up. Since we allow a max lag of 2 hours, it may take some time
+			// to actually catch up after the bulk op succeeds. That being said, once
+			// the import completes, we expect the replication stream to catch up
+			// fairly quickly.
+			cutoverTimeout: 30 * time.Minute,
+			// Because PCR begins on a nearly empty cluster, skip the node distribution check.
+			skipNodeDistributionCheck: true,
+			clouds:                    registry.OnlyGCE,
+			suites:                    registry.Suites(registry.Weekly),
+		},
+		{
+			// Catchup scan perf test on bulk import.
+			name:      "c2c/import/kv0",
+			benchmark: true,
+			srcNodes:  5,
+			dstNodes:  5,
+			cpus:      8,
+			pdSize:    500,
+			// Write ~1.2TB data to disk,takes a about 40 minutes.
+			workload: replicateImportKV{
+				replicateSplits: true,
+				replicateKV:     replicateKV{readPercent: 0, initRows: 1000000000, maxBlockBytes: 1024}},
+			timeout: 90 * time.Minute,
+			// While replicating a bulk op, expect the max latency to be the runtime
+			// of the bulk op.
+			maxAcceptedLatency: 1 * time.Hour,
+			// Cutover to one second after the import completes.
+			cutover: -1 * time.Second,
+			// After the cutover command begins, the destination cluster still needs
+			// to catch up. Since we allow a max lag of 1 hour, it may take some time
+			// to actually catch up after the bulk op succeeds. That being said, once
+			// the import completes, we expect the replication stream to catch up
+			// fairly quickly.
+			cutoverTimeout: 20 * time.Minute,
+			// Because PCR begins on a nearly empty cluster, skip the node
+			// distribution check.
+			skipNodeDistributionCheck: true,
+			clouds:                    registry.OnlyGCE,
+			suites:                    registry.Suites(registry.Weekly),
+		},
+		{
 			// Large workload to test our 23.2 perf goals.
 			name:      "c2c/weekly/kv50",
 			benchmark: true,
@@ -1763,7 +1846,10 @@ func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration
 	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
-		`SET CLUSTER SETTING physical_replication.consumer.node_lag_replanning_threshold = '5m';`)
+		`SET CLUSTER SETTING physical_replication.consumer.node_lag_replanning_threshold = '2m';`,
+		`SET CLUSTER SETTING stream_replication.replan_flow_frequency = '4m';`,
+		`SET CLUSTER SETTING server.debug.default_vmodule = 'node_lag_detector=2,stream_ingestion_frontier_processor=2';`,
+	)
 
 	if additionalDuration != 0 {
 		replanFrequency := additionalDuration / 2

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1846,9 +1846,6 @@ func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration
 	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
-		`SET CLUSTER SETTING physical_replication.consumer.node_lag_replanning_threshold = '2m';`,
-		`SET CLUSTER SETTING stream_replication.replan_flow_frequency = '4m';`,
-		`SET CLUSTER SETTING server.debug.default_vmodule = 'node_lag_detector=2,stream_ingestion_frontier_processor=2';`,
 	)
 
 	if additionalDuration != 0 {

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -44,3 +44,22 @@ func (fes RestoreFrontierEntries) Equal(fes2 RestoreFrontierEntries) bool {
 	}
 	return true
 }
+
+// ResolvedSpanEntries is a slice of ResolvedSpanEntries.
+// TODO(msbutler): use generics and combine with above.
+type ResolvedSpanEntries []ResolvedSpan
+
+func (rse ResolvedSpanEntries) Equal(rse2 ResolvedSpanEntries) bool {
+	if len(rse) != len(rse2) {
+		return false
+	}
+	for i := range rse {
+		if !rse[i].Span.Equal(rse2[i].Span) {
+			return false
+		}
+		if !rse[i].Timestamp.Equal(rse2[i].Timestamp) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "kvclient/rangefeed: allow user to resume rangefeed with span frontier" (#125044)
  * 3/3 commits from " streamingccl: tweak node lag replanning policy" (#124926)
  * 4/4 commits from "streamingccl: enable lag replanning by default" (#125789)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk, high impact change specific to PCR
