### PR TITLE
release-23.1: sql: fix nil pointer caused by "".crdb_internal.create_statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1212,6 +1212,30 @@ SELECT is_temporary FROM crdb_internal.create_statements WHERE descriptor_name =
 ----
 true
 
+statement ok
+CREATE TABLE defaultdb.public.in_other_db (x INT PRIMARY KEY);
+CREATE TABLE public.in_this_db (x INT PRIMARY KEY);
+
+# Verify that we can inspect all databases by using "" as the database name.
+query TTT colnames
+SELECT database_name, schema_name, descriptor_name
+FROM "".crdb_internal.create_statements
+WHERE descriptor_name IN ('in_other_db', 'in_this_db')
+ORDER BY 1,2,3
+----
+database_name  schema_name  descriptor_name
+defaultdb      public       in_other_db
+test           public       in_this_db
+
+# Also verify that using the virtul index on descriptor_id works.
+query TTT colnames
+SELECT database_name, schema_name, descriptor_name
+FROM "".crdb_internal.create_statements
+WHERE descriptor_id = 'defaultdb.public.in_other_db'::regclass::int
+----
+database_name  schema_name  descriptor_name
+defaultdb      public       in_other_db
+
 query TT
 SELECT * FROM crdb_internal.regions ORDER BY 1
 ----


### PR DESCRIPTION
Backport 1/1 commits from #126409.

/cc @cockroachdb/release

Release justification: bug fix for a panic

---

When querying crdb_internal, "" can be used as the database name so that the result includes information from all databases rather than just the current one.

This could cause a nil pointer for tables backed by the populateVirtualIndexForTable helper. This is now fixed.

Since this is an internal-only undocumented feature, there is no release note.

Epic: None
Release note: None
