### PR TITLE
builtins: delete start_logical_replication_job

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/jobs/jobsprofiler",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/repstream",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/server/telemetry",

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -65,7 +65,7 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 				startLDR := func(targetDB *sqlutils.SQLRunner, sourceURL string) int {
 					targetDB.Exec(t, "USE kv")
 					r := targetDB.QueryRow(t,
-						"SELECT crdb_internal.start_logical_replication_job($1, ARRAY['kv'])",
+						"CREATE LOGICAL REPLICATION STREAM FROM TABLE kv ON $1 INTO TABLE kv",
 						sourceURL,
 					)
 					var jobID int

--- a/pkg/repstream/BUILD.bazel
+++ b/pkg/repstream/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/repstream",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/repstream/streampb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/resolver",
         "//pkg/sql/clusterunique",

--- a/pkg/repstream/api.go
+++ b/pkg/repstream/api.go
@@ -13,7 +13,6 @@ package repstream
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
@@ -29,8 +28,6 @@ var GetReplicationStreamManagerHook func(ctx context.Context, evalCtx *eval.Cont
 // GetStreamIngestManagerHook is the hook to get access to the ingestion side replication APIs.
 // Used by builtin functions to trigger streaming replication.
 var GetStreamIngestManagerHook func(ctx context.Context, evalCtx *eval.Context, txn isql.Txn, sessionID clusterunique.ID) (eval.StreamIngestManager, error)
-
-var CreateRemoteProduceJobForLogicalReplicationHook func(ctx context.Context, srcAddr string, tableNames []string) (*streampb.ReplicationProducerSpec, error)
 
 // GetReplicationStreamManager returns a ReplicationStreamManager if a CCL binary is loaded.
 func GetReplicationStreamManager(
@@ -54,13 +51,4 @@ func GetStreamIngestManager(
 		return nil, errors.New("replication streaming requires a CCL binary")
 	}
 	return GetStreamIngestManagerHook(ctx, evalCtx, txn, sessionID)
-}
-
-func CreateRemoteProduceJobForLogicalReplication(
-	ctx context.Context, srcAddr string, tableNames []string,
-) (*streampb.ReplicationProducerSpec, error) {
-	if CreateRemoteProduceJobForLogicalReplicationHook == nil {
-		return nil, errors.New("replication streaming requires a CCL binary")
-	}
-	return CreateRemoteProduceJobForLogicalReplicationHook(ctx, srcAddr, tableNames)
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -362,12 +362,6 @@ func (p *DummyEvalPlanner) ExtendHistoryRetention(ctx context.Context, id jobspb
 	return errors.WithStack(errEvalPlanner)
 }
 
-func (p *DummyEvalPlanner) StartLogicalReplicationJob(
-	ctx context.Context, targetConnStr string, tableNames []string,
-) (jobspb.JobID, error) {
-	return 0, errors.WithStack(errEvalPlanner)
-}
-
 var _ eval.Planner = &DummyEvalPlanner{}
 
 var errEvalPlanner = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4417,38 +4417,6 @@ value if you rely on the HLC for accuracy.`,
 			Info:       "Write the content passed to a file at the supplied external storage URI",
 			Volatility: volatility.Volatile,
 		}),
-	// TODO(ssd): This function to be replaced with SQL syntax.
-	"crdb_internal.start_logical_replication_job": makeBuiltin(
-		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
-		},
-		tree.Overload{
-			Types: tree.ParamTypes{
-				{Name: "conn_str", Typ: types.String},
-				{Name: "table_names", Typ: types.StringArray},
-			},
-			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := evalCtx.SessionAccessor.CheckPrivilege(
-					ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPLICATION,
-				); err != nil {
-					return nil, err
-				}
-				targetConnStr := string(tree.MustBeDString(args[0]))
-				tableNameArray := tree.MustBeDArray(args[1])
-				tables := make([]string, len(tableNameArray.Array))
-				for i, tableName := range tableNameArray.Array {
-					tables[i] = string(tree.MustBeDString(tableName))
-				}
-
-				jobId, err := evalCtx.Planner.StartLogicalReplicationJob(ctx, targetConnStr, tables)
-
-				return tree.NewDInt(tree.DInt(jobId)), err
-			},
-			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility: volatility.Volatile,
-		},
-	),
 
 	"crdb_internal.datums_to_bytes": makeBuiltin(
 		tree.FunctionProperties{

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2581,9 +2581,8 @@ var builtinOidsArray = []string{
 	2613: `crdb_internal.split_at(key: bytes, ttl: interval) -> void`,
 	2614: `crdb_internal.scatter(key: bytes) -> void`,
 	2615: `crdb_internal.scatter(key: bytes, end_key: bytes) -> void`,
-	2616: `crdb_internal.start_logical_replication_job(conn_str: string, table_names: string[]) -> int`,
-	2617: `crdb_internal.plan_logical_replication(req: bytes) -> bytes`,
-	2618: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
+	2616: `crdb_internal.plan_logical_replication(req: bytes) -> bytes`,
+	2617: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -451,8 +451,6 @@ type Planner interface {
 	InsertTemporarySchema(
 		tempSchemaName string, databaseID descpb.ID, schemaID descpb.ID,
 	)
-
-	StartLogicalReplicationJob(ctx context.Context, targetConnStr string, tableNames []string) (jobspb.JobID, error)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal


### PR DESCRIPTION
Release note: none.
Epic: none.