### PR TITLE
kvserver: fix MsgSnap.Term in SendEmptySnapshot

### DIFF
--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1723,11 +1723,6 @@ func SendEmptySnapshot(
 	// explicitly for snapshots going out to followers.
 	state.DeprecatedUsingAppliedStateKey = true
 
-	hs, err := sl.LoadHardState(ctx, eng)
-	if err != nil {
-		return err
-	}
-
 	snapUUID := uuid.NewV4()
 
 	// The snapshot must use a Pebble snapshot, since it requires consistent
@@ -1767,7 +1762,7 @@ func SendEmptySnapshot(
 			Type:     raftpb.MsgSnap,
 			To:       uint64(to.ReplicaID),
 			From:     uint64(from.ReplicaID),
-			Term:     hs.Term,
+			Term:     outgoingSnap.RaftSnap.Metadata.Term,
 			Snapshot: &outgoingSnap.RaftSnap,
 		},
 	}


### PR DESCRIPTION
`SendEmptySnapshot` sends a malformed `MsgSnap` message with `Term=0`. It was trying to load the term from `HardState` in the in-memory storage engine that it creates and populates with `WriteInitialReplicaState`, but the latter function does not initialize the raft state.

Instead of loading the zero `HardState.Term`, set the message `Term` explicitly to the term of the initial snapshot.

Found by invariant checking in #126353 (https://github.com/cockroachdb/cockroach/pull/126353#issuecomment-2195882011)

Epic: none
Release note: none