### PR TITLE
changefeedccl: add support for multiple sinks in cdc roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -112,16 +112,14 @@ type cdcTester struct {
 
 	workloadWg *sync.WaitGroup
 	doneCh     chan struct{}
+
+	numSinkNodes int
 }
 
-// The node on which the webhook sink will be installed and run on.
-func (ct *cdcTester) webhookSinkNode() option.NodeListOption {
-	return ct.cluster.Node(ct.cluster.Spec().NodeCount)
-}
-
-// The node on which the kafka sink will be installed and run on.
-func (ct *cdcTester) kafkaSinkNode() option.NodeListOption {
-	return ct.cluster.Node(ct.cluster.Spec().NodeCount)
+// The nodes on which the sink will be installed and run.
+func (ct *cdcTester) sinkNodes() option.NodeListOption {
+	// by convention the nodes are split up like [crdb..., workload, sink...]. the sink nodes are always the last numSinkNodes ones.
+	return ct.cluster.Range(ct.cluster.Spec().NodeCount-ct.numSinkNodes+1, ct.cluster.Spec().NodeCount)
 }
 
 // startStatsCollection sets the start point of the stats collection window
@@ -197,7 +195,7 @@ func (ct *cdcTester) setupSink(args feedArgs) string {
 		sinkURI = `experimental-gs://cockroach-tmp/roachtest/` + ts + "?AUTH=implicit"
 	case webhookSink:
 		ct.t.Status("webhook install")
-		webhookNode := ct.webhookSinkNode()
+		webhookNode := ct.sinkNodes()
 		rootFolder := `/home/ubuntu`
 		nodeIPs, _ := ct.cluster.ExternalIP(ct.ctx, ct.logger, webhookNode)
 
@@ -243,7 +241,7 @@ func (ct *cdcTester) setupSink(args feedArgs) string {
 	case pubsubSink:
 		sinkURI = changefeedccl.GcpScheme + `://cockroach-ephemeral` + "?AUTH=implicit&topic_name=pubsubSink-roachtest&region=us-east1"
 	case kafkaSink:
-		kafka, _ := setupKafka(ct.ctx, ct.t, ct.cluster, ct.kafkaSinkNode())
+		kafka, _ := setupKafka(ct.ctx, ct.t, ct.cluster, ct.sinkNodes())
 		kafka.mon = ct.mon
 		kafka.validateOrder = args.kafkaArgs.validateOrder
 
@@ -260,12 +258,12 @@ func (ct *cdcTester) setupSink(args feedArgs) string {
 
 		sinkURI = kafka.sinkURL(ct.ctx)
 	case azureEventHubKafkaSink:
-		kafkaNode := ct.kafkaSinkNode()
+		kafkaNode := ct.sinkNodes()
 		kafka := kafkaManager{
-			t:             ct.t,
-			c:             ct.cluster,
-			kafkaSinkNode: kafkaNode,
-			mon:           ct.mon,
+			t:              ct.t,
+			c:              ct.cluster,
+			kafkaSinkNodes: kafkaNode,
+			mon:            ct.mon,
 		}
 		kafka.install(ct.ctx)
 		kafka.start(ct.ctx, "kafka")
@@ -681,7 +679,18 @@ func (cj *changefeedJob) waitForCompletion() {
 	}
 }
 
-func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster) cdcTester {
+type opt func(ct *cdcTester)
+
+// withNumSinkNodes sets the number of nodes to use for sink nodes. Only Kafka has been tested currently.
+func withNumSinkNodes(num int) opt {
+	return func(ct *cdcTester) {
+		ct.numSinkNodes = num
+		ct.crdbNodes = ct.cluster.Range(1, ct.cluster.Spec().NodeCount-ct.numSinkNodes-1)
+		ct.workloadNode = ct.cluster.Node(ct.cluster.Spec().NodeCount - ct.numSinkNodes)
+	}
+}
+
+func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster, opts ...opt) cdcTester {
 	lastCrdbNode := c.Spec().NodeCount - 1
 	if lastCrdbNode == 0 {
 		lastCrdbNode = 1
@@ -696,7 +705,13 @@ func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster) cdcTester
 		doneCh:       make(chan struct{}),
 		sinkCache:    make(map[sinkType]string),
 		workloadWg:   &sync.WaitGroup{},
+		numSinkNodes: 1,
 	}
+
+	for _, opt := range opts {
+		opt(&tester)
+	}
+
 	tester.mon = c.NewMonitor(ctx, tester.crdbNodes)
 
 	changefeedLogger, err := t.L().ChildLogger("changefeed")
@@ -1127,9 +1142,9 @@ func runCDCSchemaRegistry(ctx context.Context, t test.Test, c cluster.Cluster) {
 	crdbNodes, kafkaNode := c.Node(1), c.Node(1)
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), crdbNodes)
 	kafka := kafkaManager{
-		t:             t,
-		c:             c,
-		kafkaSinkNode: kafkaNode,
+		t:              t,
+		c:              c,
+		kafkaSinkNodes: kafkaNode,
 	}
 	kafka.install(ctx)
 	kafka.start(ctx, "schema-registry")
@@ -1243,9 +1258,9 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), crdbNodes)
 
 	kafka := kafkaManager{
-		t:             t,
-		c:             c,
-		kafkaSinkNode: kafkaNode,
+		t:              t,
+		c:              c,
+		kafkaSinkNodes: kafkaNode,
 	}
 	kafka.install(ctx)
 	testCerts := kafka.configureAuth(ctx)
@@ -1573,6 +1588,38 @@ func registerCDC(r registry.Registry) {
 			ct.waitForWorkload()
 		},
 	})
+	// An example usage of having multiple sink nodes.
+	r.Add(registry.TestSpec{
+		Name:             "cdc/kafka-chaos-multiple-sink-nodes",
+		Owner:            `cdc`,
+		Benchmark:        true,
+		Cluster:          r.MakeClusterSpec(6, spec.CPU(16)),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.AllExceptAWS,
+		Suites:           registry.Suites(registry.Nightly),
+		RequiresLicense:  true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			ct := newCDCTester(ctx, t, c, withNumSinkNodes(2))
+			defer ct.Close()
+
+			ct.runTPCCWorkload(tpccArgs{warehouses: 100, duration: "30m"})
+
+			feed := ct.newChangefeed(feedArgs{
+				sinkType: kafkaSink,
+				targets:  allTpccTargets,
+				kafkaArgs: kafkaFeedArgs{
+					kafkaChaos:    true,
+					validateOrder: true,
+				},
+				opts: map[string]string{"initial_scan": "'no'"},
+			})
+			ct.runFeedLatencyVerifier(feed, latencyTargets{
+				initialScanLatency: 3 * time.Minute,
+				steadyLatency:      5 * time.Minute,
+			})
+			ct.waitForWorkload()
+		},
+	})
 	r.Add(registry.TestSpec{
 		Name:             "cdc/kafka-chaos-single-row",
 		Owner:            `cdc`,
@@ -1873,7 +1920,7 @@ func registerCDC(r registry.Registry) {
 
 			// Consider an installation failure to be a flake which is out of
 			// our control. This should be rare.
-			err := c.Install(ctx, t.L(), ct.webhookSinkNode(), "go")
+			err := c.Install(ctx, t.L(), ct.sinkNodes(), "go")
 			if err != nil {
 				t.Skip(err)
 			}
@@ -1938,13 +1985,13 @@ func registerCDC(r registry.Registry) {
 			// (This can be removed once #108530 resolved).
 			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30s"})
 
-			kafkaNode := ct.kafkaSinkNode()
+			kafkaNode := ct.sinkNodes()
 			kafka := kafkaManager{
-				t:             ct.t,
-				c:             ct.cluster,
-				kafkaSinkNode: kafkaNode,
-				mon:           ct.mon,
-				useKafka2:     true, // The broker-side oauth configuration used only works with Kafka 2
+				t:              ct.t,
+				c:              ct.cluster,
+				kafkaSinkNodes: kafkaNode,
+				mon:            ct.mon,
+				useKafka2:      true, // The broker-side oauth configuration used only works with Kafka 2
 			}
 			kafka.install(ct.ctx)
 
@@ -2452,10 +2499,10 @@ confluent.support.customer.id=anonymous
 )
 
 type kafkaManager struct {
-	t             test.Test
-	c             cluster.Cluster
-	kafkaSinkNode option.NodeListOption
-	mon           cluster.Monitor
+	t              test.Test
+	c              cluster.Cluster
+	kafkaSinkNodes option.NodeListOption
+	mon            cluster.Monitor
 
 	// Our method of requiring OAuth on the broker only works with Kafka 2
 	useKafka2 bool
@@ -2622,17 +2669,17 @@ func (k kafkaManager) install(ctx context.Context) {
 	k.t.Status("installing kafka")
 	folder := k.basePath()
 
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), `mkdir -p `+folder)
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), `mkdir -p `+folder)
 
 	downloadScriptPath := filepath.Join(folder, "install.sh")
 	downloadScript := k.confluentDownloadScript()
-	err := k.c.PutString(ctx, downloadScript, downloadScriptPath, 0700, k.kafkaSinkNode)
+	err := k.c.PutString(ctx, downloadScript, downloadScriptPath, 0700, k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), downloadScriptPath, folder)
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), downloadScriptPath, folder)
 	if !k.c.IsLocal() {
-		k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), `mkdir -p logs`)
+		k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), `mkdir -p logs`)
 		if err := k.installJRE(ctx); err != nil {
 			k.t.Fatal(err)
 		}
@@ -2645,11 +2692,11 @@ func (k kafkaManager) installJRE(ctx context.Context) error {
 		MaxBackoff:     5 * time.Minute,
 	}
 	return retry.WithMaxAttempts(ctx, retryOpts, 3, func() error {
-		err := k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNode), `sudo apt-get -q update 2>&1 > logs/apt-get-update.log`)
+		err := k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNodes), `sudo apt-get -q update 2>&1 > logs/apt-get-update.log`)
 		if err != nil {
 			return err
 		}
-		return k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNode), `sudo DEBIAN_FRONTEND=noninteractive apt-get -yq --no-install-recommends install openssl default-jre maven 2>&1 > logs/apt-get-install.log`)
+		return k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNodes), `sudo DEBIAN_FRONTEND=noninteractive apt-get -yq --no-install-recommends install openssl default-jre maven 2>&1 > logs/apt-get-install.log`)
 	})
 }
 
@@ -2662,7 +2709,7 @@ func (k kafkaManager) installAzureCli(ctx context.Context) error {
 		MaxBackoff:     5 * time.Minute,
 	}
 	return retry.WithMaxAttempts(ctx, retryOpts, 3, func() error {
-		return k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNode), installAzureCliScript)
+		return k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNodes), installAzureCliScript)
 	})
 }
 
@@ -2681,20 +2728,20 @@ func (k kafkaManager) getAzureEventHubAccess(ctx context.Context) (string, strin
 	k.t.Status("getting azure event hub connection string")
 	// az login --service-principal -t <Tenant-ID> -u <Client-ID> -p=<Client-secret>
 	cmdStr := fmt.Sprintf("az login --service-principal -t %s -u %s -p=%s", azureTenantID, azureClientID, azureClientSecret)
-	_, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), cmdStr)
+	_, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNodes), cmdStr)
 	if err != nil {
 		return "", "", errors.Wrap(err, "error running `az login`")
 	}
 
 	cmdStr = fmt.Sprintf("az account set --subscription %s", azureSubscriptionID)
-	_, err = k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), cmdStr)
+	_, err = k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNodes), cmdStr)
 	if err != nil {
 		return "", "", errors.Wrap(err, "error running `az account set` command")
 	}
 
 	cmdStr = "az eventhubs namespace authorization-rule keys list --name cdc-roachtest-auth-rule " +
 		"--namespace-name cdc-roachtest --resource-group e2e-infra-event-hub-rg"
-	results, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), cmdStr)
+	results, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNodes), cmdStr)
 	if err != nil {
 		return "", "", errors.Wrap(err, "error running `az eventhubs` command")
 	}
@@ -2714,7 +2761,7 @@ func (k kafkaManager) runWithRetry(ctx context.Context, cmd string) {
 		MaxBackoff:     5 * time.Minute,
 	}
 	err := retry.WithMaxAttempts(ctx, retryOpts, 3, func() error {
-		return k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNode), cmd)
+		return k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNodes), cmd)
 	})
 	if err != nil {
 		k.t.Fatal(err)
@@ -2722,16 +2769,16 @@ func (k kafkaManager) runWithRetry(ctx context.Context, cmd string) {
 }
 
 func (k kafkaManager) configureHydraOauth(ctx context.Context) (string, string) {
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), `rm -rf /home/ubuntu/hydra`)
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), `rm -rf /home/ubuntu/hydra`)
 	k.runWithRetry(ctx, `bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) -d -b . hydra v2.0.3`)
 
-	err := k.c.PutString(ctx, hydraServerStartScript, "/home/ubuntu/hydra-serve.sh", 0700, k.kafkaSinkNode)
+	err := k.c.PutString(ctx, hydraServerStartScript, "/home/ubuntu/hydra-serve.sh", 0700, k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
-	mon := k.c.NewMonitor(ctx, k.kafkaSinkNode)
+	mon := k.c.NewMonitor(ctx, k.kafkaSinkNodes)
 	mon.Go(func(ctx context.Context) error {
-		err := k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNode), `/home/ubuntu/hydra-serve.sh`)
+		err := k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNodes), `/home/ubuntu/hydra-serve.sh`)
 		return errors.Wrap(err, "hydra failed")
 	})
 
@@ -2740,7 +2787,7 @@ func (k kafkaManager) configureHydraOauth(ctx context.Context) (string, string) 
 	// until it succeeds or times out.
 
 	err = retry.ForDuration(hydraRetryDuration, func() error {
-		result, err = k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), "/home/ubuntu/hydra create oauth2-client",
+		result, err = k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNodes), "/home/ubuntu/hydra create oauth2-client",
 			"-e", "http://localhost:4445",
 			"--grant-type", "client_credentials",
 			"--token-endpoint-auth-method", "client_secret_basic",
@@ -2766,7 +2813,7 @@ func (k kafkaManager) configureHydraOauth(ctx context.Context) (string, string) 
 func (k kafkaManager) configureOauth(ctx context.Context) (clientcredentials.Config, string) {
 	configDir := k.configDir()
 
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -2780,9 +2827,9 @@ func (k kafkaManager) configureOauth(ctx context.Context) (clientcredentials.Con
 
 	// In order to run Kafka with OAuth a custom implementation of certain Java
 	// classes has to be provided.
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), `rm -rf /home/ubuntu/kafka-oauth`)
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), `rm -rf /home/ubuntu/kafka-oauth`)
 	k.runWithRetry(ctx, `git clone https://github.com/jairsjunior/kafka-oauth.git /home/ubuntu/kafka-oauth`)
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), `(cd /home/ubuntu/kafka-oauth; git checkout c2b307548ef944d3fbe899b453d24e1fc8380add; mvn package)`)
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), `(cd /home/ubuntu/kafka-oauth; git checkout c2b307548ef944d3fbe899b453d24e1fc8380add; mvn package)`)
 
 	// CLASSPATH allows Kafka to load in the custom implementation
 	kafkaEnv := "CLASSPATH='/home/ubuntu/kafka-oauth/target/*'"
@@ -2819,13 +2866,13 @@ func (k kafkaManager) configureOauth(ctx context.Context) (clientcredentials.Con
 
 func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
 	k.t.Status("generating TLS certificates")
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
 	kafkaIP := ips[0]
 
-	details, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNode), "hostname", "-f")
+	details, err := k.c.RunWithDetailsSingleNode(ctx, k.t.L(), option.WithNodes(k.kafkaSinkNodes), "hostname", "-f")
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -2873,28 +2920,28 @@ func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
 
 	k.t.Status("constructing java keystores")
 	// Convert PEM cert and key into pkcs12 bundle so that it can be imported into a java keystore.
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode),
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes),
 		fmt.Sprintf("openssl pkcs12 -export -in %s -inkey %s -name kafka -out %s -password pass:%s",
 			kafkaCertPath,
 			kafkaKeyPath,
 			kafkaBundlePath,
 			keystorePassword))
 
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), fmt.Sprintf("rm -f %s", keystorePath))
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), fmt.Sprintf("rm -f %s", truststorePath))
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), fmt.Sprintf("rm -f %s", keystorePath))
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), fmt.Sprintf("rm -f %s", truststorePath))
 
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode),
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes),
 		fmt.Sprintf("keytool -importkeystore -deststorepass %s -destkeystore %s -srckeystore %s -srcstoretype PKCS12 -srcstorepass %s -alias kafka",
 			keystorePassword,
 			keystorePath,
 			kafkaBundlePath,
 			keystorePassword))
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode),
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes),
 		fmt.Sprintf("keytool -keystore %s -alias CAroot -importcert -file %s -no-prompt -storepass %s",
 			truststorePath,
 			caCertPath,
 			keystorePassword))
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode),
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes),
 		fmt.Sprintf("keytool -keystore %s -alias CAroot -importcert -file %s -no-prompt -storepass %s",
 			keystorePath,
 			caCertPath,
@@ -2904,7 +2951,7 @@ func (k kafkaManager) configureAuth(ctx context.Context) *testCerts {
 }
 
 func (k kafkaManager) PutConfigContent(ctx context.Context, data string, path string) {
-	err := k.c.PutString(ctx, data, path, 0600, k.kafkaSinkNode)
+	err := k.c.PutString(ctx, data, path, 0600, k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -2912,14 +2959,14 @@ func (k kafkaManager) PutConfigContent(ctx context.Context, data string, path st
 
 func (k kafkaManager) addSCRAMUsers(ctx context.Context) {
 	k.t.Status("adding entries for SASL/SCRAM users")
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), filepath.Join(k.binDir(), "kafka-configs"),
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), filepath.Join(k.binDir(), "kafka-configs"),
 		"--zookeeper", "localhost:2181",
 		"--alter",
 		"--add-config", "SCRAM-SHA-512=[password=scram512-secret]",
 		"--entity-type", "users",
 		"--entity-name", "scram512")
 
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), filepath.Join(k.binDir(), "kafka-configs"),
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), filepath.Join(k.binDir(), "kafka-configs"),
 		"--zookeeper", "localhost:2181",
 		"--alter",
 		"--add-config", "SCRAM-SHA-256=[password=scram256-secret]",
@@ -2929,7 +2976,7 @@ func (k kafkaManager) addSCRAMUsers(ctx context.Context) {
 
 func (k kafkaManager) start(ctx context.Context, service string, envVars ...string) {
 	// This isn't necessary for the nightly tests, but it's nice for iteration.
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), k.makeCommand("confluent", "local destroy || true"))
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), k.makeCommand("confluent", "local destroy || true"))
 	k.restart(ctx, service, envVars...)
 }
 
@@ -2942,7 +2989,7 @@ var kafkaServices = map[string][]string{
 func (k kafkaManager) restart(ctx context.Context, targetService string, envVars ...string) {
 	services := kafkaServices[targetService]
 
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), "touch", k.serverJAASConfig())
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), "touch", k.serverJAASConfig())
 	for _, svcName := range services {
 		// The confluent tool applies the KAFKA_OPTS to all
 		// services. Also, the kafka.logs.dir is used by each
@@ -2960,7 +3007,12 @@ func (k kafkaManager) restart(ctx context.Context, targetService string, envVars
 		)
 		startCmd += fmt.Sprintf(" %s local services %s start", k.confluentBin(), svcName)
 
-		k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), startCmd)
+		// Sometimes kafka wants to be difficult and not start back up first try. Give it some time.
+		k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes).WithRetryOpts(retry.Options{
+			InitialBackoff: 5 * time.Second,
+			MaxBackoff:     30 * time.Second,
+			MaxRetries:     30,
+		}).WithShouldRetryFn(func(*install.RunResultDetails) bool { return true }), startCmd)
 	}
 }
 
@@ -2973,8 +3025,8 @@ func (k kafkaManager) makeCommand(exe string, args ...string) string {
 }
 
 func (k kafkaManager) stop(ctx context.Context) {
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), fmt.Sprintf("rm -f %s", k.serverJAASConfig()))
-	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNode), k.makeCommand("confluent", "local services stop"))
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), fmt.Sprintf("rm -f %s", k.serverJAASConfig()))
+	k.c.Run(ctx, option.WithNodes(k.kafkaSinkNodes), k.makeCommand("confluent", "local services stop"))
 }
 
 func (k kafkaManager) chaosLoop(
@@ -3008,7 +3060,7 @@ func (k kafkaManager) chaosLoop(
 }
 
 func (k kafkaManager) sinkURL(ctx context.Context) string {
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3016,7 +3068,7 @@ func (k kafkaManager) sinkURL(ctx context.Context) string {
 }
 
 func (k kafkaManager) sinkURLTLS(ctx context.Context) string {
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3024,7 +3076,7 @@ func (k kafkaManager) sinkURLTLS(ctx context.Context) string {
 }
 
 func (k kafkaManager) sinkURLSASL(ctx context.Context) string {
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3034,7 +3086,7 @@ func (k kafkaManager) sinkURLSASL(ctx context.Context) string {
 // sinkURLAsConfluentCloudUrl allows the test to connect to the kafka brokers
 // as if it was connecting to kafka hosted in confluent cloud.
 func (k kafkaManager) sinkURLAsConfluentCloudUrl(ctx context.Context) string {
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3046,7 +3098,7 @@ func (k kafkaManager) sinkURLAsConfluentCloudUrl(ctx context.Context) string {
 }
 
 func (k kafkaManager) sinkURLOAuth(ctx context.Context, creds clientcredentials.Config) string {
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3067,8 +3119,19 @@ func (k kafkaManager) sinkURLOAuth(ctx context.Context, creds clientcredentials.
 	return kafkaURI.String()
 }
 
+func (k kafkaManager) advertiseURLs(ctx context.Context) []string {
+	ips, err := k.c.ExternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
+	if err != nil {
+		k.t.Fatal(err)
+	}
+	for i := range ips {
+		ips[i] += `:9092`
+	}
+	return ips
+}
+
 func (k kafkaManager) consumerURL(ctx context.Context) string {
-	ips, err := k.c.ExternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.ExternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3076,7 +3139,7 @@ func (k kafkaManager) consumerURL(ctx context.Context) string {
 }
 
 func (k kafkaManager) schemaRegistryURL(ctx context.Context) string {
-	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNode)
+	ips, err := k.c.InternalIP(ctx, k.t.L(), k.kafkaSinkNodes)
 	if err != nil {
 		k.t.Fatal(err)
 	}
@@ -3385,9 +3448,9 @@ func setupKafka(
 	ctx context.Context, t test.Test, c cluster.Cluster, nodes option.NodeListOption,
 ) (kafkaManager, func()) {
 	kafka := kafkaManager{
-		t:             t,
-		c:             c,
-		kafkaSinkNode: nodes,
+		t:              t,
+		c:              c,
+		kafkaSinkNodes: nodes,
 	}
 
 	kafka.install(ctx)
@@ -3395,8 +3458,23 @@ func setupKafka(
 		// TODO(dan): This test currently connects to kafka from the test
 		// runner, so kafka needs to advertise the external address. Better
 		// would be a binary we could run on one of the roachprod machines.
-		c.Run(ctx, option.WithNodes(kafka.kafkaSinkNode), `echo "advertised.listeners=PLAINTEXT://`+kafka.consumerURL(ctx)+`" >> `+
-			filepath.Join(kafka.configDir(), "server.properties"))
+		urls := kafka.advertiseURLs(ctx)
+		// Setup multiple kafkas.
+		for i, url := range urls {
+			c.Run(ctx, option.WithNodes([]int{[]int(kafka.kafkaSinkNodes)[i]}), `echo "advertised.listeners=PLAINTEXT://`+url+`" >> `+
+				filepath.Join(kafka.configDir(), "server.properties"))
+			c.Run(ctx, option.WithNodes([]int{[]int(kafka.kafkaSinkNodes)[i]}), `echo "broker.id=`+strconv.Itoa(i)+`" >> `+
+				filepath.Join(kafka.configDir(), "server.properties"))
+			// Default num partitions = num nodes.
+			c.Run(ctx, option.WithNodes([]int{[]int(kafka.kafkaSinkNodes)[i]}), `echo "num.partitions=`+strconv.Itoa(len(urls))+`" >> `+
+				filepath.Join(kafka.configDir(), "server.properties"))
+			// Use the zookeeper on first kafka node, and ignore the rest of them (if any).
+			if i > 0 {
+				zkUrl := strings.Replace(urls[0], ":9092", ":2181", 1)
+				c.Run(ctx, option.WithNodes([]int{[]int(kafka.kafkaSinkNodes)[i]}), `echo "zookeeper.connect=`+zkUrl+`" >> `+
+					filepath.Join(kafka.configDir(), "server.properties"))
+			}
+		}
 	}
 
 	kafka.start(ctx, "kafka")


### PR DESCRIPTION
Add support for multiple sinks in cdc roachtests. Currently only Kafka is supported.

Epic: [CRDB-38755](https://cockroachlabs.atlassian.net/browse/CRDB-38755)

Release note: none