### PR TITLE
release-23.1: cluster-ui: fix "stats last created" query in table details using sql-over-http

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1153,14 +1153,14 @@ func (s *adminServer) tableDetailsHelper(
 	row, cols, err = s.internalExecutor.QueryRowExWithCols(
 		ctx, "admin-show-statistics", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: userName},
-		fmt.Sprintf("SELECT max(created) AS created FROM [SHOW STATISTICS FOR TABLE %s]", escQualTable),
+		fmt.Sprintf("SELECT max(created) AS stats_last_created_at FROM [SHOW STATISTICS FOR TABLE %s]", escQualTable),
 	)
 	if err != nil {
 		return nil, err
 	}
 	if row != nil {
 		scanner := makeResultScanner(cols)
-		const createdCol = "created"
+		const createdCol = "stats_last_created_at"
 		var createdTs *time.Time
 		if err := scanner.Scan(row, createdCol, &createdTs); err != nil {
 			return nil, err

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -901,7 +901,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 			// Verify statistics last updated.
 			{
 
-				showStatisticsForTableQuery := fmt.Sprintf("SELECT max(created) AS created FROM [SHOW STATISTICS FOR TABLE %s.%s]", escDBName, tblName)
+				showStatisticsForTableQuery := fmt.Sprintf("SELECT max(created) AS stats_last_created_at FROM [SHOW STATISTICS FOR TABLE %s.%s]", escDBName, tblName)
 
 				row := db.QueryRow(showStatisticsForTableQuery)
 				var createdTs time.Time

--- a/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
@@ -344,7 +344,7 @@ const getTableHeuristicsDetails: TableDetailsQuery<TableHeuristicDetailsRow> = {
     );
     return {
       sql: Format(
-        `SELECT max(created) AS created FROM [SHOW STATISTICS FOR TABLE %1]`,
+        `SELECT max(created) AS stats_last_created_at FROM [SHOW STATISTICS FOR TABLE %1]`,
         [escFullTableName],
       ),
     };


### PR DESCRIPTION
Backport 1/1 commits from #122761.

/cc @cockroachdb/release

---

This commit fixes the "stats last created" query in the database details and table details page of the cluster-ui. The query was using the wrong name for the aggregation alias, which was confusing the row parsing logic. As a result, the two pages were always displaying "No table statistics found". They now display the correct value.

We mirror the change to the query string in `adminServer. tableDetailsHelper` for uniformity.

### Before

`/database/movr`

<img width="1364" alt="Screenshot 2024-04-20 at 4 28 30 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/f069cb63-53fa-4021-992c-22a4bb198818">


`/database/movr/table/"public"."promo_codes"`

<img width="1173" alt="Screenshot 2024-04-20 at 4 29 09 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/b2c9d290-9c19-4b7f-a0ab-f9d4134d880c">


### After

`/database/movr`

<img width="1361" alt="Screenshot 2024-04-20 at 4 30 10 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/e6cc23c9-bcf7-4499-89d7-9789285bad17">


`/database/movr/table/"public"."promo_codes"`

<img width="1162" alt="Screenshot 2024-04-20 at 4 29 41 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/1efdc0cf-54b4-469a-ad61-1713f444ab00">

----

Epic: None

Release note (ui change): the database details and table details pages in the cluster-ui now display the correct "stats last created" value.
