### PR TITLE
drt: add sudo to mkdir otelcol-contrib

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -115,7 +115,7 @@ EOF"
 
     case $cluster in
       "workload-chaos")
-        roachprod ssh ${cluster} -- "mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
+        roachprod ssh ${cluster} -- "sudo mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
 ---
 receivers:
   prometheus/workload:
@@ -192,7 +192,7 @@ EOF"
         ;;
 
       "workload-large")
-        roachprod ssh ${cluster} -- "mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
+        roachprod ssh ${cluster} -- "sudo mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
 ---
 receivers:
   prometheus/workload:


### PR DESCRIPTION
Previously, we had missed out on adding sudo to the `mkdir otelcol-contrib` to the datadog command for workload-chaos and workload-large. This PR fixes that.

Epic: none
Release note: None