### PR TITLE
Cannot restore backup unknown type kind COMPOSITE

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-types
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-types
@@ -155,6 +155,10 @@ CREATE TYPE d.farewell AS ENUM ('bye', 'cya');
 ----
 
 exec-sql
+CREATE TYPE d.roach_status AS (queen_roach UUID, king_roach  UUID, worker_roach INT);
+----
+
+exec-sql
 CREATE TABLE d.t1 (x d.greeting);
 ----
 

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -657,7 +657,7 @@ func TypeDescs(types []*typedesc.Mutable, descriptorRewrites jobspb.DescRewriteM
 			}
 		}
 		switch t := typ.Kind; t {
-		case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
+		case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_COMPOSITE, descpb.TypeDescriptor_MULTIREGION_ENUM:
 			if rw, ok := descriptorRewrites[typ.ArrayTypeID]; ok {
 				typ.ArrayTypeID = rw.ID
 			}


### PR DESCRIPTION
Added the handling for the composite type case.

Fixes: #125550

Release note (bug fix): Fixed a bug that made it impossible to restore a database that contains a composite type.