### PR TITLE
release-23.2: changefeedccl: log plan diagram during DistSQL planning

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
@@ -489,6 +490,21 @@ func makePlan(
 
 		p.PlanToStreamColMap = []int{1, 2, 3}
 		sql.FinalizePlan(ctx, planCtx, p)
+
+		// Log the plan diagram URL so that we don't have to rely on it being in system.job_info.
+		const maxLenDiagURL = 1 << 20 // 1 MiB
+		flowSpecs := p.GenerateFlowSpecs()
+		if _, diagURL, err := execinfrapb.GeneratePlanDiagramURL(
+			fmt.Sprintf("changefeed: %d", jobID),
+			flowSpecs,
+			execinfrapb.DiagramFlags{},
+		); err != nil {
+			log.Warningf(ctx, "failed to generate changefeed plan diagram: %s", err)
+		} else if diagURL := diagURL.String(); len(diagURL) > maxLenDiagURL {
+			log.Warningf(ctx, "changefeed plan diagram length is too large to be logged: %d", len(diagURL))
+		} else {
+			log.Infof(ctx, "changefeed plan diagram: %s", diagURL)
+		}
 
 		return p, planCtx, nil
 	}


### PR DESCRIPTION
Backport 1/1 commits from #126289.

/cc @cockroachdb/release

---

This patch logs the plan diagram URL during changefeed planning so that
we don't need to rely on it being written to the system.job_info table.
The diagrams are useful for visualizing a changefeed's plan.

Epic: CRDB-37337

Release note: None

---

Release justification: new high-priority logging