### PR TITLE
streamclient: identify logical replication subscription

### DIFF
--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -127,7 +127,7 @@ func createLogicalReplicationStreamPlanHook(
 		}
 		streamAddress = crosscluster.StreamAddress(streamURL.String())
 
-		client, err := streamclient.NewStreamClient(ctx, streamAddress, p.ExecCfg().InternalDB)
+		client, err := streamclient.NewStreamClient(ctx, streamAddress, p.ExecCfg().InternalDB, streamclient.WithLogical())
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -86,7 +86,7 @@ func createRemoteProduceJobForLogicalReplication(
 		return nil, err
 	}
 
-	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr)
+	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr, streamclient.WithLogical())
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (r *logicalReplicationResumer) ingest(
 		return err
 	}
 
-	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr, streamclient.WithStreamID(streampb.StreamID(streamID)))
+	client, err := streamclient.NewPartitionedStreamClient(ctx, streamAddr, streamclient.WithStreamID(streampb.StreamID(streamID)), streamclient.WithLogical())
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -201,6 +201,7 @@ func (lrw *logicalReplicationWriterProcessor) Start(ctx context.Context) {
 	streamClient, err := streamclient.NewStreamClient(ctx, crosscluster.StreamAddress(addr), db,
 		streamclient.WithStreamID(streampb.StreamID(lrw.spec.StreamID)),
 		streamclient.WithCompression(true),
+		streamclient.WithLogical(),
 	)
 	if err != nil {
 		lrw.MoveToDrainingAndLogError(errors.Wrapf(err, "creating client for partition spec %q from %q", token, redactedAddr))

--- a/pkg/ccl/crosscluster/streamclient/client.go
+++ b/pkg/ccl/crosscluster/streamclient/client.go
@@ -305,6 +305,7 @@ func getFirstDialer(
 type options struct {
 	streamID   streampb.StreamID
 	compressed bool
+	logical    bool
 }
 
 func (o *options) appName() string {
@@ -331,6 +332,12 @@ func WithStreamID(id streampb.StreamID) Option {
 func WithCompression(enabled bool) Option {
 	return func(o *options) {
 		o.compressed = enabled
+	}
+}
+
+func WithLogical() Option {
+	return func(o *options) {
+		o.logical = true
 	}
 }
 

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -92,6 +92,11 @@ message ReplicationProducerRequest {
   repeated string table_names = 4;
 }
 
+enum ReplicationType {
+  PHYSICAL = 0;
+  LOGICAL = 1;
+}
+
 // StreamPartitionSpec is the stream partition specification used to init an
 // eventStream.
 message StreamPartitionSpec {
@@ -144,7 +149,9 @@ message StreamPartitionSpec {
 
   bool wrapped_events = 11;
 
-  // NEXT ID: 11.
+  ReplicationType type = 12;
+
+  // NEXT ID: 13.
 }
 
 // SpanConfigEventStreamSpec is the span config event stream specification.


### PR DESCRIPTION
This patch identifies clients for logical or physical replication, and passes the replication type to the event stream specs. This will allow us to create and increment source side metrics specific for LDR and PCR.

Epic: none

Release note: none