### PR TITLE
release-23.2: sqlstats: specify UserLow qos for sql stats queries

### DIFF
--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -73,3 +73,11 @@ var NodeUserSessionDataOverride = InternalExecutorOverride{
 var RootUserSessionDataOverride = InternalExecutorOverride{
 	User: username.MakeSQLUsernameFromPreNormalizedString(username.RootUser),
 }
+
+// NodeUserWithLowUserPrioritySessionDataOverride is an InternalExecutorOverride
+// which overrides the user to the NodeUser and sets the quality of service to
+// sessiondatapb.UserLow.
+var NodeUserWithLowUserPrioritySessionDataOverride = InternalExecutorOverride{
+	User:             username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
+	QualityOfService: &sessiondatapb.UserLowQoS,
+}

--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -342,6 +342,14 @@ const (
 	LockingHighName = "locking-high"
 )
 
+// When providing SessionData overrides to the internal executor,
+// we need to use pointers to specify the QoSLevel. Since we can't
+// use pointers to constants, we define these variables to use in
+// those cases.
+var (
+	UserLowQoS = UserLow
+)
+
 var qosLevelsDict = map[QoSLevel]string{
 	SystemLow:     SystemLowName,
 	TTLLow:        TTLLowName,

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -280,7 +281,7 @@ func (u *sqlActivityUpdater) transferAllStats(
 	_, err := u.db.Executor().ExecEx(ctx,
 		"activity-flush-txn-transfer-all",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		`
 			UPSERT INTO system.public.transaction_activity 
 (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
@@ -326,7 +327,7 @@ func (u *sqlActivityUpdater) transferAllStats(
 	_, err = u.db.Executor().ExecEx(ctx,
 		"activity-flush-stmt-transfer-all",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		`
 			UPSERT
 INTO system.public.statement_activity (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name,
@@ -399,7 +400,7 @@ func (u *sqlActivityUpdater) transferTopStats(
 		_, err := txn.ExecEx(ctx,
 			"activity-flush-txn-transfer-tops",
 			txn.KV(), /* txn */
-			sessiondata.NodeUserSessionDataOverride,
+			sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 			`DELETE FROM system.public.transaction_activity WHERE aggregated_ts = $1;`,
 			aggTs)
 
@@ -416,7 +417,7 @@ func (u *sqlActivityUpdater) transferTopStats(
 		_, err = txn.ExecEx(ctx,
 			"activity-flush-txn-transfer-tops",
 			txn.KV(), /* txn */
-			sessiondata.NodeUserSessionDataOverride,
+			sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 			`
 UPSERT INTO system.public.transaction_activity
 (aggregated_ts, fingerprint_id, app_name, agg_interval, metadata,
@@ -483,7 +484,7 @@ UPSERT INTO system.public.transaction_activity
 		)
 
 		return err
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 
 	if errTxn != nil {
 		return errTxn
@@ -499,7 +500,7 @@ UPSERT INTO system.public.transaction_activity
 		_, err := txn.ExecEx(ctx,
 			"activity-flush-txn-transfer-tops",
 			txn.KV(), /* txn */
-			sessiondata.NodeUserSessionDataOverride,
+			sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 			`DELETE FROM system.public.statement_activity WHERE aggregated_ts = $1;`,
 			aggTs)
 
@@ -516,7 +517,7 @@ UPSERT INTO system.public.transaction_activity
 		_, err = txn.ExecEx(ctx,
 			"activity-flush-stmt-transfer-tops",
 			txn.KV(), /* txn */
-			sessiondata.NodeUserSessionDataOverride,
+			sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 			`
 WITH agg_stmt_stats AS (SELECT aggregated_ts,
                                fingerprint_id,
@@ -593,7 +594,7 @@ FROM (SELECT ss.aggregated_ts AS aggregated_ts,
 		)
 
 		return err
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 
 	return errTxn
 }
@@ -633,7 +634,7 @@ FROM (SELECT count_rows():::int                     AS row_count,
 	it, err := u.db.Executor().QueryIteratorEx(ctx,
 		"activity-flush-count",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		query,
 		aggTs,
 	)
@@ -706,7 +707,7 @@ func (u *sqlActivityUpdater) compactActivityTables(ctx context.Context, maxRowCo
 	_, err = u.db.Executor().ExecEx(ctx,
 		"activity-stmt-compaction",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		`
 				DELETE
 FROM system.statement_activity
@@ -723,7 +724,7 @@ WHERE aggregated_ts IN (SELECT DISTINCT aggregated_ts FROM (SELECT aggregated_ts
 	_, err = u.db.Executor().ExecEx(ctx,
 		"activity-txn-compaction",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		`
 				DELETE
 FROM system.transaction_activity
@@ -748,7 +749,7 @@ func (u *sqlActivityUpdater) getTableRowCount(
 	datums, err := u.db.Executor().QueryRowEx(ctx,
 		"activity-total-count",
 		nil, /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		query,
 	)
 

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/sqlstats/sslocal",

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/sqlstats/ssmemstorage",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/mon",

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -114,7 +113,7 @@ func (c *StatsCompactor) getRowCountForShard(
 	row, err := c.db.Executor().QueryRowEx(ctx,
 		"scan-row-count",
 		nil,
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		stmt,
 		shardIdx,
 	)
@@ -208,14 +207,10 @@ func (c *StatsCompactor) removeStaleRowsForShard(
 func (c *StatsCompactor) executeDeleteStmt(
 	ctx context.Context, delStmt string, qargs []interface{},
 ) (lastRow tree.Datums, rowsDeleted int64, err error) {
-	qosLevel := sessiondatapb.UserLow
 	it, err := c.db.Executor().QueryIteratorEx(ctx,
 		"delete-old-sql-stats",
 		nil, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User:             sessiondata.NodeUserSessionDataOverride.User,
-			QualityOfService: &qosLevel,
-		},
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		delStmt,
 		qargs...,
 	)

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -134,7 +134,7 @@ func (s *PersistedSQLStats) StmtsLimitSizeReached(ctx context.Context) (bool, er
 		ctx,
 		"fetch-stmt-count",
 		nil,
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		readStmt,
 		randomShard,
 	)
@@ -409,7 +409,7 @@ DO NOTHING
 		ctx,
 		"insert-txn-stats",
 		txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		insertStmt,
 		aggregatedTs,            // aggregated_ts
 		serializedFingerprintID, // fingerprint_id
@@ -449,7 +449,7 @@ WHERE fingerprint_id = $2
 		ctx,
 		"update-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		updateStmt,
 		statistics,              // statistics
 		serializedFingerprintID, // fingerprint_id
@@ -507,7 +507,7 @@ WHERE fingerprint_id = $3
 		ctx,
 		"update-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		updateStmt,
 		statistics,                         // statistics
 		indexRecommendations,               // index_recommendations
@@ -599,7 +599,7 @@ DO NOTHING
 		ctx,
 		"insert-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		insertStmt,
 		args...,
 	)
@@ -634,7 +634,7 @@ FOR UPDATE
 		ctx,
 		"fetch-txn-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		readStmt,                // stmt
 		serializedFingerprintID, // fingerprint_id
 		appName,                 // app_name
@@ -690,7 +690,7 @@ FOR UPDATE
 		ctx,
 		"fetch-stmt-stats",
 		txn.KV(), /* txn */
-		sessiondata.NodeUserSessionDataOverride,
+		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
 		readStmt,                           // stmt
 		serializedFingerprintID,            // fingerprint_id
 		serializedTransactionFingerprintID, // transaction_fingerprint_id

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -247,7 +248,7 @@ func (s *PersistedSQLStats) doFlushSingleTxnStats(
 			return errors.Wrapf(err, "flushing transaction %d's statistics", stats.TransactionFingerprintID)
 		}
 		return nil
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 }
 
 func (s *PersistedSQLStats) doFlushSingleStmtStats(
@@ -320,7 +321,7 @@ func (s *PersistedSQLStats) doFlushSingleStmtStats(
 			return errors.Wrapf(err, "flush statement %d's statistics", scopedStats.ID)
 		}
 		return nil
-	})
+	}, isql.WithPriority(admissionpb.UserLowPri))
 }
 
 func (s *PersistedSQLStats) doInsertElseDoUpdate(


### PR DESCRIPTION
Backport 1/1 commits from #125848.
Backport 1/1 commits from #126331.

/cc @cockroachdb/release

---

Queries in the sql stats system can be expensive as they perform periodic INSERT and DELETE operations into various system tables. We should specify their qos level as `UserLow` to ensure they don't interfere with foreground workloads.

Epic: CRDB-37544
Fixes: #125839

Release note: None

Release justification: low-risk stability/perf improvement