### PR TITLE
release-23.1: sql: has_*_privilege functions should work on the public role

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -195,3 +195,17 @@ test           sc102962     root     ALL             true
 
 statement error pgcode 2BP01 pq: cannot drop role/user r102962: grants still exist on test.sc102962
 DROP ROLE r102962
+
+subtest has_*_privilege_works_for_public
+
+statement ok
+CREATE SCHEMA roachema;
+GRANT USAGE ON SCHEMA roachema TO public;
+
+query B colnames
+SELECT has_schema_privilege('public', 'roachema', 'USAGE');
+----
+has_schema_privilege
+true
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #126211.

/cc @cockroachdb/release

---

Builtin functions such as has_database_privilege didn't work if you inspect the public role. Added an if statement that checks if the username parameter is public that we do not abort and continue with the username set as public.

Fixes: #122205
Release note (bug fix): Fixed postgres incompatibility bug when inputting public as user name for builtin functions such as has_database_privilege and has_schema_privilege.

Release justification: Bug fix.
