### PR TITLE
kvpb: removed disused Path field from ExportResp

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -682,7 +682,6 @@ func runBackupProcessor(
 								// on-disk anywhere yet.
 								metadata: backuppb.BackupManifest_File{
 									Span:                    file.Span,
-									Path:                    file.Path,
 									EntryCounts:             entryCounts,
 									LocalityKV:              destLocalityKV,
 									ApproximatePhysicalSize: uint64(len(file.SST)),

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1954,7 +1954,7 @@ message ExportResponse {
         (gogoproto.nullable) = false,
         (gogoproto.customname) = "EndKeyTS"
     ];
-    string path = 2;
+    reserved 2;
 
     BulkOpSummary exported = 6 [(gogoproto.nullable) = false];
 


### PR DESCRIPTION
Release note: none.
Epic: none.