### PR TITLE
release-24.1: sql: has_*_privilege functions should work on the public role

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -197,3 +197,17 @@ test           sc102962     root     ALL             true
 
 statement error pgcode 2BP01 pq: cannot drop role/user r102962: grants still exist on test.sc102962
 DROP ROLE r102962
+
+subtest has_*_privilege_works_for_public
+
+statement ok
+CREATE SCHEMA roachema;
+GRANT USAGE ON SCHEMA roachema TO public;
+
+query B colnames
+SELECT has_schema_privilege('public', 'roachema', 'USAGE');
+----
+has_schema_privilege
+true
+
+subtest end

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -406,6 +406,7 @@ func makePGPrivilegeInquiryDef(
 				if withUser {
 					arg := eval.UnwrapDatum(ctx, evalCtx, args[0])
 					userS, err := getNameForArg(ctx, evalCtx, arg, "pg_roles", "rolname")
+
 					if err != nil {
 						return nil, err
 					}
@@ -468,8 +469,19 @@ func getNameForArg(
 	var query string
 	switch t := arg.(type) {
 	case *tree.DString:
+		u, err := username.MakeSQLUsernameFromUserInput(string(*t), username.PurposeValidation)
+		if err != nil {
+			return "", err
+		}
+		if u == username.PublicRoleName() {
+			return username.PublicRole, nil
+		}
+		arg = tree.NewDString(u.Normalized())
 		query = fmt.Sprintf("SELECT %s FROM pg_catalog.%s WHERE %s = $1 LIMIT 1", pgCol, pgTable, pgCol)
 	case *tree.DOid:
+		if t.Oid == username.PublicRoleID {
+			return username.PublicRole, nil
+		}
 		query = fmt.Sprintf("SELECT %s FROM pg_catalog.%s WHERE oid = $1 LIMIT 1", pgCol, pgTable)
 	default:
 		return "", errors.AssertionFailedf("unexpected arg type %T", t)


### PR DESCRIPTION
Backport 1/1 commits from #126211.

/cc @cockroachdb/release

---

Builtin functions such as has_database_privilege didn't work if you inspect the public role. Added an if statement that checks if the username parameter is public that we do not abort and continue with the username set as public.

Fixes: #122205
Release note (bug fix): Fixed postgres incompatibility bug when inputting public as user name for builtin functions such as has_database_privilege and has_schema_privilege.

Release justification: Bug fix.
