### PR TITLE
kv: parallelize raft log sync callback handling

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1041,9 +1041,12 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				Engine:      r.store.TODOEngine(),
 				Sideload:    r.raftMu.sideloaded,
 				StateLoader: r.raftMu.stateLoader.StateLoader,
-				SyncWaiter:  r.store.syncWaiter,
-				EntryCache:  r.store.raftEntryCache,
-				Settings:    r.store.cfg.Settings,
+				// NOTE: we use the same SyncWaiter callback loop for all raft log
+				// writes performed by a given range. This ensures that callbacks are
+				// processed in order.
+				SyncWaiter: r.store.syncWaiters[int(r.RangeID)%len(r.store.syncWaiters)],
+				EntryCache: r.store.raftEntryCache,
+				Settings:   r.store.cfg.Settings,
 				Metrics: logstore.Metrics{
 					RaftLogCommitLatency: r.store.metrics.RaftLogCommitLatency,
 				},

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -899,7 +899,7 @@ type Store struct {
 	intentResolver      *intentresolver.IntentResolver
 	recoveryMgr         txnrecovery.Manager
 	storeLiveness       storeliveness.Fabric
-	syncWaiter          *logstore.SyncWaiterLoop
+	syncWaiters         []*logstore.SyncWaiterLoop
 	raftEntryCache      *raftentry.Cache
 	limiters            batcheval.Limiters
 	txnWaitMetrics      *txnwait.Metrics
@@ -1532,7 +1532,16 @@ func NewStore(
 		cfg.RaftSchedulerConcurrency, cfg.RaftSchedulerShardSize, cfg.RaftSchedulerConcurrencyPriority,
 		cfg.RaftElectionTimeoutTicks)
 
-	s.syncWaiter = logstore.NewSyncWaiterLoop()
+	// Run a log SyncWaiter loop for every 32 raft scheduler goroutines.
+	// Experiments on c5d.12xlarge instances (48 vCPUs, the largest single-socket
+	// instance AWS offers) show that with fewer SyncWaiters, raft log callback
+	// processing can become a bottleneck for write heavy workloads, which can
+	// drive about 100k raft log appends per second, per store.
+	numSyncWaiters := (cfg.RaftSchedulerConcurrency-1)/32 + 1 // ceil division
+	s.syncWaiters = make([]*logstore.SyncWaiterLoop, numSyncWaiters)
+	for i := range s.syncWaiters {
+		s.syncWaiters[i] = logstore.NewSyncWaiterLoop()
+	}
 
 	s.raftEntryCache = raftentry.NewCache(cfg.RaftEntryCacheSize)
 	s.metrics.registry.AddMetricStruct(s.raftEntryCache.Metrics())

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -766,7 +766,9 @@ func (s *Store) processRaft(ctx context.Context) {
 		s.cfg.Transport.StopOutgoingMessage(s.StoreID())
 	}))
 
-	s.syncWaiter.Start(ctx, s.stopper)
+	for _, w := range s.syncWaiters {
+		w.Start(ctx, s.stopper)
+	}
 
 	// We'll want to cancel all in-flight proposals. Proposals embed tracing
 	// spans in them, and we don't want to be leaking any.


### PR DESCRIPTION
This commit runs a raft log `SyncWaiter` loop for every 32 raft scheduler goroutines on a store. Experiments on `c5d.12xlarge` instances (48 vCPUs, the largest single-socket instance AWS offers) show that with fewer SyncWaiters, raft log callback processing can become a bottleneck for write heavy workloads, which can drive about 100k raft log appends per second, per store.

### Experiment:

I found this while running kv0 against an 8-node, 48 vCPU cluster.
```bash
# create cluster with 8 single-NUMA node instances
roachprod create nathan-numa-small -n=8 --clouds aws --aws-machine-type-ssd=c5d.12xlarge --local-ssd --geo --aws-zones='us-east-2a' --aws-enable-multiple-stores
roachprod stage  nathan-numa-small release v24.1.1
roachprod start  nathan-numa-small --insecure

# create load generator
roachprod create nathan-numa-load  -n=1 --clouds aws --aws-machine-type=c5.4xlarge --local-ssd=false --geo --aws-zones='us-east-2a'
roachprod stage  nathan-numa-load release v24.1.1
roachprod run    nathan-numa-load -- "./cockroach workload init kv --splits=100 --scatter $(roachprod pgurl  nathan-numa-small --insecure)"
roachprod run    nathan-numa-load -- "./cockroach workload run  kv --concurrency=384  --ramp=1m --duration=3m $(roachprod pgurl  nathan-numa-small --insecure)"
roachprod run    nathan-numa-load -- "./cockroach workload run  kv --concurrency=768  --ramp=1m --duration=3m $(roachprod pgurl  nathan-numa-small --insecure)"
roachprod run    nathan-numa-load -- "./cockroach workload run  kv --concurrency=1152 --ramp=1m --duration=3m $(roachprod pgurl  nathan-numa-small --insecure)"
roachprod run    nathan-numa-load -- "./cockroach workload run  kv --concurrency=1536 --ramp=1m --duration=3m $(roachprod pgurl  nathan-numa-small --insecure)"
```

When getting up around 160k qps, I saw that the raft log commit latency (p50) started to spike on one node.

<img width="984" alt="Screenshot 2024-07-01 at 4 12 22 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/9a899825-69d0-4247-abe5-c142e2fc4cf1">

However, the WAL fsync latency did not show a similar outlier. Fsyncs were much faster than the raft log commit latency. This implied a delay in processing raft log syncs.

<img width="981" alt="Screenshot 2024-07-01 at 4 57 01 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/6c72e484-1026-410f-abee-e1c087fe857a">

I switched async raft log writes off @ 253.0s using `SET CLUSTER SETTING kv.raft_log.non_blocking_synchronization.enabled = false;` and saw the following effect:
```
_elapsed___errors__ops/sec(inst)___ops/sec(cum)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
  241.0s        0       164616.1       172351.8      1.6     46.1     52.4     62.9 write
  242.0s        0       165625.3       172323.9      1.6     46.1     50.3     56.6 write
  243.0s        0       165949.2       172298.3      1.6     44.0     52.4     65.0 write
  244.0s        0       170499.2       172290.4      1.6     39.8     50.3     60.8 write
  245.0s        0       164996.9       172260.7      1.6     46.1     52.4     67.1 write
  246.0s        0       168431.2       172245.3      1.6     44.0     50.3     62.9 write
  247.0s        0       164665.5       172214.7      1.6     44.0     50.3     65.0 write
  248.0s        0       169326.8       172203.0      1.6     44.0     50.3     65.0 write
  249.0s        0       169797.3       172193.0      1.6     41.9     50.3     62.9 write
  250.0s        0       166716.1       172171.1      1.6     44.0     52.4     65.0 write
  251.0s        0       166091.3       172146.7      1.6     46.1     50.3     62.9 write
  252.0s        0       183925.8       172193.6      1.7     15.7     46.1     60.8 write
  253.0s        0       266399.1       172565.7      2.4      6.8     12.1     32.5 write
  254.0s        0       265088.5       172930.8      2.4      6.8     12.6     35.7 write
  255.0s        0       267436.0       173301.4      2.4      6.8     11.5     39.8 write
  256.0s        0       260245.0       173641.2      2.4      7.1     12.6     35.7 write
  257.0s        0       263763.1       173992.0      2.4      6.8     12.6     39.8 write
  258.0s        0       265126.7       174344.0      2.4      6.8     11.5     30.4 write
  259.0s        0       266493.2       174701.0      2.5      6.3     10.5     35.7 write
  260.0s        0       260532.4       175030.0      2.4      6.8     12.6    209.7 write
```
Notably, p50 latency increased, but p95 and p99 decreased. The throughput also jumped up, because the workload was no longer bottlenecked on one slow node's slow acknowledgement of log appends.

With this patch, we avoid the bottleneck. Throughput can sit comfortably at 260k writes per second with async log writes enabled and raft log commit latency stays in the microseconds:

<img width="990" alt="Screenshot 2024-07-01 at 5 02 23 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/e4f4fa48-1971-46c1-88b9-5b2f2ccc6996">
<img width="984" alt="Screenshot 2024-07-01 at 5 02 33 PM" src="https://github.com/cockroachdb/cockroach/assets/5438456/03d8cb28-408b-4584-8eab-423df8aaee14">

---- 

Epic: None

Release note (performance improvement): raft log sync callback handling is now parallelized, which can improve write-heavy workload performance on large, single-store nodes.