### PR TITLE
streamingccl: skip TestStreamingAutoReplan under deadlock

### DIFF
--- a/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
@@ -783,6 +783,7 @@ func TestStreamingAutoReplan(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "multi cluster/node config exhausts hardware")
+	skip.UnderDeadlock(t, "scatter may take too long")
 
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs


### PR DESCRIPTION
Fixes #125991

Release note: none