### PR TITLE
raft: move maybeCommit to the right layer

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -476,17 +476,6 @@ func (l *raftLog) matchTerm(id entryID) bool {
 	return t == id.term
 }
 
-func (l *raftLog) maybeCommit(at entryID) bool {
-	// NB: term should never be 0 on a commit because the leader campaigned at
-	// least at term 1. But if it is 0 for some reason, we don't consider this a
-	// term match.
-	if at.term != 0 && at.index > l.committed && l.matchTerm(at) {
-		l.commitTo(at.index)
-		return true
-	}
-	return false
-}
-
 func (l *raftLog) restore(s pb.Snapshot) {
 	l.logger.Infof("log [%s] starts to restore snapshot [index: %d, term: %d]", l, s.Metadata.Index, s.Metadata.Term)
 	l.committed = s.Metadata.Index

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -277,7 +277,7 @@ func TestCompactionSideEffects(t *testing.T) {
 	raftLog := newLog(storage, discardLogger)
 	require.True(t, raftLog.append(unstable))
 
-	require.True(t, raftLog.maybeCommit(raftLog.lastEntryID()))
+	raftLog.commitTo(raftLog.lastIndex())
 	raftLog.appliedTo(raftLog.committed, 0 /* size */)
 
 	offset := uint64(500)
@@ -343,7 +343,7 @@ func TestHasNextCommittedEnts(t *testing.T) {
 			raftLog := newLog(storage, discardLogger)
 			require.True(t, raftLog.append(init))
 			raftLog.stableTo(entryID{term: 1, index: 4})
-			raftLog.maybeCommit(entryID{term: 1, index: 5})
+			raftLog.commitTo(5)
 			raftLog.appliedTo(tt.applied, 0 /* size */)
 			raftLog.acceptApplying(tt.applying, 0 /* size */, tt.allowUnstable)
 			raftLog.applyingEntsPaused = tt.paused
@@ -396,7 +396,7 @@ func TestNextCommittedEnts(t *testing.T) {
 			raftLog := newLog(storage, discardLogger)
 			require.True(t, raftLog.append(init))
 			raftLog.stableTo(entryID{term: 1, index: 4})
-			raftLog.maybeCommit(entryID{term: 1, index: 5})
+			raftLog.commitTo(5)
 			raftLog.appliedTo(tt.applied, 0 /* size */)
 			raftLog.acceptApplying(tt.applying, 0 /* size */, tt.allowUnstable)
 			raftLog.applyingEntsPaused = tt.paused
@@ -450,7 +450,7 @@ func TestAcceptApplying(t *testing.T) {
 			raftLog := newLogWithSize(storage, discardLogger, maxSize)
 			require.True(t, raftLog.append(init))
 			raftLog.stableTo(entryID{term: 1, index: 4})
-			raftLog.maybeCommit(entryID{term: 1, index: 5})
+			raftLog.commitTo(5)
 			raftLog.appliedTo(3, 0 /* size */)
 
 			raftLog.acceptApplying(tt.index, tt.size, tt.allowUnstable)
@@ -494,7 +494,7 @@ func TestAppliedTo(t *testing.T) {
 			raftLog := newLogWithSize(storage, discardLogger, maxSize)
 			require.True(t, raftLog.append(init))
 			raftLog.stableTo(entryID{term: 1, index: 4})
-			raftLog.maybeCommit(entryID{term: 1, index: 5})
+			raftLog.commitTo(5)
 			raftLog.appliedTo(3, 0 /* size */)
 			raftLog.acceptApplying(5, maxSize+overshoot, false /* allowUnstable */)
 
@@ -644,7 +644,7 @@ func TestCompaction(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.Append(index(1).termRange(1, tt.lastIndex+1)))
 			raftLog := newLog(storage, discardLogger)
-			raftLog.maybeCommit(entryID{term: 0, index: tt.lastIndex}) // TODO(pav-kv): this is a no-op
+			raftLog.commitTo(tt.lastIndex)
 
 			raftLog.appliedTo(raftLog.committed, 0 /* size */)
 			for j := 0; j < len(tt.compact); j++ {


### PR DESCRIPTION
Previously, the "maybe commit" logic was in the `raftLog` type. This isn't the right place for this check, because the `raftLog` is the "acceptor" level concept, while the commit criterion is the leader / "proposer" concept.

This commit moves the logic up from `raftLog` to the `raft` struct, and documents it in a better way.

Related to https://github.com/cockroachdb/cockroach/pull/126475#pullrequestreview-2155442286
Epic: CRDB-37516
Release note: none