### PR TITLE
loqrecovery: skip TestReplicaCollection under deadlock

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -52,6 +52,8 @@ func TestReplicaCollection(t *testing.T) {
 
 	ctx := context.Background()
 
+	skip.UnderDeadlock(t, "occasionally flakes")
+
 	// This test stops cluster servers. Use "reusable" listeners, otherwise the
 	// ports can be reused by other test clusters, and we may accidentally connect
 	// to a wrong node.


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/123624 Closes https://github.com/cockroachdb/cockroach/issues/122773

Release note: None