### PR TITLE
dev: add a shorthand for cloudupload

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -79,6 +79,7 @@ var buildTargetMapping = map[string]string{
 	"bazel-remote":         bazelRemoteTarget,
 	"buildifier":           "@com_github_bazelbuild_buildtools//buildifier:buildifier",
 	"buildozer":            "@com_github_bazelbuild_buildtools//buildozer:buildozer",
+	"cloudupload":          "//pkg/cmd/cloudupload:cloudupload",
 	"cockroach":            cockroachTarget,
 	"cockroach-sql":        "//pkg/cmd/cockroach-sql:cockroach-sql",
 	"cockroach-oss":        cockroachTargetOss,


### PR DESCRIPTION
Observability team needs to upload artifacts to GCS. We would like to use existing cloudupload command. This patch adds a `dev` shorthand for the `cloudupload` CLI tool.

Epic: [CC-28996](https://cockroachlabs.atlassian.net/browse/CC-28996)
Release note: None