### PR TITLE
roachprod: implement "Reset" for aws and azure.

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -992,9 +992,8 @@ var runCmd = &cobra.Command{
 var resetCmd = &cobra.Command{
 	Use:   "reset <cluster>",
 	Short: "reset *all* VMs in a cluster",
-	Long: `Reset a cloud VM. This may not be implemented for all
-environments and will fall back to a no-op.`,
-	Args: cobra.ExactArgs(1),
+	Long:  `Reset a cloud VM.`,
+	Args:  cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 		return roachprod.Reset(config.Logger, args[0])
 	}),

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -727,9 +727,26 @@ func (p *Provider) Delete(l *logger.Logger, vms vm.List) error {
 	return g.Wait()
 }
 
-// Reset is part of vm.Provider. It is a no-op.
+// Reset is part of vm.Provider.
 func (p *Provider) Reset(l *logger.Logger, vms vm.List) error {
-	return nil // unimplemented
+	byRegion, err := regionMap(vms)
+	if err != nil {
+		return err
+	}
+	g := errgroup.Group{}
+	for region, list := range byRegion {
+		args := []string{
+			"ec2", "reboot-instances",
+			"--region", region,
+			"--instance-ids",
+		}
+		args = append(args, list.ProviderIDs()...)
+		g.Go(func() error {
+			_, e := p.runCommand(l, args)
+			return e
+		})
+	}
+	return g.Wait()
 }
 
 // Extend is part of the vm.Provider interface.


### PR DESCRIPTION
Reset VM operation was not implemented for aws and azure. As a result some roachtests may be flaky when executing outside of GCE e.g. roachperf uses Reset. For AWS implemented `aws ec2 reboot-instances --region <region> --instances-id <id-1> <id-2>`. For Azure implemented `az vm restart -g <resource-group> -n <resource-name>`.

Fixes: #77628
Epic: CRDB-10428

Release note: None