### PR TITLE
roachtest: add manual compaction operation

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "backup_restore.go",
         "cluster_settings.go",
         "disk_stall.go",
+        "manual_compaction.go",
         "network_partition.go",
         "node_kill.go",
         "register.go",

--- a/pkg/cmd/roachtest/operations/manual_compaction.go
+++ b/pkg/cmd/roachtest/operations/manual_compaction.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func runManualCompaction(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	rng, _ := randutil.NewPseudoRand()
+
+	nodes := c.All()
+	nid := nodes[rng.Intn(len(nodes))]
+
+	conn := c.Conn(ctx, o.L(), nid, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	dbName := pickRandomDB(ctx, o, conn, systemDBs)
+	tableName := pickRandomTable(ctx, o, conn, dbName)
+	sid := pickRandomStore(ctx, o, conn, nid)
+
+	compactionStmt := fmt.Sprintf(`SELECT crdb_internal.compact_engine_span(
+				%d, %d,
+				(SELECT raw_start_key FROM [SHOW RANGES FROM TABLE %s.%s WITH KEYS] LIMIT 1),
+				(SELECT raw_end_key FROM [SHOW RANGES FROM TABLE %s.%s WITH KEYS] LIMIT 1))`,
+		nid, sid, dbName, tableName, dbName, tableName)
+	o.Status(fmt.Sprintf("compacting a range for table %s.%s in n%d, s%d",
+		dbName, tableName, nid, sid))
+	_, err := conn.ExecContext(ctx, compactionStmt)
+	if err != nil {
+		o.Fatal(err)
+	}
+	return nil
+}
+
+func registerManualCompaction(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "manual-compaction",
+		Owner:            registry.OwnerStorage,
+		Timeout:          24 * time.Hour,
+		CompatibleClouds: registry.OnlyGCE,
+		Dependencies:     []registry.OperationDependency{registry.OperationRequiresZeroUnavailableRanges},
+		Run:              runManualCompaction,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -21,4 +21,5 @@ func RegisterOperations(r registry.Registry) {
 	registerNodeKill(r)
 	registerClusterSettings(r)
 	registerBackupRestore(r)
+	registerManualCompaction(r)
 }


### PR DESCRIPTION
This change is to add a new operation that will enable us to run
 manual compaction. Having a manual compaction ongoing would induce
 a moderate amount of chaos, and could possibly lead to interesting
 behaviour in Storage as well as elsewhere in CockroachDB.

 Fixes: #126480
 Epic: None