### PR TITLE
release-23.1: opt: check privileges after object resolution for staleness checks

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3769,9 +3769,11 @@ func (t *logicTest) validateAfterTestCompletion() error {
 	// txn and second we reset vectorize mode in case it was switched to
 	// `experimental_always`.
 	_, _ = t.db.Exec("ROLLBACK")
-	_, err := t.db.Exec("RESET vectorize")
-	if err != nil {
+	if _, err := t.db.Exec("RESET vectorize"); err != nil {
 		t.Fatal(errors.Wrap(err, "could not reset vectorize mode"))
+	}
+	if _, err := t.db.Exec("RESET ROLE"); err != nil {
+		t.Fatal(errors.Wrap(err, "could not reset role"))
 	}
 
 	validate := func() (string, error) {

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1324,3 +1324,95 @@ DROP DATABASE testdb1 CASCADE;
 DROP DATABASE testdb2 CASCADE;
 
 subtest end
+
+# Regression test for #126244: during Memo staleness checking, check object
+# resolution before privileges, to avoid spurious privilege errors.
+subtest check_privileges_after_resolution
+
+statement ok
+create database foo;
+
+statement ok
+create database bar;
+
+statement ok
+create user foo_user;
+
+statement ok
+create user bar_user;
+
+statement ok
+create ROLE foo_role;
+
+statement ok
+create ROLE bar_role;
+
+statement ok
+use foo;
+
+statement ok
+CREATE TABLE baz (
+  id   int NOT NULL,
+  name varchar NOT NULL,
+  PRIMARY KEY (id)
+);
+
+statement ok
+CREATE FUNCTION qux() RETURNS void LANGUAGE SQL AS $$
+    SELECT * FROM baz;
+$$;
+
+statement ok
+ALTER TABLE baz OWNER TO foo_role;
+
+statement ok
+use bar;
+
+statement ok
+CREATE TABLE baz (
+  id   int NOT NULL,
+  name varchar NOT NULL,
+  PRIMARY KEY (id)
+);
+
+statement ok
+CREATE FUNCTION qux() RETURNS void LANGUAGE SQL AS $$
+    SELECT * FROM baz;
+$$;
+
+statement ok
+ALTER TABLE baz OWNER TO bar_role;
+
+statement ok
+GRANT foo_role TO foo_user;
+
+statement ok
+GRANT bar_role TO bar_user;
+
+statement ok
+use foo;
+set role foo_user;
+
+query IT rowsort
+select * from baz;
+----
+
+query T
+SELECT qux();
+----
+NULL
+
+statement ok
+use bar;
+set role bar_user;
+
+query IT rowsort
+select * from baz;
+----
+
+query T
+SELECT qux();
+----
+NULL
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #126349.
Backport 1/2 commits from #107626.

/cc @cockroachdb/release

---

Before a query plan can be reused from the query cache, it is necessary to check that all references still resolve to the same database objects, and that the current user has the required permissions on those objects. Since v22.2, we've checked data source permissions before checking object resolution for routines.

This could lead to the following bug in the query cache:
1. There are two databases, each with their own user. Each user has permissions only for its own database.
2. Both databases have a table with the same name.
3. Both databases have a routine with the same signature, which references the table from (2).
4. A SQL query that invokes the routine is executed against both databases.

With all the above conditions fulfilled, the plan for the query would be cached for one database. Then, when the query was executed against the other database, we would check that the table from the previous database still exists (it does), and then that the current user has the required permissions (it doesn't). This would cause a spurious permission error.

This patch fixes the bug by moving all privilege checks after the object resolution checks. This ensures that the query plan is invalidated in cases like the one above, with no spurious error returned to the user.

Fixes #126244

Release note (bug fix): Fixed a bug that could cause spurious user permission errors when multiple databases shared a common schema with a routine referencing a table. The bug has existed since UDFs were introduced in v22.2.

---

logictest: reset role before doing post-test checks

This makes sure we run the checks with the root user.

Release note: None

---

Release justification: correctness bug fix