### PR TITLE
sql: disable partial stats at extremes for enum and bool columns

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -272,6 +272,11 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 						"on virtual columns",
 				)
 			}
+			if typFam := columns[i].GetType().Family(); n.Options.UsingExtremes &&
+				(typFam == types.BoolFamily || typFam == types.EnumFamily) &&
+				!n.p.SessionData().EnableCreateStatsUsingExtremesBoolEnum {
+				return nil, pgerror.Newf(pgcode.FeatureNotSupported, "creating partial statistics at extremes on bool and enum columns is disabled")
+			}
 			columnIDs[i] = columns[i].GetID()
 		}
 		col, err := catalog.MustFindColumnByID(tableDesc, columnIDs[0])

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3702,6 +3702,10 @@ func (m *sessionDataMutator) SetEnableCreateStatsUsingExtremes(val bool) {
 	m.data.EnableCreateStatsUsingExtremes = val
 }
 
+func (m *sessionDataMutator) SetEnableCreateStatsUsingExtremesBoolEnum(val bool) {
+	m.data.EnableCreateStatsUsingExtremesBoolEnum = val
+}
+
 func (m *sessionDataMutator) SetAllowRoleMembershipsToChangeDuringTransaction(val bool) {
 	m.data.AllowRoleMembershipsToChangeDuringTransaction = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -3080,6 +3080,44 @@ WHERE statistics_name = 'timestamp_outer_buckets_partial'
 statistics_name                  partial_predicate                                                                                    row_count  null_count
 timestamp_outer_buckets_partial  (a IS NULL) OR ((a < '2024-06-26 01:00:00':::TIMESTAMP) OR (a > '2024-06-27 02:30:00':::TIMESTAMP))  3          0
 
+# Verify that we can't create partial stats using extremes on bool/enums columns
+# by default.
+statement ok
+CREATE TABLE bool_table (a bool PRIMARY KEY)
+
+statement ok
+INSERT INTO bool_table VALUES (true), (false)
+
+statement ok
+CREATE STATISTICS bool_table_full ON a FROM bool_table
+
+statement error pgcode 0A000 creating partial statistics at extremes on bool and enum columns is disabled
+CREATE STATISTICS bool_table_partial ON a FROM bool_table USING EXTREMES;
+
+statement ok
+CREATE TABLE enum_table (a e PRIMARY KEY)
+
+statement ok
+INSERT INTO enum_table VALUES ('hello'), ('howdy'), ('hi')
+
+statement ok
+CREATE STATISTICS enum_table_full ON a FROM enum_table
+
+statement error pgcode 0A000 creating partial statistics at extremes on bool and enum columns is disabled
+CREATE STATISTICS enum_table_full ON a FROM enum_table USING EXTREMES
+
+statement ok
+SET enable_create_stats_using_extremes_bool_enum = on
+
+statement ok
+CREATE STATISTICS bool_table_full ON a FROM bool_table USING EXTREMES
+
+statement ok
+CREATE STATISTICS enum_table_partial ON a FROM bool_table USING EXTREMES
+
+statement ok
+RESET enable_create_stats_using_extremes_bool_enum
+
 statement ok
 RESET enable_create_stats_using_extremes
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6111,6 +6111,7 @@ disallow_full_table_scans                                  off
 distsql_plan_gateway_bias                                  2
 enable_auto_rehoming                                       off
 enable_create_stats_using_extremes                         off
+enable_create_stats_using_extremes_bool_enum               off
 enable_durable_locking_for_serializable                    off
 enable_experimental_alter_column_type_general              off
 enable_implicit_fk_locking_for_serializable                off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2836,6 +2836,7 @@ distsql                                                    off                 N
 distsql_plan_gateway_bias                                  2                   NULL      NULL        NULL        string
 enable_auto_rehoming                                       off                 NULL      NULL        NULL        string
 enable_create_stats_using_extremes                         off                 NULL      NULL        NULL        string
+enable_create_stats_using_extremes_bool_enum               off                 NULL      NULL        NULL        string
 enable_durable_locking_for_serializable                    off                 NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general              off                 NULL      NULL        NULL        string
 enable_implicit_fk_locking_for_serializable                off                 NULL      NULL        NULL        string
@@ -3023,6 +3024,7 @@ distsql                                                    off                 N
 distsql_plan_gateway_bias                                  2                   NULL  user     NULL      2                   2
 enable_auto_rehoming                                       off                 NULL  user     NULL      off                 off
 enable_create_stats_using_extremes                         off                 NULL  user     NULL      off                 off
+enable_create_stats_using_extremes_bool_enum               off                 NULL  user     NULL      off                 off
 enable_durable_locking_for_serializable                    off                 NULL  user     NULL      off                 off
 enable_experimental_alter_column_type_general              off                 NULL  user     NULL      off                 off
 enable_implicit_fk_locking_for_serializable                off                 NULL  user     NULL      off                 off
@@ -3207,6 +3209,7 @@ distsql_plan_gateway_bias                                  NULL    NULL     NULL
 distsql_workmem                                            NULL    NULL     NULL     NULL        NULL
 enable_auto_rehoming                                       NULL    NULL     NULL     NULL        NULL
 enable_create_stats_using_extremes                         NULL    NULL     NULL     NULL        NULL
+enable_create_stats_using_extremes_bool_enum               NULL    NULL     NULL     NULL        NULL
 enable_durable_locking_for_serializable                    NULL    NULL     NULL     NULL        NULL
 enable_experimental_alter_column_type_general              NULL    NULL     NULL     NULL        NULL
 enable_implicit_fk_locking_for_serializable                NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -68,6 +68,7 @@ distsql                                                    off
 distsql_plan_gateway_bias                                  2
 enable_auto_rehoming                                       off
 enable_create_stats_using_extremes                         off
+enable_create_stats_using_extremes_bool_enum               off
 enable_durable_locking_for_serializable                    off
 enable_experimental_alter_column_type_general              off
 enable_implicit_fk_locking_for_serializable                off

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -534,6 +534,9 @@ message LocalOnlySessionData {
   // write of unspecified origin, and 2+ are reserved to identify remote writes
   // from specific clusters.
   uint32 origin_id_for_logical_data_replication = 135 [(gogoproto.customname) = "OriginIDForLogicalDataReplication"];
+  // EnableCreateStatsUsingExtremesBoolEnum, when true, allows the use of CREATE
+  // STATISTICS .. USING EXTREMES on bool and enum columns.
+  bool enable_create_stats_using_extremes_bool_enum = 136;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2839,6 +2839,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`enable_create_stats_using_extremes_bool_enum`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_create_stats_using_extremes_bool_enum`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_create_stats_using_extremes_bool_enum", s)
+			if err != nil {
+				return err
+			}
+			m.SetEnableCreateStatsUsingExtremesBoolEnum(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableCreateStatsUsingExtremesBoolEnum), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`allow_role_memberships_to_change_during_transaction`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`allow_role_memberships_to_change_during_transaction`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Enums and bool types have arbitrary orderings, so it doesn't make sense to collect stats `USING EXTREMES` (scanning beyond the previous max and min) for these column types. Adds the
`enable_create_stats_using_extremes_bool_enum` session setting to allow creating partial stats at extremes on bool and enum columns, which is disabled by default.

Fixes: #126401

See also: #125950

Release note: None