### PR TITLE
workload: move duration flag addition after init

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -129,6 +129,7 @@ func init() {
 			Use:   `run`,
 			Short: `run a workload's operations against a cluster`,
 		})
+
 		for _, meta := range workload.Registered() {
 			gen := meta.New()
 			if _, ok := gen.(workload.Opser); !ok {
@@ -140,7 +141,6 @@ func init() {
 			var genFlags *pflag.FlagSet
 			if f, ok := gen.(workload.Flagser); ok {
 				genFlags = f.Flags().FlagSet
-				gen.(workload.Flagser).Flags().AddFlag(runFlags.Lookup("duration"))
 			}
 
 			genRunCmd := SetCmdDefaults(&cobra.Command{
@@ -401,6 +401,8 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 		}
 	}
 
+	// Adding --duration to the generator flags for checking long duration workload in tpcc
+	gen.(workload.Flagser).Flags().AddFlag(runFlags.Lookup("duration"))
 	var limiter *rate.Limiter
 	if *maxRate > 0 {
 		// Create a limiter using maxRate specified on the command line and


### PR DESCRIPTION
The `--duration` flag was being added before the `init` run of a workload generator. This was causing issues in ycsb workload.

The addition of the `duration` flag has been moved after initialisation in this change. Tested both `ycsb` and `tpcc` with this change.

This change:
Fixes: #126620 #126621 #126622 #126623
Epic: None
Release note: None