### PR TITLE
raft: add termAt and forward helpers to logSlice

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -114,8 +114,8 @@ func (l *raftLog) maybeAppend(a logSlice) bool {
 		return false
 	}
 	// Fast-forward the appended log slice to the last matching entry.
-	// NB: a.prev.index <= match.index <= a.lastIndex(), so the call is safe.
-	a = a.forward(match.index)
+	// NB: a.prev.index <= match <= a.lastIndex(), so the call is safe.
+	a = a.forward(match)
 
 	// TODO(pav-kv): pass the logSlice down the stack, for safety checks and
 	// bookkeeping in the unstable structure.
@@ -133,24 +133,18 @@ func (l *raftLog) append(ents ...pb.Entry) {
 	l.unstable.truncateAndAppend(ents)
 }
 
-// match finds the last entry in the given log slice that matches the log. The
-// next entry either mismatches, or is missing.
+// match finds the longest prefix of the given log slice that matches the log.
 //
-// If the slice partially/fully matches, this method returns true. The returned
-// entryID is the ID of the last matching entry. It can be s.prev if it is the
-// only matching entry. It is guaranteed that the returned entryID.index is in
-// the [s.prev.index, s.lastIndex()] range.
+// Returns the index of the last matching entry, in [s.prev.index, s.lastIndex]
+// interval. The next entry either mismatches, or is missing. Returns false if
+// the s.prev entry doesn't match, or is missing.
 //
-// All the entries up to the returned entryID are already present in the log,
-// and do not need to be appended again. The caller can safely fast-forward an
-// append request to the next entry after it.
-//
-// Returns false if the given slice mismatches the log entirely, i.e. the s.prev
-// entry has a mismatching entryID.term. In this case an append request can not
-// proceed.
-func (l *raftLog) match(s logSlice) (entryID, bool) {
+// All the entries up to the returned index are already present in the log, and
+// do not need to be rewritten. The caller can safely fast-forward the appended
+// logSlice to this index.
+func (l *raftLog) match(s logSlice) (uint64, bool) {
 	if !l.matchTerm(s.prev) {
-		return entryID{}, false
+		return 0, false
 	}
 
 	// TODO(pav-kv): add a fast-path here using the Log Matching property of raft.
@@ -163,11 +157,11 @@ func (l *raftLog) match(s logSlice) (entryID, bool) {
 	// to fetching an entry from storage. This is inefficient, we can improve it.
 	// Logs that don't match at one index, don't match at all indices above. So we
 	// can use binary search to find the fork.
-	match := s.prev
+	match := s.prev.index
 	for i := range s.entries {
 		id := pbEntryID(&s.entries[i])
 		if l.matchTerm(id) {
-			match = id
+			match = id.index
 			continue
 		}
 		if id.index <= l.lastIndex() {

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -113,11 +113,9 @@ func (l *raftLog) maybeAppend(a logSlice) bool {
 	if !ok {
 		return false
 	}
-
 	// Fast-forward to the first mismatching or missing entry.
-	// NB: prev.index <= match.index <= a.lastIndex(), so the sub-slicing is safe.
-	a.entries = a.entries[match.index-a.prev.index:]
-	a.prev = match
+	// NB: a.prev.index <= match.index <= a.lastIndex(), so the call is safe.
+	a = a.forward(match.index)
 
 	// TODO(pav-kv): pass the logSlice down the stack, for safety checks and
 	// bookkeeping in the unstable structure.

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -35,27 +35,27 @@ func TestMatch(t *testing.T) {
 		prev  entryID
 		ents  []pb.Entry
 		notOk bool
-		want  entryID
+		want  uint64
 	}{
 		// prev does not match the log
 		{prev: entryID{term: 10, index: 1}, notOk: true},
 		{prev: entryID{term: 4, index: 1}, ents: index(2).terms(4, 4), notOk: true},
 		{prev: entryID{term: 5, index: 2}, ents: index(3).terms(5, 6), notOk: true},
 		// no conflict, empty entries
-		{ents: nil, want: ids[0]},
+		{ents: nil, want: 0},
 		// no conflict
-		{prev: ids[0], ents: index(1).terms(1, 2, 3), want: ids[3]},
-		{prev: ids[1], ents: index(2).terms(2, 3), want: ids[3]},
-		{prev: ids[2], ents: index(3).terms(3), want: ids[3]},
+		{prev: ids[0], ents: index(1).terms(1, 2, 3), want: 3},
+		{prev: ids[1], ents: index(2).terms(2, 3), want: 3},
+		{prev: ids[2], ents: index(3).terms(3), want: 3},
 		// no conflict, but has new entries
-		{prev: ids[0], ents: index(1).terms(1, 2, 3, 4, 4), want: ids[3]},
-		{prev: ids[1], ents: index(2).terms(2, 3, 4, 4), want: ids[3]},
-		{prev: ids[2], ents: index(3).terms(3, 4, 4), want: ids[3]},
-		{prev: ids[3], ents: index(4).terms(4, 4), want: ids[3]},
+		{prev: ids[0], ents: index(1).terms(1, 2, 3, 4, 4), want: 3},
+		{prev: ids[1], ents: index(2).terms(2, 3, 4, 4), want: 3},
+		{prev: ids[2], ents: index(3).terms(3, 4, 4), want: 3},
+		{prev: ids[3], ents: index(4).terms(4, 4), want: 3},
 		// passes prev check, but conflicts with existing entries
-		{prev: ids[0], ents: index(1).terms(4, 4), want: ids[0]},
-		{prev: ids[1], ents: index(2).terms(1, 4, 4), want: ids[1]},
-		{prev: ids[2], ents: index(3).terms(2, 2, 4, 4), want: ids[2]},
+		{prev: ids[0], ents: index(1).terms(4, 4), want: 0},
+		{prev: ids[1], ents: index(2).terms(1, 4, 4), want: 1},
+		{prev: ids[2], ents: index(3).terms(2, 2, 4, 4), want: 2},
 		// out of bounds
 		{prev: entryID{term: 3, index: 10}, ents: index(11).terms(3), notOk: true},
 		// just touching the right bound, but still out of bounds

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFindConflict(t *testing.T) {
+func TestMatch(t *testing.T) {
 	previousEnts := index(1).terms(1, 2, 3)
 	ids := make([]entryID, 1, len(previousEnts)+1) // dummy (0, 0) at index 0
 	for i := range previousEnts {
@@ -66,7 +66,7 @@ func TestFindConflict(t *testing.T) {
 			log.append(previousEnts...)
 			app := logSlice{term: 100, prev: tt.prev, entries: tt.ents}
 			require.NoError(t, app.valid())
-			match, ok := log.findConflict(app)
+			match, ok := log.match(app)
 			require.Equal(t, !tt.notOk, ok)
 			require.Equal(t, tt.want, match)
 		})

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -91,6 +91,15 @@ func (s logSlice) lastEntryID() entryID {
 	return s.prev
 }
 
+// termAt returns the term of the entry at the given index.
+// Requires: prev.index <= index <= lastIndex().
+func (s logSlice) termAt(index uint64) uint64 {
+	if index == s.prev.index {
+		return s.prev.term
+	}
+	return s.entries[index-s.prev.index-1].Term
+}
+
 // valid returns nil iff the logSlice is a well-formed log slice. See logSlice
 // comment for details on what constitutes a valid raft log slice.
 func (s logSlice) valid() error {

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -100,6 +100,16 @@ func (s logSlice) termAt(index uint64) uint64 {
 	return s.entries[index-s.prev.index-1].Term
 }
 
+// forward returns a logSlice with prev forwarded to the given index.
+// Requires: prev.index <= index <= lastIndex().
+func (s logSlice) forward(index uint64) logSlice {
+	return logSlice{
+		term:    s.term,
+		prev:    entryID{term: s.termAt(index), index: index},
+		entries: s.entries[index-s.prev.index:],
+	}
+}
+
 // valid returns nil iff the logSlice is a well-formed log slice. See logSlice
 // comment for details on what constitutes a valid raft log slice.
 func (s logSlice) valid() error {

--- a/pkg/raft/types_test.go
+++ b/pkg/raft/types_test.go
@@ -86,10 +86,15 @@ func TestLogSlice(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			s := logSlice{term: tt.term, prev: tt.prev, entries: tt.entries}
 			require.Equal(t, tt.notOk, s.valid() != nil)
-			if !tt.notOk {
-				last := s.lastEntryID()
-				require.Equal(t, tt.last, last)
-				require.Equal(t, last.index, s.lastIndex())
+			if tt.notOk {
+				return
+			}
+			last := s.lastEntryID()
+			require.Equal(t, tt.last, last)
+			require.Equal(t, last.index, s.lastIndex())
+			require.Equal(t, tt.prev.term, s.termAt(tt.prev.index))
+			for _, e := range tt.entries {
+				require.Equal(t, e.Term, s.termAt(e.Index))
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a couple of `logSlice` helpers in preparation for making the `unstable` log data structure a `logSlice`. We use the helpers in this PR to simplify and clean up the `raftLog.findConflict` method.

Epic: none
Release note: none