### PR TITLE
ui: fix expand row icons on Nodes Overview page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
@@ -47,23 +47,6 @@
   }
   // END: Table Column
 
-  // Expand/Collapse icon
-  :global(.ant-table-row-expand-icon) {
-    border: none;
-    background-color: transparent;
-  }
-
-  :global(.ant-table-row-collapsed)::after {
-    content: "▶";
-    font-size: 8px;
-  }
-
-  :global(.ant-table-row-expanded)::after {
-    content: "▼";
-    font-size: 8px;
-  }
-  // END: Expand/Collapse icon
-
   // Table row
   :global(.ant-table-row) {
     @include text--body;
@@ -129,4 +112,8 @@
       border: none;
     }
   }
+}
+
+.expand-toggle {
+  margin-right: 8px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/table/table.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/table/table.tsx
@@ -12,6 +12,7 @@ import React from "react";
 import { Table as AntTable, ConfigProvider } from "antd";
 import classnames from "classnames/bind";
 import isArray from "lodash/isArray";
+import { CaretDownOutlined, CaretRightOutlined } from "@ant-design/icons";
 
 import styles from "./table.module.scss";
 
@@ -35,7 +36,7 @@ const customizeRenderEmpty = (node: React.ReactNode) => () => (
   <div className={cx("empty-table__message")}>{node}</div>
 );
 
-export function Table<T extends object>(
+export function Table<T extends object & { children?: T[] }>(
   props: TableProps<T>,
 ): React.ReactElement {
   const {
@@ -55,7 +56,6 @@ export function Table<T extends object>(
         })}
         columns={columns}
         dataSource={dataSource}
-        expandRowByClick
         tableLayout={tableLayout}
         pagination={{ hideOnSinglePage: true, pageSize }}
         onChange={(_pagination, _filters, sorter) => {
@@ -65,6 +65,26 @@ export function Table<T extends object>(
               sorter.order === "ascend",
             );
           }
+        }}
+        expandable={{
+          expandRowByClick: true,
+          expandIcon: ({ expanded, onExpand, record }) => {
+            // Don't render expand icon for row that doesn't have children elements.
+            if (!(record.children && record.children.length > 0)) {
+              return null;
+            }
+            return expanded ? (
+              <CaretDownOutlined
+                onClick={e => onExpand(record, e)}
+                className={cx("expand-toggle")}
+              />
+            ) : (
+              <CaretRightOutlined
+                onClick={e => onExpand(record, e)}
+                className={cx("expand-toggle")}
+              />
+            );
+          },
         }}
       />
     </ConfigProvider>


### PR DESCRIPTION
This change fixes broken icons of table with expandable rows (on Nodes Overview page) which is a regression after the change (592c1e3954481e82ce0812b42b68ea5ae531ad01). Before, customized icons for expand/collapse rows were implemented by overriding of styles of existing icons, but with new `antd` version there's dedicated API to specify which icons we want to use. `Table` component is updated to use CaretDown/CaretRight icons if rows have nested rows, otherwise it doesn't show expand icon.

Depends on: #126638

Release note (ui change): fix expand/collapse icon for tables with expandable rows (on Node Overview page)
Epic: None

https://github.com/cockroachdb/cockroach/assets/3106437/a27e185e-500a-4e15-ae82-ed1177d2cfaf

