### PR TITLE
changefeedccl: fix sink leaks in a few places

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -65,7 +65,7 @@ func TestAlterChangefeedAddTargetPrivileges(t *testing.T) {
 						if _, ok := s.(*externalConnectionKafkaSink); ok {
 							return s
 						}
-						return &externalConnectionKafkaSink{sink: s}
+						return &externalConnectionKafkaSink{sink: s, ignoreDialError: true}
 					},
 				},
 			},

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3192,7 +3192,7 @@ func TestChangefeedCreateAuthorizationWithChangefeedPriv(t *testing.T) {
 						if _, ok := s.(*externalConnectionKafkaSink); ok {
 							return s
 						}
-						return &externalConnectionKafkaSink{sink: s}
+						return &externalConnectionKafkaSink{sink: s, ignoreDialError: true}
 					},
 				},
 			},

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -133,7 +133,7 @@ func TestShowChangefeedJobsRedacted(t *testing.T) {
 		if _, ok := s.(*externalConnectionKafkaSink); ok {
 			return s
 		}
-		return &externalConnectionKafkaSink{sink: s}
+		return &externalConnectionKafkaSink{sink: s, ignoreDialError: true}
 	}
 
 	sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -242,7 +242,7 @@ func TestShowChangefeedJobs(t *testing.T) {
 
 	var singleChangefeedID, multiChangefeedID jobspb.JobID
 
-	query = `CREATE CHANGEFEED FOR TABLE foo INTO 
+	query = `CREATE CHANGEFEED FOR TABLE foo INTO
 		'webhook-https://fake-http-sink:8081' WITH webhook_auth_header='Basic Zm9v'`
 	sqlDB.QueryRow(t, query).Scan(&singleChangefeedID)
 

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -154,7 +154,13 @@ func getAndDialSink(
 	if err != nil {
 		return nil, err
 	}
-	return sink, sink.Dial()
+	if err := sink.Dial(); err != nil {
+		if closeErr := sink.Close(); closeErr != nil {
+			return nil, errors.CombineErrors(err, errors.Wrap(closeErr, `failed to close sink`))
+		}
+		return nil, err
+	}
+	return sink, nil
 }
 
 // WebhookV2Enabled determines whether or not the refactored Webhook sink

--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -77,10 +77,13 @@ func validateExternalConnectionSinkURI(
 	//
 	// TODO(adityamaru): When we add `CREATE EXTERNAL CONNECTION ... WITH` support
 	// to accept JSONConfig we should validate that here too.
-	_, err := getSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
+	s, err := getSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
 		jobspb.JobID(0), (*sliMetrics)(nil))
 	if err != nil {
 		return errors.Wrap(err, "invalid changefeed sink URI")
+	}
+	if err := s.Close(); err != nil {
+		return errors.Wrap(err, "failed to close canary sink")
 	}
 
 	return nil

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -33,6 +33,10 @@ import (
 // Connections route to the correct sink.
 type externalConnectionKafkaSink struct {
 	sink Sink
+	// ignoreDialError causes this wrapper to ignore errors calling its inner
+	// sink's Dial() method. This can happen for a few reasons, such as giving
+	// it a bad address for testing purposes.
+	ignoreDialError bool
 }
 
 func (e *externalConnectionKafkaSink) getConcreteType() sinkType {
@@ -41,7 +45,16 @@ func (e *externalConnectionKafkaSink) getConcreteType() sinkType {
 
 // Dial implements the Sink interface.
 func (e *externalConnectionKafkaSink) Dial() error {
-	if _, ok := e.sink.(*kafkaSink); !ok {
+	switch sink := e.sink.(type) {
+	case *kafkaSink:
+		if err := sink.Dial(); err != nil && !e.ignoreDialError {
+			return err
+		}
+	case *batchingSink:
+		if err := sink.Dial(); err != nil && !e.ignoreDialError {
+			return err
+		}
+	default:
 		return errors.Newf("unexpected sink type %T; expected a kafka sink", e.sink)
 	}
 	return nil
@@ -49,7 +62,7 @@ func (e *externalConnectionKafkaSink) Dial() error {
 
 // Close implements the Sink interface.
 func (e *externalConnectionKafkaSink) Close() error {
-	return nil
+	return e.sink.Close()
 }
 
 // EmitRow implements the Sink interface.
@@ -90,7 +103,7 @@ func TestChangefeedExternalConnections(t *testing.T) {
 		if _, ok := s.(*externalConnectionKafkaSink); ok {
 			return s
 		}
-		return &externalConnectionKafkaSink{sink: s}
+		return &externalConnectionKafkaSink{sink: s, ignoreDialError: true}
 	}
 
 	sqlDB := sqlutils.MakeSQLRunner(s.DB)

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -499,16 +499,16 @@ func (p *deprecatedGcpPubsubClient) openTopic(topicName string) (*pubsub.Topic, 
 }
 
 func (p *deprecatedGcpPubsubClient) close() error {
+	if p.client == nil {
+		return nil
+	}
 	_ = p.forEachTopic(func(_ string, t *pubsub.Topic) error {
 		t.Stop()
 		return nil
 	})
-	if p.client != nil {
-		// Close the client to release resources held by the client to avoid memory
-		// leaks.
-		return p.client.Close()
-	}
-	return nil
+	// Close the client to release resources held by the client to avoid memory
+	// leaks.
+	return p.client.Close()
 }
 
 // sendMessage sends a message to the topic


### PR DESCRIPTION
There are some places where we neglect to close
sinks, which lead to goroutine leaks and thus test
failures in the new Kafka sink PR.

Epic: CRDB-38892

Release note (bug fix): Fixed small memory leaks that occur during changfeed creation.
