### PR TITLE
roachtest: use `CompatibleClouds` to define clouds where a test can run

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -23,6 +23,12 @@ import (
 )
 
 func registerAcceptance(r registry.Registry) {
+	// TODO(renato): delete once #126775 is merged.
+	allExceptLocal := strings.Split(
+		registry.AllExceptLocal.String(),
+		",",
+	)
+
 	testCases := map[registry.Owner][]struct {
 		name               string
 		fn                 func(ctx context.Context, t test.Test, c cluster.Cluster)
@@ -74,9 +80,10 @@ func registerAcceptance(r registry.Registry) {
 		},
 		registry.OwnerDisasterRecovery: {
 			{
-				name:     "c2c",
-				fn:       runAcceptanceClusterReplication,
-				numNodes: 3,
+				name:               "c2c",
+				fn:                 runAcceptanceClusterReplication,
+				numNodes:           3,
+				incompatibleClouds: allExceptLocal,
 			},
 			{
 				name:               "multitenant",

--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
@@ -177,10 +178,12 @@ func registerCancel(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             fmt.Sprintf("cancel/tpch/distsql/queries=%s,nodes=%d", queries, numNodes),
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(numNodes),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    fmt.Sprintf("cancel/tpch/distsql/queries=%s,nodes=%d", queries, numNodes),
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(numNodes),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -189,10 +192,12 @@ func registerCancel(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             fmt.Sprintf("cancel/tpch/local/queries=%s,nodes=%d", queries, numNodes),
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(numNodes),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    fmt.Sprintf("cancel/tpch/local/queries=%s,nodes=%d", queries, numNodes),
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(numNodes),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -394,9 +394,6 @@ func (bo replicateBulkOps) sourceRunCmd(tenantName string, nodes option.NodeList
 func (bo replicateBulkOps) runDriver(
 	workloadCtx context.Context, c cluster.Cluster, t test.Test, setup *c2cSetup,
 ) error {
-	if c.Cloud() != spec.GCE && !c.IsLocal() {
-		t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-	}
 	runBackupMVCCRangeTombstones(workloadCtx, t, c, mvccRangeTombstoneConfig{
 		skipBackupRestore: true,
 		skipClusterSetup:  true,
@@ -1083,9 +1080,6 @@ func c2cRegisterWrapper(
 }
 
 func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster.Cluster) {
-	if !c.IsLocal() {
-		t.Skip("c2c/acceptance is only meant to run on a local cluster")
-	}
 	sp := replicationSpec{
 		srcNodes: 1,
 		dstNodes: 1,
@@ -1345,7 +1339,6 @@ func registerClusterToCluster(r registry.Registry) {
 			skip:                      "used for debugging when the full test fails",
 		},
 	} {
-		sp := sp
 		c2cRegisterWrapper(r, sp,
 			func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				rd := makeReplicationDriver(t, c, sp)

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -192,16 +192,15 @@ func registerCopy(r registry.Registry) {
 	for _, tc := range testcases {
 		tc := tc
 		r.Add(registry.TestSpec{
-			Name:             fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", tc.rows, tc.nodes, tc.txn),
-			Owner:            registry.OwnerKV,
-			Cluster:          r.MakeClusterSpec(tc.nodes),
-			CompatibleClouds: registry.AllExceptAWS,
+			Name:    fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", tc.rows, tc.nodes, tc.txn),
+			Owner:   registry.OwnerKV,
+			Cluster: r.MakeClusterSpec(tc.nodes),
+			// Uses gs://cockroach-fixtures-us-east1. See:
+			// https://github.com/cockroachdb/cockroach/issues/105968
+			CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Cloud() != spec.GCE && !c.IsLocal() {
-					t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-				}
 				runCopy(ctx, t, c, tc.rows, tc.txn)
 			},
 		})

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -86,16 +86,15 @@ func registerImportNodeShutdown(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "import/nodeShutdown/worker",
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(4),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "import/nodeShutdown/worker",
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(4),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 			gatewayNode := 2
 			nodeToShutdown := 3
@@ -105,16 +104,15 @@ func registerImportNodeShutdown(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:             "import/nodeShutdown/coordinator",
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(4),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "import/nodeShutdown/coordinator",
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(4),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 			gatewayNode := 2
 			nodeToShutdown := 2
@@ -235,19 +233,18 @@ func registerImportTPCH(r registry.Registry) {
 	} {
 		item := item
 		r.Add(registry.TestSpec{
-			Name:              fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
-			Owner:             registry.OwnerSQLQueries,
-			Benchmark:         true,
-			Cluster:           r.MakeClusterSpec(item.nodes),
-			CompatibleClouds:  registry.AllExceptAWS,
+			Name:      fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
+			Owner:     registry.OwnerSQLQueries,
+			Benchmark: true,
+			Cluster:   r.MakeClusterSpec(item.nodes),
+			// Uses gs://cockroach-fixtures-us-east1. See:
+			// https://github.com/cockroachdb/cockroach/issues/105968
+			CompatibleClouds:  registry.Clouds(spec.GCE, spec.Local),
 			Suites:            registry.Suites(registry.Nightly),
 			Timeout:           item.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			Leases:            registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Cloud() != spec.GCE && !c.IsLocal() {
-					t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-				}
 				tick, perfBuf := initBulkJobPerfArtifacts(t.Name(), item.timeout)
 
 				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -32,17 +32,16 @@ import (
 
 func registerImportCancellation(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             `import-cancellation`,
-		Owner:            registry.OwnerSQLQueries,
-		Timeout:          6 * time.Hour,
-		Cluster:          r.MakeClusterSpec(6, spec.CPU(32)),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    `import-cancellation`,
+		Owner:   registry.OwnerSQLQueries,
+		Timeout: 6 * time.Hour,
+		Cluster: r.MakeClusterSpec(6, spec.CPU(32)),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
 			runImportCancellation(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2574,13 +2574,11 @@ func registerBackupMixedVersion(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		RequiresLicense:   true,
 		NativeLibs:        registry.LibGEOS,
-		CompatibleClouds:  registry.AllExceptAWS,
-		Suites:            registry.Suites(registry.Nightly),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
+		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroachdb-backup-testing-long-ttl; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
-
 			roachNodes := c.Range(1, c.Spec().NodeCount-1)
 			workloadNode := c.Node(c.Spec().NodeCount)
 			mvt := mixedversion.NewTest(

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -29,15 +29,14 @@ import (
 
 func registerDeclSchemaChangeCompatMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "schemachange/mixed-versions-compat",
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(1),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "schemachange/mixed-versions-compat",
+		Owner:   registry.OwnerSQLFoundations,
+		Cluster: r.MakeClusterSpec(1),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroach-corpus; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
 			runDeclSchemaChangeCompatMixedVersions(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -150,11 +151,13 @@ func registerMultiTenantTPCH(r registry.Registry) {
 				name += "/enable_direct_scans"
 			}
 			r.Add(registry.TestSpec{
-				Name:             name,
-				Owner:            registry.OwnerSQLQueries,
-				Benchmark:        true,
-				Cluster:          r.MakeClusterSpec(1 /* nodeCount */),
-				CompatibleClouds: registry.CloudsWithServiceRegistration,
+				Name:      name,
+				Owner:     registry.OwnerSQLQueries,
+				Benchmark: true,
+				Cluster:   r.MakeClusterSpec(1 /* nodeCount */),
+				// Uses gs://cockroach-fixtures-us-east1. See:
+				// https://github.com/cockroachdb/cockroach/issues/105968
+				CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 				Suites:           registry.Suites(registry.Nightly),
 				Leases:           registry.MetamorphicLeases,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -29,16 +29,15 @@ import (
 
 func registerSchemaChangeDuringKV(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             `schemachange/during/kv`,
-		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(5),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    `schemachange/during/kv`,
+		Owner:   registry.OwnerSQLFoundations,
+		Cluster: r.MakeClusterSpec(5),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
 			const fixturePath = `gs://cockroach-fixtures-us-east1/workload/tpch/scalefactor=10/backup?AUTH=implicit`
 
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload")

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -335,10 +335,12 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			clusterSpec = r.MakeClusterSpec(numNodes)
 		}
 		r.Add(registry.TestSpec{
-			Name:             fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
-			Owner:            registry.OwnerSQLQueries,
-			Cluster:          clusterSpec,
-			CompatibleClouds: registry.AllExceptAWS,
+			Name:    fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
+			Owner:   registry.OwnerSQLQueries,
+			Cluster: clusterSpec,
+			// Uses gs://cockroach-fixtures-us-east1. See:
+			// https://github.com/cockroachdb/cockroach/issues/105968
+			CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			NativeLibs:       registry.LibGEOS,
@@ -347,9 +349,6 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			// NB: sqlsmith failures should never block a release.
 			NonReleaseBlocker: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				if c.Cloud() != spec.GCE && !c.IsLocal() {
-					t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-				}
 				runSQLSmith(ctx, t, c, setup, setting)
 			},
 			ExtraLabels: []string{"O-rsg"},

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -43,10 +42,6 @@ func loadTPCHDataset(
 	roachNodes option.NodeListOption,
 	disableMergeQueue bool,
 ) (retErr error) {
-	if c.Cloud() != spec.GCE && !c.IsLocal() {
-		t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-	}
-
 	_, err := db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;")
 	if retErr != nil {
 		return err

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -186,16 +186,15 @@ WITH unsafe_restore_incompatible_version;
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "tpcdsvec",
-		Owner:            registry.OwnerSQLQueries,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(3),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      "tpcdsvec",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(3),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.GCE && !c.IsLocal() {
-				t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")
-			}
 			runTPCDSVec(ctx, t, c)
 		},
 	})

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
@@ -203,11 +204,13 @@ func registerTPCHConcurrency(r registry.Registry) {
 	// the overload point, so it cannot withstand any metamorphic perturbations.
 	cockroachBinary := registry.StandardCockroach
 	r.Add(registry.TestSpec{
-		Name:             "tpch_concurrency",
-		Owner:            registry.OwnerSQLQueries,
-		Timeout:          timeout,
-		Cluster:          r.MakeClusterSpec(numNodes),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "tpch_concurrency",
+		Owner:   registry.OwnerSQLQueries,
+		Timeout: timeout,
+		Cluster: r.MakeClusterSpec(numNodes),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		CockroachBinary:  cockroachBinary,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -216,11 +219,13 @@ func registerTPCHConcurrency(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "tpch_concurrency/no_streamer",
-		Owner:            registry.OwnerSQLQueries,
-		Timeout:          timeout,
-		Cluster:          r.MakeClusterSpec(numNodes),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "tpch_concurrency/no_streamer",
+		Owner:   registry.OwnerSQLQueries,
+		Timeout: timeout,
+		Cluster: r.MakeClusterSpec(numNodes),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		CockroachBinary:  cockroachBinary,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -164,11 +165,13 @@ func registerTPCHBenchSpec(r registry.Registry, b tpchBenchSpec) {
 	numNodes := b.Nodes + 1
 
 	r.Add(registry.TestSpec{
-		Name:             strings.Join(nameParts, "/"),
-		Owner:            registry.OwnerSQLQueries,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(numNodes),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      strings.Join(nameParts, "/"),
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(numNodes),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHBench(ctx, t, c, b)

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -584,11 +585,13 @@ const tpchVecNodeCount = 3
 
 func registerTPCHVec(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "tpchvec/perf",
-		Owner:            registry.OwnerSQLQueries,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(tpchVecNodeCount),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      "tpchvec/perf",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
@@ -600,10 +603,12 @@ func registerTPCHVec(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "tpchvec/disk",
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(tpchVecNodeCount),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "tpchvec/disk",
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(tpchVecNodeCount),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, tpchVecDiskTest{})
@@ -611,11 +616,13 @@ func registerTPCHVec(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "tpchvec/streamer",
-		Owner:            registry.OwnerSQLQueries,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(tpchVecNodeCount),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      "tpchvec/streamer",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
@@ -627,11 +634,13 @@ func registerTPCHVec(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "tpchvec/direct_scans",
-		Owner:            registry.OwnerSQLQueries,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(tpchVecNodeCount),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      "tpchvec/direct_scans",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
@@ -643,11 +652,13 @@ func registerTPCHVec(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "tpchvec/direct_scans/mt-shared-process",
-		Owner:            registry.OwnerSQLQueries,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(tpchVecNodeCount),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:      "tpchvec/direct_scans/mt-shared-process",
+		Owner:     registry.OwnerSQLQueries,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(tpchVecNodeCount),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			p := newTpchVecPerfTest(
@@ -665,10 +676,12 @@ func registerTPCHVec(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:             "tpchvec/bench",
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(tpchVecNodeCount),
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    "tpchvec/bench",
+		Owner:   registry.OwnerSQLQueries,
+		Cluster: r.MakeClusterSpec(tpchVecNodeCount),
+		// Uses gs://cockroach-fixtures-us-east1. See:
+		// https://github.com/cockroachdb/cockroach/issues/105968
+		CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 		Suites:           registry.Suites(registry.Nightly),
 		Skip: "This config can be used to perform some benchmarking and is not " +
 			"meant to be run on a nightly basis",


### PR DESCRIPTION
This removes the vast majority of cloud checks during test run time. These checks typically verify whether the test is running in specific (set of) clouds, and then skip the test if it is not.

However, that is purpose of the `CompatibleClouds` field. Declaring cloud compatibility in the cloud spec has the added benefit that the test runner won't assign a cluster to run the test, only to have the test skip itself shortly after.

Epic: none

Release note: None