### PR TITLE
gossip: use atomic value for ready channel

### DIFF
--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -187,10 +187,9 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 			if err := send(reply); err != nil {
 				return err
 			}
-			s.mu.Lock()
+		} else {
+			s.mu.Unlock()
 		}
-
-		s.mu.Unlock()
 
 		select {
 		case <-s.stopper.ShouldQuiesce():


### PR DESCRIPTION
The ready channel is used to signal waiting gossip requests. Previously, the gossip mutex was held when signaling the channel which led to contention.

Use an atomic instead of holding the gossip mutex when signaling the ready channel.

Epic: none
Release note: None