### PR TITLE
logical: add eval logical replication options

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/sql/privilege",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
+        "//pkg/sql/sem/asof",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",

--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/resolver",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/exprutil",

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -27,9 +27,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/issuelink"
@@ -86,8 +89,12 @@ func createLogicalReplicationStreamPlanHook(
 		); err != nil {
 			return err
 		}
-
 		if !stmt.Options.IsDefault() {
+			// TODO: update handling of the the returned options
+			_, err := evalLogicalReplicationOptions(ctx, stmt.Options, exprEval, &p.ExtendedEvalContext().Context, p.SemaCtx())
+			if err != nil {
+				return err
+			}
 			return errors.UnimplementedErrorf(issuelink.IssueLink{}, "logical replication stream options are not yet supported")
 		}
 		if stmt.From.Database != "" {
@@ -132,7 +139,7 @@ func createLogicalReplicationStreamPlanHook(
 				return errors.WithHintf(errors.Newf(
 					"tables written to by logical replication currently require a %q DECIMAL column",
 					originTimestampColumnName,
-				), "try 'ALTER %s ADD COLUMN %s DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL",
+				), "try 'ALTER TABLE %s ADD COLUMN %s DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL",
 					dstObjName.String(), originTimestampColumnName,
 				)
 			}
@@ -213,11 +220,104 @@ func createLogicalReplicationStreamTypeCheck(
 	if !ok {
 		return false, nil, nil
 	}
-	if err := exprutil.TypeCheck(ctx, "LOGICAL REPLICATION STREAM", p.SemaCtx(),
+	toTypeCheck := []exprutil.ToTypeCheck{
 		exprutil.Strings{stmt.PGURL},
+		exprutil.Strings{
+			stmt.Options.Cursor,
+			stmt.Options.DefaultFunction,
+			stmt.Options.Mode,
+		},
+	}
+	if err := exprutil.TypeCheck(ctx, "LOGICAL REPLICATION STREAM", p.SemaCtx(),
+		toTypeCheck...,
 	); err != nil {
 		return false, nil, err
 	}
 
 	return true, streamCreationHeader, nil
+}
+
+type resolvedLogicalReplicationOptions struct {
+	cursor          *hlc.Timestamp
+	mode            *string
+	defaultFunction *string
+	userFunctions   map[tree.TableName]tree.RoutineName
+}
+
+func evalLogicalReplicationOptions(
+	ctx context.Context,
+	options tree.LogicalReplicationOptions,
+	eval exprutil.Evaluator,
+	evalCtx *eval.Context,
+	semaCtx *tree.SemaContext,
+) (*resolvedLogicalReplicationOptions, error) {
+	r := &resolvedLogicalReplicationOptions{}
+	if options.Mode != nil {
+		mode, err := eval.String(ctx, options.Mode)
+		if err != nil {
+			return nil, err
+		}
+		r.mode = &mode
+	}
+	if options.Cursor != nil {
+		cursor, err := eval.String(ctx, options.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}
+		asOf, err := asof.Eval(ctx, asOfClause, semaCtx, evalCtx)
+		if err != nil {
+			return nil, err
+		}
+		r.cursor = &asOf.Timestamp
+	}
+	if options.DefaultFunction != nil {
+		defaultFnc, err := eval.String(ctx, options.DefaultFunction)
+		if err != nil {
+			return nil, err
+		}
+		r.defaultFunction = &defaultFnc
+	}
+	if options.UserFunctions != nil {
+		r.userFunctions = make(map[tree.TableName]tree.RoutineName)
+		for tb, fnc := range options.UserFunctions {
+			objName, err := tb.ToUnresolvedObjectName(tree.NoAnnotation)
+			if err != nil {
+				return nil, err
+			}
+			r.userFunctions[objName.ToTableName()] = fnc
+		}
+	}
+	return r, nil
+}
+
+func (r *resolvedLogicalReplicationOptions) GetCursor() (hlc.Timestamp, bool) {
+	if r == nil || r.cursor == nil {
+		return hlc.Timestamp{}, false
+	}
+	return *r.cursor, true
+}
+
+func (r *resolvedLogicalReplicationOptions) GetMode() (string, bool) {
+	if r == nil || r.mode == nil {
+		return "", false
+	}
+	return *r.mode, true
+}
+
+func (r *resolvedLogicalReplicationOptions) GetDefaultFunction() (string, bool) {
+	if r == nil || r.defaultFunction == nil {
+		return "", false
+	}
+	return *r.defaultFunction, true
+}
+
+func (r *resolvedLogicalReplicationOptions) GetUserFunctions() (
+	map[tree.TableName]tree.RoutineName,
+	bool,
+) {
+	if r == nil || r.userFunctions == nil {
+		return map[tree.TableName]tree.RoutineName{}, false
+	}
+	return r.userFunctions, true
 }

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -11,6 +11,7 @@ package logical
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster"
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/streamclient"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/exprutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -131,7 +133,7 @@ func createLogicalReplicationStreamPlanHook(
 				return errors.WithHintf(errors.Newf(
 					"tables written to by logical replication currently require a %q DECIMAL column",
 					originTimestampColumnName,
-				), "try 'ALTER TABLE %s ADD COLUMN %s DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL",
+				), "try 'ALTER TABLE %s ADD COLUMN %s DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL'",
 					dstObjName.String(), originTimestampColumnName,
 				)
 			}
@@ -191,19 +193,32 @@ func createLogicalReplicationStreamPlanHook(
 			replicationStartTime = cursor
 			progress.ReplicatedTime = cursor
 		}
-		// TODO: Handle the plumbing of the other options once ready.
+
+		if uf, ok := options.GetUserFunctions(); ok {
+			for i, name := range srcTableNames {
+				repPairs[i].SrcFunctionID = uf[name]
+			}
+		}
+		// Default conflict resolution if not set will be LWW
+		defaultConflictResolution := jobspb.LogicalReplicationDetails_DefaultConflictResolution{
+			ConflictResolutionType: jobspb.LogicalReplicationDetails_DefaultConflictResolution_LWW,
+		}
+		if cr, ok := options.GetDefaultFunction(); ok {
+			defaultConflictResolution = *cr
+		}
 
 		jr := jobs.Record{
 			JobID:       p.ExecCfg().JobRegistry.MakeJobID(),
 			Description: fmt.Sprintf("LOGICAL REPLICATION STREAM into %s from %s", targetsDescription, streamAddress),
 			Username:    p.User(),
 			Details: jobspb.LogicalReplicationDetails{
-				StreamID:             uint64(spec.StreamID),
-				SourceClusterID:      spec.SourceClusterID,
-				ReplicationStartTime: replicationStartTime,
-				TargetClusterConnStr: string(streamAddress),
-				ReplicationPairs:     repPairs,
-				TableNames:           srcTableNames,
+				StreamID:                  uint64(spec.StreamID),
+				SourceClusterID:           spec.SourceClusterID,
+				ReplicationStartTime:      replicationStartTime,
+				TargetClusterConnStr:      string(streamAddress),
+				ReplicationPairs:          repPairs,
+				TableNames:                srcTableNames,
+				DefaultConflictResolution: defaultConflictResolution,
 			},
 			Progress: progress,
 		}
@@ -245,8 +260,9 @@ func createLogicalReplicationStreamTypeCheck(
 type resolvedLogicalReplicationOptions struct {
 	cursor          *hlc.Timestamp
 	mode            *string
-	defaultFunction *string
-	userFunctions   map[tree.TableName]tree.RoutineName
+	defaultFunction *jobspb.LogicalReplicationDetails_DefaultConflictResolution
+	// Mapping of table name to function descriptor
+	userFunctions map[string]int32
 }
 
 func evalLogicalReplicationOptions(
@@ -276,23 +292,65 @@ func evalLogicalReplicationOptions(
 		r.cursor = &asOf.Timestamp
 	}
 	if options.DefaultFunction != nil {
+		defaultResolution := &jobspb.LogicalReplicationDetails_DefaultConflictResolution{}
 		defaultFnc, err := eval.String(ctx, options.DefaultFunction)
 		if err != nil {
 			return nil, err
 		}
-		r.defaultFunction = &defaultFnc
+		switch strings.ToLower(defaultFnc) {
+		case "lww":
+			defaultResolution.ConflictResolutionType = jobspb.LogicalReplicationDetails_DefaultConflictResolution_LWW
+		case "dlq":
+			defaultResolution.ConflictResolutionType = jobspb.LogicalReplicationDetails_DefaultConflictResolution_DLQ
+		// This case will assume that a function name was passed in
+		// and we will try to resolve it.
+		default:
+			urn := tree.MakeUnresolvedName(defaultFnc)
+			descID, err := lookupFunctionID(ctx, p, urn)
+			if err != nil {
+				return nil, err
+			}
+			defaultResolution.ConflictResolutionType = jobspb.LogicalReplicationDetails_DefaultConflictResolution_UDF
+			defaultResolution.FunctionId = descID
+		}
+
+		r.defaultFunction = defaultResolution
 	}
 	if options.UserFunctions != nil {
-		r.userFunctions = make(map[tree.TableName]tree.RoutineName)
+		r.userFunctions = make(map[string]int32)
 		for tb, fnc := range options.UserFunctions {
 			objName, err := tb.ToUnresolvedObjectName(tree.NoAnnotation)
 			if err != nil {
 				return nil, err
 			}
-			r.userFunctions[objName.ToTableName()] = fnc
+
+			urn := tree.MakeUnresolvedName(fnc.String())
+			descID, err := lookupFunctionID(ctx, p, urn)
+			if err != nil {
+				return nil, err
+			}
+			r.userFunctions[objName.String()] = descID
 		}
 	}
 	return r, nil
+}
+
+func lookupFunctionID(
+	ctx context.Context, p sql.PlanHookState, u tree.UnresolvedName,
+) (int32, error) {
+	rf, err := p.ResolveFunction(ctx, tree.MakeUnresolvedFunctionName(&u), &p.SessionData().SearchPath)
+	if err != nil {
+		return 0, err
+	}
+	if len(rf.Overloads) > 1 {
+		return 0, errors.Newf("function '%s' has more than 1 overload", u.String())
+	}
+	fnOID := rf.Overloads[0].Oid
+	var descID int32
+	if descID := typedesc.UserDefinedTypeOIDToID(fnOID); descID == 0 {
+		return 0, errors.Newf("function '%s' is not a user defined type", u.String())
+	}
+	return descID, nil
 }
 
 func (r *resolvedLogicalReplicationOptions) GetCursor() (hlc.Timestamp, bool) {
@@ -309,19 +367,19 @@ func (r *resolvedLogicalReplicationOptions) GetMode() (string, bool) {
 	return *r.mode, true
 }
 
-func (r *resolvedLogicalReplicationOptions) GetDefaultFunction() (string, bool) {
-	if r == nil || r.defaultFunction == nil {
-		return "", false
-	}
-	return *r.defaultFunction, true
-}
-
-func (r *resolvedLogicalReplicationOptions) GetUserFunctions() (
-	map[tree.TableName]tree.RoutineName,
+func (r *resolvedLogicalReplicationOptions) GetDefaultFunction() (
+	*jobspb.LogicalReplicationDetails_DefaultConflictResolution,
 	bool,
 ) {
+	if r == nil || r.defaultFunction == nil {
+		return &jobspb.LogicalReplicationDetails_DefaultConflictResolution{}, false
+	}
+	return r.defaultFunction, true
+}
+
+func (r *resolvedLogicalReplicationOptions) GetUserFunctions() (map[string]int32, bool) {
 	if r == nil || r.userFunctions == nil {
-		return map[tree.TableName]tree.RoutineName{}, false
+		return map[string]int32{}, false
 	}
 	return r.userFunctions, true
 }

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -223,6 +223,7 @@ message LogicalReplicationDetails {
   message ReplicationPair {
     int32 src_descriptor_id = 1 [(gogoproto.customname) = "SrcDescriptorID"];
     int32 dst_descriptor_id = 2 [(gogoproto.customname) = "DstDescriptorID"];
+    int32 function_id = 3 [(gogoproto.customname) = "SrcFunctionID"];
   }
   repeated ReplicationPair replication_pairs = 3 [(gogoproto.nullable) = false];
 
@@ -240,6 +241,17 @@ message LogicalReplicationDetails {
       (gogoproto.nullable) = false,
       (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
       (gogoproto.customname) = "SourceClusterID"];
+  
+  message DefaultConflictResolution{
+    enum DefaultConflictResolution {
+      LWW = 0;
+      DLQ = 1;
+      UDF = 2;
+    }
+    DefaultConflictResolution conflict_resolution_type = 1;
+    int32 function_id = 2;
+  }
+  DefaultConflictResolution default_conflict_resolution = 7 [(gogoproto.nullable) = false];
 }
 
 message LogicalReplicationProgress {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4594,12 +4594,13 @@ create_stmt:
 // %Category: Experimental
 // %Text:
 // CREATE LOGICAL REPLICATION STREAM 
-//  FROM 'stream_uri' 
-//  ON <TABLE remote_name | TABLES (remote_name, ...) | DATABASE remote_name>
+//  FROM <TABLE remote_name | TABLES (remote_name, ...) | DATABASE remote_name> 
+//  ON 'stream_uri'
 //  INTO <TABLE remote_name | TABLES (remote_name, ...) | DATABASE remote_name>
 //  [WITH
-//  < MODE= immediate | transactional > |
+//  < MODE = immediate | transactional > |
 //  < CURSOR = start_time > |
+//  < DEFAULT FUNCTION = lww | dlq | udf
 //  < FUNCTION 'udf' FOR TABLE local_name  , ... >
 // ]
 create_logical_replication_stream_stmt:


### PR DESCRIPTION
This commit adds the ability for the plan hook to be able to evaluate the incoming options from the sql statement. As of right now, the function will only evaluate the options, but nothing will be done with them. If there is an error in the format of an option, the associated error will be returned.

See individual commits for details.

Epic: None
Release note: None