### PR TITLE
storeliveness: create Store Liveness interface

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1497,6 +1497,7 @@ GO_TARGETS = [
     "//pkg/kv/kvserver/stateloader:stateloader",
     "//pkg/kv/kvserver/stateloader:stateloader_test",
     "//pkg/kv/kvserver/storeliveness/storelivenesspb:storelivenesspb",
+    "//pkg/kv/kvserver/storeliveness:storeliveness",
     "//pkg/kv/kvserver/tenantrate:tenantrate",
     "//pkg/kv/kvserver/tenantrate:tenantrate_test",
     "//pkg/kv/kvserver/tscache:tscache",

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "storeliveness",
+    srcs = ["fabric.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv/kvserver/storeliveness/storelivenesspb",
+        "//pkg/util/hlc",
+    ],
+)

--- a/pkg/kv/kvserver/storeliveness/fabric.go
+++ b/pkg/kv/kvserver/storeliveness/fabric.go
@@ -1,0 +1,53 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storeliveness
+
+import (
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// Fabric is a representation of the Store Liveness fabric. It provides
+// information about uninterrupted periods of "support" between stores.
+type Fabric interface {
+	// SupportFor returns the epoch of the current uninterrupted period of Store
+	// Liveness support from the local store (S_local) for the store (S_remote)
+	// corresponding to the specified id, and a boolean indicating whether S_local
+	// is currently supporting S_remote.
+	//
+	// If S_local is not currently supporting S_remote, the epoch will be 0 and
+	// the boolean will be false.
+	//
+	// S_remote may not be aware of the full extent of support from S_local, as
+	// Store Liveness heartbeat response messages may be lost or delayed. However,
+	// S_local will never be unaware of support it is providing.
+	//
+	// If S_local is unaware of the remote store S_remote, false will be returned.
+	SupportFor(id slpb.StoreIdent) (slpb.Epoch, bool)
+
+	// SupportFrom returns the epoch of the current uninterrupted period of Store
+	// Liveness support for the local store (S_local) from the store (S_remote)
+	// corresponding to the specified id, the timestamp until which the support is
+	// provided (an expiration), and a boolean indicating whether S_local is
+	// currently supported by S_remote.
+	//
+	// If S_local is not currently supported by S_remote, the epoch will be 0, the
+	// timestamp will be the zero timestamp, and the boolean will be false.
+	//
+	// S_local may not be aware of the full extent of support from S_remote, as
+	// Store Liveness heartbeat response messages may be lost or delayed. However,
+	// S_remote will never be unaware of support it is providing.
+	//
+	// If S_local is unaware of the remote store S_remote, false will be returned,
+	// and S_local will initiate a heartbeat loop to S_remote in order to
+	// request support so that future calls to SupportFrom may succeed.
+	SupportFrom(id slpb.StoreIdent) (slpb.Epoch, hlc.Timestamp, bool)
+}


### PR DESCRIPTION
This patch introduces the Fabric interface, which any local store can use to obtain information about Store Liveness support provided and requested by other remote stores.

The API includes:

- `SupportFor(id StoreIdent) (Epoch, bool)`: given a remote store id, returns whether the local store supports the remote store, and an epoch denoting the current uninterrupted period of support.

- `SupportFrom(id StoreIdent) (Epoch, hlc.Timestamp, bool)`: given a remote store id, returns whether the local store has support from the remote store, an epoch denoting the current uninterrupted period of support, and an timestamp indicating when this support expires.

Fixes: #125058

Release note: None