### PR TITLE
kvserver: skip TestGossipHandlesReplacedNode under race

### DIFF
--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -147,6 +147,7 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	// As of Nov 2018 it takes 3.6s.
 	skip.UnderShort(t)
 	skip.UnderDeadlock(t)
+	skip.UnderRace(t)
 	ctx := context.Background()
 
 	// Shorten the raft tick interval and election timeout to make range leases


### PR DESCRIPTION
Closes #126815

Release note: None