### PR TITLE
sql: create_as logic test can fail when txn retries happen

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -378,10 +378,10 @@ CREATE SEQUENCE seq;
 statement OK
 CREATE TABLE tab_from_seq AS (SELECT nextval('seq'))
 
-query I
-SELECT * FROM tab_from_seq
+query B
+SELECT nextval >= 2 FROM tab_from_seq
 ----
-2
+true
 
 # Regression test for #105393
 subtest regression_105393


### PR DESCRIPTION
Previously, the create_as test could fail when creating a table asthe nextval invocation on a sequence, and checking the value afterward. If transaction retries occur, the values could be larger, leading to test flakiness. To address this, the test is updated to expect a value incremented one or more in the CTAS table.

Fixes: #125940

Release note: None