### PR TITLE
sql: do not generate range scans of virtual indexes

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -75,7 +75,7 @@ exp,benchmark
 4,Jobs/non_admin_show_jobs
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types
-6,ORMQueries/column_descriptions_json_agg
+4,ORMQueries/column_descriptions_json_agg
 4,ORMQueries/django_column_introspection_1_table
 4,ORMQueries/django_column_introspection_4_tables
 4,ORMQueries/django_column_introspection_8_tables

--- a/pkg/kv/kvserver/testdata/flow_control_integration/split_merge
+++ b/pkg/kv/kvserver/testdata/flow_control_integration/split_merge
@@ -45,7 +45,7 @@ ORDER BY name ASC;
 SELECT range_id, count(*) AS streams
     FROM crdb_internal.kv_flow_control_handles
 GROUP BY (range_id)
-ORDER BY streams DESC;
+ORDER BY 1, 2;
 
   range_id | stream_count  
 -----------+---------------

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -427,30 +427,27 @@ vectorized: true
         │       │           │   └── • virtual table
         │       │           │         table: pg_namespace@primary
         │       │           │
-        │       │           └── • merge join (left outer)
+        │       │           └── • hash join (left outer)
         │       │               │ equality: (oid) = (objoid)
         │       │               │
         │       │               ├── • filter
         │       │               │   │ filter: relkind IN ('S', 'm', __more1_10__, 'v')
         │       │               │   │
         │       │               │   └── • virtual table
-        │       │               │         table: pg_class@pg_class_oid_idx
+        │       │               │         table: pg_class@primary
         │       │               │
-        │       │               └── • sort
-        │       │                   │ order: +objoid
+        │       │               └── • render
         │       │                   │
-        │       │                   └── • render
+        │       │                   └── • filter
+        │       │                       │ filter: objsubid = 0
         │       │                       │
-        │       │                       └── • filter
-        │       │                           │ filter: objsubid = 0
+        │       │                       └── • render
         │       │                           │
-        │       │                           └── • render
+        │       │                           └── • filter
+        │       │                               │ filter: classoid = 4294967091
         │       │                               │
-        │       │                               └── • filter
-        │       │                                   │ filter: classoid = 4294967091
-        │       │                                   │
-        │       │                                   └── • virtual table
-        │       │                                         table: kv_catalog_comments@primary
+        │       │                               └── • virtual table
+        │       │                                     table: kv_catalog_comments@primary
         │       │
         │       └── • virtual table
         │             table: table_row_statistics@primary

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -517,11 +517,12 @@ EXPLAIN SELECT oid, typname FROM pg_type ORDER BY oid LIMIT 10
 distribution: local
 vectorized: true
 ·
-• limit
-│ count: 10
+• top-k
+│ order: +oid
+│ k: 10
 │
 └── • virtual table
-      table: pg_type@pg_type_oid_idx
+      table: pg_type@primary
 
 # A limit can be pushed into the scan of a virtual table without ORDER BY.
 query T
@@ -542,12 +543,15 @@ EXPLAIN SELECT oid, typname FROM pg_type WHERE OID BETWEEN 1 AND 1000 ORDER BY o
 distribution: local
 vectorized: true
 ·
-• limit
-│ count: 10
+• top-k
+│ order: +oid
+│ k: 10
 │
-└── • virtual table
-      table: pg_type@pg_type_oid_idx
-      spans: [/1 - /1000]
+└── • filter
+    │ filter: (oid >= 1) AND (oid <= 1000)
+    │
+    └── • virtual table
+          table: pg_type@primary
 
 # Regression test for #69685 - a limit cannot be pushed below a window function
 # if its order-by references the window function.

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -159,24 +159,23 @@ vectorized: true
                     └── • render
                         │
                         └── • merge join
-                            │ equality: (oid) = (confrelid)
+                            │ equality: (oid) = (conrelid)
                             │
-                            ├── • virtual table
-                            │     table: pg_class@pg_class_oid_idx
+                            ├── • filter
+                            │   │ filter: oid = 'b'::REGCLASS
+                            │   │
+                            │   └── • virtual table
+                            │         table: pg_class@primary
                             │
                             └── • virtual table lookup join
                                 │ table: pg_class@pg_class_oid_idx
-                                │ equality: (conrelid) = (oid)
-                                │ pred: oid = 'b'::REGCLASS
+                                │ equality: (confrelid) = (oid)
                                 │
-                                └── • sort
-                                    │ order: +confrelid
+                                └── • filter
+                                    │ filter: (conrelid = 'b'::REGCLASS) AND (contype = 'f')
                                     │
-                                    └── • filter
-                                        │ filter: (conrelid = 'b'::REGCLASS) AND (contype = 'f')
-                                        │
-                                        └── • virtual table
-                                              table: pg_constraint@primary
+                                    └── • virtual table
+                                          table: pg_constraint@primary
 
 # Test that limits are respected.
 query T
@@ -529,3 +528,17 @@ vectorized: true
 
 statement ok
 RESET disallow_full_table_scans;
+
+# Verify that we're not fooling ourselves by showing that we can use a virtual
+# index when we actually can't (#108317).
+query T
+EXPLAIN SELECT * FROM crdb_internal.system_jobs WHERE id > 100;
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: id > 100
+│
+└── • virtual table
+      table: system_jobs@primary

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -561,6 +561,11 @@ func (c *CustomFuncs) GenerateLimitedGroupByScans(
 		if len(constProj) != 0 {
 			panic(errors.AssertionFailedf("expected constProj to be empty"))
 		}
+		if sp.IsVirtualTable(c.e.mem.Metadata()) {
+			if !c.IsVirtualIndexScanSupported(index, sp.Constraint) {
+				return
+			}
+		}
 
 		// If the secondary index includes the set of needed columns, then this
 		// case does not need a limited group by and will be covered in

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -128,6 +128,11 @@ func (c *CustomFuncs) GenerateLimitedScans(
 		if len(constProj) != 0 {
 			panic(errors.AssertionFailedf("expected constProj to be empty"))
 		}
+		if scanPrivate.IsVirtualTable(c.e.mem.Metadata()) {
+			if !c.IsVirtualIndexScanSupported(index, scanPrivate.Constraint) {
+				return
+			}
+		}
 
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Distribution.Regions = nil
@@ -296,6 +301,11 @@ func (c *CustomFuncs) GenerateLimitedTopKScans(
 		// panic to avoid performing a logically incorrect transformation.
 		if len(constProj) != 0 {
 			panic(errors.AssertionFailedf("expected constProj to be empty"))
+		}
+		if sp.IsVirtualTable(c.e.mem.Metadata()) {
+			if !c.IsVirtualIndexScanSupported(index, sp.Constraint) {
+				return
+			}
 		}
 
 		// If the secondary index includes the set of needed columns, then this

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -109,6 +109,12 @@ func (c *CustomFuncs) GeneratePartialIndexScans(
 	var iter scanIndexIter
 	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, scanPrivate, filters, rejectNonPartialIndexes|rejectInvertedIndexes)
 	iter.ForEach(func(index cat.Index, remainingFilters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool, constProj memo.ProjectionsExpr) {
+		if scanPrivate.IsVirtualTable(c.e.mem.Metadata()) {
+			if !c.IsVirtualIndexScanSupported(index, scanPrivate.Constraint) {
+				return
+			}
+		}
+
 		var sb indexScanBuilder
 		sb.Init(c, scanPrivate.Table)
 		newScanPrivate := *scanPrivate
@@ -476,6 +482,12 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 						return
 					}
 				}
+			}
+		}
+
+		if scanPrivate.IsVirtualTable(c.e.mem.Metadata()) {
+			if !c.IsVirtualIndexScanSupported(index, combinedConstraint) {
+				return
 			}
 		}
 

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -993,35 +993,28 @@ WHERE
 project
  ├── columns: attname:3!null atttypid:4!null typbasetype:53 typtype:35
  ├── stats: [rows=198]
- ├── cost: 2928.23877
- └── inner-join (merge)
+ ├── cost: 2929.32
+ └── inner-join (hash)
       ├── columns: attname:3!null atttypid:4!null oid:29!null typtype:35 typbasetype:53
-      ├── left ordering: +29
-      ├── right ordering: +4
       ├── stats: [rows=198, distinct(4)=17.2927, null(4)=0, distinct(29)=17.2927, null(29)=0]
-      ├── cost: 2926.23877
+      ├── cost: 2927.32
       ├── fd: (4)==(29), (29)==(4)
-      ├── scan pg_type@pg_type_oid_idx [as=t]
+      ├── scan pg_type [as=t]
       │    ├── columns: oid:29!null typtype:35 typbasetype:53
       │    ├── stats: [rows=1000, distinct(29)=100, null(29)=0]
-      │    ├── cost: 1481.52
-      │    └── ordering: +29
-      ├── sort
+      │    └── cost: 1481.52
+      ├── select
       │    ├── columns: attname:3!null atttypid:4
       │    ├── stats: [rows=20, distinct(3)=2, null(3)=0, distinct(4)=18.2927, null(4)=0.2]
-      │    ├── cost: 1433.49877
-      │    ├── ordering: +4
-      │    └── select
-      │         ├── columns: attname:3!null atttypid:4
-      │         ├── stats: [rows=20, distinct(3)=2, null(3)=0, distinct(4)=18.2927, null(4)=0.2]
-      │         ├── cost: 1430.95
-      │         ├── scan pg_attribute [as=a]
-      │         │    ├── columns: attname:3 atttypid:4
-      │         │    ├── stats: [rows=1000, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=10]
-      │         │    └── cost: 1420.92
-      │         └── filters
-      │              └── attname:3 IN ('descriptor_id', 'descriptor_name') [outer=(3), constraints=(/3: [/'descriptor_id' - /'descriptor_id'] [/'descriptor_name' - /'descriptor_name']; tight)]
-      └── filters (true)
+      │    ├── cost: 1430.95
+      │    ├── scan pg_attribute [as=a]
+      │    │    ├── columns: attname:3 atttypid:4
+      │    │    ├── stats: [rows=1000, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=10]
+      │    │    └── cost: 1420.92
+      │    └── filters
+      │         └── attname:3 IN ('descriptor_id', 'descriptor_name') [outer=(3), constraints=(/3: [/'descriptor_id' - /'descriptor_id'] [/'descriptor_name' - /'descriptor_name']; tight)]
+      └── filters
+           └── atttypid:4 = oid:29 [outer=(4,29), constraints=(/4: (/NULL - ]; /29: (/NULL - ]), fd=(4)==(29), (29)==(4)]
 
 
 # A lookup join should be performed with a virtual table if the filter

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -306,40 +306,35 @@ sort
       │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
       │    │    │    │    │    │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7)
-      │    │    │    │    │    │    │    ├── inner-join (merge)
-      │    │    │    │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
-      │    │    │    │    │    │    │    │    ├── left ordering: +44
-      │    │    │    │    │    │    │    │    ├── right ordering: +7
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(60), (7)==(44), (44)==(7)
-      │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    │    ├── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
-      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(60)
-      │    │    │    │    │    │    │    │    │    ├── ordering: +44 opt(60) [actual: +44]
-      │    │    │    │    │    │    │    │    │    ├── scan pg_attribute@pg_attribute_attrelid_idx [as=a]
-      │    │    │    │    │    │    │    │    │    │    ├── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49 atttypmod:52 a.attnotnull:56 attisdropped:60
-      │    │    │    │    │    │    │    │    │    │    └── ordering: +44
-      │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │         ├── attnum:49 > 0 [outer=(49), constraints=(/49: [/1 - ]; tight)]
-      │    │    │    │    │    │    │    │    │         └── NOT attisdropped:60 [outer=(60), constraints=(/60: [/false - /false]; tight), fd=()-->(60)]
+      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    ├── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(60)
+      │    │    │    │    │    │    │    │    ├── scan pg_attribute [as=a]
+      │    │    │    │    │    │    │    │    │    └── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49 atttypmod:52 a.attnotnull:56 attisdropped:60
+      │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         ├── attnum:49 > 0 [outer=(49), constraints=(/49: [/1 - ]; tight)]
+      │    │    │    │    │    │    │    │         └── NOT attisdropped:60 [outer=(60), constraints=(/60: [/false - /false]; tight), fd=()-->(60)]
+      │    │    │    │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(3), (2)==(9), (9)==(2)
       │    │    │    │    │    │    │    │    ├── select
       │    │    │    │    │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24!null
-      │    │    │    │    │    │    │    │    │    ├── ordering: +7
-      │    │    │    │    │    │    │    │    │    ├── scan pg_class@pg_class_oid_idx [as=c]
-      │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24
-      │    │    │    │    │    │    │    │    │    │    └── ordering: +7
+      │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+      │    │    │    │    │    │    │    │    │    │    └── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24
       │    │    │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │    │    │         ├── c.relkind:24 IN ('f', 'm', 'p', 'r', 'v') [outer=(24), constraints=(/24: [/'f' - /'f'] [/'m' - /'m'] [/'p' - /'p'] [/'r' - /'r'] [/'v' - /'v']; tight)]
       │    │    │    │    │    │    │    │    │         └── c.relname:8 LIKE '%' [outer=(8), constraints=(/8: (/NULL - ])]
-      │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: n.oid:2 n.nspname:3!null
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(3)
-      │    │    │    │    │    │    │    │    ├── scan pg_namespace [as=n]
-      │    │    │    │    │    │    │    │    │    └── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    │    ├── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(3)
+      │    │    │    │    │    │    │    │    │    ├── scan pg_namespace [as=n]
+      │    │    │    │    │    │    │    │    │    │    └── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │    │         └── n.nspname:3 LIKE 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]
       │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── n.nspname:3 LIKE 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]
+      │    │    │    │    │    │    │    │         └── c.relnamespace:9 = n.oid:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── c.relnamespace:9 = n.oid:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      │    │    │    │    │    │    │         └── attrelid:44 = c.oid:7 [outer=(7,44), constraints=(/7: (/NULL - ]; /44: (/NULL - ]), fd=(7)==(44), (44)==(7)]
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         ├── c.oid:7 = objoid:119 [outer=(7,119), constraints=(/7: (/NULL - ]; /119: (/NULL - ]), fd=(7)==(119), (119)==(7)]
       │    │    │    │    │    │         └── attnum:49 = objsubid:121 [outer=(49,121), constraints=(/49: (/NULL - ]; /121: (/NULL - ]), fd=(49)==(121), (121)==(49)]


### PR DESCRIPTION
The execution infrastructure for the virtual tables has a few limitations, one of them being not able to utilize the virtual indexes for range scans (i.e. only point lookups are supported). We do so transparently by handling the prefix of point lookups, and once we find the first range span in the index constraint, we fall back to the "full scan" of the PK. Previously, the EXPLAIN output would always show that we're using the constrained virtual index scan which can be misleading.

This commit avoids this possible point of confusion by not generating plans in the optimizer that utilize the virtual indexes whenever it is known that the execution won't be able to utilize it (which is the case with range scans as well as with unconstrained scans). This approach removes the previous "optimization" of being able to handle both point and range lookups, but I doubt it'll be noticeably worse performance-wise.

Fixes: #108317.

Release note: None