### PR TITLE
sql: fix pg_catalog formatting of BYTES expressions

### DIFF
--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -64,7 +64,6 @@ go_test(
         "//pkg/server",
         "//pkg/sql/parser",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/internal/sqlsmith/setup_test.go
+++ b/pkg/internal/sqlsmith/setup_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -65,8 +64,6 @@ func TestSetups(t *testing.T) {
 func TestGenerateParse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.WithIssue(t, 126344)
 
 	ctx := context.Background()
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5169,10 +5169,13 @@ subtest regression_126042
 statement ok
 CREATE TABLE t126042 (
   id INT8 NOT NULL PRIMARY KEY,
-  bytes_array BYTES[] DEFAULT '{f}'::BYTES[]
+  b BYTES DEFAULT 'f'::BYTES,
+  bytes_array BYTES[] DEFAULT '{f}'::BYTES[],
+  text_array TEXT[] DEFAULT '{a, b}'::TEXT[]
 )
 
-# Regression test for #126042. Expressions of type BYTES[] should be parsable.
+# Regression test for #126042 and #126344. Expressions of type BYTES and BYTES[]
+# should be parsable.
 query TT
 SELECT a.attname, pg_get_expr(d.adbin, d.adrelid)
 FROM pg_attribute a
@@ -5180,8 +5183,10 @@ LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
 WHERE a.attrelid = 't126042'::REGCLASS
 ORDER BY 1
 ----
+b            '\x66'::BYTES
 bytes_array  '{"\\x66"}'::BYTES[]
 id           NULL
+text_array   '{a,b}'::STRING[]
 
 subtest end
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1563,7 +1563,7 @@ func writeAsHexString(ctx *FmtCtx, b string) {
 // Format implements the NodeFormatter interface.
 func (d *DBytes) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if f.HasFlags(fmtPgwireFormat) || f.HasFlags(fmtPGCatalog) {
+	if f.HasFlags(fmtPgwireFormat) {
 		ctx.WriteString(`\x`)
 		writeAsHexString(ctx, string(*d))
 	} else if f.HasFlags(fmtFormatByteLiterals) {
@@ -1572,7 +1572,7 @@ func (d *DBytes) Format(ctx *FmtCtx) {
 		_, _ = hex.NewEncoder(ctx).Write([]byte(*d))
 		ctx.WriteByte('\'')
 	} else {
-		withQuotes := !f.HasFlags(FmtFlags(lexbase.EncBareStrings))
+		withQuotes := !f.HasFlags(FmtBareStrings)
 		if withQuotes {
 			ctx.WriteByte('\'')
 		}
@@ -4907,6 +4907,7 @@ func (d *DArray) Format(ctx *FmtCtx) {
 	if ctx.flags.HasAnyFlags(fmtPgwireFormat | fmtPGCatalog) {
 		defer func(f FmtFlags) { ctx.flags = f }(ctx.flags)
 		ctx.flags = ctx.flags & ^fmtPGCatalogCasts
+		ctx.flags = ctx.flags | FmtBareStrings
 		d.pgwireFormat(ctx)
 		return
 	}


### PR DESCRIPTION
#### sql: fix pg_catalog formatting of BYTES expressions

This commit fixes a regression introduced in #126297 that caused
incorrect formatting of BYTES expressions in pg_catalog.

Fixes #126344

There is no release note because this bug is not present in any
releases.

Release note: None

#### sqlsmith: unskip TestGenerateParse

Release note: None
