### PR TITLE
release-24.1: kvserver: add sstable compression algorithm metrics

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -713,6 +713,10 @@
 <tr><td>STORAGE</td><td>storage.shared-storage.write</td><td>Bytes written to external storage</td><td>Bytes</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>storage.single-delete.ineffectual</td><td>Number of SingleDeletes that were ineffectual</td><td>Events</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>storage.single-delete.invariant-violation</td><td>Number of SingleDelete invariant violations</td><td>Events</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>storage.sstable.compression.none.count</td><td>Count of SSTables that are uncompressed.</td><td>SSTables</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>storage.sstable.compression.snappy.count</td><td>Count of SSTables that have been compressed with the snappy compression algorithm.</td><td>SSTables</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>storage.sstable.compression.unknown.count</td><td>Count of SSTables that have an unknown compression algorithm.</td><td>SSTables</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>storage.sstable.compression.zstd.count</td><td>Count of SSTables that have been compressed with the zstd compression algorithm.</td><td>SSTables</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>storage.sstable.zombie.bytes</td><td>Bytes in SSTables that have been logically deleted, but can&#39;t yet be physically deleted because an open iterator may be reading them.</td><td>Bytes</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>storage.wal.bytes_in</td><td>The number of logical bytes the storage engine has written to the WAL</td><td>Events</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>storage.wal.bytes_written</td><td>The number of bytes the storage engine has written to the WAL</td><td>Events</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -962,6 +962,32 @@ bytes preserved during flushes and compactions over the lifetime of the process.
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaSSTableCompressionSnappy = metric.Metadata{
+		Name: "storage.sstable.compression.snappy.count",
+		Help: "Count of SSTables that have been compressed with the snappy " +
+			"compression algorithm.",
+		Measurement: "SSTables",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaSSTableCompressionZstd = metric.Metadata{
+		Name: "storage.sstable.compression.zstd.count",
+		Help: "Count of SSTables that have been compressed with the zstd " +
+			"compression algorithm.",
+		Measurement: "SSTables",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaSSTableCompressionUnknown = metric.Metadata{
+		Name:        "storage.sstable.compression.unknown.count",
+		Help:        "Count of SSTables that have an unknown compression algorithm.",
+		Measurement: "SSTables",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaSSTableCompressionNone = metric.Metadata{
+		Name:        "storage.sstable.compression.none.count",
+		Help:        "Count of SSTables that are uncompressed.",
+		Measurement: "SSTables",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 var (
@@ -2642,6 +2668,10 @@ type StoreMetrics struct {
 	BatchCommitWALRotWaitDuration     *metric.Gauge
 	BatchCommitCommitWaitDuration     *metric.Gauge
 	SSTableZombieBytes                *metric.Gauge
+	SSTableCompressionSnappy          *metric.Gauge
+	SSTableCompressionZstd            *metric.Gauge
+	SSTableCompressionUnknown         *metric.Gauge
+	SSTableCompressionNone            *metric.Gauge
 	categoryIterMetrics               pebbleCategoryIterMetricsContainer
 	WALBytesWritten                   *metric.Gauge
 	WALBytesIn                        *metric.Gauge
@@ -3351,6 +3381,10 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		BatchCommitWALRotWaitDuration:     metric.NewGauge(metaBatchCommitWALRotDuration),
 		BatchCommitCommitWaitDuration:     metric.NewGauge(metaBatchCommitCommitWaitDuration),
 		SSTableZombieBytes:                metric.NewGauge(metaSSTableZombieBytes),
+		SSTableCompressionSnappy:          metric.NewGauge(metaSSTableCompressionSnappy),
+		SSTableCompressionZstd:            metric.NewGauge(metaSSTableCompressionZstd),
+		SSTableCompressionUnknown:         metric.NewGauge(metaSSTableCompressionUnknown),
+		SSTableCompressionNone:            metric.NewGauge(metaSSTableCompressionNone),
 		categoryIterMetrics: pebbleCategoryIterMetricsContainer{
 			registry: storeRegistry,
 		},
@@ -3789,6 +3823,10 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.BatchCommitWALRotWaitDuration.Update(int64(m.BatchCommitStats.WALRotationDuration))
 	sm.BatchCommitCommitWaitDuration.Update(int64(m.BatchCommitStats.CommitWaitDuration))
 	sm.SSTableZombieBytes.Update(int64(m.Table.ZombieSize))
+	sm.SSTableCompressionSnappy.Update(m.Table.CompressedCountSnappy)
+	sm.SSTableCompressionZstd.Update(m.Table.CompressedCountZstd)
+	sm.SSTableCompressionUnknown.Update(m.Table.CompressedCountUnknown)
+	sm.SSTableCompressionNone.Update(m.Table.CompressedCountNone)
 	sm.categoryIterMetrics.update(m.CategoryStats)
 
 	for level, stats := range m.Levels {


### PR DESCRIPTION
Backport of #126330 to 24.1.

---

Add metrics tracking the count of SSTables using various compression algorithms:

- `storage.sstable.compression.snappy.count`
- `storage.sstable.compression.zstd.count`
- `storage.sstable.compression.unknown.count`
- `storage.sstable.compression.none.count`

Closes #123952.

Release note: None.

Release justification: Low risk observability enhancement.