### PR TITLE
release-23.2: sql: fix nil pointer caused by "".crdb_internal.create_statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1227,6 +1227,30 @@ SELECT is_temporary FROM crdb_internal.create_statements WHERE descriptor_name =
 ----
 true
 
+statement ok
+CREATE TABLE defaultdb.public.in_other_db (x INT PRIMARY KEY);
+CREATE TABLE public.in_this_db (x INT PRIMARY KEY);
+
+# Verify that we can inspect all databases by using "" as the database name.
+query TTT colnames
+SELECT database_name, schema_name, descriptor_name
+FROM "".crdb_internal.create_statements
+WHERE descriptor_name IN ('in_other_db', 'in_this_db')
+ORDER BY 1,2,3
+----
+database_name  schema_name  descriptor_name
+defaultdb      public       in_other_db
+test           public       in_this_db
+
+# Also verify that using the virtul index on descriptor_id works.
+query TTT colnames
+SELECT database_name, schema_name, descriptor_name
+FROM "".crdb_internal.create_statements
+WHERE descriptor_id = 'defaultdb.public.in_other_db'::regclass::int
+----
+database_name  schema_name  descriptor_name
+defaultdb      public       in_other_db
+
 query TT
 SELECT * FROM crdb_internal.regions ORDER BY 1
 ----
@@ -1590,17 +1614,17 @@ FROM crdb_internal.create_procedure_statements
 WHERE procedure_name IN ('p', 'p2')
 ORDER BY procedure_id;
 ----
-104  test  105  public  137  p   CREATE PROCEDURE public.p(IN INT8)
+104  test  105  public  139  p   CREATE PROCEDURE public.p(IN INT8)
                                    LANGUAGE SQL
                                    AS $$
                                    SELECT 1;
                                  $$
-104  test  105  public  138  p   CREATE PROCEDURE public.p(IN STRING, IN b INT8)
+104  test  105  public  140  p   CREATE PROCEDURE public.p(IN STRING, IN b INT8)
                                    LANGUAGE SQL
                                    AS $$
                                    SELECT 'hello';
                                  $$
-104  test  140  sc      141  p2  CREATE PROCEDURE sc.p2(IN STRING)
+104  test  142  sc      143  p2  CREATE PROCEDURE sc.p2(IN STRING)
                                    LANGUAGE SQL
                                    AS $$
                                    SELECT 'hello';
@@ -1620,22 +1644,22 @@ FROM "".crdb_internal.create_procedure_statements
 WHERE procedure_name IN ('p', 'p2', 'p_cross_db')
 ORDER BY procedure_id;
 ----
-104  test           105  public  137  p           CREATE PROCEDURE public.p(IN INT8)
+104  test           105  public  139  p           CREATE PROCEDURE public.p(IN INT8)
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 1;
                                                   $$
-104  test           105  public  138  p           CREATE PROCEDURE public.p(IN STRING, IN b INT8)
+104  test           105  public  140  p           CREATE PROCEDURE public.p(IN STRING, IN b INT8)
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 'hello';
                                                   $$
-104  test           140  sc      141  p2          CREATE PROCEDURE sc.p2(IN STRING)
+104  test           142  sc      143  p2          CREATE PROCEDURE sc.p2(IN STRING)
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 'hello';
                                                   $$
-142  test_cross_db  143  public  144  p_cross_db  CREATE PROCEDURE public.p_cross_db()
+144  test_cross_db  145  public  146  p_cross_db  CREATE PROCEDURE public.p_cross_db()
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 1;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1180,7 +1180,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 		indexes: []virtualIndex{
 			{
 				incomplete: includesIndexEntries,
-				populate: func(ctx context.Context, unwrappedConstraint tree.Datum, p *planner, db catalog.DatabaseDescriptor,
+				populate: func(ctx context.Context, unwrappedConstraint tree.Datum, p *planner, dbContext catalog.DatabaseDescriptor,
 					addRow func(...tree.Datum) error) (bool, error) {
 					var id descpb.ID
 					switch t := unwrappedConstraint.(type) {
@@ -1214,7 +1214,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					}
 					// Don't include tables that aren't in the current database unless
 					// they're virtual, dropped tables, or ones that the user can't see.
-					canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, db, true /*allowAdding*/)
+					canSeeDescriptor, err := userCanSeeDescriptor(ctx, p, table, dbContext, true /*allowAdding*/)
 					if err != nil {
 						return false, err
 					}
@@ -1222,7 +1222,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					// or are dropped. From a virtual index viewpoint, we will consider
 					// this result set as populated, since the underlying full table will
 					// also skip the same descriptors.
-					if (!table.IsVirtualTable() && table.GetParentID() != db.GetID()) ||
+					if (!table.IsVirtualTable() && dbContext != nil && table.GetParentID() != dbContext.GetID()) ||
 						table.Dropped() || !canSeeDescriptor {
 						return true, nil
 					}
@@ -1234,7 +1234,7 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 						// Ideally, the catalog API would be able to return the temporary
 						// schemas from other sessions, but it cannot right now. See
 						// https://github.com/cockroachdb/cockroach/issues/97822.
-						if err := forEachSchema(ctx, p, db, false /* requiresPrivileges*/, func(schema catalog.SchemaDescriptor) error {
+						if err := forEachSchema(ctx, p, dbContext, false /* requiresPrivileges*/, func(schema catalog.SchemaDescriptor) error {
 							if schema.GetID() == table.GetParentSchemaID() {
 								sc = schema
 							}
@@ -1245,6 +1245,13 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					}
 					if sc == nil {
 						sc, err = p.Descriptors().ByIDWithLeased(p.txn).WithoutNonPublic().Get().Schema(ctx, table.GetParentSchemaID())
+						if err != nil {
+							return false, err
+						}
+					}
+					db := dbContext
+					if db == nil {
+						db, err = p.Descriptors().ByIDWithLeased(p.txn).WithoutNonPublic().Get().Database(ctx, table.GetParentID())
 						if err != nil {
 							return false, err
 						}


### PR DESCRIPTION
Backport 1/1 commits from #126409.

/cc @cockroachdb/release

Release justification: bug fix for a panic

---

When querying crdb_internal, "" can be used as the database name so that the result includes information from all databases rather than just the current one.

This could cause a nil pointer for tables backed by the populateVirtualIndexForTable helper. This is now fixed.

Since this is an internal-only undocumented feature, there is no release note.

Epic: None
Release note: None
