### PR TITLE
roachtest: refactor tests to use WorkloadNode spec

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -990,7 +990,9 @@ func (f *clusterFactory) newCluster(
 		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)
 		createVMOpts.ClusterName = c.name
 		opts := []*cloud.ClusterCreateOpts{{Nodes: cfg.spec.NodeCount, CreateOpts: createVMOpts, ProviderOptsContainer: providerOptsContainer}}
-		if cfg.spec.WorkloadNode {
+		// There can only be one local cluster so creating two sequentially overwrites the first.
+		// There isn't a point to creating a different sized vm for local clusters, so skip it.
+		if cfg.spec.WorkloadNode && !cfg.localCluster {
 			opts = []*cloud.ClusterCreateOpts{
 				{Nodes: cfg.spec.NodeCount - 1, CreateOpts: createVMOpts, ProviderOptsContainer: providerOptsContainer},
 				{Nodes: 1, CreateOpts: createVMOpts, ProviderOptsContainer: workloadProviderOptsContainer},

--- a/pkg/cmd/roachtest/option/node_lister.go
+++ b/pkg/cmd/roachtest/option/node_lister.go
@@ -64,5 +64,8 @@ func (l NodeLister) Node(n int) NodeListOption {
 // WorkloadNode returns the workload node—it assumes that one has
 // been created through the cluster spec WorkloadNode option.
 func (l NodeLister) WorkloadNode() NodeListOption {
+	if !l.WorkloadNodeProvisioned {
+		l.Fatalf("workload node specified but no workload nodes were provisioned by the cluster")
+	}
 	return l.Nodes(l.NodeCount)
 }

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -36,6 +36,7 @@ func registerAcceptance(r registry.Registry) {
 		defaultLeases      bool
 		requiresLicense    bool
 		nativeLibs         []string
+		workloadNode       bool
 		incompatibleClouds registry.CloudSet
 	}{
 		// NOTE: acceptance tests are lightweight tests that run as part
@@ -88,6 +89,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:                 runAcceptanceClusterReplication,
 				numNodes:           3,
 				incompatibleClouds: cloudsWithoutServiceRegistration,
+				workloadNode:       true,
 			},
 			{
 				name:               "multitenant",
@@ -127,6 +129,10 @@ func registerAcceptance(r registry.Registry) {
 				}
 				extraOptions = append(extraOptions, spec.Geo())
 				extraOptions = append(extraOptions, spec.GCEZones(strings.Join(tc.nodeRegions, ",")))
+			}
+
+			if tc.workloadNode {
+				extraOptions = append(extraOptions, spec.WorkloadNode())
 			}
 
 			if tc.incompatibleClouds.IsInitialized() && tc.incompatibleClouds.Contains(spec.Local) {

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -32,6 +32,8 @@ func registerDatabaseDrop(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
 		spec.CPU(8),
+		spec.WorkloadNode(),
+		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(500),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
@@ -49,9 +51,6 @@ func registerDatabaseDrop(r registry.Registry) {
 		RequiresLicense:  true,
 		SnapshotPrefix:   "droppable-database-tpce-100k",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := c.Spec().NodeCount
-
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 				NamePrefix: t.SnapshotPrefix(),
 			})
@@ -93,10 +92,10 @@ func registerDatabaseDrop(r registry.Registry) {
 
 				runTPCE(ctx, t, c, tpceOptions{
 					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
+						settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
 						startOpts := option.NewStartOpts(option.NoBackupSchedule)
 						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
+						if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
 							t.Fatal(err)
 						}
 					},
@@ -104,7 +103,7 @@ func registerDatabaseDrop(r registry.Registry) {
 					disablePrometheus:  true,
 					setupType:          usingTPCEInit,
 					estimatedSetupTime: 4 * time.Hour,
-					nodes:              crdbNodes,
+					nodes:              len(c.CRDBNodes()),
 					cpus:               clusterSpec.CPUs,
 					ssds:               1,
 					onlySetup:          true,
@@ -139,7 +138,7 @@ func registerDatabaseDrop(r registry.Registry) {
 					disablePrometheus:  true,
 					setupType:          usingTPCEInit,
 					estimatedSetupTime: 4 * time.Hour,
-					nodes:              crdbNodes,
+					nodes:              len(c.CRDBNodes()),
 					cpus:               clusterSpec.CPUs,
 					ssds:               1,
 					onlySetup:          true,
@@ -170,15 +169,15 @@ func registerDatabaseDrop(r registry.Registry) {
 			}
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, crdbNodes).InstallNodes()).
-				WithCluster(c.Range(1, crdbNodes).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
 				WithScrapeConfigs(
 					prometheus.MakeWorkloadScrapeConfig("workload", "/",
 						makeWorkloadScrapeNodes(
-							c.Node(workloadNode).InstallNodes()[0],
-							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+							c.WorkloadNode().InstallNodes()[0],
+							[]workloadInstance{{nodes: c.WorkloadNode()}},
 						),
 					),
 				)
@@ -200,8 +199,8 @@ func registerDatabaseDrop(r registry.Registry) {
 					startOpts := option.NewStartOpts(option.NoBackupSchedule)
 					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
-					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
+					settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+					if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
 						t.Fatal(err)
 					}
 				},

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -46,20 +46,18 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.ManualOnly,
-		Cluster:          r.MakeClusterSpec(2, spec.CPU(8)),
+		Cluster:          r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
 		RequiresLicense:  true,
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount != 2 {
 				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
 			}
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := crdbNodes + 1
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
 			err := c.StartGrafana(ctx, t.L(), promCfg)
 			require.NoError(t, err)
@@ -69,7 +67,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				"--vmodule=io_load_listener=2")
 			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings()
-			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
+			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
 			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
 			require.NoError(t, err)
@@ -111,14 +109,14 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				))
 			}
 
-			if err := setBandwidthLimit(c.Range(1, crdbNodes), "wbps", 128<<20 /* 128MiB */, false); err != nil {
+			if err := setBandwidthLimit(c.CRDBNodes(), "wbps", 128<<20 /* 128MiB */, false); err != nil {
 				t.Fatal(err)
 			}
 
 			// TODO(aaditya): Extend this test to also limit reads once we have a
 			// mechanism to pace read traffic in AC.
 
-			db := c.Conn(ctx, t.L(), crdbNodes)
+			db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 			defer db.Close()
 
 			const bandwidthLimit = 75
@@ -130,15 +128,15 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 			}
 
 			duration := 30 * time.Minute
-			m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				t.Status(fmt.Sprintf("starting foreground kv workload thread (<%s)", time.Minute))
 				dur := " --duration=" + duration.String()
-				url := fmt.Sprintf(" {pgurl:1-%d}", crdbNodes)
+				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
 				cmd := "./cockroach workload run kv --init --histograms=perf/stats.json --concurrency=2 " +
 					"--splits=1000 --read-percent=50 --min-block-bytes=4096 --max-block-bytes=4096 " +
 					"--txn-qos='regular' --tolerate-errors" + dur + url
-				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), cmd)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil
 			})
 
@@ -146,11 +144,11 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				time.Sleep(1 * time.Minute)
 				t.Status(fmt.Sprintf("starting background kv workload thread (<%s)", time.Minute))
 				dur := " --duration=" + duration.String()
-				url := fmt.Sprintf(" {pgurl:1-%d}", crdbNodes)
+				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
 				cmd := "./cockroach workload run kv --init --histograms=perf/stats.json --concurrency=1024 " +
 					"--splits=1000 --read-percent=0 --min-block-bytes=4096 --max-block-bytes=4096 " +
 					"--txn-qos='background' --tolerate-errors" + dur + url
-				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), cmd)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil
 			})
 

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
@@ -42,23 +42,21 @@ func registerElasticControlForBackups(r registry.Registry) {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)
 			}
 
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := crdbNodes + 1
 			numWarehouses, workloadDuration, estimatedSetupTime := 1000, 90*time.Minute, 10*time.Minute
 			if c.IsLocal() {
 				numWarehouses, workloadDuration, estimatedSetupTime = 1, time.Minute, 2*time.Minute
 			}
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboardJSON(grafana.BackupAdmissionControlGrafanaJSON).
 				WithScrapeConfigs(
 					prometheus.MakeWorkloadScrapeConfig("workload", "/",
 						makeWorkloadScrapeNodes(
-							c.Node(workloadNode).InstallNodes()[0],
-							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+							c.WorkloadNode().InstallNodes()[0],
+							[]workloadInstance{{nodes: c.WorkloadNode()}},
 						),
 					),
 				)
@@ -80,13 +78,13 @@ func registerElasticControlForBackups(r registry.Registry) {
 				PrometheusConfig:              promCfg,
 				DisableDefaultScheduledBackup: true,
 				During: func(ctx context.Context) error {
-					db := c.Conn(ctx, t.L(), crdbNodes)
+					db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 					defer db.Close()
 
 					t.Status(fmt.Sprintf("during: enabling admission control (<%s)", 30*time.Second))
 					setAdmissionControl(ctx, t, c, true)
 
-					m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+					m := c.NewMonitor(ctx, c.CRDBNodes())
 					m.Go(func(ctx context.Context) error {
 						t.Status(fmt.Sprintf("during: creating full backup schedule to run every 20m (<%s)", time.Minute))
 						bucketPrefix := "gs"
@@ -113,7 +111,7 @@ func registerElasticControlForBackups(r registry.Registry) {
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		Suites:           registry.Suites(`weekly`),
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(8)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(8), spec.WorkloadNode()),
 		CompatibleClouds: registry.OnlyGCE,
 		Leases:           registry.MetamorphicLeases,
 		Run:              run("gce"),
@@ -124,7 +122,7 @@ func registerElasticControlForBackups(r registry.Registry) {
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		Suites:           registry.Suites(`weekly`),
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(8)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(8), spec.WorkloadNode()),
 		CompatibleClouds: registry.OnlyAWS,
 		Leases:           registry.MetamorphicLeases,
 		Run:              run("aws"),

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -35,7 +35,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(8)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(8), spec.WorkloadNode()),
 		RequiresLicense:  true,
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -43,23 +43,21 @@ func registerElasticControlForCDC(r registry.Registry) {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)
 			}
 
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := crdbNodes + 1
 			numWarehouses, workloadDuration, estimatedSetupTime := 1000, 60*time.Minute, 10*time.Minute
 			if c.IsLocal() {
 				numWarehouses, workloadDuration, estimatedSetupTime = 1, time.Minute, 2*time.Minute
 			}
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana).
 				WithScrapeConfigs(
 					prometheus.MakeWorkloadScrapeConfig("workload", "/",
 						makeWorkloadScrapeNodes(
-							c.Node(workloadNode).InstallNodes()[0],
-							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+							c.WorkloadNode().InstallNodes()[0],
+							[]workloadInstance{{nodes: c.WorkloadNode()}},
 						),
 					),
 				)
@@ -89,7 +87,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 				PrometheusConfig:              promCfg,
 				DisableDefaultScheduledBackup: true,
 				During: func(ctx context.Context) error {
-					db := c.Conn(ctx, t.L(), crdbNodes)
+					db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 					defer db.Close()
 
 					t.Status(fmt.Sprintf("configuring cluster (<%s)", 30*time.Second))
@@ -112,7 +110,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 					stopFeeds(db) // stop stray feeds (from repeated runs against the same cluster for ex.)
 					defer stopFeeds(db)
 
-					m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+					m := c.NewMonitor(ctx, c.CRDBNodes())
 					m.Go(func(ctx context.Context) error {
 						const iters, changefeeds = 5, 10
 						for i := 0; i < iters; i++ {

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -45,7 +45,7 @@ func registerElasticIO(r registry.Registry) {
 		Suites: registry.Suites(registry.Nightly),
 		// Tags:      registry.Tags(`weekly`),
 		// Second node is solely for Prometheus.
-		Cluster:         r.MakeClusterSpec(2, spec.CPU(8)),
+		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
 		RequiresLicense: true,
 		Leases:          registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -55,37 +55,34 @@ func registerElasticIO(r registry.Registry) {
 			if c.Spec().NodeCount != 2 {
 				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
 			}
-			crdbNodes := c.Spec().NodeCount - 1
-			workAndPromNode := crdbNodes + 1
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workAndPromNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana)
 			err := c.StartGrafana(ctx, t.L(), promCfg)
 			require.NoError(t, err)
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workAndPromNode))
 			startOpts := option.NewStartOpts(option.NoBackupSchedule)
 			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")
 			settings := install.MakeClusterSettings()
-			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
+			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
 			require.NoError(t, err)
 			statCollector := clusterstats.NewStatsCollector(ctx, promClient)
 			setAdmissionControl(ctx, t, c, true)
 			duration := 30 * time.Minute
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				dur := " --duration=" + duration.String()
-				url := fmt.Sprintf(" {pgurl:1-%d}", crdbNodes)
-				cmd := "./workload run kv --init --histograms=perf/stats.json --concurrency=512 " +
+				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
+				cmd := "./cockroach workload run kv --init --histograms=perf/stats.json --concurrency=512 " +
 					"--splits=1000 --read-percent=0 --min-block-bytes=65536 --max-block-bytes=65536 " +
 					"--txn-qos=background --tolerate-errors --secure" + dur + url
-				c.Run(ctx, option.WithNodes(c.Node(workAndPromNode)), cmd)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil
 			})
 			m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -33,6 +33,8 @@ func registerIndexBackfill(r registry.Registry) {
 	clusterSpec := r.MakeClusterSpec(
 		10, /* nodeCount */
 		spec.CPU(8),
+		spec.WorkloadNode(),
+		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(500),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
@@ -53,9 +55,6 @@ func registerIndexBackfill(r registry.Registry) {
 		RequiresLicense: true,
 		SnapshotPrefix:  "index-backfill-tpce-100k",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := c.Spec().NodeCount
-
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 				// TODO(irfansharif): Search by taking in the other parts of the
 				// snapshot fingerprint, i.e. the node count, the version, etc.
@@ -92,10 +91,10 @@ func registerIndexBackfill(r registry.Registry) {
 						// CRDB process is because when grabbing snapshots, CRDB
 						// is not running.
 						c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
-						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
+						settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
 						startOpts := option.NewStartOpts(option.NoBackupSchedule)
 						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
+						if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
 							t.Fatal(err)
 						}
 					},
@@ -103,7 +102,7 @@ func registerIndexBackfill(r registry.Registry) {
 					disablePrometheus:  true,
 					setupType:          usingTPCEInit,
 					estimatedSetupTime: 4 * time.Hour,
-					nodes:              crdbNodes,
+					nodes:              len(c.CRDBNodes()),
 					cpus:               clusterSpec.CPUs,
 					ssds:               1,
 					onlySetup:          true,
@@ -134,15 +133,15 @@ func registerIndexBackfill(r registry.Registry) {
 			}
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, crdbNodes).InstallNodes()).
-				WithCluster(c.Range(1, crdbNodes).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
 				WithScrapeConfigs(
 					prometheus.MakeWorkloadScrapeConfig("workload", "/",
 						makeWorkloadScrapeNodes(
-							c.Node(workloadNode).InstallNodes()[0],
-							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+							c.WorkloadNode().InstallNodes()[0],
+							[]workloadInstance{{nodes: c.WorkloadNode()}},
 						),
 					),
 				)
@@ -154,8 +153,8 @@ func registerIndexBackfill(r registry.Registry) {
 					startOpts := option.NewStartOpts(option.NoBackupSchedule)
 					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
-					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
+					settings := install.MakeClusterSettings(install.NumRacksOption(len(c.CRDBNodes())))
+					if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
 						t.Fatal(err)
 					}
 				},
@@ -189,7 +188,7 @@ func registerIndexBackfill(r registry.Registry) {
 					// TODO(irfansharif): These now take closer to an hour after
 					// https://github.com/cockroachdb/cockroach/pull/109085. Do
 					// something about it if customers complain.
-					m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+					m := c.NewMonitor(ctx, c.CRDBNodes())
 					m.Go(func(ctx context.Context) error {
 						t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
 						_, err := db.ExecContext(ctx,

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -45,7 +45,7 @@ func registerIntentResolutionOverload(r registry.Registry) {
 		// TODO(sumeer): Reduce to weekly after working well.
 		// Tags:      registry.Tags(`weekly`),
 		// Second node is solely for Prometheus.
-		Cluster:          r.MakeClusterSpec(2, spec.CPU(8)),
+		Cluster:          r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
 		RequiresLicense:  true,
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
@@ -54,13 +54,11 @@ func registerIntentResolutionOverload(r registry.Registry) {
 			if c.Spec().NodeCount != 2 {
 				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)
 			}
-			crdbNodes := c.Spec().NodeCount - 1
-			promNode := crdbNodes + 1
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(promNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboardJSON(grafana.ChangefeedAdmissionControlGrafana)
 			err := c.StartGrafana(ctx, t.L(), promCfg)
 			require.NoError(t, err)
@@ -70,7 +68,7 @@ func registerIntentResolutionOverload(r registry.Registry) {
 				"--vmodule=io_load_listener=2")
 			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings()
-			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
+			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
 			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
 			require.NoError(t, err)
@@ -78,9 +76,9 @@ func registerIntentResolutionOverload(r registry.Registry) {
 
 			setAdmissionControl(ctx, t, c, true)
 			t.Status("running txn")
-			m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
-				db := c.Conn(ctx, t.L(), crdbNodes)
+				db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 				defer db.Close()
 				_, err := db.Exec(`CREATE TABLE test_table(id integer PRIMARY KEY, t TEXT)`)
 				if err != nil {

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -25,11 +25,9 @@ import (
 
 func registerMultiStoreOverload(r registry.Registry) {
 	runKV := func(ctx context.Context, t test.Test, c cluster.Cluster) {
-		nodes := c.Spec().NodeCount - 1
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 		startOpts := option.NewStartOpts(option.NoBackupSchedule)
 		startOpts.RoachprodOpts.StoreCount = 2
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.CRDBNodes())
 
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
@@ -61,18 +59,18 @@ func registerMultiStoreOverload(r registry.Registry) {
 		dur := 20 * time.Minute
 		duration := " --duration=" + ifLocal(c, "10s", dur.String())
 		histograms := " --histograms=" + t.PerfArtifactsDir() + "/stats.json"
-		m1 := c.NewMonitor(ctx, c.Range(1, nodes))
+		m1 := c.NewMonitor(ctx, c.CRDBNodes())
 		m1.Go(func(ctx context.Context) error {
 			dbRegular := " --db=db1"
 			concurrencyRegular := ifLocal(c, "", " --concurrency=8")
 			readPercentRegular := " --read-percent=95"
-			cmdRegular := fmt.Sprintf("./workload run kv --init"+
+			cmdRegular := fmt.Sprintf("./cockroach workload run kv --init"+
 				dbRegular+histograms+concurrencyRegular+duration+readPercentRegular+
-				" {pgurl:1-%d}", nodes)
-			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmdRegular)
+				" {pgurl%s}", c.CRDBNodes())
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdRegular)
 			return nil
 		})
-		m2 := c.NewMonitor(ctx, c.Range(1, nodes))
+		m2 := c.NewMonitor(ctx, c.CRDBNodes())
 		m2.Go(func(ctx context.Context) error {
 			dbOverload := " --db=db2"
 			concurrencyOverload := ifLocal(c, "", " --concurrency=64")
@@ -80,10 +78,10 @@ func registerMultiStoreOverload(r registry.Registry) {
 			bs := 1 << 16 /* 64KB */
 			blockSizeOverload := fmt.Sprintf(" --min-block-bytes=%d --max-block-bytes=%d",
 				bs, bs)
-			cmdOverload := fmt.Sprintf("./workload run kv --init"+
+			cmdOverload := fmt.Sprintf("./cockroach workload run kv --init"+
 				dbOverload+histograms+concurrencyOverload+duration+readPercentOverload+blockSizeOverload+
-				" {pgurl:1-%d}", nodes)
-			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmdOverload)
+				" {pgurl%s}", c.CRDBNodes())
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdOverload)
 			return nil
 		})
 		m1.Wait()
@@ -96,7 +94,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
-		Cluster:          r.MakeClusterSpec(2, spec.CPU(8), spec.SSD(2)),
+		Cluster:          r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.SSD(2)),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKV(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/admission_control_row_level_ttl.go
+++ b/pkg/cmd/roachtest/tests/admission_control_row_level_ttl.go
@@ -25,9 +25,9 @@ import (
 
 func registerElasticControlForRowLevelTTL(r registry.Registry) {
 	const nodes = 7
-	var clusterSpec = spec.CPU(4)
-	r.Add(makeElasticControlRowLevelTTL(r.MakeClusterSpec(nodes, clusterSpec), false /* expiredRows */))
-	r.Add(makeElasticControlRowLevelTTL(r.MakeClusterSpec(nodes, clusterSpec), true /* expiredRows */))
+	var clusterSpec = r.MakeClusterSpec(nodes, spec.CPU(4), spec.WorkloadNode())
+	r.Add(makeElasticControlRowLevelTTL(clusterSpec, false /* expiredRows */))
+	r.Add(makeElasticControlRowLevelTTL(clusterSpec, true /* expiredRows */))
 }
 
 func makeElasticControlRowLevelTTL(spec spec.ClusterSpec, expiredRows bool) registry.TestSpec {
@@ -40,24 +40,21 @@ func makeElasticControlRowLevelTTL(spec spec.ClusterSpec, expiredRows bool) regi
 		Cluster:          spec,
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := crdbNodes + 1
-
 			numWarehouses, activeWarehouses, workloadDuration, estimatedSetupTime := 1500, 100, 20*time.Minute, 20*time.Minute
 			if c.IsLocal() {
 				numWarehouses, activeWarehouses, workloadDuration, estimatedSetupTime = 1, 1, 3*time.Minute, 2*time.Minute
 			}
 
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboard("https://go.crdb.dev/p/index-admission-control-grafana").
 				WithScrapeConfigs(
 					prometheus.MakeWorkloadScrapeConfig("workload", "/",
 						makeWorkloadScrapeNodes(
-							c.Node(workloadNode).InstallNodes()[0],
-							[]workloadInstance{{nodes: c.Node(workloadNode)}},
+							c.WorkloadNode().InstallNodes()[0],
+							[]workloadInstance{{nodes: c.WorkloadNode()}},
 						),
 					),
 				)

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -44,22 +44,20 @@ func registerSnapshotOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(8)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(8), spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)
 			}
 
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := crdbNodes + 1
-			for i := 1; i <= crdbNodes; i++ {
+			for i := 1; i <= len(c.CRDBNodes()); i++ {
 				startOpts := option.NewStartOpts(option.NoBackupSchedule)
 				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--attrs=n%d", i))
 				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(i))
 			}
 
-			db := c.Conn(ctx, t.L(), crdbNodes)
+			db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 			defer db.Close()
 
 			// Set a replication factor of 1 and pin replicas to n1 by default.
@@ -87,12 +85,12 @@ func registerSnapshotOverload(r registry.Registry) {
 			t.Status(fmt.Sprintf("setting up prometheus/grafana (<%s)", 2*time.Minute))
 			{
 				promCfg := &prometheus.Config{}
-				promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0])
-				promCfg.WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes())
-				promCfg.WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes())
+				promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0])
+				promCfg.WithNodeExporter(c.CRDBNodes().InstallNodes())
+				promCfg.WithCluster(c.CRDBNodes().InstallNodes())
 				promCfg.ScrapeConfigs = append(promCfg.ScrapeConfigs, prometheus.MakeWorkloadScrapeConfig("workload",
-					"/", makeWorkloadScrapeNodes(c.Node(workloadNode).InstallNodes()[0], []workloadInstance{
-						{nodes: c.Node(workloadNode)},
+					"/", makeWorkloadScrapeNodes(c.WorkloadNode().InstallNodes()[0], []workloadInstance{
+						{nodes: c.WorkloadNode()},
 					})))
 				promCfg.WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
 				_, cleanupFunc := setupPrometheusForRoachtest(ctx, t, c, promCfg, nil)
@@ -100,7 +98,7 @@ func registerSnapshotOverload(r registry.Registry) {
 			}
 
 			var constraints []string
-			for i := 1; i <= crdbNodes; i++ {
+			for i := 1; i <= len(c.CRDBNodes()); i++ {
 				constraints = append(constraints, fmt.Sprintf("+n%d: 1", i))
 			}
 			constraint := strings.Join(constraints, ",")
@@ -110,11 +108,11 @@ func registerSnapshotOverload(r registry.Registry) {
 			t.Status(fmt.Sprintf("initializing kv dataset (<%s)", time.Minute))
 			if !t.SkipInit() {
 				splits := ifLocal(c, " --splits=10", " --splits=100")
-				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload init kv "+splits+" {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), "./cockroach workload init kv "+splits+" {pgurl:1}")
 
 				if _, err := db.ExecContext(ctx, fmt.Sprintf(
 					"ALTER DATABASE kv CONFIGURE ZONE USING num_replicas = %d, constraints = '{%s}', lease_preferences = '[[+n1]]'",
-					crdbNodes, constraint),
+					len(c.CRDBNodes()), constraint),
 				); err != nil {
 					t.Fatalf("failed to configure zone for DATABASE kv: %v", err)
 				}
@@ -123,7 +121,7 @@ func registerSnapshotOverload(r registry.Registry) {
 			t.Status(fmt.Sprintf("initializing tpcc dataset (<%s)", 20*time.Minute))
 			if !t.SkipInit() {
 				warehouses := ifLocal(c, " --warehouses=10", " --warehouses=2000")
-				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload fixtures import tpcc --checks=false"+warehouses+" {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), "./cockroach workload fixtures import tpcc --checks=false"+warehouses+" {pgurl:1}")
 			}
 
 			const iters = 4
@@ -145,16 +143,16 @@ func registerSnapshotOverload(r registry.Registry) {
 			totalWorkloadDuration := totalTransferDuration + (2 * padDuration)
 
 			t.Status(fmt.Sprintf("starting kv workload thread to run for %s (<%s)", totalWorkloadDuration, time.Minute))
-			m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				duration := " --duration=" + totalWorkloadDuration.String()
 				histograms := " --histograms=" + t.PerfArtifactsDir() + "/stats.json"
 				concurrency := ifLocal(c, "  --concurrency=8", " --concurrency=256")
 				maxRate := ifLocal(c, "  --max-rate=100", " --max-rate=12000")
 				splits := ifLocal(c, "  --splits=10", " --splits=100")
-				c.Run(ctx, option.WithNodes(c.Node(crdbNodes+1)),
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 					"./cockroach workload run kv --max-block-bytes=1 --read-percent=95 "+
-						histograms+duration+concurrency+maxRate+splits+fmt.Sprintf(" {pgurl:1-%d}", crdbNodes),
+						histograms+duration+concurrency+maxRate+splits+fmt.Sprintf(" {pgurl%s}", c.CRDBNodes()),
 				)
 				return nil
 			})
@@ -165,13 +163,13 @@ func registerSnapshotOverload(r registry.Registry) {
 			t.Status(fmt.Sprintf("starting snapshot transfers for %s (<%s)", totalTransferDuration, time.Minute))
 			m.Go(func(ctx context.Context) error {
 				for i := 0; i < iters; i++ {
-					nextDestinationNode := 1 + ((i + 1) % crdbNodes) // if crdbNodes = 3, this cycles through 2, 3, 1, 2, 3, 1, ...
+					nextDestinationNode := 1 + ((i + 1) % len(c.CRDBNodes())) // if crdbNodes = 3, this cycles through 2, 3, 1, 2, 3, 1, ...
 					t.Status(fmt.Sprintf("snapshot round %d/%d: inert data and active leases routing to n%d (<%s)",
 						i+1, iters, nextDestinationNode, transferDuration))
 
 					if _, err := db.ExecContext(ctx, fmt.Sprintf(
 						"ALTER DATABASE kv CONFIGURE ZONE USING num_replicas = %d, constraints = '{%s}', lease_preferences = '[[+n%d]]'",
-						crdbNodes, constraint, nextDestinationNode),
+						len(c.CRDBNodes()), constraint, nextDestinationNode),
 					); err != nil {
 						t.Fatalf("failed to configure zone for DATABASE kv: %v", err)
 					}

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_excise.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_excise.go
@@ -47,7 +47,7 @@ func registerSnapshotOverloadExcise(r registry.Registry) {
 		Suites: registry.Suites(registry.Nightly),
 		// The test uses a large volume size to ensure high provisioned bandwidth
 		// from the cloud provider.
-		Cluster: r.MakeClusterSpec(4, spec.CPU(4), spec.VolumeSize(2000)),
+		Cluster: r.MakeClusterSpec(4, spec.CPU(4), spec.WorkloadNode(), spec.VolumeSize(2000)),
 		Leases:  registry.MetamorphicLeases,
 		Timeout: 12 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -71,15 +71,13 @@ func registerSnapshotOverloadExcise(r registry.Registry) {
 				"COCKROACH_CONCURRENT_SNAPSHOT_SEND_LIMIT=100",
 			}
 
-			crdbNodes := c.Spec().NodeCount - 1
-			workloadNode := crdbNodes + 1
 			startOpts := option.NewStartOpts(option.NoBackupSchedule)
 			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings(envOptions)
-			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
+			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
-			db := c.Conn(ctx, t.L(), crdbNodes)
+			db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 			defer db.Close()
 
 			t.Status(fmt.Sprintf("configuring cluster settings (<%s)", 30*time.Second))
@@ -107,9 +105,9 @@ func registerSnapshotOverloadExcise(r registry.Registry) {
 			t.Status(fmt.Sprintf("setting up prometheus/grafana (<%s)", 2*time.Minute))
 			var statCollector clusterstats.StatCollector
 			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.Node(workloadNode).InstallNodes()[0]).
-				WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
-				WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes()).
+			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+				WithNodeExporter(c.CRDBNodes().InstallNodes()).
+				WithCluster(c.CRDBNodes().InstallNodes()).
 				WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
 			err := c.StartGrafana(ctx, t.L(), promCfg)
 			require.NoError(t, err)
@@ -125,14 +123,14 @@ func registerSnapshotOverloadExcise(r registry.Registry) {
 
 			// Initialize the kv database,
 			t.Status(fmt.Sprintf("initializing kv dataset (<%s)", 2*time.Hour))
-			c.Run(ctx, option.WithNodes(c.Node(workloadNode)),
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 				"./cockroach workload init kv --drop --insert-count=40000000 "+
 					"--max-block-bytes=12288 --min-block-bytes=12288 {pgurl:1-3}")
 
 			t.Status(fmt.Sprintf("starting kv workload thread (<%s)", time.Minute))
-			m := c.NewMonitor(ctx, c.Range(1, crdbNodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(c.Node(workloadNode)),
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 					fmt.Sprintf("./cockroach workload run kv --tolerate-errors "+
 						"--splits=1000 --histograms=%s/stats.json --read-percent=75 "+
 						"--max-rate=600 --max-block-bytes=12288 --min-block-bytes=12288 "+

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -38,7 +38,7 @@ const allocatorStableSeconds = 120
 func registerAllocator(r registry.Registry) {
 	runAllocator := func(ctx context.Context, t test.Test, c cluster.Cluster, start int, maxStdDev float64) {
 		// Put away one node to be the stats collector.
-		nodes := c.Spec().NodeCount - 1
+		nodes := len(c.CRDBNodes())
 
 		// Don't start scheduled backups in this perf sensitive test that reports to roachperf
 		startOpts := option.NewStartOpts(option.NoBackupSchedule)
@@ -61,11 +61,9 @@ func registerAllocator(r registry.Registry) {
 		m.Wait()
 
 		// Setup the prometheus instance and client.
-		clusNodes := c.Range(1, nodes)
-		promNode := c.Node(c.Spec().NodeCount)
 		cfg := (&prometheus.Config{}).
-			WithCluster(clusNodes.InstallNodes()).
-			WithPrometheusNode(promNode.InstallNodes()[0])
+			WithCluster(c.CRDBNodes().InstallNodes()).
+			WithPrometheusNode(c.WorkloadNode().InstallNodes()[0])
 
 		err := c.StartGrafana(ctx, t.L(), cfg)
 		require.NoError(t, err)
@@ -104,7 +102,7 @@ func registerAllocator(r registry.Registry) {
 		// Wait for 3x replication, we record the time taken to achieve this.
 		var replicateTime time.Time
 		startTime := timeutil.Now()
-		m = c.NewMonitor(ctx, clusNodes)
+		m = c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			err := WaitFor3XReplication(ctx, t, t.L(), db)
 			replicateTime = timeutil.Now()
@@ -114,7 +112,7 @@ func registerAllocator(r registry.Registry) {
 
 		// Wait for replica count balance, this occurs only following
 		// up-replication finishing.
-		m = c.NewMonitor(ctx, clusNodes)
+		m = c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			t.Status("waiting for reblance")
 			err := waitForRebalance(ctx, t.L(), db, maxStdDev, allocatorStableSeconds)
@@ -149,7 +147,7 @@ func registerAllocator(r registry.Registry) {
 		Name:             `replicate/up/1to3`,
 		Owner:            registry.OwnerKV,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(4),
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
@@ -161,7 +159,7 @@ func registerAllocator(r registry.Registry) {
 		Name:             `replicate/rebalance/3to5`,
 		Owner:            registry.OwnerKV,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(6),
+		Cluster:          r.MakeClusterSpec(6, spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
@@ -176,7 +174,7 @@ func registerAllocator(r registry.Registry) {
 		// Allow a longer running time to account for runs that use a
 		// cockroach build with runtime assertions enabled.
 		Timeout:          30 * time.Minute,
-		Cluster:          r.MakeClusterSpec(9, spec.CPU(1)),
+		Cluster:          r.MakeClusterSpec(9, spec.CPU(1), spec.WorkloadNode(), spec.WorkloadNodeCPU(1)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -26,15 +26,11 @@ import (
 
 func registerAlterPK(r registry.Registry) {
 
-	setupTest := func(ctx context.Context, t test.Test, c cluster.Cluster) (option.NodeListOption, option.NodeListOption) {
-		roachNodes := c.Range(1, c.Spec().NodeCount-1)
-		loadNode := c.Node(c.Spec().NodeCount)
+	setupTest := func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.Status("copying binaries")
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 
 		t.Status("starting cockroach nodes")
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
-		return roachNodes, loadNode
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 	}
 
 	// runAlterPKBank runs a primary key change while the bank workload runs.
@@ -42,30 +38,26 @@ func registerAlterPK(r registry.Registry) {
 		const numRows = 1000000
 		const duration = 3 * time.Minute
 
-		roachNodes, loadNode := setupTest(ctx, t, c)
+		setupTest(ctx, t, c)
 
 		initDone := make(chan struct{}, 1)
 		pkChangeDone := make(chan struct{}, 1)
 
-		m := c.NewMonitor(ctx, roachNodes)
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			// Load up a relatively small dataset to perform a workload on.
 
 			// Init the workload.
-			cmd := fmt.Sprintf("./workload init bank --drop --rows %d {pgurl%s}", numRows, roachNodes)
-			if err := c.RunE(ctx, option.WithNodes(loadNode), cmd); err != nil {
+			cmd := fmt.Sprintf("./cockroach workload init bank --drop --rows %d {pgurl%s}", numRows, c.CRDBNodes())
+			if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd); err != nil {
 				t.Fatal(err)
 			}
 			initDone <- struct{}{}
 
 			// Run the workload while the primary key change is happening.
-			cmd = fmt.Sprintf("./workload run bank --duration=%s {pgurl%s}", duration, roachNodes)
-			c.Run(ctx, option.WithNodes(loadNode), cmd)
-			// Wait for the primary key change to finish.
-			<-pkChangeDone
 			t.Status("starting second run of the workload after primary key change")
 			// Run the workload after the primary key change occurs.
-			c.Run(ctx, option.WithNodes(loadNode), cmd)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			return nil
 		})
 		m.Go(func(ctx context.Context) error {
@@ -76,7 +68,7 @@ func registerAlterPK(r registry.Registry) {
 
 			t.Status("beginning primary key change")
 			defer func() { pkChangeDone <- struct{}{} }()
-			db := c.Conn(ctx, t.L(), roachNodes[0])
+			db := c.Conn(ctx, t.L(), c.WorkloadNode()[0])
 			defer db.Close()
 			cmds := []string{
 				`SET CLUSTER SETTING kv.transaction.internal.max_auto_retries = 10000`,
@@ -104,26 +96,26 @@ func registerAlterPK(r registry.Registry) {
 	runAlterPKTPCC := func(ctx context.Context, t test.Test, c cluster.Cluster, warehouses int, expensiveChecks bool) {
 		const duration = 10 * time.Minute
 
-		roachNodes, loadNode := setupTest(ctx, t, c)
+		setupTest(ctx, t, c)
 		cmd := fmt.Sprintf(
 			"./cockroach workload fixtures import tpcc --warehouses=%d --db=tpcc {pgurl:1}",
 			warehouses,
 		)
-		if err := c.RunE(ctx, option.WithNodes(c.Node(roachNodes[0])), cmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(c.Node(c.CRDBNodes()[0])), cmd); err != nil {
 			t.Fatal(err)
 		}
 
-		m := c.NewMonitor(ctx, roachNodes)
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			// Start running the workload.
 			runCmd := fmt.Sprintf(
-				"./workload run tpcc --warehouses=%d --split --scatter --duration=%s {pgurl%s}",
+				"./cockroach workload run tpcc --warehouses=%d --split --scatter --duration=%s {pgurl%s}",
 				warehouses,
 				duration,
-				roachNodes,
+				c.CRDBNodes(),
 			)
 			t.Status("beginning workload")
-			c.Run(ctx, option.WithNodes(loadNode), runCmd)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), runCmd)
 			t.Status("finished running workload")
 			return nil
 		})
@@ -148,7 +140,7 @@ func registerAlterPK(r registry.Registry) {
 			randStmt := alterStmts[rand.Intn(len(alterStmts))]
 			t.Status("Running command: ", randStmt)
 
-			db := c.Conn(ctx, t.L(), roachNodes[0])
+			db := c.Conn(ctx, t.L(), c.CRDBNodes()[0])
 			defer db.Close()
 			alterCmd := `USE tpcc; %s;`
 			t.Status("beginning primary key change")
@@ -167,13 +159,13 @@ func registerAlterPK(r registry.Registry) {
 			expensiveChecksArg = "--expensive-checks"
 		}
 		checkCmd := fmt.Sprintf(
-			"./workload check tpcc --warehouses %d %s {pgurl%s}",
+			"./cockroach workload check tpcc --warehouses %d %s {pgurl%s}",
 			warehouses,
 			expensiveChecksArg,
-			c.Node(roachNodes[0]),
+			c.Node(1),
 		)
 		t.Status("beginning database verification")
-		c.Run(ctx, option.WithNodes(loadNode), checkCmd)
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), checkCmd)
 		t.Status("finished database verification")
 	}
 	r.Add(registry.TestSpec{
@@ -181,7 +173,7 @@ func registerAlterPK(r registry.Registry) {
 		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
-		Cluster:          r.MakeClusterSpec(4),
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
@@ -192,7 +184,7 @@ func registerAlterPK(r registry.Registry) {
 		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(32)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(32), spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
@@ -205,7 +197,7 @@ func registerAlterPK(r registry.Registry) {
 		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -96,8 +96,6 @@ func importBankDataSplit(
 ) string {
 	dest := destinationName(c)
 
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload")
-
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
 	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings())
@@ -615,7 +613,6 @@ func runBackupMVCCRangeTombstones(
 	ctx context.Context, t test.Test, c cluster.Cluster, config mvccRangeTombstoneConfig,
 ) {
 	if !config.skipClusterSetup {
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload") // required for tpch
 		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings())
 	}
 	t.Status("starting csv servers")

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -81,7 +81,7 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			Name:              sp.name,
 			Timeout:           4 * time.Hour,
 			Owner:             registry.OwnerDisasterRecovery,
-			Cluster:           r.MakeClusterSpec(4),
+			Cluster:           r.MakeClusterSpec(4, spec.WorkloadNode()),
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			RequiresLicense:   true,
 			NativeLibs:        registry.LibGEOS,
@@ -102,8 +102,6 @@ func backupRestoreRoundTrip(
 	ctx context.Context, t test.Test, c cluster.Cluster, sp roundTripSpecs,
 ) {
 	pauseProbability := 0.2
-	roachNodes := c.Range(1, c.Spec().NodeCount-1)
-	workloadNode := c.Node(c.Spec().NodeCount)
 	testRNG, seed := randutil.NewLockedPseudoRand()
 	t.L().Printf("random seed: %d", seed)
 
@@ -111,18 +109,18 @@ func backupRestoreRoundTrip(
 		"COCKROACH_MIN_RANGE_MAX_BYTES=1",
 	})
 
-	c.Start(ctx, t.L(), maybeUseMemoryBudget(t, 50), install.MakeClusterSettings(envOption), roachNodes)
-	m := c.NewMonitor(ctx, roachNodes)
+	c.Start(ctx, t.L(), maybeUseMemoryBudget(t, 50), install.MakeClusterSettings(envOption), c.CRDBNodes())
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	m.Go(func(ctx context.Context) error {
-		testUtils, err := newCommonTestUtils(ctx, t, c, roachNodes, sp.mock, sp.onlineRestore)
+		testUtils, err := newCommonTestUtils(ctx, t, c, c.CRDBNodes(), sp.mock, sp.onlineRestore)
 		if err != nil {
 			return err
 		}
 		defer testUtils.CloseConnections()
 
 		dbs := []string{"bank", "tpcc", schemaChangeDB}
-		runBackgroundWorkload, err := startBackgroundWorkloads(ctx, t.L(), c, m, testRNG, roachNodes, workloadNode, testUtils, dbs)
+		runBackgroundWorkload, err := startBackgroundWorkloads(ctx, t.L(), c, m, testRNG, c.CRDBNodes(), c.WorkloadNode(), testUtils, dbs)
 		if err != nil {
 			return err
 		}
@@ -130,7 +128,7 @@ func backupRestoreRoundTrip(
 		if err != nil {
 			return err
 		}
-		d, err := newBackupRestoreTestDriver(ctx, t, c, testUtils, roachNodes, dbs, tables)
+		d, err := newBackupRestoreTestDriver(ctx, t, c, testUtils, c.CRDBNodes(), dbs, tables)
 		if err != nil {
 			return err
 		}
@@ -152,7 +150,7 @@ func backupRestoreRoundTrip(
 		defer stopBackgroundCommands()
 
 		for i := 0; i < numFullBackups; i++ {
-			allNodes := labeledNodes{Nodes: roachNodes, Version: clusterupgrade.CurrentVersion().String()}
+			allNodes := labeledNodes{Nodes: c.CRDBNodes(), Version: clusterupgrade.CurrentVersion().String()}
 			bspec := backupSpec{
 				PauseProbability: pauseProbability,
 				Plan:             allNodes,

--- a/pkg/cmd/roachtest/tests/buffered_logging.go
+++ b/pkg/cmd/roachtest/tests/buffered_logging.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -39,18 +40,15 @@ func registerBufferedLogging(r registry.Registry) {
 		t test.Test,
 		c cluster.Cluster,
 	) {
-		crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-		workloadNode := c.Node(c.Spec().NodeCount)
-
 		// Install Docker, which we'll use for FluentBit.
 		t.Status("installing docker")
-		if err := c.Install(ctx, t.L(), crdbNodes, "docker"); err != nil {
+		if err := c.Install(ctx, t.L(), c.CRDBNodes(), "docker"); err != nil {
 			t.Fatalf("failed to install docker: %v", err)
 		}
 
 		t.Status("installing FluentBit containers on CRDB nodes")
 		// Create FluentBit container on the node with a TCP input and dev/null output.
-		err := c.RunE(ctx, option.WithNodes(crdbNodes), fmt.Sprintf(
+		err := c.RunE(ctx, option.WithNodes(c.CRDBNodes()), fmt.Sprintf(
 			"sudo docker run -d -p %d:%d --name=fluentbit fluent/fluent-bit -i tcp -o null",
 			fluentBitTCPPort,
 			fluentBitTCPPort))
@@ -69,7 +67,7 @@ func registerBufferedLogging(r registry.Registry) {
 		startOpts.RoachprodOpts.ExtraArgs = []string{
 			"--log", logCfg,
 		}
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), crdbNodes)
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.CRDBNodes())
 
 		// Construct pgurls for the workload runner. As a roundabout way of detecting deadlocks,
 		// we set a client timeout on the workload pgclient. If the server becomes unavailable
@@ -78,7 +76,7 @@ func registerBufferedLogging(r registry.Registry) {
 		// so this helps detect such a case.
 		secureUrls, err := roachprod.PgURL(ctx,
 			t.L(),
-			c.MakeNodes(crdbNodes),
+			c.MakeNodes(c.CRDBNodes()),
 			install.CockroachNodeCertsDir, /* certsDir */
 			roachprod.PGURLOptions{
 				External: false,
@@ -97,14 +95,14 @@ func registerBufferedLogging(r registry.Registry) {
 		// Init & run a workload on the workload node.
 		t.Status("initializing workload")
 		initWorkloadCmd := fmt.Sprintf("./cockroach workload init kv %s ", secureUrls[0])
-		c.Run(ctx, option.WithNodes(workloadNode), initWorkloadCmd)
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), initWorkloadCmd)
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx, crdbNodes)
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			joinedURLs := strings.Join(workloadPGURLs, " ")
 			runWorkloadCmd := fmt.Sprintf("./cockroach workload run kv --concurrency=32 --duration=1h %s", joinedURLs)
-			return c.RunE(ctx, option.WithNodes(workloadNode), runWorkloadCmd)
+			return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runWorkloadCmd)
 		})
 		m.Wait()
 	}
@@ -112,7 +110,7 @@ func registerBufferedLogging(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "buffered_logging",
 		Owner:            registry.OwnerObservability,
-		Cluster:          r.MakeClusterSpec(numNodesBufferedLogging),
+		Cluster:          r.MakeClusterSpec(numNodesBufferedLogging, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -225,13 +225,13 @@ type replicateTPCC struct {
 }
 
 func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
-	return fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d {pgurl%s:%s}`,
+	return fmt.Sprintf(`./cockroach workload init tpcc --data-loader import --warehouses %d {pgurl%s:%s}`,
 		tpcc.warehouses, nodes, tenantName)
 }
 
 func (tpcc replicateTPCC) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
 	// added --tolerate-errors flags to prevent test from flaking due to a transaction retry error
-	return fmt.Sprintf(`./workload run tpcc --warehouses %d --tolerate-errors {pgurl%s:%s}`,
+	return fmt.Sprintf(`./cockroach workload run tpcc --warehouses %d --tolerate-errors {pgurl%s:%s}`,
 		tpcc.warehouses, nodes, tenantName)
 }
 
@@ -309,7 +309,7 @@ type replicateKV struct {
 }
 
 func (kv replicateKV) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
-	cmd := roachtestutil.NewCommand(`./workload init kv`).
+	cmd := roachtestutil.NewCommand(`./cockroach workload init kv`).
 		MaybeFlag(kv.initRows > 0, "insert-count", kv.initRows).
 		// Only set the max block byte values for the init command if we
 		// actually need to insert rows.
@@ -321,7 +321,7 @@ func (kv replicateKV) sourceInitCmd(tenantName string, nodes option.NodeListOpti
 }
 
 func (kv replicateKV) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
-	cmd := roachtestutil.NewCommand(`./workload run kv`).
+	cmd := roachtestutil.NewCommand(`./cockroach workload run kv`).
 		Option("tolerate-errors").
 		Flag("max-block-bytes", kv.maxBlockBytes).
 		Flag("read-percent", kv.readPercent).
@@ -525,8 +525,7 @@ func (rd *replicationDriver) setupC2C(
 
 	srcCluster := c.Range(1, rd.rs.srcNodes)
 	dstCluster := c.Range(rd.rs.srcNodes+1, rd.rs.srcNodes+rd.rs.dstNodes)
-	workloadNode := c.Node(rd.rs.srcNodes + rd.rs.dstNodes + 1)
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
+	workloadNode := c.WorkloadNode()
 
 	// TODO(msbutler): allow for backups once this test stabilizes a bit more.
 	srcStartOps := option.NewStartOpts(option.NoBackupSchedule)
@@ -1054,6 +1053,7 @@ func c2cRegisterWrapper(
 	if sp.pdSize != 0 {
 		clusterOps = append(clusterOps, spec.VolumeSize(sp.pdSize))
 	}
+	clusterOps = append(clusterOps, spec.WorkloadNode(), spec.WorkloadNodeCPU(sp.cpus))
 
 	if len(sp.multiregion.srcLocalities) > 0 {
 		allZones := make([]string, 0, sp.srcNodes+sp.dstNodes+1)

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -34,6 +34,8 @@ const (
 func runConnectionLatencyTest(
 	ctx context.Context, t test.Test, c cluster.Cluster, numNodes int, numZones int, password bool,
 ) {
+	// The connection latency workload is not available in the cockroach binary,
+	// so we must use the deprecated workload.
 	err := c.PutE(ctx, t.L(), t.DeprecatedWorkload(), "./workload")
 	require.NoError(t, err)
 
@@ -107,7 +109,7 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Owner:     registry.OwnerSQLFoundations,
 		Benchmark: true,
 		// Add one more node for load node.
-		Cluster:          r.MakeClusterSpec(numNodes+1, spec.GCEZones(regionUsCentral)),
+		Cluster:          r.MakeClusterSpec(numNodes+1, spec.WorkloadNode(), spec.GCEZones(regionUsCentral)),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -47,7 +47,6 @@ func registerCopy(r registry.Registry) {
 		const rowOverheadEstimate = 160
 		const rowEstimate = rowOverheadEstimate + payload
 
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
 		// We run this without metamorphic constants as kv-batch-size = 1 makes
 		// this test take far too long to complete.
 		// TODO(DarrylWong): Use a metamorphic constants exclusion list instead.
@@ -77,14 +76,14 @@ func registerCopy(r registry.Registry) {
 
 			t.Status("importing Bank fixture")
 			c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf(
-				"./workload fixtures load bank --rows=%d --payload-bytes=%d --seed %d {pgurl:1}",
+				"./cockroach workload fixtures load bank --rows=%d --payload-bytes=%d --seed %d {pgurl:1}",
 				rows, payload, fixturesRandomSeed))
 			if _, err := db.Exec("ALTER TABLE bank.bank RENAME TO bank.bank_orig"); err != nil {
 				t.Fatalf("failed to rename table: %v", err)
 			}
 
 			t.Status("create copy of Bank schema")
-			c.Run(ctx, option.WithNodes(c.Node(1)), "./workload init bank --rows=0 --ranges=0 {pgurl:1}")
+			c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach workload init bank --rows=0 --ranges=0 {pgurl:1}")
 
 			rangeCount := func() int {
 				var count int

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -251,7 +251,6 @@ func runDecommission(
 	// node1 is kept pinned (i.e. not decommissioned/restarted), and is the node
 	// through which we run the workload and other queries.
 	pinnedNode := 1
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(pinnedNode))
 
 	for i := 1; i <= nodes; i++ {
 		startOpts := option.DefaultStartOpts()
@@ -262,7 +261,7 @@ func runDecommission(
 		c.Start(ctx, t.L(), withDecommissionVMod(startOpts), install.MakeClusterSettings(), c.Node(i))
 	}
 	c.Run(ctx, option.WithNodes(c.Node(pinnedNode)),
-		fmt.Sprintf(`./workload init kv --drop {pgurl:%d}`, pinnedNode))
+		fmt.Sprintf(`./cockroach workload init kv --drop {pgurl:%d}`, pinnedNode))
 
 	h := newDecommTestHelper(t, c)
 
@@ -274,7 +273,7 @@ func runDecommission(
 		// TODO(tschottdorf): in remote mode, the ui shows that we consistently write
 		// at 330 qps (despite asking for 500 below). Locally we get 500qps (and a lot
 		// more without rate limiting). Check what's up with that.
-		fmt.Sprintf("./workload run kv --max-rate 500 --tolerate-errors --duration=%s {pgurl:1-%d}", duration.String(), nodes),
+		fmt.Sprintf("./cockroach workload run kv --max-rate 500 --tolerate-errors --duration=%s {pgurl:1-%d}", duration.String(), nodes),
 	}
 
 	run := func(stmt string) {

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -277,6 +277,13 @@ func registerDecommissionBenchSpec(r registry.Registry, benchSpec decommissionBe
 		extraNameParts = append(extraNameParts, "multi-region")
 	}
 
+	// Save some money and CPU quota by using a smaller workload CPU. Only
+	// do this for cluster of size 3 or smaller to avoid regressions.
+	specOptions = append(specOptions, spec.WorkloadNode())
+	if benchSpec.nodes > 3 {
+		spec.WorkloadNodeCPU(16)
+	}
+
 	// If run with ROACHTEST_DECOMMISSION_NOSKIP=1, roachtest will enable all specs.
 	noSkipFlag := os.Getenv(envDecommissionNoSkipFlag)
 	if noSkipFlag != "" {
@@ -370,10 +377,9 @@ func setupDecommissionBench(
 	t test.Test,
 	c cluster.Cluster,
 	benchSpec decommissionBenchSpec,
-	workloadNode, pinnedNode int,
+	pinnedNode int,
 	importCmd string,
 ) {
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workloadNode))
 	for i := 1; i <= benchSpec.nodes; i++ {
 		// Don't start a scheduled backup as this roachtest reports to roachperf.
 		startOpts := option.NewStartOpts(option.NoBackupSchedule)
@@ -606,7 +612,7 @@ func runDecommissionBench(
 		`./cockroach workload fixtures import tpcc --warehouses=%d`,
 		benchSpec.warehouses,
 	)
-	workloadCmd := fmt.Sprintf("./workload run tpcc --warehouses=%d --max-rate=%d --duration=%s "+
+	workloadCmd := fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --max-rate=%d --duration=%s "+
 		"--histograms=%s/stats.json --ramp=%s --tolerate-errors {pgurl:1-%d}", maxRate, benchSpec.warehouses,
 		testTimeout, t.PerfArtifactsDir(), rampDuration, benchSpec.nodes)
 
@@ -614,13 +620,13 @@ func runDecommissionBench(
 	// to run a write-heavy workload known to be difficult for compactions to keep
 	// pace with.
 	if benchSpec.slowWrites {
-		workloadCmd = fmt.Sprintf("./workload run kv --init --concurrency=%d --splits=1000 "+
+		workloadCmd = fmt.Sprintf("./cockroach workload run kv --init --concurrency=%d --splits=1000 "+
 			"--read-percent=50 --min-block-bytes=8192 --max-block-bytes=8192 --duration=%s "+
 			"--histograms=%s/stats.json --ramp=%s --tolerate-errors {pgurl:1-%d}", benchSpec.nodes*64,
 			testTimeout, t.PerfArtifactsDir(), rampDuration, benchSpec.nodes)
 	}
 
-	setupDecommissionBench(ctx, t, c, benchSpec, workloadNode, pinnedNode, importCmd)
+	setupDecommissionBench(ctx, t, c, benchSpec, pinnedNode, importCmd)
 
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
 	m := c.NewMonitor(workloadCtx, crdbNodes)
@@ -632,7 +638,7 @@ func runDecommissionBench(
 
 				// Run workload effectively indefinitely, to be later killed by context
 				// cancellation once decommission has completed.
-				err := c.RunE(ctx, option.WithNodes(c.Node(workloadNode)), workloadCmd)
+				err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), workloadCmd)
 				if errors.Is(ctx.Err(), context.Canceled) {
 					// Workload intentionally cancelled via context, so don't return error.
 					return nil
@@ -751,11 +757,11 @@ func runDecommissionBenchLong(
 		`./cockroach workload fixtures import tpcc --warehouses=%d`,
 		benchSpec.warehouses,
 	)
-	workloadCmd := fmt.Sprintf("./workload run tpcc --warehouses=%d --max-rate=%d --duration=%s "+
+	workloadCmd := fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --max-rate=%d --duration=%s "+
 		"--histograms=%s/stats.json --ramp=%s --tolerate-errors {pgurl:1-%d}", maxRate, benchSpec.warehouses,
 		testTimeout, t.PerfArtifactsDir(), rampDuration, benchSpec.nodes)
 
-	setupDecommissionBench(ctx, t, c, benchSpec, workloadNode, pinnedNode, importCmd)
+	setupDecommissionBench(ctx, t, c, benchSpec, pinnedNode, importCmd)
 
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
 	m := c.NewMonitor(workloadCtx, crdbNodes)

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -30,7 +31,7 @@ func registerDiskFull(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "disk-full",
 		Owner:            registry.OwnerStorage,
-		Cluster:          r.MakeClusterSpec(5),
+		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -39,8 +40,7 @@ func registerDiskFull(r registry.Registry) {
 				t.Skip("you probably don't want to fill your local disk")
 			}
 
-			nodes := c.Spec().NodeCount - 1
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 			// Node 1 will soon be killed, when the ballast file fills up its disk. To
 			// ensure that the ranges containing system tables are available on other
@@ -54,19 +54,19 @@ func registerDiskFull(r registry.Registry) {
 			_ = db.Close()
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.Range(1, nodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf(
 					"./cockroach workload run kv --tolerate-errors --init --read-percent=0"+
 						" --concurrency=10 --duration=4m {pgurl:2-%d}",
-					nodes)
-				c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+					len(c.CRDBNodes()))
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				return nil
 			})
 
 			// Each node should have an automatically created
 			// EMERGENCY_BALLAST file in the auxiliary directory.
-			c.Run(ctx, option.WithNodes(c.Range(1, nodes)), "stat {store-dir}/auxiliary/EMERGENCY_BALLAST")
+			c.Run(ctx, option.WithNodes(c.CRDBNodes()), "stat {store-dir}/auxiliary/EMERGENCY_BALLAST")
 
 			m.Go(func(ctx context.Context) error {
 				const n = 1

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -37,7 +37,7 @@ func registerDiskStalledWALFailover(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                "disk-stalled/wal-failover/among-stores",
 		Owner:               registry.OwnerStorage,
-		Cluster:             r.MakeClusterSpec(4, spec.CPU(16), spec.ReuseNone(), spec.SSD(2)),
+		Cluster:             r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.ReuseNone(), spec.SSD(2)),
 		CompatibleClouds:    registry.OnlyGCE,
 		Suites:              registry.Suites(registry.Nightly),
 		Timeout:             3 * time.Hour,
@@ -83,7 +83,7 @@ func runDiskStalledWALFailover(
 		"--log", fmt.Sprintf(`{file-defaults: {dir: "%s", buffered-writes: false, buffering: {max-staleness: 1s, flush-trigger-size: 256KiB, max-buffer-size: 50MiB}}}`, s.LogDir()),
 		"--wal-failover=" + failoverFlag,
 	}
-	c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))
+	c.Start(ctx, t.L(), startOpts, startSettings, c.CRDBNodes())
 
 	// Open a SQL connection to n1, the node that will be stalled.
 	n1Conn := c.Conn(ctx, t.L(), 1)
@@ -94,15 +94,15 @@ func runDiskStalledWALFailover(
 	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, t.L(), c.Nodes(2))
 	require.NoError(t, err)
 	adminURL := adminUIAddrs[0]
-	c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 	_, err = n1Conn.ExecContext(ctx, `USE kv;`)
 	require.NoError(t, err)
 
 	t.Status("starting workload")
 	workloadStartAt := timeutil.Now()
-	m := c.NewMonitor(ctx, c.Range(1, 3))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload run kv --read-percent 0 `+
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 0 `+
 			`--duration 60m --concurrency 4096 --ramp=1m --max-rate 4096 --tolerate-errors `+
 			` --min-block-bytes=2048 --max-block-bytes=2048 --timeout 1s `+
 			`{pgurl:1-3}`)
@@ -184,7 +184,7 @@ func runDiskStalledWALFailover(
 	m.Wait()
 
 	// Shut down the nodes, allowing any devices to be unmounted during cleanup.
-	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 3))
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.CRDBNodes())
 }
 
 // registerDiskStalledDetection registers the disk stall detection tests. These
@@ -210,7 +210,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 			Owner: registry.OwnerStorage,
 			// Use PDs in an attempt to work around flakes encountered when using SSDs.
 			// See #97968.
-			Cluster:             r.MakeClusterSpec(4, spec.ReuseNone(), spec.DisableLocalSSD()),
+			Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode(), spec.ReuseNone(), spec.DisableLocalSSD()),
 			CompatibleClouds:    registry.OnlyGCE,
 			Suites:              registry.Suites(registry.Nightly),
 			Timeout:             30 * time.Minute,
@@ -250,7 +250,7 @@ func runDiskStalledDetection(
 	defer s.Cleanup(ctx)
 
 	t.Status("starting cluster")
-	c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))
+	c.Start(ctx, t.L(), startOpts, startSettings, c.CRDBNodes())
 
 	// Assert the process monotonic times are as expected.
 	var ok bool
@@ -278,19 +278,19 @@ func runDiskStalledDetection(
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, t.L(), n2conn))
 
-	c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 	_, err = n2conn.ExecContext(ctx, `USE kv;`)
 	require.NoError(t, err)
 
 	t.Status("starting workload")
 	workloadStartAt := timeutil.Now()
-	m := c.NewMonitor(ctx, c.Range(1, 3))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		// NB: Since we stall node 1, we run the workload only on nodes 2-3 so
 		// the post-stall QPS isn't affected by the fact that 1/3rd of workload
 		// workers just can't connect to a working node.
-		c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload run kv --read-percent 50 `+
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 10m --concurrency 256 --max-rate 2048 --tolerate-errors `+
 			` --min-block-bytes=512 --max-block-bytes=512 `+
 			`{pgurl:2-3}`)
@@ -397,7 +397,7 @@ func runDiskStalledDetection(
 	m.Wait()
 
 	// Shut down the nodes, allowing any devices to be unmounted during cleanup.
-	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 3))
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.CRDBNodes())
 }
 
 func getProcessStartMonotonic(

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -35,12 +35,11 @@ func registerDrop(r registry.Registry) {
 	// rows). Next, it issues a `DROP` for the whole database, and sets the GC TTL
 	// to one second.
 	runDrop := func(ctx context.Context, t test.Test, c cluster.Cluster, warehouses, nodes int) {
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Range(1, nodes))
 		settings := install.MakeClusterSettings()
 		settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=15s")
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Range(1, nodes))
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings)
 
-		m := c.NewMonitor(ctx, c.Range(1, nodes))
+		m := c.NewMonitor(ctx, c.All())
 		m.Go(func(ctx context.Context) error {
 			t.WorkerStatus("importing TPCC fixture")
 			c.Run(ctx, option.WithNodes(c.Node(1)), tpccImportCmd("", warehouses, "{pgurl:1}"))

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -82,8 +82,8 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             90 * time.Minute,
-				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.DisableLocalSSD(), spec.ReuseNone()), // uses disk stalls
-				CompatibleClouds:    registry.OnlyGCE,                                                             // dmsetup only configured for gce
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2), spec.DisableLocalSSD(), spec.ReuseNone()), // uses disk stalls
+				CompatibleClouds:    registry.OnlyGCE,                                                                                                           // dmsetup only configured for gce
 				Suites:              registry.Suites(registry.Nightly),
 				Leases:              leases,
 				SkipPostValidations: registry.PostValidationNoDeadNodes, // cleanup kills nodes
@@ -98,7 +98,7 @@ func registerFailover(r registry.Registry) {
 			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			Timeout:          30 * time.Minute,
-			Cluster:          r.MakeClusterSpec(8, spec.CPU(2)),
+			Cluster:          r.MakeClusterSpec(8, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2)),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           leases,
@@ -110,7 +110,7 @@ func registerFailover(r registry.Registry) {
 			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			Timeout:          30 * time.Minute,
-			Cluster:          r.MakeClusterSpec(7, spec.CPU(2)),
+			Cluster:          r.MakeClusterSpec(7, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2)),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           leases,
@@ -122,7 +122,7 @@ func registerFailover(r registry.Registry) {
 			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			Timeout:          30 * time.Minute,
-			Cluster:          r.MakeClusterSpec(8, spec.CPU(2)),
+			Cluster:          r.MakeClusterSpec(8, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2)),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           leases,
@@ -131,7 +131,7 @@ func registerFailover(r registry.Registry) {
 
 		for _, failureMode := range allFailureModes {
 			clusterOpts := make([]spec.Option, 0)
-			clusterOpts = append(clusterOpts, spec.CPU(2))
+			clusterOpts = append(clusterOpts, spec.CPU(2), spec.WorkloadNode(), spec.WorkloadNodeCPU(2))
 			clouds := registry.AllExceptAWS
 
 			var postValidation registry.PostValidation
@@ -217,7 +217,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	// breakers for all ranges by default.
 	settings.ClusterSettings["kv.dist_sender.circuit_breakers.mode"] = "all ranges"
 
-	m := c.NewMonitor(ctx, c.Range(1, 9))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failers := []Failer{}
 	for _, failureMode := range allFailureModes {
@@ -231,7 +231,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 		failers = append(failers, failer)
 	}
 
-	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.Range(1, 9))
+	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.CRDBNodes())
 
 	conn := c.Conn(ctx, t.L(), 1)
 
@@ -252,7 +252,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	t.L().Printf("creating workload database")
 	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
-	c.Run(ctx, option.WithNodes(c.Node(10)), fmt.Sprintf(
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(
 		`./cockroach workload init kv --splits 1000 --insert-count %d {pgurl:1}`, insertCount))
 
 	// Scatter the ranges, then relocate them off of the SQL gateways n1-n2.
@@ -273,7 +273,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 		if readOnly {
 			readPercent = 100
 		}
-		err := c.RunE(ctx, option.WithNodes(c.Node(10)), fmt.Sprintf(
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(
 			`./cockroach workload run kv --read-percent %d --write-seq R%d `+
 				`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 				`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-2}`,
@@ -410,13 +410,13 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.Range(1, 7))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureModeBlackhole, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
-	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.Range(1, 7))
+	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.CRDBNodes())
 
 	conn := c.Conn(ctx, t.L(), 1)
 
@@ -449,7 +449,7 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	// Run workload on n8 via n6-n7 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		err := c.RunE(ctx, option.WithNodes(c.Node(8)), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:6-7}`)
 		if ctx.Err() != nil {
@@ -544,7 +544,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	settings.Env = append(settings.Env, "COCKROACH_DISABLE_LEADER_FOLLOWS_LEASEHOLDER=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.Range(1, 6))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureModeBlackhole, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
@@ -597,7 +597,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		err := c.RunE(ctx, option.WithNodes(c.Node(7)), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
 		if ctx.Err() != nil {
@@ -673,13 +673,13 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.Range(1, 7))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureModeBlackhole, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
-	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.Range(1, 7))
+	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.CRDBNodes())
 
 	conn := c.Conn(ctx, t.L(), 1)
 
@@ -711,7 +711,7 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	// ends (context cancels).
 	t.L().Printf("running workload")
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		err := c.RunE(ctx, option.WithNodes(c.Node(8)), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
 		if ctx.Err() != nil {
@@ -789,13 +789,13 @@ func runFailoverNonSystem(
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.Range(1, 6))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureMode, settings, rng)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
-	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.Range(1, 6))
+	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.CRDBNodes())
 
 	conn := c.Conn(ctx, t.L(), 1)
 
@@ -822,7 +822,7 @@ func runFailoverNonSystem(
 	// Run workload on n7 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		err := c.RunE(ctx, option.WithNodes(c.Node(7)), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
 		if ctx.Err() != nil {
@@ -896,13 +896,13 @@ func runFailoverLiveness(
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.Range(1, 4))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureMode, settings, rng)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
-	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.Range(1, 4))
+	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.CRDBNodes())
 
 	conn := c.Conn(ctx, t.L(), 1)
 
@@ -921,7 +921,7 @@ func runFailoverLiveness(
 	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
-	c.Run(ctx, option.WithNodes(c.Node(5)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 	// The replicate queue takes forever to move the other ranges off of n4 so we
 	// do it ourselves. Precreating the database/range and moving it to the
@@ -935,7 +935,7 @@ func runFailoverLiveness(
 	// Run workload on n5 via n1-n3 gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		err := c.RunE(ctx, option.WithNodes(c.Node(5)), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
 		if ctx.Err() != nil {
@@ -1009,13 +1009,13 @@ func runFailoverSystemNonLiveness(
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.Range(1, 6))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureMode, settings, rng)
 	failer.Setup(ctx)
 	defer failer.Cleanup(ctx)
 
-	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.Range(1, 6))
+	c.Start(ctx, t.L(), failoverStartOpts(), settings, c.CRDBNodes())
 
 	conn := c.Conn(ctx, t.L(), 1)
 
@@ -1033,7 +1033,7 @@ func runFailoverSystemNonLiveness(
 	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
-	c.Run(ctx, option.WithNodes(c.Node(7)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 	// The replicate queue takes forever to move the kv ranges from n4-n6 to
 	// n1-n3, so we do it ourselves. Precreating the database/range and moving it
@@ -1047,7 +1047,7 @@ func runFailoverSystemNonLiveness(
 	// Run workload on n7 via n1-n3 as gateways until test ends (context cancels).
 	t.L().Printf("running workload")
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		err := c.RunE(ctx, option.WithNodes(c.Node(7)), `./cockroach workload run kv --read-percent 50 `+
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 50 `+
 			`--concurrency 256 --max-rate 2048 --timeout 1m --tolerate-errors `+
 			`--histograms=`+t.PerfArtifactsDir()+`/stats.json {pgurl:1-3}`)
 		if ctx.Err() != nil {

--- a/pkg/cmd/roachtest/tests/hotspotsplits.go
+++ b/pkg/cmd/roachtest/tests/hotspotsplits.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -31,13 +32,9 @@ func registerHotSpotSplits(r registry.Registry) {
 	// to force a large range. We then make sure that the largest range isn't larger than a threshold and
 	// that backpressure is working correctly.
 	runHotSpot := func(ctx context.Context, t test.Test, c cluster.Cluster, duration time.Duration, concurrency int) {
-		roachNodes := c.Range(1, c.Spec().NodeCount-1)
-		appNode := c.Node(c.Spec().NodeCount)
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
-
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", appNode)
-		c.Run(ctx, option.WithNodes(appNode), `./workload init kv --drop {pgurl:1}`)
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload init kv --drop {pgurl:1}`)
 
 		var m *errgroup.Group // see comment in version.go
 		m, ctx = errgroup.WithContext(ctx)
@@ -46,10 +43,10 @@ func registerHotSpotSplits(r registry.Registry) {
 			t.L().Printf("starting load generator\n")
 
 			const blockSize = 1 << 18 // 256 KB
-			return c.RunE(ctx, option.WithNodes(appNode), fmt.Sprintf(
-				"./workload run kv --read-percent=0 --tolerate-errors --concurrency=%d "+
-					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl:1-3}",
-				concurrency, blockSize, blockSize, duration.String()))
+			return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(
+				"./cockroach workload run kv --read-percent=0 --tolerate-errors --concurrency=%d "+
+					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl%s}",
+				concurrency, blockSize, blockSize, duration.String(), c.CRDBNodes()))
 		})
 
 		m.Go(func() error {
@@ -97,7 +94,7 @@ func registerHotSpotSplits(r registry.Registry) {
 		// Test OOMs below this version because of scans over the large rows.
 		// No problem in 20.1 thanks to:
 		// https://github.com/cockroachdb/cockroach/pull/45323.
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -126,10 +126,9 @@ func registerImportNodeShutdown(r registry.Registry) {
 func registerImportTPCC(r registry.Registry) {
 	runImportTPCC := func(ctx context.Context, t test.Test, c cluster.Cluster, testName string,
 		timeout time.Duration, warehouses int) {
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
-		c.Run(ctx, option.WithNodes(c.All()), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+		c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		t.Status("running workload")
 		m := c.NewMonitor(ctx)
@@ -356,10 +355,9 @@ func registerImportDecommissioned(r registry.Registry) {
 			warehouses = 10
 		}
 
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
-		c.Run(ctx, option.WithNodes(c.All()), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+		c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		// Decommission a node.
 		nodeToDecommission := 2

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -48,7 +48,6 @@ func registerImportCancellation(r registry.Registry) {
 }
 
 func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload") // required for tpch
 	startOpts := maybeUseMemoryBudget(t, 50)
 	startOpts.RoachprodOpts.ScheduleBackups = true
 	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings())
@@ -162,7 +161,7 @@ func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) 
 		// were run 2 times.
 		maxOps := 2 * numQueries
 		cmd := fmt.Sprintf(
-			"./workload run tpch --db=csv --concurrency=1 --queries=%s --max-ops=%d {pgurl%s} "+
+			"./cockroach workload run tpch --db=csv --concurrency=1 --queries=%s --max-ops=%d {pgurl%s} "+
 				"--enable-checks=true", queries, maxOps, c.All())
 		if err := c.RunE(ctx, option.WithNodes(c.Node(1)), cmd); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -37,6 +37,8 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 		Cluster: r.MakeClusterSpec(
 			nodes+1,
 			spec.CPU(16),
+			spec.WorkloadNode(),
+			spec.WorkloadNodeCPU(16),
 			spec.Geo(),
 			spec.GCEZones(strings.Join(gceGeoZones, ",")),
 			spec.AWSZones(strings.Join(awsGeoZones, ",")),
@@ -50,20 +52,20 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 			if c.Cloud() == spec.AWS {
 				firstAZ = awsGeoZones[0]
 			}
-			roachNodes := c.Range(1, nodes)
 			gatewayNodes := c.Range(1, nodes/3)
-			loadNode := c.Node(nodes + 1)
 
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
+			// The indexes workload is not available in the cockroach binary,
+			// so we must use the deprecated workload.
+			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.WorkloadNode())
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 			conn := c.Conn(ctx, t.L(), 1)
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, roachNodes)
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				secondary := " --secondary-indexes=" + strconv.Itoa(secondaryIndexes)
 				initCmd := "./workload init indexes" + secondary + " {pgurl:1}"
-				c.Run(ctx, option.WithNodes(loadNode), initCmd)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), initCmd)
 
 				// Set lease preferences so that all leases for the table are
 				// located in the availability zone with the load generator.
@@ -136,7 +138,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 				duration := " --duration=" + ifLocal(c, "10s", "10m")
 				runCmd := fmt.Sprintf("./workload run indexes --histograms="+t.PerfArtifactsDir()+"/stats.json"+
 					payload+concurrency+duration+" {pgurl%s}", gatewayNodes)
-				c.Run(ctx, option.WithNodes(loadNode), runCmd)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), runCmd)
 				return nil
 			})
 			m.Wait()

--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -27,7 +28,7 @@ func registerSchemaChangeInvertedIndex(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "schemachange/invertedindex",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(5),
+		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -40,14 +41,13 @@ func registerSchemaChangeInvertedIndex(r registry.Registry) {
 // runInvertedIndex tests the correctness and performance of building an
 // inverted index on randomly generated JSON data (from the JSON workload).
 func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cluster) {
-	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-	workloadNode := c.Node(c.Spec().NodeCount)
-
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), crdbNodes)
+	// The json workload is not available in the cockroach binary,
+	// so we must use the deprecated workload.
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.WorkloadNode())
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 	cmdInit := "./workload init json {pgurl:1}"
-	c.Run(ctx, option.WithNodes(workloadNode), cmdInit)
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdInit)
 
 	// On a 4-node GCE cluster with the standard configuration, this generates ~10 million rows
 	initialDataDuration := time.Minute * 20
@@ -59,14 +59,14 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 
 	// First generate random JSON data using the JSON workload.
 	// TODO (lucy): Using a pre-generated test fixture would be much faster
-	m := c.NewMonitor(ctx, crdbNodes)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	cmdWrite := fmt.Sprintf(
-		"./workload run json --read-percent=0 --duration %s {pgurl:1-%d} --batch 1000 --sequential",
-		initialDataDuration.String(), c.Spec().NodeCount-1,
+		"./workload run json --read-percent=0 --duration %s {pgurl%s} --batch 1000 --sequential",
+		initialDataDuration.String(), c.CRDBNodes(),
 	)
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, option.WithNodes(workloadNode), cmdWrite)
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
 
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
@@ -83,14 +83,14 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 	m.Wait()
 
 	// Run the workload (with both reads and writes), and create the index at the same time.
-	m = c.NewMonitor(ctx, crdbNodes)
+	m = c.NewMonitor(ctx, c.CRDBNodes())
 
 	cmdWriteAndRead := fmt.Sprintf(
-		"./workload run json --read-percent=50 --duration %s {pgurl:1-%d} --sequential",
-		indexDuration.String(), c.Spec().NodeCount-1,
+		"./workload run json --read-percent=50 --duration %s {pgurl%s} --sequential",
+		indexDuration.String(), c.CRDBNodes(),
 	)
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, option.WithNodes(workloadNode), cmdWriteAndRead)
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWriteAndRead)
 		return nil
 	})
 

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -377,20 +377,18 @@ func registerKVContention(r registry.Registry) {
 		Name:             fmt.Sprintf("kv/contention/nodes=%d", nodes),
 		Owner:            registry.OwnerKV,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(nodes + 1),
+		Cluster:          r.MakeClusterSpec(nodes+1, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
-
 			// Start the cluster with an extremely high txn liveness threshold.
 			// If requests ever get stuck on a transaction that was abandoned
 			// then it will take 10m for them to get unstuck, at which point the
 			// QPS threshold check in the test is guaranteed to fail.
 			settings := install.MakeClusterSettings()
 			settings.Env = append(settings.Env, "COCKROACH_TXN_LIVENESS_HEARTBEAT_MULTIPLIER=600")
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Range(1, nodes))
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.CRDBNodes())
 
 			conn := c.Conn(ctx, t.L(), 1)
 			// Enable request tracing, which is a good tool for understanding
@@ -409,7 +407,7 @@ func registerKVContention(r registry.Registry) {
 			}
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.Range(1, nodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				// Write to a small number of keys to generate a large amount of
 				// contention. Use a relatively high amount of concurrency and
@@ -425,11 +423,11 @@ func registerKVContention(r registry.Registry) {
 				// Run the workload for an hour. Add a secondary index to avoid
 				// UPSERTs performing blind writes.
 				const duration = 1 * time.Hour
-				cmd := fmt.Sprintf("./workload run kv --init --secondary-index --duration=%s "+
-					"--cycle-length=%d --concurrency=%d --batch=%d --splits=%d {pgurl:1-%d}",
-					duration, cycleLength, concurrency, batchSize, splits, nodes)
+				cmd := fmt.Sprintf("./cockroach workload run kv --init --secondary-index --duration=%s "+
+					"--cycle-length=%d --concurrency=%d --batch=%d --splits=%d {pgurl%s}",
+					duration, cycleLength, concurrency, batchSize, splits, c.CRDBNodes())
 				start := timeutil.Now()
-				c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 				end := timeutil.Now()
 
 				// Assert that the average throughput stayed above a certain
@@ -448,19 +446,17 @@ func registerKVQuiescenceDead(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                "kv/quiescence/nodes=3",
 		Owner:               registry.OwnerReplication,
-		Cluster:             r.MakeClusterSpec(4),
+		Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds:    registry.AllExceptAWS,
 		Suites:              registry.Suites(registry.Nightly),
 		Leases:              registry.EpochLeases,
 		SkipPostValidations: registry.PostValidationNoDeadNodes,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			nodes := c.Spec().NodeCount - 1
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 			settings := install.MakeClusterSettings(install.ClusterSettingsOption{
 				"sql.stats.automatic_collection.enabled": "false",
 			})
-			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.Range(1, nodes))
-			m := c.NewMonitor(ctx, c.Range(1, nodes))
+			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.CRDBNodes())
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()
@@ -487,15 +483,15 @@ func registerKVQuiescenceDead(r registry.Registry) {
 				return (after - before) / timeutil.Since(tBegin).Seconds()
 			}
 
-			const kv = "./workload run kv --duration=10m --read-percent=0"
+			const kv = "./cockroach workload run kv --duration=10m --read-percent=0"
 
 			// Initialize the database with ~10k ranges so that the absence of
 			// quiescence hits hard once a node goes down.
-			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), "./workload run kv --init --max-ops=1 --splits 10000 --concurrency 100 {pgurl:1}")
-			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), kv+" --seed 0 {pgurl:1}")
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), "./cockroach workload run kv --init --max-ops=1 --splits 10000 --concurrency 100 {pgurl:1}")
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), kv+" --seed 0 {pgurl:1}")
 			// Measure qps with all nodes up (i.e. with quiescence).
 			qpsAllUp := qps(func() {
-				c.Run(ctx, option.WithNodes(c.Node(nodes+1)), kv+" --seed 1 {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), kv+" --seed 1 {pgurl:1}")
 			})
 			// Graceful shut down third node.
 			m.ExpectDeath()
@@ -503,14 +499,14 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			gracefulOpts.RoachprodOpts.Sig = 15 // SIGTERM
 			gracefulOpts.RoachprodOpts.Wait = true
 			gracefulOpts.RoachprodOpts.MaxWait = 30
-			c.Stop(ctx, t.L(), gracefulOpts, c.Node(nodes))
+			c.Stop(ctx, t.L(), gracefulOpts, c.Node(len(c.CRDBNodes())))
 			// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
-			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(nodes))
+			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(len(c.CRDBNodes())))
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
 				// Use a different seed to make sure it's not just stepping into the
 				// other earlier kv invocation's footsteps.
-				c.Run(ctx, option.WithNodes(c.Node(nodes+1)), kv+" --seed 2 {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), kv+" --seed 2 {pgurl:1}")
 			})
 
 			if minFrac, actFrac := 0.8, qpsOneDown/qpsAllUp; actFrac < minFrac {
@@ -528,20 +524,18 @@ func registerKVGracefulDraining(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "kv/gracefuldraining",
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(7),
+		Cluster:          r.MakeClusterSpec(7, spec.WorkloadNode()),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.WorkloadNode())
-
 			t.Status("starting cluster")
 			// If the test ever fails, the person who investigates the
 			// failure will likely be thankful for this additional logging.
 			startOpts := option.DefaultStartOpts()
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=store=2,store_rebalancer=2")
-			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
+			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.CRDBNodes())
 
 			// Don't connect to the node we are going to shut down.
 			dbs := make([]*gosql.DB, nodes-1)
@@ -559,7 +553,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// before it starts draining.
 			c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach workload init kv --splits 100 {pgurl:1}")
 
-			m := c.NewMonitor(ctx, c.Nodes(1, nodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.ExpectDeath()
 
 			// specifiedQPS is going to be the --max-rate for the kv workload.
@@ -579,14 +573,14 @@ func registerKVGracefulDraining(r registry.Registry) {
 			desiredRunDuration := 10 * time.Minute
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf(
-					"./cockroach workload run kv --duration=%s --read-percent=50 --follower-read-percent=50 --concurrency=200 --max-rate=%d {pgurl:1-%d}",
-					desiredRunDuration, specifiedQPS, nodes-1)
+					"./cockroach workload run kv --duration=%s --read-percent=50 --follower-read-percent=50 --concurrency=200 --max-rate=%d {pgurl%s}",
+					desiredRunDuration, specifiedQPS, c.CRDBNodes())
 				t.WorkerStatus(cmd)
 				defer func() {
 					t.WorkerStatus("workload command completed")
 					t.WorkerStatus()
 				}()
-				return c.RunE(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			})
 
 			verifyQPS := func(ctx context.Context) error {
@@ -707,33 +701,32 @@ func registerKVSplits(r registry.Registry) {
 			Name:             fmt.Sprintf("kv/splits/nodes=3/quiesce=%t/lease=%s", item.quiesce, item.leases),
 			Owner:            registry.OwnerKV,
 			Timeout:          item.timeout,
-			Cluster:          r.MakeClusterSpec(4),
+			Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           item.leases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				nodes := c.Spec().NodeCount - 1
-				c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 
 				settings := install.MakeClusterSettings()
 				settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=1m", "COCKROACH_DISABLE_QUIESCENCE="+strconv.FormatBool(!item.quiesce))
 				startOpts := option.NewStartOpts(option.NoBackupSchedule)
 				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--cache=256MiB")
-				c.Start(ctx, t.L(), startOpts, settings, c.Range(1, nodes))
+				c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
 				t.Status("running workload")
 				workloadCtx, workloadCancel := context.WithCancel(ctx)
-				m := c.NewMonitor(workloadCtx, c.Range(1, nodes))
+				m := c.NewMonitor(workloadCtx, c.CRDBNodes())
 				m.Go(func(ctx context.Context) error {
 					defer workloadCancel()
 					concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(nodes*64))
 					splits := " --splits=" + ifLocal(c, "2000", fmt.Sprint(item.splits))
 					cmd := fmt.Sprintf(
-						"./workload run kv --init --max-ops=1"+
+						"./cockroach workload run kv --init --max-ops=1"+
 							concurrency+splits+
-							" {pgurl:1-%d}",
-						nodes)
-					c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+							" {pgurl%s}",
+						c.CRDBNodes())
+					c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 					return nil
 				})
 				m.Wait()
@@ -744,24 +737,22 @@ func registerKVSplits(r registry.Registry) {
 
 func registerKVScalability(r registry.Registry) {
 	runScalability := func(ctx context.Context, t test.Test, c cluster.Cluster, percent int) {
-		nodes := c.Spec().NodeCount - 1
-
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
+		nodes := len(c.CRDBNodes())
 
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
-			c.Wipe(ctx, c.Range(1, nodes))
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
+			c.Wipe(ctx, c.CRDBNodes())
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.Range(1, nodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
-				cmd := fmt.Sprintf("./workload run kv --init --read-percent=%d "+
+				cmd := fmt.Sprintf("./cockroach workload run kv --init --read-percent=%d "+
 					"--splits=1000 --duration=1m "+fmt.Sprintf("--concurrency=%d", i)+
-					" {pgurl:1-%d}",
-					percent, nodes)
+					" {pgurl%s}",
+					percent, c.CRDBNodes())
 
-				return c.RunE(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			})
 			m.Wait()
 		}
@@ -774,7 +765,7 @@ func registerKVScalability(r registry.Registry) {
 			r.Add(registry.TestSpec{
 				Name:             fmt.Sprintf("kv%d/scale/nodes=6", p),
 				Owner:            registry.OwnerKV,
-				Cluster:          r.MakeClusterSpec(7, spec.CPU(8)),
+				Cluster:          r.MakeClusterSpec(7, spec.CPU(8), spec.WorkloadNode(), spec.WorkloadNodeCPU(8)),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 				Leases:           registry.MetamorphicLeases,
@@ -799,44 +790,42 @@ func registerKVRangeLookups(r registry.Registry) {
 	)
 
 	runRangeLookups := func(ctx context.Context, t test.Test, c cluster.Cluster, workers int, workloadType rangeLookupWorkloadType, maximumRangeLookupsPerSec float64) {
-		nodes := c.Spec().NodeCount - 1
 		doneInit := make(chan struct{})
 		doneWorkload := make(chan struct{})
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 		t.Status("running workload")
 
-		conns := make([]*gosql.DB, nodes)
-		for i := 0; i < nodes; i++ {
+		conns := make([]*gosql.DB, len(c.CRDBNodes()))
+		for i := 0; i < len(c.CRDBNodes()); i++ {
 			conns[i] = c.Conn(ctx, t.L(), i+1)
 		}
 		defer func() {
-			for i := 0; i < nodes; i++ {
+			for i := 0; i < len(c.CRDBNodes()); i++ {
 				conns[i].Close()
 			}
 		}()
 		err := WaitFor3XReplication(ctx, t, t.L(), conns[0])
 		require.NoError(t, err)
 
-		m := c.NewMonitor(ctx, c.Range(1, nodes))
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			defer close(doneWorkload)
 			defer close(doneInit)
-			cmd := "./workload init kv --splits=1000 {pgurl:1}"
-			if err = c.RunE(ctx, option.WithNodes(c.Node(nodes+1)), cmd); err != nil {
+			cmd := "./cockroach workload init kv --splits=1000 {pgurl:1}"
+			if err = c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd); err != nil {
 				return err
 			}
-			concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(nodes*64))
+			concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(len(c.CRDBNodes())*64))
 			duration := " --duration=10m"
 			readPercent := " --read-percent=50"
 			// We run kv with --tolerate-errors, since the relocate workload is
 			// expected to create `result is ambiguous (replica removed)` errors.
-			cmd = fmt.Sprintf("./workload run kv --tolerate-errors"+
+			cmd = fmt.Sprintf("./cockroach workload run kv --tolerate-errors"+
 				concurrency+duration+readPercent+
-				" {pgurl:1-%d}", nodes)
+				" {pgurl%s}", c.CRDBNodes())
 			start := timeutil.Now()
-			if err = c.RunE(ctx, option.WithNodes(c.Node(nodes+1)), cmd); err != nil {
+			if err = c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd); err != nil {
 				return err
 			}
 			end := timeutil.Now()
@@ -856,7 +845,7 @@ func registerKVRangeLookups(r registry.Registry) {
 					default:
 					}
 
-					conn := conns[c.Range(1, nodes).RandNode()[0]-1]
+					conn := conns[c.CRDBNodes().RandNode()[0]-1]
 					switch workloadType {
 					case splitWorkload:
 						_, err := conn.ExecContext(ctx, `
@@ -869,7 +858,7 @@ func registerKVRangeLookups(r registry.Registry) {
 							return err
 						}
 					case relocateWorkload:
-						newReplicas := rand.Perm(nodes)[:3]
+						newReplicas := rand.Perm(len(c.CRDBNodes()))[:3]
 						_, err := conn.ExecContext(ctx, `
 							ALTER TABLE
 								kv.kv
@@ -911,7 +900,7 @@ func registerKVRangeLookups(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("kv50/rangelookups/%s/nodes=%d", workloadName, nodes),
 			Owner:            registry.OwnerKV,
-			Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(cpus)),
+			Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
@@ -979,17 +968,16 @@ func registerKVRestartImpact(r registry.Registry) {
 		Suites:           registry.Suites(registry.Weekly),
 		Owner:            registry.OwnerAdmissionControl,
 		Timeout:          4 * time.Hour,
-		Cluster:          r.MakeClusterSpec(13, spec.CPU(8), spec.DisableLocalSSD()),
+		Cluster:          r.MakeClusterSpec(13, spec.CPU(8), spec.WorkloadNode(), spec.WorkloadNodeCPU(8), spec.DisableLocalSSD()),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			nodes := c.Spec().NodeCount - 1
-			workloadNode := c.Spec().NodeCount
+			nodes := len(c.CRDBNodes())
 			startOpts := option.NewStartOpts(option.NoBackupSchedule)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=store_rebalancer=2,allocator=2,allocator_scorer=1,replicate_queue=2,lease=2")
 			settings := install.MakeClusterSettings()
 
-			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, nodes))
+			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
 			// Run long enough to create a large amount of pebble data.
 			testDuration := 3 * time.Hour
@@ -1024,13 +1012,13 @@ func registerKVRestartImpact(r registry.Registry) {
 				defer db.Close()
 			}
 
-			c.Run(ctx, option.WithNodes(c.Node(workloadNode)), fmt.Sprintf("./cockroach workload init kv --splits=%d {pgurl:1}", splits))
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf("./cockroach workload init kv --splits=%d {pgurl:1}", splits))
 
 			workloadStartTime := timeutil.Now()
 			t.Status(fmt.Sprintf("starting kv workload thread to run for %s", testDuration))
 
 			// Three goroutines run and we wait for all to complete.
-			m := c.NewMonitor(ctx, c.Range(1, nodes))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.ExpectDeath()
 			m.Go(func(ctx context.Context) error {
 				// Don't include the last node when starting the workload since
@@ -1041,7 +1029,7 @@ func registerKVRestartImpact(r registry.Registry) {
 					testDuration.String(), concurrency, targetQPS, nodes-1,
 				)
 
-				return c.RunE(ctx, option.WithNodes(c.Node(workloadNode)), cmd)
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			})
 
 			// Begin the monitoring goroutine to track QPS every 5 seconds.

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -67,7 +67,7 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 	if b.NumShards > 0 {
 		nameParts = append(nameParts, fmt.Sprintf("shards=%d", b.NumShards))
 	}
-	opts := []spec.Option{spec.CPU(b.CPUs)}
+	opts := []spec.Option{spec.CPU(b.CPUs), spec.WorkloadNode(), spec.WorkloadNodeCPU(b.CPUs)}
 	switch b.KeyDistribution {
 	case sequential:
 		nameParts = append(nameParts, "sequential")
@@ -184,13 +184,6 @@ func registerKVBench(r registry.Registry) {
 	}
 }
 
-func makeKVLoadGroup(c cluster.Cluster, numRoachNodes, numLoadNodes int) loadGroup {
-	return loadGroup{
-		roachNodes: c.Range(1, numRoachNodes),
-		loadNodes:  c.Range(numRoachNodes+1, numRoachNodes+numLoadNodes),
-	}
-}
-
 // KVBench is a benchmarking tool that runs the `kv` workload against CockroachDB based on
 // various configuration settings (see `kvBenchSpec`). The tool searches for the maximum
 // throughput that can be sustained while maintaining an average latency below a certain
@@ -200,14 +193,6 @@ func makeKVLoadGroup(c cluster.Cluster, numRoachNodes, numLoadNodes int) loadGro
 // performance characteristics of using hash sharded indexes, for sequential workloads
 // which would've otherwise created a single-range hotspot.
 func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSpec) {
-	loadGrp := makeKVLoadGroup(c, b.Nodes, 1)
-	roachNodes := loadGrp.roachNodes
-	loadNodes := loadGrp.loadNodes
-
-	if err := c.PutE(ctx, t.L(), t.DeprecatedWorkload(), "./workload", loadNodes); err != nil {
-		t.Fatal(err)
-	}
-
 	const restartWait = 15 * time.Second
 	// TODO(aayush): I do not have a good reasoning for why I chose this precision value.
 	precision := int(math.Max(1.0, float64(b.EstimatedMaxThroughput/50)))
@@ -222,14 +207,14 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 	}
 	s := search.NewLineSearcher(100 /* min */, 10000000 /* max */, b.EstimatedMaxThroughput, initStepSize, precision)
 	searchPredicate := func(maxrate int) (bool, error) {
-		m := c.NewMonitor(ctx, roachNodes)
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		// Restart
-		m.ExpectDeaths(int32(len(roachNodes)))
+		m.ExpectDeaths(int32(len(c.CRDBNodes())))
 		// Wipe cluster before starting a new run because factors like load-based
 		// splitting can significantly change the underlying layout of the table and
 		// affect benchmark results.
-		c.Wipe(ctx, roachNodes)
-		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), roachNodes)
+		c.Wipe(ctx, c.CRDBNodes())
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
 		time.Sleep(restartWait)
 
 		// We currently only support one loadGroup.
@@ -239,13 +224,13 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 
 			var initCmd strings.Builder
 
-			fmt.Fprintf(&initCmd, `./workload init kv --num-shards=%d`,
+			fmt.Fprintf(&initCmd, `./cockroach workload init kv --num-shards=%d`,
 				b.NumShards)
 			if b.SecondaryIndex {
 				initCmd.WriteString(` --secondary-index`)
 			}
-			fmt.Fprintf(&initCmd, ` {pgurl%s}`, roachNodes)
-			if err := c.RunE(ctx, option.WithNodes(loadNodes), initCmd.String()); err != nil {
+			fmt.Fprintf(&initCmd, ` {pgurl%s}`, c.CRDBNodes())
+			if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), initCmd.String()); err != nil {
 				return err
 			}
 
@@ -285,9 +270,9 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 			const duration = time.Second * 300
 
 			fmt.Fprintf(&workloadCmd,
-				`./workload run kv --ramp=%fs --duration=%fs {pgurl%s} --read-percent=0`+
+				`./cockroach workload run kv --ramp=%fs --duration=%fs {pgurl%s} --read-percent=0`+
 					` --concurrency=%d --histograms=%s --max-rate=%d --num-shards=%d`,
-				ramp.Seconds(), duration.Seconds(), roachNodes,
+				ramp.Seconds(), duration.Seconds(), c.CRDBNodes(),
 				b.CPUs*loadConcurrency, clusterHistPath, maxrate, b.NumShards)
 			switch b.KeyDistribution {
 			case sequential:
@@ -300,13 +285,13 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 				panic(`unexpected`)
 			}
 
-			err := c.RunE(ctx, option.WithNodes(loadNodes), workloadCmd.String())
+			err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), workloadCmd.String())
 			if err != nil {
 				return errors.Wrapf(err, `error running workload`)
 			}
 
 			localHistPath := filepath.Join(resultsDir, fmt.Sprintf(`kvbench-%d-stats.json`, maxrate))
-			if err := c.Get(ctx, t.L(), clusterHistPath, localHistPath, loadNodes); err != nil {
+			if err := c.Get(ctx, t.L(), clusterHistPath, localHistPath, c.WorkloadNode()); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -44,6 +44,8 @@ func registerLargeSchemaBenchmarks(r registry.Registry) {
 func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiRegion bool) {
 	clusterSpec := []spec.Option{
 		spec.CPU(8),
+		spec.WorkloadNode(),
+		spec.WorkloadNodeCPU(8),
 		spec.VolumeSize(800),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
@@ -123,7 +125,6 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 			// Create all the databases based on our lists of active vs inactive
 			// ones.
 			const inactiveDbListType = 1
-			var workloadNode option.NodeListOption
 			for dbListType, dbList := range [][]string{activeDBList, inactiveDBList} {
 				populateFileName := fmt.Sprintf("populate_%d", dbListType)
 				regionsArg := ""
@@ -171,19 +172,18 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 						require.NoError(t, err)
 					}
 				}
-				err := c.PutString(ctx, strings.Join(dbList, "\n"), populateFileName, 0755, c.Node(c.Spec().NodeCount))
+				err := c.PutString(ctx, strings.Join(dbList, "\n"), populateFileName, 0755, c.WorkloadNode())
 				require.NoError(t, err)
-				_, workloadNode = setupTPCC(ctx, t, t.L(), c, options)
 			}
 			// Upload a file containing the ORM queries.
-			require.NoError(t, c.PutString(ctx, LargeSchemaOrmQueries, "ormQueries.sql", 0755, workloadNode))
+			require.NoError(t, c.PutString(ctx, LargeSchemaOrmQueries, "ormQueries.sql", 0755, c.WorkloadNode()))
 			mon := c.NewMonitor(ctx, c.All())
 			// Upload a file containing the web API calls we want to benchmark.
 			require.NoError(t, c.PutString(ctx,
 				LargeSchemaAPICalls,
 				"apiCalls",
 				0755,
-				workloadNode))
+				c.WorkloadNode()))
 			// Get a list of web console URLs.
 			webConsoleURLs, err := c.ExternalAdminUIAddr(ctx, t.L(), c.Range(1, c.Spec().NodeCount-1))
 			require.NoError(t, err)
@@ -210,7 +210,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 						wlInstance = append(
 							wlInstance,
 							workloadInstance{
-								nodes:          c.Range(1, c.Spec().NodeCount-1),
+								nodes:          c.CRDBNodes(),
 								prometheusPort: 5050,
 							},
 						)

--- a/pkg/cmd/roachtest/tests/limit_capacity.go
+++ b/pkg/cmd/roachtest/tests/limit_capacity.go
@@ -33,7 +33,7 @@ func registerLimitCapacity(r registry.Registry) {
 			Timeout:          1 * time.Hour,
 			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.ManualOnly,
-			Cluster:          r.MakeClusterSpec(5, spec.CPU(8)),
+			Cluster:          r.MakeClusterSpec(5, spec.CPU(8), spec.WorkloadNode()),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runLimitCapacity(ctx, t, c, cfg)
 			},
@@ -75,32 +75,29 @@ func (a limitCapacityOpts) limitWriteCap(bytes int) limitCapacityOpts {
 func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg limitCapacityOpts) {
 	require.False(t, c.IsLocal())
 
-	appNodeID := c.Spec().NodeCount
 	limitedNodeID := c.Spec().NodeCount - 1
-	nodes := c.Range(1, limitedNodeID)
-	appNode := c.Node(appNodeID)
 	limitedNode := c.Node(limitedNodeID)
 
 	initialDuration := 10 * time.Minute
 	limitDuration := 2 * time.Minute
 
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), nodes)
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
 	require.NoError(t, WaitFor3XReplication(ctx, t, t.L(), conn))
 	var cancels []func()
 
-	c.Run(ctx, option.WithNodes(appNode), "./cockroach workload init kv --splits=1000 {pgurl:1}")
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()), "./cockroach workload init kv --splits=1000 {pgurl:1}")
 
-	m := c.NewMonitor(ctx, nodes)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	cancels = append(cancels, m.GoWithCancel(func(ctx context.Context) error {
 		t.L().Printf("starting load generator\n")
 		// NB: kv50 with 4kb block size at 5k rate will incur approx. 500mb/s write
 		// bandwidth after 10 minutes across the cluster. Spread across 4 CRDB
 		// nodes, expect approx. 125 mb/s write bandwidth each and 30-50% CPU
 		// utilization.
-		err := c.RunE(ctx, option.WithNodes(appNode), fmt.Sprintf(
+		err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(
 			"./cockroach workload run kv --read-percent=50 --tolerate-errors --concurrency=400 "+
 				"--min-block-bytes=4096 --max-block-bytes=4096 --max-rate=5000 "+
 				"--duration=30m {pgurl:1-%d}", c.Spec().NodeCount-2))
@@ -108,7 +105,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 	}))
 
 	t.Status(fmt.Sprintf("waiting %s for baseline workload throughput", initialDuration))
-	wait(c.NewMonitor(ctx, nodes), initialDuration)
+	wait(c.NewMonitor(ctx, c.CRDBNodes()), initialDuration)
 	qpsInitial := measureQPS(ctx, t, 10*time.Second, conn)
 	t.Status(fmt.Sprintf("initial (single node) qps: %.0f", qpsInitial))
 
@@ -134,7 +131,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 		}))
 	}
 
-	wait(c.NewMonitor(ctx, nodes), limitDuration)
+	wait(c.NewMonitor(ctx, c.CRDBNodes()), limitDuration)
 	qpsFinal := measureQPS(ctx, t, 10*time.Second, conn)
 	qpsRelative := qpsFinal / qpsInitial
 	t.Status(fmt.Sprintf("initial qps=%f final qps=%f (%f%%)", qpsInitial, qpsFinal, 100*qpsRelative))

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -41,6 +41,8 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 				rightNodes: 3,
 				clusterOpts: []spec.Option{
 					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
 					spec.VolumeSize(100),
 				},
 			},
@@ -289,8 +291,7 @@ func (mc *multiCluster) StartCluster(
 func (mc *multiCluster) Start(ctx context.Context, t test.Test) (multiClusterSetup, func()) {
 	leftCluster := mc.c.Range(1, mc.spec.leftNodes)
 	rightCluster := mc.c.Range(mc.spec.leftNodes+1, mc.spec.leftNodes+mc.spec.rightNodes)
-	workloadNode := mc.c.Node(mc.spec.NodeCount())
-	mc.c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
+	workloadNode := mc.c.WorkloadNode()
 
 	left, cleanupLeft := mc.StartCluster(ctx, t, "left", leftCluster, mc.spec.LeftClusterStart())
 	right, cleanupRight := mc.StartCluster(ctx, t, "right", rightCluster, mc.spec.RightClusterStart())

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	spec2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -60,7 +61,7 @@ func (s loqTestSpec) testName(mode string) string {
 }
 
 func registerLOQRecovery(r registry.Registry) {
-	spec := r.MakeClusterSpec(6)
+	spec := r.MakeClusterSpec(6, spec2.WorkloadNode())
 	for _, s := range []loqTestSpec{
 		{wl: movrLoqWorkload{concurrency: 32}, rangeSizeMB: 2},
 		{wl: movrLoqWorkload{concurrency: 32}},
@@ -162,11 +163,6 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 	// clusters running.
 	debugFailures := t.IsDebug()
 
-	// Number of cockroach cluster nodes.
-	maxNode := c.Spec().NodeCount - 1
-	nodes := c.Range(1, maxNode)
-	// Controller node runs offline procedures and workload.
-	controller := c.Spec().NodeCount
 	// Nodes that we plan to keep after simulated failure.
 	remaining := []int{1, 4, 5}
 	planName := "recover-plan.json"
@@ -177,7 +173,7 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 	settings := install.MakeClusterSettings(install.EnvOption([]string{
 		"COCKROACH_MIN_RANGE_MAX_BYTES=1",
 	}))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, nodes)
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.CRDBNodes())
 
 	// Cleanup stale files generated during recovery. We do this for the case
 	// where the cluster is reused and cli would refuse to overwrite files
@@ -204,11 +200,11 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 		_, err = db.Exec("SET CLUSTER SETTING sql.trace.stmt.enable_threshold = '30s'")
 	}
 
-	m := c.NewMonitor(ctx, nodes)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		t.L().Printf("initializing workload")
 
-		c.Run(ctx, option.WithNodes(c.Node(controller)), s.wl.initCmd(pgURL, dbName))
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), s.wl.initCmd(pgURL, dbName))
 
 		if s.rangeSizeMB > 0 {
 			err = setDBRangeLimits(ctx, db, dbName, s.rangeSizeMB*(1<<20))
@@ -222,12 +218,12 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 		require.NoError(t, err, "failed to set default statement timeout")
 
 		t.L().Printf("running workload")
-		c.Run(ctx, option.WithNodes(c.Node(controller)), s.wl.runCmd(pgURL, dbName, ifLocal(c, "10s", "30s"), ""))
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), s.wl.runCmd(pgURL, dbName, ifLocal(c, "10s", "30s"), ""))
 		t.L().Printf("workload finished")
 
 		m.ExpectDeaths(int32(c.Spec().NodeCount - 1))
 		stopOpts := option.DefaultStopOpts()
-		c.Stop(ctx, t.L(), stopOpts, nodes)
+		c.Stop(ctx, t.L(), stopOpts, c.CRDBNodes())
 
 		planArguments := ""
 		for _, node := range remaining {
@@ -239,20 +235,20 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 				c.Node(node)); err != nil {
 				t.Fatalf("failed to collect node replica info %s from node %d: %s", name, node, err)
 			}
-			c.Put(ctx, path.Join(t.ArtifactsDir(), name), name, c.Nodes(controller))
+			c.Put(ctx, path.Join(t.ArtifactsDir(), name), name, c.WorkloadNode())
 			planArguments += " " + name
 		}
 		t.L().Printf("running plan creation")
 		planCmd := "./cockroach debug recover make-plan --confirm y -o " + planName + planArguments
-		if err = c.RunE(ctx, option.WithNodes(c.Node(controller)), planCmd); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(c.WorkloadNode()), planCmd); err != nil {
 			t.L().Printf("failed to create plan, test can't proceed assuming unrecoverable cluster: %s",
 				err)
 			return &recoveryImpossibleError{testOutcome: planCantBeCreated}
 		}
 
 		if err := c.Get(ctx, t.L(), planName, path.Join(t.ArtifactsDir(), planName),
-			c.Node(controller)); err != nil {
-			t.Fatalf("failed to collect plan %s from controller node %d: %s", planName, controller, err)
+			c.WorkloadNode()); err != nil {
+			t.Fatalf("failed to collect plan %s from controller node %s: %s", planName, c.WorkloadNode(), err)
 		}
 
 		t.L().Printf("distributing and applying recovery plan")
@@ -306,7 +302,7 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 			func(ctx context.Context) error {
 				decommissionCmd := fmt.Sprintf(
 					"./cockroach node decommission --wait none --url={pgurl:%d} 2 3", 1)
-				return c.RunE(ctx, option.WithNodes(c.Node(controller)), decommissionCmd)
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), decommissionCmd)
 			}); err != nil {
 			// Timeout means we failed to recover ranges especially system ones
 			// correctly. We don't wait for all ranges to drain from the nodes to
@@ -314,9 +310,9 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 			return &recoveryImpossibleError{testOutcome: decommissionFailed}
 		}
 		t.L().Printf("resuming workload")
-		if err = c.RunE(ctx, option.WithNodes(c.Node(controller)),
+		if err = c.RunE(ctx, option.WithNodes(c.WorkloadNode()),
 			s.wl.runCmd(
-				fmt.Sprintf("{pgurl:1,4-%d}", maxNode), dbName, ifLocal(c, "30s", "3m"),
+				fmt.Sprintf("{pgurl:1,4-%d}", len(c.CRDBNodes())), dbName, ifLocal(c, "30s", "3m"),
 				workloadHistogramFile)); err != nil {
 			return &recoveryImpossibleError{testOutcome: workloadFailed}
 		}
@@ -332,7 +328,7 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 			func(ctx context.Context) error {
 				decommissionCmd := fmt.Sprintf(
 					"./cockroach node decommission --wait all --url={pgurl:%d} 2 3", 1)
-				return c.RunE(ctx, option.WithNodes(c.Nodes(controller)), decommissionCmd)
+				return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), decommissionCmd)
 			}); err != nil {
 			// Timeout means we failed to drain all ranges from failed nodes, possibly
 			// because some ranges were not recovered.
@@ -377,11 +373,6 @@ func runHalfOnlineRecoverLossOfQuorum(
 	// clusters running.
 	debugFailures := t.IsDebug()
 
-	// Number of cockroach cluster nodes.
-	maxNode := c.Spec().NodeCount - 1
-	nodes := c.Range(1, maxNode)
-	// Controller node runs offline procedures and workload.
-	controller := c.Spec().NodeCount
 	// Nodes that we plan to keep after simulated failure.
 	remaining := []int{1, 4, 5}
 	killed := []int{2, 3}
@@ -394,7 +385,7 @@ func runHalfOnlineRecoverLossOfQuorum(
 	settings := install.MakeClusterSettings(install.EnvOption([]string{
 		"COCKROACH_MIN_RANGE_MAX_BYTES=1",
 	}))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, nodes)
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.CRDBNodes())
 
 	// Cleanup stale files generated during recovery. We do this for the case
 	// where the cluster is reused and cli would refuse to overwrite files
@@ -417,11 +408,11 @@ func runHalfOnlineRecoverLossOfQuorum(
 		_, err = db.Exec("SET CLUSTER SETTING sql.trace.stmt.enable_threshold = '30s'")
 	}
 
-	m := c.NewMonitor(ctx, nodes)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		t.L().Printf("initializing workload")
 
-		c.Run(ctx, option.WithNodes(c.Node(controller)), s.wl.initCmd(pgURL, dbName))
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), s.wl.initCmd(pgURL, dbName))
 
 		if s.rangeSizeMB > 0 {
 			err = setDBRangeLimits(ctx, db, dbName, s.rangeSizeMB*(1<<20))
@@ -435,7 +426,7 @@ func runHalfOnlineRecoverLossOfQuorum(
 		require.NoError(t, err, "failed to set default statement timeout")
 
 		t.L().Printf("running workload")
-		c.Run(ctx, option.WithNodes(c.Node(controller)), s.wl.runCmd(pgURL, dbName, ifLocal(c, "10s", "30s"), ""))
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), s.wl.runCmd(pgURL, dbName, ifLocal(c, "10s", "30s"), ""))
 		t.L().Printf("workload finished")
 
 		m.ExpectDeaths(int32(len(killed)))
@@ -449,20 +440,20 @@ func runHalfOnlineRecoverLossOfQuorum(
 		addr := addrs[0]
 		planCmd := "./cockroach debug recover make-plan --confirm y --host " + addr + " -o " + planName
 
-		if err = c.RunE(ctx, option.WithNodes(c.Node(controller)), planCmd); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(c.WorkloadNode()), planCmd); err != nil {
 			t.L().Printf("failed to create plan, test can't proceed assuming unrecoverable cluster: %s",
 				err)
 			return &recoveryImpossibleError{testOutcome: planCantBeCreated}
 		}
 
 		if err := c.Get(ctx, t.L(), planName, path.Join(t.ArtifactsDir(), planName),
-			c.Node(controller)); err != nil {
-			t.Fatalf("failed to collect plan %s from controller node %d: %s", planName, controller, err)
+			c.WorkloadNode()); err != nil {
+			t.Fatalf("failed to collect plan %s from controller node %s: %s", planName, c.WorkloadNode(), err)
 		}
 
 		t.L().Printf("staging recovery plan")
 		applyCommand := "./cockroach debug recover apply-plan --confirm y --host " + addr + " " + planName
-		c.Run(ctx, option.WithNodes(c.Nodes(controller)), applyCommand)
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), applyCommand)
 
 		// Ignore node failures because they could fail if recovered ranges
 		// generate panics. We don't want test to fail in that case, and we
@@ -481,7 +472,7 @@ func runHalfOnlineRecoverLossOfQuorum(
 		if err = timeutil.RunWithTimeout(ctx, "wait-for-restart", 2*time.Minute,
 			func(ctx context.Context) error {
 				for {
-					res, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(controller)), verifyCommand)
+					res, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.WorkloadNode()), verifyCommand)
 					if res.RemoteExitStatus == 0 {
 						if ctx.Err() != nil {
 							return &recoveryImpossibleError{testOutcome: restartFailed}
@@ -524,9 +515,9 @@ func runHalfOnlineRecoverLossOfQuorum(
 		}
 
 		t.L().Printf("resuming workload")
-		if err = c.RunE(ctx, option.WithNodes(c.Node(controller)),
+		if err = c.RunE(ctx, option.WithNodes(c.WorkloadNode()),
 			s.wl.runCmd(
-				fmt.Sprintf("{pgurl:1,4-%d}", maxNode), dbName, ifLocal(c, "30s", "3m"),
+				fmt.Sprintf("{pgurl:1,4-%d}", len(c.CRDBNodes())), dbName, ifLocal(c, "30s", "3m"),
 				workloadHistogramFile)); err != nil {
 			return &recoveryImpossibleError{testOutcome: workloadFailed}
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2574,7 +2574,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 		Name:              "backup-restore/mixed-version",
 		Timeout:           8 * time.Hour,
 		Owner:             registry.OwnerDisasterRecovery,
-		Cluster:           r.MakeClusterSpec(5),
+		Cluster:           r.MakeClusterSpec(5, spec.WorkloadNode()),
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		RequiresLicense:   true,
 		NativeLibs:        registry.LibGEOS,
@@ -2583,10 +2583,8 @@ func registerBackupMixedVersion(r registry.Registry) {
 		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			roachNodes := c.Range(1, c.Spec().NodeCount-1)
-			workloadNode := c.Node(c.Spec().NodeCount)
 			mvt := mixedversion.NewTest(
-				ctx, t, t.L(), c, roachNodes,
+				ctx, t, t.L(), c, c.CRDBNodes(),
 				// We use a longer upgrade timeout in this test to give the
 				// migrations enough time to finish considering all the data
 				// that might exist in the cluster by the time the upgrade is
@@ -2610,10 +2608,10 @@ func registerBackupMixedVersion(r registry.Registry) {
 			)
 			testRNG := mvt.RNG()
 
-			uploadCockroach(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
+			uploadCockroach(ctx, t, c, c.WorkloadNode(), clusterupgrade.CurrentVersion())
 
 			dbs := []string{"bank", "tpcc"}
-			backupTest, err := newMixedVersionBackup(t, c, roachNodes, dbs)
+			backupTest, err := newMixedVersionBackup(t, c, c.CRDBNodes(), dbs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2629,8 +2627,8 @@ func registerBackupMixedVersion(r registry.Registry) {
 			// for the cluster used in this test without overloading it,
 			// which can make the backups take much longer to finish.
 			const numWarehouses = 100
-			bankInit, bankRun := bankWorkloadCmd(t.L(), testRNG, roachNodes, false)
-			tpccInit, tpccRun := tpccWorkloadCmd(t.L(), testRNG, numWarehouses, roachNodes)
+			bankInit, bankRun := bankWorkloadCmd(t.L(), testRNG, c.CRDBNodes(), false)
+			tpccInit, tpccRun := tpccWorkloadCmd(t.L(), testRNG, numWarehouses, c.CRDBNodes())
 
 			mvt.OnStartup("set short job interval", backupTest.setShortJobIntervals)
 			mvt.OnStartup("take backup in previous version", backupTest.maybeTakePreviousVersionBackup)
@@ -2644,8 +2642,8 @@ func registerBackupMixedVersion(r registry.Registry) {
 			//   the cluster relatively busy while the backup and restores
 			//   take place. Its schema is also more complex, and the
 			//   operations more closely resemble a customer workload.
-			stopBank := mvt.Workload("bank", workloadNode, bankInit, bankRun)
-			stopTPCC := mvt.Workload("tpcc", workloadNode, tpccInit, tpccRun)
+			stopBank := mvt.Workload("bank", c.WorkloadNode(), bankInit, bankRun)
+			stopTPCC := mvt.Workload("tpcc", c.WorkloadNode(), tpccInit, tpccRun)
 			stopSystemWriter := mvt.BackgroundFunc("system table writer", backupTest.systemTableWriter)
 
 			mvt.InMixedVersion("plan and run backups", backupTest.planAndRunBackups)

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -71,7 +71,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/mixed-versions",
 		Owner:            registry.OwnerCDC,
-		Cluster:          r.MakeClusterSpec(5, spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
+		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode(), spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
 		Timeout:          120 * time.Minute,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
@@ -126,20 +126,13 @@ type cdcMixedVersionTester struct {
 	fprintV   *cdctest.FingerprintValidator
 }
 
-func newCDCMixedVersionTester(
-	ctx context.Context, t test.Test, c cluster.Cluster,
-) cdcMixedVersionTester {
-	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-	lastNode := c.Node(c.Spec().NodeCount)
-
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", lastNode)
-
+func newCDCMixedVersionTester(ctx context.Context, c cluster.Cluster) cdcMixedVersionTester {
 	return cdcMixedVersionTester{
 		ctx:           ctx,
 		c:             c,
-		crdbNodes:     crdbNodes,
-		workloadNodes: lastNode,
-		kafkaNodes:    lastNode,
+		crdbNodes:     c.CRDBNodes(),
+		workloadNodes: c.WorkloadNode(),
+		kafkaNodes:    c.WorkloadNode(),
 		workloadInit:  make(chan struct{}),
 	}
 }
@@ -500,7 +493,7 @@ func canMixedVersionUseDeletedClusterSetting(
 }
 
 func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
-	tester := newCDCMixedVersionTester(ctx, t, c)
+	tester := newCDCMixedVersionTester(ctx, c)
 
 	// NB: We rely on the testing framework to choose a random predecessor
 	// to upgrade from.

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 )
@@ -30,7 +31,7 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 		// in a mixed version state, validating that the cluster is still healthy (via debug doctor examine).
 		Name:             "schemachange/mixed-versions",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(4),
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		NativeLibs:       registry.LibGEOS,
@@ -62,8 +63,7 @@ func runSchemaChangeMixedVersions(
 		mixedversion.AlwaysUseLatestPredecessors,
 	)
 
-	workloadNode := c.Node(c.Spec().NodeCount)
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.WorkloadNode())
 
 	// Run the schemachange workload on a random node, along with validating the schema changes for the cluster on a random node.
 	schemaChangeAndValidationStep := func(
@@ -78,7 +78,7 @@ func runSchemaChangeMixedVersions(
 			Flag("concurrency", concurrency).
 			Arg("{pgurl%s}", c.All()).
 			String()
-		if err := c.RunE(ctx, option.WithNodes(workloadNode), runCmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runCmd); err != nil {
 			return err
 		}
 
@@ -88,12 +88,12 @@ func runSchemaChangeMixedVersions(
 		runCmd = roachtestutil.NewCommand("%s debug doctor examine cluster", test.DefaultCockroachPath).
 			Flag("url", doctorURL).
 			String()
-		return c.RunE(ctx, option.WithNodes(workloadNode), runCmd)
+		return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), runCmd)
 	}
 
 	// Stage our workload node with the schemachange workload.
 	mvt.OnStartup("set up schemachange workload", func(ctx context.Context, l *logger.Logger, r *rand.Rand, helper *mixedversion.Helper) error {
-		return c.RunE(ctx, option.WithNodes(workloadNode), fmt.Sprintf("./workload init schemachange {pgurl%s}", workloadNode))
+		return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf("./workload init schemachange {pgurl%s}", c.WorkloadNode()))
 	})
 
 	mvt.InMixedVersion("run schemachange workload and validation in mixed version", schemaChangeAndValidationStep)

--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -42,7 +43,7 @@ func registerSqlStatsMixedVersion(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "sql-stats/mixed-version",
 		Owner:            registry.OwnerObservability,
-		Cluster:          r.MakeClusterSpec(5),
+		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.Suites(registry.Nightly),
 		Run:              runSQLStatsMixedVersion,
@@ -52,16 +53,14 @@ func registerSqlStatsMixedVersion(r registry.Registry) {
 
 // runSQLStatsMixedVersion tests that accessing sql stats works across mixed version clusters.
 func runSQLStatsMixedVersion(ctx context.Context, t test.Test, c cluster.Cluster) {
-	roachNodes := c.Range(1, c.Spec().NodeCount-1)
-	workloadNode := c.Node(c.Spec().NodeCount)
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c,
-		roachNodes, mixedversion.MinimumSupportedVersion("v23.1.8"))
+		c.CRDBNodes(), mixedversion.MinimumSupportedVersion("v23.1.8"))
 	flushInterval := 2 * time.Minute
 
 	initWorkload := roachtestutil.NewCommand("./cockroach workload init tpcc").
-		Arg("{pgurl%s}", roachNodes)
+		Arg("{pgurl%s}", c.CRDBNodes())
 	runWorkload := roachtestutil.NewCommand("./cockroach workload run tpcc").
-		Arg("{pgurl%s}", roachNodes).
+		Arg("{pgurl%s}", c.CRDBNodes()).
 		Option("tolerate-errors")
 
 	setClusterSettings := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
@@ -71,7 +70,7 @@ func runSQLStatsMixedVersion(ctx context.Context, t test.Test, c cluster.Cluster
 	}
 
 	mvt.OnStartup("set cluster settings", setClusterSettings)
-	stopTpcc := mvt.Workload("tpcc", workloadNode, initWorkload, runWorkload)
+	stopTpcc := mvt.Workload("tpcc", c.WorkloadNode(), initWorkload, runWorkload)
 	defer stopTpcc()
 
 	requestTypes := map[string]serverpb.CombinedStatementsStatsRequest_StatsType{
@@ -81,7 +80,7 @@ func runSQLStatsMixedVersion(ctx context.Context, t test.Test, c cluster.Cluster
 
 	for name, reqType := range requestTypes {
 		mvt.InMixedVersion("request "+name, func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			return runGetRequests(ctx, c, l, roachNodes, reqType)
+			return runGetRequests(ctx, c, l, c.CRDBNodes(), reqType)
 		})
 	}
 	mvt.Run()

--- a/pkg/cmd/roachtest/tests/queue.go
+++ b/pkg/cmd/roachtest/tests/queue.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -31,7 +32,7 @@ func registerQueue(r registry.Registry) {
 		Skip:             "https://github.com/cockroachdb/cockroach/issues/17229",
 		Name:             fmt.Sprintf("queue/nodes=%d", numNodes-1),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -43,14 +44,14 @@ func registerQueue(r registry.Registry) {
 
 func runQueue(ctx context.Context, t test.Test, c cluster.Cluster) {
 	dbNodeCount := c.Spec().NodeCount - 1
-	workloadNode := c.Spec().NodeCount
-
 	// Distribute programs to the correct nodes and start CockroachDB.
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workloadNode))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, dbNodeCount))
+	// The queue workload is not available in the cockroach binary,
+	// so we must use the deprecated workload.
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.WorkloadNode())
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 	runQueueWorkload := func(duration time.Duration, initTables bool) {
-		m := c.NewMonitor(ctx, c.Range(1, dbNodeCount))
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(dbNodeCount*64))
 			duration := fmt.Sprintf(" --duration=%s", duration.String())
@@ -65,10 +66,10 @@ func runQueue(ctx context.Context, t test.Test, c cluster.Cluster) {
 					concurrency+
 					duration+
 					batch+
-					" {pgurl:1-%d}",
-				dbNodeCount,
+					" {pgurl%s}",
+				c.CRDBNodes(),
 			)
-			c.Run(ctx, option.WithNodes(c.Node(workloadNode)), cmd)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			return nil
 		})
 		m.Wait()

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -767,7 +767,7 @@ func (tpce tpceRestore) getSpec(
 	if tpce.spec != nil {
 		return tpce.spec
 	}
-	tpceSpec, err := initTPCESpec(ctx, t.L(), c, sp.getWorkloadNode(), sp.getCRDBNodes())
+	tpceSpec, err := initTPCESpec(ctx, t.L(), c)
 	require.NoError(t, err)
 	return tpceSpec
 }

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -24,6 +24,8 @@ import (
 
 func registerRoachmart(r registry.Registry) {
 	runRoachmart := func(ctx context.Context, t test.Test, c cluster.Cluster, partition bool) {
+		// The roachmart workload is not available in the cockroach binary,
+		// so we must use the deprecated workload.
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -40,8 +40,6 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			const fixturePath = `gs://cockroach-fixtures-us-east1/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload")
-
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()
@@ -57,13 +55,13 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 			})
 			m.Wait()
 
-			c.Run(ctx, option.WithNodes(c.Node(1)), `./workload init kv --drop --db=test {pgurl:1}`)
+			c.Run(ctx, option.WithNodes(c.Node(1)), `./cockroach workload init kv --drop --db=test {pgurl:1}`)
 			for node := 1; node <= c.Spec().NodeCount; node++ {
 				node := node
 				// TODO(dan): Ideally, the test would fail if this queryload failed,
 				// but we can't put it in monitor as-is because the test deadlocks.
 				go func() {
-					const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=127 --db=test {pgurl%s}`
+					const cmd = `./cockroach workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=127 --db=test {pgurl%s}`
 					l, err := t.L().ChildLogger(fmt.Sprintf(`kv-%d`, node))
 					if err != nil {
 						t.Fatal(err)
@@ -299,18 +297,18 @@ func findIndexProblem(
 }
 
 func registerSchemaChangeIndexTPCC800(r registry.Registry) {
-	r.Add(makeIndexAddTpccTest(r.MakeClusterSpec(5, spec.CPU(16)), 800, time.Hour*2))
+	r.Add(makeIndexAddTpccTest(r.MakeClusterSpec(5, spec.CPU(16), spec.WorkloadNode()), 800, time.Hour*2))
 }
 
 func registerSchemaChangeIndexTPCC100(r registry.Registry) {
-	r.Add(makeIndexAddTpccTest(r.MakeClusterSpec(5), 100, time.Minute*15))
+	r.Add(makeIndexAddTpccTest(r.MakeClusterSpec(5, spec.WorkloadNode()), 100, time.Minute*15))
 }
 
 func makeIndexAddTpccTest(
 	spec spec.ClusterSpec, warehouses int, length time.Duration,
 ) registry.TestSpec {
 	return registry.TestSpec{
-		Name:             fmt.Sprintf("schemachange/index/tpcc/w=%d", warehouses),
+		Name:             fmt.Sprintf("schemachange/indexschemachange/index/tpcc/w=%d", warehouses),
 		Owner:            registry.OwnerSQLFoundations,
 		Benchmark:        true,
 		Cluster:          spec,
@@ -350,7 +348,7 @@ func makeSchemaChangeBulkIngestTest(
 	return registry.TestSpec{
 		Name:             "schemachange/bulkingest",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -367,13 +365,9 @@ func makeSchemaChangeBulkIngestTest(
 			cNum := 1
 			payloadBytes := 4
 
-			crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-			workloadNode := c.Node(c.Spec().NodeCount)
-
-			c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 			// TODO (lucy): Remove flag once the faster import is enabled by default
 			settings := install.MakeClusterSettings(install.EnvOption([]string{"COCKROACH_IMPORT_WORKLOAD_FASTER=true"}))
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, crdbNodes)
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.CRDBNodes())
 
 			// Don't add another index when importing.
 			cmdWrite := fmt.Sprintf(
@@ -383,20 +377,20 @@ func makeSchemaChangeBulkIngestTest(
 				aNum, bNum, cNum, payloadBytes,
 			)
 
-			c.Run(ctx, option.WithNodes(workloadNode), cmdWrite)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
 
-			m := c.NewMonitor(ctx, crdbNodes)
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 
 			indexDuration := length
 			if c.IsLocal() {
 				indexDuration = time.Second * 30
 			}
 			cmdWriteAndRead := fmt.Sprintf(
-				"./workload run bulkingest --duration %s {pgurl:1-%d} --a %d --b %d --c %d --payload-bytes %d",
+				"./cockroach workload run bulkingest --duration %s {pgurl:1-%d} --a %d --b %d --c %d --payload-bytes %d",
 				indexDuration.String(), c.Spec().NodeCount-1, aNum, bNum, cNum, payloadBytes,
 			)
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(workloadNode), cmdWriteAndRead)
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWriteAndRead)
 				return nil
 			})
 

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -89,7 +89,6 @@ func runSchemaChangeRandomLoad(
 			t.Fatalf("found %d invalid objects", numInvalidObjects)
 		}
 	}
-
 	loadNode := c.Node(1)
 	roachNodes := c.Range(1, c.Spec().NodeCount)
 	t.Status("copying binaries")

--- a/pkg/cmd/roachtest/tests/scrub.go
+++ b/pkg/cmd/roachtest/tests/scrub.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -57,7 +58,7 @@ func makeScrubTPCCTest(
 		Name:             fmt.Sprintf("scrub/%s/tpcc/w=%d", optionName, warehouses),
 		Owner:            registry.OwnerSQLQueries,
 		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -58,7 +59,7 @@ type kvSplitLoad struct {
 
 func (ksl kvSplitLoad) init(ctx context.Context, t test.Test, c cluster.Cluster) error {
 	t.Status("running uniform kv workload")
-	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf("./workload init kv {pgurl:1-%d}", c.Spec().NodeCount-1))
+	return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf("./cockroach workload init kv {pgurl%s}", c.CRDBNodes()))
 }
 
 func (ksl kvSplitLoad) rangeCount(db *gosql.DB) (int, error) {
@@ -74,9 +75,9 @@ func (ksl kvSplitLoad) run(ctx context.Context, t test.Test, c cluster.Cluster) 
 		extraFlags += fmt.Sprintf("--min-block-bytes=%d --max-block-bytes=%d ",
 			ksl.blockSize, ksl.blockSize)
 	}
-	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf("./workload run kv "+
-		"--init --concurrency=%d --read-percent=%d --span-percent=%d %s {pgurl:1-%d} --duration='%s'",
-		ksl.concurrency, ksl.readPercent, ksl.spanPercent, extraFlags, c.Spec().NodeCount-1,
+	return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf("./cockroach workload run kv "+
+		"--init --concurrency=%d --read-percent=%d --span-percent=%d %s {pgurl%s} --duration='%s'",
+		ksl.concurrency, ksl.readPercent, ksl.spanPercent, extraFlags, c.CRDBNodes(),
 		ksl.waitDuration.String()))
 }
 
@@ -100,9 +101,9 @@ func (ysl ycsbSplitLoad) init(ctx context.Context, t test.Test, c cluster.Cluste
 		extraArgs += "--insert-hash"
 	}
 
-	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf(
-		"./workload init ycsb --insert-count=%d --workload=%s %s {pgurl:1-%d}",
-		ysl.insertCount, ysl.workload, extraArgs, c.Spec().NodeCount-1))
+	return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(
+		"./cockroach workload init ycsb --insert-count=%d --workload=%s %s {pgurl%s}",
+		ysl.insertCount, ysl.workload, extraArgs, c.CRDBNodes()))
 }
 
 func (ysl ycsbSplitLoad) rangeCount(db *gosql.DB) (int, error) {
@@ -115,11 +116,11 @@ func (ysl ycsbSplitLoad) run(ctx context.Context, t test.Test, c cluster.Cluster
 		extraArgs += "--insert-hash"
 	}
 
-	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf(
-		"./workload run ycsb --record-count=%d --workload=%s --concurrency=%d "+
-			"--duration='%s' %s {pgurl:1-%d}",
+	return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(
+		"./cockroach workload run ycsb --record-count=%d --workload=%s --concurrency=%d "+
+			"--duration='%s' %s {pgurl%s}",
 		ysl.insertCount, ysl.workload, ysl.concurrency,
-		ysl.waitDuration.String(), extraArgs, c.Spec().NodeCount-1))
+		ysl.waitDuration.String(), extraArgs, c.CRDBNodes()))
 }
 
 func rangeCountFrom(from string, db *gosql.DB) (int, error) {
@@ -146,11 +147,12 @@ func registerLoadSplits(r registry.Registry) {
 	// Use the 4th node as the workload runner.
 	const numNodes = 4
 	const numRoachNodes = 3
+	cSpec := r.MakeClusterSpec(numNodes, spec.WorkloadNode())
 
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/uniform/nodes=%d", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -198,7 +200,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/uniform/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -220,7 +222,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/sequential/nodes=%d", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -246,7 +248,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/sequential/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -273,7 +275,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/spanning/nodes=%d", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -294,7 +296,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/spanning/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -324,7 +326,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/a/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -349,7 +351,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/b/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -373,7 +375,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/d/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -398,7 +400,7 @@ func registerLoadSplits(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/e/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(numNodes),
+		Cluster:          cSpec,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -425,11 +427,6 @@ func registerLoadSplits(r registry.Registry) {
 // conditions defined by the params. It checks whether certain number of
 // splits occur in different workload scenarios.
 func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params splitParams) {
-	// Use the last node only for the workload.
-	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-	workloadNode := c.Node(c.Spec().NodeCount)
-
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 	// We run this without metamorphic constants as the tests make
 	// incorrect assumptions about the absolute values of QPS.
 	// See: https://github.com/cockroachdb/cockroach/issues/112664
@@ -441,9 +438,9 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 		"--vmodule=split_queue=2,store_rebalancer=2,allocator=2,replicate_queue=2,"+
 			"decider=3,replica_split_load=1",
 	)
-	c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
+	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
-	m := c.NewMonitor(ctx, crdbNodes)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
@@ -591,7 +588,6 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	rows := size / rowEstimate
 	const minBytes = 16 << 20 // 16 MB
 
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
 	numNodes := c.Spec().NodeCount
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
 
@@ -646,7 +642,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 
 			// NB: would probably be faster to use --data-loader=IMPORT here, but IMPORT
 			// will disregard our preference to keep things in a single range.
-			c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("./workload init bank "+
+			c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("./cockroach workload init bank "+
 				"--rows=%d --payload-bytes=%d --data-loader INSERT --ranges=1 {pgurl:1}", rows, payload))
 
 			if rc, s := rangeCount(t); rc != 1 {

--- a/pkg/cmd/roachtest/tests/tombstones.go
+++ b/pkg/cmd/roachtest/tests/tombstones.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/dustin/go-humanize"
@@ -31,7 +32,7 @@ func registerPointTombstone(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "point-tombstone/heterogeneous-value-sizes",
 		Owner:            registry.OwnerStorage,
-		Cluster:          r.MakeClusterSpec(4),
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllExceptAWS,
 		// This roachtest is useful but relatively specific. Running it weekly
 		// should be fine to ensure we don't regress.
@@ -46,7 +47,7 @@ func registerPointTombstone(r registry.Registry) {
 			startSettings.Env = append(startSettings.Env, "COCKROACH_AUTO_BALLAST=false")
 
 			t.Status("starting cluster")
-			c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))
+			c.Start(ctx, t.L(), startOpts, startSettings, c.CRDBNodes())
 
 			// Wait for upreplication.
 			conn := c.Conn(ctx, t.L(), 2)
@@ -60,7 +61,7 @@ func registerPointTombstone(r registry.Registry) {
 				}
 			}
 
-			c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 			// Set a low 2m GC ttl.
 			execSQLOrFail("alter database kv configure zone using gc.ttlseconds = $1", 120)
@@ -69,9 +70,9 @@ func registerPointTombstone(r registry.Registry) {
 			// logical value data.
 			const numOps1MB = 30720
 			t.Status("starting 1MB-value workload")
-			m := c.NewMonitor(ctx, c.Range(1, 3))
+			m := c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(c.Node(4)), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--concurrency 128 --max-rate 512 --tolerate-errors `+
 					` --min-block-bytes=1048576 --max-block-bytes=1048576 `+
 					` --max-ops %d `+
@@ -87,7 +88,7 @@ func registerPointTombstone(r registry.Registry) {
 			t.Status("starting 4KB-value workload")
 			m = c.NewMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(c.Node(4)), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+				c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--concurrency 256 --max-rate 1024 --tolerate-errors `+
 					` --min-block-bytes=4096 --max-block-bytes=4096 `+
 					` --max-ops 122880 --write-seq R%d `+
@@ -99,7 +100,7 @@ func registerPointTombstone(r registry.Registry) {
 			// Delete the initially written 1MB values (eg, ~30 GB)
 			t.Status("deleting previously-written 1MB values")
 			var statsAfterDeletes tableSizeInfo
-			m = c.NewMonitor(ctx, c.Range(1, 3))
+			m = c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				n1Conn := c.Conn(ctx, t.L(), 1)
 				defer n1Conn.Close()
@@ -131,7 +132,7 @@ func registerPointTombstone(r registry.Registry) {
 			// Wait for garbage collection to delete the non-live data.
 			targetSize := uint64(3 << 30) /* 3 GiB */
 			t.Status("waiting for garbage collection and compaction to reduce on-disk size to ", humanize.IBytes(targetSize))
-			m = c.NewMonitor(ctx, c.Range(1, 3))
+			m = c.NewMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				ticker := time.NewTicker(10 * time.Second)
 				defer ticker.Stop()

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -165,14 +165,10 @@ func tpccImportCmdWithCockroachBinary(
 
 func setupTPCC(
 	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, opts tpccOptions,
-) (crdbNodes, workloadNode option.NodeListOption) {
-	// Randomize starting with encryption-at-rest enabled.
-	crdbNodes = c.Range(1, c.Spec().NodeCount-1)
-	workloadNode = c.Node(c.Spec().NodeCount)
-
+) {
 	// If setup should be skipped, then nothing to o here.
 	if opts.SkipSetup {
-		return crdbNodes, workloadNode
+		return
 	}
 
 	if c.IsLocal() {
@@ -189,7 +185,7 @@ func setupTPCC(
 			startOpts := option.DefaultStartOpts()
 			startOpts.RoachprodOpts.ExtraArgs = opts.ExtraStartArgs
 			startOpts.RoachprodOpts.ScheduleBackups = !opts.DisableDefaultScheduledBackup
-			c.Start(ctx, l, startOpts, settings, crdbNodes)
+			c.Start(ctx, l, startOpts, settings, c.CRDBNodes())
 		}
 	}
 
@@ -218,7 +214,7 @@ func setupTPCC(
 			// Do nothing.
 		case usingImport:
 			t.Status("loading fixture" + estimatedSetupTimeStr)
-			c.Run(ctx, option.WithNodes(crdbNodes[:1]), tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, opts.DB, opts.getWorkloadCmd(), opts.Warehouses, opts.ExtraSetupArgs, "{pgurl:1}"))
+			c.Run(ctx, option.WithNodes(c.Node(1)), tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, opts.DB, opts.getWorkloadCmd(), opts.Warehouses, opts.ExtraSetupArgs, "{pgurl:1}"))
 		case usingInit:
 			l.Printf("initializing tables" + estimatedSetupTimeStr)
 			extraArgs := opts.ExtraSetupArgs
@@ -228,13 +224,12 @@ func setupTPCC(
 				Arg(extraArgs).
 				Arg("{pgurl:1}")
 
-			c.Run(ctx, option.WithNodes(workloadNode), cmd.String())
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd.String())
 		default:
 			t.Fatal("unknown tpcc setup type")
 		}
 		l.Printf("finished tpc-c setup")
 	}()
-	return crdbNodes, workloadNode
 }
 
 func runTPCC(
@@ -245,7 +240,7 @@ func runTPCC(
 		workloadInstances = append(
 			workloadInstances,
 			workloadInstance{
-				nodes:          c.Range(1, c.Spec().NodeCount-1),
+				nodes:          c.CRDBNodes(),
 				prometheusPort: 2112,
 			},
 		)
@@ -287,8 +282,8 @@ func runTPCC(
 			opts.Duration = time.Minute
 		}
 	}
-	crdbNodes, workloadNode := setupTPCC(ctx, t, l, c, opts)
-	m := c.NewMonitor(ctx, crdbNodes)
+	setupTPCC(ctx, t, l, c, opts)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.ExpectDeaths(int32(opts.ExpectedDeaths))
 	rampDur := rampDuration(c.IsLocal())
 	for i := range workloadInstances {
@@ -317,7 +312,7 @@ func runTPCC(
 				Arg(workloadInstances[i].extraRunArgs).
 				Arg(pgURLs[i])
 
-			err := c.RunE(ctx, option.WithNodes(workloadNode), cmd.String())
+			err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd.String())
 			// Don't fail the test if we are running the workload throughout
 			// the entire test. Canceling the context just means that the
 			// test already failed, or that the test finished (and therefore
@@ -345,7 +340,7 @@ func runTPCC(
 			Flag("warehouses", opts.Warehouses).
 			Arg("{pgurl:1}")
 
-		c.Run(ctx, option.WithNodes(workloadNode), cmd.String())
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd.String())
 	}
 
 	// Check no errors from metrics.
@@ -421,9 +416,6 @@ func maxSupportedTPCCWarehouses(
 // by the mixed-version framework which chooses a random predecessor version
 // and upgrades until it reaches the current version.
 func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
-	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-	workloadNode := c.Node(c.Spec().NodeCount)
-
 	maxWarehouses := maxSupportedTPCCWarehouses(*t.BuildVersion(), c.Cloud(), c.Spec())
 	headroomWarehouses := int(float64(maxWarehouses) * 0.7)
 	if c.IsLocal() {
@@ -440,12 +432,12 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	mvt := mixedversion.NewTest(
-		ctx, t, t.L(), c, crdbNodes,
+		ctx, t, t.L(), c, c.CRDBNodes(),
 		mixedversion.MaxUpgrades(3),
 	)
 
 	importTPCC := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-		randomNode := c.Node(crdbNodes.SeededRandNode(rng)[0])
+		randomNode := c.Node(c.CRDBNodes().SeededRandNode(rng)[0])
 		cmd := tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, "", "tpcc", headroomWarehouses, fmt.Sprintf("{pgurl%s}", randomNode))
 		return c.RunE(ctx, option.WithNodes(randomNode), cmd)
 	}
@@ -454,7 +446,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// upgrade machinery, in which a) all ranges are touched and b) work proportional
 	// to the amount data may be carried out.
 	importLargeBank := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-		randomNode := c.Node(crdbNodes.SeededRandNode(rng)[0])
+		randomNode := c.Node(c.CRDBNodes().SeededRandNode(rng)[0])
 		cmd := roachtestutil.NewCommand(fmt.Sprintf("%s workload fixtures import bank", test.DefaultCockroachPath)).
 			Arg("{pgurl%s}", randomNode).
 			Flag("payload-bytes", 10240).
@@ -485,7 +477,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 			}
 		}
 		cmd := roachtestutil.NewCommand("./cockroach workload run tpcc").
-			Arg("{pgurl%s}", crdbNodes).
+			Arg("{pgurl%s}", c.CRDBNodes()).
 			Flag("duration", workloadDur).
 			Flag("warehouses", headroomWarehouses).
 			Flag("histograms", t.PerfArtifactsDir()+"/stats.json").
@@ -493,7 +485,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 			Flag("prometheus-port", 2112).
 			Flag("pprofport", workloadPProfStartPort).
 			String()
-		return c.RunE(ctx, option.WithNodes(workloadNode), cmd)
+		return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 	}
 
 	checkTPCCWorkload := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
@@ -501,10 +493,10 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 			Arg("{pgurl:1}").
 			Flag("warehouses", headroomWarehouses).
 			String()
-		return c.RunE(ctx, option.WithNodes(workloadNode), cmd)
+		return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 	}
 
-	uploadCockroach(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
+	uploadCockroach(ctx, t, c, c.WorkloadNode(), clusterupgrade.CurrentVersion())
 	mvt.OnStartup("load TPCC dataset", importTPCC)
 	mvt.OnStartup("load bank dataset", importLargeBank)
 	mvt.InMixedVersion("TPCC workload", runTPCCWorkload)
@@ -513,7 +505,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 }
 
 func registerTPCC(r registry.Registry) {
-	headroomSpec := r.MakeClusterSpec(4, spec.CPU(16), spec.RandomlyUseZfs())
+	headroomSpec := r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.RandomlyUseZfs())
 	r.Add(registry.TestSpec{
 		// w=headroom runs tpcc for a semi-extended period with some amount of
 		// headroom, more closely mirroring a real production deployment than
@@ -565,7 +557,7 @@ func registerTPCC(r registry.Registry) {
 		},
 	})
 
-	mixedHeadroomSpec := r.MakeClusterSpec(5, spec.CPU(16), spec.RandomlyUseZfs())
+	mixedHeadroomSpec := r.MakeClusterSpec(5, spec.CPU(16), spec.WorkloadNode(), spec.RandomlyUseZfs())
 	r.Add(registry.TestSpec{
 		// mixed-headroom is similar to w=headroom, but with an additional
 		// node and on a mixed version cluster which runs its long-running
@@ -589,7 +581,7 @@ func registerTPCC(r registry.Registry) {
 		Name:              "tpcc-nowait/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
 		Benchmark:         true,
-		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
+		Cluster:           r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionMetamorphic,
@@ -608,7 +600,7 @@ func registerTPCC(r registry.Registry) {
 		Name:              "tpcc-nowait/isolation-level=snapshot/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
 		Benchmark:         true,
-		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
+		Cluster:           r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionMetamorphic,
@@ -627,7 +619,7 @@ func registerTPCC(r registry.Registry) {
 		Name:              "tpcc-nowait/isolation-level=read-committed/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
 		Benchmark:         true,
-		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
+		Cluster:           r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionMetamorphic,
@@ -650,7 +642,7 @@ func registerTPCC(r registry.Registry) {
 		Name:              "tpcc-nowait/isolation-level=mixed/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
 		Benchmark:         true,
-		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
+		Cluster:           r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionMetamorphic,
@@ -686,7 +678,7 @@ func registerTPCC(r registry.Registry) {
 							args += " --conn-vars=enable_durable_locking_for_serializable=true"
 						}
 						ret = append(ret, workloadInstance{
-							nodes:          c.Range(1, c.Spec().NodeCount-1),
+							nodes:          c.CRDBNodes(),
 							prometheusPort: 2112 + i,
 							extraRunArgs:   args,
 						})
@@ -703,7 +695,7 @@ func registerTPCC(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
-		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode()),
 		// Give the test a generous extra 10 hours to load the dataset and
 		// slowly ramp up the load.
 		Timeout:           4*24*time.Hour + 10*time.Hour,
@@ -825,7 +817,7 @@ func registerTPCC(r registry.Registry) {
 				Name:  tc.name,
 				Owner: registry.OwnerSQLFoundations,
 				// Add an extra node which serves as the workload nodes.
-				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.GCEZones(strings.Join(zs, ","))),
+				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.WorkloadNode(), spec.Geo(), spec.GCEZones(strings.Join(zs, ","))),
 				CompatibleClouds:  registry.OnlyGCE,
 				Suites:            registry.Suites(registry.Nightly),
 				EncryptionSupport: registry.EncryptionMetamorphic,
@@ -919,7 +911,7 @@ func registerTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "tpcc/w=100/nodes=3/chaos=true",
 		Owner:             registry.OwnerTestEng,
-		Cluster:           r.MakeClusterSpec(4),
+		Cluster:           r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		EncryptionSupport: registry.EncryptionMetamorphic,
@@ -1806,10 +1798,10 @@ func setupPrometheusForRoachtest(
 			return nil, func() {}
 		}
 		cfg = &prometheus.Config{}
-		workloadNode := c.Node(c.Spec().NodeCount).InstallNodes()[0]
+		workloadNode := c.WorkloadNode().InstallNodes()[0]
 		cfg.WithPrometheusNode(workloadNode)
-		cfg.WithNodeExporter(c.Range(1, c.Spec().NodeCount-1).InstallNodes())
-		cfg.WithCluster(c.Range(1, c.Spec().NodeCount-1).InstallNodes())
+		cfg.WithNodeExporter(c.CRDBNodes().InstallNodes())
+		cfg.WithCluster(c.CRDBNodes().InstallNodes())
 		if len(workloadInstances) > 0 {
 			cfg.ScrapeConfigs = append(cfg.ScrapeConfigs, prometheus.MakeWorkloadScrapeConfig("workload",
 				"/", makeWorkloadScrapeNodes(workloadNode, workloadInstances)))

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -34,8 +34,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		c cluster.Cluster,
 		disableStreamer bool,
 	) {
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(numNodes))
-		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.Range(1, numNodes-1))
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
 
 		conn := c.Conn(ctx, t.L(), 1)
 		if disableStreamer {
@@ -45,16 +44,16 @@ func registerTPCHConcurrency(r registry.Registry) {
 		}
 
 		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.Range(1, numNodes-1)),
-			c.Range(1, numNodes-1), true, /* disableMergeQueue */
+			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.CRDBNodes()),
+			c.CRDBNodes(), true, /* disableMergeQueue */
 		); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	restartCluster := func(ctx context.Context, c cluster.Cluster, t test.Test) {
-		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, numNodes-1))
-		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.Range(1, numNodes-1))
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.CRDBNodes())
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
 	}
 
 	// checkConcurrency returns an error if at least one node of the cluster
@@ -63,7 +62,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 	checkConcurrency := func(ctx context.Context, t test.Test, c cluster.Cluster, concurrency int) error {
 		// Make sure to kill any workloads running from the previous
 		// iteration.
-		_ = c.RunE(ctx, option.WithNodes(c.Node(numNodes)), "killall workload")
+		_ = c.RunE(ctx, option.WithNodes(c.WorkloadNode()), "killall workload")
 
 		restartCluster(ctx, c, t)
 
@@ -90,7 +89,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 			}
 		}
 
-		m := c.NewMonitor(ctx, c.Range(1, numNodes-1))
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			t.Status(fmt.Sprintf("running with concurrency = %d", concurrency))
 			// Run each query once on each connection.
@@ -141,11 +140,11 @@ func registerTPCHConcurrency(r registry.Registry) {
 				// Use very short duration for --display-every parameter so that
 				// all query runs are logged.
 				cmd := fmt.Sprintf(
-					"./workload run tpch {pgurl:1-%d} --display-every=1ns --tolerate-errors "+
+					"./cockroach workload run tpch {pgurl%s} --display-every=1ns --tolerate-errors "+
 						"--count-errors --queries=%d --concurrency=%d --max-ops=%d",
-					numNodes-1, queryNum, concurrency, maxOps,
+					c.CRDBNodes(), queryNum, concurrency, maxOps,
 				)
-				if err := c.RunE(ctx, option.WithNodes(c.Node(numNodes)), cmd); err != nil {
+				if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd); err != nil {
 					return err
 				}
 			}
@@ -207,7 +206,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Name:    "tpch_concurrency",
 		Owner:   registry.OwnerSQLQueries,
 		Timeout: timeout,
-		Cluster: r.MakeClusterSpec(numNodes),
+		Cluster: r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		// Uses gs://cockroach-fixtures-us-east1. See:
 		// https://github.com/cockroachdb/cockroach/issues/105968
 		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
@@ -222,7 +221,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Name:    "tpch_concurrency/no_streamer",
 		Owner:   registry.OwnerSQLQueries,
 		Timeout: timeout,
-		Cluster: r.MakeClusterSpec(numNodes),
+		Cluster: r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		// Uses gs://cockroach-fixtures-us-east1. See:
 		// https://github.com/cockroachdb/cockroach/issues/105968
 		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -51,29 +51,23 @@ type tpchBenchSpec struct {
 // This benchmark runs with a single load generator node running a single
 // worker.
 func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBenchSpec) {
-	roachNodes := c.Range(1, c.Spec().NodeCount-1)
-	loadNode := c.Node(c.Spec().NodeCount)
-
-	t.Status("copying binaries")
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
-
 	filename := b.benchType
 	t.Status(fmt.Sprintf("downloading %s query file from %s", filename, b.url))
-	if err := c.RunE(ctx, option.WithNodes(loadNode), fmt.Sprintf("curl %s > %s", b.url, filename)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf("curl %s > %s", b.url, filename)); err != nil {
 		t.Fatal(err)
 	}
 
 	t.Status("starting nodes")
-	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), roachNodes)
+	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
 
-	m := c.NewMonitor(ctx, roachNodes)
+	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		conn := c.Conn(ctx, t.L(), 1)
 		defer conn.Close()
 
 		t.Status("setting up dataset")
 		err := loadTPCHDataset(
-			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true, /* disableMergeQueue */
+			ctx, t, c, conn, b.ScaleFactor, m, c.CRDBNodes(), true, /* disableMergeQueue */
 		)
 		if err != nil {
 			return err
@@ -91,16 +85,16 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 		// Run with only one worker to get best-case single-query performance.
 		cmd := fmt.Sprintf(
-			"./workload run querybench --db=tpch --concurrency=1 --query-file=%s "+
+			"./cockroach workload run querybench --db=tpch --concurrency=1 --query-file=%s "+
 				"--num-runs=%d --max-ops=%d {pgurl%s} "+
 				"--histograms="+t.PerfArtifactsDir()+"/stats.json --histograms-max-latency=%s",
 			filename,
 			b.numRunsPerQuery,
 			maxOps,
-			roachNodes,
+			c.CRDBNodes(),
 			b.maxLatency.String(),
 		)
-		if err := c.RunE(ctx, option.WithNodes(loadNode), cmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd); err != nil {
 			t.Fatal(err)
 		}
 		return nil
@@ -168,7 +162,7 @@ func registerTPCHBenchSpec(r registry.Registry, b tpchBenchSpec) {
 		Name:      strings.Join(nameParts, "/"),
 		Owner:     registry.OwnerSQLQueries,
 		Benchmark: true,
-		Cluster:   r.MakeClusterSpec(numNodes),
+		Cluster:   r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
 		// Uses gs://cockroach-fixtures-us-east1. See:
 		// https://github.com/cockroachdb/cockroach/issues/105968
 		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -519,14 +519,12 @@ func getTPCHVecWorkloadCmd(numRunsPerQuery, queryNum int, sharedProcessMT bool) 
 	// Note that we use --default-vectorize flag which tells tpch workload to
 	// use the current cluster setting sql.defaults.vectorize which must have
 	// been set correctly in preQueryRunHook.
-	return fmt.Sprintf("./workload run tpch --concurrency=1 --db=tpch "+
+	return fmt.Sprintf("./cockroach workload run tpch --concurrency=1 --db=tpch "+
 		"--default-vectorize --max-ops=%d --queries=%d %s --enable-checks=true",
 		numRunsPerQuery, queryNum, url)
 }
 
 func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tpchVecTestCase) {
-	firstNode := c.Node(1)
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", firstNode)
 	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings())
 
 	var conn *gosql.DB

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -62,8 +62,6 @@ func registerYCSB(r registry.Registry) {
 			t.Skip("YCSB zfs benchmark can only be run on GCE", "")
 		}
 
-		nodes := c.Spec().NodeCount - 1
-
 		conc, ok := concurrencyConfigs[wl][cpus]
 		if !ok {
 			t.Fatalf("missing concurrency for (workload, cpus) = (%s, %d)", wl, cpus)
@@ -74,8 +72,7 @@ func registerYCSB(r registry.Registry) {
 			settings.Env = append(settings.Env, "COCKROACH_GLOBAL_MVCC_RANGE_TOMBSTONE=true")
 		}
 
-		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
-		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.Range(1, nodes))
+		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.CRDBNodes())
 
 		db := c.Conn(ctx, t.L(), 1)
 		err := enableIsolationLevels(ctx, t, db)
@@ -85,7 +82,7 @@ func registerYCSB(r registry.Registry) {
 		require.NoError(t, db.Close())
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx, c.Range(1, nodes))
+		m := c.NewMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			var args string
 			args += " --ramp=" + ifLocal(c, "0s", "2m")
@@ -100,11 +97,11 @@ func registerYCSB(r registry.Registry) {
 				args += " " + envFlags
 			}
 			cmd := fmt.Sprintf(
-				"./workload run ycsb --init --insert-count=1000000 --workload=%s --concurrency=%d"+
+				"./cockroach workload run ycsb --init --insert-count=1000000 --workload=%s --concurrency=%d"+
 					" --splits=%d --histograms="+t.PerfArtifactsDir()+"/stats.json"+args+
-					" {pgurl:1-%d}",
-				wl, conc, nodes, nodes)
-			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
+					" {pgurl%s}",
+				wl, conc, len(c.CRDBNodes()), c.CRDBNodes())
+			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 			return nil
 		})
 		m.Wait()
@@ -122,7 +119,7 @@ func registerYCSB(r registry.Registry) {
 				Name:      name,
 				Owner:     registry.OwnerTestEng,
 				Benchmark: true,
-				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
+				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, ycsbOptions{})
 				},
@@ -135,7 +132,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("zfs/ycsb/%s/nodes=3/cpu=%d", wl, cpus),
 					Owner:     registry.OwnerStorage,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.SetFileSystem(spec.Zfs)),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.SetFileSystem(spec.Zfs)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{})
 					},
@@ -149,7 +146,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("%s/isolation-level=read-committed", name),
 					Owner:     registry.OwnerTestEng,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{readCommitted: true})
 					},
@@ -163,7 +160,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("%s/mvcc-range-keys=global", name),
 					Owner:     registry.OwnerTestEng,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{rangeTombstone: true})
 					},
@@ -182,7 +179,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("%s/uniform", name),
 					Owner:     registry.OwnerTestEng,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus)),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{uniformDistribution: true})
 					},


### PR DESCRIPTION
This change refactors roachtests to use the new WorkloadNode
cluster spec and the helpers that come with it. It also uses
smaller workload nodes for certain tests.

This change also removes unnecessary usage of the deprecated
workload, opting to use cockroach workload when possible.

Release note: none
Fixes: #62302

--------------
Sorry for the big diff, but most of the changes boil down to:

1. Switching `workload` to `cockroach workload` when possible.
2. Specifying `spec.WorkloadNodes` when a test uses a workload only node.
3. Using the new `c.WorkloadNodes` and `c.CRDBNodes` helpers instead of doing node arithmetic (i.e. `c.Range(1, c.NodeCount - 1)`

Smoke testing is a bit scattered between TC and local runs, but I made a [spreadsheet here](https://docs.google.com/spreadsheets/d/1kIE39psGmeaSxJdsQ_XaO9X5qAzvCrvFekyVJ0RdhcQ/edit?gid=0#gid=0) of all changed tests  and made sure there weren't any regressions in the case of using a smaller workload node.