### PR TITLE
roachtest: only set cluster settings on start for storage cluster

### DIFF
--- a/pkg/roachprod/install/cluster_settings.go
+++ b/pkg/roachprod/install/cluster_settings.go
@@ -29,6 +29,11 @@ type ClusterSettings struct {
 	DebugDir string
 	// ClusterSettings are, eh, actual cluster settings, i.e.
 	// SET CLUSTER SETTING foo = 'bar'. The name clash is unfortunate.
+	//
+	// NOTE: these cluster settings are only applied when starting the
+	// storage cluster. In the future, we could support some kind of
+	// representation that allows the caller to indicate if the setting
+	// also applies to virtual clusters.
 	ClusterSettings map[string]string
 }
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1283,7 +1283,14 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 		"enterprise.license":   config.CockroachDevLicense,
 	}
 	for name, value := range c.ClusterSettings.ClusterSettings {
-		clusterSettings[name] = value
+		// Only set the cluster settings passed when calling `Start` if we
+		// are starting the storage cluster. Setting them unconditionally
+		// would mean only supporting `ApplicationLevel` cluster settings
+		// in this field. That is not easily enforceable and a lot of
+		// tests already use this field to set `SystemOnly` settings.
+		if tenantPrefix == "" {
+			clusterSettings[name] = value
+		}
 	}
 	var clusterSettingsString string
 	for name, value := range clusterSettings {


### PR DESCRIPTION
See comments included in the code for rationale.

Epic: none

Release note: None