### PR TITLE
multitenant: allow auto-upgrades to internal versions

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -85,7 +85,6 @@ func testTenantAutoUpgrade(t *testing.T, clusterSetting *autoUpgradeClusterSetti
 
 	expectedInitialTenantVersion := v0.Version()
 	expectedFinalTenantVersion := clusterversion.Latest.Version()
-	expectedFinalTenantVersion.Internal = 0 // tenants only upgrade to non-internal versions
 
 	tenantSettings := cluster.MakeTestingClusterSettingsWithVersions(
 		clusterversion.Latest.Version(),


### PR DESCRIPTION
Previously, tenants would only auto upgrade to non-internal versions (`Internal` field is zero). The rationale is that we only want tenants to start attempting to upgrade when the storage cluster has finished its own upgrades.

However, allowing auto upgrades to internal versions is more consistent with how the storage cluster performs auto upgrades. It's also very helpful while testing upgrades on master.

In this commit, we allow tenants to auto upgrade to any version, as long as we know that the storage cluster version is the same as the latest cluster version known in the tenant's binary.

Fixes: #115045

Release note: None