### PR TITLE
sql/telemetry: include TCL statements in sampling

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -110,14 +110,13 @@ const (
 )
 
 // shouldForceLogStatement returns true if the statement should be force logged to
-// TELEMETRY. Currently the criteria is if the statement is not of type DML and is
-// not BEGIN or COMMIT.
+// TELEMETRY. Currently the criteria is if the statement is not of type DML or TCL.
 func shouldForceLogStatement(ast tree.Statement) bool {
-	switch ast.(type) {
-	case *tree.BeginTransaction, *tree.CommitTransaction:
+	switch ast.StatementType() {
+	case tree.TypeDML, tree.TypeTCL:
 		return false
 	default:
-		return ast.StatementType() != tree.TypeDML
+		return true
 	}
 }
 
@@ -295,7 +294,7 @@ func (p *planner) maybeLogStatementInternal(
 		tracingEnabled := telemetryMetrics.isTracing(p.curPlan.instrumentation.Tracing())
 
 		// Always sample if one of the scenarios is true:
-		// - statement is not of type DML and is not BEGIN or COMMIT
+		// - statement is not of type DML or TCL
 		// - tracing is enabled for this statement
 		// - this is a query emitted by our console (application_name starts with `$ internal-console`) and
 		// the cluster setting to log console queries is enabled

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -251,4 +251,124 @@ SELECT 'hello';
 	"User": "root"
 }
 
+# Reset app name. Note that the sampled_query event
+# will still be logged due to the current application
+# being set to the internal console app name.
+spy-sql unixSecs=0.1
+SET application_name = 'telemetry-logging';
+----
+{
+	"ApplicationName": "telemetry-logging",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"PlanGist": "Ais=",
+	"Statement": "SET application_name = ‹'telemetry-logging'›",
+	"StatementFingerprintID": "16494915433690409681",
+	"StmtPosInTxn": 1,
+	"Tag": "SET",
+	"User": "root"
+}
+
+subtest end
+
+subtest stmt_mode_force_non_dml_tcl_statements
+# sampled_query events should be force logged if they are not of type DML or TCL
+
+reset-last-sampled
+----
+
+
+reset-telemetry-cluster-settings
+----
+
+
+# This first SELECT statement should be emitted.
+spy-sql unixSecs=1
+SELECT 1;
+----
+{
+	"ApplicationName": "telemetry-logging",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICAgYC",
+	"Statement": "SELECT ‹1›",
+	"StatementFingerprintID": "2101516650360649860",
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+
+# Now we'll execute some statements stubbed at the same time.
+# All statement types that aren't TCL or DML should be logged.
+
+# CREATE statement should always be emitted.
+spy-sql unixSecs=1
+CREATE TABLE foo (a INT, b INT);
+----
+{
+	"ApplicationName": "telemetry-logging",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"PlanGist": "AiXKAQ==",
+	"Statement": "CREATE TABLE defaultdb.public.foo (a INT8, b INT8)",
+	"StatementFingerprintID": "12417278439037856579",
+	"StmtPosInTxn": 1,
+	"Tag": "CREATE TABLE",
+	"User": "root"
+}
+
+# Skipped due to not enough time elapsed.
+spy-sql unixSecs=1
+SELECT * FROM foo
+----
+
+
+# Skipped due to not enough time elapsed.
+spy-sql unixSecs=1
+BEGIN;
+INSERT INTO foo VALUES (1, 2), (3, 4);
+COMMIT;
+----
+
+
+spy-sql unixSecs=1
+BEGIN;
+SET TRANSACTION PRIORITY HIGH;
+SELECT 1;
+CREATE USER craig;
+GRANT admin TO craig;
+COMMIT;
+----
+{
+	"ApplicationName": "telemetry-logging",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"PlanGist": "Ais=",
+	"SkippedQueries": 7,
+	"Statement": "CREATE USER craig",
+	"StatementFingerprintID": "4157831042514459868",
+	"StmtPosInTxn": 3,
+	"Tag": "CREATE ROLE",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"PlanGist": "Ais=",
+	"Statement": "GRANT admin TO craig",
+	"StatementFingerprintID": "9654126880073528913",
+	"StmtPosInTxn": 4,
+	"Tag": "GRANT",
+	"User": "root"
+}
+
+
 subtest end


### PR DESCRIPTION
Previously we only applied sampling rules to DML statements when emitting sampled_query events to TELEMETRY, emitting  all other statement types unconditionally. This commit includes TCL statements in the sampled statements since they are executed at a high volume.

Fixes: #126290

Release note (ops change): For the TELEMETRY channel, TCL `sampled_query` events will now be sampled along with DML statements according to the setting `sql.telemetry.query_sampling.max_event_frequency`.