### PR TITLE
cli: bump default worker pool to heavy

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -358,7 +358,10 @@ go_test(
     embed = [":cli"],
     exec_properties = select({
         "//build/toolchains:is_heavy": {"test.Pool": "large"},
-        "//conditions:default": {"test.Pool": "default"},
+        # For the benefit of TestDebugCheckStore. That test is skipped under
+        # race/deadlock, so the "default" configuration is higher than the
+        # "is_heavy" configuration.
+        "//conditions:default": {"test.Pool": "heavy"},
     }),
     shard_count = 16,
     deps = [


### PR DESCRIPTION
For the benefit of TestDebugCheckStore.

Closes #122328
Closes #126593

Epic: none

Release note: None