### PR TITLE
release-23.2: server: inject cluster version when changing system visible settings

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2278,8 +2278,20 @@ func (n *Node) TenantSettings(
 			// All-tenant overrides have changed, send them again.
 			// TODO(multitenant): We can optimize this by only sending the delta since the last
 			// update, with Incremental set to true.
+
+			// Inject the current storage logical version as an override to
+			// work around the situation where the `system.tenant_settings`
+			// has a wrong version data (see #125702).
+			//
+			// TODO(multitenant): remove this override when the minimum
+			// supported version is 24.1+.
+			verSetting, versionUpdateCh = n.getVersionSettingWithUpdateCh(ctx)
 			allOverrides, allCh = settingsWatcher.GetAllTenantOverrides(ctx)
-			if err := sendSettings(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, allOverrides, false /* incremental */); err != nil {
+			actualOverrides := append(
+				append([]kvpb.TenantSetting{}, allOverrides...),
+				verSetting,
+			)
+			if err := sendSettings(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, actualOverrides, false /* incremental */); err != nil {
 				return err
 			}
 

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -633,7 +633,23 @@ func (s *SettingsWatcher) setSystemVisibleDefault(ctx context.Context, key setti
 
 	log.VEventf(ctx, 1, "propagating read-only default %+v", payload)
 
-	s.notifySystemVisibleChange(ctx, []kvpb.TenantSetting{payload})
+	// Inject the current cluster version in the overrides to work
+	// around the possibility of incorrect data in the
+	// `system.tenant_settings` table. See #125702 for details.
+	//
+	// TODO(multitenant): remove this logic once the minimum supported
+	// version is 24.2+.
+	overrides := []kvpb.TenantSetting{
+		payload,
+		{
+			InternalKey: clusterversion.KeyVersionSetting,
+			Value: settings.EncodedValue{
+				Type:  settings.VersionSettingValueType,
+				Value: s.settings.Version.ActiveVersion(ctx).String(),
+			},
+		},
+	}
+	s.notifySystemVisibleChange(ctx, overrides)
 }
 
 func (s *SettingsWatcher) getSettingAndValue(key settings.InternalKey) (bool, kvpb.TenantSetting) {


### PR DESCRIPTION
Backport 1/3 commits from #125881.

/cc @cockroachdb/release

---

**server: inject cluster version when changing system visible settings**
This commit adds the storage cluster's version when notifying tenants
of changes in `SystemVisible` cluster settings. This change is to work
around the situation where the `system.tenant_settings` table has
wrong data, in which case the tenant could have the wrong view of the
storage cluster's version, potentially preventing upgrades.

Release note (bug fix): Fix a bug in non-system tenants where tenants
could have an incorrect view of the storage cluster's version in certain
situations, preventing tenant upgrades until they were restarted.

Release justification: fixes a bug that can be disruptive for clusters using
secondary tenants.