### PR TITLE
roachtest: clean up acceptance tests

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -290,10 +290,9 @@ func (cs CloudSet) NoAzure() CloudSet {
 }
 
 // Remove removes all clouds passed in and returns the new set.
-func (cs CloudSet) Remove(clouds ...string) CloudSet {
-	assertValidValues(allClouds, clouds...)
+func (cs CloudSet) Remove(clouds CloudSet) CloudSet {
 	copyCs := CloudSet{m: cs.m}
-	for _, c := range clouds {
+	for c := range clouds.m {
 		copyCs.m = removeFromSet(copyCs.m, c)
 	}
 
@@ -314,9 +313,13 @@ func (cs CloudSet) String() string {
 
 // AssertInitialized panics if the CloudSet is the zero value.
 func (cs CloudSet) AssertInitialized() {
-	if cs.m == nil {
+	if !cs.IsInitialized() {
 		panic("CloudSet not initialized")
 	}
+}
+
+func (cs CloudSet) IsInitialized() bool {
+	return cs.m != nil
 }
 
 // Suite names.
@@ -379,7 +382,7 @@ func (ss SuiteSet) String() string {
 
 // AssertInitialized panics if the SuiteSet is the zero value.
 func (ss SuiteSet) AssertInitialized() {
-	if ss.m == nil {
+	if !ss.IsInitialized() {
 		panic("SuiteSet not initialized")
 	}
 }

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -23,11 +23,7 @@ import (
 )
 
 func registerAcceptance(r registry.Registry) {
-	// TODO(renato): delete once #126775 is merged.
-	allExceptLocal := strings.Split(
-		registry.AllExceptLocal.String(),
-		",",
-	)
+	cloudsWithoutServiceRegistration := registry.AllClouds.Remove(registry.CloudsWithServiceRegistration)
 
 	testCases := map[registry.Owner][]struct {
 		name               string
@@ -40,9 +36,17 @@ func registerAcceptance(r registry.Registry) {
 		defaultLeases      bool
 		requiresLicense    bool
 		nativeLibs         []string
-		incompatibleClouds []string // Already assumes AWS is incompatible.
+		incompatibleClouds registry.CloudSet
 	}{
-		registry.OwnerReleaseEng: {},
+		// NOTE: acceptance tests are lightweight tests that run as part
+		// of CI. As such, they must:
+		//
+		// 1. finish quickly
+		// 2. be compatible with roachtest local
+		//
+		// If you are adding a test that does not satisfy either of these
+		// properties, please register it separately (not as an acceptance
+		// test).
 		registry.OwnerKV: {
 			{name: "decommission-self", fn: runDecommissionSelf},
 			{name: "event-log", fn: runEventLog},
@@ -83,13 +87,13 @@ func registerAcceptance(r registry.Registry) {
 				name:               "c2c",
 				fn:                 runAcceptanceClusterReplication,
 				numNodes:           3,
-				incompatibleClouds: allExceptLocal,
+				incompatibleClouds: cloudsWithoutServiceRegistration,
 			},
 			{
 				name:               "multitenant",
 				fn:                 runAcceptanceMultitenant,
 				timeout:            time.Minute * 20,
-				incompatibleClouds: []string{spec.Azure}, // Requires service registration.
+				incompatibleClouds: cloudsWithoutServiceRegistration,
 			},
 		},
 		registry.OwnerSQLFoundations: {
@@ -104,17 +108,6 @@ func registerAcceptance(r registry.Registry) {
 				name:     "mismatched-locality",
 				fn:       runMismatchedLocalityTest,
 				numNodes: 3,
-			},
-			{
-				name:     "multitenant-multiregion",
-				fn:       runAcceptanceMultitenantMultiRegion,
-				timeout:  20 * time.Minute,
-				numNodes: 9,
-				nodeRegions: []string{"us-west1-b", "us-west1-b", "us-west1-b",
-					"us-west1-b", "us-west1-b", "us-west1-b",
-					"us-east1-b", "us-east1-b", "us-east1-b"},
-				requiresLicense:    true,
-				incompatibleClouds: []string{spec.Local, spec.Azure}, // Requires service registration.
 			},
 		},
 	}
@@ -136,6 +129,13 @@ func registerAcceptance(r registry.Registry) {
 				extraOptions = append(extraOptions, spec.GCEZones(strings.Join(tc.nodeRegions, ",")))
 			}
 
+			if tc.incompatibleClouds.IsInitialized() && tc.incompatibleClouds.Contains(spec.Local) {
+				panic(errors.AssertionFailedf(
+					"acceptance tests must be able to run on roachtest local, but %q is incompatible",
+					tc.name,
+				))
+			}
+
 			testSpec := registry.TestSpec{
 				Name:              "acceptance/" + tc.name,
 				Owner:             owner,
@@ -143,7 +143,7 @@ func registerAcceptance(r registry.Registry) {
 				Skip:              tc.skip,
 				EncryptionSupport: tc.encryptionSupport,
 				Timeout:           10 * time.Minute,
-				CompatibleClouds:  registry.AllExceptAWS.Remove(tc.incompatibleClouds...),
+				CompatibleClouds:  registry.AllClouds.Remove(tc.incompatibleClouds),
 				Suites:            registry.Suites(registry.Nightly, registry.Quick, registry.Acceptance),
 				RequiresLicense:   tc.requiresLicense,
 			}

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1089,7 +1089,6 @@ func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster
 		additionalDuration:        0 * time.Minute,
 		cutover:                   30 * time.Second,
 		skipNodeDistributionCheck: true,
-		clouds:                    registry.OnlyGCE,
 		suites:                    registry.Suites(registry.Nightly),
 	}
 	rd := makeReplicationDriver(t, c, sp)

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -97,6 +97,7 @@ func RegisterTests(r registry.Registry) {
 	registerMVCCGC(r)
 	registerMultiStoreRemove(r)
 	registerMultiTenantDistSQL(r)
+	registerMultiTenantMultiregion(r)
 	registerMultiTenantTPCH(r)
 	registerMultiTenantUpgrade(r)
 	registerMultiTenantSharedProcess(r)


### PR DESCRIPTION
Acceptance tests are tests that are run as part of CI. As such, they need to be compatible with roachtest local, otherwise there's no point in declaring them as "acceptance".

This commit enforces that requirement, and removes tests that are registered as `acceptance` but don't fit these criteria.

Epic: none

Release note: None