### PR TITLE
sql: implement plan_cache_mode=force_generic_plan

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2859,3 +2859,10 @@ func TestTenantExecBuild_distsql_tenant(
 	defer leaktest.AfterTest(t)()
 	runExecBuildLogicTest(t, "distsql_tenant")
 }
+
+func TestTenantExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}

--- a/pkg/ccl/logictestccl/tests/local-read-committed/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 35,
+    shard_count = 36,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -315,6 +315,13 @@ func TestReadCommittedExecBuild_fk_read_committed(
 	runExecBuildLogicTest(t, "fk_read_committed")
 }
 
+func TestReadCommittedExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestReadCommittedExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -57,7 +57,7 @@ func init() {
 		opt.VariableOp:       (*Builder).buildVariable,
 		opt.ConstOp:          (*Builder).buildTypedExpr,
 		opt.NullOp:           (*Builder).buildNull,
-		opt.PlaceholderOp:    (*Builder).buildTypedExpr,
+		opt.PlaceholderOp:    (*Builder).buildPlaceholder,
 		opt.TupleOp:          (*Builder).buildTuple,
 		opt.FunctionOp:       (*Builder).buildFunction,
 		opt.CaseOp:           (*Builder).buildCase,
@@ -129,6 +129,15 @@ func (b *Builder) buildTypedExpr(
 	ctx *buildScalarCtx, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {
 	return scalar.Private().(tree.TypedExpr), nil
+}
+
+func (b *Builder) buildPlaceholder(
+	ctx *buildScalarCtx, scalar opt.ScalarExpr,
+) (tree.TypedExpr, error) {
+	if b.evalCtx != nil && b.evalCtx.Placeholders != nil {
+		return eval.Expr(b.ctx, b.evalCtx, scalar.Private().(*tree.Placeholder))
+	}
+	return b.buildTypedExpr(ctx, scalar)
 }
 
 func (b *Builder) buildNull(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/generic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/generic
@@ -1,0 +1,647 @@
+# Disable stats collection to prevent automatic stats collection from
+# invalidating plans.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  t TIMESTAMPTZ,
+  INDEX (a),
+  INDEX (t)
+)
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
+
+# A generic, reusable plan can be built during PREPARE for queries with no
+# placeholders nor stable expressions.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+# The generic plan is reused even when forcing a custom plan because it will
+# always be optimal.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+DEALLOCATE p
+
+# Prepare the same query with plan_cache_mode set to force_custom_plan.
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
+
+# Execute it once with plan_cache_mode set to force_custom_plan.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+# The plan is generic (it has no placeholders), so it can be reused with
+# plan_cache_mode set to force_generic_plan.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE k = $1
+
+# A generic, reusable plan can be built during PREPARE when the placeholder
+# fast-path can be used.
+query T
+EXPLAIN ANALYZE EXECUTE p(33)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
+  missing stats
+  table: t@t_pkey
+  spans: [/33 - /33]
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+# The generic plan is reused even when forcing a custom plan because it will
+# always be optimal.
+query T
+EXPLAIN ANALYZE EXECUTE p(33)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
+  missing stats
+  table: t@t_pkey
+  spans: [/33 - /33]
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = $1 AND c = $2
+
+# A simple generic plan can be built during EXECUTE.
+query T
+EXPLAIN ANALYZE EXECUTE p(1, 2)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: t@t_pkey
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: c = "$2"
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: t@t_a_idx
+    │ equality: ($1) = (a)
+    │
+    └── • values
+          sql nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          size: 2 columns, 1 row
+
+# The generic plan can be reused with different placeholder values.
+query T
+EXPLAIN ANALYZE EXECUTE p(11, 22)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: t@t_pkey
+│ equality: (k) = (k)
+│ equality cols are key
+│ pred: c = "$2"
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: t@t_a_idx
+    │ equality: ($1) = (a)
+    │
+    └── • values
+          sql nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          size: 2 columns, 1 row
+
+statement ok
+SET plan_cache_mode = force_custom_plan
+
+# The generic plan is not reused when forcing a custom plan.
+query T
+EXPLAIN ANALYZE EXECUTE p(1, 2)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 2
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE t = now()
+
+# A generic plan with a stable expression.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: t = now()
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+# The generic plan can be reused.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: t = now()
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT k FROM t WHERE c = $1
+
+# A simple generic plan.
+query T
+EXPLAIN ANALYZE EXECUTE p(1)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 1
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+statement ok
+ALTER TABLE t ADD COLUMN z INT
+
+# A schema change invalidates the generic plan, and it must be re-optimized.
+# The generic plan can be reused.
+query T
+EXPLAIN ANALYZE EXECUTE p(1)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 1
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_pkey
+      spans: FULL SCAN
+
+statement ok
+DEALLOCATE p
+
+statement ok
+ALTER TABLE t DROP COLUMN z

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
@@ -90,6 +90,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
@@ -90,6 +90,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
@@ -90,6 +90,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/generated_test.go
@@ -90,6 +90,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/generated_test.go
@@ -90,6 +90,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
@@ -90,6 +90,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -258,6 +258,13 @@ func TestExecBuild_forecast1401(
 	runExecBuildLogicTest(t, "forecast1401")
 }
 
+func TestExecBuild_generic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "generic")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -308,6 +308,19 @@ func (ob *OutputBuilder) AddVectorized(value bool) {
 	ob.AddFlakyTopLevelField(DeflakeVectorized, "vectorized", fmt.Sprintf("%t", value))
 }
 
+// AddGeneric adds a top-level generic field, if value is true. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddPlanType(generic, optimized bool) {
+	switch {
+	case generic && optimized:
+		ob.AddTopLevelField("plan type", "generic, re-optimized")
+	case generic && !optimized:
+		ob.AddTopLevelField("plan type", "generic, reused")
+	default:
+		ob.AddTopLevelField("plan type", "custom")
+	}
+}
+
 // AddPlanningTime adds a top-level planning time field. Cannot be called
 // while inside a node.
 func (ob *OutputBuilder) AddPlanningTime(delta time.Duration) {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -486,7 +486,11 @@ func (p *planTop) savePlanInfo() {
 		distribution = physicalplan.PartiallyDistributedPlan
 	}
 	containsMutation := p.flags.IsSet(planFlagContainsMutation)
-	p.instrumentation.RecordPlanInfo(distribution, vectorized, containsMutation)
+	generic := p.flags.IsSet(planFlagGeneric)
+	optimized := p.flags.IsSet(planFlagOptimized)
+	p.instrumentation.RecordPlanInfo(
+		distribution, vectorized, containsMutation, generic, optimized,
+	)
 }
 
 // startExec calls startExec() on each planNode using a depth-first, post-order
@@ -631,6 +635,15 @@ const (
 	// planFlagSessionMigration is set if the plan is being created during
 	// a session migration.
 	planFlagSessionMigration
+
+	// planFlagGeneric is set if a generic query plan was used. A generic query
+	// plan is a plan that is fully-optimized once and can be reused without
+	// being re-optimized.
+	planFlagGeneric
+
+	// planFlagOptimized is set if optimization was performed during the
+	// current execution of the query.
+	planFlagOptimized
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -527,20 +527,10 @@ func (opc *optPlanningCtx) reuseMemo(
 	return f.Memo(), nil
 }
 
-// buildExecMemo creates a fully optimized memo, possibly reusing a previously
-// cached memo as a starting point.
-//
-// The returned memo is only safe to use in one thread, during execution of the
-// current statement.
-func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ error) {
-	if resumeProc := opc.p.storedProcTxnState.getResumeProc(); resumeProc != nil {
-		// We are executing a stored procedure which has paused to commit or
-		// rollback its transaction. Use resumeProc to resume execution in a new
-		// transaction where the control statement left off.
-		opc.log(ctx, "resuming stored procedure execution in a new transaction")
-		return opc.reuseMemo(ctx, resumeProc)
-	}
-
+// fetchPreparedMemoLegacy attempts to fetch a prepared memo. If a valid (i.e.,
+// non-stale) memo is found, it is used. Otherwise, a new statement will be
+// built. If memo reuse is not allowed, nil is returned.
+func (opc *optPlanningCtx) fetchPreparedMemoLegacy(ctx context.Context) (_ *memo.Memo, err error) {
 	prepared := opc.p.stmt.Prepared
 	p := opc.p
 	if opc.allowMemoReuse && prepared != nil && prepared.Memo != nil {
@@ -562,6 +552,32 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		return opc.reuseMemo(ctx, prepared.Memo)
 	}
 
+	return nil, nil
+}
+
+// buildExecMemo creates a fully optimized memo, possibly reusing a previously
+// cached memo as a starting point.
+//
+// The returned memo is only safe to use in one thread, during execution of the
+// current statement.
+func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ error) {
+	if resumeProc := opc.p.storedProcTxnState.getResumeProc(); resumeProc != nil {
+		// We are executing a stored procedure which has paused to commit or
+		// rollback its transaction. Use resumeProc to resume execution in a new
+		// transaction where the control statement left off.
+		opc.log(ctx, "resuming stored procedure execution in a new transaction")
+		return opc.reuseMemo(ctx, resumeProc)
+	}
+
+	m, err := opc.fetchPreparedMemoLegacy(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if m != nil {
+		return m, nil
+	}
+
+	p := opc.p
 	if opc.useCache {
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)


### PR DESCRIPTION
#### sql: refactor plan_opt.go

The logic for picking a prepared memo has been moved to a function,
`fetchPreparedMemoLegacy`. This makes it easy in the following commit
to fallback to this logic based on the `plan_cache_mode` setting.

Release note: None

#### sql: implement plan_cache_mode=force_generic_plan

The `force_generic_plan` option for the session setting
`plan_cache_mode` has been implemented. Under this setting, prepared
statements will reuse a fully optimized, generic query plan, if a
non-stale one exists. If such a plan does not exist or is stale, a new
generic query plan will be built.

A "generic query plan" is a plan that is fully optimized, even if it
contains placeholders. It can be reused without re-optimization for
multiple executions of the same statement. It may not be the most
optimal plan possible because the placeholder values are not known
during optimization.

A "perfect generic query plan" is a plan that is guaranteed to be
optimal across all executions of the prepared statement. This is the
case for statements that either have no placeholders nor fold-able
stable expressions, or query plans that use the placeholder fast-path.

The query cache, which is shared across all sessions on a gateway node,
only contains normalized, unoptimized memos, or fully optimizer,
perfect, generic memos. It does not contain "non-perfect generic query
plans".

Epic: CRDB-37712

Release note (sql change): The session setting
plan_cache_mode=force_generic_plan can now be used to force prepared
statements to use query plans that are optimized once and reused in
future executions without re-optimization, as long as it does not become
stale due to schema changes or collection of new table statistics. The
setting takes effect during EXECUTE commands. EXPLAIN ANALYZE includes a
"plan type" field. If a generic query plan is optimized for the current
execution, the "plan type" will be "generic, re-optimized". If a generic
query plan is reused for the current execution without performing
optimization, the "plan type" will be "generic, reused". Otherwise, the
"plan type" will be "custom".
