### PR TITLE
sql: clarify usage of the PK of virtual tables in some cases

### DIFF
--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -17,11 +16,10 @@ import (
 // constructor must be delayed during query execution (as opposed to
 // SQL prepare) for resource tracking purposes.
 type delayedNode struct {
-	name            string
-	columns         colinfo.ResultColumns
-	indexConstraint *constraint.Constraint
-	constructor     nodeConstructor
-	plan            planNode
+	name        string
+	columns     colinfo.ResultColumns
+	constructor nodeConstructor
+	plan        planNode
 }
 
 type nodeConstructor func(context.Context, *planner) (planNode, error)

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -259,9 +259,8 @@ func constructVirtualScan(
 	)
 
 	n, err := delayedNodeCallback(&delayedNode{
-		name:            fmt.Sprintf("%s@%s", table.Name(), index.Name()),
-		columns:         columns,
-		indexConstraint: params.IndexConstraint,
+		name:    fmt.Sprintf("%s@%s", table.Name(), index.Name()),
+		columns: columns,
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
 			return constructor(ctx, p, tn.Catalog())
 		},

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -225,7 +225,7 @@ func emitExplain(
 		return catalogkeys.PrettySpans(idx, spans, skip)
 	}
 
-	return explain.Emit(ctx, explainPlan, ob, spanFormatFn)
+	return explain.Emit(ctx, evalCtx, explainPlan, ob, spanFormatFn)
 }
 
 func (e *explainPlanNode) Next(params runParams) (bool, error) { return e.run.results.Next(params) }

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -546,8 +546,8 @@ vectorized: true
 │ count: 10
 │
 └── • virtual table
-      table: pg_type@pg_type_oid_idx
-      spans: [/1 - /1000]
+      table: pg_type@primary
+      virtual table filter
 
 # Regression test for #69685 - a limit cannot be pushed below a window function
 # if its order-by references the window function.

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -529,3 +529,15 @@ vectorized: true
 
 statement ok
 RESET disallow_full_table_scans;
+
+# Verify that we're not fooling ourselves by showing that we can use a virtual
+# index when we actually can't (#108317).
+query T
+EXPLAIN SELECT * FROM crdb_internal.system_jobs WHERE id > 100;
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  table: system_jobs@primary
+  virtual table filter

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -156,7 +157,7 @@ func (f *PlanGistFactory) PlanGist() PlanGist {
 
 // DecodePlanGistToRows converts a gist to a logical plan and returns the rows.
 func DecodePlanGistToRows(
-	ctx context.Context, gist string, catalog cat.Catalog,
+	ctx context.Context, evalCtx *eval.Context, gist string, catalog cat.Catalog,
 ) (_ []string, retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -180,7 +181,7 @@ func DecodePlanGistToRows(
 	if err != nil {
 		return nil, err
 	}
-	err = Emit(ctx, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = Emit(ctx, evalCtx, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -46,7 +46,7 @@ func explainGist(gist string, catalog cat.Catalog) string {
 	if err != nil {
 		panic(err)
 	}
-	err = explain.Emit(context.Background(), explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	}
 	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true}
 	ob := explain.NewOutputBuilder(flags)
-	err = explain.Emit(context.Background(), explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -956,7 +956,7 @@ func (p *planner) DecodeGist(ctx context.Context, gist string, external bool) ([
 	if !external {
 		cat = p.optPlanningCtx.catalog
 	}
-	return explain.DecodePlanGistToRows(ctx, gist, cat)
+	return explain.DecodePlanGistToRows(ctx, p.EvalContext(), gist, cat)
 }
 
 // makeQueryIndexRecommendation builds a statement and walks through it to find


### PR DESCRIPTION
The execution infrastructure for the virtual tables has a few limitations, one of them being not able to utilize the virtual indexes for range scans (i.e. only point lookups are supported). We do so transparently by handling the prefix of point lookups, and once we find the first range span in the index constraint, we fall back to the "full scan" of the PK. Previously, the EXPLAIN output would always show that we're using the constrained virtual index scan which can be misleading. This commit adjusts the EXPLAIN output to always show usage of the PK and to omit the spans altogether.

I considered applying the adjustment earlier, in the execbuilder, so that the virtual index wouldn't be chosen in the first place (which would effectively push the knowledge of the limitation of the execution higher), but I ran into a couple of difficulties:
- we would need to also teach the explain and plan-gist factories about the adjustment (because they capture their arguments before calling the wrapped factory)
- the execution infra currently assumes that whenever a constrained scan is used, we must be using a virtual secondary index. Making adjustments to this seems tricky and somewhat risky.

Fixes: #108317.

Release note: None