### PR TITLE
roachtest: default to us-central1 when using ARM64

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -3070,9 +3070,11 @@ func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSp
 		arch = vm.ArchAMD64
 	}
 	if roachtestflags.Cloud == spec.GCE && arch == vm.ArchARM64 {
-		// N.B. T2A support is rather limited, both in terms of supported regions and no local SSDs. Thus, we must
-		// fall back to AMD64 in those cases. See #122035.
-		if !gce.IsSupportedT2AZone(strings.Split(testSpec.Cluster.GCE.Zones, ",")) {
+		// N.B. T2A support is rather limited, both in terms of supported
+		// regions and no local SSDs. Thus, we must fall back to AMD64 in
+		// those cases. See #122035.
+		if testSpec.Cluster.GCE.Zones != "" &&
+			!gce.IsSupportedT2AZone(strings.Split(testSpec.Cluster.GCE.Zones, ",")) {
 			l.PrintfCtx(ctx, "%q specified one or more GCE regions unsupported by T2A, falling back to AMD64; see #122035", testSpec.Name)
 			return vm.ArchAMD64
 		}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -959,11 +959,16 @@ type ProjectsVal struct {
 // https://cloud.google.com/compute/docs/regions-zones#available
 //
 // Note that the default zone (the first zone returned by this
-// function) is always in the us-east1 region, but we randomize the
-// specific zone. This is to avoid "zone exhausted" errors in one
-// particular zone, especially during nightly roachtest runs.
-func defaultZones() []string {
+// function) is always in the us-east1 region (or us-central1 for
+// ARM64 builds), but we randomize the specific zone. This is to avoid
+// "zone exhausted" errors in one particular zone, especially during
+// nightly roachtest runs.
+func defaultZones(arch string) []string {
 	zones := []string{"us-east1-b", "us-east1-c", "us-east1-d"}
+	if vm.ParseArch(arch) == vm.ArchARM64 {
+		// T2A instances are only available in us-central1 in NA.
+		zones = []string{"us-central1-a", "us-central1-b", "us-central1-f"}
+	}
 	rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
 
 	return []string{
@@ -1058,7 +1063,7 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		fmt.Sprintf("Zones for cluster. If zones are formatted as AZ:N where N is an integer, the zone\n"+
 			"will be repeated N times. If > 1 zone specified, nodes will be geo-distributed\n"+
 			"regardless of geo (default [%s])",
-			strings.Join(defaultZones(), ",")))
+			strings.Join(defaultZones(string(vm.ArchAMD64)), ",")))
 	flags.BoolVar(&o.preemptible, ProviderName+"-preemptible", false,
 		"use preemptible GCE instances (lifetime cannot exceed 24h)")
 	flags.BoolVar(&o.UseSpot, ProviderName+"-use-spot", false,
@@ -1263,9 +1268,9 @@ func computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, err
 	}
 	if len(zones) == 0 {
 		if opts.GeoDistributed {
-			zones = defaultZones()
+			zones = defaultZones(opts.Arch)
 		} else {
-			zones = []string{defaultZones()[0]}
+			zones = []string{defaultZones(opts.Arch)[0]}
 		}
 	}
 	if providerOpts.useArmAMI() {


### PR DESCRIPTION
Previously, the GCE implementation would choose a random zone in the `us-east1` region. However, T2A VMs are not available in those zones. As a result, the test runner would always fall back to n2 instances in those cases. In other words, unless the test went out of its way to specify a custom GCE zone that happened to support T2A instances, we would never test ARM64 builds on GCE.

In this commit, we change the default set of zones to take the desired architecture into account.

Epic: none

Release note: None