### PR TITLE
sqlstats: fix discarded stats metric

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3145,10 +3145,13 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 			}
 		}
 
-		ex.statsCollector.EndTransaction(
+		discardedStats := ex.statsCollector.EndTransaction(
 			ctx,
 			transactionFingerprintID,
 		)
+		if discardedStats > 0 {
+			ex.server.ServerMetrics.StatsMetrics.DiscardedStatsCount.Inc(discardedStats)
+		}
 
 		if ex.server.cfg.TestingKnobs.BeforeTxnStatsRecorded != nil {
 			ex.server.cfg.TestingKnobs.BeforeTxnStatsRecorded(


### PR DESCRIPTION
`sql.stats.discarded.current` was missing the discarded stats count since it wasn't accounting for the statements discarded when flushing the local transaction stats container to the parent.

Fixes: #126341

Release note (bug fix): `sql.stats.discarded.current` metric was incorrect as it was missing the discarded statement count. It now accurately reports both discarded statement and transaction stats.