### PR TITLE
storage: add trace statement for lock table scans

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -2082,6 +2082,12 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 		return false, err
 	}
 	defer iter.Close()
+	if log.ExpensiveLogEnabled(ctx, 3) {
+		defer func() {
+			ss := iter.Stats().Stats
+			log.VEventf(ctx, 3, "lock table scan stats: %s", ss.String())
+		}()
+	}
 
 	var meta enginepb.MVCCMetadata
 	var ok bool


### PR DESCRIPTION
To paint a fuller picture of where time is spent when executing a batch, log the Pebble iterator scan stats for lock table scans.

Closes #126582.

Release note: None.

Epic: None.