### PR TITLE
storage: remove unnecessarily strict RangeBounds assertion

### DIFF
--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -1049,9 +1049,6 @@ func (i *intentInterleavingIter) HasPointAndRange() (bool, bool) {
 
 // RangeBounds implements SimpleMVCCIterator.
 func (i *intentInterleavingIter) RangeBounds() roachpb.Span {
-	if _, hasRange := i.HasPointAndRange(); !hasRange {
-		return roachpb.Span{}
-	}
 	return i.iter.RangeBounds()
 }
 

--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -143,7 +143,7 @@ func (i *assertionIter) RangeBounds() ([]byte, []byte) {
 		panic(errors.AssertionFailedf("RangeBounds() called on !Valid() pebble.Iterator"))
 	}
 	if _, hasRange := i.Iterator.HasPointAndRange(); !hasRange {
-		panic(errors.AssertionFailedf("RangeBounds() called on pebble.Iterator without range keys"))
+		return nil, nil
 	}
 	// See maybeSaveAndMangleRangeKeyBufs for where these are saved.
 	j := i.rangeKeyBufs.idx


### PR DESCRIPTION
pebble.Iterator permits calling `RangeBounds` when there is no range key.

Epic: none

Release note: None