### PR TITLE
kvclient/rangefeed: add WithEmitMatchingOriginIDs rangefeed client option

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -290,7 +290,7 @@ func (s *activeMuxRangeFeed) start(ctx context.Context, m *rangefeedMuxer) error
 
 		for !s.transport.IsExhausted() {
 			args := makeRangeFeedRequest(
-				s.Span, s.token.Desc().RangeID, m.cfg.overSystemTable, s.startAfter, m.cfg.withDiff, m.cfg.withFiltering)
+				s.Span, s.token.Desc().RangeID, m.cfg.overSystemTable, s.startAfter, m.cfg.withDiff, m.cfg.withFiltering, m.cfg.withMatchingOriginIDs)
 			args.Replica = s.transport.NextReplica()
 			args.StreamID = streamID
 			s.ReplicaDescriptor = args.Replica

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -41,18 +41,19 @@ type config struct {
 
 	invoker func(func() error) error
 
-	withDiff             bool
-	withFiltering        bool
-	onUnrecoverableError OnUnrecoverableError
-	onCheckpoint         OnCheckpoint
-	frontierQuantize     time.Duration
-	onFrontierAdvance    OnFrontierAdvance
-	frontierVisitor      FrontierSpanVisitor
-	onSSTable            OnSSTable
-	onValues             OnValues
-	onDeleteRange        OnDeleteRange
-	onMetadata           OnMetadata
-	extraPProfLabels     []string
+	withDiff              bool
+	withFiltering         bool
+	withMatchingOriginIDs []uint32
+	onUnrecoverableError  OnUnrecoverableError
+	onCheckpoint          OnCheckpoint
+	frontierQuantize      time.Duration
+	onFrontierAdvance     OnFrontierAdvance
+	frontierVisitor       FrontierSpanVisitor
+	onSSTable             OnSSTable
+	onValues              OnValues
+	onDeleteRange         OnDeleteRange
+	onMetadata            OnMetadata
+	extraPProfLabels      []string
 }
 
 type scanConfig struct {
@@ -154,6 +155,12 @@ func WithDiff(withDiff bool) Option {
 func WithFiltering(withFiltering bool) Option {
 	return optionFunc(func(c *config) {
 		c.withFiltering = withFiltering
+	})
+}
+
+func WithOriginIDsMatching(originIDs ...uint32) Option {
+	return optionFunc(func(c *config) {
+		c.withMatchingOriginIDs = originIDs
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -348,6 +348,9 @@ func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier, resumeWithF
 	if f.withFiltering {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithFiltering())
 	}
+	if len(f.withMatchingOriginIDs) != 0 {
+		rangefeedOpts = append(rangefeedOpts, kvcoord.WithMatchingOriginIDs(f.withMatchingOriginIDs...))
+	}
 	if f.onMetadata != nil {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithMetadata())
 	}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3200,6 +3200,13 @@ message RangeFeedRequest {
   // OmitInRangefeeds = true, the write will not be emitted on the rangefeed.
   // WithFiltering should NOT be set for system-table rangefeeds.
   bool with_filtering = 7;
+  
+  // WithMatchingOriginIDs specifies if the rangefeed server should emit events
+  // originating from specific clusters during Logical Data Replication. If this
+  // field is empty, all events are emitted.
+  repeated uint32 with_matching_origin_ids = 8 [(gogoproto.customname) = "WithMatchingOriginIDs"];
+
+  // NextID = 9;
 }
 
 // RangeFeedValue is a variant of RangeFeedEvent that represents an update to


### PR DESCRIPTION
This patch adds a rangefeed client level configuration option that configures
the rangefeed to emit events originally written by clusters with a matching
OriginID during LogicalDataReplication. Currently rangefeeds only support
matching to OriginID 0, local writes.

Informs https://github.com/cockroachdb/cockroach/issues/126253

Release note: none