### PR TITLE
gossip: remove mutex acquisition in updateStoreMap

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -802,8 +802,6 @@ func (g *Gossip) updateStoreMap(key string, content roachpb.Value) {
 
 	log.VInfof(ctx, 1, "updateStoreMap called on %q with desc %+v", key, desc)
 
-	g.mu.Lock()
-	defer g.mu.Unlock()
 	g.storeDescs.Store(int64(desc.StoreID), unsafe.Pointer(&desc))
 }
 


### PR DESCRIPTION
This commit removes the `Gossip.mu` mutex acquisition in the `Gossip.updateStoreMap` callback. As of 50413ad4, `Gossip.storeDescs` has been a concurrent `sync.IntMap`, so acquiring an exclusive mutex to update the map is no longer necessary.

Epic: None
Release note: None