### PR TITLE
sql: add pgvector in a couple of missing places

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -623,6 +623,12 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 				return tree.ParseDTSVector(x.(string))
 			},
 		)
+	// case types.PGVectorFamily:
+	//
+	// We could have easily supported PGVector type via stringification, but it
+	// would probably be quite inefficient; thus, in order to not back ourselves
+	// into a corner with compatibility, we choose to return an error instead
+	// for now.
 	case types.EnumFamily:
 		setNullable(
 			avroSchemaString,

--- a/pkg/ccl/logictestccl/testdata/logic_test/vector
+++ b/pkg/ccl/logictestccl/testdata/logic_test/vector
@@ -101,3 +101,9 @@ SELECT l1_distance(v1,v2), l2_distance(v1,v2), cosine_distance(v1,v2), inner_pro
 3     3     2     -2    1     1
 NULL  NULL  NULL  NULL  NULL  NULL
 NULL  NULL  NULL  NULL  1     1
+
+# Regression test for not handling the vector type in a builtin (#126797).
+query T
+SELECT json_build_object('[1, 2]':::VECTOR, 1);
+----
+{"[1,2]": 1}

--- a/pkg/sql/pgwire/testdata/pgtest/pgvector
+++ b/pkg/sql/pgwire/testdata/pgtest/pgvector
@@ -1,0 +1,47 @@
+send
+Query {"String": "DROP TABLE IF EXISTS v"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE v (v VECTOR)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "INSERT INTO v VALUES('[1]'), ('[2,3]')"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# "ResultFormatCodes": [1] = binary
+send
+Parse {"Name": "s", "Query": "SELECT * FROM v"}
+Bind {"DestinationPortal": "p", "PreparedStatement": "s", "ResultFormatCodes": [1]}
+Execute {"Portal": "p"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"000100003f800000"}]}
+{"Type":"DataRow","Values":[{"binary":"000200004000000040400000"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -775,6 +775,16 @@ func writeBinaryDatumNotNull(
 		lengthToWrite := b.Len() - (initialLen + 4)
 		b.putInt32AtIndex(initialLen /* index to write at */, int32(lengthToWrite))
 
+	case *tree.DPGVector:
+		// 2 bytes for dimensions, 2 bytes for unused, and 4 bytes for each
+		// float4.
+		b.putInt32(int32(4 + 4*len(v.T)))
+		b.putInt16(int16(len(v.T)))
+		b.putInt16(int16(0)) // vec->unused - "reserved for future use, always zero"
+		for _, f := range v.T {
+			b.putInt32(int32(math.Float32bits(f)))
+		}
+
 	case *tree.DArray:
 		if v.ParamTyp.Family() == types.ArrayFamily {
 			b.setError(unimplemented.NewWithIssueDetail(32552,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -11257,8 +11257,8 @@ func asJSONBuildObjectKey(
 	case *tree.DBitArray, *tree.DBool, *tree.DBox2D, *tree.DBytes, *tree.DDate,
 		*tree.DDecimal, *tree.DEnum, *tree.DFloat, *tree.DGeography,
 		*tree.DGeometry, *tree.DIPAddr, *tree.DInt, *tree.DInterval, *tree.DOid,
-		*tree.DOidWrapper, *tree.DPGLSN, *tree.DTime, *tree.DTimeTZ, *tree.DTimestamp,
-		*tree.DTSQuery, *tree.DTSVector, *tree.DUuid, *tree.DVoid:
+		*tree.DOidWrapper, *tree.DPGLSN, *tree.DPGVector, *tree.DTime, *tree.DTimeTZ,
+		*tree.DTimestamp, *tree.DTSQuery, *tree.DTSVector, *tree.DUuid, *tree.DVoid:
 		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
 	default:
 		return "", errors.AssertionFailedf("unexpected type %T for key value", d)


### PR DESCRIPTION
This commit expands the recently added support for PGVector to the following places:
- PG binary encoding is now supported (see https://github.com/pgvector/pgvector/blob/8772c8de68cf11fba59b381db8f262951222358f/src/vector.c#L413-L430 for the source code)
- `json_build_object` builtin

It also adds a comment for why we consciously didn't add support for PGVector in CDC avro format.

Fixes: #126797.

Release note: None