### PR TITLE
raft: rm redundant return value from maybeAppend

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1681,14 +1681,15 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed})
 		return
 	}
-	if mlastIndex, ok := r.raftLog.maybeAppend(a); ok {
+	if r.raftLog.maybeAppend(a) {
 		r.accTerm = m.Term // our log is now consistent with the m.Term leader
 		// TODO(pav-kv): make it possible to commit even if the append did not
 		// succeed or is stale. If r.accTerm >= m.Term, then our log contains all
 		// committed entries at m.Term (by raft invariants), so it is safe to bump
 		// the commit index even if the MsgApp is stale.
-		r.raftLog.commitTo(min(m.Commit, mlastIndex))
-		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: mlastIndex})
+		lastIndex := a.lastIndex()
+		r.raftLog.commitTo(min(m.Commit, lastIndex))
+		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: lastIndex})
 		return
 	}
 	r.logger.Debugf("%x [logterm: %d, index: %d] rejected MsgApp [logterm: %d, index: %d] from %x",


### PR DESCRIPTION
The caller knows the last appended index and compute it themselves if the append succeeds.

Epic: none
Release note: none