### PR TITLE
sql: avoid an allocation when running subqueries in some cases

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1080,7 +1080,10 @@ func (s *Server) newConnExecutor(
 			execTestingKnobs: s.GetExecutorConfig().TestingKnobs,
 		},
 		memMetrics: memMetrics,
-		planner:    planner{execCfg: s.cfg},
+		planner: planner{
+			execCfg:    s.cfg,
+			datumAlloc: &tree.DatumAlloc{},
+		},
 
 		// ctxHolder will be reset at the start of run(). We only define
 		// it here so that an early call to close() doesn't panic.

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1882,7 +1882,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 				// a single value against a tuple.
 				toAppend = row[0]
 			} else {
-				toAppend = &tree.DTuple{D: row}
+				toAppend = planner.datumAlloc.NewDTuple(tree.DTuple{D: row})
 			}
 			// Perform memory accounting for this datum. We do this in an
 			// incremental fashion since we might be materializing a lot of data

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -291,8 +291,7 @@ type planner struct {
 	// checkScanParallelizationIfLocal.
 	parallelizationChecker localScanParallelizationChecker
 
-	// datumAlloc is used when decoding datums and is initialized in
-	// initPlanner.
+	// datumAlloc is used when decoding datums and running subqueries.
 	datumAlloc *tree.DatumAlloc
 }
 
@@ -416,7 +415,7 @@ func newInternalPlanner(
 	})
 	plannerMon.StartNoReserved(ctx, execCfg.RootMemoryMonitor)
 
-	p := &planner{execCfg: execCfg}
+	p := &planner{execCfg: execCfg, datumAlloc: &tree.DatumAlloc{}}
 	p.resetPlanner(ctx, txn, sd, plannerMon, nil /* sessionMon */)
 
 	smi := &sessionDataMutatorIterator{


### PR DESCRIPTION
This commit reuses recently added `DatumAlloc` to the planner when creating the tuple that is the result of a subquery evaluation in order to reduce allocations. In a profile obtained from a customer I observed this allocation to be about 2% of all allocated objects.

Epic: None

Release note: None