### PR TITLE
raft: add term invariant checks

### DIFF
--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
+        "//pkg/util/buildutil",
     ],
 )
 

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -61,6 +61,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 
 		ents[i] = pb.Entry{Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data}
 	}
+	rn.raft.accTerm = 1
 	rn.raft.raftLog.append(ents...)
 
 	// Now apply them, mainly so that the application can call Campaign

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -485,6 +485,16 @@ func newRaft(c *Config) *raft {
 	return r
 }
 
+// checkInvariants checks the raft node invariants. For testing.
+func (r *raft) checkInvariants() error {
+	last := r.raftLog.lastEntryID()
+	if r.accTerm < last.term || r.Term < r.accTerm {
+		return fmt.Errorf("lastTerm, accTerm, Term not ordered: %d, %d, %d", last.term, r.accTerm, r.Term)
+	}
+	// TODO(pav-kv): add more invariants.
+	return nil
+}
+
 func (r *raft) hasLeader() bool { return r.lead != None }
 
 func (r *raft) softState() SoftState { return SoftState{Lead: r.lead, RaftState: r.state} }

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -417,6 +417,12 @@ func newRaft(c *Config) *raft {
 		panic(err) // TODO(bdarnell)
 	}
 
+	// Check term correctness invariant.
+	lastID := raftlog.lastEntryID()
+	if hs.Term < lastID.term {
+		c.Logger.Panicf("%x: Storage: HardState.Term < Term(LastIndex): %d < %d", c.ID, hs.Term, lastID.term)
+	}
+
 	r := &raft{
 		id:                          c.ID,
 		lead:                        None,
@@ -434,7 +440,6 @@ func newRaft(c *Config) *raft {
 		disableConfChangeValidation: c.DisableConfChangeValidation,
 		stepDownOnRemoval:           c.StepDownOnRemoval,
 	}
-	lastID := r.raftLog.lastEntryID()
 
 	// To initialize accTerm correctly, we make sure its invariant is true: the
 	// log is a prefix of the accTerm leader's log. This can be achieved by

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 )
 
 const (
@@ -1053,6 +1054,14 @@ func (r *raft) poll(
 }
 
 func (r *raft) Step(m pb.Message) error {
+	if buildutil.CrdbTestBuild {
+		defer func() {
+			if err := r.checkInvariants(); err != nil {
+				r.logger.Panicf("%x: invariant check failed: %v", r.id, err)
+			}
+		}()
+	}
+
 	// Handle the message term, which may result in our stepping down to a follower.
 	switch {
 	case m.Term == 0:

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -622,7 +622,7 @@ func TestFollowerAppendEntries(t *testing.T) {
 		storage.Append([]pb.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}})
 		r := newTestRaft(1, 10, 1, storage)
 
-		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgApp, Term: 2, LogTerm: tt.term, Index: tt.index, Entries: tt.ents})
+		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgApp, Term: 4, LogTerm: tt.term, Index: tt.index, Entries: tt.ents})
 
 		assert.Equal(t, tt.wents, r.raftLog.allEntries(), "#%d", i)
 		assert.Equal(t, tt.wunstable, r.raftLog.nextUnstableEnts(), "#%d", i)

--- a/pkg/raft/rafttest/interaction_env_handler.go
+++ b/pkg/raft/rafttest/interaction_env_handler.go
@@ -204,6 +204,14 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		}
 		env.Output.WriteString(err.Error())
 	}
+
+	// Check invariants on every node.
+	for _, n := range env.Nodes {
+		if err := n.CheckInvariants(); err != nil {
+			t.Fatalf("%d: CheckInvariants: %v", n.Config.ID, err)
+		}
+	}
+
 	if env.Output.Len() == 0 {
 		return "ok"
 	}

--- a/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
+++ b/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
@@ -108,6 +108,11 @@ func (env *InteractionEnv) AddNodes(n int, cfg raft.Config, snap pb.Snapshot) er
 				return errors.New("index must be specified as > 1 due to bootstrap")
 			}
 			snap.Metadata.Term = 1
+			if err := s.SetHardState(pb.HardState{
+				Term: 1, Commit: snap.Metadata.Index,
+			}); err != nil {
+				return err
+			}
 			if err := s.ApplySnapshot(snap); err != nil {
 				return err
 			}

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -530,3 +530,8 @@ func (rn *RawNode) TransferLeader(transferee uint64) {
 func (rn *RawNode) ForgetLeader() error {
 	return rn.raft.Step(pb.Message{Type: pb.MsgForgetLeader})
 }
+
+// CheckInvariants checks the raft node invariants. For testing.
+func (rn *RawNode) CheckInvariants() error {
+	return rn.raft.checkInvariants()
+}

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -4,225 +4,225 @@
 add-nodes 3 voters=(1,2,3) index=10 async-storage-writes=true
 ----
 INFO 1 switched to configuration voters=(1 2 3)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1,2,3], term: 1, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
 INFO 2 switched to configuration voters=(1 2 3)
-INFO 2 became follower at term 0
-INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 became follower at term 1
+INFO newRaft 2 [peers: [1,2,3], term: 1, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
 INFO 3 switched to configuration voters=(1 2 3)
-INFO 3 became follower at term 0
-INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 became follower at term 1
+INFO newRaft 3 [peers: [1,2,3], term: 1, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
-INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
-INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 2
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 2
 
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:1 Vote:1 Commit:10
+  HardState Term:2 Vote:1 Commit:10
   Messages:
-  1->2 MsgVote Term:1 Log:1/10
-  1->3 MsgVote Term:1 Log:1/10
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Responses:[
-    1->1 MsgVoteResp Term:1 Log:0/0
+  1->2 MsgVote Term:2 Log:1/10
+  1->3 MsgVote Term:2 Log:1/10
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:10 Vote:1 Responses:[
+    1->1 MsgVoteResp Term:2 Log:0/0
   ]
 > 2 receiving messages
-  1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+  1->2 MsgVote Term:2 Log:1/10
+  INFO 2 [term: 1] received a MsgVote message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 2
 > 3 receiving messages
-  1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
-  INFO 3 became follower at term 1
-  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+  1->3 MsgVote Term:2 Log:1/10
+  INFO 3 [term: 1] received a MsgVote message with higher term from 1 [term: 2]
+  INFO 3 became follower at term 2
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 2
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:10 Vote:1
   Responses:
-  1->1 MsgVoteResp Term:1 Log:0/0
+  1->1 MsgVoteResp Term:2 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:10
+  HardState Term:2 Vote:1 Commit:10
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Responses:[
-    2->1 MsgVoteResp Term:1 Log:0/0
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:10 Vote:1 Responses:[
+    2->1 MsgVoteResp Term:2 Log:0/0
   ]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:10
+  HardState Term:2 Vote:1 Commit:10
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Responses:[
-    3->1 MsgVoteResp Term:1 Log:0/0
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:10 Vote:1 Responses:[
+    3->1 MsgVoteResp Term:2 Log:0/0
   ]
 > 1 receiving messages
-  1->1 MsgVoteResp Term:1 Log:0/0
-  INFO 1 received MsgVoteResp from 1 at term 1
+  1->1 MsgVoteResp Term:2 Log:0/0
+  INFO 1 received MsgVoteResp from 1 at term 2
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:10 Vote:1
   Responses:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:2 Log:0/0
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:10 Vote:1
   Responses:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
-  INFO 1 received MsgVoteResp from 2 at term 1
+  2->1 MsgVoteResp Term:2 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 2
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 became leader at term 2
+  3->1 MsgVoteResp Term:2 Log:0/0
 > 1 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/11 EntryNormal ""
+  2/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/11
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/11
+  1->2 MsgApp Term:2 Log:1/10 Commit:10 Entries:[2/11 EntryNormal ""]
+  1->3 MsgApp Term:2 Log:1/10 Commit:10 Entries:[2/11 EntryNormal ""]
+  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/11 EntryNormal ""] Responses:[
+    1->1 MsgAppResp Term:2 Log:0/11
+    AppendThread->1 MsgStorageAppendResp Term:2 Log:2/11
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:1/10 Commit:10 Entries:[2/11 EntryNormal ""]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:2 Log:1/10 Commit:10 Entries:[2/11 EntryNormal ""]
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/11
+  1->1 MsgAppResp Term:2 Log:0/11
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/11
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
   Entries:
-  1/11 EntryNormal ""
+  2/11 EntryNormal ""
   Messages:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/11
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/11
+  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/11 EntryNormal ""] Responses:[
+    2->1 MsgAppResp Term:2 Log:0/11
+    AppendThread->2 MsgStorageAppendResp Term:2 Log:2/11
   ]
 > 3 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
   Entries:
-  1/11 EntryNormal ""
+  2/11 EntryNormal ""
   Messages:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/11
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
+  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/11 EntryNormal ""] Responses:[
+    3->1 MsgAppResp Term:2 Log:0/11
+    AppendThread->3 MsgStorageAppendResp Term:2 Log:2/11
   ]
 > 1 receiving messages
-  1->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/11
+  1->1 MsgAppResp Term:2 Log:0/11
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/11
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/11
+  2->1 MsgAppResp Term:2 Log:0/11
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/11
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
+  3->1 MsgAppResp Term:2 Log:0/11
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11
-  3->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:2 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
 > 2 receiving messages
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/11
 > 3 receiving messages
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/11
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:11
+  HardState Term:2 Vote:1 Commit:11
   CommittedEntries:
-  1/11 EntryNormal ""
+  2/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/11 Commit:11
-  1->3 MsgApp Term:1 Log:1/11 Commit:11
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:2/11 Commit:11
+  1->3 MsgApp Term:2 Log:2/11 Commit:11
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:1
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/11 EntryNormal ""] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->2 MsgApp Term:2 Log:2/11 Commit:11
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:2 Log:2/11 Commit:11
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:1
   Responses:
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:11
+  HardState Term:2 Vote:1 Commit:11
   CommittedEntries:
-  1/11 EntryNormal ""
+  2/11 EntryNormal ""
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/11
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:1 Responses:[
+    2->1 MsgAppResp Term:2 Log:0/11
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/11 EntryNormal ""] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   ]
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:11
+  HardState Term:2 Vote:1 Commit:11
   CommittedEntries:
-  1/11 EntryNormal ""
+  2/11 EntryNormal ""
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Responses:[
-    3->1 MsgAppResp Term:1 Log:0/11
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:1 Responses:[
+    3->1 MsgAppResp Term:2 Log:0/11
   ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/11 EntryNormal ""] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   ]
 > 1 receiving messages
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:2 Log:0/11
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
 > 2 processing apply thread
   Processing:
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   Responses:
-  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
 > 3 processing apply thread
   Processing:
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
   Responses:
-  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11
-  3->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:2 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
 > 2 receiving messages
-  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
 > 3 receiving messages
-  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/11 EntryNormal ""]
 
 propose 1 prop_1
 ----
@@ -233,13 +233,13 @@ process-ready 1 2 3
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
-  1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/12
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+  1->2 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
+  1->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
+  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"] Responses:[
+    1->1 MsgAppResp Term:2 Log:0/12
+    AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
   ]
 > 2 handling Ready
   <empty Ready>
@@ -248,8 +248,8 @@ process-ready 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
-1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
+1->2 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
+1->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
 
 process-ready 1 2 3
 ----
@@ -258,20 +258,20 @@ process-ready 1 2 3
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/12
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
+  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"] Responses:[
+    2->1 MsgAppResp Term:2 Log:0/12
+    AppendThread->2 MsgStorageAppendResp Term:2 Log:2/12
   ]
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/12
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"] Responses:[
+    3->1 MsgAppResp Term:2 Log:0/12
+    AppendThread->3 MsgStorageAppendResp Term:2 Log:2/12
   ]
 
 propose 1 prop_2
@@ -283,13 +283,13 @@ process-ready 1 2 3
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/13 EntryNormal "prop_2"
+  2/13 EntryNormal "prop_2"
   Messages:
-  1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
-  1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/13
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/13
+  1->2 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "prop_2"]
+  1->3 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "prop_2"]
+  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"] Responses:[
+    1->1 MsgAppResp Term:2 Log:0/13
+    AppendThread->1 MsgStorageAppendResp Term:2 Log:2/13
   ]
 > 2 handling Ready
   <empty Ready>
@@ -298,8 +298,8 @@ process-ready 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
-1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
+1->2 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "prop_2"]
+1->3 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "prop_2"]
 
 process-ready 1 2 3
 ----
@@ -308,51 +308,51 @@ process-ready 1 2 3
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/13 EntryNormal "prop_2"
+  2/13 EntryNormal "prop_2"
   Messages:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/13
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/13
+  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"] Responses:[
+    2->1 MsgAppResp Term:2 Log:0/13
+    AppendThread->2 MsgStorageAppendResp Term:2 Log:2/13
   ]
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/13 EntryNormal "prop_2"
+  2/13 EntryNormal "prop_2"
   Messages:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/13
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/13
+  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"] Responses:[
+    3->1 MsgAppResp Term:2 Log:0/13
+    AppendThread->3 MsgStorageAppendResp Term:2 Log:2/13
   ]
 
 process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+  1->1 MsgAppResp Term:2 Log:0/12
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/12
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
+  2->1 MsgAppResp Term:2 Log:0/12
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/12
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/12
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+  3->1 MsgAppResp Term:2 Log:0/12
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/12
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/12
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
-2->1 MsgAppResp Term:1 Log:0/12
-3->1 MsgAppResp Term:1 Log:0/12
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+1->1 MsgAppResp Term:2 Log:0/12
+AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
+2->1 MsgAppResp Term:2 Log:0/12
+3->1 MsgAppResp Term:2 Log:0/12
+AppendThread->2 MsgStorageAppendResp Term:2 Log:2/12
+AppendThread->3 MsgStorageAppendResp Term:2 Log:2/12
 
 propose 1 prop_3
 ----
@@ -362,22 +362,22 @@ process-ready 1 2 3
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:12
+  HardState Term:2 Vote:1 Commit:12
   Entries:
-  1/14 EntryNormal "prop_3"
+  2/14 EntryNormal "prop_3"
   CommittedEntries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  1->2 MsgApp Term:1 Log:1/13 Commit:12
-  1->3 MsgApp Term:1 Log:1/13 Commit:12
-  1->2 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
-  1->3 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/14
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/14
+  1->2 MsgApp Term:2 Log:2/13 Commit:12
+  1->3 MsgApp Term:2 Log:2/13 Commit:12
+  1->2 MsgApp Term:2 Log:2/13 Commit:12 Entries:[2/14 EntryNormal "prop_3"]
+  1->3 MsgApp Term:2 Log:2/13 Commit:12 Entries:[2/14 EntryNormal "prop_3"]
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:12 Vote:1 Entries:[2/14 EntryNormal "prop_3"] Responses:[
+    1->1 MsgAppResp Term:2 Log:0/14
+    AppendThread->1 MsgStorageAppendResp Term:2 Log:2/14
   ]
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   ]
 > 2 handling Ready
   <empty Ready>
@@ -386,10 +386,10 @@ process-ready 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->2 MsgApp Term:1 Log:1/13 Commit:12
-1->2 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
-1->3 MsgApp Term:1 Log:1/13 Commit:12
-1->3 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
+1->2 MsgApp Term:2 Log:2/13 Commit:12
+1->2 MsgApp Term:2 Log:2/13 Commit:12 Entries:[2/14 EntryNormal "prop_3"]
+1->3 MsgApp Term:2 Log:2/13 Commit:12
+1->3 MsgApp Term:2 Log:2/13 Commit:12 Entries:[2/14 EntryNormal "prop_3"]
 
 process-ready 1 2 3
 ----
@@ -397,66 +397,66 @@ process-ready 1 2 3
   <empty Ready>
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:12
+  HardState Term:2 Vote:1 Commit:12
   Entries:
-  1/14 EntryNormal "prop_3"
+  2/14 EntryNormal "prop_3"
   CommittedEntries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/13
-    2->1 MsgAppResp Term:1 Log:0/14
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/14
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:12 Vote:1 Entries:[2/14 EntryNormal "prop_3"] Responses:[
+    2->1 MsgAppResp Term:2 Log:0/13
+    2->1 MsgAppResp Term:2 Log:0/14
+    AppendThread->2 MsgStorageAppendResp Term:2 Log:2/14
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   ]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:12
+  HardState Term:2 Vote:1 Commit:12
   Entries:
-  1/14 EntryNormal "prop_3"
+  2/14 EntryNormal "prop_3"
   CommittedEntries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/13
-    3->1 MsgAppResp Term:1 Log:0/14
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/14
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:12 Vote:1 Entries:[2/14 EntryNormal "prop_3"] Responses:[
+    3->1 MsgAppResp Term:2 Log:0/13
+    3->1 MsgAppResp Term:2 Log:0/14
+    AppendThread->3 MsgStorageAppendResp Term:2 Log:2/14
   ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   ]
 
 process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/13
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/13
+  1->1 MsgAppResp Term:2 Log:0/13
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/13
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/13
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/13
+  2->1 MsgAppResp Term:2 Log:0/13
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/13
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/13
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/13
+  3->1 MsgAppResp Term:2 Log:0/13
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/13
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/13
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/13
-2->1 MsgAppResp Term:1 Log:0/13
-3->1 MsgAppResp Term:1 Log:0/13
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/13
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/13
+1->1 MsgAppResp Term:2 Log:0/13
+AppendThread->1 MsgStorageAppendResp Term:2 Log:2/13
+2->1 MsgAppResp Term:2 Log:0/13
+3->1 MsgAppResp Term:2 Log:0/13
+AppendThread->2 MsgStorageAppendResp Term:2 Log:2/13
+AppendThread->3 MsgStorageAppendResp Term:2 Log:2/13
 
 propose 1 prop_4
 ----
@@ -466,22 +466,22 @@ process-ready 1 2 3
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:13
+  HardState Term:2 Vote:1 Commit:13
   Entries:
-  1/15 EntryNormal "prop_4"
+  2/15 EntryNormal "prop_4"
   CommittedEntries:
-  1/13 EntryNormal "prop_2"
+  2/13 EntryNormal "prop_2"
   Messages:
-  1->2 MsgApp Term:1 Log:1/14 Commit:13
-  1->3 MsgApp Term:1 Log:1/14 Commit:13
-  1->2 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
-  1->3 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+  1->2 MsgApp Term:2 Log:2/14 Commit:13
+  1->3 MsgApp Term:2 Log:2/14 Commit:13
+  1->2 MsgApp Term:2 Log:2/14 Commit:13 Entries:[2/15 EntryNormal "prop_4"]
+  1->3 MsgApp Term:2 Log:2/14 Commit:13 Entries:[2/15 EntryNormal "prop_4"]
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:13 Vote:1 Entries:[2/15 EntryNormal "prop_4"] Responses:[
+    1->1 MsgAppResp Term:2 Log:0/15
+    AppendThread->1 MsgStorageAppendResp Term:2 Log:2/15
   ]
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   ]
 > 2 handling Ready
   <empty Ready>
@@ -490,10 +490,10 @@ process-ready 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->2 MsgApp Term:1 Log:1/14 Commit:13
-1->2 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
-1->3 MsgApp Term:1 Log:1/14 Commit:13
-1->3 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
+1->2 MsgApp Term:2 Log:2/14 Commit:13
+1->2 MsgApp Term:2 Log:2/14 Commit:13 Entries:[2/15 EntryNormal "prop_4"]
+1->3 MsgApp Term:2 Log:2/14 Commit:13
+1->3 MsgApp Term:2 Log:2/14 Commit:13 Entries:[2/15 EntryNormal "prop_4"]
 
 process-ready 1 2 3
 ----
@@ -501,107 +501,107 @@ process-ready 1 2 3
   <empty Ready>
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:13
+  HardState Term:2 Vote:1 Commit:13
   Entries:
-  1/15 EntryNormal "prop_4"
+  2/15 EntryNormal "prop_4"
   CommittedEntries:
-  1/13 EntryNormal "prop_2"
+  2/13 EntryNormal "prop_2"
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/14
-    2->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:13 Vote:1 Entries:[2/15 EntryNormal "prop_4"] Responses:[
+    2->1 MsgAppResp Term:2 Log:0/14
+    2->1 MsgAppResp Term:2 Log:0/15
+    AppendThread->2 MsgStorageAppendResp Term:2 Log:2/15
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   ]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:13
+  HardState Term:2 Vote:1 Commit:13
   Entries:
-  1/15 EntryNormal "prop_4"
+  2/15 EntryNormal "prop_4"
   CommittedEntries:
-  1/13 EntryNormal "prop_2"
+  2/13 EntryNormal "prop_2"
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/14
-    3->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:13 Vote:1 Entries:[2/15 EntryNormal "prop_4"] Responses:[
+    3->1 MsgAppResp Term:2 Log:0/14
+    3->1 MsgAppResp Term:2 Log:0/15
+    AppendThread->3 MsgStorageAppendResp Term:2 Log:2/15
   ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   ]
 
 process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:12 Vote:1 Entries:[2/14 EntryNormal "prop_3"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/14
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/14
+  1->1 MsgAppResp Term:2 Log:0/14
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/14
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:12 Vote:1 Entries:[2/14 EntryNormal "prop_3"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/13
-  2->1 MsgAppResp Term:1 Log:0/14
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/14
+  2->1 MsgAppResp Term:2 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/14
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/14
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:12 Vote:1 Entries:[2/14 EntryNormal "prop_3"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/13
-  3->1 MsgAppResp Term:1 Log:0/14
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/14
+  3->1 MsgAppResp Term:2 Log:0/13
+  3->1 MsgAppResp Term:2 Log:0/14
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/14
 
 process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
 > 2 processing apply thread
   Processing:
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   Responses:
-  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
 > 3 processing apply thread
   Processing:
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
   Responses:
-  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/14
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/14
-2->1 MsgAppResp Term:1 Log:0/13
-2->1 MsgAppResp Term:1 Log:0/14
-3->1 MsgAppResp Term:1 Log:0/13
-3->1 MsgAppResp Term:1 Log:0/14
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/14
-ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/14
-ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+1->1 MsgAppResp Term:2 Log:0/14
+AppendThread->1 MsgStorageAppendResp Term:2 Log:2/14
+2->1 MsgAppResp Term:2 Log:0/13
+2->1 MsgAppResp Term:2 Log:0/14
+3->1 MsgAppResp Term:2 Log:0/13
+3->1 MsgAppResp Term:2 Log:0/14
+ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
+AppendThread->2 MsgStorageAppendResp Term:2 Log:2/14
+ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
+AppendThread->3 MsgStorageAppendResp Term:2 Log:2/14
+ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/12 EntryNormal "prop_1"]
 
 process-ready 1 2 3
 ----
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:14
+  HardState Term:2 Vote:1 Commit:14
   CommittedEntries:
-  1/14 EntryNormal "prop_3"
+  2/14 EntryNormal "prop_3"
   Messages:
-  1->2 MsgApp Term:1 Log:1/15 Commit:14
-  1->3 MsgApp Term:1 Log:1/15 Commit:14
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Responses:[
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+  1->2 MsgApp Term:2 Log:2/15 Commit:14
+  1->3 MsgApp Term:2 Log:2/15 Commit:14
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:14 Vote:1 Responses:[
+    AppendThread->1 MsgStorageAppendResp Term:2 Log:2/15
   ]
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
   ]
 > 2 handling Ready
   <empty Ready>
@@ -610,8 +610,8 @@ process-ready 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->2 MsgApp Term:1 Log:1/15 Commit:14
-1->3 MsgApp Term:1 Log:1/15 Commit:14
+1->2 MsgApp Term:2 Log:2/15 Commit:14
+1->3 MsgApp Term:2 Log:2/15 Commit:14
 
 process-ready 1 2 3
 ----
@@ -619,99 +619,99 @@ process-ready 1 2 3
   <empty Ready>
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:14
+  HardState Term:2 Vote:1 Commit:14
   CommittedEntries:
-  1/14 EntryNormal "prop_3"
+  2/14 EntryNormal "prop_3"
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:14 Vote:1 Responses:[
+    2->1 MsgAppResp Term:2 Log:0/15
+    AppendThread->2 MsgStorageAppendResp Term:2 Log:2/15
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
   ]
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:14
+  HardState Term:2 Vote:1 Commit:14
   CommittedEntries:
-  1/14 EntryNormal "prop_3"
+  2/14 EntryNormal "prop_3"
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Responses:[
-    3->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:14 Vote:1 Responses:[
+    3->1 MsgAppResp Term:2 Log:0/15
+    AppendThread->3 MsgStorageAppendResp Term:2 Log:2/15
   ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
   ]
 
 process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:13 Vote:1 Entries:[2/15 EntryNormal "prop_4"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+  1->1 MsgAppResp Term:2 Log:0/15
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/15
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:13 Vote:1 Entries:[2/15 EntryNormal "prop_4"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/14
-  2->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+  2->1 MsgAppResp Term:2 Log:0/14
+  2->1 MsgAppResp Term:2 Log:0/15
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/15
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:13 Vote:1 Entries:[2/15 EntryNormal "prop_4"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/14
-  3->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+  3->1 MsgAppResp Term:2 Log:0/14
+  3->1 MsgAppResp Term:2 Log:0/15
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/15
 
 process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
 > 2 processing apply thread
   Processing:
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   Responses:
-  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
 > 3 processing apply thread
   Processing:
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
   Responses:
-  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/15
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
-2->1 MsgAppResp Term:1 Log:0/14
-2->1 MsgAppResp Term:1 Log:0/15
-3->1 MsgAppResp Term:1 Log:0/14
-3->1 MsgAppResp Term:1 Log:0/15
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
-ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
-ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+1->1 MsgAppResp Term:2 Log:0/15
+AppendThread->1 MsgStorageAppendResp Term:2 Log:2/15
+2->1 MsgAppResp Term:2 Log:0/14
+2->1 MsgAppResp Term:2 Log:0/15
+3->1 MsgAppResp Term:2 Log:0/14
+3->1 MsgAppResp Term:2 Log:0/15
+ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
+AppendThread->2 MsgStorageAppendResp Term:2 Log:2/15
+ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
+AppendThread->3 MsgStorageAppendResp Term:2 Log:2/15
+ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/13 EntryNormal "prop_2"]
 
 process-ready 1 2 3
 ----
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:15
+  HardState Term:2 Vote:1 Commit:15
   CommittedEntries:
-  1/15 EntryNormal "prop_4"
+  2/15 EntryNormal "prop_4"
   Messages:
-  1->2 MsgApp Term:1 Log:1/15 Commit:15
-  1->3 MsgApp Term:1 Log:1/15 Commit:15
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  1->2 MsgApp Term:2 Log:2/15 Commit:15
+  1->3 MsgApp Term:2 Log:2/15 Commit:15
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:15 Vote:1
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
   ]
 > 2 handling Ready
   <empty Ready>
@@ -720,8 +720,8 @@ process-ready 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->2 MsgApp Term:1 Log:1/15 Commit:15
-1->3 MsgApp Term:1 Log:1/15 Commit:15
+1->2 MsgApp Term:2 Log:2/15 Commit:15
+1->3 MsgApp Term:2 Log:2/15 Commit:15
 
 process-ready 1 2 3
 ----
@@ -729,73 +729,73 @@ process-ready 1 2 3
   <empty Ready>
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:15
+  HardState Term:2 Vote:1 Commit:15
   CommittedEntries:
-  1/15 EntryNormal "prop_4"
+  2/15 EntryNormal "prop_4"
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/15
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:15 Vote:1 Responses:[
+    2->1 MsgAppResp Term:2 Log:0/15
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
   ]
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:15
+  HardState Term:2 Vote:1 Commit:15
   CommittedEntries:
-  1/15 EntryNormal "prop_4"
+  2/15 EntryNormal "prop_4"
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Responses:[
-    3->1 MsgAppResp Term:1 Log:0/15
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:15 Vote:1 Responses:[
+    3->1 MsgAppResp Term:2 Log:0/15
   ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
   ]
 
 process-append-thread 2 3
 ----
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:14 Vote:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+  2->1 MsgAppResp Term:2 Log:0/15
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/15
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:14 Vote:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+  3->1 MsgAppResp Term:2 Log:0/15
+  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/15
 
 process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
 > 2 processing apply thread
   Processing:
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
   Responses:
-  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
 > 3 processing apply thread
   Processing:
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
   Responses:
-  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
 
 deliver-msgs 1 2 3
 ----
-2->1 MsgAppResp Term:1 Log:0/15
-3->1 MsgAppResp Term:1 Log:0/15
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+2->1 MsgAppResp Term:2 Log:0/15
+3->1 MsgAppResp Term:2 Log:0/15
+ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
+AppendThread->2 MsgStorageAppendResp Term:2 Log:2/15
 INFO entry at index 15 missing from unstable log; ignoring
-ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
+AppendThread->3 MsgStorageAppendResp Term:2 Log:2/15
 INFO entry at index 15 missing from unstable log; ignoring
-ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/14 EntryNormal "prop_3"]
 
 process-ready 1 2 3
 ----
@@ -810,40 +810,40 @@ process-append-thread 2 3
 ----
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1
+  2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:15 Vote:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/15
+  2->1 MsgAppResp Term:2 Log:0/15
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1
+  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:15 Vote:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/15
+  3->1 MsgAppResp Term:2 Log:0/15
 
 process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
 > 2 processing apply thread
   Processing:
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
   Responses:
-  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
 > 3 processing apply thread
   Processing:
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
   Responses:
-  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
 
 deliver-msgs 1 2 3
 ----
-2->1 MsgAppResp Term:1 Log:0/15
-3->1 MsgAppResp Term:1 Log:0/15
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
-ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
-ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+2->1 MsgAppResp Term:2 Log:0/15
+3->1 MsgAppResp Term:2 Log:0/15
+ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
+ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
+ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/15 EntryNormal "prop_4"]
 
 process-ready 1 2 3
 ----
@@ -858,12 +858,12 @@ stabilize
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:14 Vote:1
   Responses:
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/15
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1
+  1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:15 Vote:1
   Responses:
 > 1 receiving messages
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/15
   INFO entry at index 15 missing from unstable log; ignoring

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -34,27 +34,27 @@ process-ready 2
 ----
 Ready MustSync=true:
 Entries:
-1/12 EntryNormal "init_prop"
+2/12 EntryNormal "init_prop"
 Messages:
-2->1 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->4 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->5 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->6 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->7 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"] Responses:[
-  2->2 MsgAppResp Term:1 Log:0/12
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
+2->1 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+2->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+2->4 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+2->5 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+2->6 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+2->7 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "init_prop"] Responses:[
+  2->2 MsgAppResp Term:2 Log:0/12
+  AppendThread->2 MsgStorageAppendResp Term:2 Log:2/12
 ]
 
 deliver-msgs 1 drop=(3,4,5,6,7)
 ----
-2->1 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-dropped: 2->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-dropped: 2->4 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-dropped: 2->5 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-dropped: 2->6 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-dropped: 2->7 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
+2->1 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+dropped: 2->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+dropped: 2->4 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+dropped: 2->5 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+dropped: 2->6 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
+dropped: 2->7 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "init_prop"]
 
 # Step 3: node 1 gets the Ready and the entries are appended asynchronously.
 
@@ -62,122 +62,122 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/12 EntryNormal "init_prop"
+2/12 EntryNormal "init_prop"
 Messages:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"] Responses:[
-  1->2 MsgAppResp Term:1 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "init_prop"] Responses:[
+  1->2 MsgAppResp Term:2 Log:0/12
+  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
 ]
 
 # Step 4: node 3 becomes the leader after getting a vote from nodes 4, 5, and 6.
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
-INFO 3 became candidate at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 4 at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 5 at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 6 at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 7 at term 2
+INFO 3 is starting a new election at term 2
+INFO 3 became candidate at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 1 at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 2 at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 4 at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 5 at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 6 at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 7 at term 3
 
 process-ready 3
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:2 Vote:3 Commit:11
+HardState Term:3 Vote:3 Commit:11
 Messages:
-3->1 MsgVote Term:2 Log:1/11
-3->2 MsgVote Term:2 Log:1/11
-3->4 MsgVote Term:2 Log:1/11
-3->5 MsgVote Term:2 Log:1/11
-3->6 MsgVote Term:2 Log:1/11
-3->7 MsgVote Term:2 Log:1/11
-3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
-  3->3 MsgVoteResp Term:2 Log:0/0
+3->1 MsgVote Term:3 Log:2/11
+3->2 MsgVote Term:3 Log:2/11
+3->4 MsgVote Term:3 Log:2/11
+3->5 MsgVote Term:3 Log:2/11
+3->6 MsgVote Term:3 Log:2/11
+3->7 MsgVote Term:3 Log:2/11
+3->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3 Responses:[
+  3->3 MsgVoteResp Term:3 Log:0/0
 ]
 
 deliver-msgs 4 5 6
 ----
-3->4 MsgVote Term:2 Log:1/11
-INFO 4 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
-INFO 4 became follower at term 2
-INFO 4 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
-3->5 MsgVote Term:2 Log:1/11
-INFO 5 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
-INFO 5 became follower at term 2
-INFO 5 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
-3->6 MsgVote Term:2 Log:1/11
-INFO 6 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
-INFO 6 became follower at term 2
-INFO 6 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
+3->4 MsgVote Term:3 Log:2/11
+INFO 4 [term: 2] received a MsgVote message with higher term from 3 [term: 3]
+INFO 4 became follower at term 3
+INFO 4 [logterm: 2, index: 11, vote: 0] cast MsgVote for 3 [logterm: 2, index: 11] at term 3
+3->5 MsgVote Term:3 Log:2/11
+INFO 5 [term: 2] received a MsgVote message with higher term from 3 [term: 3]
+INFO 5 became follower at term 3
+INFO 5 [logterm: 2, index: 11, vote: 0] cast MsgVote for 3 [logterm: 2, index: 11] at term 3
+3->6 MsgVote Term:3 Log:2/11
+INFO 6 [term: 2] received a MsgVote message with higher term from 3 [term: 3]
+INFO 6 became follower at term 3
+INFO 6 [logterm: 2, index: 11, vote: 0] cast MsgVote for 3 [logterm: 2, index: 11] at term 3
 
 process-ready 4 5 6
 ----
 > 4 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:3 Commit:11
+  HardState Term:3 Vote:3 Commit:11
   Messages:
-  4->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
-    4->3 MsgVoteResp Term:2 Log:0/0
+  4->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3 Responses:[
+    4->3 MsgVoteResp Term:3 Log:0/0
   ]
 > 5 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:3 Commit:11
+  HardState Term:3 Vote:3 Commit:11
   Messages:
-  5->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
-    5->3 MsgVoteResp Term:2 Log:0/0
+  5->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3 Responses:[
+    5->3 MsgVoteResp Term:3 Log:0/0
   ]
 > 6 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:3 Commit:11
+  HardState Term:3 Vote:3 Commit:11
   Messages:
-  6->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
-    6->3 MsgVoteResp Term:2 Log:0/0
+  6->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3 Responses:[
+    6->3 MsgVoteResp Term:3 Log:0/0
   ]
 
 process-append-thread 3 4 5 6
 ----
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3
+  3->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3
   Responses:
-  3->3 MsgVoteResp Term:2 Log:0/0
+  3->3 MsgVoteResp Term:3 Log:0/0
 > 4 processing append thread
   Processing:
-  4->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3
+  4->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3
   Responses:
-  4->3 MsgVoteResp Term:2 Log:0/0
+  4->3 MsgVoteResp Term:3 Log:0/0
 > 5 processing append thread
   Processing:
-  5->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3
+  5->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3
   Responses:
-  5->3 MsgVoteResp Term:2 Log:0/0
+  5->3 MsgVoteResp Term:3 Log:0/0
 > 6 processing append thread
   Processing:
-  6->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3
+  6->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:3
   Responses:
-  6->3 MsgVoteResp Term:2 Log:0/0
+  6->3 MsgVoteResp Term:3 Log:0/0
 
 deliver-msgs 3
 ----
-3->3 MsgVoteResp Term:2 Log:0/0
-INFO 3 received MsgVoteResp from 3 at term 2
+3->3 MsgVoteResp Term:3 Log:0/0
+INFO 3 received MsgVoteResp from 3 at term 3
 INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
-4->3 MsgVoteResp Term:2 Log:0/0
-INFO 3 received MsgVoteResp from 4 at term 2
+4->3 MsgVoteResp Term:3 Log:0/0
+INFO 3 received MsgVoteResp from 4 at term 3
 INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
-5->3 MsgVoteResp Term:2 Log:0/0
-INFO 3 received MsgVoteResp from 5 at term 2
+5->3 MsgVoteResp Term:3 Log:0/0
+INFO 3 received MsgVoteResp from 5 at term 3
 INFO 3 has received 3 MsgVoteResp votes and 0 vote rejections
-6->3 MsgVoteResp Term:2 Log:0/0
-INFO 3 received MsgVoteResp from 6 at term 2
+6->3 MsgVoteResp Term:3 Log:0/0
+INFO 3 received MsgVoteResp from 6 at term 3
 INFO 3 has received 4 MsgVoteResp votes and 0 vote rejections
-INFO 3 became leader at term 2
+INFO 3 became leader at term 3
 
 # Step 5: node 3 proposes some log entries and node 1 receives these entries,
 # overwriting the previous unstable log entries that are in the process of being
@@ -189,174 +189,174 @@ process-ready 3
 Ready MustSync=true:
 Lead:3 State:StateLeader
 Entries:
-2/12 EntryNormal ""
+3/12 EntryNormal ""
 Messages:
-3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->4 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->5 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->6 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal ""] Responses:[
-  3->3 MsgAppResp Term:2 Log:0/12
-  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/12
+3->1 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+3->2 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+3->4 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+3->5 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+3->6 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+3->7 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""] Responses:[
+  3->3 MsgAppResp Term:3 Log:0/12
+  AppendThread->3 MsgStorageAppendResp Term:3 Log:3/12
 ]
 
 deliver-msgs 1 drop=(2,4,5,6,7)
 ----
-3->1 MsgVote Term:2 Log:1/11
-INFO 1 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
-INFO 1 became follower at term 2
-INFO 1 [logterm: 1, index: 12, vote: 0] rejected MsgVote from 3 [logterm: 1, index: 11] at term 2
-3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-INFO found conflict at index 12 [existing term: 1, conflicting term: 2]
+3->1 MsgVote Term:3 Log:2/11
+INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 3]
+INFO 1 became follower at term 3
+INFO 1 [logterm: 2, index: 12, vote: 0] rejected MsgVote from 3 [logterm: 2, index: 11] at term 3
+3->1 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+INFO found conflict at index 12 [existing term: 2, conflicting term: 3]
 INFO replace the unstable entries from index 12
-dropped: 3->2 MsgVote Term:2 Log:1/11
-dropped: 3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-dropped: 3->4 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-dropped: 3->5 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-dropped: 3->6 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-dropped: 3->7 MsgVote Term:2 Log:1/11
-dropped: 3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+dropped: 3->2 MsgVote Term:3 Log:2/11
+dropped: 3->2 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+dropped: 3->4 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+dropped: 3->5 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+dropped: 3->6 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+dropped: 3->7 MsgVote Term:3 Log:2/11
+dropped: 3->7 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:3 State:StateFollower
-HardState Term:2 Commit:11
+HardState Term:3 Commit:11
 Entries:
-2/12 EntryNormal ""
+3/12 EntryNormal ""
 Messages:
-1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Entries:[2/12 EntryNormal ""] Responses:[
-  1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->3 MsgAppResp Term:2 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
+1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Entries:[3/12 EntryNormal ""] Responses:[
+  1->3 MsgVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgAppResp Term:3 Log:0/12
+  AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
 ]
 
 # Step 6: node 3 crashes and node 4 becomes leader getting the vote from 5, 6, and 7.
 
 campaign 4
 ----
-INFO 4 is starting a new election at term 2
-INFO 4 became candidate at term 3
-INFO 4 [logterm: 1, index: 11] sent MsgVote request to 1 at term 3
-INFO 4 [logterm: 1, index: 11] sent MsgVote request to 2 at term 3
-INFO 4 [logterm: 1, index: 11] sent MsgVote request to 3 at term 3
-INFO 4 [logterm: 1, index: 11] sent MsgVote request to 5 at term 3
-INFO 4 [logterm: 1, index: 11] sent MsgVote request to 6 at term 3
-INFO 4 [logterm: 1, index: 11] sent MsgVote request to 7 at term 3
+INFO 4 is starting a new election at term 3
+INFO 4 became candidate at term 4
+INFO 4 [logterm: 2, index: 11] sent MsgVote request to 1 at term 4
+INFO 4 [logterm: 2, index: 11] sent MsgVote request to 2 at term 4
+INFO 4 [logterm: 2, index: 11] sent MsgVote request to 3 at term 4
+INFO 4 [logterm: 2, index: 11] sent MsgVote request to 5 at term 4
+INFO 4 [logterm: 2, index: 11] sent MsgVote request to 6 at term 4
+INFO 4 [logterm: 2, index: 11] sent MsgVote request to 7 at term 4
 
 process-ready 4
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:3 Vote:4 Commit:11
+HardState Term:4 Vote:4 Commit:11
 Messages:
-4->1 MsgVote Term:3 Log:1/11
-4->2 MsgVote Term:3 Log:1/11
-4->3 MsgVote Term:3 Log:1/11
-4->5 MsgVote Term:3 Log:1/11
-4->6 MsgVote Term:3 Log:1/11
-4->7 MsgVote Term:3 Log:1/11
-4->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
-  4->4 MsgVoteResp Term:3 Log:0/0
+4->1 MsgVote Term:4 Log:2/11
+4->2 MsgVote Term:4 Log:2/11
+4->3 MsgVote Term:4 Log:2/11
+4->5 MsgVote Term:4 Log:2/11
+4->6 MsgVote Term:4 Log:2/11
+4->7 MsgVote Term:4 Log:2/11
+4->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4 Responses:[
+  4->4 MsgVoteResp Term:4 Log:0/0
 ]
 
 deliver-msgs 5 6 7
 ----
-4->5 MsgVote Term:3 Log:1/11
-INFO 5 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
-INFO 5 became follower at term 3
-INFO 5 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 11] at term 3
-4->6 MsgVote Term:3 Log:1/11
-INFO 6 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
-INFO 6 became follower at term 3
-INFO 6 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 11] at term 3
-4->7 MsgVote Term:3 Log:1/11
-INFO 7 [term: 1] received a MsgVote message with higher term from 4 [term: 3]
-INFO 7 became follower at term 3
-INFO 7 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 11] at term 3
+4->5 MsgVote Term:4 Log:2/11
+INFO 5 [term: 3] received a MsgVote message with higher term from 4 [term: 4]
+INFO 5 became follower at term 4
+INFO 5 [logterm: 2, index: 11, vote: 0] cast MsgVote for 4 [logterm: 2, index: 11] at term 4
+4->6 MsgVote Term:4 Log:2/11
+INFO 6 [term: 3] received a MsgVote message with higher term from 4 [term: 4]
+INFO 6 became follower at term 4
+INFO 6 [logterm: 2, index: 11, vote: 0] cast MsgVote for 4 [logterm: 2, index: 11] at term 4
+4->7 MsgVote Term:4 Log:2/11
+INFO 7 [term: 2] received a MsgVote message with higher term from 4 [term: 4]
+INFO 7 became follower at term 4
+INFO 7 [logterm: 2, index: 11, vote: 0] cast MsgVote for 4 [logterm: 2, index: 11] at term 4
 
 process-ready 5 6 7
 ----
 > 5 handling Ready
   Ready MustSync=true:
-  HardState Term:3 Vote:4 Commit:11
+  HardState Term:4 Vote:4 Commit:11
   Messages:
-  5->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
-    5->4 MsgVoteResp Term:3 Log:0/0
+  5->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4 Responses:[
+    5->4 MsgVoteResp Term:4 Log:0/0
   ]
 > 6 handling Ready
   Ready MustSync=true:
-  HardState Term:3 Vote:4 Commit:11
+  HardState Term:4 Vote:4 Commit:11
   Messages:
-  6->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
-    6->4 MsgVoteResp Term:3 Log:0/0
+  6->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4 Responses:[
+    6->4 MsgVoteResp Term:4 Log:0/0
   ]
 > 7 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:3 Vote:4 Commit:11
+  HardState Term:4 Vote:4 Commit:11
   Messages:
-  7->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
-    7->4 MsgVoteResp Term:3 Log:0/0
+  7->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4 Responses:[
+    7->4 MsgVoteResp Term:4 Log:0/0
   ]
 
 process-append-thread 4 5 6 7
 ----
 > 4 processing append thread
   Processing:
-  4->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4
+  4->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4
   Responses:
-  4->4 MsgVoteResp Term:3 Log:0/0
+  4->4 MsgVoteResp Term:4 Log:0/0
 > 5 processing append thread
   Processing:
-  5->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4
+  5->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4
   Responses:
-  5->4 MsgVoteResp Term:3 Log:0/0
+  5->4 MsgVoteResp Term:4 Log:0/0
 > 6 processing append thread
   Processing:
-  6->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4
+  6->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4
   Responses:
-  6->4 MsgVoteResp Term:3 Log:0/0
+  6->4 MsgVoteResp Term:4 Log:0/0
 > 7 processing append thread
   Processing:
-  7->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4
+  7->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Vote:4
   Responses:
-  7->4 MsgVoteResp Term:3 Log:0/0
+  7->4 MsgVoteResp Term:4 Log:0/0
 
 deliver-msgs 4
 ----
-4->4 MsgVoteResp Term:3 Log:0/0
-INFO 4 received MsgVoteResp from 4 at term 3
+4->4 MsgVoteResp Term:4 Log:0/0
+INFO 4 received MsgVoteResp from 4 at term 4
 INFO 4 has received 1 MsgVoteResp votes and 0 vote rejections
-5->4 MsgVoteResp Term:3 Log:0/0
-INFO 4 received MsgVoteResp from 5 at term 3
+5->4 MsgVoteResp Term:4 Log:0/0
+INFO 4 received MsgVoteResp from 5 at term 4
 INFO 4 has received 2 MsgVoteResp votes and 0 vote rejections
-6->4 MsgVoteResp Term:3 Log:0/0
-INFO 4 received MsgVoteResp from 6 at term 3
+6->4 MsgVoteResp Term:4 Log:0/0
+INFO 4 received MsgVoteResp from 6 at term 4
 INFO 4 has received 3 MsgVoteResp votes and 0 vote rejections
-7->4 MsgVoteResp Term:3 Log:0/0
-INFO 4 received MsgVoteResp from 7 at term 3
+7->4 MsgVoteResp Term:4 Log:0/0
+INFO 4 received MsgVoteResp from 7 at term 4
 INFO 4 has received 4 MsgVoteResp votes and 0 vote rejections
-INFO 4 became leader at term 3
+INFO 4 became leader at term 4
 
 process-ready 4
 ----
 Ready MustSync=true:
 Lead:4 State:StateLeader
 Entries:
-3/12 EntryNormal ""
+4/12 EntryNormal ""
 Messages:
-4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->2 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->5 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->6 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->7 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""] Responses:[
-  4->4 MsgAppResp Term:3 Log:0/12
-  AppendThread->4 MsgStorageAppendResp Term:3 Log:3/12
+4->1 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+4->2 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+4->3 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+4->5 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+4->6 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+4->7 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+4->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[4/12 EntryNormal ""] Responses:[
+  4->4 MsgAppResp Term:4 Log:0/12
+  AppendThread->4 MsgStorageAppendResp Term:4 Log:4/12
 ]
 
 # Step 7: before the new entries reach node 1, it hears of the term change
@@ -367,8 +367,8 @@ Messages:
 
 deliver-msgs drop=1
 ----
-dropped: 4->1 MsgVote Term:3 Log:1/11
-dropped: 4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+dropped: 4->1 MsgVote Term:4 Log:2/11
+dropped: 4->1 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
 
 tick-heartbeat 4
 ----
@@ -378,55 +378,55 @@ process-ready 4
 ----
 Ready MustSync=false:
 Messages:
-4->1 MsgHeartbeat Term:3 Log:0/0
-4->2 MsgHeartbeat Term:3 Log:0/0
-4->3 MsgHeartbeat Term:3 Log:0/0
-4->5 MsgHeartbeat Term:3 Log:0/0
-4->6 MsgHeartbeat Term:3 Log:0/0
-4->7 MsgHeartbeat Term:3 Log:0/0
+4->1 MsgHeartbeat Term:4 Log:0/0
+4->2 MsgHeartbeat Term:4 Log:0/0
+4->3 MsgHeartbeat Term:4 Log:0/0
+4->5 MsgHeartbeat Term:4 Log:0/0
+4->6 MsgHeartbeat Term:4 Log:0/0
+4->7 MsgHeartbeat Term:4 Log:0/0
 
 deliver-msgs 1
 ----
-4->1 MsgHeartbeat Term:3 Log:0/0
-INFO 1 [term: 2] received a MsgHeartbeat message with higher term from 4 [term: 3]
-INFO 1 became follower at term 3
+4->1 MsgHeartbeat Term:4 Log:0/0
+INFO 1 [term: 3] received a MsgHeartbeat message with higher term from 4 [term: 4]
+INFO 1 became follower at term 4
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:4 State:StateFollower
-HardState Term:3 Commit:11
+HardState Term:4 Commit:11
 Messages:
-1->4 MsgHeartbeatResp Term:3 Log:0/0
-1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Responses:[
-  AppendThread->1 MsgStorageAppendResp Term:3 Log:2/12
+1->4 MsgHeartbeatResp Term:4 Log:0/0
+1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11 Responses:[
+  AppendThread->1 MsgStorageAppendResp Term:4 Log:3/12
 ]
 
 deliver-msgs 4
 ----
-1->4 MsgHeartbeatResp Term:3 Log:0/0
+1->4 MsgHeartbeatResp Term:4 Log:0/0
 
 process-ready 4
 ----
 Ready MustSync=false:
 Messages:
-4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+4->1 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
 
 deliver-msgs 1
 ----
-4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-INFO found conflict at index 12 [existing term: 2, conflicting term: 3]
+4->1 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+INFO found conflict at index 12 [existing term: 3, conflicting term: 4]
 INFO replace the unstable entries from index 12
 
 process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-3/12 EntryNormal ""
+4/12 EntryNormal ""
 Messages:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""] Responses:[
-  1->4 MsgAppResp Term:3 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
+1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[4/12 EntryNormal ""] Responses:[
+  1->4 MsgAppResp Term:4 Log:0/12
+  AppendThread->1 MsgStorageAppendResp Term:4 Log:4/12
 ]
 
 # Step 8: The asynchronous log appends from the first Ready complete and the
@@ -435,20 +435,20 @@ Messages:
 
 raft-log 1
 ----
-1/11 EntryNormal ""
+2/11 EntryNormal ""
 
 process-append-thread 1
 ----
 Processing:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"]
+1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[2/12 EntryNormal "init_prop"]
 Responses:
-1->2 MsgAppResp Term:1 Log:0/12
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+1->2 MsgAppResp Term:2 Log:0/12
+AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
 
 raft-log 1
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "init_prop"
+2/11 EntryNormal ""
+2/12 EntryNormal "init_prop"
 
 # Step 9: However, the log entries from the second Ready are still in the
 # asynchronous append pipeline and will overwrite (in stable storage) the
@@ -460,58 +460,58 @@ raft-log 1
 
 deliver-msgs 1
 ----
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
-INFO 1 [term: 3] ignored entry appends from a MsgStorageAppendResp message with lower term [term: 1]
-
-process-append-thread 1
-----
-Processing:
-1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Entries:[2/12 EntryNormal ""]
-Responses:
-1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
-1->3 MsgAppResp Term:2 Log:0/12
 AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
-
-raft-log 1
-----
-1/11 EntryNormal ""
-2/12 EntryNormal ""
-
-deliver-msgs 1
-----
-AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
-INFO 1 [term: 3] ignored entry appends from a MsgStorageAppendResp message with lower term [term: 2]
+INFO 1 [term: 4] ignored entry appends from a MsgStorageAppendResp message with lower term [term: 2]
 
 process-append-thread 1
 ----
 Processing:
-1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11
+1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Entries:[3/12 EntryNormal ""]
 Responses:
-AppendThread->1 MsgStorageAppendResp Term:3 Log:2/12
-
-raft-log 1
-----
-1/11 EntryNormal ""
-2/12 EntryNormal ""
-
-deliver-msgs 1
-----
-AppendThread->1 MsgStorageAppendResp Term:3 Log:2/12
-INFO entry at (index,term)=(12,2) mismatched with entry at (12,3) in unstable log; ignoring
-
-process-append-thread 1
-----
-Processing:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""]
-Responses:
-1->4 MsgAppResp Term:3 Log:0/12
+1->3 MsgVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
+1->3 MsgAppResp Term:3 Log:0/12
 AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
 
 raft-log 1
 ----
-1/11 EntryNormal ""
+2/11 EntryNormal ""
 3/12 EntryNormal ""
 
 deliver-msgs 1
 ----
 AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
+INFO 1 [term: 4] ignored entry appends from a MsgStorageAppendResp message with lower term [term: 3]
+
+process-append-thread 1
+----
+Processing:
+1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:11
+Responses:
+AppendThread->1 MsgStorageAppendResp Term:4 Log:3/12
+
+raft-log 1
+----
+2/11 EntryNormal ""
+3/12 EntryNormal ""
+
+deliver-msgs 1
+----
+AppendThread->1 MsgStorageAppendResp Term:4 Log:3/12
+INFO entry at (index,term)=(12,3) mismatched with entry at (12,4) in unstable log; ignoring
+
+process-append-thread 1
+----
+Processing:
+1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[4/12 EntryNormal ""]
+Responses:
+1->4 MsgAppResp Term:4 Log:0/12
+AppendThread->1 MsgStorageAppendResp Term:4 Log:4/12
+
+raft-log 1
+----
+2/11 EntryNormal ""
+4/12 EntryNormal ""
+
+deliver-msgs 1
+----
+AppendThread->1 MsgStorageAppendResp Term:4 Log:4/12

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -5,114 +5,114 @@ ok
 add-nodes 3 voters=(1,2,3) index=2
 ----
 INFO 1 switched to configuration voters=(1 2 3)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1,2,3], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 INFO 2 switched to configuration voters=(1 2 3)
-INFO 2 became follower at term 0
-INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 2 became follower at term 1
+INFO newRaft 2 [peers: [1,2,3], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 INFO 3 switched to configuration voters=(1 2 3)
-INFO 3 became follower at term 0
-INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 3 became follower at term 1
+INFO newRaft 3 [peers: [1,2,3], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
-INFO 1 [logterm: 1, index: 2] sent MsgVote request to 2 at term 1
-INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
+INFO 1 [logterm: 1, index: 2] sent MsgVote request to 2 at term 2
+INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 2
 
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:1 Vote:1 Commit:2
+  HardState Term:2 Vote:1 Commit:2
   Messages:
-  1->2 MsgVote Term:1 Log:1/2
-  1->3 MsgVote Term:1 Log:1/2
-  INFO 1 received MsgVoteResp from 1 at term 1
+  1->2 MsgVote Term:2 Log:1/2
+  1->3 MsgVote Term:2 Log:1/2
+  INFO 1 received MsgVoteResp from 1 at term 2
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
-  1->2 MsgVote Term:1 Log:1/2
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
+  1->2 MsgVote Term:2 Log:1/2
+  INFO 2 [term: 1] received a MsgVote message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 2
 > 3 receiving messages
-  1->3 MsgVote Term:1 Log:1/2
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
-  INFO 3 became follower at term 1
-  INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
+  1->3 MsgVote Term:2 Log:1/2
+  INFO 3 [term: 1] received a MsgVote message with higher term from 1 [term: 2]
+  INFO 3 became follower at term 2
+  INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 2
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:2
+  HardState Term:2 Vote:1 Commit:2
   Messages:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:2 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:2
+  HardState Term:2 Vote:1 Commit:2
   Messages:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
-  INFO 1 received MsgVoteResp from 2 at term 1
+  2->1 MsgVoteResp Term:2 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 2
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 became leader at term 2
+  3->1 MsgVoteResp Term:2 Log:0/0
 > 1 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/3 EntryNormal ""
+  2/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:1/2 Commit:2 Entries:[2/3 EntryNormal ""]
+  1->3 MsgApp Term:2 Log:1/2 Commit:2 Entries:[2/3 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:1/2 Commit:2 Entries:[2/3 EntryNormal ""]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
+  1->3 MsgApp Term:2 Log:1/2 Commit:2 Entries:[2/3 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
   Entries:
-  1/3 EntryNormal ""
+  2/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:2 Log:0/3
 > 3 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
   Entries:
-  1/3 EntryNormal ""
+  2/3 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/3
+  3->1 MsgAppResp Term:2 Log:0/3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3
-  3->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:2 Log:0/3
+  3->1 MsgAppResp Term:2 Log:0/3
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:3
+  HardState Term:2 Vote:1 Commit:3
   CommittedEntries:
-  1/3 EntryNormal ""
+  2/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:3
-  1->3 MsgApp Term:1 Log:1/3 Commit:3
+  1->2 MsgApp Term:2 Log:2/3 Commit:3
+  1->3 MsgApp Term:2 Log:2/3 Commit:3
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3
+  1->2 MsgApp Term:2 Log:2/3 Commit:3
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3
+  1->3 MsgApp Term:2 Log:2/3 Commit:3
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:3
+  HardState Term:2 Vote:1 Commit:3
   CommittedEntries:
-  1/3 EntryNormal ""
+  2/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:2 Log:0/3
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:3
+  HardState Term:2 Vote:1 Commit:3
   CommittedEntries:
-  1/3 EntryNormal ""
+  2/3 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/3
+  3->1 MsgAppResp Term:2 Log:0/3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3
-  3->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:2 Log:0/3
+  3->1 MsgAppResp Term:2 Log:0/3

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -52,21 +52,21 @@ ok
 
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
-INFO 2 became candidate at term 2
-INFO 2 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
-INFO 2 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
+INFO 2 is starting a new election at term 2
+INFO 2 became candidate at term 3
+INFO 2 [logterm: 2, index: 4] sent MsgVote request to 1 at term 3
+INFO 2 [logterm: 2, index: 4] sent MsgVote request to 3 at term 3
 
 # Send out the MsgVote requests.
 process-ready 2
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:2 Vote:2 Commit:4
+HardState Term:3 Vote:2 Commit:4
 Messages:
-2->1 MsgVote Term:2 Log:1/4
-2->3 MsgVote Term:2 Log:1/4
-INFO 2 received MsgVoteResp from 2 at term 2
+2->1 MsgVote Term:3 Log:2/4
+2->3 MsgVote Term:3 Log:2/4
+INFO 2 received MsgVoteResp from 2 at term 3
 INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 
 # n2 is now campaigning while n1 is down (does not respond). The latest config
@@ -76,84 +76,84 @@ INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 stabilize 3
 ----
 > 3 receiving messages
-  2->3 MsgVote Term:2 Log:1/4
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
-  INFO 3 became follower at term 2
-  INFO 3 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 4] at term 2
+  2->3 MsgVote Term:3 Log:2/4
+  INFO 3 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 3 became follower at term 3
+  INFO 3 [logterm: 2, index: 3, vote: 0] cast MsgVote for 2 [logterm: 2, index: 4] at term 3
 > 3 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:2 Commit:3
+  HardState Term:3 Vote:2 Commit:3
   Messages:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:3 Log:0/0
 
 stabilize 2 3
 ----
 > 2 receiving messages
-  3->2 MsgVoteResp Term:2 Log:0/0
-  INFO 2 received MsgVoteResp from 3 at term 2
+  3->2 MsgVoteResp Term:3 Log:0/0
+  INFO 2 received MsgVoteResp from 3 at term 3
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 2 became leader at term 2
+  INFO 2 became leader at term 3
 > 2 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateLeader
   Entries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  2->1 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
+  2->3 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
+  2->3 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
+  DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 2, index: 4] from 2
 > 3 handling Ready
   Ready MustSync=false:
   Lead:2 State:StateFollower
   Messages:
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
+  3->2 MsgAppResp Term:3 Log:2/4 Rejected (Hint: 3)
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
-  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
+  3->2 MsgAppResp Term:3 Log:2/4 Rejected (Hint: 3)
+  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 2)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v3
-    2/5 EntryNormal ""
+  2->3 MsgApp Term:3 Log:2/3 Commit:4 Entries:[
+    2/4 EntryConfChangeV2 v3
+    3/5 EntryNormal ""
   ]
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v3
-    2/5 EntryNormal ""
+  2->3 MsgApp Term:3 Log:2/3 Commit:4 Entries:[
+    2/4 EntryConfChangeV2 v3
+    3/5 EntryNormal ""
   ]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:2 Vote:2 Commit:4
+  HardState Term:3 Vote:2 Commit:4
   Entries:
-  1/4 EntryConfChangeV2 v3
-  2/5 EntryNormal ""
+  2/4 EntryConfChangeV2 v3
+  3/5 EntryNormal ""
   CommittedEntries:
-  1/4 EntryConfChangeV2 v3
+  2/4 EntryConfChangeV2 v3
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:3 Log:0/5
   INFO 3 switched to configuration voters=(1 2 3)
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:3 Log:0/5
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:5
+  HardState Term:3 Vote:2 Commit:5
   CommittedEntries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  2->3 MsgApp Term:2 Log:2/5 Commit:5
+  2->3 MsgApp Term:3 Log:3/5 Commit:5
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:2/5 Commit:5
+  2->3 MsgApp Term:3 Log:3/5 Commit:5
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:5
+  HardState Term:3 Vote:2 Commit:5
   CommittedEntries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:3 Log:0/5
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:3 Log:0/5

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -27,28 +27,28 @@ ok
 # Campaigning will fail when there is an active leader.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
-INFO 2 became candidate at term 2
-INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
-INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
+INFO 2 is starting a new election at term 2
+INFO 2 became candidate at term 3
+INFO 2 [logterm: 2, index: 11] sent MsgVote request to 1 at term 3
+INFO 2 [logterm: 2, index: 11] sent MsgVote request to 3 at term 3
 
 stabilize
 ----
 > 2 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:2 Vote:2 Commit:11
+  HardState Term:3 Vote:2 Commit:11
   Messages:
-  2->1 MsgVote Term:2 Log:1/11
-  2->3 MsgVote Term:2 Log:1/11
-  INFO 2 received MsgVoteResp from 2 at term 2
+  2->1 MsgVote Term:3 Log:2/11
+  2->3 MsgVote Term:3 Log:2/11
+  INFO 2 received MsgVoteResp from 2 at term 3
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  2->1 MsgVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  2->1 MsgVote Term:3 Log:2/11
+  INFO 1 [logterm: 2, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 > 3 receiving messages
-  2->3 MsgVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  2->3 MsgVote Term:3 Log:2/11
+  INFO 3 [logterm: 2, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 
 # Tick the leader without processing any messages from followers. We have to
 # tick 2 election timeouts, since the followers were active in the current
@@ -60,7 +60,7 @@ ok
 tick-election 1
 ----
 WARN 1 stepped down to follower since quorum is not active
-INFO 1 became follower at term 1
+INFO 1 became follower at term 2
 
 # We'll now send all of the heartbeats that were buffered during the ticks
 # above. Conceptually, "the network was slow".
@@ -70,167 +70,167 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StateFollower
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgAppResp Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 2 [term: 2]
-  INFO 1 became follower at term 2
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
-  2->1 MsgAppResp Term:2 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  INFO 1 [term: 2] ignored a MsgHeartbeatResp message with lower term from 3 [term: 1]
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  INFO 1 [term: 2] ignored a MsgHeartbeatResp message with lower term from 3 [term: 1]
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  INFO 1 [term: 2] ignored a MsgHeartbeatResp message with lower term from 3 [term: 1]
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  INFO 1 [term: 2] ignored a MsgHeartbeatResp message with lower term from 3 [term: 1]
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  INFO 1 [term: 2] ignored a MsgHeartbeatResp message with lower term from 3 [term: 1]
+  2->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [term: 2] received a MsgAppResp message with higher term from 2 [term: 3]
+  INFO 1 became follower at term 3
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  2->1 MsgAppResp Term:3 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  INFO 1 [term: 3] ignored a MsgHeartbeatResp message with lower term from 3 [term: 2]
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  INFO 1 [term: 3] ignored a MsgHeartbeatResp message with lower term from 3 [term: 2]
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  INFO 1 [term: 3] ignored a MsgHeartbeatResp message with lower term from 3 [term: 2]
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  INFO 1 [term: 3] ignored a MsgHeartbeatResp message with lower term from 3 [term: 2]
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  INFO 1 [term: 3] ignored a MsgHeartbeatResp message with lower term from 3 [term: 2]
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:2 Commit:11
+  HardState Term:3 Commit:11
 
 # Other nodes can now successfully campaign. Note that we haven't ticked 3, so
 # it won't grant votes.
 campaign 2
 ----
-INFO 2 is starting a new election at term 2
-INFO 2 became candidate at term 3
-INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 3
-INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 3
+INFO 2 is starting a new election at term 3
+INFO 2 became candidate at term 4
+INFO 2 [logterm: 2, index: 11] sent MsgVote request to 1 at term 4
+INFO 2 [logterm: 2, index: 11] sent MsgVote request to 3 at term 4
 
 process-ready 2
 ----
 Ready MustSync=true:
-HardState Term:3 Vote:2 Commit:11
+HardState Term:4 Vote:2 Commit:11
 Messages:
-2->1 MsgVote Term:3 Log:1/11
-2->3 MsgVote Term:3 Log:1/11
-INFO 2 received MsgVoteResp from 2 at term 3
+2->1 MsgVote Term:4 Log:2/11
+2->3 MsgVote Term:4 Log:2/11
+INFO 2 received MsgVoteResp from 2 at term 4
 INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 
 deliver-msgs 1
 ----
-2->1 MsgVote Term:3 Log:1/11
-INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
-INFO 1 became follower at term 3
-INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 3
+2->1 MsgVote Term:4 Log:2/11
+INFO 1 [term: 3] received a MsgVote message with higher term from 2 [term: 4]
+INFO 1 became follower at term 4
+INFO 1 [logterm: 2, index: 11, vote: 0] cast MsgVote for 2 [logterm: 2, index: 11] at term 4
 
 deliver-msgs 3
 ----
-2->3 MsgVote Term:3 Log:1/11
-INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+2->3 MsgVote Term:4 Log:2/11
+INFO 3 [logterm: 2, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:3 Vote:2 Commit:11
+  HardState Term:4 Vote:2 Commit:11
   Messages:
-  1->2 MsgVoteResp Term:3 Log:0/0
+  1->2 MsgVoteResp Term:4 Log:0/0
 > 2 receiving messages
-  1->2 MsgVoteResp Term:3 Log:0/0
-  INFO 2 received MsgVoteResp from 1 at term 3
+  1->2 MsgVoteResp Term:4 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 4
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 2 became leader at term 3
+  INFO 2 became leader at term 4
 > 2 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateLeader
   Entries:
-  3/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-  2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+  2->1 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  2->3 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+  2->1 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-  INFO 3 [term: 1] received a MsgApp message with higher term from 2 [term: 3]
-  INFO 3 became follower at term 3
+  2->3 MsgApp Term:4 Log:2/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  INFO 3 [term: 2] received a MsgApp message with higher term from 2 [term: 4]
+  INFO 3 became follower at term 4
 > 1 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateFollower
   Entries:
-  3/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:4 Log:0/12
 > 3 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateFollower
-  HardState Term:3 Commit:11
+  HardState Term:4 Commit:11
   Entries:
-  3/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:3 Log:0/12
+  3->2 MsgAppResp Term:4 Log:0/12
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/12
-  3->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:4 Log:0/12
+  3->2 MsgAppResp Term:4 Log:0/12
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:3 Vote:2 Commit:12
+  HardState Term:4 Vote:2 Commit:12
   CommittedEntries:
-  3/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:3 Log:3/12 Commit:12
-  2->3 MsgApp Term:3 Log:3/12 Commit:12
+  2->1 MsgApp Term:4 Log:4/12 Commit:12
+  2->3 MsgApp Term:4 Log:4/12 Commit:12
 > 1 receiving messages
-  2->1 MsgApp Term:3 Log:3/12 Commit:12
+  2->1 MsgApp Term:4 Log:4/12 Commit:12
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:3/12 Commit:12
+  2->3 MsgApp Term:4 Log:4/12 Commit:12
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:3 Vote:2 Commit:12
+  HardState Term:4 Vote:2 Commit:12
   CommittedEntries:
-  3/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:4 Log:0/12
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:3 Commit:12
+  HardState Term:4 Commit:12
   CommittedEntries:
-  3/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:3 Log:0/12
+  3->2 MsgAppResp Term:4 Log:0/12
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/12
-  3->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:4 Log:0/12
+  3->2 MsgAppResp Term:4 Log:0/12

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -10,13 +10,13 @@
 add-nodes 1 voters=(1) index=2 max-committed-size-per-ready=1 disable-conf-change-validation=true
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 stabilize log-level=none
 ----
@@ -38,23 +38,23 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryNormal "foo"
-  1/5 EntryConfChangeV2 l2 l3
+  2/4 EntryNormal "foo"
+  2/5 EntryConfChangeV2 l2 l3
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/4 EntryNormal "foo"
+  2/4 EntryNormal "foo"
 > 1 handling Ready
   Ready MustSync=false:
   CommittedEntries:
-  1/5 EntryConfChangeV2 l2 l3
+  2/5 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:5 Entries:[1/5 EntryConfChangeV2 l2 l3]
-  1->3 MsgApp Term:1 Log:1/4 Commit:5 Entries:[1/5 EntryConfChangeV2 l2 l3]
+  1->2 MsgApp Term:2 Log:2/4 Commit:5 Entries:[2/5 EntryConfChangeV2 l2 l3]
+  1->3 MsgApp Term:2 Log:2/4 Commit:5 Entries:[2/5 EntryConfChangeV2 l2 l3]
 
 # Propose new config change. Note how it isn't rejected,
 # which is due to DisableConfChangeValidation=true.
@@ -68,7 +68,7 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/6 EntryConfChangeV2 l4
+2/6 EntryConfChangeV2 l4
 
 # If we process-ready on node 1 now, the second config change will come up for
 # application, and the node will panic with "config is already joint". The state

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -6,13 +6,13 @@
 add-nodes 1 voters=(1) index=2 disable-conf-change-validation=true
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 stabilize log-level=none
 ----
@@ -29,7 +29,7 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/4 EntryConfChangeV2 l2 l3
+2/4 EntryConfChangeV2 l2 l3
 
 # Propose another config change. It should be rejected, because the first config
 # change hasn't applied on the leader yet.
@@ -43,17 +43,17 @@ stabilize 1
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   Entries:
-  1/5 EntryNormal ""
+  2/5 EntryNormal ""
   CommittedEntries:
-  1/4 EntryConfChangeV2 l2 l3
+  2/4 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/5 EntryNormal ""
+  2/5 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  1->3 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryNormal ""]

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -4,22 +4,22 @@
 add-nodes 1 voters=(1) index=2
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:1 Vote:1 Commit:2
-INFO 1 received MsgVoteResp from 1 at term 1
+HardState Term:2 Vote:1 Commit:2
+INFO 1 received MsgVoteResp from 1 at term 2
 INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-INFO 1 became leader at term 1
+INFO 1 became leader at term 2
 
 # Add v2 (with an auto transition).
 propose-conf-change 1 v1=true
@@ -43,54 +43,54 @@ stabilize
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChange v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChange v2
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChange v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChange v2
   INFO 1 switched to configuration voters=(1 2)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChange v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChange v2]
+  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 2, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
-  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
+  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 2] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 2]
   INFO 2 switched to configuration voters=(1 2)
-  INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
+  INFO 2 [commit: 4, lastindex: 4, lastterm: 2] restored snapshot [index: 4, term: 2]
+  INFO 2 [commit: 4] restored snapshot [index: 4, term: 2]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Commit:4
+  Snapshot Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -23,9 +23,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # Start removing n1.
 propose-conf-change 1 v1=true
@@ -35,9 +35,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # Propose an extra entry which will be sent out together with the conf change.
 propose 1 foo
@@ -49,29 +49,29 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/4 EntryConfChange r1
-1/5 EntryNormal "foo"
+2/4 EntryConfChange r1
+2/5 EntryNormal "foo"
 Messages:
-1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
+1->2 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+1->3 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+1->2 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
+1->3 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
 
 # Send response from n2 (which is enough to commit the entries so far next time
 # n1 runs).
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
+  1->2 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+  1->2 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/5
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -87,122 +87,122 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
+  1->2 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
+  1->3 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/5
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:2 Log:2/6 Commit:4
+  1->3 MsgApp Term:2 Log:2/6 Commit:4
+  1->2 MsgApp Term:2 Log:2/6 Commit:5
+  1->3 MsgApp Term:2 Log:2/6 Commit:5
   INFO 1 switched to configuration voters=(2 3)
 
 raft-state
 ----
-1: StateLeader (Non-Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Non-Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # n2 responds, n3 doesn't yet. Quorum for 'bar' should not be reached...
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
+  1->2 MsgApp Term:2 Log:2/6 Commit:4
+  1->2 MsgApp Term:2 Log:2/6 Commit:5
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   Entries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
   INFO 2 switched to configuration voters=(2 3)
 
 # ... which thankfully is what we see on the leader.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->3 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+  1->3 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
+  1->3 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
+  1->3 MsgApp Term:2 Log:2/6 Commit:4
+  1->3 MsgApp Term:2 Log:2/6 Commit:5
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  1/6 EntryNormal "bar"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
+  2/6 EntryNormal "bar"
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
   INFO 3 switched to configuration voters=(2 3)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
+  HardState Term:2 Vote:1 Commit:6
   CommittedEntries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-  1->3 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:2 Log:2/6 Commit:6
+  1->3 MsgApp Term:2 Log:2/6 Commit:6
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:2 Log:2/6 Commit:6
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:6
+  1->3 MsgApp Term:2 Log:2/6 Commit:6
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
+  HardState Term:2 Vote:1 Commit:6
   CommittedEntries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
+  HardState Term:2 Vote:1 Commit:6
   CommittedEntries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
 
 # However not all is well. n1 is still leader but unconditionally drops all
 # proposals on the floor, so we're effectively stuck if it still heartbeats
@@ -223,28 +223,28 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:6
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:6
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:6
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:6
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 
 # Just confirming the issue above - leader does not automatically step down.
 # Expected behavior: a new leader is elected after an election timeout.
 raft-state
 ----
-1: StateLeader (Non-Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Non-Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1

--- a/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
@@ -24,9 +24,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # Start removing n1.
 propose-conf-change 1 v1=true
@@ -36,9 +36,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # Propose an extra entry which will be sent out together with the conf change.
 propose 1 foo
@@ -50,29 +50,29 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/4 EntryConfChange r1
-1/5 EntryNormal "foo"
+2/4 EntryConfChange r1
+2/5 EntryNormal "foo"
 Messages:
-1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
+1->2 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+1->3 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+1->2 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
+1->3 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
 
 # Send response from n2 (which is enough to commit the entries so far next time
 # n1 runs).
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
+  1->2 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+  1->2 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/5
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -86,102 +86,102 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
+  1->2 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
+  1->3 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/5
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:2 Log:2/6 Commit:4
+  1->3 MsgApp Term:2 Log:2/6 Commit:4
+  1->2 MsgApp Term:2 Log:2/6 Commit:5
+  1->3 MsgApp Term:2 Log:2/6 Commit:5
   INFO 1 switched to configuration voters=(2 3)
-  INFO 1 became follower at term 1
+  INFO 1 became follower at term 2
 > 1 handling Ready
   Ready MustSync=false:
   Lead:0 State:StateFollower
 
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateFollower (Non-Voter) Term:2 Lead:0
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # n2 responds, n3 doesn't yet. Quorum for 'bar' should not be reached...
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
+  1->2 MsgApp Term:2 Log:2/6 Commit:4
+  1->2 MsgApp Term:2 Log:2/6 Commit:5
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   Entries:
-  1/6 EntryNormal "bar"
+  2/6 EntryNormal "bar"
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
   INFO 2 switched to configuration voters=(2 3)
 
 # ...because the old leader n1 ignores the append responses.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->3 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChange r1]
+  1->3 MsgApp Term:2 Log:2/4 Commit:3 Entries:[2/5 EntryNormal "foo"]
+  1->3 MsgApp Term:2 Log:2/5 Commit:3 Entries:[2/6 EntryNormal "bar"]
+  1->3 MsgApp Term:2 Log:2/6 Commit:4
+  1->3 MsgApp Term:2 Log:2/6 Commit:5
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  1/6 EntryNormal "bar"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
+  2/6 EntryNormal "bar"
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  2/4 EntryConfChange r1
+  2/5 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
   INFO 3 switched to configuration voters=(2 3)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
 
 # n1 can no longer propose.
 propose 1 baz
 ----
-INFO 1 no leader at term 1; dropping proposal
+INFO 1 no leader at term 2; dropping proposal
 raft proposal dropped
 
 # Nor can it campaign to become leader.

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -6,22 +6,22 @@
 add-nodes 1 voters=(1) index=2
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:1 Vote:1 Commit:2
-INFO 1 received MsgVoteResp from 1 at term 1
+HardState Term:2 Vote:1 Commit:2
+INFO 1 received MsgVoteResp from 1 at term 2
 INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-INFO 1 became leader at term 1
+INFO 1 became leader at term 2
 
 propose-conf-change 1 transition=auto
 v2 v3
@@ -44,8 +44,8 @@ process-ready 1
 Ready MustSync=true:
 Lead:1 State:StateLeader
 Entries:
-1/3 EntryNormal ""
-1/4 EntryConfChangeV2 v2 v3
+2/3 EntryNormal ""
+2/4 EntryConfChangeV2 v2 v3
 
 # Now n1 applies the conf change. We see that it starts transitioning out of that joint
 # configuration (though we will only see that proposal in the next ready handling
@@ -54,10 +54,10 @@ Entries:
 process-ready 1
 ----
 Ready MustSync=false:
-HardState Term:1 Vote:1 Commit:4
+HardState Term:2 Vote:1 Commit:4
 CommittedEntries:
-1/3 EntryNormal ""
-1/4 EntryConfChangeV2 v2 v3
+2/3 EntryNormal ""
+2/4 EntryConfChangeV2 v2 v3
 INFO 1 switched to configuration voters=(1 2 3)&&(1) autoleave
 INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
 
@@ -67,10 +67,10 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
-  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2 v3]
+  1->3 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2 v3]
 
 # First, play out the whole interaction between n1 and n2. We see n1's probe to
 # n2 get rejected (since n2 needs a snapshot); the snapshot is delivered at which
@@ -80,118 +80,118 @@ stabilize 1
 stabilize 1 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2 v3]
+  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 2, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
-  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
+  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 2] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 2]
   INFO 2 switched to configuration voters=(1 2 3)&&(1) autoleave
-  INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
+  INFO 2 [commit: 4, lastindex: 4, lastterm: 2] restored snapshot [index: 4, term: 2]
+  INFO 2 [commit: 4] restored snapshot [index: 4, term: 2]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  HardState Term:2 Commit:4
+  Snapshot Index:4 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:5
   INFO 1 switched to configuration voters=(1 2 3)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:5
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:5
+  HardState Term:2 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
   INFO 2 switched to configuration voters=(1 2 3)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
 
 # n3 immediately receives a snapshot in the final configuration.
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
-  INFO 3 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 3 became follower at term 1
-  DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->3 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2 v3]
+  INFO 3 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 3 became follower at term 2
+  DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 2, index: 3] from 1
 > 3 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1]
-  DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 1] to 3 [StateProbe match=0 next=1]
+  DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 2] to 3 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=6 paused pendingSnap=5]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  1->3 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:5 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 3 receiving messages
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 5, term: 1]
+  1->3 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:5 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 5, term: 2]
   INFO 3 switched to configuration voters=(1 2 3)
-  INFO 3 [commit: 5, lastindex: 5, lastterm: 1] restored snapshot [index: 5, term: 1]
-  INFO 3 [commit: 5] restored snapshot [index: 5, term: 1]
+  INFO 3 [commit: 5, lastindex: 5, lastterm: 2] restored snapshot [index: 5, term: 2]
+  INFO 3 [commit: 5] restored snapshot [index: 5, term: 2]
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:5
-  Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Commit:5
+  Snapshot Index:5 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/5
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/5
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=5 next=6 paused pendingSnap=5]
 
 # Nothing else happens.
@@ -213,30 +213,30 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3
+  2/6 EntryConfChangeV2 r2 r3
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
+  1->2 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2 r2 r3]
+  1->3 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2 r2 r3]
 
 # n2, n3 ack them.
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
+  1->2 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2 r2 r3]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
+  1->3 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2 r2 r3]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3
+  2/6 EntryConfChangeV2 r2 r3
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3
+  2/6 EntryConfChangeV2 r2 r3
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
 
 # n1 gets some more proposals. This is part of a regression test: There used to
 # be a bug in which these proposals would prompt the leader to transition out of
@@ -256,76 +256,76 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
+  2/7 EntryNormal "foo"
+  2/8 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->2 MsgApp Term:2 Log:2/6 Commit:5 Entries:[2/7 EntryNormal "foo"]
+  1->3 MsgApp Term:2 Log:2/6 Commit:5 Entries:[2/7 EntryNormal "foo"]
+  1->2 MsgApp Term:2 Log:2/7 Commit:5 Entries:[2/8 EntryNormal "bar"]
+  1->3 MsgApp Term:2 Log:2/7 Commit:5 Entries:[2/8 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  3->1 MsgAppResp Term:2 Log:0/6
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
+  HardState Term:2 Vote:1 Commit:6
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
+  2/6 EntryConfChangeV2 r2 r3
   Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
+  1->2 MsgApp Term:2 Log:2/8 Commit:6
+  1->3 MsgApp Term:2 Log:2/8 Commit:6
   INFO 1 switched to configuration voters=(1)&&(1 2 3) autoleave
   INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) autoleave
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/9 EntryConfChangeV2
+  2/9 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/8 Commit:6 Entries:[2/9 EntryConfChangeV2]
+  1->3 MsgApp Term:2 Log:2/8 Commit:6 Entries:[2/9 EntryConfChangeV2]
 
 # n2 and n3 also switch to the joint config, and ack the transition out of it.
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/6 Commit:5 Entries:[2/7 EntryNormal "foo"]
+  1->2 MsgApp Term:2 Log:2/7 Commit:5 Entries:[2/8 EntryNormal "bar"]
+  1->2 MsgApp Term:2 Log:2/8 Commit:6
+  1->2 MsgApp Term:2 Log:2/8 Commit:6 Entries:[2/9 EntryConfChangeV2]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
+  1->3 MsgApp Term:2 Log:2/6 Commit:5 Entries:[2/7 EntryNormal "foo"]
+  1->3 MsgApp Term:2 Log:2/7 Commit:5 Entries:[2/8 EntryNormal "bar"]
+  1->3 MsgApp Term:2 Log:2/8 Commit:6
+  1->3 MsgApp Term:2 Log:2/8 Commit:6 Entries:[2/9 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6
+  HardState Term:2 Commit:6
   Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  2/7 EntryNormal "foo"
+  2/8 EntryNormal "bar"
+  2/9 EntryConfChangeV2
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
+  2/6 EntryConfChangeV2 r2 r3
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/7
+  2->1 MsgAppResp Term:2 Log:0/8
+  2->1 MsgAppResp Term:2 Log:0/8
+  2->1 MsgAppResp Term:2 Log:0/9
   INFO 2 switched to configuration voters=(1)&&(1 2 3) autoleave
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6
+  HardState Term:2 Commit:6
   Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  2/7 EntryNormal "foo"
+  2/8 EntryNormal "bar"
+  2/9 EntryConfChangeV2
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
+  2/6 EntryConfChangeV2 r2 r3
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/7
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/7
+  3->1 MsgAppResp Term:2 Log:0/8
+  3->1 MsgAppResp Term:2 Log:0/8
+  3->1 MsgAppResp Term:2 Log:0/9
   INFO 3 switched to configuration voters=(1)&&(1 2 3) autoleave
 
 # n2 and n3 also leave the joint config and the dust settles. We see at the very
@@ -334,71 +334,71 @@ stabilize 2 3
 stabilize
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/7
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/7
+  2->1 MsgAppResp Term:2 Log:0/8
+  2->1 MsgAppResp Term:2 Log:0/8
+  2->1 MsgAppResp Term:2 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/7
+  3->1 MsgAppResp Term:2 Log:0/8
+  3->1 MsgAppResp Term:2 Log:0/8
+  3->1 MsgAppResp Term:2 Log:0/9
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:9
+  HardState Term:2 Vote:1 Commit:9
   CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  2/7 EntryNormal "foo"
+  2/8 EntryNormal "bar"
+  2/9 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/9 Commit:7
-  1->3 MsgApp Term:1 Log:1/9 Commit:7
-  1->2 MsgApp Term:1 Log:1/9 Commit:8
-  1->3 MsgApp Term:1 Log:1/9 Commit:8
-  1->2 MsgApp Term:1 Log:1/9 Commit:9
-  1->3 MsgApp Term:1 Log:1/9 Commit:9
+  1->2 MsgApp Term:2 Log:2/9 Commit:7
+  1->3 MsgApp Term:2 Log:2/9 Commit:7
+  1->2 MsgApp Term:2 Log:2/9 Commit:8
+  1->3 MsgApp Term:2 Log:2/9 Commit:8
+  1->2 MsgApp Term:2 Log:2/9 Commit:9
+  1->3 MsgApp Term:2 Log:2/9 Commit:9
   INFO 1 switched to configuration voters=(1)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/9 Commit:7
-  1->2 MsgApp Term:1 Log:1/9 Commit:8
-  1->2 MsgApp Term:1 Log:1/9 Commit:9
+  1->2 MsgApp Term:2 Log:2/9 Commit:7
+  1->2 MsgApp Term:2 Log:2/9 Commit:8
+  1->2 MsgApp Term:2 Log:2/9 Commit:9
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/9 Commit:7
-  1->3 MsgApp Term:1 Log:1/9 Commit:8
-  1->3 MsgApp Term:1 Log:1/9 Commit:9
+  1->3 MsgApp Term:2 Log:2/9 Commit:7
+  1->3 MsgApp Term:2 Log:2/9 Commit:8
+  1->3 MsgApp Term:2 Log:2/9 Commit:9
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:9
+  HardState Term:2 Commit:9
   CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  2/7 EntryNormal "foo"
+  2/8 EntryNormal "bar"
+  2/9 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/9
-  2->1 MsgAppResp Term:1 Log:0/9
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/9
   INFO 2 switched to configuration voters=(1)
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:9
+  HardState Term:2 Commit:9
   CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  2/7 EntryNormal "foo"
+  2/8 EntryNormal "bar"
+  2/9 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/9
   INFO 3 switched to configuration voters=(1)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/9
   raft: cannot step as peer not found
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/9
   raft: cannot step as peer not found
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:2 Log:0/9
   raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/9
   raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/9
   raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:2 Log:0/9
   raft: cannot step as peer not found

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -8,22 +8,22 @@
 add-nodes 1 voters=(1) index=2
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:1 Vote:1 Commit:2
-INFO 1 received MsgVoteResp from 1 at term 1
+HardState Term:2 Vote:1 Commit:2
+INFO 1 received MsgVoteResp from 1 at term 2
 INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-INFO 1 became leader at term 1
+INFO 1 became leader at term 2
 
 propose-conf-change 1 transition=implicit
 v2
@@ -46,91 +46,91 @@ stabilize 1 2
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChangeV2 v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChangeV2 v2
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChangeV2 v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChangeV2 v2
   INFO 1 switched to configuration voters=(1 2)&&(1) autoleave
   INFO initiating automatic transition out of joint configuration voters=(1 2)&&(1) autoleave
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2]
+  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 2, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
-  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
+  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 2] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 2]
   INFO 2 switched to configuration voters=(1 2)&&(1) autoleave
-  INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
+  INFO 2 [commit: 4, lastindex: 4, lastterm: 2] restored snapshot [index: 4, term: 2]
+  INFO 2 [commit: 4] restored snapshot [index: 4, term: 2]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  HardState Term:2 Commit:4
+  Snapshot Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:5
   INFO 1 switched to configuration voters=(1 2)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:5
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:5
+  HardState Term:2 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
   INFO 2 switched to configuration voters=(1 2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -6,22 +6,22 @@
 add-nodes 1 voters=(1) index=2
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:1 Vote:1 Commit:2
-INFO 1 received MsgVoteResp from 1 at term 1
+HardState Term:2 Vote:1 Commit:2
+INFO 1 received MsgVoteResp from 1 at term 2
 INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-INFO 1 became leader at term 1
+INFO 1 became leader at term 2
 
 # Add v2 (with an auto transition).
 propose-conf-change 1
@@ -44,54 +44,54 @@ stabilize
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChangeV2 v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChangeV2 v2
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChangeV2 v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChangeV2 v2
   INFO 1 switched to configuration voters=(1 2)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2]
+  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 2, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
-  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
+  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 2] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 2]
   INFO 2 switched to configuration voters=(1 2)
-  INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
+  INFO 2 [commit: 4, lastindex: 4, lastterm: 2] restored snapshot [index: 4, term: 2]
+  INFO 2 [commit: 4] restored snapshot [index: 4, term: 2]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Commit:4
+  Snapshot Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -6,22 +6,22 @@
 add-nodes 1 voters=(1) index=2
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 process-ready 1
 ----
 Ready MustSync=true:
 Lead:0 State:StateCandidate
-HardState Term:1 Vote:1 Commit:2
-INFO 1 received MsgVoteResp from 1 at term 1
+HardState Term:2 Vote:1 Commit:2
+INFO 1 received MsgVoteResp from 1 at term 2
 INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-INFO 1 became leader at term 1
+INFO 1 became leader at term 2
 
 # Add v2 with an explicit transition.
 propose-conf-change 1 transition=explicit
@@ -44,56 +44,56 @@ stabilize 1 2
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChangeV2 v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChangeV2 v2
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/3 EntryNormal ""
-  1/4 EntryConfChangeV2 v2
+  2/3 EntryNormal ""
+  2/4 EntryConfChangeV2 v2
   INFO 1 switched to configuration voters=(1 2)&&(1)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 2 became follower at term 1
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->2 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 v2]
+  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 2 became follower at term 2
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 2, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1]
-  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1]
+  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 2] to 2 [StateProbe match=0 next=1]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
-  1->2 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  1->2 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 2]
   INFO 2 switched to configuration voters=(1 2)&&(1)
-  INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
+  INFO 2 [commit: 4, lastindex: 4, lastterm: 2] restored snapshot [index: 4, term: 2]
+  INFO 2 [commit: 4] restored snapshot [index: 4, term: 2]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Commit:4
+  Snapshot Index:4 Term:2 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
 
 # Check that we're not allowed to change membership again while in the joint state.
@@ -115,51 +115,51 @@ stabilize
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  2/5 EntryNormal ""
+  2/6 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:2/5 Commit:4 Entries:[2/6 EntryConfChangeV2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:2/5 Commit:4 Entries:[2/6 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  2/5 EntryNormal ""
+  2/6 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/6
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/6
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:6
+  HardState Term:2 Vote:1 Commit:6
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  2/5 EntryNormal ""
+  2/6 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:2 Log:2/6 Commit:5
+  1->2 MsgApp Term:2 Log:2/6 Commit:6
   INFO 1 switched to configuration voters=(1 2)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:2 Log:2/6 Commit:5
+  1->2 MsgApp Term:2 Log:2/6 Commit:6
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:6
+  HardState Term:2 Commit:6
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  2/5 EntryNormal ""
+  2/6 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
   INFO 2 switched to configuration voters=(1 2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
+  2->1 MsgAppResp Term:2 Log:0/6
 
 # Check that trying to transition out again won't do anything.
 propose-conf-change 1
@@ -172,34 +172,34 @@ stabilize
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/7 EntryNormal ""
+  2/7 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:2/6 Commit:6 Entries:[2/7 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:2/6 Commit:6 Entries:[2/7 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/7 EntryNormal ""
+  2/7 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:2 Log:0/7
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:2 Log:0/7
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:7
+  HardState Term:2 Vote:1 Commit:7
   CommittedEntries:
-  1/7 EntryNormal ""
+  2/7 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
+  1->2 MsgApp Term:2 Log:2/7 Commit:7
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
+  1->2 MsgApp Term:2 Log:2/7 Commit:7
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:7
+  HardState Term:2 Commit:7
   CommittedEntries:
-  1/7 EntryNormal ""
+  2/7 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:2 Log:0/7
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:2 Log:0/7

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -29,9 +29,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # create n4
 add-nodes 1
@@ -52,112 +52,112 @@ stabilize
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryConfChangeV2 r1 v4
+  2/4 EntryConfChangeV2 r1 v4
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
+  1->2 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChangeV2 r1 v4]
+  1->3 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChangeV2 r1 v4]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
+  1->2 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChangeV2 r1 v4]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 r1 v4]
+  1->3 MsgApp Term:2 Log:2/3 Commit:3 Entries:[2/4 EntryConfChangeV2 r1 v4]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryConfChangeV2 r1 v4
+  2/4 EntryConfChangeV2 r1 v4
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryConfChangeV2 r1 v4
+  2/4 EntryConfChangeV2 r1 v4
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/4
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/4 EntryConfChangeV2 r1 v4
+  2/4 EntryConfChangeV2 r1 v4
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
-  1->3 MsgApp Term:1 Log:1/4 Commit:4
+  1->2 MsgApp Term:2 Log:2/4 Commit:4
+  1->3 MsgApp Term:2 Log:2/4 Commit:4
   INFO 1 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4
+  1->2 MsgApp Term:2 Log:2/4 Commit:4
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/4 Commit:4
+  1->3 MsgApp Term:2 Log:2/4 Commit:4
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
+  1->4 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 r1 v4]
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/4 EntryConfChangeV2 r1 v4
+  2/4 EntryConfChangeV2 r1 v4
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
   INFO 2 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/4 EntryConfChangeV2 r1 v4
+  2/4 EntryConfChangeV2 r1 v4
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/4
   INFO 3 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:2 Log:0/4
+  3->1 MsgAppResp Term:2 Log:0/4
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
-  INFO 4 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
-  INFO 4 became follower at term 1
+  1->4 MsgApp Term:2 Log:2/3 Commit:4 Entries:[2/4 EntryConfChangeV2 r1 v4]
+  INFO 4 [term: 0] received a MsgApp message with higher term from 1 [term: 2]
+  INFO 4 became follower at term 2
 > 4 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  4->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  4->1 MsgAppResp Term:2 Log:0/3 Rejected (Hint: 0)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->4 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
+  1->4 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
 > 4 receiving messages
-  1->4 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  1->4 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:4 Term:2 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 2]
   INFO 4 switched to configuration voters=(2 3 4)&&(1 2 3)
-  INFO 4 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
-  INFO 4 [commit: 4] restored snapshot [index: 4, term: 1]
+  INFO 4 [commit: 4, lastindex: 4, lastterm: 2] restored snapshot [index: 4, term: 2]
+  INFO 4 [commit: 4] restored snapshot [index: 4, term: 2]
 > 4 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:4
-  Snapshot Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Commit:4
+  Snapshot Index:4 Term:2 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/4
+  4->1 MsgAppResp Term:2 Log:0/4
 > 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/4
+  4->1 MsgAppResp Term:2 Log:0/4
 
 
 # Transfer leadership while in the joint config.
 transfer-leadership from=1 to=4
 ----
-INFO 1 [term 1] starts to transfer leadership to 4
+INFO 1 [term 2] starts to transfer leadership to 4
 INFO 1 sends MsgTimeoutNow to 4 immediately as 4 already has up-to-date log
 
 # Leadership transfer wasn't processed yet.
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Voter) Term:2 Lead:1
 
 # Leadership transfer is happening here.
 stabilize
@@ -165,155 +165,155 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->4 MsgTimeoutNow Term:1 Log:0/0
+  1->4 MsgTimeoutNow Term:2 Log:0/0
 > 4 receiving messages
-  1->4 MsgTimeoutNow Term:1 Log:0/0
-  INFO 4 [term 1] received MsgTimeoutNow from 1 and starts an election to get leadership.
-  INFO 4 is starting a new election at term 1
-  INFO 4 became candidate at term 2
-  INFO 4 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
-  INFO 4 [logterm: 1, index: 4] sent MsgVote request to 2 at term 2
-  INFO 4 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
+  1->4 MsgTimeoutNow Term:2 Log:0/0
+  INFO 4 [term 2] received MsgTimeoutNow from 1 and starts an election to get leadership.
+  INFO 4 is starting a new election at term 2
+  INFO 4 became candidate at term 3
+  INFO 4 [logterm: 2, index: 4] sent MsgVote request to 1 at term 3
+  INFO 4 [logterm: 2, index: 4] sent MsgVote request to 2 at term 3
+  INFO 4 [logterm: 2, index: 4] sent MsgVote request to 3 at term 3
 > 4 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:2 Vote:4 Commit:4
+  HardState Term:3 Vote:4 Commit:4
   Messages:
-  4->1 MsgVote Term:2 Log:1/4
-  4->2 MsgVote Term:2 Log:1/4
-  4->3 MsgVote Term:2 Log:1/4
-  INFO 4 received MsgVoteResp from 4 at term 2
+  4->1 MsgVote Term:3 Log:2/4
+  4->2 MsgVote Term:3 Log:2/4
+  4->3 MsgVote Term:3 Log:2/4
+  INFO 4 received MsgVoteResp from 4 at term 3
   INFO 4 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  4->1 MsgVote Term:2 Log:1/4
-  INFO 1 [term: 1] received a MsgVote message with higher term from 4 [term: 2]
-  INFO 1 became follower at term 2
-  INFO 1 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
+  4->1 MsgVote Term:3 Log:2/4
+  INFO 1 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
+  INFO 1 became follower at term 3
+  INFO 1 [logterm: 2, index: 4, vote: 0] cast MsgVote for 4 [logterm: 2, index: 4] at term 3
 > 2 receiving messages
-  4->2 MsgVote Term:2 Log:1/4
-  INFO 2 [term: 1] received a MsgVote message with higher term from 4 [term: 2]
-  INFO 2 became follower at term 2
-  INFO 2 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
+  4->2 MsgVote Term:3 Log:2/4
+  INFO 2 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
+  INFO 2 became follower at term 3
+  INFO 2 [logterm: 2, index: 4, vote: 0] cast MsgVote for 4 [logterm: 2, index: 4] at term 3
 > 3 receiving messages
-  4->3 MsgVote Term:2 Log:1/4
-  INFO 3 [term: 1] received a MsgVote message with higher term from 4 [term: 2]
-  INFO 3 became follower at term 2
-  INFO 3 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
+  4->3 MsgVote Term:3 Log:2/4
+  INFO 3 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
+  INFO 3 became follower at term 3
+  INFO 3 [logterm: 2, index: 4, vote: 0] cast MsgVote for 4 [logterm: 2, index: 4] at term 3
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:4 Commit:4
+  HardState Term:3 Vote:4 Commit:4
   Messages:
-  1->4 MsgVoteResp Term:2 Log:0/0
+  1->4 MsgVoteResp Term:3 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:4 Commit:4
+  HardState Term:3 Vote:4 Commit:4
   Messages:
-  2->4 MsgVoteResp Term:2 Log:0/0
+  2->4 MsgVoteResp Term:3 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:4 Commit:4
+  HardState Term:3 Vote:4 Commit:4
   Messages:
-  3->4 MsgVoteResp Term:2 Log:0/0
+  3->4 MsgVoteResp Term:3 Log:0/0
 > 4 receiving messages
-  1->4 MsgVoteResp Term:2 Log:0/0
-  INFO 4 received MsgVoteResp from 1 at term 2
+  1->4 MsgVoteResp Term:3 Log:0/0
+  INFO 4 received MsgVoteResp from 1 at term 3
   INFO 4 has received 2 MsgVoteResp votes and 0 vote rejections
-  2->4 MsgVoteResp Term:2 Log:0/0
-  INFO 4 received MsgVoteResp from 2 at term 2
+  2->4 MsgVoteResp Term:3 Log:0/0
+  INFO 4 received MsgVoteResp from 2 at term 3
   INFO 4 has received 3 MsgVoteResp votes and 0 vote rejections
-  INFO 4 became leader at term 2
-  3->4 MsgVoteResp Term:2 Log:0/0
+  INFO 4 became leader at term 3
+  3->4 MsgVoteResp Term:3 Log:0/0
 > 4 handling Ready
   Ready MustSync=true:
   Lead:4 State:StateLeader
   Entries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  4->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  4->2 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  4->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  4->1 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
+  4->2 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
+  4->3 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
 > 1 receiving messages
-  4->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  4->1 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
 > 2 receiving messages
-  4->2 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  4->2 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
 > 3 receiving messages
-  4->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  4->3 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
   Lead:4 State:StateFollower
   Entries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:3 Log:0/5
 > 2 handling Ready
   Ready MustSync=true:
   Lead:4 State:StateFollower
   Entries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/5
+  2->4 MsgAppResp Term:3 Log:0/5
 > 3 handling Ready
   Ready MustSync=true:
   Lead:4 State:StateFollower
   Entries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/5
+  3->4 MsgAppResp Term:3 Log:0/5
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/5
-  2->4 MsgAppResp Term:2 Log:0/5
-  3->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:3 Log:0/5
+  2->4 MsgAppResp Term:3 Log:0/5
+  3->4 MsgAppResp Term:3 Log:0/5
 > 4 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
+  HardState Term:3 Vote:4 Commit:5
   CommittedEntries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  4->1 MsgApp Term:2 Log:2/5 Commit:5
-  4->2 MsgApp Term:2 Log:2/5 Commit:5
-  4->3 MsgApp Term:2 Log:2/5 Commit:5
+  4->1 MsgApp Term:3 Log:3/5 Commit:5
+  4->2 MsgApp Term:3 Log:3/5 Commit:5
+  4->3 MsgApp Term:3 Log:3/5 Commit:5
 > 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/5 Commit:5
+  4->1 MsgApp Term:3 Log:3/5 Commit:5
 > 2 receiving messages
-  4->2 MsgApp Term:2 Log:2/5 Commit:5
+  4->2 MsgApp Term:3 Log:3/5 Commit:5
 > 3 receiving messages
-  4->3 MsgApp Term:2 Log:2/5 Commit:5
+  4->3 MsgApp Term:3 Log:3/5 Commit:5
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
+  HardState Term:3 Vote:4 Commit:5
   CommittedEntries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:3 Log:0/5
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
+  HardState Term:3 Vote:4 Commit:5
   CommittedEntries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/5
+  2->4 MsgAppResp Term:3 Log:0/5
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:5
+  HardState Term:3 Vote:4 Commit:5
   CommittedEntries:
-  2/5 EntryNormal ""
+  3/5 EntryNormal ""
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/5
+  3->4 MsgAppResp Term:3 Log:0/5
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/5
-  2->4 MsgAppResp Term:2 Log:0/5
-  3->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:3 Log:0/5
+  2->4 MsgAppResp Term:3 Log:0/5
+  3->4 MsgAppResp Term:3 Log:0/5
 
 # Leadership transfer succeeded.
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:4
-2: StateFollower (Voter) Term:2 Lead:4
-3: StateFollower (Voter) Term:2 Lead:4
-4: StateLeader (Voter) Term:2 Lead:4
+1: StateFollower (Voter) Term:3 Lead:4
+2: StateFollower (Voter) Term:3 Lead:4
+3: StateFollower (Voter) Term:3 Lead:4
+4: StateLeader (Voter) Term:3 Lead:4
 
 # n4 will propose a transition out of the joint config.
 propose-conf-change 4
@@ -326,92 +326,92 @@ stabilize
 > 4 handling Ready
   Ready MustSync=true:
   Entries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  4->1 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-  4->2 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
-  4->3 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
+  4->1 MsgApp Term:3 Log:3/5 Commit:5 Entries:[3/6 EntryConfChangeV2]
+  4->2 MsgApp Term:3 Log:3/5 Commit:5 Entries:[3/6 EntryConfChangeV2]
+  4->3 MsgApp Term:3 Log:3/5 Commit:5 Entries:[3/6 EntryConfChangeV2]
 > 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
+  4->1 MsgApp Term:3 Log:3/5 Commit:5 Entries:[3/6 EntryConfChangeV2]
 > 2 receiving messages
-  4->2 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
+  4->2 MsgApp Term:3 Log:3/5 Commit:5 Entries:[3/6 EntryConfChangeV2]
 > 3 receiving messages
-  4->3 MsgApp Term:2 Log:2/5 Commit:5 Entries:[2/6 EntryConfChangeV2]
+  4->3 MsgApp Term:3 Log:3/5 Commit:5 Entries:[3/6 EntryConfChangeV2]
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:3 Log:0/6
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/6
+  2->4 MsgAppResp Term:3 Log:0/6
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/6
+  3->4 MsgAppResp Term:3 Log:0/6
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/6
-  2->4 MsgAppResp Term:2 Log:0/6
-  3->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:3 Log:0/6
+  2->4 MsgAppResp Term:3 Log:0/6
+  3->4 MsgAppResp Term:3 Log:0/6
 > 4 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
+  HardState Term:3 Vote:4 Commit:6
   CommittedEntries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  4->1 MsgApp Term:2 Log:2/6 Commit:6
-  4->2 MsgApp Term:2 Log:2/6 Commit:6
-  4->3 MsgApp Term:2 Log:2/6 Commit:6
+  4->1 MsgApp Term:3 Log:3/6 Commit:6
+  4->2 MsgApp Term:3 Log:3/6 Commit:6
+  4->3 MsgApp Term:3 Log:3/6 Commit:6
   INFO 4 switched to configuration voters=(2 3 4)
 > 1 receiving messages
-  4->1 MsgApp Term:2 Log:2/6 Commit:6
+  4->1 MsgApp Term:3 Log:3/6 Commit:6
 > 2 receiving messages
-  4->2 MsgApp Term:2 Log:2/6 Commit:6
+  4->2 MsgApp Term:3 Log:3/6 Commit:6
 > 3 receiving messages
-  4->3 MsgApp Term:2 Log:2/6 Commit:6
+  4->3 MsgApp Term:3 Log:3/6 Commit:6
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
+  HardState Term:3 Vote:4 Commit:6
   CommittedEntries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:3 Log:0/6
   INFO 1 switched to configuration voters=(2 3 4)
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
+  HardState Term:3 Vote:4 Commit:6
   CommittedEntries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/6
+  2->4 MsgAppResp Term:3 Log:0/6
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:4 Commit:6
+  HardState Term:3 Vote:4 Commit:6
   CommittedEntries:
-  2/6 EntryConfChangeV2
+  3/6 EntryConfChangeV2
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/6
+  3->4 MsgAppResp Term:3 Log:0/6
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:3 Log:0/6
   raft: cannot step as peer not found
-  2->4 MsgAppResp Term:2 Log:0/6
-  3->4 MsgAppResp Term:2 Log:0/6
+  2->4 MsgAppResp Term:3 Log:0/6
+  3->4 MsgAppResp Term:3 Log:0/6
 
 # n1 is out of the configuration.
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:2 Lead:4
-2: StateFollower (Voter) Term:2 Lead:4
-3: StateFollower (Voter) Term:2 Lead:4
-4: StateLeader (Voter) Term:2 Lead:4
+1: StateFollower (Non-Voter) Term:3 Lead:4
+2: StateFollower (Voter) Term:3 Lead:4
+3: StateFollower (Voter) Term:3 Lead:4
+4: StateLeader (Voter) Term:3 Lead:4
 
 # Make sure n1 cannot campaign to become leader.
 campaign 1

--- a/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -30,9 +30,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # create n4
 add-nodes 1
@@ -54,10 +54,10 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Voter) Term:2 Lead:1
 
 # n4 will propose a transition out of the joint config.
 propose-conf-change 4
@@ -77,95 +77,95 @@ stabilize
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
-  1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
+  1->3 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
+  1->4 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->3 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->4 MsgApp Term:2 Log:2/4 Commit:4 Entries:[2/5 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/5
 > 4 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/5
+  4->1 MsgAppResp Term:2 Log:0/5
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/5
-  4->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/5
+  4->1 MsgAppResp Term:2 Log:0/5
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
-  1->3 MsgApp Term:1 Log:1/5 Commit:5
-  1->4 MsgApp Term:1 Log:1/5 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:5
+  1->3 MsgApp Term:2 Log:2/5 Commit:5
+  1->4 MsgApp Term:2 Log:2/5 Commit:5
   INFO 1 switched to configuration voters=(2 3 4)
-  INFO 1 became follower at term 1
+  INFO 1 became follower at term 2
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->2 MsgApp Term:2 Log:2/5 Commit:5
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5
+  1->3 MsgApp Term:2 Log:2/5 Commit:5
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/5 Commit:5
+  1->4 MsgApp Term:2 Log:2/5 Commit:5
 > 1 handling Ready
   Ready MustSync=false:
   Lead:0 State:StateFollower
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:5
+  HardState Term:2 Vote:1 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/5
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:5
+  HardState Term:2 Commit:5
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  2/5 EntryConfChangeV2
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/5
+  4->1 MsgAppResp Term:2 Log:0/5
   INFO 4 switched to configuration voters=(2 3 4)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/5
-  4->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:2 Log:0/5
+  3->1 MsgAppResp Term:2 Log:0/5
+  4->1 MsgAppResp Term:2 Log:0/5
 
 # n1 is out of the configuration.
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Voter) Term:1 Lead:1
+1: StateFollower (Non-Voter) Term:2 Lead:0
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Voter) Term:2 Lead:1
 
 # Make sure n1 cannot campaign to become leader.
 campaign 1
@@ -175,10 +175,10 @@ WARN 1 is unpromotable and can not campaign
 # Campaign the dedicated voter n2 to become the new leader.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
-INFO 2 became candidate at term 2
-INFO 2 [logterm: 1, index: 5] sent MsgVote request to 3 at term 2
-INFO 2 [logterm: 1, index: 5] sent MsgVote request to 4 at term 2
+INFO 2 is starting a new election at term 2
+INFO 2 became candidate at term 3
+INFO 2 [logterm: 2, index: 5] sent MsgVote request to 3 at term 3
+INFO 2 [logterm: 2, index: 5] sent MsgVote request to 4 at term 3
 
 stabilize log-level=none
 ----
@@ -186,7 +186,7 @@ ok
 
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0
-2: StateLeader (Voter) Term:2 Lead:2
-3: StateFollower (Voter) Term:2 Lead:2
-4: StateFollower (Voter) Term:2 Lead:2
+1: StateFollower (Non-Voter) Term:2 Lead:0
+2: StateLeader (Voter) Term:3 Lead:2
+3: StateFollower (Voter) Term:3 Lead:2
+4: StateFollower (Voter) Term:3 Lead:2

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -25,23 +25,23 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Non-Voter) Term:2 Lead:1
 
 # ForgetLeader causes a follower to forget its leader, but remain in the current
 # term. It's a noop if it's called again.
 forget-leader 2
 ----
-INFO 2 forgetting leader 1 at term 1
+INFO 2 forgetting leader 1 at term 2
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:0
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Non-Voter) Term:2 Lead:1
 
 forget-leader 2
 ----
@@ -49,22 +49,22 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:0
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Non-Voter) Term:2 Lead:1
 
 # ForgetLeader also works on learners.
 forget-leader 4
 ----
-INFO 4 forgetting leader 1 at term 1
+INFO 4 forgetting leader 1 at term 2
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:0
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:0
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Non-Voter) Term:2 Lead:0
 
 # When receiving a heartbeat from the leader, they revert to followers.
 tick-heartbeat 1
@@ -76,9 +76,9 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->4 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->4 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Lead:0 State:StateFollower
@@ -86,51 +86,51 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StateFollower
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 4 receiving messages
-  1->4 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->4 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 4 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  4->1 MsgHeartbeatResp Term:1 Log:0/0
+  4->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  4->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  4->1 MsgHeartbeatResp Term:2 Log:0/0
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
+4: StateFollower (Non-Voter) Term:2 Lead:1
 
 # ForgetLeader is a noop on candidates.
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
-INFO 3 became candidate at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
-INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
+INFO 3 is starting a new election at term 2
+INFO 3 became candidate at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 1 at term 3
+INFO 3 [logterm: 2, index: 11] sent MsgVote request to 2 at term 3
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateCandidate (Voter) Term:2 Lead:0
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateCandidate (Voter) Term:3 Lead:0
+4: StateFollower (Non-Voter) Term:2 Lead:1
 
 forget-leader 3
 ----
@@ -138,10 +138,10 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateCandidate (Voter) Term:2 Lead:0
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateCandidate (Voter) Term:3 Lead:0
+4: StateFollower (Non-Voter) Term:2 Lead:1
 
 stabilize log-level=none
 ----
@@ -149,10 +149,10 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:3
-2: StateFollower (Voter) Term:2 Lead:3
-3: StateLeader (Voter) Term:2 Lead:3
-4: StateFollower (Non-Voter) Term:2 Lead:3
+1: StateFollower (Voter) Term:3 Lead:3
+2: StateFollower (Voter) Term:3 Lead:3
+3: StateLeader (Voter) Term:3 Lead:3
+4: StateFollower (Non-Voter) Term:3 Lead:3
 
 # ForgetLeader shouldn't affect the election timeout: if a follower
 # forgets the leader 1 tick before the election timeout fires, it
@@ -171,14 +171,14 @@ ok
 
 forget-leader 2
 ----
-INFO 2 forgetting leader 3 at term 2
+INFO 2 forgetting leader 3 at term 3
 
 tick-heartbeat 2
 ----
-INFO 2 is starting a new election at term 2
-INFO 2 became candidate at term 3
-INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
-INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
+INFO 2 is starting a new election at term 3
+INFO 2 became candidate at term 4
+INFO 2 [logterm: 3, index: 12] sent MsgVote request to 1 at term 4
+INFO 2 [logterm: 3, index: 12] sent MsgVote request to 3 at term 4
 
 stabilize log-level=none
 ----
@@ -186,7 +186,7 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:3 Lead:2
-2: StateLeader (Voter) Term:3 Lead:2
-3: StateFollower (Voter) Term:3 Lead:2
-4: StateFollower (Non-Voter) Term:3 Lead:2
+1: StateFollower (Voter) Term:4 Lead:2
+2: StateLeader (Voter) Term:4 Lead:2
+3: StateFollower (Voter) Term:4 Lead:2
+4: StateFollower (Non-Voter) Term:4 Lead:2

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -26,10 +26,10 @@ ok
 # If 3 attempts to campaign, 2 rejects it because it has a leader.
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
-INFO 3 became pre-candidate at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
+INFO 3 is starting a new election at term 2
+INFO 3 became pre-candidate at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 1 at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 2 at term 2
 
 stabilize 3
 ----
@@ -37,17 +37,17 @@ stabilize 3
   Ready MustSync=false:
   Lead:0 State:StatePreCandidate
   Messages:
-  3->1 MsgPreVote Term:2 Log:1/11
-  3->2 MsgPreVote Term:2 Log:1/11
-  INFO 3 received MsgPreVoteResp from 3 at term 1
+  3->1 MsgPreVote Term:3 Log:2/11
+  3->2 MsgPreVote Term:3 Log:2/11
+  INFO 3 received MsgPreVoteResp from 3 at term 2
   INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
 
 deliver-msgs 1 2
 ----
-3->1 MsgPreVote Term:2 Log:1/11
-INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
-3->2 MsgPreVote Term:2 Log:1/11
-INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+3->1 MsgPreVote Term:3 Log:2/11
+INFO 1 [logterm: 2, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
+3->2 MsgPreVote Term:3 Log:2/11
+INFO 2 [logterm: 2, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 
 # Make 1 assert leadership over 3 again.
 tick-heartbeat 1
@@ -59,50 +59,50 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  INFO 3 became follower at term 1
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  INFO 3 became follower at term 2
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:1
 
 # If 2 forgets the leader, then 3 can obtain prevotes and hold an election
 # despite 2 having heard from the leader recently.
 forget-leader 2
 ----
-INFO 2 forgetting leader 1 at term 1
+INFO 2 forgetting leader 1 at term 2
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:0
+3: StateFollower (Voter) Term:2 Lead:1
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
-INFO 3 became pre-candidate at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
+INFO 3 is starting a new election at term 2
+INFO 3 became pre-candidate at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 1 at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 2 at term 2
 
 stabilize 3
 ----
@@ -110,9 +110,9 @@ stabilize 3
   Ready MustSync=false:
   Lead:0 State:StatePreCandidate
   Messages:
-  3->1 MsgPreVote Term:2 Log:1/11
-  3->2 MsgPreVote Term:2 Log:1/11
-  INFO 3 received MsgPreVoteResp from 3 at term 1
+  3->1 MsgPreVote Term:3 Log:2/11
+  3->2 MsgPreVote Term:3 Log:2/11
+  INFO 3 received MsgPreVoteResp from 3 at term 2
   INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
 
 stabilize 2
@@ -121,30 +121,30 @@ stabilize 2
   Ready MustSync=false:
   Lead:0 State:StateFollower
 > 2 receiving messages
-  3->2 MsgPreVote Term:2 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 3 [logterm: 1, index: 11] at term 1
+  3->2 MsgPreVote Term:3 Log:2/11
+  INFO 2 [logterm: 2, index: 11, vote: 1] cast MsgPreVote for 3 [logterm: 2, index: 11] at term 2
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->3 MsgPreVoteResp Term:2 Log:0/0
+  2->3 MsgPreVoteResp Term:3 Log:0/0
 
 stabilize 3
 ----
 > 3 receiving messages
-  2->3 MsgPreVoteResp Term:2 Log:0/0
-  INFO 3 received MsgPreVoteResp from 2 at term 1
+  2->3 MsgPreVoteResp Term:3 Log:0/0
+  INFO 3 received MsgPreVoteResp from 2 at term 2
   INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
-  INFO 3 became candidate at term 2
-  INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
-  INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
+  INFO 3 became candidate at term 3
+  INFO 3 [logterm: 2, index: 11] sent MsgVote request to 1 at term 3
+  INFO 3 [logterm: 2, index: 11] sent MsgVote request to 2 at term 3
 > 3 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:2 Vote:3 Commit:11
+  HardState Term:3 Vote:3 Commit:11
   Messages:
-  3->1 MsgVote Term:2 Log:1/11
-  3->2 MsgVote Term:2 Log:1/11
-  INFO 3 received MsgVoteResp from 3 at term 2
+  3->1 MsgVote Term:3 Log:2/11
+  3->2 MsgVote Term:3 Log:2/11
+  INFO 3 received MsgVoteResp from 3 at term 3
   INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
 
 stabilize log-level=none
@@ -153,9 +153,9 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:3
-2: StateFollower (Voter) Term:2 Lead:3
-3: StateLeader (Voter) Term:2 Lead:3
+1: StateFollower (Voter) Term:3 Lead:3
+2: StateFollower (Voter) Term:3 Lead:3
+3: StateLeader (Voter) Term:3 Lead:3
 
 # Test that forgetting the leader still won't grant prevotes if the candidate
 # isn't up-to-date. We first replicate a proposal on 3 and 2.
@@ -168,47 +168,47 @@ stabilize 3
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  2/13 EntryNormal "prop_1"
+  3/13 EntryNormal "prop_1"
   Messages:
-  3->1 MsgApp Term:2 Log:2/12 Commit:12 Entries:[2/13 EntryNormal "prop_1"]
-  3->2 MsgApp Term:2 Log:2/12 Commit:12 Entries:[2/13 EntryNormal "prop_1"]
+  3->1 MsgApp Term:3 Log:3/12 Commit:12 Entries:[3/13 EntryNormal "prop_1"]
+  3->2 MsgApp Term:3 Log:3/12 Commit:12 Entries:[3/13 EntryNormal "prop_1"]
 
 stabilize 2
 ----
 > 2 receiving messages
-  3->2 MsgApp Term:2 Log:2/12 Commit:12 Entries:[2/13 EntryNormal "prop_1"]
+  3->2 MsgApp Term:3 Log:3/12 Commit:12 Entries:[3/13 EntryNormal "prop_1"]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  2/13 EntryNormal "prop_1"
+  3/13 EntryNormal "prop_1"
   Messages:
-  2->3 MsgAppResp Term:2 Log:0/13
+  2->3 MsgAppResp Term:3 Log:0/13
 
 forget-leader 2
 ----
-INFO 2 forgetting leader 3 at term 2
+INFO 2 forgetting leader 3 at term 3
 
 # 1 is now behind on its log. It tries to campaign, but fails.
 raft-log 1
 ----
-1/11 EntryNormal ""
-2/12 EntryNormal ""
+2/11 EntryNormal ""
+3/12 EntryNormal ""
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 2
-INFO 1 became pre-candidate at term 2
-INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 2 at term 2
-INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
+INFO 1 is starting a new election at term 3
+INFO 1 became pre-candidate at term 3
+INFO 1 [logterm: 3, index: 12] sent MsgPreVote request to 2 at term 3
+INFO 1 [logterm: 3, index: 12] sent MsgPreVote request to 3 at term 3
 
 process-ready 1
 ----
 Ready MustSync=false:
 Lead:0 State:StatePreCandidate
 Messages:
-1->2 MsgPreVote Term:3 Log:2/12
-1->3 MsgPreVote Term:3 Log:2/12
-INFO 1 received MsgPreVoteResp from 1 at term 2
+1->2 MsgPreVote Term:4 Log:3/12
+1->3 MsgPreVote Term:4 Log:3/12
+INFO 1 received MsgPreVoteResp from 1 at term 3
 INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 
 stabilize 2
@@ -217,12 +217,12 @@ stabilize 2
   Ready MustSync=false:
   Lead:0 State:StateFollower
 > 2 receiving messages
-  1->2 MsgPreVote Term:3 Log:2/12
-  INFO 2 [logterm: 2, index: 13, vote: 3] rejected MsgPreVote from 1 [logterm: 2, index: 12] at term 2
+  1->2 MsgPreVote Term:4 Log:3/12
+  INFO 2 [logterm: 3, index: 13, vote: 3] rejected MsgPreVote from 1 [logterm: 3, index: 12] at term 3
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgPreVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
 
 stabilize log-level=none
 ----
@@ -230,6 +230,6 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:3
-2: StateFollower (Voter) Term:2 Lead:3
-3: StateLeader (Voter) Term:2 Lead:3
+1: StateFollower (Voter) Term:3 Lead:3
+2: StateFollower (Voter) Term:3 Lead:3
+3: StateLeader (Voter) Term:3 Lead:3

--- a/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
+++ b/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
@@ -53,35 +53,35 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->2 MsgApp Term:2 Log:2/11 Commit:11
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->2 MsgApp Term:2 Log:2/11 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:2 Log:0/11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:2 Log:0/11
 
 status 1
 ----

--- a/pkg/raft/testdata/lagging_commit.txt
+++ b/pkg/raft/testdata/lagging_commit.txt
@@ -39,27 +39,27 @@ ok
 
 deliver-msgs 2 3
 ----
-1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "data1"]
-1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "data2"]
-1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "data1"]
-1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "data2"]
+1->2 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "data1"]
+1->2 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "data2"]
+1->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "data1"]
+1->3 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "data2"]
 
 process-ready 3
 ----
 Ready MustSync=true:
 Entries:
-1/12 EntryNormal "data1"
-1/13 EntryNormal "data2"
+2/12 EntryNormal "data1"
+2/13 EntryNormal "data2"
 Messages:
-3->1 MsgAppResp Term:1 Log:0/12
-3->1 MsgAppResp Term:1 Log:0/13
+3->1 MsgAppResp Term:2 Log:0/12
+3->1 MsgAppResp Term:2 Log:0/13
 
 # Suppose there is a network blip which prevents the leader learning that the
 # follower 3 has appended the proposed entries to the log.
 deliver-msgs drop=(1)
 ----
-dropped: 3->1 MsgAppResp Term:1 Log:0/12
-dropped: 3->1 MsgAppResp Term:1 Log:0/13
+dropped: 3->1 MsgAppResp Term:2 Log:0/12
+dropped: 3->1 MsgAppResp Term:2 Log:0/13
 
 # In the meantime, the entries are committed, and the leader sends the commit
 # index to all the followers.
@@ -68,47 +68,47 @@ stabilize 1 2
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/12 EntryNormal "data1"
-  1/13 EntryNormal "data2"
+  2/12 EntryNormal "data1"
+  2/13 EntryNormal "data2"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/12
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/12
+  2->1 MsgAppResp Term:2 Log:0/13
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/12
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/12
+  2->1 MsgAppResp Term:2 Log:0/13
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:13
+  HardState Term:2 Vote:1 Commit:13
   CommittedEntries:
-  1/12 EntryNormal "data1"
-  1/13 EntryNormal "data2"
+  2/12 EntryNormal "data1"
+  2/13 EntryNormal "data2"
   Messages:
-  1->2 MsgApp Term:1 Log:1/13 Commit:12
-  1->3 MsgApp Term:1 Log:1/13 Commit:12
-  1->2 MsgApp Term:1 Log:1/13 Commit:13
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
+  1->2 MsgApp Term:2 Log:2/13 Commit:12
+  1->3 MsgApp Term:2 Log:2/13 Commit:12
+  1->2 MsgApp Term:2 Log:2/13 Commit:13
+  1->3 MsgApp Term:2 Log:2/13 Commit:13
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/13 Commit:12
-  1->2 MsgApp Term:1 Log:1/13 Commit:13
+  1->2 MsgApp Term:2 Log:2/13 Commit:12
+  1->2 MsgApp Term:2 Log:2/13 Commit:13
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:13
+  HardState Term:2 Vote:1 Commit:13
   CommittedEntries:
-  1/12 EntryNormal "data1"
-  1/13 EntryNormal "data2"
+  2/12 EntryNormal "data1"
+  2/13 EntryNormal "data2"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/13
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/13
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/13
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/13
+  2->1 MsgAppResp Term:2 Log:0/13
 
 # The network blip prevents the follower 3 from learning that the previously
 # appended entries are now committed.
 deliver-msgs drop=(3)
 ----
-dropped: 1->3 MsgApp Term:1 Log:1/13 Commit:12
-dropped: 1->3 MsgApp Term:1 Log:1/13 Commit:13
+dropped: 1->3 MsgApp Term:2 Log:2/13 Commit:12
+dropped: 1->3 MsgApp Term:2 Log:2/13 Commit:13
 
 # The network blip ends here.
 
@@ -133,8 +133,8 @@ process-ready 1
 ----
 Ready MustSync=false:
 Messages:
-1->2 MsgHeartbeat Term:1 Log:0/0 Commit:13
-1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+1->2 MsgHeartbeat Term:2 Log:0/0 Commit:13
+1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 
 # Since the heartbeat message does not bump the follower's commit index, it will
 # take another roundtrip with the leader to update it. As such, the total time
@@ -149,26 +149,26 @@ Messages:
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
+  1->3 MsgApp Term:2 Log:2/13 Commit:13
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
+  1->3 MsgApp Term:2 Log:2/13 Commit:13
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:13
+  HardState Term:2 Vote:1 Commit:13
   CommittedEntries:
-  1/12 EntryNormal "data1"
-  1/13 EntryNormal "data2"
+  2/12 EntryNormal "data1"
+  2/13 EntryNormal "data2"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/13
+  3->1 MsgAppResp Term:2 Log:0/13
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/13
+  3->1 MsgAppResp Term:2 Log:0/13

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -34,107 +34,107 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/12 EntryNormal "prop_1"
+2/12 EntryNormal "prop_1"
 Messages:
-1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
-1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
+1->2 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
+1->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
 
 deliver-msgs 2
 ----
-1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
+1->2 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
 
 process-ready 2
 ----
 Ready MustSync=true:
 Entries:
-1/12 EntryNormal "prop_1"
+2/12 EntryNormal "prop_1"
 Messages:
-2->1 MsgAppResp Term:1 Log:0/12
+2->1 MsgAppResp Term:2 Log:0/12
 
 # 3 is now behind on its log. Attempt to campaign.
 raft-log 3
 ----
-1/11 EntryNormal ""
+2/11 EntryNormal ""
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
-INFO 3 became pre-candidate at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
+INFO 3 is starting a new election at term 2
+INFO 3 became pre-candidate at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 1 at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 2 at term 2
 
 process-ready 3
 ----
 Ready MustSync=false:
 Lead:0 State:StatePreCandidate
 Messages:
-3->1 MsgPreVote Term:2 Log:1/11
-3->2 MsgPreVote Term:2 Log:1/11
-INFO 3 received MsgPreVoteResp from 3 at term 1
+3->1 MsgPreVote Term:3 Log:2/11
+3->2 MsgPreVote Term:3 Log:2/11
+INFO 3 received MsgPreVoteResp from 3 at term 2
 INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
 
 deliver-msgs 1 2
 ----
-2->1 MsgAppResp Term:1 Log:0/12
-3->1 MsgPreVote Term:2 Log:1/11
-INFO 1 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, index: 11] at term 1
-3->2 MsgPreVote Term:2 Log:1/11
-INFO 2 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, index: 11] at term 1
+2->1 MsgAppResp Term:2 Log:0/12
+3->1 MsgPreVote Term:3 Log:2/11
+INFO 1 [logterm: 2, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 2, index: 11] at term 2
+3->2 MsgPreVote Term:3 Log:2/11
+INFO 2 [logterm: 2, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 2, index: 11] at term 2
 
 # 3 failed to campaign. Let the network stabilize.
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:12
+  HardState Term:2 Vote:1 Commit:12
   CommittedEntries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  1->2 MsgApp Term:1 Log:1/12 Commit:12
-  1->3 MsgApp Term:1 Log:1/12 Commit:12
-  1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgApp Term:2 Log:2/12 Commit:12
+  1->3 MsgApp Term:2 Log:2/12 Commit:12
+  1->3 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->3 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/12 Commit:12
+  1->2 MsgApp Term:2 Log:2/12 Commit:12
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
-  INFO 3 became follower at term 1
-  1->3 MsgApp Term:1 Log:1/12 Commit:12
-  1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
-  2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1"]
+  INFO 3 became follower at term 2
+  1->3 MsgApp Term:2 Log:2/12 Commit:12
+  1->3 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->3 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:12
+  HardState Term:2 Vote:1 Commit:12
   CommittedEntries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/12
+  2->1 MsgAppResp Term:2 Log:0/12
 > 3 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Vote:1 Commit:12
+  HardState Term:2 Vote:1 Commit:12
   Entries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   CommittedEntries:
-  1/12 EntryNormal "prop_1"
+  2/12 EntryNormal "prop_1"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/12
-  3->1 MsgAppResp Term:1 Log:0/12
+  3->1 MsgAppResp Term:2 Log:0/12
+  3->1 MsgAppResp Term:2 Log:0/12
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/12
-  3->1 MsgAppResp Term:1 Log:0/12
-  3->1 MsgAppResp Term:1 Log:0/12
+  2->1 MsgAppResp Term:2 Log:0/12
+  3->1 MsgAppResp Term:2 Log:0/12
+  3->1 MsgAppResp Term:2 Log:0/12
 
 # Let 2 campaign. It should succeed, since it's up-to-date on the log.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
-INFO 2 became pre-candidate at term 1
-INFO 2 [logterm: 1, index: 12] sent MsgPreVote request to 1 at term 1
-INFO 2 [logterm: 1, index: 12] sent MsgPreVote request to 3 at term 1
+INFO 2 is starting a new election at term 2
+INFO 2 became pre-candidate at term 2
+INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2
+INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 
 stabilize
 ----
@@ -142,124 +142,124 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StatePreCandidate
   Messages:
-  2->1 MsgPreVote Term:2 Log:1/12
-  2->3 MsgPreVote Term:2 Log:1/12
-  INFO 2 received MsgPreVoteResp from 2 at term 1
+  2->1 MsgPreVote Term:3 Log:2/12
+  2->3 MsgPreVote Term:3 Log:2/12
+  INFO 2 received MsgPreVoteResp from 2 at term 2
   INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  2->1 MsgPreVote Term:2 Log:1/12
-  INFO 1 [logterm: 1, index: 12, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 12] at term 1
+  2->1 MsgPreVote Term:3 Log:2/12
+  INFO 1 [logterm: 2, index: 12, vote: 1] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 3 receiving messages
-  2->3 MsgPreVote Term:2 Log:1/12
-  INFO 3 [logterm: 1, index: 12, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 12] at term 1
+  2->3 MsgPreVote Term:3 Log:2/12
+  INFO 3 [logterm: 2, index: 12, vote: 1] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgPreVoteResp Term:2 Log:0/0
+  1->2 MsgPreVoteResp Term:3 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->2 MsgPreVoteResp Term:2 Log:0/0
+  3->2 MsgPreVoteResp Term:3 Log:0/0
 > 2 receiving messages
-  1->2 MsgPreVoteResp Term:2 Log:0/0
-  INFO 2 received MsgPreVoteResp from 1 at term 1
+  1->2 MsgPreVoteResp Term:3 Log:0/0
+  INFO 2 received MsgPreVoteResp from 1 at term 2
   INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
-  INFO 2 became candidate at term 2
-  INFO 2 [logterm: 1, index: 12] sent MsgVote request to 1 at term 2
-  INFO 2 [logterm: 1, index: 12] sent MsgVote request to 3 at term 2
-  3->2 MsgPreVoteResp Term:2 Log:0/0
+  INFO 2 became candidate at term 3
+  INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
+  INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
+  3->2 MsgPreVoteResp Term:3 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:2 Vote:2 Commit:12
+  HardState Term:3 Vote:2 Commit:12
   Messages:
-  2->1 MsgVote Term:2 Log:1/12
-  2->3 MsgVote Term:2 Log:1/12
-  INFO 2 received MsgVoteResp from 2 at term 2
+  2->1 MsgVote Term:3 Log:2/12
+  2->3 MsgVote Term:3 Log:2/12
+  INFO 2 received MsgVoteResp from 2 at term 3
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  2->1 MsgVote Term:2 Log:1/12
-  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
-  INFO 1 became follower at term 2
-  INFO 1 [logterm: 1, index: 12, vote: 0] cast MsgVote for 2 [logterm: 1, index: 12] at term 2
+  2->1 MsgVote Term:3 Log:2/12
+  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 1 became follower at term 3
+  INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 3 receiving messages
-  2->3 MsgVote Term:2 Log:1/12
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
-  INFO 3 became follower at term 2
-  INFO 3 [logterm: 1, index: 12, vote: 0] cast MsgVote for 2 [logterm: 1, index: 12] at term 2
+  2->3 MsgVote Term:3 Log:2/12
+  INFO 3 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 3 became follower at term 3
+  INFO 3 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:2 Commit:12
+  HardState Term:3 Vote:2 Commit:12
   Messages:
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:3 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:2 Commit:12
+  HardState Term:3 Vote:2 Commit:12
   Messages:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:3 Log:0/0
 > 2 receiving messages
-  1->2 MsgVoteResp Term:2 Log:0/0
-  INFO 2 received MsgVoteResp from 1 at term 2
+  1->2 MsgVoteResp Term:3 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 3
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 2 became leader at term 2
-  3->2 MsgVoteResp Term:2 Log:0/0
+  INFO 2 became leader at term 3
+  3->2 MsgVoteResp Term:3 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateLeader
   Entries:
-  2/13 EntryNormal ""
+  3/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
-  2->3 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
+  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateFollower
   Entries:
-  2/13 EntryNormal ""
+  3/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13
 > 3 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateFollower
   Entries:
-  2/13 EntryNormal ""
+  3/13 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/13
-  3->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:13
+  HardState Term:3 Vote:2 Commit:13
   CommittedEntries:
-  2/13 EntryNormal ""
+  3/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:2/13 Commit:13
-  2->3 MsgApp Term:2 Log:2/13 Commit:13
+  2->1 MsgApp Term:3 Log:3/13 Commit:13
+  2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:2/13 Commit:13
+  2->1 MsgApp Term:3 Log:3/13 Commit:13
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:2/13 Commit:13
+  2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:13
+  HardState Term:3 Vote:2 Commit:13
   CommittedEntries:
-  2/13 EntryNormal ""
+  3/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:2 Commit:13
+  HardState Term:3 Vote:2 Commit:13
   CommittedEntries:
-  2/13 EntryNormal ""
+  3/13 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/13
-  3->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -26,10 +26,10 @@ ok
 # 2 should fail to campaign, leaving 1's leadership alone.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
-INFO 2 became pre-candidate at term 1
-INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
-INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
+INFO 2 is starting a new election at term 2
+INFO 2 became pre-candidate at term 2
+INFO 2 [logterm: 2, index: 11] sent MsgPreVote request to 1 at term 2
+INFO 2 [logterm: 2, index: 11] sent MsgPreVote request to 3 at term 2
 
 stabilize
 ----
@@ -37,16 +37,16 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StatePreCandidate
   Messages:
-  2->1 MsgPreVote Term:2 Log:1/11
-  2->3 MsgPreVote Term:2 Log:1/11
-  INFO 2 received MsgPreVoteResp from 2 at term 1
+  2->1 MsgPreVote Term:3 Log:2/11
+  2->3 MsgPreVote Term:3 Log:2/11
+  INFO 2 received MsgPreVoteResp from 2 at term 2
   INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  2->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  2->1 MsgPreVote Term:3 Log:2/11
+  INFO 1 [logterm: 2, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 > 3 receiving messages
-  2->3 MsgPreVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  2->3 MsgPreVote Term:3 Log:2/11
+  INFO 3 [logterm: 2, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 
 # If 2 hasn't heard from the leader in the past election timeout, it should
 # grant prevotes, allowing 3 to hold an election.
@@ -60,133 +60,133 @@ ok
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
-INFO 3 became pre-candidate at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
-INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
+INFO 3 is starting a new election at term 2
+INFO 3 became pre-candidate at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 1 at term 2
+INFO 3 [logterm: 2, index: 11] sent MsgPreVote request to 2 at term 2
 
 process-ready 3
 ----
 Ready MustSync=false:
 Lead:0 State:StatePreCandidate
 Messages:
-3->1 MsgPreVote Term:2 Log:1/11
-3->2 MsgPreVote Term:2 Log:1/11
-INFO 3 received MsgPreVoteResp from 3 at term 1
+3->1 MsgPreVote Term:3 Log:2/11
+3->2 MsgPreVote Term:3 Log:2/11
+INFO 3 received MsgPreVoteResp from 3 at term 2
 INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
 
 deliver-msgs 2
 ----
-3->2 MsgPreVote Term:2 Log:1/11
-INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 3 [logterm: 1, index: 11] at term 1
+3->2 MsgPreVote Term:3 Log:2/11
+INFO 2 [logterm: 2, index: 11, vote: 1] cast MsgPreVote for 3 [logterm: 2, index: 11] at term 2
 
 process-ready 2
 ----
 Ready MustSync=false:
 Messages:
-2->3 MsgPreVoteResp Term:2 Log:0/0
+2->3 MsgPreVoteResp Term:3 Log:0/0
 
 stabilize
 ----
 > 1 receiving messages
-  3->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  3->1 MsgPreVote Term:3 Log:2/11
+  INFO 1 [logterm: 2, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 > 3 receiving messages
-  2->3 MsgPreVoteResp Term:2 Log:0/0
-  INFO 3 received MsgPreVoteResp from 2 at term 1
+  2->3 MsgPreVoteResp Term:3 Log:0/0
+  INFO 3 received MsgPreVoteResp from 2 at term 2
   INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
-  INFO 3 became candidate at term 2
-  INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
-  INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
+  INFO 3 became candidate at term 3
+  INFO 3 [logterm: 2, index: 11] sent MsgVote request to 1 at term 3
+  INFO 3 [logterm: 2, index: 11] sent MsgVote request to 2 at term 3
 > 3 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:2 Vote:3 Commit:11
+  HardState Term:3 Vote:3 Commit:11
   Messages:
-  3->1 MsgVote Term:2 Log:1/11
-  3->2 MsgVote Term:2 Log:1/11
-  INFO 3 received MsgVoteResp from 3 at term 2
+  3->1 MsgVote Term:3 Log:2/11
+  3->2 MsgVote Term:3 Log:2/11
+  INFO 3 received MsgVoteResp from 3 at term 3
   INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  3->1 MsgVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  3->1 MsgVote Term:3 Log:2/11
+  INFO 1 [logterm: 2, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 2, index: 11] at term 2: lease is not expired (remaining ticks: 3)
 > 2 receiving messages
-  3->2 MsgVote Term:2 Log:1/11
-  INFO 2 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
-  INFO 2 became follower at term 2
-  INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
+  3->2 MsgVote Term:3 Log:2/11
+  INFO 2 [term: 2] received a MsgVote message with higher term from 3 [term: 3]
+  INFO 2 became follower at term 3
+  INFO 2 [logterm: 2, index: 11, vote: 0] cast MsgVote for 3 [logterm: 2, index: 11] at term 3
 > 2 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:2 Vote:3 Commit:11
+  HardState Term:3 Vote:3 Commit:11
   Messages:
-  2->3 MsgVoteResp Term:2 Log:0/0
+  2->3 MsgVoteResp Term:3 Log:0/0
 > 3 receiving messages
-  2->3 MsgVoteResp Term:2 Log:0/0
-  INFO 3 received MsgVoteResp from 2 at term 2
+  2->3 MsgVoteResp Term:3 Log:0/0
+  INFO 3 received MsgVoteResp from 2 at term 3
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 3 became leader at term 2
+  INFO 3 became leader at term 3
 > 3 handling Ready
   Ready MustSync=true:
   Lead:3 State:StateLeader
   Entries:
-  2/12 EntryNormal ""
+  3/12 EntryNormal ""
   Messages:
-  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-  3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+  3->1 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+  3->2 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 1 receiving messages
-  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-  INFO 1 [term: 1] received a MsgApp message with higher term from 3 [term: 2]
-  INFO 1 became follower at term 2
+  3->1 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
+  INFO 1 [term: 2] received a MsgApp message with higher term from 3 [term: 3]
+  INFO 1 became follower at term 3
 > 2 receiving messages
-  3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+  3->2 MsgApp Term:3 Log:2/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
   Lead:3 State:StateFollower
-  HardState Term:2 Commit:11
+  HardState Term:3 Commit:11
   Entries:
-  2/12 EntryNormal ""
+  3/12 EntryNormal ""
   Messages:
-  1->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:3 Log:0/12
 > 2 handling Ready
   Ready MustSync=true:
   Lead:3 State:StateFollower
   Entries:
-  2/12 EntryNormal ""
+  3/12 EntryNormal ""
   Messages:
-  2->3 MsgAppResp Term:2 Log:0/12
+  2->3 MsgAppResp Term:3 Log:0/12
 > 3 receiving messages
-  1->3 MsgAppResp Term:2 Log:0/12
-  2->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:3 Log:0/12
+  2->3 MsgAppResp Term:3 Log:0/12
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:3 Commit:12
+  HardState Term:3 Vote:3 Commit:12
   CommittedEntries:
-  2/12 EntryNormal ""
+  3/12 EntryNormal ""
   Messages:
-  3->1 MsgApp Term:2 Log:2/12 Commit:12
-  3->2 MsgApp Term:2 Log:2/12 Commit:12
+  3->1 MsgApp Term:3 Log:3/12 Commit:12
+  3->2 MsgApp Term:3 Log:3/12 Commit:12
 > 1 receiving messages
-  3->1 MsgApp Term:2 Log:2/12 Commit:12
+  3->1 MsgApp Term:3 Log:3/12 Commit:12
 > 2 receiving messages
-  3->2 MsgApp Term:2 Log:2/12 Commit:12
+  3->2 MsgApp Term:3 Log:3/12 Commit:12
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Commit:12
+  HardState Term:3 Commit:12
   CommittedEntries:
-  2/12 EntryNormal ""
+  3/12 EntryNormal ""
   Messages:
-  1->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:3 Log:0/12
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:2 Vote:3 Commit:12
+  HardState Term:3 Vote:3 Commit:12
   CommittedEntries:
-  2/12 EntryNormal ""
+  3/12 EntryNormal ""
   Messages:
-  2->3 MsgAppResp Term:2 Log:0/12
+  2->3 MsgAppResp Term:3 Log:0/12
 > 3 receiving messages
-  1->3 MsgAppResp Term:2 Log:0/12
-  2->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:3 Log:0/12
+  2->3 MsgAppResp Term:3 Log:0/12
 
 # Node 3 is now the leader. Even though the leader is active, nodes 1 and 2 can
 # still win a prevote and election if they both explicitly campaign, since the
@@ -198,10 +198,10 @@ stabilize
 # We first let 1 lose an election, as we'd otherwise get a tie.
 campaign 1
 ----
-INFO 1 is starting a new election at term 2
-INFO 1 became pre-candidate at term 2
-INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 2 at term 2
-INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
+INFO 1 is starting a new election at term 3
+INFO 1 became pre-candidate at term 3
+INFO 1 [logterm: 3, index: 12] sent MsgPreVote request to 2 at term 3
+INFO 1 [logterm: 3, index: 12] sent MsgPreVote request to 3 at term 3
 
 stabilize
 ----
@@ -209,23 +209,23 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StatePreCandidate
   Messages:
-  1->2 MsgPreVote Term:3 Log:2/12
-  1->3 MsgPreVote Term:3 Log:2/12
-  INFO 1 received MsgPreVoteResp from 1 at term 2
+  1->2 MsgPreVote Term:4 Log:3/12
+  1->3 MsgPreVote Term:4 Log:3/12
+  INFO 1 received MsgPreVoteResp from 1 at term 3
   INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
-  1->2 MsgPreVote Term:3 Log:2/12
-  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  1->2 MsgPreVote Term:4 Log:3/12
+  INFO 2 [logterm: 3, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 3, index: 12] at term 3: lease is not expired (remaining ticks: 3)
 > 3 receiving messages
-  1->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  1->3 MsgPreVote Term:4 Log:3/12
+  INFO 3 [logterm: 3, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 3, index: 12] at term 3: lease is not expired (remaining ticks: 3)
 
 campaign 2
 ----
-INFO 2 is starting a new election at term 2
-INFO 2 became pre-candidate at term 2
-INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2
-INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
+INFO 2 is starting a new election at term 3
+INFO 2 became pre-candidate at term 3
+INFO 2 [logterm: 3, index: 12] sent MsgPreVote request to 1 at term 3
+INFO 2 [logterm: 3, index: 12] sent MsgPreVote request to 3 at term 3
 
 stabilize
 ----
@@ -233,113 +233,113 @@ stabilize
   Ready MustSync=false:
   Lead:0 State:StatePreCandidate
   Messages:
-  2->1 MsgPreVote Term:3 Log:2/12
-  2->3 MsgPreVote Term:3 Log:2/12
-  INFO 2 received MsgPreVoteResp from 2 at term 2
+  2->1 MsgPreVote Term:4 Log:3/12
+  2->3 MsgPreVote Term:4 Log:3/12
+  INFO 2 received MsgPreVoteResp from 2 at term 3
   INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  2->1 MsgPreVote Term:3 Log:2/12
-  INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
+  2->1 MsgPreVote Term:4 Log:3/12
+  INFO 1 [logterm: 3, index: 12, vote: 0] cast MsgPreVote for 2 [logterm: 3, index: 12] at term 3
 > 3 receiving messages
-  2->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  2->3 MsgPreVote Term:4 Log:3/12
+  INFO 3 [logterm: 3, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 3, index: 12] at term 3: lease is not expired (remaining ticks: 3)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgPreVoteResp Term:3 Log:0/0
+  1->2 MsgPreVoteResp Term:4 Log:0/0
 > 2 receiving messages
-  1->2 MsgPreVoteResp Term:3 Log:0/0
-  INFO 2 received MsgPreVoteResp from 1 at term 2
+  1->2 MsgPreVoteResp Term:4 Log:0/0
+  INFO 2 received MsgPreVoteResp from 1 at term 3
   INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
-  INFO 2 became candidate at term 3
-  INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
-  INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
+  INFO 2 became candidate at term 4
+  INFO 2 [logterm: 3, index: 12] sent MsgVote request to 1 at term 4
+  INFO 2 [logterm: 3, index: 12] sent MsgVote request to 3 at term 4
 > 2 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:3 Vote:2 Commit:12
+  HardState Term:4 Vote:2 Commit:12
   Messages:
-  2->1 MsgVote Term:3 Log:2/12
-  2->3 MsgVote Term:3 Log:2/12
-  INFO 2 received MsgVoteResp from 2 at term 3
+  2->1 MsgVote Term:4 Log:3/12
+  2->3 MsgVote Term:4 Log:3/12
+  INFO 2 received MsgVoteResp from 2 at term 4
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
-  2->1 MsgVote Term:3 Log:2/12
-  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
-  INFO 1 became follower at term 3
-  INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
+  2->1 MsgVote Term:4 Log:3/12
+  INFO 1 [term: 3] received a MsgVote message with higher term from 2 [term: 4]
+  INFO 1 became follower at term 4
+  INFO 1 [logterm: 3, index: 12, vote: 0] cast MsgVote for 2 [logterm: 3, index: 12] at term 4
 > 3 receiving messages
-  2->3 MsgVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  2->3 MsgVote Term:4 Log:3/12
+  INFO 3 [logterm: 3, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 3, index: 12] at term 3: lease is not expired (remaining ticks: 3)
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:3 Vote:2 Commit:12
+  HardState Term:4 Vote:2 Commit:12
   Messages:
-  1->2 MsgVoteResp Term:3 Log:0/0
+  1->2 MsgVoteResp Term:4 Log:0/0
 > 2 receiving messages
-  1->2 MsgVoteResp Term:3 Log:0/0
-  INFO 2 received MsgVoteResp from 1 at term 3
+  1->2 MsgVoteResp Term:4 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 4
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 2 became leader at term 3
+  INFO 2 became leader at term 4
 > 2 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateLeader
   Entries:
-  3/13 EntryNormal ""
+  4/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
-  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+  2->1 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
+  2->3 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+  2->1 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
-  INFO 3 [term: 2] received a MsgApp message with higher term from 2 [term: 3]
-  INFO 3 became follower at term 3
+  2->3 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
+  INFO 3 [term: 3] received a MsgApp message with higher term from 2 [term: 4]
+  INFO 3 became follower at term 4
 > 1 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateFollower
   Entries:
-  3/13 EntryNormal ""
+  4/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:4 Log:0/13
 > 3 handling Ready
   Ready MustSync=true:
   Lead:2 State:StateFollower
-  HardState Term:3 Commit:12
+  HardState Term:4 Commit:12
   Entries:
-  3/13 EntryNormal ""
+  4/13 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:4 Log:0/13
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/13
-  3->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:4 Log:0/13
+  3->2 MsgAppResp Term:4 Log:0/13
 > 2 handling Ready
   Ready MustSync=false:
-  HardState Term:3 Vote:2 Commit:13
+  HardState Term:4 Vote:2 Commit:13
   CommittedEntries:
-  3/13 EntryNormal ""
+  4/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:3 Log:3/13 Commit:13
-  2->3 MsgApp Term:3 Log:3/13 Commit:13
+  2->1 MsgApp Term:4 Log:4/13 Commit:13
+  2->3 MsgApp Term:4 Log:4/13 Commit:13
 > 1 receiving messages
-  2->1 MsgApp Term:3 Log:3/13 Commit:13
+  2->1 MsgApp Term:4 Log:4/13 Commit:13
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:3/13 Commit:13
+  2->3 MsgApp Term:4 Log:4/13 Commit:13
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:3 Vote:2 Commit:13
+  HardState Term:4 Vote:2 Commit:13
   CommittedEntries:
-  3/13 EntryNormal ""
+  4/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:4 Log:0/13
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:3 Commit:13
+  HardState Term:4 Commit:13
   CommittedEntries:
-  3/13 EntryNormal ""
+  4/13 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:4 Log:0/13
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/13
-  3->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:4 Log:0/13
+  3->2 MsgAppResp Term:4 Log:0/13

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -268,101 +268,101 @@ ok
 
 raft-log 1
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-6/19 EntryNormal "prop_6_19"
-6/20 EntryNormal "prop_6_20"
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+5/14 EntryNormal ""
+5/15 EntryNormal "prop_4_15"
+6/16 EntryNormal ""
+6/17 EntryNormal "prop_5_17"
+7/18 EntryNormal ""
+7/19 EntryNormal "prop_6_19"
+7/20 EntryNormal "prop_6_20"
 
 raft-log 2
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-6/19 EntryNormal "prop_6_19"
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+5/14 EntryNormal ""
+5/15 EntryNormal "prop_4_15"
+6/16 EntryNormal ""
+6/17 EntryNormal "prop_5_17"
+7/18 EntryNormal ""
+7/19 EntryNormal "prop_6_19"
 
 raft-log 3
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+5/14 EntryNormal ""
 
 raft-log 4
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-6/19 EntryNormal "prop_6_19"
-6/20 EntryNormal "prop_6_20"
-6/21 EntryNormal "prop_6_21"
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+5/14 EntryNormal ""
+5/15 EntryNormal "prop_4_15"
+6/16 EntryNormal ""
+6/17 EntryNormal "prop_5_17"
+7/18 EntryNormal ""
+7/19 EntryNormal "prop_6_19"
+7/20 EntryNormal "prop_6_20"
+7/21 EntryNormal "prop_6_21"
 
 raft-log 5
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-5/16 EntryNormal ""
-5/17 EntryNormal "prop_5_17"
-6/18 EntryNormal ""
-7/19 EntryNormal ""
-7/20 EntryNormal "prop_7_20"
-7/21 EntryNormal "prop_7_21"
-7/22 EntryNormal "prop_7_22"
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+5/14 EntryNormal ""
+5/15 EntryNormal "prop_4_15"
+6/16 EntryNormal ""
+6/17 EntryNormal "prop_5_17"
+7/18 EntryNormal ""
+8/19 EntryNormal ""
+8/20 EntryNormal "prop_7_20"
+8/21 EntryNormal "prop_7_21"
+8/22 EntryNormal "prop_7_22"
 
 raft-log 6
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-4/14 EntryNormal ""
-4/15 EntryNormal "prop_4_15"
-4/16 EntryNormal "prop_4_16"
-4/17 EntryNormal "prop_4_17"
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+5/14 EntryNormal ""
+5/15 EntryNormal "prop_4_15"
+5/16 EntryNormal "prop_4_16"
+5/17 EntryNormal "prop_4_17"
 
 raft-log 7
 ----
-1/11 EntryNormal ""
-1/12 EntryNormal "prop_1_12"
-1/13 EntryNormal "prop_1_13"
-2/14 EntryNormal ""
-2/15 EntryNormal "prop_2_15"
-2/16 EntryNormal "prop_2_16"
-3/17 EntryNormal ""
-3/18 EntryNormal "prop_3_18"
-3/19 EntryNormal "prop_3_19"
-3/20 EntryNormal "prop_3_20"
-3/21 EntryNormal "prop_3_21"
+2/11 EntryNormal ""
+2/12 EntryNormal "prop_1_12"
+2/13 EntryNormal "prop_1_13"
+3/14 EntryNormal ""
+3/15 EntryNormal "prop_2_15"
+3/16 EntryNormal "prop_2_16"
+4/17 EntryNormal ""
+4/18 EntryNormal "prop_3_18"
+4/19 EntryNormal "prop_3_19"
+4/20 EntryNormal "prop_3_20"
+4/21 EntryNormal "prop_3_21"
 
 
 # Elect node 1 as leader and stabilize.
 campaign 1
 ----
-INFO 1 is starting a new election at term 7
-INFO 1 became candidate at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 2 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 3 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 4 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 5 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 6 at term 8
-INFO 1 [logterm: 6, index: 20] sent MsgVote request to 7 at term 8
+INFO 1 is starting a new election at term 8
+INFO 1 became candidate at term 9
+INFO 1 [logterm: 7, index: 20] sent MsgVote request to 2 at term 9
+INFO 1 [logterm: 7, index: 20] sent MsgVote request to 3 at term 9
+INFO 1 [logterm: 7, index: 20] sent MsgVote request to 4 at term 9
+INFO 1 [logterm: 7, index: 20] sent MsgVote request to 5 at term 9
+INFO 1 [logterm: 7, index: 20] sent MsgVote request to 6 at term 9
+INFO 1 [logterm: 7, index: 20] sent MsgVote request to 7 at term 9
 
 ## Get elected.
 stabilize 1
@@ -370,401 +370,401 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:8 Vote:1 Commit:18
+  HardState Term:9 Vote:1 Commit:18
   Messages:
-  1->2 MsgVote Term:8 Log:6/20
-  1->3 MsgVote Term:8 Log:6/20
-  1->4 MsgVote Term:8 Log:6/20
-  1->5 MsgVote Term:8 Log:6/20
-  1->6 MsgVote Term:8 Log:6/20
-  1->7 MsgVote Term:8 Log:6/20
-  INFO 1 received MsgVoteResp from 1 at term 8
+  1->2 MsgVote Term:9 Log:7/20
+  1->3 MsgVote Term:9 Log:7/20
+  1->4 MsgVote Term:9 Log:7/20
+  1->5 MsgVote Term:9 Log:7/20
+  1->6 MsgVote Term:9 Log:7/20
+  1->7 MsgVote Term:9 Log:7/20
+  INFO 1 received MsgVoteResp from 1 at term 9
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 
 stabilize 2 3 4 5 6 7
 ----
 > 2 receiving messages
-  1->2 MsgVote Term:8 Log:6/20
-  INFO 2 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
-  INFO 2 became follower at term 8
-  INFO 2 [logterm: 6, index: 19, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  1->2 MsgVote Term:9 Log:7/20
+  INFO 2 [term: 7] received a MsgVote message with higher term from 1 [term: 9]
+  INFO 2 became follower at term 9
+  INFO 2 [logterm: 7, index: 19, vote: 0] cast MsgVote for 1 [logterm: 7, index: 20] at term 9
 > 3 receiving messages
-  1->3 MsgVote Term:8 Log:6/20
-  INFO 3 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
-  INFO 3 became follower at term 8
-  INFO 3 [logterm: 4, index: 14, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  1->3 MsgVote Term:9 Log:7/20
+  INFO 3 [term: 8] received a MsgVote message with higher term from 1 [term: 9]
+  INFO 3 became follower at term 9
+  INFO 3 [logterm: 5, index: 14, vote: 0] cast MsgVote for 1 [logterm: 7, index: 20] at term 9
 > 4 receiving messages
-  1->4 MsgVote Term:8 Log:6/20
-  INFO 4 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
-  INFO 4 became follower at term 8
-  INFO 4 [logterm: 6, index: 21, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
+  1->4 MsgVote Term:9 Log:7/20
+  INFO 4 [term: 7] received a MsgVote message with higher term from 1 [term: 9]
+  INFO 4 became follower at term 9
+  INFO 4 [logterm: 7, index: 21, vote: 0] rejected MsgVote from 1 [logterm: 7, index: 20] at term 9
 > 5 receiving messages
-  1->5 MsgVote Term:8 Log:6/20
-  INFO 5 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
-  INFO 5 became follower at term 8
-  INFO 5 [logterm: 7, index: 22, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
+  1->5 MsgVote Term:9 Log:7/20
+  INFO 5 [term: 8] received a MsgVote message with higher term from 1 [term: 9]
+  INFO 5 became follower at term 9
+  INFO 5 [logterm: 8, index: 22, vote: 0] rejected MsgVote from 1 [logterm: 7, index: 20] at term 9
 > 6 receiving messages
-  1->6 MsgVote Term:8 Log:6/20
-  INFO 6 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
-  INFO 6 became follower at term 8
-  INFO 6 [logterm: 4, index: 17, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  1->6 MsgVote Term:9 Log:7/20
+  INFO 6 [term: 8] received a MsgVote message with higher term from 1 [term: 9]
+  INFO 6 became follower at term 9
+  INFO 6 [logterm: 5, index: 17, vote: 0] cast MsgVote for 1 [logterm: 7, index: 20] at term 9
 > 7 receiving messages
-  1->7 MsgVote Term:8 Log:6/20
-  INFO 7 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
-  INFO 7 became follower at term 8
-  INFO 7 [logterm: 3, index: 21, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
+  1->7 MsgVote Term:9 Log:7/20
+  INFO 7 [term: 8] received a MsgVote message with higher term from 1 [term: 9]
+  INFO 7 became follower at term 9
+  INFO 7 [logterm: 4, index: 21, vote: 0] cast MsgVote for 1 [logterm: 7, index: 20] at term 9
 > 2 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:8 Vote:1 Commit:18
+  HardState Term:9 Vote:1 Commit:18
   Messages:
-  2->1 MsgVoteResp Term:8 Log:0/0
+  2->1 MsgVoteResp Term:9 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:14
+  HardState Term:9 Vote:1 Commit:14
   Messages:
-  3->1 MsgVoteResp Term:8 Log:0/0
+  3->1 MsgVoteResp Term:9 Log:0/0
 > 4 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:8 Commit:18
+  HardState Term:9 Commit:18
   Messages:
-  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgVoteResp Term:9 Log:0/0 Rejected (Hint: 0)
 > 5 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateFollower
-  HardState Term:8 Commit:18
+  HardState Term:9 Commit:18
   Messages:
-  5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  5->1 MsgVoteResp Term:9 Log:0/0 Rejected (Hint: 0)
 > 6 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:15
+  HardState Term:9 Vote:1 Commit:15
   Messages:
-  6->1 MsgVoteResp Term:8 Log:0/0
+  6->1 MsgVoteResp Term:9 Log:0/0
 > 7 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:13
+  HardState Term:9 Vote:1 Commit:13
   Messages:
-  7->1 MsgVoteResp Term:8 Log:0/0
+  7->1 MsgVoteResp Term:9 Log:0/0
 
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgVoteResp Term:8 Log:0/0
-  INFO 1 received MsgVoteResp from 2 at term 8
+  2->1 MsgVoteResp Term:9 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 9
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  3->1 MsgVoteResp Term:8 Log:0/0
-  INFO 1 received MsgVoteResp from 3 at term 8
+  3->1 MsgVoteResp Term:9 Log:0/0
+  INFO 1 received MsgVoteResp from 3 at term 9
   INFO 1 has received 3 MsgVoteResp votes and 0 vote rejections
-  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
-  INFO 1 received MsgVoteResp rejection from 4 at term 8
+  4->1 MsgVoteResp Term:9 Log:0/0 Rejected (Hint: 0)
+  INFO 1 received MsgVoteResp rejection from 4 at term 9
   INFO 1 has received 3 MsgVoteResp votes and 1 vote rejections
-  5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
-  INFO 1 received MsgVoteResp rejection from 5 at term 8
+  5->1 MsgVoteResp Term:9 Log:0/0 Rejected (Hint: 0)
+  INFO 1 received MsgVoteResp rejection from 5 at term 9
   INFO 1 has received 3 MsgVoteResp votes and 2 vote rejections
-  6->1 MsgVoteResp Term:8 Log:0/0
-  INFO 1 received MsgVoteResp from 6 at term 8
+  6->1 MsgVoteResp Term:9 Log:0/0
+  INFO 1 received MsgVoteResp from 6 at term 9
   INFO 1 has received 4 MsgVoteResp votes and 2 vote rejections
-  INFO 1 became leader at term 8
-  7->1 MsgVoteResp Term:8 Log:0/0
+  INFO 1 became leader at term 9
+  7->1 MsgVoteResp Term:9 Log:0/0
 > 1 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  8/21 EntryNormal ""
+  9/21 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->2 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
+  1->3 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
+  1->4 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
+  1->5 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
+  1->6 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
+  1->7 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
 
 ## Recover each follower, one by one.
 stabilize 1 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->2 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:9 Log:7/20 Rejected (Hint: 19)
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:9 Log:7/20 Rejected (Hint: 19)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->2 MsgApp Term:9 Log:7/19 Commit:18 Entries:[
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->2 MsgApp Term:9 Log:7/19 Commit:18 Entries:[
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:9 Log:0/21
 
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->3 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
 > 3 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:9 Log:5/20 Rejected (Hint: 14)
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:9 Log:5/20 Rejected (Hint: 14)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
-    4/15 EntryNormal "prop_4_15"
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->3 MsgApp Term:9 Log:5/14 Commit:18 Entries:[
+    5/15 EntryNormal "prop_4_15"
+    6/16 EntryNormal ""
+    6/17 EntryNormal "prop_5_17"
+    7/18 EntryNormal ""
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 3 receiving messages
-  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
-    4/15 EntryNormal "prop_4_15"
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->3 MsgApp Term:9 Log:5/14 Commit:18 Entries:[
+    5/15 EntryNormal "prop_4_15"
+    6/16 EntryNormal ""
+    6/17 EntryNormal "prop_5_17"
+    7/18 EntryNormal ""
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:18
+  HardState Term:9 Vote:1 Commit:18
   Entries:
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  5/15 EntryNormal "prop_4_15"
+  6/16 EntryNormal ""
+  6/17 EntryNormal "prop_5_17"
+  7/18 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   CommittedEntries:
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
+  5/15 EntryNormal "prop_4_15"
+  6/16 EntryNormal ""
+  6/17 EntryNormal "prop_5_17"
+  7/18 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:9 Log:0/21
 
 stabilize 1 4
 ----
 > 4 receiving messages
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  INFO found conflict at index 21 [existing term: 6, conflicting term: 8]
+  1->4 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
+  INFO found conflict at index 21 [existing term: 7, conflicting term: 9]
   INFO replace the unstable entries from index 21
 > 4 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
   Entries:
-  8/21 EntryNormal ""
+  9/21 EntryNormal ""
   Messages:
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:9 Log:0/21
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:8 Vote:1 Commit:21
+  HardState Term:9 Vote:1 Commit:21
   CommittedEntries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:8 Log:8/21 Commit:21
-  1->3 MsgApp Term:8 Log:8/21 Commit:21
-  1->4 MsgApp Term:8 Log:8/21 Commit:21
+  1->2 MsgApp Term:9 Log:9/21 Commit:21
+  1->3 MsgApp Term:9 Log:9/21 Commit:21
+  1->4 MsgApp Term:9 Log:9/21 Commit:21
 > 4 receiving messages
-  1->4 MsgApp Term:8 Log:8/21 Commit:21
+  1->4 MsgApp Term:9 Log:9/21 Commit:21
 > 4 handling Ready
   Ready MustSync=false:
-  HardState Term:8 Commit:21
+  HardState Term:9 Commit:21
   CommittedEntries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   Messages:
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:9 Log:0/21
 
 stabilize 1 5
 ----
 > 5 receiving messages
-  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->5 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
 > 5 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
+  5->1 MsgAppResp Term:9 Log:7/20 Rejected (Hint: 18)
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
+  5->1 MsgAppResp Term:9 Log:7/20 Rejected (Hint: 18)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->5 MsgApp Term:9 Log:7/18 Commit:21 Entries:[
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 5 receiving messages
-  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->5 MsgApp Term:9 Log:7/18 Commit:21 Entries:[
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
-  INFO found conflict at index 19 [existing term: 7, conflicting term: 6]
+  INFO found conflict at index 19 [existing term: 8, conflicting term: 7]
   INFO replace the unstable entries from index 19
 > 5 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Commit:21
+  HardState Term:9 Commit:21
   Entries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   CommittedEntries:
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   Messages:
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:9 Log:0/21
 
 stabilize 1 6
 ----
 > 6 receiving messages
-  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->6 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
 > 6 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:9 Log:5/20 Rejected (Hint: 17)
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:9 Log:5/20 Rejected (Hint: 17)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->6 MsgApp Term:9 Log:5/15 Commit:21 Entries:[
+    6/16 EntryNormal ""
+    6/17 EntryNormal "prop_5_17"
+    7/18 EntryNormal ""
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 6 receiving messages
-  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->6 MsgApp Term:9 Log:5/15 Commit:21 Entries:[
+    6/16 EntryNormal ""
+    6/17 EntryNormal "prop_5_17"
+    7/18 EntryNormal ""
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
-  INFO found conflict at index 16 [existing term: 4, conflicting term: 5]
+  INFO found conflict at index 16 [existing term: 5, conflicting term: 6]
   INFO replace the unstable entries from index 16
 > 6 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:21
+  HardState Term:9 Vote:1 Commit:21
   Entries:
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  6/16 EntryNormal ""
+  6/17 EntryNormal "prop_5_17"
+  7/18 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   CommittedEntries:
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  6/16 EntryNormal ""
+  6/17 EntryNormal "prop_5_17"
+  7/18 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   Messages:
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:9 Log:0/21
 
 stabilize 1 7
 ----
 > 7 receiving messages
-  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->7 MsgApp Term:9 Log:7/20 Commit:18 Entries:[9/21 EntryNormal ""]
 > 7 handling Ready
   Ready MustSync=false:
   Lead:1 State:StateFollower
   Messages:
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
+  7->1 MsgAppResp Term:9 Log:4/20 Rejected (Hint: 20)
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
+  7->1 MsgAppResp Term:9 Log:4/20 Rejected (Hint: 20)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
-    4/14 EntryNormal ""
-    4/15 EntryNormal "prop_4_15"
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->7 MsgApp Term:9 Log:2/13 Commit:21 Entries:[
+    5/14 EntryNormal ""
+    5/15 EntryNormal "prop_4_15"
+    6/16 EntryNormal ""
+    6/17 EntryNormal "prop_5_17"
+    7/18 EntryNormal ""
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
 > 7 receiving messages
-  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
-    4/14 EntryNormal ""
-    4/15 EntryNormal "prop_4_15"
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
+  1->7 MsgApp Term:9 Log:2/13 Commit:21 Entries:[
+    5/14 EntryNormal ""
+    5/15 EntryNormal "prop_4_15"
+    6/16 EntryNormal ""
+    6/17 EntryNormal "prop_5_17"
+    7/18 EntryNormal ""
+    7/19 EntryNormal "prop_6_19"
+    7/20 EntryNormal "prop_6_20"
+    9/21 EntryNormal ""
   ]
-  INFO found conflict at index 14 [existing term: 2, conflicting term: 4]
+  INFO found conflict at index 14 [existing term: 3, conflicting term: 5]
   INFO replace the unstable entries from index 14
 > 7 handling Ready
   Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:21
+  HardState Term:9 Vote:1 Commit:21
   Entries:
-  4/14 EntryNormal ""
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  5/14 EntryNormal ""
+  5/15 EntryNormal "prop_4_15"
+  6/16 EntryNormal ""
+  6/17 EntryNormal "prop_5_17"
+  7/18 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   CommittedEntries:
-  4/14 EntryNormal ""
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
+  5/14 EntryNormal ""
+  5/15 EntryNormal "prop_4_15"
+  6/16 EntryNormal ""
+  6/17 EntryNormal "prop_5_17"
+  7/18 EntryNormal ""
+  7/19 EntryNormal "prop_6_19"
+  7/20 EntryNormal "prop_6_20"
+  9/21 EntryNormal ""
   Messages:
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:9 Log:0/21
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:9 Log:0/21

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -73,12 +73,12 @@ status 1
 # Drop append messages to node 3.
 deliver-msgs drop=3
 ----
-dropped: 1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
-dropped: 1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
-dropped: 1->3 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
-dropped: 1->3 MsgApp Term:1 Log:1/14 Commit:12
-dropped: 1->3 MsgApp Term:1 Log:1/14 Commit:13
-dropped: 1->3 MsgApp Term:1 Log:1/14 Commit:14
+dropped: 1->3 MsgApp Term:2 Log:2/11 Commit:11 Entries:[2/12 EntryNormal "prop_1_12"]
+dropped: 1->3 MsgApp Term:2 Log:2/12 Commit:11 Entries:[2/13 EntryNormal "prop_1_13"]
+dropped: 1->3 MsgApp Term:2 Log:2/13 Commit:11 Entries:[2/14 EntryNormal "prop_1_14"]
+dropped: 1->3 MsgApp Term:2 Log:2/14 Commit:12
+dropped: 1->3 MsgApp Term:2 Log:2/14 Commit:13
+dropped: 1->3 MsgApp Term:2 Log:2/14 Commit:14
 
 
 # Repeat committing 3 entries.
@@ -131,23 +131,23 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:17
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:17
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 
 # After handling heartbeat responses, node 1 sends an empty MsgApp to a
 # throttled node 3 because it hasn't yet replied to a single MsgApp, and the
@@ -155,23 +155,23 @@ stabilize 2 3
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/14 Commit:17
+  1->3 MsgApp Term:2 Log:2/14 Commit:17
 
 # Node 3 finally receives a MsgApp, but there was a gap, so it rejects it.
 stabilize 3
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/14 Commit:17
-  DEBUG 3 [logterm: 0, index: 14] rejected MsgApp [logterm: 1, index: 14] from 1
+  1->3 MsgApp Term:2 Log:2/14 Commit:17
+  DEBUG 3 [logterm: 0, index: 14] rejected MsgApp [logterm: 2, index: 14] from 1
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11)
+  3->1 MsgAppResp Term:2 Log:2/14 Rejected (Hint: 11)
 
 log-level none
 ----

--- a/pkg/raft/testdata/single_node.txt
+++ b/pkg/raft/testdata/single_node.txt
@@ -5,30 +5,30 @@ ok
 add-nodes 1 voters=(1) index=3
 ----
 INFO 1 switched to configuration voters=(1)
-INFO 1 became follower at term 0
-INFO newRaft 1 [peers: [1], term: 0, commit: 3, applied: 3, lastindex: 3, lastterm: 1]
+INFO 1 became follower at term 1
+INFO newRaft 1 [peers: [1], term: 1, commit: 3, applied: 3, lastindex: 3, lastterm: 1]
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
-INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
 
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
   Lead:0 State:StateCandidate
-  HardState Term:1 Vote:1 Commit:3
-  INFO 1 received MsgVoteResp from 1 at term 1
+  HardState Term:2 Vote:1 Commit:3
+  INFO 1 received MsgVoteResp from 1 at term 2
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-  INFO 1 became leader at term 1
+  INFO 1 became leader at term 2
 > 1 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateLeader
   Entries:
-  1/4 EntryNormal ""
+  2/4 EntryNormal ""
 > 1 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:4
+  HardState Term:2 Vote:1 Commit:4
   CommittedEntries:
-  1/4 EntryNormal ""
+  2/4 EntryNormal ""

--- a/pkg/raft/testdata/slow_follower_after_compaction.txt
+++ b/pkg/raft/testdata/slow_follower_after_compaction.txt
@@ -86,15 +86,15 @@ status 1
 # Break the MsgApp flow from the leader to node 3.
 deliver-msgs drop=3
 ----
-dropped: 1->3 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "prop_1_15"]
-dropped: 1->3 MsgApp Term:1 Log:1/15 Commit:14 Entries:[1/16 EntryNormal "prop_1_16"]
-dropped: 1->3 MsgApp Term:1 Log:1/16 Commit:15
-dropped: 1->3 MsgApp Term:1 Log:1/16 Commit:16
+dropped: 1->3 MsgApp Term:2 Log:2/14 Commit:14 Entries:[2/15 EntryNormal "prop_1_15"]
+dropped: 1->3 MsgApp Term:2 Log:2/15 Commit:14 Entries:[2/16 EntryNormal "prop_1_16"]
+dropped: 1->3 MsgApp Term:2 Log:2/16 Commit:15
+dropped: 1->3 MsgApp Term:2 Log:2/16 Commit:16
 
 # Truncate the leader's log beyond node 3 log size.
 compact 1 17
 ----
-1/18 EntryNormal "prop_1_18"
+2/18 EntryNormal "prop_1_18"
 
 # Trigger a round of empty MsgApp "probe" from leader. It will reach node 3
 # which will reply with a rejection MsgApp because it sees a gap in the log.

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -63,36 +63,36 @@ process-ready 1
 ----
 Ready MustSync=false:
 Messages:
-1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-1->3 MsgHeartbeat Term:1 Log:0/0
+1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
+1->3 MsgHeartbeat Term:2 Log:0/0
 
 # Iterate until no more work is done by the new peer. It receives the heartbeat
 # and responds.
 stabilize 3
 ----
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
-  INFO 3 became follower at term 1
+  1->3 MsgHeartbeat Term:2 Log:0/0
+  INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 2]
+  INFO 3 became follower at term 2
 > 3 handling Ready
   Ready MustSync=true:
   Lead:1 State:StateFollower
-  HardState Term:1 Commit:0
+  HardState Term:2 Commit:0
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
 
 # The leader in turn will realize that n3 needs a snapshot, which it initiates.
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-  DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 1] to 3 [StateProbe match=0 next=11]
+  3->1 MsgHeartbeatResp Term:2 Log:0/0
+  DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 2] to 3 [StateProbe match=0 next=11]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 paused pendingSnap=11]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  1->3 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:11 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 status 1
 ----
@@ -107,25 +107,25 @@ status 1
 stabilize 3
 ----
 > 3 receiving messages
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
+  1->3 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:11 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 2]
   INFO 3 switched to configuration voters=(1 2 3)
-  INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
-  INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
+  INFO 3 [commit: 11, lastindex: 11, lastterm: 2] restored snapshot [index: 11, term: 2]
+  INFO 3 [commit: 11] restored snapshot [index: 11, term: 2]
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Commit:11
-  Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Commit:11
+  Snapshot Index:11 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
 
 # The MsgAppResp lets the leader move the follower back to replicating state.
 # Leader sends another MsgAppResp, to communicate the updated commit index.
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=12 paused pendingSnap=11]
 
 status 1
@@ -138,10 +138,10 @@ status 1
 stabilize
 ----
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:2 Log:0/0 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0
 > 1 receiving messages
-  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  2->1 MsgHeartbeatResp Term:2 Log:0/0

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -42,9 +42,9 @@ ok
 # is still at index 5, and has not received any MsgApp from the leader yet.
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:0
+1: StateLeader (Voter) Term:2 Lead:1
+2: StateFollower (Voter) Term:2 Lead:1
+3: StateFollower (Voter) Term:2 Lead:0
 
 status 1
 ----
@@ -60,8 +60,8 @@ log is empty: first index=6, last index=5
 # does not move 3 to StateSnapshot.
 send-snapshot 1 3
 ----
-1->3 MsgSnap Term:1 Log:0/0
-  Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+1->3 MsgSnap Term:2 Log:0/0
+  Snapshot: Index:11 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 # Propose and commit an additional entry, which makes the leader's
 # last index 12, beyond the snapshot it sent at index 11.
@@ -91,7 +91,7 @@ status 1
 # 11 but this is rejected because the follower's log started at index 5.
 deliver-msgs 3 type=MsgApp
 ----
-1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+1->3 MsgApp Term:2 Log:1/10 Commit:10 Entries:[2/11 EntryNormal ""]
 DEBUG 3 [logterm: 0, index: 10] rejected MsgApp [logterm: 1, index: 10] from 1
 
 # Note below that the RejectionHint is 5, which is below the first index 10 of the
@@ -102,17 +102,17 @@ process-ready 3
 Ready MustSync=false:
 Lead:1 State:StateFollower
 Messages:
-3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5)
+3->1 MsgAppResp Term:2 Log:1/10 Rejected (Hint: 5)
 
 # 3 receives and applies the snapshot, but doesn't respond with MsgAppResp yet.
 deliver-msgs 3
 ----
-1->3 MsgSnap Term:1 Log:0/0
-  Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
+1->3 MsgSnap Term:2 Log:0/0
+  Snapshot: Index:11 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 2]
 INFO 3 switched to configuration voters=(1 2 3)
-INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
-INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
+INFO 3 [commit: 11, lastindex: 11, lastterm: 2] restored snapshot [index: 11, term: 2]
+INFO 3 [commit: 11] restored snapshot [index: 11, term: 2]
 
 
 # 1 sees the MsgApp rejection and asks for a snapshot at index 12 (which is 1's
@@ -120,22 +120,22 @@ INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5)
+  3->1 MsgAppResp Term:2 Log:1/10 Rejected (Hint: 5)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 5, term 1)) from 3 for index 10
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=6]
-  DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6]
+  DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 2] to 3 [StateProbe match=0 next=6]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=13 paused pendingSnap=12]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  1->3 MsgSnap Term:2 Log:0/0
+    Snapshot: Index:12 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 # Drop the extra MsgSnap(index=12) that 1 just sent, to keep the test tidy.
 deliver-msgs drop=(3)
 ----
-dropped: 1->3 MsgSnap Term:1 Log:0/0
-  Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+dropped: 1->3 MsgSnap Term:2 Log:0/0
+  Snapshot: Index:12 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 # 3 sends the affirmative MsgAppResp that resulted from applying the snapshot
 # at index 11.
@@ -143,20 +143,20 @@ stabilize 3
 ----
 > 3 handling Ready
   Ready MustSync=false:
-  HardState Term:1 Vote:1 Commit:11
-  Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:2 Vote:1 Commit:11
+  Snapshot Index:11 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
 
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:2 Log:0/11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 paused pendingSnap=12]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/11 Commit:12 Entries:[1/12 EntryNormal "\"foo\""]
+  1->3 MsgApp Term:2 Log:2/11 Commit:12 Entries:[2/12 EntryNormal "\"foo\""]
 
 # 3 is in StateReplicate thanks to receiving the snapshot at index 11.
 # This is despite its PendingSnapshot having been 12.


### PR DESCRIPTION
This PR adds a `Term` invariant check to the `newRaft` initialization code, and in tests:

```
raftLog.lastTerm() <= accTerm <= Term
```

A bunch of tests call `newRaft` to initialize a node from `Storage` that doesn't have a correct `HardState`. As a result, nodes are initialized with a non-empty log, containing entries at terms >= 1, but `Term` == 0. Another group of tests manipulates the `RawNode` directly and breaks invariants, or sends incorrectly formed messages. All of these are fixed in this PR.

Epic: none
Release note: none