### PR TITLE
sql: reduce allocations when planning aggregators

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -147,9 +147,10 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 	for _, inputTypeFamily := range []types.Family{types.IntFamily, types.DecimalFamily, types.FloatFamily, types.IntervalFamily} {
 		tmplInfo := avgAggTypeTmplInfo{TypeFamily: familyToString(inputTypeFamily)}
 		for _, inputTypeWidth := range supportedWidthsByCanonicalTypeFamily[inputTypeFamily] {
-			// Note that we don't use execinfrapb.GetAggregateInfo because we don't
-			// want to bring in a dependency on that package to reduce the burden
-			// of regenerating execgen code when the protobufs get generated.
+			// Note that we don't use execinfrapb.GetAggregateOutputType because
+			// we don't want to bring in a dependency on that package to reduce
+			// the burden of regenerating execgen code when the protobufs get
+			// generated.
 			retTypeFamily, retTypeWidth := inputTypeFamily, inputTypeWidth
 			if inputTypeFamily == types.IntFamily {
 				// Average of integers is a decimal.

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -164,9 +164,10 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 			TypeFamily: familyToString(inputTypeFamily),
 		}
 		for _, inputTypeWidth := range supportedWidthsByCanonicalTypeFamily[inputTypeFamily] {
-			// Note that we don't use execinfrapb.GetAggregateInfo because we don't
-			// want to bring in a dependency on that package to reduce the burden
-			// of regenerating execgen code when the protobufs get generated.
+			// Note that we don't use execinfrapb.GetAggregateOutputType because
+			// we don't want to bring in a dependency on that package to reduce
+			// the burden of regenerating execgen code when the protobufs get
+			// generated.
 			retTypeFamily, retTypeWidth := inputTypeFamily, inputTypeWidth
 			if inputTypeFamily == types.IntFamily {
 				if isSumInt {

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -260,7 +260,7 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 								// There is a special case for some functions when at
 								// least one argument is a tuple or an array of
 								// tuples.
-								// Such cases pass GetAggregateInfo check below,
+								// Such cases pass GetAggregateOutputType check below,
 								// but they are actually invalid, and during normal
 								// execution it is caught during type-checking.
 								// However, we don't want to do fully-fledged type
@@ -288,7 +288,7 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 								for _, typ := range aggFnInputTypes {
 									hasJSONColumn = hasJSONColumn || typ.Family() == types.JsonFamily
 								}
-								if _, outputType, err := execagg.GetAggregateInfo(aggFn, aggFnInputTypes...); err == nil {
+								if outputType, err := execagg.GetAggregateOutputType(aggFn, aggFnInputTypes); err == nil {
 									outputTypes[i] = outputType
 									break
 								}

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -190,8 +190,7 @@ func checkDistAggregationInfo(
 	// (e.g. DECIMAL instead of INT).
 	intermediaryTypes := make([]*types.T, numIntermediary)
 	for i, fn := range info.LocalStage {
-		var err error
-		_, returnTyp, err := execagg.GetAggregateInfo(fn, colTypes...)
+		returnTyp, err := execagg.GetAggregateOutputType(fn, colTypes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -210,7 +209,7 @@ func checkDistAggregationInfo(
 			inputTypes[i] = intermediaryTypes[localIdx]
 		}
 		var err error
-		_, finalOutputTypes[i], err = execagg.GetAggregateInfo(finalInfo.Fn, inputTypes...)
+		finalOutputTypes[i], err = execagg.GetAggregateOutputType(finalInfo.Fn, inputTypes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -512,7 +511,7 @@ func TestSingleArgumentDistAggregateFunctions(t *testing.T) {
 				continue
 			}
 			// See if this column works with this function.
-			_, _, err := execagg.GetAggregateInfo(fn, col.GetType())
+			_, err := execagg.GetAggregateOutputType(fn, []*types.T{col.GetType()})
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Previously, when performing the physical planning of the aggregators we would allocate a separate slice for input types of each aggregate function when we're retrieving the function's output type. This is suboptimal since that slice is only captured and cannot be mutated if the aggregate constructor function will be utilized. This is only the case during the execution, so during the physical planning we're free to reuse the same slice between multiple aggregates, which is what this commit does. In a profile from some customer queries this allocation accounted for 2.2% of all allocations.

Epic: None

Release note: None