### PR TITLE
release-23.2: Revert "sql: sort overload functions according to search_path"

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -608,35 +608,3 @@ SELECT nextval('s108297')
 2
 
 subtest end
-
-# Regression test for #124538. User should be able to override built-in functions
-# by moving "pg_catalog" to the back of the search path.
-subtest regression_124538
-
-statement ok
-CREATE FUNCTION now() RETURNS TIMESTAMP STABLE LANGUAGE SQL AS $$ SELECT TIMESTAMP '1999-12-31 23:59:59.999999'; $$;
-
-query B
-SELECT now() > '2024-06-21 19:04:25.625514+00'
-----
-true
-
-statement ok
-SET search_path = public, pg_catalog
-
-query T
-SELECT public.now()
-----
-1999-12-31 23:59:59.999999 +0000 +0000
-
-query T
-SELECT now()
-----
-1999-12-31 23:59:59.999999 +0000 +0000
-
-query B
-SELECT now() > '2024-06-21 19:04:25.625514+00'
-----
-false
-
-subtest end

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -473,7 +473,7 @@ func (sr *schemaResolver) ResolveFunction(
 
 	switch {
 	case builtinDef != nil && routine != nil:
-		return builtinDef.MergeWith(routine, path)
+		return builtinDef.MergeWith(routine)
 	case builtinDef != nil:
 		props, _ := builtinsregistry.GetBuiltinProperties(builtinDef.Name)
 		if props.UnsupportedWithIssue != 0 {
@@ -596,7 +596,7 @@ func maybeLookupRoutine(
 		if !found {
 			continue
 		}
-		udfDef, err = udfDef.MergeWith(curUdfDef, path)
+		udfDef, err = udfDef.MergeWith(curUdfDef)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -233,7 +233,7 @@ func (fd *ResolvedFunctionDefinition) String() string { return AsString(fd) }
 
 // MergeWith is used to merge two UDF definitions with same name.
 func (fd *ResolvedFunctionDefinition) MergeWith(
-	another *ResolvedFunctionDefinition, path SearchPath,
+	another *ResolvedFunctionDefinition,
 ) (*ResolvedFunctionDefinition, error) {
 	if fd == nil {
 		return another, nil
@@ -248,7 +248,7 @@ func (fd *ResolvedFunctionDefinition) MergeWith(
 
 	return &ResolvedFunctionDefinition{
 		Name:      fd.Name,
-		Overloads: combineOverloads(fd.Overloads, another.Overloads, path),
+		Overloads: combineOverloads(fd.Overloads, another.Overloads),
 	}, nil
 }
 
@@ -346,61 +346,8 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 	return ret[0], nil
 }
 
-func combineOverloads(a, b []QualifiedOverload, path SearchPath) []QualifiedOverload {
-	// Corner case: if the path is empty, we can just append a and b.
-	if path == nil || path.NumElements() == 0 {
-		return append(append(make([]QualifiedOverload, 0, len(a)+len(b)), a...), b...)
-	}
-
-	result := make([]QualifiedOverload, 0, len(a)+len(b))
-
-	// Append overloads to the result according to the schema order in the path.
-	isSchemaInSearchPath := make(map[string]bool, path.NumElements())
-	for i := 0; i < path.NumElements(); i++ {
-		schema := path.GetSchema(i)
-		isSchemaInSearchPath[schema] = true
-
-		for _, overload := range a {
-			if overload.Schema == schema {
-				result = append(result, overload)
-			}
-		}
-
-		for _, overload := range b {
-			if overload.Schema == schema {
-				result = append(result, overload)
-			}
-		}
-	}
-
-	// Append any remaining overloads that are not in the path.
-	for _, overload := range a {
-		if _, ok := isSchemaInSearchPath[overload.Schema]; !ok {
-			result = append(result, overload)
-		}
-	}
-
-	for _, overload := range b {
-		if _, ok := isSchemaInSearchPath[overload.Schema]; !ok {
-			result = append(result, overload)
-		}
-	}
-
-	foundUDFOverload := false
-	for _, overload := range result {
-		if overload.Type == UDFRoutine {
-			foundUDFOverload = true
-		}
-	}
-	// When a UDF overload is found, reset the "prefered" attribute.
-	if foundUDFOverload {
-		for i, overload := range result {
-			overload.PreferredOverload = false
-			result[i] = overload
-		}
-	}
-
-	return result
+func combineOverloads(a, b []QualifiedOverload) []QualifiedOverload {
+	return append(append(make([]QualifiedOverload, 0, len(a)+len(b)), a...), b...)
 }
 
 // GetClass returns function class by checking each overload's Class and returns

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -3484,8 +3484,7 @@ func getMostSignificantOverload(
 		schema := searchPath.GetSchema(i)
 		for _, idx := range filter {
 			if r := qualifiedOverloads[idx]; r.Schema == schema {
-				// Only throw "ambiguous function" error for user-defined functions.
-				if found && r.Type == UDFRoutine {
+				if found {
 					return QualifiedOverload{}, ambiguousError()
 				}
 				found = true


### PR DESCRIPTION
This reverts commit 3663ccb312e768aca656d6fc55c7c7a3ec785d77.

This was causing test issues on the 23.2 branch, likely because this fix requires other commits to be backported to work correctly.

Since the bug is not extremely severe, we'll just revert the attempted fix.

fixes https://github.com/cockroachdb/cockroach/issues/126717
fixes https://github.com/cockroachdb/cockroach/issues/126718
Release justification: revert a recent commit
Release note: None