### PR TITLE
release-24.1: opt: check privileges after object resolution for staleness checks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1374,4 +1374,99 @@ SELECT database_name, schema_name, grantee, privilege_type FROM [SHOW GRANTS ON 
 ----
 should_not_have_create  public  public  USAGE
 
+statement ok
+RESET CLUSTER SETTING sql.auth.public_schema_create_privilege.enabled
+
+subtest end
+
+# Regression test for #126244: during Memo staleness checking, check object
+# resolution before privileges, to avoid spurious privilege errors.
+subtest check_privileges_after_resolution
+
+statement ok
+create database foo;
+
+statement ok
+create database bar;
+
+statement ok
+create user foo_user;
+
+statement ok
+create user bar_user;
+
+statement ok
+create ROLE foo_role;
+
+statement ok
+create ROLE bar_role;
+
+statement ok
+use foo;
+
+statement ok
+CREATE TABLE baz (
+  id   int NOT NULL,
+  name varchar NOT NULL,
+  PRIMARY KEY (id)
+);
+
+statement ok
+CREATE FUNCTION qux() RETURNS void LANGUAGE SQL AS $$
+    SELECT * FROM baz;
+$$;
+
+statement ok
+ALTER TABLE baz OWNER TO foo_role;
+
+statement ok
+use bar;
+
+statement ok
+CREATE TABLE baz (
+  id   int NOT NULL,
+  name varchar NOT NULL,
+  PRIMARY KEY (id)
+);
+
+statement ok
+CREATE FUNCTION qux() RETURNS void LANGUAGE SQL AS $$
+    SELECT * FROM baz;
+$$;
+
+statement ok
+ALTER TABLE baz OWNER TO bar_role;
+
+statement ok
+GRANT foo_role TO foo_user;
+
+statement ok
+GRANT bar_role TO bar_user;
+
+statement ok
+use foo;
+set role foo_user;
+
+query IT rowsort
+select * from baz;
+----
+
+query T
+SELECT qux();
+----
+NULL
+
+statement ok
+use bar;
+set role bar_user;
+
+query IT rowsort
+select * from baz;
+----
+
+query T
+SELECT qux();
+----
+NULL
+
 subtest end

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -404,11 +404,6 @@ func (md *Metadata) CheckDependencies(
 		}
 	}
 
-	// Ensure that all required privileges for the data sources are still valid.
-	if err := md.checkDataSourcePrivileges(ctx, optCatalog); err != nil {
-		return false, err
-	}
-
 	// Check that no referenced user defined types have changed.
 	for _, typ := range md.AllUserDefinedTypes() {
 		id := cat.StableID(catid.UserDefinedOIDToID(typ.Oid()))
@@ -488,14 +483,6 @@ func (md *Metadata) CheckDependencies(
 		}
 	}
 
-	// Check that the role still has execution privilege on the user defined
-	// functions.
-	for _, dep := range md.udfDeps {
-		if err := optCatalog.CheckExecutionPrivilege(ctx, dep.overload.Oid); err != nil {
-			return false, err
-		}
-	}
-
 	// Check that any references to builtin functions do not now resolve to a UDF
 	// with the same signature (e.g. after changes to the search path).
 	for name := range md.builtinRefsByName {
@@ -509,6 +496,21 @@ func (md *Metadata) CheckDependencies(
 			if definition.Overloads[i].Type == tree.UDFRoutine {
 				return false, nil
 			}
+		}
+	}
+
+	// Check that the role still has the required privileges for the data sources
+	// and routines.
+	//
+	// NOTE: this check has to happen after the object resolution checks, or else
+	// we may end up returning a privilege error when the memo should have just
+	// been invalidated.
+	if err := md.checkDataSourcePrivileges(ctx, optCatalog); err != nil {
+		return false, err
+	}
+	for _, dep := range md.udfDeps {
+		if err := optCatalog.CheckExecutionPrivilege(ctx, dep.overload.Oid); err != nil {
+			return false, err
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #126349.

/cc @cockroachdb/release

---

Before a query plan can be reused from the query cache, it is necessary to check that all references still resolve to the same database objects, and that the current user has the required permissions on those objects. Since v22.2, we've checked data source permissions before checking object resolution for routines.

This could lead to the following bug in the query cache:
1. There are two databases, each with their own user. Each user has permissions only for its own database.
2. Both databases have a table with the same name.
3. Both databases have a routine with the same signature, which references the table from (2).
4. A SQL query that invokes the routine is executed against both databases.

With all the above conditions fulfilled, the plan for the query would be cached for one database. Then, when the query was executed against the other database, we would check that the table from the previous database still exists (it does), and then that the current user has the required permissions (it doesn't). This would cause a spurious permission error.

This patch fixes the bug by moving all privilege checks after the object resolution checks. This ensures that the query plan is invalidated in cases like the one above, with no spurious error returned to the user.

Fixes #126244

Release note (bug fix): Fixed a bug that could cause spurious user permission errors when multiple databases shared a common schema with a routine referencing a table. The bug has existed since UDFs were introduced in v22.2.

---

Release justification: correctness bug fix