### PR TITLE
catalog/lease: address TestDescriptorRefreshOnRetry flake

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -948,7 +948,11 @@ func TestDescriptorRefreshOnRetry(t *testing.T) {
 	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.Background())
 	s := srv.ApplicationLayer()
-
+	// Disable the automatic stats collection, which could interfere with
+	// the lease acquisition counts in this test.
+	if _, err := sqlDB.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false"); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.foo (v INT);
@@ -1313,6 +1317,11 @@ CREATE DATABASE t;
 CREATE TABLE t.test1 (k CHAR PRIMARY KEY, v CHAR);
 CREATE TABLE t.test2 ();
 `); err != nil {
+		t.Fatal(err)
+	}
+	// Disable the automatic stats collection, which could interfere with
+	// the lease acquisition counts in this test.
+	if _, err := t.db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false"); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Previously, it was possible for this test to flake if the stats collection ran after table creation, which would cause the release count to not match the acquire count. To address this, this patch will disable automatic stats collection for this leasing test.

Fixes: #125976

Release note: None