### PR TITLE
kvserver/rangefeed: wrap muxer inside setRangeIDEventSink

### DIFF
--- a/pkg/kv/kvserver/rangefeed/stream_muxer.go
+++ b/pkg/kv/kvserver/rangefeed/stream_muxer.go
@@ -30,7 +30,7 @@ type RangefeedMetricsRecorder interface {
 // ServerStreamSender forwards MuxRangefeedEvents from StreamMuxer to the
 // underlying stream.
 type ServerStreamSender interface {
-	// Send must be thread safe to be called concurrently.
+	// Send must be thread-safe to be called concurrently.
 	Send(*kvpb.MuxRangeFeedEvent) error
 	// SendIsThreadSafe is a no-op declaration method. It is a contract that the
 	// interface has a thread-safe Send method.
@@ -151,6 +151,15 @@ func (sm *StreamMuxer) AddStream(streamID int64, cancel context.CancelFunc) {
 		log.Fatalf(context.Background(), "stream %d already exists", streamID)
 	}
 	sm.metrics.UpdateMetricsOnRangefeedConnect()
+}
+
+// SendIsThreadSafe is a no-op declaration method. It is a contract that the
+// Send method is thread-safe. Note that Send wraps ServerStreamSender which
+// also declares its Send method to be thread-safe.
+func (sm *StreamMuxer) SendIsThreadSafe() {}
+
+func (sm *StreamMuxer) Send(e *kvpb.MuxRangeFeedEvent) error {
+	return sm.sender.Send(e)
 }
 
 // transformRangefeedErrToClientError converts a rangefeed error to a client

--- a/pkg/kv/kvserver/rangefeed/stream_muxer_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_muxer_test.go
@@ -171,7 +171,7 @@ func TestStreamMuxerOnBlockingIO(t *testing.T) {
 	expectedErrEvent.MustSetValue(&kvpb.RangeFeedError{
 		Error: *kvpb.NewError(kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_NO_LEASEHOLDER)),
 	})
-	// Receive the event after non-blocking.
+	// Receive the event after getting unblocked.
 	require.Truef(t, testServerStream.hasEvent(expectedErrEvent),
 		"expected event %v not found in %v", ev, testServerStream)
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1838,7 +1838,6 @@ func (n *Node) RangeLookup(
 // calls.
 type setRangeIDEventSink struct {
 	ctx      context.Context
-	cancel   context.CancelFunc
 	rangeID  roachpb.RangeID
 	streamID int64
 	wrapped  *lockedMuxStream
@@ -1921,7 +1920,6 @@ func (n *Node) MuxRangeFeed(stream kvpb.Internal_MuxRangeFeedServer) error {
 
 			streamSink := &setRangeIDEventSink{
 				ctx:      streamCtx,
-				cancel:   cancel,
 				rangeID:  req.RangeID,
 				streamID: req.StreamID,
 				wrapped:  muxStream,


### PR DESCRIPTION
**kvserver/rangefeed: remove unused cancel**

This patch removes the unused field cancel from setRangeIDEventSink.

Epic: none
Release note: none

---

**kvserver/rangefeed: wrap muxer inside setRangeIDEventSink**

Previously, each rangefeed stream setRangeIDEventSink wrapped the underlying
muxstream to send to grpc stream. This patch changes the stream to wrap the
stream muxer struct instead which itself wraps the underlying muxstream.

Note that this patch doesn’t change any existing behavior but only to make
future commits cleaner when we change muxer to send data to a buffered stream
instead of directly to grpc.

Part of: #126561
Release note: none

---

**kvserver/rangefeed: rename setRangeIDEventSink to perRangeEventSink**

This patch renames `setRangeIDEventSink` to `perRangeEventSink` for clarity.

Epic: none
Release note: none
