### PR TITLE
timeutil: don't redact operation name in TimeoutError

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -10,7 +10,6 @@ package backupccl
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -584,7 +583,7 @@ func runBackupProcessor(
 						var pErr *kvpb.Error
 						requestSentAt := timeutil.Now()
 						exportRequestErr := timeutil.RunWithTimeout(ctx,
-							fmt.Sprintf("ExportRequest for span %s", span.span),
+							redact.Sprintf("ExportRequest for span %s", span.span),
 							timeoutPerAttempt.Get(&clusterSettings.SV), func(ctx context.Context) error {
 								sp := tracing.SpanFromContext(ctx)
 								opts := make([]tracing.SpanOption, 0)

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -334,6 +334,7 @@ go_test(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//types",
         "@com_github_golang_mock//gomock",

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
@@ -261,7 +262,7 @@ func withTimeout(
 		jobID = jobFeed.JobID()
 	}
 	return timeutil.RunWithTimeout(context.Background(),
-		fmt.Sprintf("withTimeout-%d", jobID), timeout,
+		redact.Sprintf("withTimeout-%d", jobID), timeout,
 		func(ctx context.Context) error {
 			defer stopFeedWhenDone(ctx, f)()
 			return fn(ctx)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/jackc/pgx/v4"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -908,8 +909,8 @@ func (c *tableFeed) Partitions() []string {
 	return []string{`0`, `1`, `2`}
 }
 
-func timeoutOp(op string, id jobspb.JobID) string {
-	return fmt.Sprintf("%s-%d", op, id)
+func timeoutOp(op string, id jobspb.JobID) redact.RedactableString {
+	return redact.Sprintf("%s-%d", op, id)
 }
 
 // Next implements the TestFeed interface.

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	tracezipper "github.com/cockroachdb/cockroach/pkg/util/tracing/zipper"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/jackc/pgconn"
 	"github.com/marusama/semaphore"
 	"github.com/spf13/cobra"
@@ -80,7 +81,7 @@ func (zc *debugZipContext) runZipFnWithTimeout(
 // runZipRequest runs a zipRequest and stores its JSON result or error
 // message in the output zip.
 func (zc *debugZipContext) runZipRequest(ctx context.Context, zr *zipReporter, r zipRequest) error {
-	s := zr.start("requesting data for %s", r.pathName)
+	s := zr.start(redact.Sprintf("requesting data for %s", r.pathName))
 	var data interface{}
 	err := zc.runZipFn(ctx, s, func(ctx context.Context) error {
 		thisData, err := r.fn(ctx)
@@ -222,7 +223,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	dirName := args[0]
-	s := zr.start("creating output file %s", dirName)
+	s := zr.start(redact.Sprintf("creating output file %s", dirName))
 	out, err := os.Create(dirName)
 	if err != nil {
 		return s.fail(err)
@@ -241,7 +242,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 			cfg.AdvertiseAddr = tenant.RpcAddr
 			sqlAddr := tenant.SqlAddr
 
-			s := zr.start("establishing RPC connection to %s", cfg.AdvertiseAddr)
+			s := zr.start(redact.Sprintf("establishing RPC connection to %s", cfg.AdvertiseAddr))
 			conn, finish, err := getClientGRPCConn(ctx, cfg)
 			if err != nil {
 				return s.fail(err)
@@ -257,7 +258,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 				// SQL and RPC.
 				sqlAddr = tenant.RpcAddr
 			}
-			s = zr.start("using SQL address: %s", sqlAddr)
+			s = zr.start(redact.Sprintf("using SQL address: %s", sqlAddr))
 
 			cliCtx.clientOpts.ServerHost, cliCtx.clientOpts.ServerPort, err = net.SplitHostPort(sqlAddr)
 			if err != nil {
@@ -470,7 +471,7 @@ INNER JOIN latestprogress ON j.id = latestprogress.job_id;`,
 
 			ts := timeutil.Now().Format(`20060102150405`)
 			name := fmt.Sprintf("%s/jobs/%d/%s/trace.zip", zc.prefix, jobTrace.jobID, ts)
-			s := zc.clusterPrinter.start("requesting traces for job %d", jobTrace.jobID)
+			s := zc.clusterPrinter.start(redact.Sprintf("requesting traces for job %d", jobTrace.jobID))
 			if err := zc.z.createRaw(s, name, jobZip); err != nil {
 				log.Warningf(ctx, "failed to write inflight trace zip for job %d to file %s: %v",
 					jobTrace.jobID, name, err)
@@ -495,7 +496,7 @@ func (zc *debugZipContext) dumpTableDataForZip(
 	ctx := context.Background()
 	baseName := base + "/" + sanitizeFilename(table)
 
-	s := zr.start("retrieving SQL data for %s", table)
+	s := zr.start(redact.Sprintf("retrieving SQL data for %s", table))
 	const maxRetries = 5
 	suffix := ""
 
@@ -556,7 +557,7 @@ func (zc *debugZipContext) dumpTableDataForZip(
 					query = tableQuery.fallback
 					numRetries = 1 // Reset counter since this is a different query.
 					baseName = baseName + ".fallback"
-					s = zr.start("retrieving SQL data for %s (fallback)", table)
+					s = zr.start(redact.Sprintf("retrieving SQL data for %s (fallback)", table))
 
 					continue
 				}
@@ -566,7 +567,7 @@ func (zc *debugZipContext) dumpTableDataForZip(
 			}
 			// We've encountered a retry error. Add a suffix then loop.
 			suffix = fmt.Sprintf(".%d", numRetries)
-			s = zr.start("retrying %s", table)
+			s = zr.start(redact.Sprintf("retrying %s", table))
 			continue
 		}
 		s.done()

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -192,9 +193,9 @@ func (zc *debugZipContext) collectClusterData(
 				sort.Slice(rangeList.Ranges, func(i, j int) bool {
 					return rangeList.Ranges[i].RangeID > rangeList.Ranges[j].RangeID
 				})
-				sLocality := zc.clusterPrinter.start("writing tenant ranges for locality: %s", locality)
+				sLocality := zc.clusterPrinter.start(redact.Sprintf("writing tenant ranges for locality: %s", locality))
 				name := fmt.Sprintf("%s/%s/%s", zc.prefix, tenantRangesName, locality)
-				s := zc.clusterPrinter.start("writing tenant ranges for locality %s", locality)
+				s := zc.clusterPrinter.start(redact.Sprintf("writing tenant ranges for locality %s", locality))
 				if err := zc.z.createJSON(s, name+".json", rangeList.Ranges); err != nil {
 					return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, s.fail(err)
 				}

--- a/pkg/cli/zip_helpers.go
+++ b/pkg/cli/zip_helpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // zipper is the interface to the zip file stored on disk.
@@ -310,7 +311,7 @@ var zipReportingMu syncutil.Mutex
 // progress messages for the zip command.
 type zipReporter struct {
 	// prefix is the string printed at the start of new lines.
-	prefix string
+	prefix redact.RedactableString
 
 	// flowing when set indicates the reporter should attempt to print
 	// progress about a single item of work on the same line of output.
@@ -331,10 +332,10 @@ type zipReporter struct {
 	sqlOutputFilenameExtension string
 }
 
-func (zc *zipContext) newZipReporter(format string, args ...interface{}) *zipReporter {
+func (zc *zipContext) newZipReporter(prefix redact.RedactableString) *zipReporter {
 	return &zipReporter{
 		flowing: zc.concurrency == 1,
-		prefix:  "[" + fmt.Sprintf(format, args...) + "]",
+		prefix:  "[" + prefix + "]",
 		newline: true,
 		inItem:  false,
 	}
@@ -342,7 +343,7 @@ func (zc *zipContext) newZipReporter(format string, args ...interface{}) *zipRep
 
 // withPrefix creates a reported which adds the provided formatted
 // message as additional prefix at the start of new lines.
-func (z *zipReporter) withPrefix(format string, args ...interface{}) *zipReporter {
+func (z *zipReporter) withPrefix(prefix redact.RedactableString) *zipReporter {
 	zipReportingMu.Lock()
 	defer zipReportingMu.Unlock()
 
@@ -352,7 +353,7 @@ func (z *zipReporter) withPrefix(format string, args ...interface{}) *zipReporte
 
 	z.completeprevLocked()
 	return &zipReporter{
-		prefix:  z.prefix + " [" + fmt.Sprintf(format, args...) + "]",
+		prefix:  z.prefix + " [" + prefix + "]",
 		flowing: z.flowing,
 		newline: z.newline,
 	}
@@ -362,7 +363,7 @@ func (z *zipReporter) withPrefix(format string, args ...interface{}) *zipReporte
 // specific to that unit of work. The caller can call .progress()
 // zero or more times, and complete with .done() / .fail() /
 // .result().
-func (z *zipReporter) start(format string, args ...interface{}) *zipReporter {
+func (z *zipReporter) start(description redact.RedactableString) *zipReporter {
 	zipReportingMu.Lock()
 	defer zipReportingMu.Unlock()
 
@@ -371,13 +372,13 @@ func (z *zipReporter) start(format string, args ...interface{}) *zipReporter {
 	}
 
 	z.completeprevLocked()
-	msg := z.prefix + " " + fmt.Sprintf(format, args...)
+	msg := z.prefix + " " + description
 	nz := &zipReporter{
 		prefix:  msg,
 		flowing: z.flowing,
 		inItem:  true,
 	}
-	fmt.Print(msg + "...")
+	fmt.Print(msg.StripMarkers() + "...")
 	nz.flowLocked()
 	return nz
 }
@@ -402,7 +403,7 @@ func (z *zipReporter) flowLocked() {
 func (z *zipReporter) resumeLocked() {
 	zipReportingMu.AssertHeld()
 	if !z.flowing || z.newline {
-		fmt.Print(z.prefix + ":")
+		fmt.Print(z.prefix.StripMarkers() + ":")
 	}
 	if z.flowing {
 		z.newline = false
@@ -441,7 +442,7 @@ func (z *zipReporter) info(format string, args ...interface{}) {
 	defer zipReportingMu.Unlock()
 
 	z.completeprevLocked()
-	fmt.Print(z.prefix)
+	fmt.Print(z.prefix.StripMarkers())
 	fmt.Print(" ")
 	fmt.Printf(format, args...)
 	z.endlLocked()
@@ -472,7 +473,7 @@ func (z *zipReporter) shout(format string, args ...interface{}) {
 	defer zipReportingMu.Unlock()
 
 	z.completeprevLocked()
-	fmt.Print(z.prefix + ": ")
+	fmt.Print(z.prefix.StripMarkers() + ": ")
 	fmt.Printf(format, args...)
 	z.endlLocked()
 }

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -136,7 +136,7 @@ func (zc *debugZipContext) collectCPUProfiles(
 		}
 		nodeID := nodeList[i].NodeID
 		prefix := fmt.Sprintf("%s%s/%s", zc.prefix, nodesPrefix, fmt.Sprintf("%d", nodeID))
-		s := zc.clusterPrinter.start("profile for node %d", nodeID)
+		s := zc.clusterPrinter.start(redact.Sprintf("profile for node %d", nodeID))
 		if err := zc.z.createRawOrError(s, prefix+"/cpu.pprof", pd.data, pd.err); err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func (zc *debugZipContext) collectFileList(
 	}
 
 	var files *serverpb.GetFilesResponse
-	s := nodePrinter.start("requesting %s list", fileKind)
+	s := nodePrinter.start(redact.Sprintf("requesting %s list", fileKind))
 	if requestErr := zc.runZipFn(ctx, s,
 		func(ctx context.Context) error {
 			var err error
@@ -202,7 +202,7 @@ func (zc *debugZipContext) collectFileList(
 
 			// NB: for goroutine dumps, the files have a .txt.gz suffix already.
 			name := prefix + "/" + file.Name
-			fs := nodePrinter.start("retrieving %s", file.Name)
+			fs := nodePrinter.start(redact.Sprintf("retrieving %s", file.Name))
 			var onefile *serverpb.GetFilesResponse
 			if fileErr := zc.runZipFn(ctx, fs, func(ctx context.Context) error {
 				var err error
@@ -261,7 +261,7 @@ func (zc *debugZipContext) collectPerNodeData(
 		}
 	}
 
-	nodePrinter := zipCtx.newZipReporter("node %d", nodeID)
+	nodePrinter := zipCtx.newZipReporter(redact.Sprintf("node %d", nodeID))
 	id := fmt.Sprintf("%d", nodeID)
 	prefix := fmt.Sprintf("%s%s/%s", zc.prefix, nodesPrefix, id)
 
@@ -439,7 +439,7 @@ func (zc *debugZipContext) collectPerNodeData(
 				continue
 			}
 
-			logPrinter := nodePrinter.withPrefix("log file: %s", file.Name)
+			logPrinter := nodePrinter.withPrefix(redact.Sprintf("log file: %s", file.Name))
 			name := prefix + "/logs/" + file.Name
 			var entries *serverpb.LogEntriesResponse
 			sf := logPrinter.start("requesting file")

--- a/pkg/cloud/httpsink/BUILD.bazel
+++ b/pkg/cloud/httpsink/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 func parseHTTPURL(uri *url.URL) (cloudpb.ExternalStorage, error) {
@@ -178,7 +179,7 @@ func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) er
 }
 
 func (h *httpStorage) Delete(ctx context.Context, basename string) error {
-	return timeutil.RunWithTimeout(ctx, fmt.Sprintf("DELETE %s", basename),
+	return timeutil.RunWithTimeout(ctx, redact.Sprintf("DELETE %s", basename),
 		cloud.Timeout.Get(&h.settings.SV), func(ctx context.Context) error {
 			_, err := h.reqNoBody(ctx, "DELETE", basename, nil)
 			return err
@@ -187,7 +188,7 @@ func (h *httpStorage) Delete(ctx context.Context, basename string) error {
 
 func (h *httpStorage) Size(ctx context.Context, basename string) (int64, error) {
 	var resp *http.Response
-	if err := timeutil.RunWithTimeout(ctx, fmt.Sprintf("HEAD %s", basename),
+	if err := timeutil.RunWithTimeout(ctx, redact.Sprintf("HEAD %s", basename),
 		cloud.Timeout.Get(&h.settings.SV), func(ctx context.Context) error {
 			var err error
 			resp, err = h.reqNoBody(ctx, "HEAD", basename, nil)

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -294,6 +294,7 @@ go_library(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_ttycolor//:ttycolor",
         "@com_github_codahale_hdrhistogram//:hdrhistogram",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/internal/client/requestbatcher/BUILD.bazel
+++ b/pkg/internal/client/requestbatcher/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 // CreatedByScheduledJobs identifies the job that was created
@@ -264,7 +265,7 @@ func (s *jobScheduler) executeCandidateSchedule(
 	if processErr := withSavePoint(ctx, txn.KV(), func() error {
 		if timeout > 0 {
 			return timeutil.RunWithTimeout(
-				ctx, fmt.Sprintf("process-schedule-%d", schedule.ScheduleID()), timeout,
+				ctx, redact.Sprintf("process-schedule-%d", schedule.ScheduleID()), timeout,
 				func(ctx context.Context) error {
 					return s.processSchedule(ctx, schedule, numRunning, txn)
 				})

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_cockroachdb_redact//:redact",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sync//errgroup",
     ],

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
@@ -618,7 +619,7 @@ func verifyRecoveryNodeStatusParallelFn(
 	ctx context.Context, nss *threadSafeSlice[loqrecoverypb.NodeRecoveryStatus],
 ) visitNodeAdminFn {
 	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
-		return timeutil.RunWithTimeout(ctx, fmt.Sprintf("retrieve status of n%d", nodeID),
+		return timeutil.RunWithTimeout(ctx, redact.Sprintf("retrieve status of n%d", nodeID),
 			retrieveNodeStatusTimeout,
 			func(ctx context.Context) error {
 				res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -974,7 +974,7 @@ func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) er
 		return err
 	}
 
-	return timeutil.RunWithTimeout(ctx, fmt.Sprintf("%s queue process replica %d", bq.name, repl.GetRangeID()),
+	return timeutil.RunWithTimeout(ctx, redact.Sprintf("%s queue process replica %d", bq.name, repl.GetRangeID()),
 		bq.processTimeoutFunc(bq.store.ClusterSettings(), repl), func(ctx context.Context) error {
 			log.VEventf(ctx, 3, "processing...")
 			// NB: in production code, this type assertion is always true. In tests,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1999,7 +1999,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 	// until they're all gone, up to the configured timeout.
 	transferTimeout := LeaseTransferPerIterationTimeout.Get(&s.cfg.Settings.SV)
 
-	drainLeasesOp := "transfer range leases"
+	const drainLeasesOp = "transfer range leases"
 	if err := timeutil.RunWithTimeout(ctx, drainLeasesOp, transferTimeout,
 		func(ctx context.Context) error {
 			opts := retry.Options{

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -75,6 +75,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingui"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	gwutil "github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"google.golang.org/grpc"
@@ -3195,7 +3196,7 @@ func (s *systemAdminServer) EnqueueRange(
 
 	if err := timeutil.RunWithTimeout(ctx, "enqueue range", time.Minute, func(ctx context.Context) error {
 		return iterateNodes(
-			ctx, s.serverIterator, s.server.stopper, fmt.Sprintf("enqueue r%d in queue %s", req.RangeID, req.Queue),
+			ctx, s.serverIterator, s.server.stopper, redact.Sprintf("enqueue r%d in queue %s", req.RangeID, req.Queue),
 			noTimeout,
 			dialFn, nodeFn, responseFn, errorFn,
 		)

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/redact"
 	"github.com/gorilla/mux"
 )
 
@@ -234,7 +234,7 @@ func (a *apiV2Server) listRange(w http.ResponseWriter, r *http.Request) {
 		ctx,
 		a.status.serverIterator,
 		a.status.stopper,
-		fmt.Sprintf("details about range %d", rangeID),
+		redact.Sprintf("details about range %d", rangeID),
 		noTimeout,
 		a.status.dialNode,
 		nodeFn,

--- a/pkg/server/pagination.go
+++ b/pkg/server/pagination.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // simplePaginate takes in an input slice, and returns a sub-slice of the next
@@ -292,7 +293,7 @@ type paginatedNodeResponse[T any] struct {
 type rpcNodePaginator[Client, Result any] struct {
 	limit        int
 	numNodes     int
-	errorCtx     string
+	errorCtx     redact.RedactableString
 	pagState     paginationState
 	responseChan chan paginatedNodeResponse[Result]
 	nodeStatuses map[serverID]livenesspb.NodeLivenessStatus

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1674,7 +1674,7 @@ func (s *statusServer) fetchProfileFromAllNodes(
 	}
 	senderServerVersion := resp.Desc.ServerVersion
 
-	opName := fmt.Sprintf("fetch cluster-wide %s profile", req.Type)
+	opName := redact.Sprintf("fetch cluster-wide %s profile", req.Type)
 	nodeFn := func(ctx context.Context, statusClient serverpb.StatusClient, nodeID roachpb.NodeID) (*profData, error) {
 		var pd *profData
 		err := timeutil.RunWithTimeout(ctx, opName, 1*time.Minute, func(ctx context.Context) error {
@@ -3129,7 +3129,7 @@ func (s *statusServer) Range(
 	}
 
 	if err := iterateNodes(
-		ctx, s.serverIterator, s.stopper, fmt.Sprintf("details about range %d", req.RangeId), noTimeout,
+		ctx, s.serverIterator, s.stopper, redact.Sprintf("details about range %d", req.RangeId), noTimeout,
 		s.dialNode, nodeFn, responseFn, errorFn,
 	); err != nil {
 		return nil, srverrors.ServerError(ctx, err)
@@ -3160,7 +3160,7 @@ func iterateNodes[Client, Result any](
 	ctx context.Context,
 	iter ServerIterator,
 	stopper *stop.Stopper,
-	errorCtx string,
+	errorCtx redact.RedactableString,
 	nodeFnTimeout time.Duration,
 	dialFn func(ctx context.Context, nodeID roachpb.NodeID) (Client, error),
 	nodeFn func(ctx context.Context, client Client, nodeID roachpb.NodeID) (Result, error),
@@ -3260,7 +3260,7 @@ func iterateNodes[Client, Result any](
 func paginatedIterateNodes[Result any](
 	ctx context.Context,
 	s *statusServer,
-	errorCtx string,
+	errorCtx redact.RedactableString,
 	limit int,
 	pagState paginationState,
 	requestedNodes []roachpb.NodeID,

--- a/pkg/sql/fingerprint_span.go
+++ b/pkg/sql/fingerprint_span.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -30,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 var maxFingerprintNumWorkers = settings.RegisterIntSetting(
@@ -232,7 +232,7 @@ func fingerprintSpanImpl(
 		var recording tracingpb.Recording
 		var pErr *kvpb.Error
 		exportRequestErr := timeutil.RunWithTimeout(ctx,
-			fmt.Sprintf("ExportRequest fingerprint for span %s", roachpb.Span{Key: span.Key,
+			redact.Sprintf("ExportRequest fingerprint for span %s", roachpb.Span{Key: span.Key,
 				EndKey: span.EndKey}),
 			5*time.Minute, func(ctx context.Context) error {
 				sp := tracing.SpanFromContext(ctx)

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 func init() {
@@ -175,14 +176,14 @@ func (p *probeRangeGenerator) Next(ctx context.Context) (bool, error) {
 	p.ranges = p.ranges[1:]
 	p.curr = probeRangeRow{}
 
-	var opName string
+	var opName redact.RedactableString
 	if p.isWrite {
 		opName = "write probe"
 	} else {
 		opName = "read probe"
 	}
 	ctx, sp := tracing.EnsureChildSpan(
-		ctx, p.tracer, opName,
+		ctx, p.tracer, opName.StripMarkers(),
 		tracing.WithRecording(tracingpb.RecordingVerbose),
 	)
 	defer func() {

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // getCurrentEncodedVersionSettingValue returns the encoded value of
@@ -54,7 +54,7 @@ func (p *planner) getCurrentEncodedVersionSettingValue(
 	// the same time guaranteeing that a node reporting a certain version has
 	// also processed the corresponding version bump (which is important as only
 	// then does the node update its persisted state; see #22796).
-	if err := timeutil.RunWithTimeout(ctx, fmt.Sprintf("show cluster setting %s", name), 2*time.Minute,
+	if err := timeutil.RunWithTimeout(ctx, redact.Sprintf("show cluster setting %s", name), 2*time.Minute,
 		func(ctx context.Context) error {
 			tBegin := timeutil.Now()
 

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/go-ldap/ldap/v3"
 )
 
@@ -228,7 +229,7 @@ func GetUserSessionInitInfo(
 }
 
 func getUserInfoRunFn(
-	execCfg *ExecutorConfig, userName username.SQLUsername, opName string,
+	execCfg *ExecutorConfig, userName username.SQLUsername, opName redact.RedactableString,
 ) func(context.Context, func(context.Context) error) error {
 	// We may be operating with a timeout.
 	timeout := userLoginTimeout.Get(&execCfg.Settings.SV)

--- a/pkg/testutils/docker/BUILD.bazel
+++ b/pkg/testutils/docker/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_docker_docker//api/types",
         "@com_github_docker_docker//api/types/container",
         "@com_github_docker_docker//api/types/filters",

--- a/pkg/testutils/docker/single_node_docker_test.go
+++ b/pkg/testutils/docker/single_node_docker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -239,7 +240,7 @@ func TestSingleNodeDocker(t *testing.T) {
 
 				if err := timeutil.RunWithTimeout(
 					ctx,
-					fmt.Sprintf("execute command \"%s\"", query),
+					redact.Sprintf("execute command \"%s\"", query),
 					defaultTimeout,
 					func(ctx context.Context) error {
 						resp, err := dn.execSQLQuery(ctx, query, test.sqlOpts)

--- a/pkg/util/timeutil/BUILD.bazel
+++ b/pkg/util/timeutil/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errorspb",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//proto",
     ],
 )

--- a/pkg/util/timeutil/timeout.go
+++ b/pkg/util/timeutil/timeout.go
@@ -15,13 +15,17 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // RunWithTimeout runs a function with a timeout, the same way you'd do with
 // context.WithTimeout. It improves the opaque error messages returned by
 // WithTimeout by augmenting them with the op string that is passed in.
 func RunWithTimeout(
-	ctx context.Context, op string, timeout time.Duration, fn func(ctx context.Context) error,
+	ctx context.Context,
+	op redact.RedactableString,
+	timeout time.Duration,
+	fn func(ctx context.Context) error,
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout) // nolint:context
 	defer cancel()


### PR DESCRIPTION
These operations names are all static strings created by CRDB code, so don't have sensitive data.

Jira issue: CRDB-39951
Epic: CRDB-39822
Release note: None