### PR TITLE
github: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -264,9 +264,9 @@
 /pkg/kv/bulk/                           @cockroachdb/disaster-recovery
 /pkg/kv/kvbase/                         @cockroachdb/kv-prs
 /pkg/kv/kvclient/                       @cockroachdb/kv-prs
-/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/repl-prs
+/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/kv-prs
 /pkg/kv/kvclient/kvstreamer             @cockroachdb/sql-queries-prs
-/pkg/kv/kvclient/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvclient/rangefeed/             @cockroachdb/kv-prs
 /pkg/kv/kvnemesis/                      @cockroachdb/kv-prs
 /pkg/kv/kvpb/                           @cockroachdb/kv-prs
 /pkg/kv/kvpb/.gitattributes             @cockroachdb/dev-inf
@@ -284,24 +284,24 @@
 /pkg/kv/kvprober/                       @cockroachdb/kv-prs
 # Same subdirectory rule as above for `/pkg/kv`
 /pkg/kv/kvserver/*.*                    @cockroachdb/kv-prs
-/pkg/kv/kvserver/*circuit*.go           @cockroachdb/repl-prs
-/pkg/kv/kvserver/*closed*ts*.go         @cockroachdb/repl-prs
-/pkg/kv/kvserver/*_app*.go              @cockroachdb/repl-prs
-/pkg/kv/kvserver/*closed_timestamp*.go  @cockroachdb/repl-prs
-/pkg/kv/kvserver/*consistency*.go       @cockroachdb/repl-prs
-/pkg/kv/kvserver/*probe*.go             @cockroachdb/repl-prs
-/pkg/kv/kvserver/*proposal*.go          @cockroachdb/repl-prs
-/pkg/kv/kvserver/*raft*.go              @cockroachdb/repl-prs
-/pkg/kv/kvserver/*raft*/                @cockroachdb/repl-prs
-/pkg/kv/kvserver/*rangefeed*.go         @cockroachdb/repl-prs
-/pkg/kv/kvserver/*sideload*.go          @cockroachdb/repl-prs
+/pkg/kv/kvserver/*circuit*.go           @cockroachdb/kv-prs
+/pkg/kv/kvserver/*closed*ts*.go         @cockroachdb/kv-prs
+/pkg/kv/kvserver/*_app*.go              @cockroachdb/kv-prs
+/pkg/kv/kvserver/*closed_timestamp*.go  @cockroachdb/kv-prs
+/pkg/kv/kvserver/*consistency*.go       @cockroachdb/kv-prs
+/pkg/kv/kvserver/*probe*.go             @cockroachdb/kv-prs
+/pkg/kv/kvserver/*proposal*.go          @cockroachdb/kv-prs
+/pkg/kv/kvserver/*raft*.go              @cockroachdb/kv-prs
+/pkg/kv/kvserver/*raft*/                @cockroachdb/kv-prs
+/pkg/kv/kvserver/*rangefeed*.go         @cockroachdb/kv-prs
+/pkg/kv/kvserver/*sideload*.go          @cockroachdb/kv-prs
 /pkg/kv/kvserver/abortspan/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/allocator/             @cockroachdb/kv-prs
-/pkg/kv/kvserver/apply/                 @cockroachdb/repl-prs
+/pkg/kv/kvserver/apply/                 @cockroachdb/kv-prs
 /pkg/kv/kvserver/asim/                  @cockroachdb/kv-prs
 /pkg/kv/kvserver/batcheval/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/benignerror/           @cockroachdb/kv-prs
-/pkg/kv/kvserver/closedts/              @cockroachdb/repl-prs
+/pkg/kv/kvserver/closedts/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/concurrency/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/constraint/            @cockroachdb/kv-prs
 /pkg/kv/kvserver/diskmap/               @cockroachdb/kv-prs
@@ -312,18 +312,18 @@
 /pkg/kv/kvserver/kvflowcontrol/         @cockroachdb/admission-control
 /pkg/kv/kvserver/kvserverbase/          @cockroachdb/kv-prs
 /pkg/kv/kvserver/kvserverpb/            @cockroachdb/kv-prs
-/pkg/kv/kvserver/kvstorage/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/kvstorage/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/leases/                @cockroachdb/kv-prs
 /pkg/kv/kvserver/liveness/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/load/                  @cockroachdb/kv-prs
 /pkg/kv/kvserver/lockspanset/           @cockroachdb/kv-prs
-/pkg/kv/kvserver/logstore/              @cockroachdb/repl-prs
-/pkg/kv/kvserver/loqrecovery/           @cockroachdb/repl-prs
+/pkg/kv/kvserver/logstore/              @cockroachdb/kv-prs
+/pkg/kv/kvserver/loqrecovery/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/multiqueue/            @cockroachdb/kv-prs
 /pkg/kv/kvserver/protectedts/           @cockroachdb/kv-prs
-/pkg/kv/kvserver/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/rangefeed/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/rangelog/              @cockroachdb/kv-prs
-/pkg/kv/kvserver/rditer/                @cockroachdb/repl-prs
+/pkg/kv/kvserver/rditer/                @cockroachdb/kv-prs
 /pkg/kv/kvserver/readsummary/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/replicastats/          @cockroachdb/kv-prs
 /pkg/kv/kvserver/reports/               @cockroachdb/kv-prs
@@ -339,9 +339,9 @@
 /pkg/kv/kvserver/txnwait/               @cockroachdb/kv-prs
 /pkg/kv/kvserver/uncertainty/           @cockroachdb/kv-prs
 
-# KV/replication team owns integration with raft.
+# The KV team owns integration with raft.
 #
-/pkg/raft/ @cockroachdb/repl-prs
+/pkg/raft/ @cockroachdb/kv-prs
 
 /pkg/ccl/spanconfigccl/                            @cockroachdb/kv-prs @cockroachdb/sql-foundations
 /pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/    @cockroachdb/kv-prs


### PR DESCRIPTION
Update all instances of `repl-prs` to `kv-prs`.

Release note: None.

Epic: None.