### PR TITLE
workload: fix incorrect tpcc check command

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -336,7 +336,7 @@ func runTPCC(
 	m.Wait()
 
 	if !opts.SkipPostRunCheck {
-		cmd := roachtestutil.NewCommand("%s workload check %s", opts.getWorkloadCmd(), test.DefaultCockroachPath).
+		cmd := roachtestutil.NewCommand("%s workload check %s", test.DefaultCockroachPath, opts.getWorkloadCmd()).
 			MaybeFlag(opts.DB != "", "db", opts.DB).
 			MaybeOption(opts.ExpensiveChecks, "expensive-checks").
 			Flag("warehouses", opts.Warehouses).


### PR DESCRIPTION
Previously, when adding support for invoking a different tpcc worload commands, the check operation was accidentally regressed by generating an invalid command (due to an incorrect argument order). To address, this patch will generate a valid check command.

Fixes: #126443
Fixes: #126451
Fixes: #126447
Fixes: #126446
Fixes: #126443
Fixes: #126442
Fixes: #126440,
Fixes: #126439
Fixes: #126438
Fixes: #126437
Fixes: #126436
Fixes: #126435
Fixes: #126454

Release note: None