### PR TITLE
drtprod: emit audit logs for drt-chaos

### DIFF
--- a/pkg/roachprod/fluentbit/files/fluent-bit.yaml.tmpl
+++ b/pkg/roachprod/fluentbit/files/fluent-bit.yaml.tmpl
@@ -1,4 +1,6 @@
 ---
+includes:
+- config-override.yaml
 service:
   flush: 1
   daemon: off
@@ -23,6 +25,11 @@ pipeline:
     format: json
     storage.type: filesystem
     alias: cockroachdb
+  filters:
+  - name: modify
+    match: "*"
+    set:
+    - hostname {{ .Hostname }}
   outputs:
   - name: datadog
     match: cockroachdb

--- a/pkg/roachprod/fluentbit/fluentbit.go
+++ b/pkg/roachprod/fluentbit/fluentbit.go
@@ -60,7 +60,6 @@ func Install(ctx context.Context, l *logger.Logger, c *install.SyncedCluster, co
 		tags := []string{
 			// Reserved Datadog tags.
 			"env:development",
-			fmt.Sprintf("host:%s", vm.Name(c.Name, int(node))),
 
 			// Custom tags.
 			fmt.Sprintf("cluster:%s", c.Name),
@@ -71,6 +70,7 @@ func Install(ctx context.Context, l *logger.Logger, c *install.SyncedCluster, co
 			DatadogSite:    config.DatadogSite,
 			DatadogAPIKey:  config.DatadogAPIKey,
 			DatadogService: config.DatadogService,
+			Hostname:       vm.Name(c.Name, int(node)),
 			Tags:           tags,
 		}
 
@@ -90,11 +90,15 @@ func Install(ctx context.Context, l *logger.Logger, c *install.SyncedCluster, co
 			return res, res.Err
 		}
 
+		// The `/etc/fluent-bit/config-override.yaml` file is created with no
+		// content so that the fluent-bit service can successfully start. Operators
+		// can add additional configuration in there to suit their needs.
 		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(install.Nodes{node}), "fluent-bit", `
-sudo cp /tmp/fluent-bit.yaml /etc/fluent-bit/fluent-bit.yaml && rm /tmp/fluent-bit.yaml
-sudo cp /tmp/fluent-bit.service /etc/systemd/system/fluent-bit.service && rm /tmp/fluent-bit.service
-sudo systemctl daemon-reload && sudo systemctl enable fluent-bit && sudo systemctl restart fluent-bit
-`); err != nil {
+		sudo cp /tmp/fluent-bit.yaml /etc/fluent-bit/fluent-bit.yaml && rm /tmp/fluent-bit.yaml
+		sudo touch /etc/fluent-bit/config-override.yaml
+		sudo cp /tmp/fluent-bit.service /etc/systemd/system/fluent-bit.service && rm /tmp/fluent-bit.service
+		sudo systemctl daemon-reload && sudo systemctl enable fluent-bit && sudo systemctl restart fluent-bit
+		`); err != nil {
 			res.Err = errors.Wrap(err, "failed enabling and starting fluent bit service")
 			return res, res.Err
 		}
@@ -122,6 +126,7 @@ type templateData struct {
 	DatadogSite    string
 	DatadogAPIKey  string
 	DatadogService string
+	Hostname       string
 	Tags           []string
 }
 

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -97,7 +97,7 @@ case $1 in
 
     # Disable the default integrations for the Datadog agent in preparation for
     # its removal.
-    roachprod ssh ${cluster} -- 'sudo bash -c "for file in $(find /etc/datadog-agent/conf.d -type f -name conf.yaml.default); do mv ${file} ${file}.bak; done"'
+    roachprod ssh ${cluster} -- 'sudo bash -c "for file in \$(find /etc/datadog-agent/conf.d -type f -name conf.yaml.default); do mv \${file} \${file}.bak; done"'
 
     roachprod ssh ${cluster} -- "sudo tee /etc/datadog-agent/datadog.yaml > /dev/null << EOF
 ---
@@ -114,6 +114,32 @@ tags:
 EOF"
 
     case $cluster in
+      "drt-chaos")
+        roachprod ssh ${cluster} -- "sudo mkdir -p /etc/fluent-bit && sudo tee /etc/fluent-bit/config-override.yaml > /dev/null << EOF
+---
+pipeline:
+  inputs:
+  - name: tail
+    path: /var/log/audit/audit.log
+    tag: audit
+    key: message
+    storage.type: filesystem
+    alias: audit
+  outputs:
+  - name: datadog
+    match: audit
+    host: http-intake.logs.${dd_site}
+    tls: on
+    compress: gzip
+    apikey: ${dd_api_key}
+    dd_source: audit
+    dd_service: drt-cockroachdb
+    dd_tags: env:development,cluster:${cluster%:*},service:drt-cockroachdb,team:drt
+    alias: audit
+    storage.total_limit_size: 25MB
+EOF"
+        ;;
+
       "workload-chaos")
         roachprod ssh ${cluster} -- "sudo mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
 ---


### PR DESCRIPTION
This patch updates the Fluent Bit configuration for DRT clusters to emit audit logs. This is only configured for the `drt-chaos` cluster for now, but can easily be expanded to other clusters in the future.

This patch also updates the way Fluent Bit sets the hostname on logs since Fluent Bit has not cut a release that contains the fix for https://github.com/fluent/fluent-bit/issues/8971.

Finally, this patch also fixes an issue with the Datadog agent configuration removal throwing a shell error.

Epic: CLOUDOPS-9609

Release note: None
