### PR TITLE
release-24.1: roachtest: clean up acceptance tests

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -262,10 +262,9 @@ func (cs CloudSet) NoAzure() CloudSet {
 }
 
 // Remove removes all clouds passed in and returns the new set.
-func (cs CloudSet) Remove(clouds ...string) CloudSet {
-	assertValidValues(allClouds, clouds...)
+func (cs CloudSet) Remove(clouds CloudSet) CloudSet {
 	copyCs := CloudSet{m: cs.m}
-	for _, c := range clouds {
+	for c := range clouds.m {
 		copyCs.m = removeFromSet(copyCs.m, c)
 	}
 
@@ -286,9 +285,13 @@ func (cs CloudSet) String() string {
 
 // AssertInitialized panics if the CloudSet is the zero value.
 func (cs CloudSet) AssertInitialized() {
-	if cs.m == nil {
+	if !cs.IsInitialized() {
 		panic("CloudSet not initialized")
 	}
+}
+
+func (cs CloudSet) IsInitialized() bool {
+	return cs.m != nil
 }
 
 // Suite names.
@@ -351,7 +354,7 @@ func (ss SuiteSet) String() string {
 
 // AssertInitialized panics if the SuiteSet is the zero value.
 func (ss SuiteSet) AssertInitialized() {
-	if ss.m == nil {
+	if !ss.IsInitialized() {
 		panic("SuiteSet not initialized")
 	}
 }

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1092,7 +1092,6 @@ func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster
 		additionalDuration:        0 * time.Minute,
 		cutover:                   30 * time.Second,
 		skipNodeDistributionCheck: true,
-		clouds:                    registry.AllExceptAWS,
 		suites:                    registry.Suites(registry.Nightly),
 	}
 	rd := makeReplicationDriver(t, c, sp)

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -95,6 +95,7 @@ func RegisterTests(r registry.Registry) {
 	registerLoadSplits(r)
 	registerMVCCGC(r)
 	registerMultiTenantDistSQL(r)
+	registerMultiTenantMultiregion(r)
 	registerMultiTenantTPCH(r)
 	registerMultiTenantUpgrade(r)
 	registerMultiTenantSharedProcess(r)


### PR DESCRIPTION
Backport 1/1 commits from #126775.

/cc @cockroachdb/release

---

Acceptance tests are tests that are run as part of CI. As such, they need to be compatible with roachtest local, otherwise there's no point in declaring them as "acceptance".

This commit enforces that requirement, and removes tests that are registered as `acceptance` but don't fit these criteria.

Epic: none

Release note: None

Release justification: test only changes.
