### PR TITLE
sql: implement plan_cache_mode=force_generic_plan

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
@@ -143,6 +143,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -164,6 +165,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -57,7 +57,7 @@ func init() {
 		opt.VariableOp:       (*Builder).buildVariable,
 		opt.ConstOp:          (*Builder).buildTypedExpr,
 		opt.NullOp:           (*Builder).buildNull,
-		opt.PlaceholderOp:    (*Builder).buildTypedExpr,
+		opt.PlaceholderOp:    (*Builder).buildPlaceholder,
 		opt.TupleOp:          (*Builder).buildTuple,
 		opt.FunctionOp:       (*Builder).buildFunction,
 		opt.CaseOp:           (*Builder).buildCase,
@@ -129,6 +129,15 @@ func (b *Builder) buildTypedExpr(
 	ctx *buildScalarCtx, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {
 	return scalar.Private().(tree.TypedExpr), nil
+}
+
+func (b *Builder) buildPlaceholder(
+	ctx *buildScalarCtx, scalar opt.ScalarExpr,
+) (tree.TypedExpr, error) {
+	if b.evalCtx != nil && b.evalCtx.Placeholders != nil {
+		return eval.Expr(b.ctx, b.evalCtx, scalar.Private().(*tree.Placeholder))
+	}
+	return b.buildTypedExpr(ctx, scalar)
 }
 
 func (b *Builder) buildNull(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -137,6 +137,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -158,6 +159,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1047,6 +1047,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 9 (72 B, 18 KVs, 9 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -56,6 +56,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -94,6 +95,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -105,6 +105,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -145,6 +146,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -164,6 +166,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -183,6 +186,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -205,6 +209,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -236,6 +241,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -259,6 +265,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -285,6 +292,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -311,6 +319,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2230,6 +2230,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -10,6 +10,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -42,6 +43,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -65,6 +65,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -132,6 +133,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -207,6 +209,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -295,6 +298,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -337,6 +341,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -374,6 +379,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
@@ -24,6 +24,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -65,6 +66,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 7 (56 B, 14 KVs, 7 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/generic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/generic
@@ -1,0 +1,648 @@
+# LogicTest: local
+
+# Disable stats collection to prevent automatic stats collection from
+# invalidating plans.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  t TIMESTAMPTZ,
+  INDEX (a),
+  INDEX (t)
+)
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
+
+# A generic, reusable plan can be built during PREPARE for queries with no
+# placeholders nor stable expressions.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+# The generic plan is reused even when forcing a custom plan because it will
+# always be optimal.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+DEALLOCATE p
+
+# Prepare the same query with plan_cache_mode set to force_custom_plan.
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
+
+# Execute it once with plan_cache_mode set to force_custom_plan.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+# The plan is generic (it has no placeholders), so it can be reused with
+# plan_cache_mode set to force_generic_plan.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE k = $1
+
+# A generic, reusable plan can be built during PREPARE when the placeholder
+# fast-path can be used.
+query T
+EXPLAIN ANALYZE EXECUTE p(33)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
+  missing stats
+  table: t@t_pkey
+  spans: [/33 - /33]
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+# The generic plan is reused even when forcing a custom plan because it will
+# always be optimal.
+query T
+EXPLAIN ANALYZE EXECUTE p(33)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
+  missing stats
+  table: t@t_pkey
+  spans: [/33 - /33]
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = $1 AND c = $2
+
+# A simple generic plan can be built during EXECUTE.
+query T
+EXPLAIN ANALYZE EXECUTE p(1, 2)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: t@t_pkey
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: c = "$2"
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: t@t_a_idx
+    │ equality: ($1) = (a)
+    │
+    └── • values
+          sql nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          size: 2 columns, 1 row
+
+# The generic plan can be reused with different placeholder values.
+query T
+EXPLAIN ANALYZE EXECUTE p(11, 22)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: t@t_pkey
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: c = "$2"
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: t@t_a_idx
+    │ equality: ($1) = (a)
+    │
+    └── • values
+          sql nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          size: 2 columns, 1 row
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+# The generic plan is not reused when forcing a custom plan.
+query T
+EXPLAIN ANALYZE EXECUTE p(1, 2)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 2
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE t = now()
+
+# A generic plan with a stable expression.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: t = now()
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+# The generic plan can be reused.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: t = now()
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT k FROM t WHERE c = $1
+
+# A simple generic plan.
+query T
+EXPLAIN ANALYZE EXECUTE p(1)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 1
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+statement ok
+ALTER TABLE t ADD COLUMN z INT
+
+# A schema change invalidates the generic plan, and it must be re-optimized.
+query T
+EXPLAIN ANALYZE EXECUTE p(1)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 1
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+statement ok
+DEALLOCATE p
+
+statement ok
+ALTER TABLE t DROP COLUMN z

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -26,6 +26,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -120,6 +121,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: generic, re-optimized
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -198,6 +200,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: generic, re-optimized
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -80,6 +80,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -166,6 +167,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: generic, reused
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -325,6 +327,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -422,6 +425,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -115,6 +115,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: generic, reused
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -146,6 +147,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: generic, reused
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -605,6 +605,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -722,6 +723,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -2607,6 +2609,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -42,6 +42,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 2,001 (16 KiB, 4,002 KVs, 2,001 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -75,6 +76,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -126,6 +128,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
@@ -214,6 +217,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
+plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -258,6 +258,13 @@ func TestExecBuild_forecast1401(
 	runExecBuildLogicTest(t, "forecast1401")
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -308,6 +308,19 @@ func (ob *OutputBuilder) AddVectorized(value bool) {
 	ob.AddFlakyTopLevelField(DeflakeVectorized, "vectorized", fmt.Sprintf("%t", value))
 }
 
+// AddGeneric adds a top-level generic field, if value is true. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddPlanType(generic, optimized bool) {
+	switch {
+	case generic && optimized:
+		ob.AddTopLevelField("plan type", "generic, re-optimized")
+	case generic && !optimized:
+		ob.AddTopLevelField("plan type", "generic, reused")
+	default:
+		ob.AddTopLevelField("plan type", "custom")
+	}
+}
+
 // AddPlanningTime adds a top-level planning time field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddPlanningTime(delta time.Duration) {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -486,7 +486,11 @@ func (p *planTop) savePlanInfo() {
 		distribution = physicalplan.PartiallyDistributedPlan
 	}
 	containsMutation := p.flags.IsSet(planFlagContainsMutation)
-	p.instrumentation.RecordPlanInfo(distribution, vectorized, containsMutation)
+	generic := p.flags.IsSet(planFlagGeneric)
+	optimized := p.flags.IsSet(planFlagOptimized)
+	p.instrumentation.RecordPlanInfo(
+		distribution, vectorized, containsMutation, generic, optimized,
+	)
 }
 
 // startExec calls startExec() on each planNode using a depth-first, post-order
@@ -631,6 +635,15 @@ const (
 	// planFlagSessionMigration is set if the plan is being created during
 	// a session migration.
 	planFlagSessionMigration
+
+	// planFlagGeneric is set if a generic query plan was used. A generic query
+	// plan is a plan that is fully-optimized once and can be reused without
+	// being re-optimized.
+	planFlagGeneric
+
+	// planFlagOptimized is set if optimization was performed during the
+	// current execution of the query.
+	planFlagOptimized
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -527,20 +527,10 @@ func (opc *optPlanningCtx) reuseMemo(
 	return f.Memo(), nil
 }
 
-// buildExecMemo creates a fully optimized memo, possibly reusing a previously
-// cached memo as a starting point.
-//
-// The returned memo is only safe to use in one thread, during execution of the
-// current statement.
-func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ error) {
-	if resumeProc := opc.p.storedProcTxnState.getResumeProc(); resumeProc != nil {
-		// We are executing a stored procedure which has paused to commit or
-		// rollback its transaction. Use resumeProc to resume execution in a new
-		// transaction where the control statement left off.
-		opc.log(ctx, "resuming stored procedure execution in a new transaction")
-		return opc.reuseMemo(ctx, resumeProc)
-	}
-
+// fetchPreparedMemoLegacy attempts to fetch a prepared memo. If a valid (i.e.,
+// non-stale) memo is found, it is used. Otherwise, a new statement will be
+// built. If memo reuse is not allowed, nil is returned.
+func (opc *optPlanningCtx) fetchPreparedMemoLegacy(ctx context.Context) (_ *memo.Memo, err error) {
 	prepared := opc.p.stmt.Prepared
 	p := opc.p
 	if opc.allowMemoReuse && prepared != nil && prepared.BaseMemo != nil {
@@ -562,6 +552,32 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		return opc.reuseMemo(ctx, prepared.BaseMemo)
 	}
 
+	return nil, nil
+}
+
+// buildExecMemo creates a fully optimized memo, possibly reusing a previously
+// cached memo as a starting point.
+//
+// The returned memo is only safe to use in one thread, during execution of the
+// current statement.
+func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ error) {
+	if resumeProc := opc.p.storedProcTxnState.getResumeProc(); resumeProc != nil {
+		// We are executing a stored procedure which has paused to commit or
+		// rollback its transaction. Use resumeProc to resume execution in a new
+		// transaction where the control statement left off.
+		opc.log(ctx, "resuming stored procedure execution in a new transaction")
+		return opc.reuseMemo(ctx, resumeProc)
+	}
+
+	m, err := opc.fetchPreparedMemoLegacy(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if m != nil {
+		return m, nil
+	}
+
+	p := opc.p
 	if opc.useCache {
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -167,7 +167,8 @@ func (p *planner) prepareUsingOptimizer(
 		opc.flags.Set(planFlagOptCacheMiss)
 	}
 
-	memo, err := opc.buildReusableMemo(ctx)
+	// Build the memo. Do not attempt to build a generic plan at PREPARE-time.
+	memo, _, err := opc.buildReusableMemo(ctx, false /* allowGeneric */)
 	if err != nil {
 		return 0, err
 	}
@@ -409,28 +410,38 @@ func (opc *optPlanningCtx) log(ctx context.Context, msg redact.SafeString) {
 
 // buildReusableMemo builds the statement into a memo that can be stored for
 // prepared statements and can later be used as a starting point for
-// optimization. The returned memo is fully detached from the planner and can be
-// used with reuseMemo independently and concurrently by multiple threads.
-func (opc *optPlanningCtx) buildReusableMemo(ctx context.Context) (_ *memo.Memo, _ error) {
+// optimization. The returned memo is fully optimized if:
+//
+//  1. The statement does not contain placeholders nor fold-able stable
+//     operators.
+//  2. Or, the placeholder fast path is used.
+//  3. Or, useGeneric is true and the plan is fully optimized as best as
+//     possible in the presence of placeholders.
+//
+// The returned memo is fully detached from the planner and can be used with
+// reuseMemo independently and concurrently by multiple threads.
+func (opc *optPlanningCtx) buildReusableMemo(
+	ctx context.Context, useGeneric bool,
+) (_ *memo.Memo, generic bool, _ error) {
 	p := opc.p
 
 	_, isCanned := opc.p.stmt.AST.(*tree.CannedOptPlan)
 	if isCanned {
 		if !p.EvalContext().SessionData().AllowPrepareAsOptPlan {
-			return nil, pgerror.New(pgcode.InsufficientPrivilege,
+			return nil, false, pgerror.New(pgcode.InsufficientPrivilege,
 				"PREPARE AS OPT PLAN is a testing facility that should not be used directly",
 			)
 		}
 
 		if !p.SessionData().User().IsRootUser() {
-			return nil, pgerror.New(pgcode.InsufficientPrivilege,
+			return nil, false, pgerror.New(pgcode.InsufficientPrivilege,
 				"PREPARE AS OPT PLAN may only be used by root",
 			)
 		}
 	}
 
 	if p.SessionData().SaveTablesPrefix != "" && !p.SessionData().User().IsRootUser() {
-		return nil, pgerror.New(pgcode.InsufficientPrivilege,
+		return nil, false, pgerror.New(pgcode.InsufficientPrivilege,
 			"sub-expression tables creation may only be used by root",
 		)
 	}
@@ -448,7 +459,7 @@ func (opc *optPlanningCtx) buildReusableMemo(ctx context.Context) (_ *memo.Memo,
 		bld.SkipAOST = true
 	}
 	if err := bld.Build(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if bld.DisableMemoReuse {
@@ -462,38 +473,48 @@ func (opc *optPlanningCtx) buildReusableMemo(ctx context.Context) (_ *memo.Memo,
 			// We don't support placeholders inside the canned plan. The main reason
 			// is that they would be invisible to the parser (which reports the number
 			// of placeholders, used to initialize the relevant structures).
-			return nil, pgerror.Newf(pgcode.Syntax,
+			return nil, false, pgerror.Newf(pgcode.Syntax,
 				"placeholders are not supported with PREPARE AS OPT PLAN")
 		}
 		// With a canned plan, we don't want to optimize the memo.
-		return opc.optimizer.DetachMemo(ctx), nil
+		return opc.optimizer.DetachMemo(ctx), false, nil
 	}
 
-	if f.Memo().HasPlaceholders() {
-		// Try the placeholder fast path.
-		_, ok, err := opc.optimizer.TryPlaceholderFastPath()
-		if err != nil {
-			return nil, err
+	// If the memo doesn't have placeholders and did not encounter any stable
+	// operators that can be constant-folded, then fully optimize it now - it
+	// can be reused without further changes to build the execution tree.
+	if !f.Memo().HasPlaceholders() && !f.FoldingControl().PreventedStableFold() {
+		opc.log(ctx, "optimizing (no placeholders)")
+		if _, err := opc.optimizer.Optimize(); err != nil {
+			return nil, false, err
 		}
-		if ok {
-			opc.log(ctx, "placeholder fast path")
+		opc.flags.Set(planFlagOptimized)
+		return opc.optimizer.DetachMemo(ctx), false, nil
+	}
+
+	// If the memo has placeholders, first try the placeholder fast path.
+	_, ok, err := opc.optimizer.TryPlaceholderFastPath()
+	if err != nil {
+		return nil, false, err
+	}
+	if ok {
+		opc.log(ctx, "placeholder fast path")
+		opc.flags.Set(planFlagOptimized)
+	} else if useGeneric {
+		// Build a generic query plan if the placeholder fast path failed and a
+		// generic plan was requested.
+		opc.log(ctx, "optimizing (generic)")
+		if _, err := opc.optimizer.Optimize(); err != nil {
+			return nil, false, err
 		}
-	} else {
-		// If the memo doesn't have placeholders and did not encounter any stable
-		// operators that can be constant folded, then fully optimize it now - it
-		// can be reused without further changes to build the execution tree.
-		if !f.FoldingControl().PreventedStableFold() {
-			opc.log(ctx, "optimizing (no placeholders)")
-			if _, err := opc.optimizer.Optimize(); err != nil {
-				return nil, err
-			}
-		}
+		opc.flags.Set(planFlagOptimized)
+		return opc.optimizer.DetachMemo(ctx), true, nil
 	}
 
 	// Detach the prepared memo from the factory and transfer its ownership
 	// to the prepared statement. DetachMemo will re-initialize the optimizer
 	// to an empty memo.
-	return opc.optimizer.DetachMemo(ctx), nil
+	return opc.optimizer.DetachMemo(ctx), false, nil
 }
 
 // reuseMemo returns an optimized memo using a cached memo as a starting point.
@@ -507,9 +528,9 @@ func (opc *optPlanningCtx) reuseMemo(
 	ctx context.Context, cachedMemo *memo.Memo,
 ) (*memo.Memo, error) {
 	if cachedMemo.IsOptimized() {
-		// The query could have been already fully optimized if there were no
-		// placeholders or the placeholder fast path succeeded (see
-		// buildReusableMemo).
+		// The query could have been already fully optimized in
+		// buildReusableMemo, in which case it is considered a "generic" plan.
+		opc.flags.Set(planFlagGeneric)
 		return cachedMemo, nil
 	}
 	f := opc.optimizer.Factory()
@@ -524,7 +545,122 @@ func (opc *optPlanningCtx) reuseMemo(
 	if _, err := opc.optimizer.Optimize(); err != nil {
 		return nil, err
 	}
+	opc.flags.Set(planFlagOptimized)
 	return f.Memo(), nil
+}
+
+// chooseValidPreparedMemo returns an optimized memo that is equal to, or built
+// from, baseMemo or genericMemo. It returns nil if both memos are stale. It
+// selects baseMemo or genericMemo based on the following rules, in order:
+//
+//  1. If baseMemo is fully optimized and not stale, it is returned as-is.
+//  2. If useGeneric is true and genericMemo is not stale, it is returned
+//     as-is.
+//  3. If useGeneric is true and genericMemo is stale or nil, nil is returned.
+//     The caller is responsible for building a new generic memo.
+//  4. If baseMemo is not stale and unoptimized, optimize and return it.
+//  5. Otherwise, nil is returned. The caller is responsible for building a new
+//     memo.
+//
+// The logic is structured to avoid unnecessary (*memo.Memo).IsStale calls,
+// since they can be expensive.
+func (opc *optPlanningCtx) chooseValidPreparedMemo(
+	ctx context.Context, baseMemo *memo.Memo, genericMemo *memo.Memo, useGeneric bool,
+) (*memo.Memo, error) {
+	// First check for a fully optimized, non-stale, base memo.
+	if baseMemo != nil && baseMemo.IsOptimized() {
+		isStale, err := baseMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		if err != nil {
+			return nil, err
+		} else if !isStale {
+			return baseMemo, nil
+		}
+	}
+
+	// Next check for a non-stale, generic memo.
+	if useGeneric && genericMemo != nil {
+		isStale, err := genericMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		if err != nil {
+			return nil, err
+		} else if !isStale {
+			return genericMemo, nil
+		}
+	}
+
+	// Next, check for a non-stale, normalized memo, if a generic memo is
+	// not allowed.
+	if !useGeneric && baseMemo != nil && !baseMemo.IsOptimized() {
+		isStale, err := baseMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		if err != nil {
+			return nil, err
+		} else if !isStale {
+			return baseMemo, nil
+		}
+	}
+
+	// A valid memo was not found.
+	return nil, nil
+}
+
+// fetchPreparedMemo attempts to fetch a memo from the prepared statement
+// struct. If a valid (i.e., non-stale) memo is found, it is used. Otherwise, a
+// new statement will be built.
+//
+// The plan_cache_mode session setting controls how this function decides
+// between what type of memo to use or reuse:
+//
+//   - force_custom_plan: A fully optimized generic memo will be used if it
+//     either has no placeholders nor fold-able stable expressions, or it
+//     utilizes the placeholder fast-path. Otherwise, a normalized memo will be
+//     fetched or rebuilt, copied into a new memo with placeholders replaced
+//     with values, and re-optimized.
+//
+//   - force_generic_plan: A fully optimized generic memo will always be used.
+//     The BaseMemo will be used if it is fully optimized. Otherwise, the
+//     GenericMemo will be used.
+//
+//   - auto: This currently behaves the same as force_custom_plan.
+//
+// TODO(mgartner): Implement "auto".
+func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo, err error) {
+	p := opc.p
+	prep := p.stmt.Prepared
+	if !opc.allowMemoReuse || prep == nil {
+		return nil, nil
+	}
+
+	useGeneric := opc.p.SessionData().PlanCacheMode == sessiondatapb.PlanCacheModeForceGeneric
+
+	// If the statement was previously prepared, check for a reusable memo.
+	// First check for a valid (non-stale) memo.
+	validMemo, err := opc.chooseValidPreparedMemo(ctx, prep.BaseMemo, prep.GenericMemo, useGeneric)
+	if err != nil {
+		return nil, err
+	}
+	if validMemo != nil {
+		opc.log(ctx, "reusing cached memo")
+		return opc.reuseMemo(ctx, validMemo)
+	}
+
+	// Otherwise, we need to rebuild the memo.
+	//
+	// TODO(mgartner): If we have a non-stale, normalized base memo, we can
+	// build a generic memo from it instead of building the memo from
+	// scratch.
+	opc.log(ctx, "rebuilding cached memo")
+	newMemo, generic, err := opc.buildReusableMemo(ctx, useGeneric)
+	if err != nil {
+		return nil, err
+	}
+	if generic {
+		// TODO(mgartner): Add the generic memo to the query cache so that it
+		// can be reused by future prepared statements.
+		prep.GenericMemo = newMemo
+	} else {
+		prep.BaseMemo = newMemo
+	}
+	// Re-optimize the memo, if necessary.
+	return opc.reuseMemo(ctx, newMemo)
 }
 
 // fetchPreparedMemoLegacy attempts to fetch a prepared memo. If a valid (i.e.,
@@ -543,7 +679,7 @@ func (opc *optPlanningCtx) fetchPreparedMemoLegacy(ctx context.Context) (_ *memo
 			return nil, err
 		} else if isStale {
 			opc.log(ctx, "rebuilding cached memo")
-			prepared.BaseMemo, err = opc.buildReusableMemo(ctx)
+			prepared.BaseMemo, _, err = opc.buildReusableMemo(ctx, false /* useGeneric */)
 			if err != nil {
 				return nil, err
 			}
@@ -569,15 +705,29 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		return opc.reuseMemo(ctx, resumeProc)
 	}
 
-	m, err := opc.fetchPreparedMemoLegacy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if m != nil {
-		return m, nil
+	p := opc.p
+	if p.SessionData().PlanCacheMode == sessiondatapb.PlanCacheModeForceCustom {
+		// Fallback to the legacy logic for reusing memos if plan_cache_mode is
+		// set to force_custom_plan.
+		m, err := opc.fetchPreparedMemoLegacy(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if m != nil {
+			return m, nil
+		}
+	} else {
+		// Use new logic for reusing memos if plan_cache_mode is set to
+		// force_generic_plan or auto.
+		m, err := opc.fetchPreparedMemo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if m != nil {
+			return m, nil
+		}
 	}
 
-	p := opc.p
 	if opc.useCache {
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)
@@ -586,7 +736,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 				return nil, err
 			} else if isStale {
 				opc.log(ctx, "query cache hit but needed update")
-				cachedData.Memo, err = opc.buildReusableMemo(ctx)
+				cachedData.Memo, _, err = opc.buildReusableMemo(ctx, false /* allowGeneric */)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -55,7 +55,7 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 //   - Columns
 //   - Types
 //   - AnonymizedStr
-//   - Memo (for reuse during exec, if appropriate).
+//   - BaseMemo (for reuse during exec, if appropriate).
 func (p *planner) prepareUsingOptimizer(
 	ctx context.Context, origin PreparedStatementOrigin,
 ) (planFlags, error) {
@@ -154,7 +154,7 @@ func (p *planner) prepareUsingOptimizer(
 					stmt.Prepared.StatementNoConstants = pm.StatementNoConstants
 					stmt.Prepared.Columns = pm.Columns
 					stmt.Prepared.Types = pm.Types
-					stmt.Prepared.Memo = cachedData.Memo
+					stmt.Prepared.BaseMemo = cachedData.Memo
 					return opc.flags, nil
 				}
 				opc.log(ctx, "query cache hit but memo is stale (prepare)")
@@ -217,7 +217,7 @@ func (p *planner) prepareUsingOptimizer(
 	stmt.Prepared.Columns = resultCols
 	stmt.Prepared.Types = p.semaCtx.Placeholders.Types
 	if opc.allowMemoReuse {
-		stmt.Prepared.Memo = memo
+		stmt.Prepared.BaseMemo = memo
 		if opc.useCache {
 			// execPrepare sets the PrepareMetadata.InferredTypes field after this
 			// point. However, once the PrepareMetadata goes into the cache, it
@@ -543,23 +543,23 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 
 	prepared := opc.p.stmt.Prepared
 	p := opc.p
-	if opc.allowMemoReuse && prepared != nil && prepared.Memo != nil {
+	if opc.allowMemoReuse && prepared != nil && prepared.BaseMemo != nil {
 		// We are executing a previously prepared statement and a reusable memo is
 		// available.
 
 		// If the prepared memo has been invalidated by schema or other changes,
 		// re-prepare it.
-		if isStale, err := prepared.Memo.IsStale(ctx, p.EvalContext(), opc.catalog); err != nil {
+		if isStale, err := prepared.BaseMemo.IsStale(ctx, p.EvalContext(), opc.catalog); err != nil {
 			return nil, err
 		} else if isStale {
 			opc.log(ctx, "rebuilding cached memo")
-			prepared.Memo, err = opc.buildReusableMemo(ctx)
+			prepared.BaseMemo, err = opc.buildReusableMemo(ctx)
 			if err != nil {
 				return nil, err
 			}
 		}
 		opc.log(ctx, "reusing cached memo")
-		return opc.reuseMemo(ctx, prepared.Memo)
+		return opc.reuseMemo(ctx, prepared.BaseMemo)
 	}
 
 	if opc.useCache {

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -55,10 +55,11 @@ const (
 type PreparedStatement struct {
 	querycache.PrepareMetadata
 
-	// Memo is the memoized data structure constructed by the cost-based optimizer
-	// during prepare of a SQL statement. It can significantly speed up execution
-	// if it is used by the optimizer as a starting point.
-	Memo *memo.Memo
+	// BaseMemo is the memoized data structure constructed by the cost-based
+	// optimizer during prepare of a SQL statement. It may be a fully-optimized
+	// memo if the prepared statement has no placeholders and no fold-able
+	// stable expressions. Otherwise, it is an unoptimized, normalized memo.
+	BaseMemo *memo.Memo
 
 	// refCount keeps track of the number of references to this PreparedStatement.
 	// New references are registered through incRef().
@@ -84,8 +85,8 @@ func (p *PreparedStatement) MemoryEstimate() int64 {
 	//   1. Size of the prepare metadata.
 	//   2. Size of the prepared memo, if using the cost-based optimizer.
 	size := p.PrepareMetadata.MemoryEstimate()
-	if p.Memo != nil {
-		size += p.Memo.MemoryEstimate()
+	if p.BaseMemo != nil {
+		size += p.BaseMemo.MemoryEstimate()
 	}
 	return size
 }

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -61,6 +61,12 @@ type PreparedStatement struct {
 	// stable expressions. Otherwise, it is an unoptimized, normalized memo.
 	BaseMemo *memo.Memo
 
+	// GenericMemo, if present, is a fully-optimized memo that can be executed
+	// as-is.
+	// TODO(mgartner): Put all fully-optimized plans in the GenericMemo field to
+	// reduce confusion.
+	GenericMemo *memo.Memo
+
 	// refCount keeps track of the number of references to this PreparedStatement.
 	// New references are registered through incRef().
 	// Once refCount hits 0 (through calls to decRef()), the following memAcc is
@@ -87,6 +93,9 @@ func (p *PreparedStatement) MemoryEstimate() int64 {
 	size := p.PrepareMetadata.MemoryEstimate()
 	if p.BaseMemo != nil {
 		size += p.BaseMemo.MemoryEstimate()
+	}
+	if p.GenericMemo != nil {
+		size += p.GenericMemo.MemoryEstimate()
 	}
 	return size
 }

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -11,6 +11,7 @@ planning time: 0µs
 execution time: 0µs
 distribution: local
 vectorized: false
+plan type: custom
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
 isolation level: serializable
@@ -46,6 +47,7 @@ planning time: 0µs
 execution time: 0µs
 distribution: local
 vectorized: false
+plan type: custom
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
 isolation level: serializable
@@ -81,6 +83,7 @@ planning time: 0µs
 execution time: 0µs
 distribution: local
 vectorized: false
+plan type: custom
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
 isolation level: serializable
@@ -162,6 +165,7 @@ planning time: 0µs
 execution time: 0µs
 distribution: local
 vectorized: false
+plan type: custom
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
 isolation level: serializable
@@ -197,6 +201,7 @@ planning time: 0µs
 execution time: 0µs
 distribution: local
 vectorized: false
+plan type: custom
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
 isolation level: serializable
@@ -289,6 +294,7 @@ planning time: 0µs
 execution time: 0µs
 distribution: local
 vectorized: false
+plan type: custom
 maximum memory usage: 0 B
 network usage: 0 B (0 messages)
 isolation level: serializable


### PR DESCRIPTION
#### sql: rename PreparedStatement.Memo to BaseMemo

Release note: None

#### sql: refactor plan_opt.go

The logic for picking a prepared memo has been moved to a function,
`fetchPreparedMemoLegacy`. This makes it easy in the following commit
to fallback to this logic based on the `plan_cache_mode` setting.

Release note: None

#### sql: implement plan_cache_mode=force_generic_plan

The `force_generic_plan` option for the session setting
`plan_cache_mode` has been implemented. Under this setting, prepared
statements will reuse a fully optimized, generic query plan, if a
non-stale one exists. If such a plan does not exist or is stale, a new
generic query plan will be built.

The term "generic query plan" is used in user-facing contexts to
represent any plan that is fully optimized without knowledge of specific
placeholder values nor folding stable expressions. Therefore, all of the
following are considered "generic":

  1. A plan for a query with no placeholders nor fold-able stable
     expressions.
  2. A plan utilizing the placeholder fast-path.
  3. A plan fully optimized without replacing placeholders with values.

However, only (3) is currently stored in the
`PreparedStatement.GenericMemo` field. This was a deliberate decision
that allows falling back to the original prepared statement logic when
switching between `force_custom_plan` and `force_generic_plan`. This
will make backports with this commit less risky. My goal, in a future
commit, is to put all generic query plans in the `GenericMemo` field to
reduce the confusion between the user-facing definition of "generic" and
the internal logic.

This commit does not change the behavior of the query cache. Fully
optimized plans for statements without placeholders or placeholder
fast-path plans are still cached in the query cache. Generic query plans
optimized in the presence of placeholders are not cached.

Epic: CRDB-37712

Release note (sql change): The session setting
`plan_cache_mode=force_generic_plan` can now be used to force prepared
statements to use query plans that are optimized once and reused in
future executions without re-optimization, as long as it does not become
stale due to schema changes or a collection of new table statistics. The
setting takes effect during `EXECUTE` commands. `EXPLAIN ANALYZE`
includes a "plan type" field. If a generic query plan is optimized for
the current execution, the "plan type" will be "generic, re-optimized".
If a generic query plan is reused for the current execution without
performing optimization, the "plan type" will be "generic, reused".
Otherwise, the "plan type" will be "custom".
