### PR TITLE
opt: eliminate unnecessary NULL reordering of NOT NULL columns

### DIFF
--- a/pkg/sql/opt/norm/project_funcs.go
+++ b/pkg/sql/opt/norm/project_funcs.go
@@ -903,3 +903,34 @@ func (c *CustomFuncs) RemapProjectionCols(
 func (c *CustomFuncs) CanUseImprovedJoinElimination(from, to opt.ColSet) bool {
 	return c.f.evalCtx.SessionData().OptimizerUseImprovedJoinElimination || from.SubsetOf(to)
 }
+
+// FoldIsNullProjectionsItems folds all projections in the form "x IS NULL" if
+// "x" is known to be not null in the input relational expression.
+func (c *CustomFuncs) FoldIsNullProjectionsItems(
+	projections memo.ProjectionsExpr, input memo.RelExpr,
+) memo.ProjectionsExpr {
+	isNullColExpr := func(e opt.ScalarExpr) (opt.ColumnID, bool) {
+		is, ok := e.(*memo.IsExpr)
+		if !ok {
+			return 0, false
+		}
+		v, ok := is.Left.(*memo.VariableExpr)
+		if !ok {
+			return 0, false
+		}
+		if _, ok := is.Right.(*memo.NullExpr); !ok {
+			return 0, false
+		}
+		return v.Col, true
+	}
+	newProjections := make(memo.ProjectionsExpr, len(projections))
+	for i := range projections {
+		p := &projections[i]
+		if col, ok := isNullColExpr(p.Element); ok && c.IsColNotNull(col, input) {
+			newProjections[i] = c.f.ConstructProjectionsItem(memo.FalseSingleton, p.Col)
+		} else {
+			newProjections[i] = *p
+		}
+	}
+	return newProjections
+}

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -330,3 +330,24 @@ $input
     (FoldJSONFieldAccess $projections $jsonCols $col $input)
     $passthrough
 )
+
+# FoldIsNullProject folds "x IS NULL" projections to false if "x" is not null in
+# the Project's input. It matches if there is at least one projection that can
+# be folded, and it replaces all projections that can be folded.
+[FoldIsNullProject, Normalize]
+(Project
+    $input:*
+    $projections:[
+            ...
+            $item:(ProjectionsItem (Is (Variable $col:*) (Null)))
+            ...
+        ] &
+        (IsColNotNull $col $input)
+    $passthrough:*
+)
+=>
+(Project
+    $input
+    (FoldIsNullProjectionsItems $projections $input)
+    $passthrough
+)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -1916,3 +1916,105 @@ project
  │    └── ('["foo", "baz"]',)
  └── projections
       └── column1:1->'foo' [as="?column?":2, outer=(1), immutable]
+
+# --------------------------------------------------
+# FoldIsNullProject
+# --------------------------------------------------
+
+norm expect=FoldIsNullProject
+SELECT x IS NULL FROM a
+----
+project
+ ├── columns: "?column?":7!null
+ ├── fd: ()-->(7)
+ ├── scan a
+ └── projections
+      └── false [as="?column?":7]
+
+norm expect=FoldIsNullProject
+SELECT k IS NULL, v IS NULL, r1 IS NULL FROM fks
+----
+project
+ ├── columns: "?column?":8!null "?column?":9!null "?column?":10!null
+ ├── fd: ()-->(8,10)
+ ├── scan fks
+ │    └── columns: v:2
+ └── projections
+      ├── false [as="?column?":8]
+      ├── v:2 IS NULL [as="?column?":9, outer=(2)]
+      └── false [as="?column?":10]
+
+norm expect-not=FoldIsNullProject
+SELECT y IS NULL FROM a
+----
+project
+ ├── columns: "?column?":7!null
+ ├── scan a
+ │    └── columns: y:2
+ └── projections
+      └── y:2 IS NULL [as="?column?":7, outer=(2)]
+
+# The column "b.x" is not nullable in the base table, but could be NULL after
+# the left-join, so b.x IS NULL cannot be folded.
+norm expect=FoldIsNullProject
+SELECT a.x IS NULL, b.x IS NULL FROM a LEFT JOIN b ON a.x = b.x;
+----
+project
+ ├── columns: "?column?":12!null "?column?":13!null
+ ├── fd: ()-->(12)
+ ├── left-join (hash)
+ │    ├── columns: a.x:1!null b.x:7
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(7)
+ │    ├── scan a
+ │    │    ├── columns: a.x:1!null
+ │    │    └── key: (1)
+ │    ├── scan b
+ │    │    ├── columns: b.x:7!null
+ │    │    └── key: (7)
+ │    └── filters
+ │         └── a.x:1 = b.x:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ └── projections
+      ├── false [as="?column?":12]
+      └── b.x:7 IS NULL [as="?column?":13, outer=(7)]
+
+# FoldIsNullProject helps eliminate NULL reordering for ASC NULLS LAST if the
+# order by column is not nullable.
+norm expect=FoldIsNullProject
+SELECT x FROM a ORDER BY x ASC NULLS LAST
+----
+scan a
+ ├── columns: x:1!null
+ ├── key: (1)
+ └── ordering: +1
+
+# FoldIsNullProject helps eliminate NULL reordering for DESC NULLS LAST if the
+# order by column is not nullable.
+norm expect=FoldIsNullProject
+SELECT x FROM a ORDER BY x DESC NULLS FIRST
+----
+scan a,rev
+ ├── columns: x:1!null
+ ├── key: (1)
+ └── ordering: -1
+
+# Null reordering is needed for "y" but not for "x".
+norm expect=FoldIsNullProject
+SELECT x FROM a ORDER BY y DESC NULLS FIRST, x DESC NULLS FIRST
+----
+sort
+ ├── columns: x:1!null  [hidden: y:2 nulls_ordering_y:7!null]
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(7)
+ ├── ordering: -7,-2,-1
+ └── project
+      ├── columns: nulls_ordering_y:7!null x:1!null y:2
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(7)
+      ├── scan a
+      │    ├── columns: x:1!null y:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── projections
+           └── y:2 IS NULL [as=nulls_ordering_y:7, outer=(2)]


### PR DESCRIPTION
In order to produce non-standard orderings of NULL values, i.e., when an
`ORDER BY` expression has an `ASC NULLS LAST` or `DESC NULLS FIRST`
clause, the optimizer plans "NULL reordering". Indexes never store
NULL values in these orderings, so the NULL reordering often results
in a full table scan and a sort.

However, observe that `ORDER BY col ASC NULLS FIRST` is equivalent to
`ORDER BY col ASC NULLS LAST` if `col` is known to not be NULL. The same
equivalence is true for `ORDER BY col DESC NULLS LAST` and
`ORDER BY col DESC NULLS FIRST`. Therefore, NULL reordering is unnecessary
if the ordering column is not nullable.

The `FoldIsNullProject` rule has been added which folds `x IS NOT NULL`
projections to `false` if `x` is known to be not `NULL`. This allows
other rules to fire, like `SimplifyRootOrdering`, which together
eliminate the NULL reordering steps, avoiding full table scans and
sorting operations.

Fixes #126675

Release note (performance improvement): The query optimizer now
generates more efficient plans for queries with clauses like
`ORDER BY col ASC NULLS LAST` and `ORDER BY col DESC NULLS FIRST` when
`col` is guaranteed to not be `NULL`.
