### PR TITLE
tree: avoid race on Overload.PreferredOverload

### DIFF
--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -483,11 +483,16 @@ func combineOverloads(a, b []QualifiedOverload, path SearchPath) []QualifiedOver
 			foundUDFOverload = true
 		}
 	}
-	// When a UDF overload is found, reset the "prefered" attribute.
+	// When a UDF overload is found, reset the "preferred" attribute. We need to
+	// copy the overload to avoid modifying the hardcoded definition.
 	if foundUDFOverload {
 		for i, overload := range result {
-			overload.PreferredOverload = false
-			result[i] = overload
+			copiedOverload := *overload.Overload
+			copiedOverload.PreferredOverload = false
+			result[i] = QualifiedOverload{
+				Schema:   overload.Schema,
+				Overload: &copiedOverload,
+			}
 		}
 	}
 


### PR DESCRIPTION
We need to modify the PreferredOverload field if there is a UDF with the same name as a builtin function. However, we should make a copy so that we avoid modifying the hardcoded builtin overload definition.

fixes https://github.com/cockroachdb/cockroach/issues/126789
Release note: None