### PR TITLE
sqlstats: fix qos definition for sqlstats flush ops

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/sql/sqlstats/sslocal",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/mon",

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -197,7 +198,7 @@ func (s *PersistedSQLStats) doFlushSingleTxnStats(
 			return errors.Wrapf(err, "flushing transaction %d's statistics", stats.TransactionFingerprintID)
 		}
 		return nil
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 }
 
 func (s *PersistedSQLStats) doFlushSingleStmtStats(
@@ -221,7 +222,7 @@ func (s *PersistedSQLStats) doFlushSingleStmtStats(
 			return errors.Wrapf(err, "flush statement %d's statistics", stats.ID)
 		}
 		return nil
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 }
 
 // ComputeAggregatedTs returns the aggregation timestamp to assign


### PR DESCRIPTION
Internal execs started with a txn should specify qos using `WithPriority`. This commit fixes that definition for some flush queries that were missed in https://github.com/cockroachdb/cockroach/pull/125848.

Epic: none
Part of: #125839

Release note: None