### PR TITLE
release-24.1: server: inject cluster version when changing system visible settings

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2447,8 +2447,20 @@ func (n *Node) TenantSettings(
 			// All-tenant overrides have changed, send them again.
 			// TODO(multitenant): We can optimize this by only sending the delta since the last
 			// update, with Incremental set to true.
+
+			// Inject the current storage logical version as an override to
+			// work around the situation where the `system.tenant_settings`
+			// has a wrong version data (see #125702).
+			//
+			// TODO(multitenant): remove this override when the minimum
+			// supported version is 24.1+.
+			verSetting, versionUpdateCh = n.getVersionSettingWithUpdateCh(ctx)
 			allOverrides, allCh = settingsWatcher.GetAllTenantOverrides(ctx)
-			if err := sendSettings(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, allOverrides, false /* incremental */); err != nil {
+			actualOverrides := append(
+				append([]kvpb.TenantSetting{}, allOverrides...),
+				verSetting,
+			)
+			if err := sendSettings(kvpb.TenantSettingsEvent_ALL_TENANTS_OVERRIDES, actualOverrides, false /* incremental */); err != nil {
 				return err
 			}
 

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -699,15 +700,21 @@ func TestNotifyCalledUponReadOnlySettingChanges(t *testing.T) {
 			}
 			require.Equal(t, "newval", v)
 
+			seen, v = contains("version")
+			if !seen {
+				return errors.New("version not seen yet")
+			}
+			require.Equal(t, clusterversion.Latest.Version().String(), v)
+
 			// The rangefeed event for str.baz was delivered after those for
 			// str.foo and str.yay. If we had incorrectly notified an update
 			// for non-SystemVisible setting, they would show up in the
 			// updated list.
 			mu.Lock()
 			defer mu.Unlock()
-			if len(mu.updated) != 1 {
-				t.Errorf("expected 1 setting update, got: %+v", mu.updated)
-			}
+			// The updates should include only the setting being updated and
+			// the `version` setting.
+			require.Len(t, mu.updated, 2)
 			return nil
 		})
 	})


### PR DESCRIPTION
Backport 1/3 commits from #125881.

/cc @cockroachdb/release

---

**server: inject cluster version when changing system visible settings**
This commit adds the storage cluster's version when notifying tenants
of changes in `SystemVisible` cluster settings. This change is to work
around the situation where the `system.tenant_settings` table has
wrong data, in which case the tenant could have the wrong view of the
storage cluster's version, potentially preventing upgrades.

Release note (bug fix): Fix a bug in non-system tenants where tenants
could have an incorrect view of the storage cluster's version in certain
situations, preventing tenant upgrades until they were restarted.

Release justification: fixes a bug that can be disruptive for clusters using
secondary tenants.