### PR TITLE
raft: merge append and maybeAppend methods

### DIFF
--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -37,9 +37,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	lastIndex, err := rn.raft.raftLog.storage.LastIndex()
 	if err != nil {
 		return err
-	}
-
-	if lastIndex != 0 {
+	} else if lastIndex != 0 {
 		return errors.New("can't bootstrap a nonempty Storage")
 	}
 
@@ -51,17 +49,22 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	// TODO(tbg): remove StartNode and give the application the right tools to
 	// bootstrap the initial membership in a cleaner way.
 	rn.raft.becomeFollower(1, None)
-	ents := make([]pb.Entry, len(peers))
+	app := logSlice{term: 1, entries: make([]pb.Entry, 0, len(peers))}
 	for i, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		data, err := cc.Marshal()
 		if err != nil {
 			return err
 		}
-
-		ents[i] = pb.Entry{Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data}
+		app.entries = append(app.entries, pb.Entry{
+			Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data,
+		})
 	}
-	rn.raft.raftLog.append(ents...)
+	if err := app.valid(); err != nil {
+		return err
+	} else if !rn.raft.raftLog.maybeAppend(app) {
+		return errors.New("could not append to the log")
+	}
 
 	// Now apply them, mainly so that the application can call Campaign
 	// immediately after StartNode in tests. Note that these nodes will
@@ -75,7 +78,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	//
 	// TODO(bdarnell): These entries are still unstable; do we need to preserve
 	// the invariant that committed < unstable?
-	rn.raft.raftLog.committed = uint64(len(ents))
+	rn.raft.raftLog.committed = app.lastIndex()
 	for _, peer := range peers {
 		rn.raft.applyConfChange(pb.ConfChange{NodeID: peer.ID, Type: pb.ConfChangeAddNode}.AsV2())
 	}

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -122,9 +122,7 @@ func (l *raftLog) maybeAppend(a logSlice) bool {
 	if first := a.entries[0].Index; first <= l.committed {
 		l.logger.Panicf("entry %d is already committed [committed(%d)]", first, l.committed)
 	}
-	// TODO(pav-kv): pass the logSlice down the stack, for safety checks and
-	// bookkeeping in the unstable structure.
-	l.unstable.truncateAndAppend(a.entries)
+	l.unstable.truncateAndAppend(a)
 	return true
 }
 

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -25,11 +25,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func (l *raftLog) bootstrap(t testing.TB, entries []pb.Entry) {
+	last := l.lastEntryID()
+	term := last.term
+	if ln := len(entries); ln != 0 {
+		term = entries[ln-1].Term
+	}
+	app := logSlice{term: term, prev: last, entries: entries}
+	require.NoError(t, app.valid())
+	require.True(t, l.maybeAppend(app))
+}
+
 func TestFindConflict(t *testing.T) {
-	initial := entryID{}.terms(1, 2, 3)
-	ids := make([]entryID, 1, len(initial.entries)+1) // dummy (0, 0) at index 0
-	for i := range initial.entries {
-		ids = append(ids, pbEntryID(&initial.entries[i]))
+	previousEnts := index(1).terms(1, 2, 3)
+	ids := make([]entryID, 1, len(previousEnts)+1) // dummy (0, 0) at index 0
+	for i := range previousEnts {
+		ids = append(ids, pbEntryID(&previousEnts[i]))
 	}
 	for _, tt := range []struct {
 		prev  entryID
@@ -63,7 +74,7 @@ func TestFindConflict(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			log := newLog(NewMemoryStorage(), discardLogger)
-			log.append(initial)
+			log.bootstrap(t, previousEnts)
 			app := logSlice{term: 100, prev: tt.prev, entries: tt.ents}
 			require.NoError(t, app.valid())
 			match, ok := log.findConflict(app)
@@ -112,7 +123,7 @@ func TestFindConflictByTerm(t *testing.T) {
 				Term:  tt.ents[0].Term,
 			}})
 			l := newLog(st, raftLogger)
-			l.append(tt.ents[1:]...)
+			l.bootstrap(t, tt.ents[1:])
 
 			index, term := l.findConflictByTerm(tt.index, tt.term)
 			require.Equal(t, tt.want, index)
@@ -124,9 +135,9 @@ func TestFindConflictByTerm(t *testing.T) {
 }
 
 func TestIsUpToDate(t *testing.T) {
-	initial := entryID{}.terms(1, 2, 3)
+	previousEnts := index(1).terms(1, 2, 3)
 	raftLog := newLog(NewMemoryStorage(), raftLogger)
-	raftLog.append(initial)
+	raftLog.bootstrap(t, previousEnts)
 	tests := []struct {
 		lastIndex uint64
 		term      uint64
@@ -153,7 +164,8 @@ func TestIsUpToDate(t *testing.T) {
 	}
 }
 
-// TODO(pav-kv): merge into TestLogMaybeAppend when the two method are merged.
+// TODO(pav-kv): merge into TestLogMaybeAppend when unstable is integrated with
+// logSlice, and does all the necessary correctness checks.
 func TestLogAppend(t *testing.T) {
 	init := logSlice{term: 2, entries: index(1).terms(1, 2)}
 	require.NoError(t, init.valid())
@@ -193,8 +205,9 @@ func TestLogAppend(t *testing.T) {
 			raftLog := newLog(storage, discardLogger)
 			raftLog.committed = commit
 
+			// TODO(pav-kv): vary the term when maybeAppend respects it.
 			require.NoError(t, tt.app.valid())
-			raftLog.append(tt.app.entries...) // TODO(pav-kv): pass the logSlice
+			raftLog.maybeAppend(tt.app)
 
 			entries := raftLog.allEntries()
 			require.Equal(t, tt.want, entries)
@@ -256,7 +269,7 @@ func TestLogMaybeAppend(t *testing.T) {
 		require.NoError(t, app.valid())
 
 		raftLog := newLog(NewMemoryStorage(), discardLogger)
-		raftLog.append(init)
+		require.True(t, raftLog.maybeAppend(init))
 		raftLog.committed = commit
 
 		t.Run("", func(t *testing.T) {
@@ -282,7 +295,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	storage := NewMemoryStorage()
 	require.NoError(t, storage.Append(index(1).termRange(1, unstableIndex+1)))
 	raftLog := newLog(storage, raftLogger)
-	raftLog.append(index(unstableIndex+1).termRange(unstableIndex+1, lastIndex+1)...)
+	raftLog.bootstrap(t, index(unstableIndex+1).termRange(unstableIndex+1, lastIndex+1))
 
 	require.True(t, raftLog.maybeCommit(raftLog.lastEntryID()))
 	raftLog.appliedTo(raftLog.committed, 0 /* size */)
@@ -304,7 +317,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	require.Equal(t, uint64(751), unstableEnts[0].Index)
 
 	prev := raftLog.lastIndex()
-	raftLog.append(pb.Entry{Index: raftLog.lastIndex() + 1, Term: raftLog.lastIndex() + 1})
+	raftLog.bootstrap(t, []pb.Entry{{Index: prev + 1, Term: prev + 1}})
 	require.Equal(t, prev+1, raftLog.lastIndex())
 
 	ents, err := raftLog.entries(raftLog.lastIndex(), noLimit)
@@ -350,7 +363,7 @@ func TestHasNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(ents...)
+			raftLog.bootstrap(t, ents[1:])
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -370,8 +383,7 @@ func TestNextCommittedEnts(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
-	initial := entryID{term: 1, index: 3}.terms(1, 1, 1)
-	ents := initial.entries
+	ents := index(4).terms(1, 1, 1)
 	tests := []struct {
 		applied       uint64
 		applying      uint64
@@ -405,7 +417,7 @@ func TestNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(initial)
+			raftLog.bootstrap(t, ents[1:])
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -426,7 +438,7 @@ func TestAcceptApplying(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
-	initial := entryID{term: 1, index: 3}.terms(1, 1, 1)
+	ents := index(4).terms(1, 1, 1)
 	tests := []struct {
 		index         uint64
 		allowUnstable bool
@@ -457,10 +469,10 @@ func TestAcceptApplying(t *testing.T) {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.ApplySnapshot(snap))
-			require.NoError(t, storage.Append(initial.entries[:1]))
+			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLogWithSize(storage, raftLogger, maxSize)
-			raftLog.append(initial)
+			raftLog.bootstrap(t, ents[1:])
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(3, 0 /* size */)
@@ -477,7 +489,7 @@ func TestAppliedTo(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
-	initial := entryID{term: 1, index: 3}.terms(1, 1, 1)
+	ents := index(4).terms(1, 1, 1)
 	tests := []struct {
 		index         uint64
 		size          entryEncodingSize
@@ -502,10 +514,10 @@ func TestAppliedTo(t *testing.T) {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.ApplySnapshot(snap))
-			require.NoError(t, storage.Append(initial.entries[:1]))
+			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLogWithSize(storage, raftLogger, maxSize)
-			raftLog.append(initial)
+			raftLog.bootstrap(t, ents[1:])
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(3, 0 /* size */)
@@ -523,24 +535,24 @@ func TestAppliedTo(t *testing.T) {
 // TestNextUnstableEnts ensures unstableEntries returns the unstable part of the
 // entries correctly.
 func TestNextUnstableEnts(t *testing.T) {
-	initial := entryID{}.terms(1, 2)
+	previousEnts := index(1).terms(1, 2)
 	tests := []struct {
 		unstable uint64
 		wents    []pb.Entry
 	}{
 		{3, nil},
-		{1, initial.entries},
+		{1, previousEnts},
 	}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			// append stable entries to storage
 			storage := NewMemoryStorage()
-			require.NoError(t, storage.Append(initial.entries[:tt.unstable-1]))
+			require.NoError(t, storage.Append(previousEnts[:tt.unstable-1]))
 
 			// append unstable entries to raftlog
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(previousEnts[tt.unstable-1:]...)
+			raftLog.bootstrap(t, previousEnts[tt.unstable-1:])
 
 			ents := raftLog.nextUnstableEnts()
 			if l := len(ents); l > 0 {
@@ -571,7 +583,7 @@ func TestCommitTo(t *testing.T) {
 				}
 			}()
 			raftLog := newLog(NewMemoryStorage(), discardLogger)
-			raftLog.append(initial)
+			raftLog.maybeAppend(initial)
 			raftLog.committed = commit
 			raftLog.commitTo(tt.commit)
 			require.Equal(t, tt.want, raftLog.committed)
@@ -593,7 +605,7 @@ func TestStableTo(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			raftLog := newLog(NewMemoryStorage(), raftLogger)
-			raftLog.append(entryID{}.terms(1, 2))
+			raftLog.bootstrap(t, index(1).terms(1, 2))
 			raftLog.stableTo(entryID{term: tt.stablet, index: tt.stablei})
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})
@@ -630,7 +642,7 @@ func TestStableToWithSnap(t *testing.T) {
 			s := NewMemoryStorage()
 			require.NoError(t, s.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: snapi, Term: snapt}}))
 			raftLog := newLog(s, raftLogger)
-			raftLog.append(tt.newEnts...)
+			raftLog.bootstrap(t, tt.newEnts)
 			raftLog.stableTo(entryID{term: tt.stablet, index: tt.stablei})
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})
@@ -698,7 +710,7 @@ func TestIsOutOfBounds(t *testing.T) {
 	storage := NewMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset}})
 	l := newLog(storage, raftLogger)
-	l.append(index(offset+1).termRange(offset+1, offset+num+1)...)
+	l.bootstrap(t, index(offset+1).termRange(offset+1, offset+num+1))
 
 	first := offset + 1
 	tests := []struct {
@@ -770,7 +782,7 @@ func TestTerm(t *testing.T) {
 	storage := NewMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset, Term: 1}})
 	l := newLog(storage, raftLogger)
-	l.append(index(offset+1).termRange(1, num)...)
+	l.bootstrap(t, index(offset+1).termRange(1, num))
 
 	for i, tt := range []struct {
 		idx  uint64
@@ -839,7 +851,7 @@ func TestSlice(t *testing.T) {
 		Metadata: pb.SnapshotMetadata{Index: offset}}))
 	require.NoError(t, storage.Append(entries(offset+1, half)))
 	l := newLog(storage, raftLogger)
-	l.append(entries(half, last)...)
+	l.bootstrap(t, entries(half, last))
 
 	for _, tt := range []struct {
 		lo  uint64
@@ -925,7 +937,7 @@ func TestScan(t *testing.T) {
 		Metadata: pb.SnapshotMetadata{Index: offset}}))
 	require.NoError(t, storage.Append(entries(offset+1, half)))
 	l := newLog(storage, raftLogger)
-	l.append(entries(half, last)...)
+	l.bootstrap(t, entries(half, last))
 
 	// Test that scan() returns the same entries as slice(), on all inputs.
 	for _, pageSize := range []entryEncodingSize{0, 1, 10, 100, entrySize, entrySize + 1} {

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -26,10 +26,10 @@ import (
 )
 
 func TestFindConflict(t *testing.T) {
-	previousEnts := index(1).terms(1, 2, 3)
-	ids := make([]entryID, 1, len(previousEnts)+1) // dummy (0, 0) at index 0
-	for i := range previousEnts {
-		ids = append(ids, pbEntryID(&previousEnts[i]))
+	initial := entryID{}.terms(1, 2, 3)
+	ids := make([]entryID, 1, len(initial.entries)+1) // dummy (0, 0) at index 0
+	for i := range initial.entries {
+		ids = append(ids, pbEntryID(&initial.entries[i]))
 	}
 	for _, tt := range []struct {
 		prev  entryID
@@ -63,7 +63,7 @@ func TestFindConflict(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			log := newLog(NewMemoryStorage(), discardLogger)
-			log.append(previousEnts...)
+			log.append(initial)
 			app := logSlice{term: 100, prev: tt.prev, entries: tt.ents}
 			require.NoError(t, app.valid())
 			match, ok := log.findConflict(app)
@@ -124,9 +124,9 @@ func TestFindConflictByTerm(t *testing.T) {
 }
 
 func TestIsUpToDate(t *testing.T) {
-	previousEnts := index(1).terms(1, 2, 3)
+	initial := entryID{}.terms(1, 2, 3)
 	raftLog := newLog(NewMemoryStorage(), raftLogger)
-	raftLog.append(previousEnts...)
+	raftLog.append(initial)
 	tests := []struct {
 		lastIndex uint64
 		term      uint64
@@ -256,7 +256,7 @@ func TestLogMaybeAppend(t *testing.T) {
 		require.NoError(t, app.valid())
 
 		raftLog := newLog(NewMemoryStorage(), discardLogger)
-		raftLog.append(init.entries...)
+		raftLog.append(init)
 		raftLog.committed = commit
 
 		t.Run("", func(t *testing.T) {
@@ -370,7 +370,8 @@ func TestNextCommittedEnts(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
-	ents := index(4).terms(1, 1, 1)
+	initial := entryID{term: 1, index: 3}.terms(1, 1, 1)
+	ents := initial.entries
 	tests := []struct {
 		applied       uint64
 		applying      uint64
@@ -404,7 +405,7 @@ func TestNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, raftLogger)
-			raftLog.append(ents...)
+			raftLog.append(initial)
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -425,7 +426,7 @@ func TestAcceptApplying(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
-	ents := index(4).terms(1, 1, 1)
+	initial := entryID{term: 1, index: 3}.terms(1, 1, 1)
 	tests := []struct {
 		index         uint64
 		allowUnstable bool
@@ -456,10 +457,10 @@ func TestAcceptApplying(t *testing.T) {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.ApplySnapshot(snap))
-			require.NoError(t, storage.Append(ents[:1]))
+			require.NoError(t, storage.Append(initial.entries[:1]))
 
 			raftLog := newLogWithSize(storage, raftLogger, maxSize)
-			raftLog.append(ents...)
+			raftLog.append(initial)
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(3, 0 /* size */)
@@ -476,7 +477,7 @@ func TestAppliedTo(t *testing.T) {
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
-	ents := index(4).terms(1, 1, 1)
+	initial := entryID{term: 1, index: 3}.terms(1, 1, 1)
 	tests := []struct {
 		index         uint64
 		size          entryEncodingSize
@@ -501,10 +502,10 @@ func TestAppliedTo(t *testing.T) {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.ApplySnapshot(snap))
-			require.NoError(t, storage.Append(ents[:1]))
+			require.NoError(t, storage.Append(initial.entries[:1]))
 
 			raftLog := newLogWithSize(storage, raftLogger, maxSize)
-			raftLog.append(ents...)
+			raftLog.append(initial)
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(3, 0 /* size */)
@@ -522,20 +523,20 @@ func TestAppliedTo(t *testing.T) {
 // TestNextUnstableEnts ensures unstableEntries returns the unstable part of the
 // entries correctly.
 func TestNextUnstableEnts(t *testing.T) {
-	previousEnts := index(1).terms(1, 2)
+	initial := entryID{}.terms(1, 2)
 	tests := []struct {
 		unstable uint64
 		wents    []pb.Entry
 	}{
 		{3, nil},
-		{1, previousEnts},
+		{1, initial.entries},
 	}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			// append stable entries to storage
 			storage := NewMemoryStorage()
-			require.NoError(t, storage.Append(previousEnts[:tt.unstable-1]))
+			require.NoError(t, storage.Append(initial.entries[:tt.unstable-1]))
 
 			// append unstable entries to raftlog
 			raftLog := newLog(storage, raftLogger)
@@ -552,7 +553,7 @@ func TestNextUnstableEnts(t *testing.T) {
 }
 
 func TestCommitTo(t *testing.T) {
-	previousEnts := index(1).terms(1, 2, 3)
+	initial := entryID{}.terms(1, 2, 3)
 	commit := uint64(2)
 	for _, tt := range []struct {
 		commit uint64
@@ -570,7 +571,7 @@ func TestCommitTo(t *testing.T) {
 				}
 			}()
 			raftLog := newLog(NewMemoryStorage(), discardLogger)
-			raftLog.append(previousEnts...)
+			raftLog.append(initial)
 			raftLog.committed = commit
 			raftLog.commitTo(tt.commit)
 			require.Equal(t, tt.want, raftLog.committed)
@@ -592,7 +593,7 @@ func TestStableTo(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			raftLog := newLog(NewMemoryStorage(), raftLogger)
-			raftLog.append(index(1).terms(1, 2)...)
+			raftLog.append(entryID{}.terms(1, 2))
 			raftLog.stableTo(entryID{term: tt.stablet, index: tt.stablei})
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -583,7 +583,7 @@ func TestUnstableTruncateAndAppend(t *testing.T) {
 			u.checkInvariants(t)
 
 			require.NoError(t, tt.app.valid())
-			u.truncateAndAppend(tt.app.entries)
+			u.truncateAndAppend(tt.app)
 			u.checkInvariants(t)
 			require.Equal(t, tt.woffset, u.offset)
 			require.Equal(t, tt.woffsetInProgress, u.offsetInProgress)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -773,10 +773,10 @@ func (r *raft) reset(term uint64) {
 }
 
 func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
-	li := r.raftLog.lastIndex()
+	last := r.raftLog.lastEntryID()
 	for i := range es {
 		es[i].Term = r.Term
-		es[i].Index = li + 1 + uint64(i)
+		es[i].Index = last.index + 1 + uint64(i)
 	}
 	// Track the size of this uncommitted proposal.
 	if !r.increaseUncommittedSize(es) {
@@ -787,7 +787,12 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 		// Drop the proposal.
 		return false
 	}
-	r.raftLog.append(es...)
+	app := logSlice{term: r.Term, prev: last, entries: es}
+	if err := app.valid(); err != nil {
+		r.logger.Panicf("%x constructed an invalid log slice: %v", r.id, err)
+	} else if !r.raftLog.maybeAppend(app) {
+		r.logger.Panicf("%x leader could not append to its log", r.id)
+	}
 	// The leader needs to self-ack the entries just appended once they have
 	// been durably persisted (since it doesn't send an MsgApp to itself). This
 	// response message will be added to msgsAfterAppend and delivered back to

--- a/pkg/raft/raft_snap_test.go
+++ b/pkg/raft/raft_snap_test.go
@@ -36,6 +36,7 @@ var (
 func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -54,6 +55,7 @@ func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 func TestPendingSnapshotPauseReplication(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -71,6 +73,7 @@ func TestPendingSnapshotPauseReplication(t *testing.T) {
 func TestSnapshotFailure(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -94,6 +97,7 @@ func TestSnapshotFailure(t *testing.T) {
 func TestSnapshotSucceed(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -117,6 +121,7 @@ func TestSnapshotSucceed(t *testing.T) {
 func TestSnapshotAbort(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()


### PR DESCRIPTION
All appends to the local log are conditional to the same set of constraints on the `logSlice` being appended. It is beneficial to handle all these cases in a uniform way.

Epic: none
Release note: none