### PR TITLE
raft: make unstable a logSlice

### DIFF
--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -37,9 +37,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	lastIndex, err := rn.raft.raftLog.storage.LastIndex()
 	if err != nil {
 		return err
-	}
-
-	if lastIndex != 0 {
+	} else if lastIndex != 0 {
 		return errors.New("can't bootstrap a nonempty Storage")
 	}
 

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -487,11 +487,14 @@ func (l *raftLog) matchTerm(id entryID) bool {
 	return t == id.term
 }
 
-func (l *raftLog) restore(s snapshot) {
+func (l *raftLog) restore(s snapshot) bool {
 	id := s.lastEntryID()
 	l.logger.Infof("log [%s] starts to restore snapshot [index: %d, term: %d]", l, id.index, id.term)
-	l.unstable.restore(s)
+	if !l.unstable.restore(s) {
+		return false
+	}
 	l.committed = id.index
+	return true
 }
 
 // scan visits all log entries in the [lo, hi) range, returning them via the

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -137,10 +137,7 @@ func (l *raftLog) append(a logSlice) bool {
 	if first := a.entries[0].Index; first <= l.committed {
 		l.logger.Panicf("entry %d is already committed [committed(%d)]", first, l.committed)
 	}
-	// TODO(pav-kv): pass the logSlice down the stack, for safety checks and
-	// bookkeeping in the unstable structure.
-	l.unstable.truncateAndAppend(a.entries)
-	return true
+	return l.unstable.truncateAndAppend(a)
 }
 
 // match finds the longest prefix of the given log slice that matches the log.

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -147,16 +147,7 @@ func (l *raftLog) maybeAppend(a logSlice) bool {
 // Returns false if the operation can not be done: entry a.prev does not match
 // the lastEntryID of this log, or a.term is outdated.
 func (l *raftLog) append(a logSlice) bool {
-	if a.prev != l.lastEntryID() {
-		return false
-	}
-	if len(a.entries) == 0 {
-		// TODO(pav-kv): remove this clause and handle it in unstable. The log slice
-		// can carry a newer a.term, which should update our accTerm.
-		return true
-	}
-	// TODO(pav-kv): add unstable.append method which never truncates the log.
-	return l.unstable.truncateAndAppend(a)
+	return l.unstable.append(a)
 }
 
 // match finds the longest prefix of the given log slice that matches the log.

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -343,8 +343,8 @@ func TestHasNextCommittedEnts(t *testing.T) {
 			raftLog.applyingEntsPaused = tt.paused
 			if tt.snap {
 				newSnap := snap
-				newSnap.snap.Metadata.Index++
-				raftLog.restore(newSnap)
+				newSnap.snap.Metadata.Index = init.lastIndex() + 1
+				require.True(t, raftLog.restore(newSnap))
 			}
 			require.Equal(t, tt.whasNext, raftLog.hasNextCommittedEnts(tt.allowUnstable))
 		})
@@ -397,8 +397,8 @@ func TestNextCommittedEnts(t *testing.T) {
 			raftLog.applyingEntsPaused = tt.paused
 			if tt.snap {
 				newSnap := snap
-				newSnap.snap.Metadata.Index++
-				raftLog.restore(newSnap)
+				newSnap.snap.Metadata.Index = init.lastIndex() + 1
+				require.True(t, raftLog.restore(newSnap))
 			}
 			require.Equal(t, tt.wents, raftLog.nextCommittedEnts(tt.allowUnstable))
 		})
@@ -776,10 +776,10 @@ func TestTermWithUnstableSnapshot(t *testing.T) {
 	storage := NewMemoryStorage()
 	storage.ApplySnapshot(pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: storagesnapi, Term: 1}})
 	l := newLog(storage, discardLogger)
-	l.restore(snapshot{
+	require.True(t, l.restore(snapshot{
 		term: 1,
 		snap: pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: unstablesnapi, Term: 1}},
-	})
+	}))
 
 	for _, tt := range []struct {
 		idx  uint64

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -100,6 +100,21 @@ type unstable struct {
 }
 
 func newUnstable(last entryID, logger Logger) unstable {
+	// To initialize the last accepted term (logSlice.term) correctly, we make
+	// sure its invariant is true: the log is a prefix of the term's leader's log.
+	// This can be achieved by conservatively initializing to the term of the last
+	// log entry.
+	//
+	// We can't pick any lower term because the lower term's leader can't have
+	// last.term entries in it. We can't pick a higher term because we don't have
+	// any information about the higher-term leaders and their logs. So last.term
+	// is the only valid choice.
+	//
+	// TODO(pav-kv): persist the accepted term in HardState and load it. Our
+	// initialization is conservative. Before restart, the accepted term could
+	// have been higher. Setting a higher term (ideally, matching the current
+	// leader Term) gives us more information about the log, and then allows
+	// bumping its commit index sooner than when the next MsgApp arrives.
 	return unstable{
 		logSlice:        logSlice{term: last.term, prev: last},
 		entryInProgress: last.index,

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -244,6 +244,19 @@ func (u *unstable) restore(s snapshot) bool {
 	return true
 }
 
+// append adds the given log slice to the end of the log. Returns false if this
+// can not be done.
+func (u *unstable) append(a logSlice) bool {
+	if a.term < u.term {
+		return false // append from an outdated log
+	} else if a.prev != u.lastEntryID() {
+		return false // not a valid append at the end of the log
+	}
+	u.term = a.term // update the last accepted term
+	u.entries = append(u.entries, a.entries...)
+	return true
+}
+
 func (u *unstable) truncateAndAppend(a logSlice) bool {
 	if a.term < u.term {
 		return false // append from an outdated log

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -19,60 +19,91 @@ package raft
 
 import pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 
-// unstable contains "unstable" log entries and snapshot state that has
-// not yet been written to Storage. The type serves two roles. First, it
-// holds on to new log entries and an optional snapshot until they are
-// handed to a Ready struct for persistence. Second, it continues to
-// hold on to this state after it has been handed off to provide raftLog
-// with a view of the in-progress log entries and snapshot until their
-// writes have been stabilized and are guaranteed to be reflected in
-// queries of Storage. After this point, the corresponding log entries
-// and/or snapshot can be cleared from unstable.
+// unstable is a suffix of the raft log pending to be written to Storage. The
+// "log" can be represented by a snapshot, and/or a contiguous slice of entries.
 //
-// unstable.entries[i] has raft log position i+unstable.offset.
-// Note that unstable.offset may be less than the highest log
-// position in storage; this means that the next write to storage
-// might need to truncate the log before persisting unstable.entries.
+// The possible states:
+//  1. Both the snapshot and the entries logSlice are empty. This means the log
+//     is fully in Storage. The logSlice.prev is the lastEntryID of the log.
+//  2. The snapshot is empty, and the logSlice is non-empty. The state up to
+//     (including) logSlice.prev is in Storage, and the logSlice is pending.
+//  3. The snapshot is non-empty, and the logSlice is empty. The snapshot
+//     overrides the entire log in Storage.
+//  4. Both the snapshot and logSlice are non-empty. The snapshot immediately
+//     precedes the entries, i.e. logSlice.prev == snapshot.lastEntryID. This
+//     state overrides the entire log in Storage.
+//
+// The type serves two roles. First, it holds on to the latest snapshot / log
+// entries until they are handed to storage for persistence (via Ready API) and
+// subsequently acknowledged. This provides the RawNode with a consistent view
+// on the latest state of the log: the raftLog struct combines a log prefix from
+// Storage with the suffix held by unstable.
+//
+// Second, it supports the asynchronous log writes protocol. The snapshot and
+// the entries are handed to storage in the order that guarantees consistency of
+// the raftLog. Writes on the storage happen in the same order, and issue
+// acknowledgements delivered back to unstable. On acknowledgement, the snapshot
+// and the entries are released from memory when it is safe to do so. There is
+// no strict requirement on the order of acknowledgement delivery.
+//
+// TODO(pav-kv): describe the order requirements in more detail when accTerm
+// (logSlice.term) is integrated into the protocol.
+//
+// Note that the in-memory prefix of the log can contain entries at indices less
+// than Storage.LastIndex(). This means that the next write to storage might
+// need to truncate the log before persisting the new suffix. Such a situation
+// happens when there is a leader change, and the new leader overwrites entries
+// that haven't been committed yet.
+//
+// TODO(pav-kv): decouple the "in progress" part into a separate struct which
+// drives the storage write protocol.
 type unstable struct {
-	// the incoming unstable snapshot, if any.
+	// snapshot is the pending unstable snapshot, if any.
 	//
-	// Invariants:
-	//	- snapshot == nil ==> !snapshotInProgress
-	//	- snapshot != nil ==> offset == snapshot.Metadata.Index + 1
+	// Invariant: snapshot == nil ==> !snapshotInProgress
+	// Invariant: snapshot != nil ==> snapshot.lastEntryID == logSlice.prev
 	//
 	// The last invariant enforces the order of handling a situation when there is
-	// both a snapshot and entries. The snapshot must be acknowledged first,
-	// before entries are acknowledged and offset moves forward.
+	// both a snapshot and entries. The snapshot write must be acknowledged first,
+	// before entries are acknowledged and the logSlice moves forward.
 	snapshot *pb.Snapshot
-	// all entries that have not yet been written to storage.
-	entries []pb.Entry
-	// entries[i] has raft log position i+offset.
-	offset uint64
 
-	// if true, snapshot is being written to storage.
+	// logSlice is the suffix of the raft log that is not yet written to storage.
+	// If all the entries are written, or covered by the pending snapshot, then
+	// logSlice.entries is empty.
+	//
+	// Invariant: snapshot != nil ==> logSlice.prev == snapshot.lastEntryID
+	// Invariant: snapshot == nil ==> logSlice.prev is in Storage
+	// Invariant: logSlice.lastEntryID() is the end of the log at all times
+	//
+	// Invariant: logSlice.term, a.k.a. the "last accepted term", is the term of
+	// the leader whose append (either entries or snapshot) we accepted last. Our
+	// state is consistent with the leader log at this term.
+	logSlice
+
+	// snapshotInProgress is true if the snapshot is being written to storage.
 	//
 	// Invariant: snapshotInProgress ==> snapshot != nil
 	snapshotInProgress bool
-	// entries[:offsetInProgress-offset] are being written to storage.
-	// Like offset, offsetInProgress is exclusive, meaning that it
-	// contains the index following the largest in-progress entry.
+	// entryInProgress is the index of the last entry in logSlice already present
+	// in, or being written to storage.
 	//
-	// Invariant: offset <= offsetInProgress
-	// Invariant: offsetInProgress - offset <= len(entries)
-	// Invariant: offsetInProgress > offset ==> snapshot == nil || snapshotInProgress
+	// Invariant: prev.index <= entryInProgress <= lastIndex()
+	// Invariant: entryInProgress > prev.index && snapshot != nil ==> snapshotInProgress
 	//
 	// The last invariant enforces the order of handling a situation when there is
-	// both a snapshot and entries. The snapshot must be sent to storage first.
-	offsetInProgress uint64
+	// both a snapshot and entries. The snapshot must be sent to storage first, or
+	// together with the entries.
+	entryInProgress uint64
 
 	logger Logger
 }
 
-func newUnstable(offset uint64, logger Logger) unstable {
+func newUnstable(last entryID, logger Logger) unstable {
 	return unstable{
-		offset:           offset,
-		offsetInProgress: offset,
-		logger:           logger,
+		logSlice:        logSlice{term: last.term, prev: last},
+		entryInProgress: last.index,
+		logger:          logger,
 	}
 }
 
@@ -85,47 +116,21 @@ func (u *unstable) maybeFirstIndex() (uint64, bool) {
 	return 0, false
 }
 
-// maybeLastIndex returns the last index if it has at least one
-// unstable entry or snapshot.
-func (u *unstable) maybeLastIndex() (uint64, bool) {
-	if l := len(u.entries); l != 0 {
-		return u.offset + uint64(l) - 1, true
-	}
-	if u.snapshot != nil {
-		return u.snapshot.Metadata.Index, true
-	}
-	return 0, false
-}
-
-// maybeTerm returns the term of the entry at index i, if there
-// is any.
+// maybeTerm returns the term of the entry at index i, if there is any.
 func (u *unstable) maybeTerm(i uint64) (uint64, bool) {
-	if i < u.offset {
-		if u.snapshot != nil && u.snapshot.Metadata.Index == i {
-			return u.snapshot.Metadata.Term, true
-		}
+	if i < u.prev.index || i > u.lastIndex() {
 		return 0, false
 	}
-
-	last, ok := u.maybeLastIndex()
-	if !ok {
-		return 0, false
-	}
-	if i > last {
-		return 0, false
-	}
-
-	return u.entries[i-u.offset].Term, true
+	return u.termAt(i), true
 }
 
 // nextEntries returns the unstable entries that are not already in the process
 // of being written to storage.
 func (u *unstable) nextEntries() []pb.Entry {
-	inProgress := int(u.offsetInProgress - u.offset)
-	if len(u.entries) == inProgress {
+	if u.entryInProgress == u.lastIndex() {
 		return nil
 	}
-	return u.entries[inProgress:]
+	return u.entries[u.entryInProgress-u.prev.index:]
 }
 
 // nextSnapshot returns the unstable snapshot, if one exists that is not already
@@ -143,13 +148,8 @@ func (u *unstable) nextSnapshot() *pb.Snapshot {
 // entries/snapshots added after a call to acceptInProgress will be returned
 // from those methods, until the next call to acceptInProgress.
 func (u *unstable) acceptInProgress() {
-	if u.snapshot != nil {
-		u.snapshotInProgress = true
-	}
-	if len(u.entries) > 0 {
-		// NOTE: +1 because offsetInProgress is exclusive, like offset.
-		u.offsetInProgress = u.entries[len(u.entries)-1].Index + 1
-	}
+	u.snapshotInProgress = u.snapshot != nil
+	u.entryInProgress = u.lastIndex()
 }
 
 // stableTo marks entries up to the entry with the specified (index, term) as
@@ -159,34 +159,34 @@ func (u *unstable) acceptInProgress() {
 // can not be overwritten by an in-progress log append. See the related comment
 // in newStorageAppendRespMsg.
 func (u *unstable) stableTo(id entryID) {
-	gt, ok := u.maybeTerm(id.index)
-	if !ok {
-		// Unstable entry missing. Ignore.
-		u.logger.Infof("entry at index %d missing from unstable log; ignoring", id.index)
-		return
-	}
-	if id.index < u.offset {
+	if u.snapshot != nil && id.index == u.snapshot.Metadata.Index {
 		// Index matched unstable snapshot, not unstable entry. Ignore.
 		u.logger.Infof("entry at index %d matched unstable snapshot; ignoring", id.index)
 		return
 	}
-	if gt != id.term {
+	if id.index <= u.prev.index || id.index > u.lastIndex() {
+		// Unstable entry missing. Ignore.
+		u.logger.Infof("entry at index %d missing from unstable log; ignoring", id.index)
+		return
+	}
+	if term := u.termAt(id.index); term != id.term {
 		// Term mismatch between unstable entry and specified entry. Ignore.
 		// This is possible if part or all of the unstable log was replaced
 		// between that time that a set of entries started to be written to
 		// stable storage and when they finished.
 		u.logger.Infof("entry at (index,term)=(%d,%d) mismatched with "+
-			"entry at (%d,%d) in unstable log; ignoring", id.index, id.term, id.index, gt)
+			"entry at (%d,%d) in unstable log; ignoring", id.index, id.term, id.index, term)
 		return
 	}
 	if u.snapshot != nil {
 		u.logger.Panicf("entry %+v acked earlier than the snapshot(in-progress=%t): %s",
 			id, u.snapshotInProgress, DescribeSnapshot(*u.snapshot))
 	}
-	num := int(id.index + 1 - u.offset)
-	u.entries = u.entries[num:]
-	u.offset = id.index + 1
-	u.offsetInProgress = max(u.offsetInProgress, u.offset)
+	u.logSlice = u.forward(id.index)
+	// TODO(pav-kv): why can id.index overtake u.entryInProgress? Probably bugs in
+	// tests using the log writes incorrectly, e.g. TestLeaderStartReplication
+	// takes nextUnstableEnts() without acceptInProgress().
+	u.entryInProgress = max(u.entryInProgress, id.index)
 	u.shrinkEntriesArray()
 }
 
@@ -211,20 +211,21 @@ func (u *unstable) shrinkEntriesArray() {
 
 func (u *unstable) stableSnapTo(i uint64) {
 	if u.snapshot != nil && u.snapshot.Metadata.Index == i {
-		u.snapshot = nil
 		u.snapshotInProgress = false
+		u.snapshot = nil
 	}
 }
 
+// restore resets the state to the given snapshot. It effectively truncates the
+// log after s.lastEntryID(), so the caller must ensure this is safe.
 func (u *unstable) restore(s snapshot) {
 	// TODO(pav-kv): add a safety check making sure the snapshot does not regress
 	// the logMark of unstable. The ("accepted term", lastIndex) is the logical
 	// clock that must not regress.
-	u.offset = s.lastIndex() + 1
-	u.offsetInProgress = u.offset
-	u.entries = nil
 	u.snapshot = &s.snap
+	u.logSlice = logSlice{term: s.term, prev: s.lastEntryID()}
 	u.snapshotInProgress = false
+	u.entryInProgress = u.prev.index
 }
 
 func (u *unstable) truncateAndAppend(a logSlice) bool {
@@ -245,25 +246,22 @@ func (u *unstable) truncateAndAppend(a logSlice) bool {
 	}
 
 	switch {
-	case fromIndex == u.offset+uint64(len(u.entries)):
-		// fromIndex is the next index in the u.entries, so append directly.
+	case a.prev.index == u.lastIndex(): // append at the end of the log
 		u.entries = append(u.entries, a.entries...)
-	case fromIndex <= u.offset:
+	case a.prev.index <= u.prev.index:
 		u.logger.Infof("replace the unstable entries from index %d", fromIndex)
-		// The log is being truncated to before our current offset
-		// portion, so set the offset and replace the entries.
-		u.entries = a.entries
-		u.offset = fromIndex
-		u.offsetInProgress = u.offset
+		// The unstable log is truncated entirely. Replace the logSlice wholesale.
+		u.logSlice = a
+		u.entryInProgress = a.prev.index
 	default:
-		// Truncate to fromIndex (exclusive), and append the new entries.
+		// The unstable log is truncated partially, after entry a.prev.
 		u.logger.Infof("truncate the unstable entries before index %d", fromIndex)
-		keep := u.slice(u.offset, fromIndex)   // NB: appending to this slice is safe,
-		u.entries = append(keep, a.entries...) // and will reallocate/copy it
-		// Only in-progress entries before fromIndex are still considered to be
-		// in-progress.
-		u.offsetInProgress = min(u.offsetInProgress, fromIndex)
+		keep := u.slice(u.prev.index+1, fromIndex) // NB: appending to this slice is safe,
+		u.entries = append(keep, a.entries...)     // and will reallocate/copy it
+		// Only entries up to a.prev are still considered to be in-progress.
+		u.entryInProgress = min(u.entryInProgress, a.prev.index)
 	}
+	u.term = a.term // update the last accepted term
 	return true
 }
 
@@ -280,16 +278,20 @@ func (u *unstable) slice(lo uint64, hi uint64) []pb.Entry {
 	// NB: use the full slice expression to limit what the caller can do with the
 	// returned slice. For example, an append will reallocate and copy this slice
 	// instead of corrupting the neighbouring u.entries.
-	return u.entries[lo-u.offset : hi-u.offset : hi-u.offset]
+	offset := u.prev.index + 1
+	return u.entries[lo-offset : hi-offset : hi-offset]
 }
 
-// u.offset <= lo <= hi <= u.offset+len(u.entries)
+// mustCheckOutOfBounds checks that [lo, hi) interval is included in
+// (u.prev.index, u.lastIndex()].
+// Equivalently, u.prev.index + 1 <= lo <= hi <= u.lastIndex() + 1.
+//
+// TODO(pav-kv): the callers check this already. Remove.
 func (u *unstable) mustCheckOutOfBounds(lo, hi uint64) {
 	if lo > hi {
 		u.logger.Panicf("invalid unstable.slice %d > %d", lo, hi)
 	}
-	upper := u.offset + uint64(len(u.entries))
-	if lo < u.offset || hi > upper {
-		u.logger.Panicf("unstable.slice[%d,%d) out of bound [%d,%d]", lo, hi, u.offset, upper)
+	if last := u.lastIndex(); lo <= u.prev.index || hi > last+1 {
+		u.logger.Panicf("unstable.slice[%d,%d) out of bound (%d,%d]", lo, hi, u.prev.index, last)
 	}
 }

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -198,7 +198,7 @@ func TestUnstableRestore(t *testing.T) {
 		term: 2,
 		snap: pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 6, Term: 2}},
 	}
-	u.restore(s)
+	require.True(t, u.restore(s))
 	u.checkInvariants(t)
 
 	require.Equal(t, uint64(6), u.entryInProgress)

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -18,7 +18,6 @@
 package raft
 
 import (
-	"fmt"
 	"testing"
 
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -43,7 +42,7 @@ func (u *unstable) checkInvariants(t testing.TB) {
 }
 
 func TestUnstableMaybeFirstIndex(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries []pb.Entry
 		offset  uint64
 		snap    *pb.Snapshot
@@ -69,10 +68,8 @@ func TestUnstableMaybeFirstIndex(t *testing.T) {
 			[]pb.Entry{}, 5, &pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 4, Term: 1}},
 			true, 5,
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snap
 			u.entries = tt.entries
@@ -86,7 +83,7 @@ func TestUnstableMaybeFirstIndex(t *testing.T) {
 }
 
 func TestMaybeLastIndex(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries []pb.Entry
 		offset  uint64
 		snap    *pb.Snapshot
@@ -113,10 +110,8 @@ func TestMaybeLastIndex(t *testing.T) {
 			[]pb.Entry{}, 0, nil,
 			false, 0,
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snap
 			u.entries = tt.entries
@@ -130,7 +125,7 @@ func TestMaybeLastIndex(t *testing.T) {
 }
 
 func TestUnstableMaybeTerm(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries []pb.Entry
 		offset  uint64
 		snap    *pb.Snapshot
@@ -191,10 +186,8 @@ func TestUnstableMaybeTerm(t *testing.T) {
 			5,
 			false, 0,
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snap
 			u.entries = tt.entries
@@ -233,7 +226,7 @@ func TestUnstableRestore(t *testing.T) {
 }
 
 func TestUnstableNextEntries(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries          []pb.Entry
 		offset           uint64
 		offsetInProgress uint64
@@ -255,10 +248,8 @@ func TestUnstableNextEntries(t *testing.T) {
 			index(5).terms(1, 1), 5, 7,
 			nil, // nil, not empty slice
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.entries = tt.entries
 			u.offsetInProgress = tt.offsetInProgress
@@ -270,7 +261,7 @@ func TestUnstableNextEntries(t *testing.T) {
 
 func TestUnstableNextSnapshot(t *testing.T) {
 	s := &pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 4, Term: 1}}
-	tests := []struct {
+	for _, tt := range []struct {
 		offset             uint64
 		snapshot           *pb.Snapshot
 		snapshotInProgress bool
@@ -292,10 +283,8 @@ func TestUnstableNextSnapshot(t *testing.T) {
 			5, s, true,
 			nil,
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snapshot
 			u.snapshotInProgress = tt.snapshotInProgress
@@ -306,7 +295,7 @@ func TestUnstableNextSnapshot(t *testing.T) {
 }
 
 func TestUnstableAcceptInProgress(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries            []pb.Entry
 		snapshot           *pb.Snapshot
 		offset             uint64
@@ -395,10 +384,8 @@ func TestUnstableAcceptInProgress(t *testing.T) {
 			true, // snapshot already in progress
 			7, true,
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snapshot
 			u.entries = tt.entries
@@ -415,7 +402,7 @@ func TestUnstableAcceptInProgress(t *testing.T) {
 }
 
 func TestUnstableStableTo(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries          []pb.Entry
 		offset           uint64
 		offsetInProgress uint64
@@ -492,10 +479,8 @@ func TestUnstableStableTo(t *testing.T) {
 			4, 1, // stable to old entry
 			5, 6, 1,
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snap
 			u.entries = tt.entries
@@ -517,7 +502,7 @@ func TestUnstableStableTo(t *testing.T) {
 }
 
 func TestUnstableTruncateAndAppend(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		entries          []pb.Entry
 		offset           uint64
 		offsetInProgress uint64
@@ -576,10 +561,8 @@ func TestUnstableTruncateAndAppend(t *testing.T) {
 			index(6).terms(2),
 			5, 6, index(5).terms(1, 2),
 		},
-	}
-
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+	} {
+		t.Run("", func(t *testing.T) {
 			u := newUnstable(tt.offset, raftLogger)
 			u.snapshot = tt.snap
 			u.entries = tt.entries

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -579,7 +579,7 @@ func TestUnstableTruncateAndAppend(t *testing.T) {
 			u.snapshotInProgress = u.snapshot != nil && u.offsetInProgress > u.offset
 			u.checkInvariants(t)
 
-			u.truncateAndAppend(tt.app.entries)
+			u.truncateAndAppend(tt.app)
 			u.checkInvariants(t)
 			require.Equal(t, tt.want.prev.index+1, u.offset)
 			require.Equal(t, tt.want.entries, u.entries)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1892,7 +1892,10 @@ func (r *raft) restore(s snapshot) bool {
 		return false
 	}
 
-	r.raftLog.restore(s)
+	if !r.raftLog.restore(s) {
+		r.logger.Errorf("%x unable to restore snapshot [index: %d, term: %d]", r.id, id.index, id.term)
+		return false
+	}
 
 	// Reset the configuration and add the (potentially updated) peers in anew.
 	r.trk = tracker.MakeProgressTracker(r.trk.MaxInflight, r.trk.MaxInflightBytes)

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1104,7 +1104,7 @@ func TestHandleMsgApp(t *testing.T) {
 
 		// Ensure 2
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 1}, 2, 1, false},
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 0, Index: 0, Commit: 1, Entries: []pb.Entry{{Index: 1, Term: 2}}}, 1, 1, false},
+		{pb.Message{Type: pb.MsgApp, Term: 3, LogTerm: 0, Index: 0, Commit: 1, Entries: []pb.Entry{{Index: 1, Term: 3}}}, 1, 1, false},
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 3, Entries: []pb.Entry{{Index: 3, Term: 2}, {Index: 4, Term: 2}}}, 4, 3, false},
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 4, Entries: []pb.Entry{{Index: 3, Term: 2}}}, 3, 3, false},
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 4, Entries: []pb.Entry{{Index: 2, Term: 2}}}, 2, 2, false},


### PR DESCRIPTION
This PR refactors `raft.unstable` data structure to be a type-safe `logSlice`, and equips it with safety checks protecting the log append stack from appends that do not comply with the expected raft behaviours.

One immediate benefit of doing so is that `unstable` now knows the `lastEntryID` at all times, whereas previously it would fall back to fetching it from `Storage` interface when empty.

The second benefit is introducing the `logSlice.term` field, which carries strong semantics: the log is consistent with the leader log at this term. This allows implementing safety checks in append methods, preventing log truncations when not expected. Log truncations in raft can only happen when accepting a higher-term log append.

The `logSlice.term` field replaces `raft.accTerm`.

Part of #124440