### PR TITLE
sql: fix casts for TSVector and TSQuery

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -490,3 +490,14 @@ SELECT count(*) FROM cte AS cte1 JOIN cte AS cte2 ON cte1.col = cte2.col;
 statement ok
 RESET vectorize;
 RESET distsql_workmem;
+
+
+# Regression test for tsvector to tsvector assignment cast.
+statement ok
+CREATE TABLE t126773 (pk INT PRIMARY KEY, v TSVECTOR);
+
+statement ok
+INSERT INTO t126773 (pk, v) values (1, tsvector('splendid water fowl'));
+
+statement ok
+SELECT t126773::t126773 FROM t126773;

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -890,6 +890,8 @@ func performCastWithoutPrecisionTruncation(
 				return nil, err
 			}
 			return &tree.DTSQuery{TSQuery: q}, nil
+		case *tree.DTSQuery:
+			return d, nil
 		}
 	case types.TSVectorFamily:
 		switch v := d.(type) {
@@ -899,6 +901,8 @@ func performCastWithoutPrecisionTruncation(
 				return nil, err
 			}
 			return &tree.DTSVector{TSVector: vec}, nil
+		case *tree.DTSVector:
+			return d, nil
 		}
 	case types.ArrayFamily:
 		switch v := d.(type) {


### PR DESCRIPTION
Previously, both tsvector and tsquery would produce errors such as

    sql: invalid cast: tsvector -> tsvector

When passing a type containing a tsvector to a function or trying to cast such a type.

Fixes #126773
Release note: None