### PR TITLE
raft: minimize/strengthen TestLogMaybeAppend

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -335,6 +335,12 @@ func (l *raftLog) lastIndex() uint64 {
 	return i
 }
 
+// commitTo bumps the commit index to the given value if it is higher than the
+// current commit index.
+//
+// TODO(pav-kv): this method should accept the term of the leader on whose
+// behalf the commit index is bumped. It is only safe to update the commit index
+// if our log is consistent with this leader, i.e. accTerm >= term.
 func (l *raftLog) commitTo(tocommit uint64) {
 	// never decrease commit
 	if l.committed < tocommit {

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -210,92 +210,65 @@ func TestAppend(t *testing.T) {
 //  2. If the request is accepted, the slice is appended to the log, and all the
 //     entries at higher indices are truncated.
 func TestLogMaybeAppend(t *testing.T) {
-	previousEnts := index(1).terms(1, 2, 3)
-	lastindex := uint64(3)
-	lastterm := uint64(3)
+	init := logSlice{term: 3, entries: index(1).terms(1, 2, 3)}
+	require.NoError(t, init.valid())
+	last := init.lastEntryID()
 	commit := uint64(1)
 
-	// TODO(pav-kv): clean-up this test.
-	tests := []struct {
-		prev entryID
-		ents []pb.Entry
-
-		wappend bool
-		wpanic  bool
+	for _, tt := range []struct {
+		app   logSlice
+		notOk bool
+		panic bool
 	}{
-		// not match: term is different
+		// rejected appends
 		{
-			entryID{term: lastterm - 1, index: lastindex},
-			index(lastindex + 1).terms(4),
-			false, false,
+			app:   entryID{term: 2, index: 3}.terms(4),
+			notOk: true, // term mismatch
+		}, {
+			app:   entryID{term: 3, index: 4}.terms(4),
+			notOk: true, // out of bounds
 		},
-		// not match: index out of bound
+		// appends at the end of the log
+		{app: last.terms()},
+		{app: last.terms(4)},
+		{app: last.terms(4, 4)},
+		// appends from before the end of the log
+		{app: logSlice{}},
+		{app: entryID{term: 1, index: 1}.terms(4)},
+		{app: entryID{term: 1, index: 1}.terms(4, 4)},
+		{app: entryID{term: 2, index: 2}.terms(4)},
+		// panics
 		{
-			entryID{term: lastterm, index: lastindex + 1},
-			index(lastindex + 2).terms(4),
-			false, false,
+			app:   entryID{}.terms(4),
+			panic: true, // conflict with existing committed entry
 		},
-		// match with the last existing entry
-		{
-			entryID{term: lastterm, index: lastindex}, nil,
-			true, false,
-		},
-		{
-			entryID{term: lastterm, index: lastindex},
-			index(lastindex + 1).terms(4),
-			true, false,
-		},
-		// match with an entry before the last one
-		{
-			entryID{}, nil,
-			true, false,
-		},
-		{
-			entryID{term: lastterm - 1, index: lastindex - 1},
-			index(lastindex).terms(4),
-			true, false,
-		},
-		{
-			entryID{term: lastterm - 2, index: lastindex - 2},
-			index(lastindex - 1).terms(4),
-			true, false,
-		},
-		// panic
-		{
-			entryID{term: lastterm - 3, index: lastindex - 3},
-			index(lastindex - 2).terms(4),
-			true, true, // conflict with existing committed entry
-		},
-	}
-
-	for i, tt := range tests {
+	} {
 		// TODO(pav-kv): for now, we pick a high enough app.term so that it
 		// represents a valid append message. The maybeAppend currently ignores it,
 		// but it must check that the append does not regress the term.
-		app := logSlice{
-			term:    100,
-			prev:    tt.prev,
-			entries: tt.ents,
-		}
+		app := tt.app
+		app.term = 100
 		require.NoError(t, app.valid())
 
-		raftLog := newLog(NewMemoryStorage(), raftLogger)
-		raftLog.append(previousEnts...)
+		raftLog := newLog(NewMemoryStorage(), discardLogger)
+		raftLog.append(init.entries...)
 		raftLog.committed = commit
 
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run("", func(t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
-					require.True(t, tt.wpanic)
+					require.True(t, tt.panic)
 				}
 			}()
-			gappend := raftLog.maybeAppend(app)
-			require.Equal(t, tt.wappend, gappend)
+			ok := raftLog.maybeAppend(app)
+			require.Equal(t, !tt.notOk, ok)
 			require.Equal(t, commit, raftLog.committed) // commit index did not change
-			if gappend && len(tt.ents) != 0 {
-				gents, err := raftLog.slice(raftLog.lastIndex()-uint64(len(tt.ents))+1, raftLog.lastIndex()+1, noLimit)
+			if ok {
+				entries, err := raftLog.slice(app.prev.index+1, app.lastIndex()+1, noLimit)
 				require.NoError(t, err)
-				require.Equal(t, tt.ents, gents)
+				require.Equal(t, app.entries, entries)
+			} else {
+				require.Equal(t, init.entries, raftLog.allEntries())
 			}
 		})
 	}
@@ -1005,6 +978,9 @@ type index uint64
 // terms generates a slice of entries at indices [index, index+len(terms)), with
 // the given terms of each entry. Terms must be non-decreasing.
 func (i index) terms(terms ...uint64) []pb.Entry {
+	if len(terms) == 0 {
+		return nil
+	}
 	index := uint64(i)
 	entries := make([]pb.Entry, 0, len(terms))
 	for _, term := range terms {
@@ -1024,4 +1000,19 @@ func (i index) termRange(from, to uint64) []pb.Entry {
 		index++
 	}
 	return entries
+}
+
+// terms generates a logSlice of entries appended after the given entry ID, at
+// indices [id.index+1, id.index+len(terms)], with the given terms of each
+// entry. Terms must be >= id.term, and non-decreasing.
+func (id entryID) terms(terms ...uint64) logSlice {
+	term := id.term
+	if ln := len(terms); ln != 0 {
+		term = terms[ln-1]
+	}
+	return logSlice{
+		term:    term,
+		prev:    id,
+		entries: index(id.index + 1).terms(terms...),
+	}
 }

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -204,16 +204,11 @@ func TestAppend(t *testing.T) {
 	}
 }
 
-// TestLogMaybeAppend ensures:
-// If the given (index, term) matches with the existing log:
-//  1. If an existing entry conflicts with a new one (same index
-//     but different terms), delete the existing entry and all that
-//     follow it
-//     2.Append any new entries not already in the log
-//
-// If the given (index, term) does not match with the existing log:
-//
-//	return false
+// TestLogMaybeAppend tests the behaviour of maybeAppend method:
+//  1. The request is rejected if the "previous entry" check fails, when the
+//     corresponding entry is missing or has a mismatching term.
+//  2. If the request is accepted, the slice is appended to the log, and all the
+//     entries at higher indices are truncated.
 func TestLogMaybeAppend(t *testing.T) {
 	previousEnts := index(1).terms(1, 2, 3)
 	lastindex := uint64(3)
@@ -222,87 +217,54 @@ func TestLogMaybeAppend(t *testing.T) {
 
 	// TODO(pav-kv): clean-up this test.
 	tests := []struct {
-		prev      entryID
-		committed uint64
-		ents      []pb.Entry
+		prev entryID
+		ents []pb.Entry
 
 		wappend bool
-		wcommit uint64
 		wpanic  bool
 	}{
 		// not match: term is different
 		{
-			entryID{term: lastterm - 1, index: lastindex}, lastindex,
+			entryID{term: lastterm - 1, index: lastindex},
 			index(lastindex + 1).terms(4),
-			false, commit, false,
+			false, false,
 		},
 		// not match: index out of bound
 		{
-			entryID{term: lastterm, index: lastindex + 1}, lastindex,
+			entryID{term: lastterm, index: lastindex + 1},
 			index(lastindex + 2).terms(4),
-			false, commit, false,
+			false, false,
 		},
 		// match with the last existing entry
 		{
-			entryID{term: lastterm, index: lastindex}, lastindex, nil,
-			true, lastindex, false,
+			entryID{term: lastterm, index: lastindex}, nil,
+			true, false,
 		},
 		{
-			entryID{term: lastterm, index: lastindex}, lastindex + 1, nil,
-			true, lastindex, false, // do not increase commit higher than lastnewi
-		},
-		{
-			entryID{term: lastterm, index: lastindex}, lastindex - 1, nil,
-			true, lastindex - 1, false, // commit up to the commit in the message
-		},
-		{
-			entryID{term: lastterm, index: lastindex}, 0, nil,
-			true, commit, false, // commit do not decrease
-		},
-		{
-			entryID{}, lastindex, nil,
-			true, commit, false, // commit do not decrease
-		},
-		{
-			entryID{term: lastterm, index: lastindex}, lastindex,
+			entryID{term: lastterm, index: lastindex},
 			index(lastindex + 1).terms(4),
-			true, lastindex, false,
+			true, false,
+		},
+		// match with an entry before the last one
+		{
+			entryID{}, nil,
+			true, false,
 		},
 		{
-			entryID{term: lastterm, index: lastindex}, lastindex + 1,
-			index(lastindex + 1).terms(4),
-			true, lastindex + 1, false,
-		},
-		{
-			entryID{term: lastterm, index: lastindex}, lastindex + 2,
-			index(lastindex + 1).terms(4),
-			true, lastindex + 1, false, // do not increase commit higher than lastnewi
-		},
-		{
-			entryID{term: lastterm, index: lastindex}, lastindex + 2,
-			index(lastindex+1).terms(4, 4),
-			true, lastindex + 2, false,
-		},
-		// match with the entry in the middle
-		{
-			entryID{term: lastterm - 1, index: lastindex - 1}, lastindex,
+			entryID{term: lastterm - 1, index: lastindex - 1},
 			index(lastindex).terms(4),
-			true, lastindex, false,
+			true, false,
 		},
 		{
-			entryID{term: lastterm - 2, index: lastindex - 2}, lastindex,
+			entryID{term: lastterm - 2, index: lastindex - 2},
 			index(lastindex - 1).terms(4),
-			true, lastindex - 1, false,
+			true, false,
 		},
+		// panic
 		{
-			entryID{term: lastterm - 3, index: lastindex - 3}, lastindex,
+			entryID{term: lastterm - 3, index: lastindex - 3},
 			index(lastindex - 2).terms(4),
-			true, lastindex - 2, true, // conflict with existing committed entry
-		},
-		{
-			entryID{term: lastterm - 2, index: lastindex - 2}, lastindex,
-			index(lastindex-1).terms(4, 4),
-			true, lastindex, false,
+			true, true, // conflict with existing committed entry
 		},
 	}
 
@@ -329,10 +291,7 @@ func TestLogMaybeAppend(t *testing.T) {
 			}()
 			gappend := raftLog.maybeAppend(app)
 			require.Equal(t, tt.wappend, gappend)
-			if gappend {
-				raftLog.commitTo(min(app.lastIndex(), tt.committed))
-			}
-			require.Equal(t, tt.wcommit, raftLog.committed)
+			require.Equal(t, commit, raftLog.committed) // commit index did not change
 			if gappend && len(tt.ents) != 0 {
 				gents, err := raftLog.slice(raftLog.lastIndex()-uint64(len(tt.ents))+1, raftLog.lastIndex()+1, noLimit)
 				require.NoError(t, err)


### PR DESCRIPTION
`TestLogMaybeAppend` was testing both `maybeAppend` and `commitTo` methods. The latter is already tested in `TestCommitTo`, so we don't need to test both and have combinatorial explosion in `TestLogMaybeAppend`.

This PR minimizes the test, and makes the checks in it stronger (verify the entire content of the log instead of just a sub-slice).

This is a prerequisite for further clean-ups around `maybeAppend`, `commitTo` and the corresponding tests.

Related to #126320
Epic: none
Release note: none