### PR TITLE
CODEOWNERS: mark `sql/distsql_plan_bulk` as owned by DR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -250,7 +250,7 @@
 /pkg/ccl/storageccl/         @cockroachdb/disaster-recovery
 /pkg/ccl/cloudccl/           @cockroachdb/disaster-recovery
 /pkg/cloud/                  @cockroachdb/disaster-recovery
-/pkg/sql/distsql_plan_csv.go @cockroachdb/disaster-recovery
+/pkg/sql/distsql_plan_bulk*  @cockroachdb/disaster-recovery
 
 /pkg/geo/                    @cockroachdb/spatial
 


### PR DESCRIPTION
Also remove stale `distsql_plan_csv` entry.

Epic: None

Release note: None