### PR TITLE
raft: pass logSlice from maybeAppend to append

### DIFF
--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -57,5 +57,6 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//constraints",
     ],
 )

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -61,7 +61,9 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 
 		ents[i] = pb.Entry{Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data}
 	}
-	rn.raft.raftLog.append(ents...)
+	if !rn.raft.raftLog.append(ents...) {
+		return errors.New("could not append to the log")
+	}
 
 	// Now apply them, mainly so that the application can call Campaign
 	// immediately after StartNode in tests. Note that these nodes will

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -51,17 +51,20 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	// TODO(tbg): remove StartNode and give the application the right tools to
 	// bootstrap the initial membership in a cleaner way.
 	rn.raft.becomeFollower(1, None)
-	ents := make([]pb.Entry, len(peers))
+	app := logSlice{term: 1, entries: make([]pb.Entry, 0, len(peers))}
 	for i, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		data, err := cc.Marshal()
 		if err != nil {
 			return err
 		}
-
-		ents[i] = pb.Entry{Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data}
+		app.entries = append(app.entries, pb.Entry{
+			Type: pb.EntryConfChange, Term: 1, Index: uint64(i + 1), Data: data,
+		})
 	}
-	if !rn.raft.raftLog.append(ents...) {
+	if err := app.valid(); err != nil {
+		return err
+	} else if !rn.raft.raftLog.append(app) {
 		return errors.New("could not append to the log")
 	}
 
@@ -77,7 +80,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	//
 	// TODO(bdarnell): These entries are still unstable; do we need to preserve
 	// the invariant that committed < unstable?
-	rn.raft.raftLog.committed = uint64(len(ents))
+	rn.raft.raftLog.committed = app.lastIndex()
 	for _, peer := range peers {
 		rn.raft.applyConfChange(pb.ConfChange{NodeID: peer.ID, Type: pb.ConfChangeAddNode}.AsV2())
 	}

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -70,45 +70,46 @@ func TestMatch(t *testing.T) {
 }
 
 func TestFindConflictByTerm(t *testing.T) {
+	noSnap := entryID{}
+	snap10 := entryID{term: 3, index: 10}
 	for _, tt := range []struct {
-		ents  []pb.Entry // ents[0] contains the (index, term) of the snapshot
+		sl    logSlice
 		index uint64
 		term  uint64
 		want  uint64
 	}{
 		// Log starts from index 1.
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 100, term: 2, want: 100}, // ErrUnavailable
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 5, term: 6, want: 5},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 5, term: 5, want: 5},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 5, term: 4, want: 2},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 5, term: 2, want: 2},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 5, term: 1, want: 0},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 1, term: 2, want: 1},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 1, term: 1, want: 0},
-		{ents: index(0).terms(0, 2, 2, 5, 5, 5), index: 0, term: 0, want: 0},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 100, term: 2, want: 100}, // ErrUnavailable
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 6, want: 5},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 5, want: 5},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 4, want: 2},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 2, want: 2},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 1, want: 0},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 1, term: 2, want: 1},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 1, term: 1, want: 0},
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 0, term: 0, want: 0},
 		// Log with compacted entries.
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 30, term: 3, want: 30}, // ErrUnavailable
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 14, term: 9, want: 14},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 14, term: 4, want: 14},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 14, term: 3, want: 12},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 14, term: 2, want: 9},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 11, term: 5, want: 11},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 10, term: 5, want: 10},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 10, term: 3, want: 10},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 10, term: 2, want: 9},
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 9, term: 2, want: 9}, // ErrCompacted
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 4, term: 2, want: 4}, // ErrCompacted
-		{ents: index(10).terms(3, 3, 3, 4, 4, 4), index: 0, term: 0, want: 0}, // ErrCompacted
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 30, term: 3, want: 30}, // ErrUnavailable
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 9, want: 14},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 4, want: 14},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 3, want: 12},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 2, want: 9},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 11, term: 5, want: 11},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 10, term: 5, want: 10},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 10, term: 3, want: 10},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 10, term: 2, want: 9},
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 9, term: 2, want: 9}, // ErrCompacted
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 4, term: 2, want: 4}, // ErrCompacted
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 0, term: 0, want: 0}, // ErrCompacted
 	} {
 		t.Run("", func(t *testing.T) {
 			st := NewMemoryStorage()
-			require.NotEmpty(t, tt.ents)
 			st.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{
-				Index: tt.ents[0].Index,
-				Term:  tt.ents[0].Term,
+				Term:  tt.sl.prev.term,
+				Index: tt.sl.prev.index,
 			}})
 			l := newLog(st, discardLogger)
-			l.append(tt.ents[1:]...)
+			l.append(tt.sl.entries...)
 
 			index, term := l.findConflictByTerm(tt.index, tt.term)
 			require.Equal(t, tt.want, index)

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -62,7 +62,7 @@ func TestMatch(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			log := newLog(NewMemoryStorage(), discardLogger)
-			log.append(init.entries...)
+			require.True(t, log.append(init.entries...))
 			match, ok := log.match(tt.sl)
 			require.Equal(t, !tt.notOk, ok)
 			require.Equal(t, tt.want, match)
@@ -110,7 +110,7 @@ func TestFindConflictByTerm(t *testing.T) {
 				Index: tt.sl.prev.index,
 			}})
 			l := newLog(st, discardLogger)
-			l.append(tt.sl.entries...)
+			require.True(t, l.append(tt.sl.entries...))
 
 			index, term := l.findConflictByTerm(tt.index, tt.term)
 			require.Equal(t, tt.want, index)
@@ -124,7 +124,7 @@ func TestFindConflictByTerm(t *testing.T) {
 func TestIsUpToDate(t *testing.T) {
 	init := entryID{}.append(1, 1, 2, 2, 3)
 	raftLog := newLog(NewMemoryStorage(), discardLogger)
-	raftLog.append(init.entries...)
+	require.True(t, raftLog.append(init.entries...))
 	last := raftLog.lastEntryID()
 	require.Equal(t, entryID{term: 3, index: 5}, last)
 	for _, tt := range []struct {
@@ -187,7 +187,7 @@ func TestAppend(t *testing.T) {
 			raftLog := newLog(storage, discardLogger)
 			raftLog.commitTo(commit)
 
-			raftLog.append(tt.app.entries...)
+			require.True(t, raftLog.append(tt.app.entries...))
 			require.False(t, tt.panic)
 			// TODO(pav-kv): check the term and prev too.
 			require.Equal(t, tt.want.entries, raftLog.allEntries())
@@ -246,7 +246,7 @@ func TestLogMaybeAppend(t *testing.T) {
 		require.NoError(t, app.valid())
 
 		raftLog := newLog(NewMemoryStorage(), discardLogger)
-		raftLog.append(init.entries...)
+		require.True(t, raftLog.append(init.entries...))
 		raftLog.committed = commit
 
 		t.Run("", func(t *testing.T) {
@@ -275,7 +275,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	require.NoError(t, storage.SetHardState(pb.HardState{Term: stable.term}))
 	require.NoError(t, storage.Append(stable.entries))
 	raftLog := newLog(storage, discardLogger)
-	raftLog.append(unstable.entries...)
+	require.True(t, raftLog.append(unstable.entries...))
 
 	require.True(t, raftLog.maybeCommit(raftLog.lastEntryID()))
 	raftLog.appliedTo(raftLog.committed, 0 /* size */)
@@ -296,7 +296,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	require.Equal(t, uint64(751), unstableEnts[0].Index)
 
 	last := raftLog.lastEntryID()
-	raftLog.append(pb.Entry{Term: last.term + 1, Index: last.index + 1})
+	require.True(t, raftLog.append(pb.Entry{Term: last.term + 1, Index: last.index + 1}))
 	require.Equal(t, last.index+1, raftLog.lastIndex())
 
 	want := append(stable.entries[offset:], unstable.entries...)
@@ -341,7 +341,7 @@ func TestHasNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, discardLogger)
-			raftLog.append(ents...)
+			require.True(t, raftLog.append(ents...))
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -394,7 +394,7 @@ func TestNextCommittedEnts(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLog(storage, discardLogger)
-			raftLog.append(ents...)
+			require.True(t, raftLog.append(ents...))
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(tt.applied, 0 /* size */)
@@ -448,7 +448,7 @@ func TestAcceptApplying(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLogWithSize(storage, discardLogger, maxSize)
-			raftLog.append(ents...)
+			require.True(t, raftLog.append(ents...))
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(3, 0 /* size */)
@@ -492,7 +492,7 @@ func TestAppliedTo(t *testing.T) {
 			require.NoError(t, storage.Append(ents[:1]))
 
 			raftLog := newLogWithSize(storage, discardLogger, maxSize)
-			raftLog.append(ents...)
+			require.True(t, raftLog.append(ents...))
 			raftLog.stableTo(entryID{term: 1, index: 4})
 			raftLog.maybeCommit(entryID{term: 1, index: 5})
 			raftLog.appliedTo(3, 0 /* size */)
@@ -524,7 +524,7 @@ func TestNextUnstableEnts(t *testing.T) {
 
 			// append unstable entries to raftlog
 			raftLog := newLog(storage, discardLogger)
-			raftLog.append(tt.entries...)
+			require.True(t, raftLog.append(tt.entries...))
 			require.Equal(t, tt.prev.index+1, raftLog.unstable.offset)
 
 			require.Equal(t, len(tt.entries) != 0, raftLog.hasNextUnstableEnts())
@@ -556,7 +556,7 @@ func TestCommitTo(t *testing.T) {
 				}
 			}()
 			raftLog := newLog(NewMemoryStorage(), discardLogger)
-			raftLog.append(previousEnts...)
+			require.True(t, raftLog.append(previousEnts...))
 			raftLog.committed = commit
 			raftLog.commitTo(tt.commit)
 			require.Equal(t, tt.want, raftLog.committed)
@@ -577,7 +577,7 @@ func TestStableTo(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			raftLog := newLog(NewMemoryStorage(), discardLogger)
-			raftLog.append(index(1).terms(1, 2)...)
+			require.True(t, raftLog.append(index(1).terms(1, 2)...))
 			raftLog.stableTo(entryID{term: tt.stablet, index: tt.stablei})
 			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
 		})
@@ -613,7 +613,7 @@ func TestStableToWithSnap(t *testing.T) {
 			require.NoError(t, s.SetHardState(pb.HardState{Term: snapID.term}))
 			require.NoError(t, s.ApplySnapshot(snap))
 			raftLog := newLog(s, discardLogger)
-			raftLog.append(tt.sl.entries...)
+			require.True(t, raftLog.append(tt.sl.entries...))
 			raftLog.stableTo(tt.to)
 			require.Equal(t, tt.want, raftLog.unstable.offset)
 		})
@@ -679,7 +679,7 @@ func TestIsOutOfBounds(t *testing.T) {
 	storage := NewMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset}})
 	l := newLog(storage, discardLogger)
-	l.append(index(offset+1).termRange(offset+1, offset+num+1)...)
+	require.True(t, l.append(index(offset+1).termRange(offset+1, offset+num+1)...))
 
 	first := offset + 1
 	for _, tt := range []struct {
@@ -749,7 +749,7 @@ func TestTerm(t *testing.T) {
 	storage := NewMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: offset, Term: 1}})
 	l := newLog(storage, discardLogger)
-	l.append(index(offset+1).termRange(1, num)...)
+	require.True(t, l.append(index(offset+1).termRange(1, num)...))
 
 	for _, tt := range []struct {
 		idx  uint64
@@ -818,7 +818,7 @@ func TestSlice(t *testing.T) {
 		Metadata: pb.SnapshotMetadata{Index: offset}}))
 	require.NoError(t, storage.Append(entries(offset+1, half)))
 	l := newLog(storage, discardLogger)
-	l.append(entries(half, last)...)
+	require.True(t, l.append(entries(half, last)...))
 
 	for _, tt := range []struct {
 		lo  uint64
@@ -904,7 +904,7 @@ func TestScan(t *testing.T) {
 		Metadata: pb.SnapshotMetadata{Index: offset}}))
 	require.NoError(t, storage.Append(entries(offset+1, half)))
 	l := newLog(storage, discardLogger)
-	l.append(entries(half, last)...)
+	require.True(t, l.append(entries(half, last)...))
 
 	// Test that scan() returns the same entries as slice(), on all inputs.
 	for _, pageSize := range []entryEncodingSize{0, 1, 10, 100, entrySize, entrySize + 1} {

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -151,50 +151,49 @@ func TestIsUpToDate(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
-	previousEnts := index(1).terms(1, 2)
+	init := entryID{}.append(1, 2, 2)
+	commit := uint64(1)
 	for _, tt := range []struct {
-		ents      []pb.Entry
-		windex    uint64
-		wents     []pb.Entry
-		wunstable uint64
+		app   logSlice
+		want  logSlice
+		panic bool
 	}{
+		{app: logSlice{}, want: init},
 		{
-			nil,
-			2,
-			index(1).terms(1, 2),
-			3,
-		},
-		{
-			index(3).terms(2),
-			3,
-			index(1).terms(1, 2, 2),
-			3,
-		},
-		// conflicts with index 1
-		{
-			index(1).terms(2),
-			1,
-			index(1).terms(2),
-			1,
-		},
-		// conflicts with index 2
-		{
-			index(2).terms(3, 3),
-			3,
-			index(1).terms(1, 3, 3),
-			2,
+			app:  entryID{term: 2, index: 3}.append(2),
+			want: entryID{}.append(1, 2, 2, 2),
+		}, {
+			app:  entryID{term: 1, index: 1}.append(3),
+			want: entryID{}.append(1, 3), // overwrite from index 2
+		}, {
+			app:  entryID{term: 2, index: 2}.append(3, 4, 5),
+			want: entryID{}.append(1, 2, 3, 4, 5), // overwrite from index 3
+		}, {
+			app:   entryID{}.append(3, 4),
+			panic: true, // entry 1 is already committed
 		},
 	} {
 		t.Run("", func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					require.True(t, tt.panic)
+				}
+			}()
+
 			storage := NewMemoryStorage()
-			storage.Append(previousEnts)
+			require.NoError(t, storage.SetHardState(pb.HardState{Term: init.term}))
+			require.NoError(t, storage.Append(init.entries))
 			raftLog := newLog(storage, discardLogger)
-			raftLog.append(tt.ents...)
-			require.Equal(t, tt.windex, raftLog.lastIndex())
-			g, err := raftLog.entries(1, noLimit)
-			require.NoError(t, err)
-			require.Equal(t, tt.wents, g)
-			require.Equal(t, tt.wunstable, raftLog.unstable.offset)
+			raftLog.commitTo(commit)
+
+			raftLog.append(tt.app.entries...)
+			require.False(t, tt.panic)
+			// TODO(pav-kv): check the term and prev too.
+			require.Equal(t, tt.want.entries, raftLog.allEntries())
+			if len(tt.app.entries) != 0 {
+				require.Equal(t, tt.app.lastIndex(), raftLog.lastIndex())
+				require.Equal(t, tt.app.prev.index+1, raftLog.unstable.offset)
+			}
 		})
 	}
 }
@@ -257,6 +256,7 @@ func TestLogMaybeAppend(t *testing.T) {
 			}()
 			ok := raftLog.maybeAppend(app)
 			require.Equal(t, !tt.notOk, ok)
+			require.False(t, tt.panic)
 			require.Equal(t, commit, raftLog.committed) // commit index did not change
 			require.Equal(t, tt.want, raftLog.allEntries())
 		})

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -121,29 +121,31 @@ func TestFindConflictByTerm(t *testing.T) {
 }
 
 func TestIsUpToDate(t *testing.T) {
-	previousEnts := index(1).terms(1, 2, 3)
+	init := entryID{}.append(1, 1, 2, 2, 3)
 	raftLog := newLog(NewMemoryStorage(), discardLogger)
-	raftLog.append(previousEnts...)
+	raftLog.append(init.entries...)
+	last := raftLog.lastEntryID()
+	require.Equal(t, entryID{term: 3, index: 5}, last)
 	for _, tt := range []struct {
-		lastIndex uint64
-		term      uint64
-		wUpToDate bool
+		term  uint64
+		index uint64
+		want  bool
 	}{
-		// greater term, ignore lastIndex
-		{raftLog.lastIndex() - 1, 4, true},
-		{raftLog.lastIndex(), 4, true},
-		{raftLog.lastIndex() + 1, 4, true},
-		// smaller term, ignore lastIndex
-		{raftLog.lastIndex() - 1, 2, false},
-		{raftLog.lastIndex(), 2, false},
-		{raftLog.lastIndex() + 1, 2, false},
-		// equal term, equal or lager lastIndex wins
-		{raftLog.lastIndex() - 1, 3, false},
-		{raftLog.lastIndex(), 3, true},
-		{raftLog.lastIndex() + 1, 3, true},
+		// greater term, ignore last index
+		{term: last.term + 1, index: last.index - 1, want: true},
+		{term: last.term + 1, index: last.index, want: true},
+		{term: last.term + 1, index: last.index + 1, want: true},
+		// smaller term, ignore last index
+		{term: last.term - 1, index: last.index - 1, want: false},
+		{term: last.term - 1, index: last.index, want: false},
+		{term: last.term - 1, index: last.index + 1, want: false},
+		// equal term, lager or equal index wins
+		{term: last.term, index: last.index - 1, want: false},
+		{term: last.term, index: last.index, want: true},
+		{term: last.term, index: last.index + 1, want: true},
 	} {
 		t.Run("", func(t *testing.T) {
-			require.Equal(t, tt.wUpToDate, raftLog.isUpToDate(entryID{term: tt.term, index: tt.lastIndex}))
+			require.Equal(t, tt.want, raftLog.isUpToDate(entryID{term: tt.term, index: tt.index}))
 		})
 	}
 }

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -795,7 +795,9 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 		// Drop the proposal.
 		return false
 	}
-	r.raftLog.append(es...)
+	if !r.raftLog.append(es...) {
+		r.logger.Panicf("%x leader could not append to its log", r.id)
+	}
 	// The leader needs to self-ack the entries just appended once they have
 	// been durably persisted (since it doesn't send an MsgApp to itself). This
 	// response message will be added to msgsAfterAppend and delivered back to

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -781,10 +781,10 @@ func (r *raft) reset(term uint64) {
 }
 
 func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
-	li := r.raftLog.lastIndex()
+	last := r.raftLog.lastEntryID()
 	for i := range es {
 		es[i].Term = r.Term
-		es[i].Index = li + 1 + uint64(i)
+		es[i].Index = last.index + 1 + uint64(i)
 	}
 	// Track the size of this uncommitted proposal.
 	if !r.increaseUncommittedSize(es) {
@@ -795,7 +795,10 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 		// Drop the proposal.
 		return false
 	}
-	if !r.raftLog.append(es...) {
+	app := logSlice{term: r.Term, prev: last, entries: es}
+	if err := app.valid(); err != nil {
+		r.logger.Panicf("%x leader could not append to its log: %v", r.id, err)
+	} else if !r.raftLog.append(app) {
 		r.logger.Panicf("%x leader could not append to its log", r.id)
 	}
 	// The leader needs to self-ack the entries just appended once they have

--- a/pkg/raft/raft_snap_test.go
+++ b/pkg/raft/raft_snap_test.go
@@ -36,6 +36,7 @@ var (
 func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -54,6 +55,7 @@ func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 func TestPendingSnapshotPauseReplication(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -71,6 +73,7 @@ func TestPendingSnapshotPauseReplication(t *testing.T) {
 func TestSnapshotFailure(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -94,6 +97,7 @@ func TestSnapshotFailure(t *testing.T) {
 func TestSnapshotSucceed(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()
@@ -117,6 +121,7 @@ func TestSnapshotSucceed(t *testing.T) {
 func TestSnapshotAbort(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
+	sm.becomeFollower(testingSnap.Metadata.Term, None)
 	sm.restore(testingSnap)
 
 	sm.becomeCandidate()

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2044,7 +2044,7 @@ func TestLeaderIncreaseNext(t *testing.T) {
 
 	for i, tt := range tests {
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
-		sm.raftLog.append(previousEnts...)
+		require.True(t, sm.raftLog.append(previousEnts...))
 		sm.becomeCandidate()
 		sm.becomeLeader()
 		sm.trk.Progress[2].State = tt.state
@@ -2320,7 +2320,7 @@ func TestRestoreIgnoreSnapshot(t *testing.T) {
 	commit := uint64(1)
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
-	sm.raftLog.append(previousEnts...)
+	require.True(t, sm.raftLog.append(previousEnts...))
 	sm.raftLog.commitTo(commit)
 
 	s := pb.Snapshot{


### PR DESCRIPTION
This PR propagates the appended `logSlice` down the stack from `maybeAppend` to `append`. All appends should use this type for readability and safety. Ultimately, the `logSlice` will be passed from the append method to `unstable.truncateAndAppend` which will implement a few more safety checks and use the `logSlice.term` to track the "last accepted term".

This change helped fixing a bunch of bugs in tests that initialized `RawNode` or `raftLog` incorrectly.

Part of #124440