### PR TITLE
metric: add prev, next values in counter update panic

### DIFF
--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -12,6 +12,7 @@ package metric
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"sync/atomic"
 	"time"
@@ -751,8 +752,10 @@ func (c *Counter) Inc(v int64) {
 // truth; instead it is a (periodically updated) copy of a counter that is
 // maintained elsewhere.
 func (c *Counter) Update(val int64) {
-	if buildutil.CrdbTestBuild && val < c.count.Load() {
-		panic("Counters should not decrease")
+	if buildutil.CrdbTestBuild {
+		if prev := c.count.Load(); val < prev {
+			panic(fmt.Sprintf("Counters should not decrease, prev: %d, new: %d.", prev, val))
+		}
 	}
 	c.count.Store(val)
 }
@@ -839,8 +842,10 @@ func (c *CounterFloat64) Inc(i float64) {
 // truth; instead it is a (periodically updated) copy of a counter that is
 // maintained elsewhere.
 func (c *CounterFloat64) Update(val float64) {
-	if buildutil.CrdbTestBuild && val < c.count.Load() {
-		panic("Counters should not decrease")
+	if buildutil.CrdbTestBuild {
+		if prev := c.count.Load(); val < prev {
+			panic(fmt.Sprintf("Counters should not decrease, prev: %f, new: %f.", prev, val))
+		}
 	}
 	c.count.Store(val)
 }


### PR DESCRIPTION
This should help investigate potential bugs in metrics.

Informs #126470.

Release note: None