### PR TITLE
kv-obs: annotate consistency queue graph with explanation

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -338,6 +338,10 @@ export default function (props: GraphDashboardProps) {
       sources={storeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
+      tooltip={`The Consistency Checker Queue periodically checks 
+      that all replicas in a given range are consistent. For large 
+      clusters, the queue is always expected to have a pending 
+      backlog.`}
     >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric


### PR DESCRIPTION
This commit annotates the consistency queue graph with a hint that explains what the role of the queue is and that a persistent pending backlog is expected and benign.

Fixes: #83869

Release note: None

<img width="979" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20375035/fa7113a9-cfc0-483b-8ad1-4c7360b8b463">
