### PR TITLE
roachtest: use cockroach workload in kv test

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -173,7 +173,7 @@ func registerKV(r registry.Registry) {
 				url = fmt.Sprintf(" {pgurl:1-%d:%s}", nodes, appTenantName)
 			}
 			cmd := fmt.Sprintf(
-				"./workload run kv --tolerate-errors --init --user=%s --password=%s", install.DefaultUser, install.DefaultPassword,
+				"./cockroach workload run kv --tolerate-errors --init --user=%s --password=%s", install.DefaultUser, install.DefaultPassword,
 			) +
 				histograms + concurrency + splits + duration + readPercent +
 				batchSize + blockSize + sequential + envFlags + url


### PR DESCRIPTION
We removed the uploading of the deprecated workload, but did not switch over to using cockroach workload. This change does that.

Fixes: #126378
Release note: none