### PR TITLE
sql: fix bugs and improve merging partial and full statistics

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1052,8 +1052,14 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
     "histo_buckets": [
         {
             "distinct_range": 0,
-            "num_eq": 1,
+            "num_eq": 0,
             "num_range": 0,
+            "upper_bound": "-9223372036854775808"
+        },
+        {
+            "distinct_range": 0.5,
+            "num_eq": 1,
+            "num_range": 1,
             "upper_bound": "0"
         },
         {
@@ -1133,6 +1139,12 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
             "num_eq": 1,
             "num_range": 4,
             "upper_bound": "55"
+        },
+        {
+            "distinct_range": 0.5,
+            "num_eq": 0,
+            "num_range": 1,
+            "upper_bound": "9223372036854775807"
         }
     ],
     "histo_col_type": "INT8",
@@ -1158,7 +1170,7 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
         {
             "distinct_range": 9,
             "num_eq": 1,
-            "num_range": 9,
+            "num_range": 10,
             "upper_bound": "10"
         },
         {
@@ -1204,9 +1216,9 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
             "upper_bound": "36"
         },
         {
-            "distinct_range": 2,
+            "distinct_range": 3,
             "num_eq": 1,
-            "num_range": 3,
+            "num_range": 4,
             "upper_bound": "40"
         },
         {
@@ -1261,3 +1273,46 @@ __merged__       {b}           2022-12-13 15:22:21.988179 +0000 UTC  61         
 # Finally, restore forecasts setting to its previous value.
 statement ok
 SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev
+
+# Verify that we can merge partial stats with full stats that have outer
+# buckets.
+statement ok
+SET enable_create_stats_using_extremes = on
+
+statement ok
+CREATE TABLE ka (k INT PRIMARY KEY, a INT, INDEX(a))
+
+statement ok
+INSERT INTO ka select x, x from generate_series(0, 9998) as g(x)
+
+statement ok
+INSERT INTO ka VALUES (9999, NULL)
+
+statement ok
+CREATE STATISTICS ka_fullstat ON a FROM ka
+
+let $hist_id_ka_outer_buckets_full
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE ka] WHERE statistics_name = 'ka_fullstat'
+
+# The full stats collection should have added 2 outer buckets for a total of 202
+# with upper bounds of MaxInt64 and MinInt64.
+query I
+SELECT count(*) FROM [SHOW HISTOGRAM $hist_id_ka_outer_buckets_full]
+----
+202
+
+statement ok
+INSERT INTO ka VALUES (10000, 9999), (10001, 10000)
+
+statement ok
+CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
+ORDER BY statistics_name
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__merged__       {a}           10002      9803            1
+ka_fullstat      {a}           10000      9920            1
+ka_partialstat   {a}           3          3               1

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1052,14 +1052,8 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
     "histo_buckets": [
         {
             "distinct_range": 0,
-            "num_eq": 0,
-            "num_range": 0,
-            "upper_bound": "-9223372036854775808"
-        },
-        {
-            "distinct_range": 0.5,
             "num_eq": 1,
-            "num_range": 1,
+            "num_range": 0,
             "upper_bound": "0"
         },
         {
@@ -1139,12 +1133,6 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
             "num_eq": 1,
             "num_range": 4,
             "upper_bound": "55"
-        },
-        {
-            "distinct_range": 0.5,
-            "num_eq": 0,
-            "num_range": 1,
-            "upper_bound": "9223372036854775807"
         }
     ],
     "histo_col_type": "INT8",
@@ -1170,7 +1158,7 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
         {
             "distinct_range": 9,
             "num_eq": 1,
-            "num_range": 10,
+            "num_range": 9,
             "upper_bound": "10"
         },
         {
@@ -1216,9 +1204,9 @@ WHERE stat->>'name' = '__merged__' ORDER BY stat->>'created_at';
             "upper_bound": "36"
         },
         {
-            "distinct_range": 3,
+            "distinct_range": 2,
             "num_eq": 1,
-            "num_range": 4,
+            "num_range": 3,
             "upper_bound": "40"
         },
         {
@@ -1313,6 +1301,67 @@ FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
 ORDER BY statistics_name
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__merged__       {a}           10002      9803            1
+__merged__       {a}           10002      9922            1
 ka_fullstat      {a}           10000      9920            1
 ka_partialstat   {a}           3          3               1
+
+# Verify that the merged histogram correctly appends the partial stat buckets
+query T
+SELECT jsonb_pretty(bucket)
+FROM (
+SELECT jsonb_array_elements(stat->'histo_buckets') AS bucket
+FROM (
+SELECT jsonb_array_elements(statistics) AS stat FROM [SHOW STATISTICS USING JSON FOR TABLE ka WITH MERGE]
+)
+WHERE stat->>'name' = '__merged__'
+)
+ORDER BY (bucket->>'upper_bound')::INT DESC
+LIMIT 3
+----
+{
+    "distinct_range": 0,
+    "num_eq": 1,
+    "num_range": 0,
+    "upper_bound": "10000"
+}
+{
+    "distinct_range": 0,
+    "num_eq": 1,
+    "num_range": 0,
+    "upper_bound": "9999"
+}
+{
+    "distinct_range": 49.59173044047086,
+    "num_eq": 1,
+    "num_range": 50,
+    "upper_bound": "9998"
+}
+
+# Verify that distinct counts and null counts are merged correctly.
+statement ok
+SET CLUSTER SETTING sql.stats.histogram_samples.count = 10005
+
+statement ok
+INSERT INTO ka VALUES (10002, 10001)
+
+statement ok
+CREATE STATISTICS ka_fullstat ON a FROM ka
+
+statement ok
+INSERT INTO ka VALUES (10003, 10002), (10004, NULL)
+
+statement ok
+CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
+
+query TTIII colnames
+SELECT statistics_name, column_names, row_count, distinct_count, null_count
+FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
+ORDER BY statistics_name
+----
+statistics_name  column_names  row_count  distinct_count  null_count
+__merged__       {a}           10005      9924            2
+ka_fullstat      {a}           10003      9923            1
+ka_partialstat   {a}           3          2               2
+
+statement ok
+RESET CLUSTER SETTING sql.stats.histogram_samples.count

--- a/pkg/sql/stats/merge_test.go
+++ b/pkg/sql/stats/merge_test.go
@@ -49,11 +49,11 @@ func TestMergeStatistics(t *testing.T) {
 		{
 			// Multiple buckets at extremes.
 			initial: &testStat{
-				at: 1, row: 5, dist: 3, null: 0, size: 2,
+				at: 1, row: 5, dist: 5, null: 0, size: 2,
 				hist: testHistogram{
 					{1, 0, 0, 2},
-					{1, 1, 0, 4},
-					{1, 1, 0, 6},
+					{1, 1, 1, 4},
+					{1, 1, 1, 6},
 				},
 			},
 			partial: &testStat{
@@ -66,13 +66,13 @@ func TestMergeStatistics(t *testing.T) {
 				},
 			},
 			expected: &testStat{
-				at: 2, row: 13, dist: 7, null: 0, size: 2,
+				at: 2, row: 13, dist: 9, null: 0, size: 2,
 				hist: testHistogram{
 					{2, 0, 0, 0},
 					{2, 0, 0, 1},
 					{1, 0, 0, 2},
-					{1, 1, 0, 4},
-					{1, 1, 0, 6},
+					{1, 1, 1, 4},
+					{1, 1, 1, 6},
 					{2, 0, 0, 7},
 					{2, 0, 0, 8},
 				},
@@ -228,7 +228,7 @@ func TestMergedStatistics(t *testing.T) {
 			// Simplest case, one newer partial stat for each new full stat.
 			full: []*testStat{
 				{
-					at: 5, row: 14, dist: 13, null: 4, size: 1, colID: 1,
+					at: 5, row: 18, dist: 13, null: 4, size: 1, colID: 1,
 					hist: testHistogram{{1, 3, 3, 30}, {1, 9, 7, 40}},
 				},
 				{


### PR DESCRIPTION
#### sql: ignore outer buckets when merging partial and full statistics

We merge partial stats with full stats by prepending partial histogram buckets with UpperBound less than the first full histogram bucket and appending partial histogram buckets with UpperBounds greater than the last full histogram bucket. This doesn't work when outer buckets exist in either histogram since they have max or min valued UpperBounds, which overlap with the other statistic's buckets.

This commit fixes this by removing outer buckets from both histograms before merging them, and then adjusting counts at the end to add outer buckets back if necessary.

#### sql: fix and improve the computation of merged statistic counts

Previously, we were iterating over the buckets of the merged histogram to compute its RowCount and DistinctCount. We were casting each bucket's DistinctRange count from a float to an int in this loop, which resulted in a final distinct count that was less than expected for the merged stat for larger tables.

This commit fixes this and simplifies the computation of the merged stat counts by using the partial and full stat counts instead of iterating over the merged histogram.

Fixes: #126822
Fixes: #126730

See also: #125950

Release note (bug fix): Fixed a bug when creating partial statistics using extremes (which is disabled by default) where it would occasionally fail to merge the new partial stat with existing full stats. This occurs when outer buckets were added to either statistic to account for extra distinct count. Also fixed a bug where creating partial statistics would result in a merged statistic with inaccurate distinct counts, and made the merged statistic computation more efficient.