### PR TITLE
ui: alter role events render correctly

### DIFF
--- a/pkg/ui/workspaces/db-console/src/util/events.ts
+++ b/pkg/ui/workspaces/db-console/src/util/events.ts
@@ -179,7 +179,11 @@ export function getEventDescription(e: clusterUiApi.EventColumns): string {
     case eventTypes.DROP_ROLE:
       return `Role Dropped: User ${info.User} dropped role ${info.RoleName}`;
     case eventTypes.ALTER_ROLE:
-      return `Role Altered: User ${info.User} altered role ${info.RoleName} with options ${info.Options}`;
+      if (info.Options && info.Options.length > 0) {
+        return `Role Altered: User ${info.User} altered role ${info.RoleName} with options ${info.Options}`;
+      } else {
+        return `Role Altered: User ${info.User} altered role ${info.RoleName}`;
+      }
     case eventTypes.IMPORT:
       return `Import Job: User ${info.User} has a job ${info.JobID} running with status ${info.Status}`;
     case eventTypes.RESTORE:


### PR DESCRIPTION
Previously, ALTER ROLE events without role options would render with an "undefined" option in the event log on the DB Console. This change amends the rendering logic to correctly render events without any options.

Resolves #124871
Epic: None

Release note (bug fix,ui change): ALTER ROLE events in the DB Console event log now render correctly when the event does not contain any role options.