### PR TITLE
release-23.1: sql: DROP REGION can fail if inaccessible columns exist on tables

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1602,3 +1602,17 @@ statement ok
 SET sql_safe_updates = false;
 DROP DATABASE "mr-create-table-as";
 SET sql_safe_updates = true
+
+# Checks that DROP REGION works when index expressions exist on tables,
+# which will create public inaccessible columns (#126549).
+subtest drop_region_126549
+
+statement ok
+CREATE DATABASE  drop_region_126549 PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
+CREATE TABLE drop_region_126549.t1 (n string PRIMARY KEY, INDEX((lower(n)))) LOCALITY REGIONAL BY ROW;
+
+statement ok
+ALTER DATABASE drop_region_126549 DROP REGION "us-east-1";
+
+subtest end
+

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -770,7 +770,7 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 		}
 
 		var query strings.Builder
-		colSelectors := tabledesc.ColumnsSelectors(desc.PublicColumns())
+		colSelectors := tabledesc.ColumnsSelectors(desc.AccessibleColumns())
 		columns := tree.AsStringWithFlags(&colSelectors, tree.FmtSerializable)
 		query.WriteString(fmt.Sprintf("SELECT %s FROM [%d as t] WHERE", columns, ID))
 		firstClause := true


### PR DESCRIPTION
Backport 1/1 commits from #126555.

/cc @cockroachdb/release

---

When ALTER DATABASE DROP REGION is issued we attempt to find all references to this column that could potentially exist inside tables under a given database. This logic involves selecting from columns within the table to make sure the value that is being used is no longer in use. When an index expression exists a table can end up with a virtual inaccessible column, which the drop region logic attempts to add into the SELECT clause for the validation query. To address this, the drop region logic will only look at accessible columns.

Fixes: #126549

Release note (bug fix): DROP REGION can fail if any tables under a given database have indexes on expressions.
Release justification: a low risk fix for a issue that can prevent dropping of regions on certain schemas
