### PR TITLE
crosscluster/logical: rename user-created LWW column to avoid crdb_internal

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -58,7 +58,7 @@ var (
 
 		"SET CLUSTER SETTING logical_replication.consumer.job_checkpoint_frequency = '100ms'",
 	}
-	lwwColumnAdd = "ALTER TABLE tab ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
+	lwwColumnAdd = "ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
 )
 
 func TestLogicalStreamIngestionJob(t *testing.T) {
@@ -133,8 +133,8 @@ func TestLogicalStreamIngestionJob(t *testing.T) {
 	createStmt := "CREATE TABLE tab (pk int primary key, payload string)"
 	dbA.Exec(t, createStmt)
 	dbB.Exec(t, createStmt)
-	dbA.Exec(t, lwwColumnAdd)
-	dbB.Exec(t, lwwColumnAdd)
+	dbA.Exec(t, "ALTER TABLE tab "+lwwColumnAdd)
+	dbB.Exec(t, "ALTER TABLE tab "+lwwColumnAdd)
 
 	desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "a", "tab")
 	keyPrefix = rowenc.MakeIndexKeyPrefix(s.Codec(), desc.GetID(), desc.GetPrimaryIndexID())
@@ -223,7 +223,7 @@ func TestLogicalStreamIngestionErrors(t *testing.T) {
 
 	dbB.ExpectErrWithHint(t, "currently require a .* DECIMAL column", "ADD COLUMN", createQ, urlA)
 
-	dbB.Exec(t, "ALTER TABLE tab ADD COLUMN crdb_internal_origin_timestamp STRING")
+	dbB.Exec(t, "ALTER TABLE tab ADD COLUMN crdb_replication_origin_timestamp STRING")
 	dbB.ExpectErr(t, ".*column must be type DECIMAL for use by logical replication", createQ, urlA)
 
 	dbB.Exec(t, fmt.Sprintf("ALTER TABLE tab RENAME COLUMN %[1]s TO str_col, ADD COLUMN %[1]s DECIMAL", originTimestampColumnName))
@@ -275,8 +275,8 @@ family f2(other_payload, v2))
 `
 	serverASQL.Exec(t, createStmt)
 	serverBSQL.Exec(t, createStmt)
-	serverASQL.Exec(t, lwwColumnAdd)
-	serverBSQL.Exec(t, lwwColumnAdd)
+	serverASQL.Exec(t, "ALTER TABLE tab "+lwwColumnAdd)
+	serverBSQL.Exec(t, "ALTER TABLE tab "+lwwColumnAdd)
 
 	serverASQL.Exec(t, "INSERT INTO tab(pk, payload, other_payload) VALUES (1, 'hello', 'ruroh1')")
 
@@ -350,9 +350,7 @@ func TestRandomTables(t *testing.T) {
 		sqlA, tableName, numInserts, nil)
 	require.NoError(t, err)
 
-	addCol := fmt.Sprintf(
-		`ALTER TABLE %s ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL`,
-		tableName)
+	addCol := fmt.Sprintf(`ALTER TABLE %s `+lwwColumnAdd, tableName)
 	runnerA.Exec(t, addCol)
 	runnerB.Exec(t, addCol)
 
@@ -425,9 +423,7 @@ func TestPreviouslyInterestingTables(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tableName := fmt.Sprintf("%s%d", baseTableName, i)
 			schemaStmt := strings.ReplaceAll(tc.schema, baseTableName, tableName)
-			addCol := fmt.Sprintf(
-				`ALTER TABLE %s ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL`,
-				tableName)
+			addCol := fmt.Sprintf(`ALTER TABLE %s `+lwwColumnAdd, tableName)
 			runnerA.Exec(t, schemaStmt)
 			runnerB.Exec(t, schemaStmt)
 			runnerA.Exec(t, addCol)

--- a/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
@@ -64,7 +64,7 @@ func TestLWWInsertQueryQuoting(t *testing.T) {
 		tableName := fmt.Sprintf("tab%d", tableNumber)
 		runner.Exec(t, fmt.Sprintf(stmt, tableName))
 		runner.Exec(t, fmt.Sprintf(
-			"ALTER TABLE %s ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL",
+			"ALTER TABLE %s "+lwwColumnAdd,
 			tableName))
 		tableNumber++
 		return tableName
@@ -123,7 +123,7 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 	tableName := "tab"
 	runner.Exec(b, "CREATE TABLE tab (pk INT PRIMARY KEY, payload STRING)")
-	runner.Exec(b, "ALTER TABLE tab ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL")
+	runner.Exec(b, "ALTER TABLE tab "+lwwColumnAdd)
 
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
 	// Simulate how we set up the row processor on the main code path.

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -59,8 +59,8 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 					kvWorkload.sourceInitCmd("system", setup.right.nodes))
 
 				// Setup LDR-specific columns
-				setup.left.sysSQL.Exec(t, "ALTER TABLE kv.kv ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL")
-				setup.right.sysSQL.Exec(t, "ALTER TABLE kv.kv ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL")
+				setup.left.sysSQL.Exec(t, "ALTER TABLE kv.kv ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL")
+				setup.right.sysSQL.Exec(t, "ALTER TABLE kv.kv ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL")
 
 				startLDR := func(targetDB *sqlutils.SQLRunner, sourceURL string) int {
 					targetDB.Exec(t, "USE kv")

--- a/scripts/ldr
+++ b/scripts/ldr
@@ -128,8 +128,8 @@ case $1 in
       "init")
         roachprod run $A:1 "./workload init ycsb --drop --families=false --splits 1000 $(roachprod pgurl --insecure $A)"
         roachprod run $B:1 "./workload init ycsb --drop --families=false --splits 1000 $(roachprod pgurl --insecure $B)"
-        roachprod sql $A:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
-        roachprod sql $B:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_internal_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
+        roachprod sql $A:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
+        roachprod sql $B:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
         roachprod sql $A:1 -- -e "ALTER TABLE ycsb.public.usertable SET (ttl_expire_after = '3 hours');"
         roachprod sql $B:1 -- -e "ALTER TABLE ycsb.public.usertable SET (ttl_expire_after = '3 hours');"
         ;;


### PR DESCRIPTION
"crdb_internal" is supposed to be reserved for *internal* usage (it's right in the name), but a column that we'll ask users to create and interact with in a UDFs is not internal.

Release note: none.
Epic: none.