### PR TITLE
bazel, ui: public hoist dependencies of dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -287,6 +287,12 @@ npm_translate_lock(
     },
     pnpm_lock = "//pkg/ui:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
+    # public_hoist_packages should contain the same packages defined in .npmrc file > public-hoist-pattern.
+    public_hoist_packages = {
+        # `antd` components inherit prop types from rc-* components which types aren't hoisted to be
+        # publicly accessible but it still needed to properly resolve types by Typescript.
+        "rc-table": ["pkg/ui/workspaces/cluster-ui"],
+    },
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")

--- a/pkg/ui/.npmrc
+++ b/pkg/ui/.npmrc
@@ -1,1 +1,2 @@
 hoist=false
+public-hoist-pattern[]=rc-table


### PR DESCRIPTION
This change resolves an issue that prevents properly infer types of Antd components that are inherited from rc- components (ie rc-table). The problem tied to the isolation of dependencies by PNPM package manager, it is possible to access only dependencies that defined in `package.json` and dependencies of dependencies aren't accessible in code (see https://pnpm.io/8.x/npmrc#public-hoist-pattern).
With `public-hoist-pattern` option in `.npmrc` it is possible to define what packages we want to hoist to get visible from the code. In addition, the same changes should be applied for Bazel builds, but it in slightly different way (as it doesn't work by applying the same options in `.npmrc.bazel` file). Instead, we add `public_hoist_packages` in `WORKSPACE` file which allows us to do the same (https://docs.aspect.build/rulesets/aspect_rules_js/docs/npm_translate_lock/#public_hoist_packages).

 This updated configuration will be required with upcoming change to properly
 access props of `Antd`'s Table component which depend on `rc-table` package.

Release note: None
Epic: None