### PR TITLE
roachprod-microbench: add clean command

### DIFF
--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "roachprod-microbench_lib",
     srcs = [
+        "clean.go",
         "compare.go",
         "executor.go",
         "export.go",

--- a/pkg/cmd/roachprod-microbench/clean.go
+++ b/pkg/cmd/roachprod-microbench/clean.go
@@ -1,0 +1,85 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+type cleanConfig struct {
+	inputFilePath  string
+	outputFilePath string
+}
+
+type clean struct {
+	cleanConfig
+	inputFile *os.File
+}
+
+func defaultCleanConfig() cleanConfig {
+	return cleanConfig{
+		inputFilePath:  "",
+		outputFilePath: "",
+	}
+}
+
+func newClean(config cleanConfig) (*clean, error) {
+	file, err := os.Open(config.inputFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clean{cleanConfig: config, inputFile: file}, nil
+}
+
+func (c *clean) writeCleanOutputToFile(cleanedBenchmarkOutputLog benchmarkExtractionResult) error {
+
+	if err := os.MkdirAll(filepath.Dir(c.outputFilePath), os.ModePerm); err != nil {
+		return err
+	}
+
+	outputFile, err := os.Create(c.outputFilePath)
+	if err != nil {
+		return err
+	}
+	defer outputFile.Close()
+
+	for _, benchmarkResult := range cleanedBenchmarkOutputLog.results {
+		if _, writeErr := outputFile.WriteString(
+			fmt.Sprintf("%s\n", strings.Join(benchmarkResult, " "))); writeErr != nil {
+			return errors.Wrap(writeErr, "failed to write benchmark result to file")
+		}
+	}
+
+	return nil
+}
+
+func (c *clean) cleanBenchmarkOutputLog() error {
+	defer c.inputFile.Close()
+
+	rawBenchmarkLogs, err := io.ReadAll(c.inputFile)
+	if err != nil {
+		return err
+	}
+
+	cleanedBenchmarkOutputLog := extractBenchmarkResults(string(rawBenchmarkLogs))
+	if err = c.writeCleanOutputToFile(cleanedBenchmarkOutputLog); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -48,7 +48,32 @@ Typical usage:
 	command.AddCommand(makeCompareCommand())
 	command.AddCommand(makeRunCommand())
 	command.AddCommand(makeExportCommand())
+	command.AddCommand(makeCleanCommand())
 
+	return command
+}
+
+func makeCleanCommand() *cobra.Command {
+	config := defaultCleanConfig()
+	runCmdFunc := func(cmd *cobra.Command, commandLine []string) error {
+		args, _ := splitArgsAtDash(cmd, commandLine)
+
+		config.inputFilePath = args[0]
+		config.outputFilePath = args[1]
+		c, err := newClean(config)
+		if err != nil {
+			return err
+		}
+
+		return c.cleanBenchmarkOutputLog()
+	}
+	command := &cobra.Command{
+		Use:   "clean <inputFilePath> <outputFilePath>",
+		Short: "remove noisy logs from the benchmark output and dump it to a file",
+		Long:  `remove noisy logs from the benchmark output and dump it to a file`,
+		Args:  cobra.ExactArgs(2),
+		RunE:  runCmdFunc,
+	}
 	return command
 }
 


### PR DESCRIPTION
Epic: none

Release note: None

This change adds a new utility command to `roachprod-microbench` as part of fixing #106661.