### PR TITLE
sessiondata: add OriginIDForLogicalDataReplication session variable

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -932,6 +932,9 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.DisableChangefeedReplication {
 		sd.DisableChangefeedReplication = true
 	}
+	if o.OriginIDForLogicalDataReplication != 0 {
+		sd.OriginIDForLogicalDataReplication = o.OriginIDForLogicalDataReplication
+	}
 
 	if o.MultiOverride != "" {
 		overrides := strings.Split(o.MultiOverride, ",")

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -69,6 +69,13 @@ type InternalExecutorOverride struct {
 	// being emitted for changes to data made in a session. It is illegal to set
 	// this option when using the internal executor with an outer txn.
 	DisableChangefeedReplication bool
+
+	// OriginIDForLogicalDataReplication is an identifier for the cluster that
+	// originally wrote the data that are being written in this session. An
+	// originID of 0 (the default) identifies a local write, 1 identifies a remote
+	// write of unspecified origin, and 2+ are reserved to identify remote writes
+	// from specific clusters.
+	OriginIDForLogicalDataReplication uint32
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -528,6 +528,12 @@ message LocalOnlySessionData {
   // validate a routine's polymorphic parameters during overload resolution
   // and type-checking.
   bool optimizer_use_polymorphic_parameter_fix = 134;
+  // OriginIDForLogicalDataReplication is an identifier for the cluster that
+  // originally wrote the data that are being written in this session. An
+  // originID of 0 (the default) identifies a local write, 1 identifies a remote
+  // write of unspecified origin, and 2+ are reserved to identify remote writes
+  // from specific clusters.
+  uint32 origin_id_for_logical_data_replication = 135 [(gogoproto.customname) = "OriginIDForLogicalDataReplication"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //


### PR DESCRIPTION
sessiondata: add OriginIDForLogicalDataReplication session variable
This patch adds a new OriginIDForLogicalDataReplication session variable which
only the internal executor may set, which all LDR writes pass through.

Informs https://github.com/cockroachdb/cockroach/issues/126253

Release note: none

----

sql: bind LogicalDataReplicationOriginID session var value to tableWriter batch

This patch follows a similar strategy for plumbing OmitFromRangefeeds, except
this patch binds the LogicalDataReplicationOriginID val to the batch header
created by all table writers, rather than the batch txn. This was done because
this value will get plumbed to each written key's MVCCValueHeader, even if a
transaction is not used in the kv layer (e.g. via 1 phase commit).

Note this patch does not plumb this session val to other plan nodes (e.g. the
delete range node), as all LDR replicated writes will pass through the
tableWriter plan node.

Informs https://github.com/cockroachdb/cockroach/issues/126253

Release note: none

