### PR TITLE
ui: lazily load UI assets on startup

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -845,13 +846,16 @@ Binary built without web UI.
 				Data: []byte("console.log('hello world');"),
 			},
 		}
-		fsys, err := mapfs.Sub(".")
-		require.NoError(t, err)
-		ui.Assets = fsys
+
+		ui.Assets = func() fs.FS {
+			fsys, err := mapfs.Sub(".")
+			require.NoError(t, err)
+			return fsys
+		}
 
 		// Clear fake asset FS when we're done
 		defer func() {
-			ui.Assets = nil
+			ui.Assets = ui.NoAssets
 		}()
 
 		srv := serverutils.StartServerOnly(t, base.TestServerArgs{})

--- a/pkg/ui/distoss/distoss.go
+++ b/pkg/ui/distoss/distoss.go
@@ -19,6 +19,8 @@ package distoss
 import (
 	"bytes"
 	_ "embed"
+	"io/fs"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util/assetbundle"
@@ -26,12 +28,19 @@ import (
 
 //go:embed assets.tar.zst
 var assets []byte
+var loadOnce sync.Once
+var lazyLoadedAssets fs.FS
 
 func init() {
-	fs, err := assetbundle.AsFS(bytes.NewBuffer(assets))
-	if err != nil {
-		panic(err)
+	ui.Assets = func() fs.FS {
+		loadOnce.Do(func() {
+			var err error
+			lazyLoadedAssets, err = assetbundle.AsFS(bytes.NewBuffer(assets))
+			if err != nil {
+				panic(err)
+			}
+		})
+		return lazyLoadedAssets
 	}
-	ui.Assets = fs
 	ui.HaveUI = true
 }

--- a/pkg/ui/distoss/distoss_no_bazel.go
+++ b/pkg/ui/distoss/distoss_no_bazel.go
@@ -19,18 +19,26 @@ package distoss
 import (
 	"embed"
 	"io/fs"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/ui"
 )
 
 //go:embed assets/*
 var assets embed.FS
+var loadOnce sync.Once
+var lazyLoadedAssets fs.FS
 
 func init() {
-	var err error
-	ui.Assets, err = fs.Sub(assets, "assets")
-	if err != nil {
-		panic(err)
+	ui.Assets = func() fs.FS {
+		loadOnce.Do(func() {
+			var err error
+			lazyLoadedAssets, err = fs.Sub(assets, "assets")
+			if err != nil {
+				panic(err)
+			}
+		})
+		return lazyLoadedAssets
 	}
 	ui.HaveUI = true
 }

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -51,7 +51,7 @@ func TestUIHandlerDevelopment(t *testing.T) {
 
 	defer func() func() {
 		hold := Assets
-		Assets = &testFs{}
+		Assets = func() fs.FS { return &testFs{} }
 		return func() {
 			Assets = hold
 		}


### PR DESCRIPTION
Unzipping these assets takes substantial time that we pay on cockroach invocations that don't necessarily need the UI.

Epic: none
Release note: None