### PR TITLE
server: rename BinaryVersionOverride to ClusterVersionOverride

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -178,7 +178,7 @@ func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 			t.Fatalf("clusterVersion %s does not exist in data driven global map", cfg.beforeVersion)
 		}
 		params.ServerArgs.Knobs.Server = &server.TestingKnobs{
-			BinaryVersionOverride:          beforeKey.Version(),
+			ClusterVersionOverride:         beforeKey.Version(),
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
 		}
 	}

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -70,7 +70,7 @@ func testTenantAutoUpgrade(t *testing.T, clusterSetting *autoUpgradeClusterSetti
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v0.Version(),
+				ClusterVersionOverride:         v0.Version(),
 			},
 			SQLEvalContext: &eval.TestingKnobs{
 				// When the host binary version is not equal to its cluster version, tenant logical version is set
@@ -106,7 +106,7 @@ func testTenantAutoUpgrade(t *testing.T, clusterSetting *autoUpgradeClusterSetti
 				Server: &server.TestingKnobs{
 					TenantAutoUpgradeInfo:          upgradeInfoCh,
 					TenantAutoUpgradeLoopFrequency: time.Second,
-					BinaryVersionOverride:          v0.Version(),
+					ClusterVersionOverride:         v0.Version(),
 				},
 			},
 		}
@@ -242,7 +242,7 @@ func TestTenantUpgrade(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v1,
+				ClusterVersionOverride:         v1,
 			},
 			// Make the upgrade faster by accelerating jobs.
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -378,7 +378,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v0,
+				ClusterVersionOverride:         v0,
 			},
 		},
 	})

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -139,7 +139,7 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					// Initialize to the minimum supported version
 					// so that we can perform the upgrade below.
-					BinaryVersionOverride: msv,
+					ClusterVersionOverride: msv,
 				},
 			},
 		},

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -558,7 +558,7 @@ func TestMrSystemDatabaseUpgrade(t *testing.T) {
 		base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 			},
 		},
 		multiregionccltestutils.WithSettings(makeSettings()))
@@ -572,7 +572,7 @@ func TestMrSystemDatabaseUpgrade(t *testing.T) {
 		TestingKnobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 			},
 		},
 		TenantID: id,

--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -424,7 +424,7 @@ func TestPreMigration(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          (clusterversion.V24_2_TenantRates - 1).Version(),
+				ClusterVersionOverride:         (clusterversion.V24_2_TenantRates - 1).Version(),
 			},
 		},
 	})

--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -46,7 +46,7 @@ func (f MultiRegionTestClusterFactory) WithSchemaChangerKnobs(
 // WithMixedVersion implements the sctest.TestServerFactory interface.
 func (f MultiRegionTestClusterFactory) WithMixedVersion() sctest.TestServerFactory {
 	f.server = &server.TestingKnobs{
-		BinaryVersionOverride:          sctest.OldVersionKey.Version(),
+		ClusterVersionOverride:         sctest.OldVersionKey.Version(),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}
 	return f

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -97,7 +97,7 @@ func TestServerStartupGuardrails(t *testing.T) {
 				Settings:          storageSettings,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						BinaryVersionOverride:          test.storageBinaryVersion,
+						ClusterVersionOverride:         test.storageBinaryVersion,
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
 					},
 					SQLEvalContext: &eval.TestingKnobs{
@@ -124,7 +124,7 @@ func TestServerStartupGuardrails(t *testing.T) {
 					TenantID: serverutils.TestTenantID(),
 					TestingKnobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
-							BinaryVersionOverride:          test.tenantBinaryVersion,
+							ClusterVersionOverride:         test.tenantBinaryVersion,
 							DisableAutomaticVersionUpgrade: make(chan struct{}),
 						},
 					},

--- a/pkg/ccl/serverccl/tenant_migration_test.go
+++ b/pkg/ccl/serverccl/tenant_migration_test.go
@@ -91,7 +91,7 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 				Settings:          makeSettings(),
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						BinaryVersionOverride: test.binaryVersion,
+						ClusterVersionOverride: test.binaryVersion,
 						// We're bumping cluster versions manually ourselves. We
 						// want to avoid racing with the auto-upgrade process.
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
@@ -107,7 +107,7 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 					TenantID: serverutils.TestTenantID(),
 					TestingKnobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
-							BinaryVersionOverride: test.binaryVersion,
+							ClusterVersionOverride: test.binaryVersion,
 						},
 					},
 				})
@@ -207,7 +207,7 @@ func TestBumpTenantClusterVersion(t *testing.T) {
 						// This test wants to bootstrap at the previously active
 						// cluster version, so we can actually bump the cluster
 						// version to the binary version.
-						BinaryVersionOverride: test.initialClusterVersion.Version,
+						ClusterVersionOverride: test.initialClusterVersion.Version,
 						// We're bumping cluster versions manually ourselves. We
 						// want to avoid racing with the auto-upgrade process.
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
@@ -222,7 +222,7 @@ func TestBumpTenantClusterVersion(t *testing.T) {
 					TenantID: serverutils.TestTenantID(),
 					TestingKnobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
-							BinaryVersionOverride: test.initialClusterVersion.Version,
+							ClusterVersionOverride: test.initialClusterVersion.Version,
 						},
 					},
 				})

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2366,7 +2366,7 @@ func TestStartableJobMixedVersion(t *testing.T) {
 		Settings: st,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 		},

--- a/pkg/kv/kvserver/client_migration_test.go
+++ b/pkg/kv/kvserver/client_migration_test.go
@@ -253,7 +253,7 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 			Settings: cluster.MakeTestingClusterSettingsWithVersions(endV, startV, false),
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          startV,
+					ClusterVersionOverride:         startV,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				UpgradeManager: &upgradebase.TestingKnobs{

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4110,7 +4110,7 @@ func TestStrictGCEnforcement(t *testing.T) {
 		testCache = true
 		args.ServerArgs.Knobs.Server = &server.TestingKnobs{
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
-			BinaryVersionOverride:          (clusterversion.V24_1_MigrateOldStylePTSRecords - 1).Version(),
+			ClusterVersionOverride:         (clusterversion.V24_1_MigrateOldStylePTSRecords - 1).Version(),
 		}
 	}
 
@@ -4924,7 +4924,7 @@ func TestRangeMigration(t *testing.T) {
 			Settings: cluster.MakeTestingClusterSettingsWithVersions(endV, startV, false),
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          startV,
+					ClusterVersionOverride:         startV,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 			},

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -331,7 +331,7 @@ func TestJoinVersionGate(t *testing.T) {
 
 	knobs := base.TestingKnobs{
 		Server: &server.TestingKnobs{
-			BinaryVersionOverride: oldVersion,
+			ClusterVersionOverride: oldVersion,
 		},
 	}
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -642,12 +642,12 @@ func newInitServerConfig(
 	latestVersion := cfg.Settings.Version.LatestVersion()
 	minSupportedVersion := cfg.Settings.Version.MinSupportedVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
-		if overrideVersion := knobs.(*TestingKnobs).BinaryVersionOverride; overrideVersion != (roachpb.Version{}) {
+		if overrideVersion := knobs.(*TestingKnobs).ClusterVersionOverride; overrideVersion != (roachpb.Version{}) {
 			// We are customizing the cluster version. We can only bootstrap a fresh
 			// cluster at specific versions (specifically, the current version and
-			// previously released versions down to the minimum supported).
-			// We choose the closest version that's not newer than the target version.;
-			// later on, we will upgrade to `BinaryVersionOverride` (this happens
+			// previously released versions down to the minimum supported). We choose
+			// the closest version that's not newer than the target version.; later
+			// on, we will upgrade to `ClusterVersionOverride` (this happens
 			// separately when we Activate the server).
 			var bootstrapVersion roachpb.Version
 			for _, v := range bootstrap.VersionsWithInitialValues() {
@@ -657,7 +657,7 @@ func newInitServerConfig(
 				}
 			}
 			if bootstrapVersion == (roachpb.Version{}) {
-				panic(fmt.Sprintf("BinaryVersionOverride version %s too low", overrideVersion))
+				panic(fmt.Sprintf("ClusterVersionOverride version %s too low", overrideVersion))
 			}
 			latestVersion = bootstrapVersion
 		}

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -105,7 +105,7 @@ func TestValidateTargetClusterVersion(t *testing.T) {
 			Settings: st,
 			Knobs: base.TestingKnobs{
 				Server: &TestingKnobs{
-					BinaryVersionOverride: test.latestVersion,
+					ClusterVersionOverride: test.latestVersion,
 				},
 			},
 		})
@@ -141,8 +141,8 @@ func TestSyncAllEngines(t *testing.T) {
 		StoreSpecs: []base.StoreSpec{storeSpec},
 		Knobs: base.TestingKnobs{
 			Server: &TestingKnobs{
-				BinaryVersionOverride: clusterversion.PreviousRelease.Version(),
-				StickyVFSRegistry:     vfsRegistry,
+				ClusterVersionOverride: clusterversion.PreviousRelease.Version(),
+				StickyVFSRegistry:      vfsRegistry,
 			},
 		},
 	}
@@ -258,7 +258,7 @@ func TestBumpClusterVersion(t *testing.T) {
 						// cluster version, so we can actually bump the cluster
 						// version to the binary version. Think a cluster with
 						// active cluster version v20.1, but running v20.2 binaries.
-						BinaryVersionOverride: test.activeClusterVersion,
+						ClusterVersionOverride: test.activeClusterVersion,
 						// We're bumping cluster versions manually ourselves. We
 						// want avoid racing with the auto-upgrade process.
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
@@ -358,7 +358,7 @@ func TestUpgradeHappensAfterMigrations(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &TestingKnobs{
 				DisableAutomaticVersionUpgrade: automaticUpgrade,
-				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 			},
 			UpgradeManager: &upgradebase.TestingKnobs{
 				AfterRunPermanentUpgrades: func() {

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -60,42 +60,27 @@ type TestingKnobs struct {
 	// server fails to start.
 	RPCListener net.Listener
 
-	// BinaryVersionOverride overrides the binary version that the CRDB server
-	// will end up running. This value could also influence what version the
-	// cluster is bootstrapped at.
+	// ClusterVersionOverride can be used to override the version of the cluster
+	// (assuming that one has to be created).
 	//
-	// This value, when set, influences test cluster/server creation in two
-	// different ways:
+	// Normally (when this knob isn't used), the cluster is initialized at
+	// cluster.Settings.Version.LatestVersion().
 	//
-	// Case 1:
-	// ------
-	// If the test has not overridden the
-	// `cluster.Settings.Version.MinSupportedVersion`, then the cluster will be
-	// bootstrapped at `minSupportedVersion`  (if this server is the one
-	// bootstrapping the cluster). After all the servers in the test cluster have
-	// been started, `SET CLUSTER SETTING version = BinaryVersionOverride` will be
-	// run to step through the upgrades until the specified override.
+	// When ClusterVersionOverride is set, the cluster will be at this version
+	// once initialization is complete. Note that we cannot bootstrap clusters at
+	// arbitrary versions - we can only bootstrap clusters at the Latest version
+	// and at final versions of previous supported releases. The cluster will be
+	// bootstrapped at the most recent bootstrappable version that is at most
+	// ClusterVersionOverride; after all the servers in the test cluster have been
+	// started, `SET CLUSTER SETTING version = ClusterVersionOverride` will be run
+	// to step through the upgrades until the specified version.
 	//
-	// Case 2:
-	// ------
-	// If the test has overridden the
-	// `cluster.Settings.Version.MinSupportedVersion` then it is not safe for us
-	// to bootstrap at `minSupportedVersion` as it might be less than the
-	// overridden minimum supported version. Furthermore, we do not have the
-	// initial cluster data (system tables etc.) to bootstrap at the overridden
-	// minimum supported version. In this case we bootstrap at
-	// `BinaryVersionOverride` and populate the cluster with initial data
-	// corresponding to the `binaryVersion`. In other words no upgrades are
-	// *really* run and the server only thinks that it is running at
-	// `BinaryVersionOverride`. Tests that fall in this category should be audited
-	// for correctness.
-	//
-	// The version that we bootstrap at is also used when advertising this
-	// server's binary version when sending out join requests.
+	// ClusterVersionOverride is also used when advertising this server's binary
+	// version when sending out join requests.
 	//
 	// NB: When setting this, you probably also want to set
 	// DisableAutomaticVersionUpgrade.
-	BinaryVersionOverride roachpb.Version
+	ClusterVersionOverride roachpb.Version
 	// An (additional) callback invoked whenever a
 	// node is permanently removed from the cluster.
 	OnDecommissionedCallback func(id roachpb.NodeID)

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -221,7 +221,7 @@ func TestClusterVersionUpgrade(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          oldVersion,
+					ClusterVersionOverride:         oldVersion,
 					DisableAutomaticVersionUpgrade: disableUpgradeCh,
 				},
 			},
@@ -401,7 +401,7 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 	knobs := base.TestingKnobs{
 		Server: &server.TestingKnobs{
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
-			BinaryVersionOverride:          v0,
+			ClusterVersionOverride:         v0,
 		},
 		// Inject an upgrade which would run to upgrade the cluster.
 		// We'll validate that we never create a job for this upgrade.

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3031,7 +3031,7 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 		},
 	}
 	params.Knobs.Server = &server.TestingKnobs{
-		BinaryVersionOverride:          clusterversion.V23_2.Version(),
+		ClusterVersionOverride:         clusterversion.V23_2.Version(),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}
 	s, sqlDB, _ := serverutils.StartServer(t, params)
@@ -3873,7 +3873,7 @@ func TestSessionLeasingTable(t *testing.T) {
 		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.V23_2.Version(),
+				ClusterVersionOverride:         clusterversion.V23_2.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 		},
@@ -3949,7 +3949,7 @@ func TestLongLeaseWaitMetrics(t *testing.T) {
 		DefaultTestTenant: base.TestNeedsTightIntegrationBetweenAPIsAndTestingKnobs,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.V23_2.Version(),
+				ClusterVersionOverride:         clusterversion.V23_2.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 		},

--- a/pkg/sql/catalog/tabledesc/validate_version_gating_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_version_gating_test.go
@@ -73,7 +73,7 @@ func TestIndexDoesNotStorePrimaryKeyColumnMixedVersion(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v0.Version(),
+				ClusterVersionOverride:         v0.Version(),
 			},
 		},
 	})

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1496,7 +1496,7 @@ func (t *logicTest) newCluster(
 		if params.ServerArgs.Knobs.Server == nil {
 			params.ServerArgs.Knobs.Server = &server.TestingKnobs{}
 		}
-		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).BinaryVersionOverride = cfg.BootstrapVersion.Version()
+		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).ClusterVersionOverride = cfg.BootstrapVersion.Version()
 	}
 	if cfg.DisableUpgrade {
 		if params.ServerArgs.Knobs.Server == nil {

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -69,7 +69,7 @@ func (f SingleNodeTestClusterFactory) WithSchemaChangerKnobs(
 // WithMixedVersion implements the TestServerFactory interface.
 func (f SingleNodeTestClusterFactory) WithMixedVersion() TestServerFactory {
 	f.server = &server.TestingKnobs{
-		BinaryVersionOverride:          OldVersionKey.Version(),
+		ClusterVersionOverride:         OldVersionKey.Version(),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}
 	return f

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -50,7 +50,7 @@ func TestDropTenantSynchronous(t *testing.T) {
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
-						BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+						ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 					},
 				},
 			},

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -128,10 +128,6 @@ type TestServerController interface {
 	// ready. This is only effective when called before Start().
 	SetReadyFn(fn func(bool))
 
-	// BinaryVersionOverride returns the value of an override if set using
-	// TestingKnobs.
-	BinaryVersionOverride() roachpb.Version
-
 	// RunInitialSQL is used by 'cockroach demo' to initialize
 	// an admin user.
 	// TODO(knz): Migrate this logic to a demo-specific init task

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -84,7 +84,7 @@ func TestAlreadyRunningJobsAreHandledProperly(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          startCV.Version(),
+					ClusterVersionOverride:         startCV.Version(),
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				DistSQL: &execinfra.TestingKnobs{
@@ -288,7 +288,7 @@ func TestPostJobInfoTableQueryDuplicateJobInfo(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 			UpgradeManager: &upgradebase.TestingKnobs{
@@ -302,7 +302,7 @@ func TestPostJobInfoTableQueryDuplicateJobInfo(t *testing.T) {
 		TenantID: roachpb.MustMakeTenantID(10),
 		TestingKnobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -384,7 +384,7 @@ func TestMigrateUpdatesReplicaVersion(t *testing.T) {
 
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          startCV,
+					ClusterVersionOverride:         startCV,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				UpgradeManager: &upgradebase.TestingKnobs{
@@ -493,7 +493,7 @@ func TestConcurrentMigrationAttempts(t *testing.T) {
 			),
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          versions[0],
+					ClusterVersionOverride:         versions[0],
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				UpgradeManager: &upgradebase.TestingKnobs{
@@ -577,7 +577,7 @@ func TestPauseMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          startCV.Version(),
+					ClusterVersionOverride:         startCV.Version(),
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				UpgradeManager: &upgradebase.TestingKnobs{
@@ -705,7 +705,7 @@ func TestPrecondition(t *testing.T) {
 	knobs := base.TestingKnobs{
 		Server: &server.TestingKnobs{
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
-			BinaryVersionOverride:          v0,
+			ClusterVersionOverride:         v0,
 		},
 		// Inject an upgrade which would run to upgrade the cluster.
 		// We'll validate that we never create a job for this upgrade.
@@ -859,7 +859,7 @@ func TestMigrationFailure(t *testing.T) {
 		TestingKnobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          startVersion,
+				ClusterVersionOverride:         startVersion,
 			},
 			UpgradeManager: &upgradebase.TestingKnobs{
 				DontUseJobs: true,

--- a/pkg/upgrade/upgrades/builtins_test.go
+++ b/pkg/upgrade/upgrades/builtins_test.go
@@ -32,7 +32,7 @@ func TestIsAtLeastVersionBuiltin(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+					ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/first_upgrade_test.go
+++ b/pkg/upgrade/upgrades/first_upgrade_test.go
@@ -55,7 +55,7 @@ func TestFirstUpgrade(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v0,
+				ClusterVersionOverride:         v0,
 			},
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},
@@ -160,7 +160,7 @@ func TestFirstUpgradeRepair(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v0,
+				ClusterVersionOverride:         v0,
 			},
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},

--- a/pkg/upgrade/upgrades/redacted_stmt_diagnostics_requests_test.go
+++ b/pkg/upgrade/upgrades/redacted_stmt_diagnostics_requests_test.go
@@ -41,7 +41,7 @@ func TestStmtDiagRedactedMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          (clusterversion.V24_2_StmtDiagRedacted - 1).Version(),
+					ClusterVersionOverride:         (clusterversion.V24_2_StmtDiagRedacted - 1).Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -341,7 +341,7 @@ func testMigrationWithFailures(
 					Knobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
 							DisableAutomaticVersionUpgrade: make(chan struct{}),
-							BinaryVersionOverride:          startCV,
+							ClusterVersionOverride:         startCV,
 						},
 						JobsTestingKnobs: jobsKnobs,
 						SQLExecutor: &sql.ExecutorTestingKnobs{

--- a/pkg/upgrade/upgrades/v24_1_add_span_counts_test.go
+++ b/pkg/upgrade/upgrades/v24_1_add_span_counts_test.go
@@ -35,7 +35,7 @@ func TestAddSpanCounts(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+					ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v24_1_drop_payload_and_progress_jobs_test.go
+++ b/pkg/upgrade/upgrades/v24_1_drop_payload_and_progress_jobs_test.go
@@ -35,7 +35,7 @@ func TestHidePayloadAndProgressSystemJobs(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+					ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v24_1_migrate_pts_records_test.go
+++ b/pkg/upgrade/upgrades/v24_1_migrate_pts_records_test.go
@@ -49,7 +49,7 @@ func TestMigrateOldStlePTSRecords(t *testing.T) {
 					WriteDeprecatedPTSRecords: true},
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+					ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v24_1_session_based_lease_test.go
+++ b/pkg/upgrade/upgrades/v24_1_session_based_lease_test.go
@@ -42,7 +42,7 @@ func TestSessionBasedLeaseUpgrade(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          (clusterversion.V24_1_SessionBasedLeasingDualWrite - 1).Version(),
+					ClusterVersionOverride:         (clusterversion.V24_1_SessionBasedLeasingDualWrite - 1).Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v24_2_delete_version_tenant_settings_test.go
+++ b/pkg/upgrade/upgrades/v24_2_delete_version_tenant_settings_test.go
@@ -34,7 +34,7 @@ func TestDeleteVersionTenantSettings(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.V24_1.Version(),
+					ClusterVersionOverride:         clusterversion.V24_1.Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v24_2_tenant_rates_test.go
+++ b/pkg/upgrade/upgrades/v24_2_tenant_rates_test.go
@@ -34,7 +34,7 @@ func TestTenantRatesMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.MinSupported.Version(),
+					ClusterVersionOverride:         clusterversion.MinSupported.Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v24_2_tenant_system_tables_test.go
+++ b/pkg/upgrade/upgrades/v24_2_tenant_system_tables_test.go
@@ -53,7 +53,7 @@ func TestCreateTenantSystemTables(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
-				BinaryVersionOverride:          v1,
+				ClusterVersionOverride:         v1,
 			},
 			// Make the upgrade faster by accelerating jobs.
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),

--- a/pkg/upgrade/upgrades/version_starvation_test.go
+++ b/pkg/upgrade/upgrades/version_starvation_test.go
@@ -53,7 +53,7 @@ func TestLeasingClusterVersionStarvation(t *testing.T) {
 				},
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.V23_2.Version(),
+					ClusterVersionOverride:         clusterversion.V23_2.Version(),
 				},
 			},
 		},


### PR DESCRIPTION
This commit renames the field and updates the comment.

Epic: none
Release note: None