### PR TITLE
roachtest: add `MaxUpgrades` option back to `validate-system-schema`

### DIFF
--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -76,6 +76,9 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
 		// Fixtures are generated on a version that's too old for this test.
 		mixedversion.NeverUseFixtures,
+		// We limit the number of upgrades since the test is not expected to work
+		// on versions older than 22.2.
+		mixedversion.MaxUpgrades(2),
 	)
 	mvt.AfterUpgradeFinalized(
 		"obtain system schema from the upgraded cluster",


### PR DESCRIPTION
This option was mistakenly removed in #126277 along with other tests that specified 23.1 as a minimum version because of compatibility issues. This test, however, needs to be bootstrapped on 22.2+ due to issues in older releases that we no longer support.

Epic: none
backport fixes https://github.com/cockroachdb/cockroach/issues/126608
Release note: None