### PR TITLE
execbuilder: limit assignment_cast function search to builtins

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -248,10 +248,14 @@ func (b *Builder) Build() (_ exec.Plan, err error) {
 	)
 }
 
-func (b *Builder) wrapFunction(fnName string) (tree.ResolvableFunctionReference, error) {
-	if b.evalCtx != nil && b.catalog != nil { // Some tests leave those unset.
+type functionLookupHelper func(context.Context, tree.UnresolvedRoutineName, tree.SearchPath) (*tree.ResolvedFunctionDefinition, error)
+
+func (b *Builder) wrapFunctionImpl(
+	fnName string, lookup functionLookupHelper,
+) (tree.ResolvableFunctionReference, error) {
+	if lookup != nil {
 		unresolved := tree.MakeUnresolvedName(fnName)
-		fnDef, err := b.catalog.ResolveFunction(
+		fnDef, err := lookup(
 			context.Background(),
 			tree.MakeUnresolvedFunctionName(&unresolved),
 			&b.evalCtx.SessionData().SearchPath,
@@ -262,6 +266,26 @@ func (b *Builder) wrapFunction(fnName string) (tree.ResolvableFunctionReference,
 		return tree.ResolvableFunctionReference{FunctionReference: fnDef}, nil
 	}
 	return tree.WrapFunction(fnName), nil
+}
+
+func (b *Builder) wrapBuiltinFunction(fnName string) (tree.ResolvableFunctionReference, error) {
+	lookup := func(_ context.Context, fn tree.UnresolvedRoutineName, path tree.SearchPath) (*tree.ResolvedFunctionDefinition, error) {
+		uname, err := fn.UnresolvedName().ToRoutineName()
+		if err != nil {
+			return nil, err
+		}
+		return tree.GetBuiltinFuncDefinitionOrFail(uname, path)
+	}
+	return b.wrapFunctionImpl(fnName, lookup)
+}
+
+func (b *Builder) wrapFunction(fnName string) (tree.ResolvableFunctionReference, error) {
+	var lookup functionLookupHelper = nil
+	// Some tests leave those unset.
+	if b.evalCtx != nil && b.catalog != nil {
+		lookup = b.catalog.ResolveFunction
+	}
+	return b.wrapFunctionImpl(fnName, lookup)
 }
 
 func (b *Builder) build(e opt.Expr) (_ execPlan, outputCols colOrdMap, err error) {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3654,7 +3654,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (_ execPlan, outputCols colOrd
 			OrderBy:    orderingExprs,
 			Frame:      frame,
 		}
-		wrappedFn, err := b.wrapFunction(name)
+		wrappedFn, err := b.wrapBuiltinFunction(name)
 		if err != nil {
 			return execPlan{}, colOrdMap{}, err
 		}

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -391,8 +391,9 @@ func (b *Builder) buildAssignmentCast(
 		// (though there could be cornercases where the type does matter).
 		return input, nil
 	}
+
 	const fnName = "crdb_internal.assignment_cast"
-	funcRef, err := b.wrapFunction(fnName)
+	funcRef, err := b.wrapBuiltinFunction(fnName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously execbuilder would search the function catalog for the assignment_cast function. This was inefficient and could possibly lead to incorrect behavior if an application defined a function called crdb_internal.assignment_cast. Instead of resolving the function in this manner, we now just consult the map of builtin functions.

Fixes: #121460
Releasenote: None