### PR TITLE
build: add script to build fuzzers in oss-fuzz

### DIFF
--- a/build/oss-fuzz/build.sh
+++ b/build/oss-fuzz/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -eu
+
+# Don't need the stdlib and libc++ gives linker error
+CXXFLAGS="${CXXFLAGS/-stdlib=libc++/}"
+
+# Needed for initialize the submodules, the submodule directories are empty.
+# Some header files (proj_api.h here) do not actually exist in cockroach, it exists in the submodule.
+git submodule update --init --recursive
+
+# Install dependencies for compile_native_go_fuzzer
+go install github.com/AdamKorcz/go-118-fuzz-build@latest
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+# Generate artifacts for building the binary
+bazel run pkg/gen:code
+bazel run pkg/cmd/generate-cgo:generate-cgo --run_under "cd $SRC/cockroach && "
+
+# File is not being built via bazel and outdated (gives compilation errors in SessionIDEncoding)
+rm pkg/sql/pgwire/fuzz.go
+
+# Rename as go-118-fuzz-build cant read _test.go files (used by sessionID and frontier)
+mv ./pkg/util/span/frontier_test.go pkg/util/span/frontier_test_fuzz.go
+
+# Build the native go fuzz targets
+compile_native_go_fuzzer ./pkg/keys FuzzPrettyPrint fuzzPrettyPrint
+
+compile_native_go_fuzzer ./pkg/sql/sqlliveness/slstorage FuzzSessionIDEncoding fuzzSessionIDEncoding
+
+compile_native_go_fuzzer ./pkg/util/span FuzzBtreeFrontier fuzzBtreeFrontier
+
+compile_native_go_fuzzer ./pkg/util/span FuzzLLRBFrontier fuzzLLRBFrontier
+
+compile_native_go_fuzzer ./pkg/ccl/pgcryptoccl/pgcryptocipherccl FuzzEncryptDecryptAES fuzzEncryptDecryptAES
+
+compile_native_go_fuzzer ./pkg/ccl/pgcryptoccl/pgcryptocipherccl FuzzNoPaddingEncryptDecryptAES fuzzNoPaddingEncryptDecryptAES
+
+compile_native_go_fuzzer ./pkg/storage FuzzEngineKeysInvariants fuzzEngineKeysInvariants
+
+# Build old fuzz targets which used `gofuzz`
+compile_go_fuzzer /src/cockroach/pkg/util/uuid Fuzz fuzzuuid
+
+# Generate seed corpus
+zip -r $OUT/fuzzPrettyPrint_seed_corpus.zip ./pkg/keys/testdata/fuzz/FuzzPrettyPrint || true
+zip -r $OUT/fuzzuuid_seed_corpus.zip ./pkg/util/uuid/testdata/corpus || true

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -409,7 +409,7 @@ func advanceFrontier(t *testing.T, f Frontier, s roachpb.Span, wall int64) {
 	require.NoError(t, err)
 }
 
-// TestForwardInvertedSpan is a replay of a failure uncovered by FuzzLLRBFrontier test.
+// TestForwardInvertedSpan is a replay of a failure uncovered by fuzzLLRBFrontier test.
 // It verifies frontier behaves as expected when attempting to forward inverted span.
 func TestForwardInvertedSpan(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
This commit allows us to build and add fuzz tests to oss-fuzz from CRDB instead of using the one they provide.

Epic: none
Release note: None