### PR TITLE
sql: implement plan_cache_mode=auto

### DIFF
--- a/docs/RFCS/20240103_generic_query_plans.md
+++ b/docs/RFCS/20240103_generic_query_plans.md
@@ -114,7 +114,7 @@ plan regressions in early versions of generic query plans.
 There is one exception for `force_custom_plan` with statements that either have
 no placeholders nor fold-able, stable expressions, or statements that can
 utilize the placeholder fast path. These statements can be fully optimized into
-_absolute_ generic plans that can be reused without re-optimization because the
+_ideal_ generic plans that can be reused without re-optimization because the
 optimal query plan will not change between executions.
 
 If `plan_cache_mode` is set to `auto`, the optimizer will automatically choose
@@ -143,8 +143,8 @@ statements are prepared.
 The prepared statement namespace will be expanded to store both a "base memo"
 and a "generic memo". The base memo will be a normalized, yet unoptimized memo
 that can be used as a starting point for build custom plans. The generic memo
-will be fully optimized as an absolute generic query plan or non-absolute
-generic query plan.
+will be fully optimized as an ideal generic query plan or non-ideal generic
+query plan.
 
 ### Using Lookup-Joins as "Constrained Scans"
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -686,6 +686,7 @@ go_test(
         "pg_oid_test.go",
         "pgwire_internal_test.go",
         "plan_opt_test.go",
+        "prepared_stmt_test.go",
         "privileged_accessor_test.go",
         "region_util_test.go",
         "rename_test.go",

--- a/pkg/sql/opt/exec/execbuilder/testdata/generic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/generic
@@ -11,9 +11,26 @@ CREATE TABLE t (
   a INT,
   b INT,
   c INT,
+  s STRING,
   t TIMESTAMPTZ,
   INDEX (a),
+  INDEX (s),
   INDEX (t)
+)
+
+statement ok
+CREATE TABLE c (
+  k INT PRIMARY KEY,
+  a INT,
+  INDEX (a)
+)
+
+statement ok
+CREATE TABLE g (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX (a, b)
 )
 
 statement ok
@@ -22,7 +39,7 @@ SET plan_cache_mode = force_generic_plan
 statement ok
 PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
 
-# A generic, reusable plan can be built during PREPARE for queries with no
+# An ideal generic plan can be built during PREPARE for queries with no
 # placeholders nor stable expressions.
 query T
 EXPLAIN ANALYZE EXECUTE p
@@ -76,8 +93,8 @@ quality of service: regular
 statement ok
 SET plan_cache_mode = force_custom_plan
 
-# The generic plan is reused even when forcing a custom plan because it will
-# always be optimal.
+# The ideal generic plan is reused even when forcing a custom plan because it
+# will always be optimal.
 query T
 EXPLAIN ANALYZE EXECUTE p
 ----
@@ -187,8 +204,8 @@ quality of service: regular
 statement ok
 SET plan_cache_mode = force_generic_plan
 
-# The plan is generic (it has no placeholders), so it can be reused with
-# plan_cache_mode set to force_generic_plan.
+# The plan is an ideal generic plan (it has no placeholders), so it can be
+# reused with plan_cache_mode set to force_generic_plan.
 query T
 EXPLAIN ANALYZE EXECUTE p
 ----
@@ -244,7 +261,7 @@ DEALLOCATE p
 statement ok
 PREPARE p AS SELECT * FROM t WHERE k = $1
 
-# A generic, reusable plan can be built during PREPARE when the placeholder
+# An ideal generic plan can be built during PREPARE when the placeholder
 # fast-path can be used.
 query T
 EXPLAIN ANALYZE EXECUTE p(33)
@@ -279,8 +296,8 @@ quality of service: regular
 statement ok
 SET plan_cache_mode = force_custom_plan
 
-# The generic plan is reused even when forcing a custom plan because it will
-# always be optimal.
+# The ideal generic plan is reused even when forcing a custom plan because it
+# will always be optimal.
 query T
 EXPLAIN ANALYZE EXECUTE p(33)
 ----
@@ -562,6 +579,49 @@ statement ok
 DEALLOCATE p
 
 statement ok
+PREPARE p AS SELECT k FROM t WHERE s LIKE $1
+
+# A suboptimal generic query plan is chosen if it is forced.
+query T
+EXPLAIN ANALYZE EXECUTE p('foo%')
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: s LIKE 'foo%'
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV contention time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t@t_s_idx
+      spans: (/NULL - ]
+
+statement ok
+DEALLOCATE p
+
+statement ok
 PREPARE p AS SELECT k FROM t WHERE c = $1
 
 # A simple generic plan.
@@ -646,3 +706,464 @@ DEALLOCATE p
 
 statement ok
 ALTER TABLE t DROP COLUMN z
+
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
+
+# An ideal generic plan is used immediately with plan_cache_mode=auto.
+query T
+EXPLAIN ANALYZE EXECUTE p
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: (b = 2) AND (c = 3)
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/1 - /1]
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS SELECT * FROM t WHERE a = $1 AND c = $2
+
+statement ok
+EXECUTE p(1, 2);
+EXECUTE p(10, 20);
+EXECUTE p(100, 200);
+EXECUTE p(1000, 2000);
+EXECUTE p(10000, 20000);
+
+# On the sixth execution a generic query plan will be generated. The cost of the
+# generic plan is more than the average cost of the five custom plans (plus some
+# overhead cost of optimization), so the custom plan is chosen.
+query T
+EXPLAIN ANALYZE EXECUTE p(10000, 20000)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• filter
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ filter: c = 20000
+│
+└── • index join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: t@t_pkey
+    │
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t@t_a_idx
+          spans: [/10000 - /10000]
+
+statement ok
+DEALLOCATE p
+
+# Now use a more complex query that could have multiple join orderings.
+statement ok
+PREPARE p AS
+SELECT * FROM t
+JOIN c ON t.k = c.a
+JOIN g ON c.k = g.a
+WHERE t.a = $1 AND t.c = $2
+
+statement ok
+EXECUTE p(1, 2);
+EXECUTE p(10, 20);
+EXECUTE p(100, 200);
+EXECUTE p(1000, 2000);
+
+# The first five executions will use a custom plan. This is the fifth.
+query T
+EXPLAIN ANALYZE EXECUTE p(10000, 20000)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join (streamer)
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: g@g_a_b_idx
+│ equality: (k) = (a)
+│
+└── • lookup join (streamer)
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: c@c_a_idx
+    │ equality: (k) = (a)
+    │
+    └── • filter
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ filter: c = 20000
+        │
+        └── • index join (streamer)
+            │ sql nodes: <hidden>
+            │ regions: <hidden>
+            │ actual row count: 0
+            │ KV time: 0µs
+            │ KV contention time: 0µs
+            │ KV rows decoded: 0
+            │ KV bytes read: 0 B
+            │ KV gRPC calls: 0
+            │ estimated max memory allocated: 0 B
+            │ estimated max sql temp disk usage: 0 B
+            │ table: t@t_pkey
+            │
+            └── • scan
+                  sql nodes: <hidden>
+                  kv nodes: <hidden>
+                  regions: <hidden>
+                  actual row count: 0
+                  KV time: 0µs
+                  KV contention time: 0µs
+                  KV rows decoded: 0
+                  KV bytes read: 0 B
+                  KV gRPC calls: 0
+                  estimated max memory allocated: 0 B
+                  missing stats
+                  table: t@t_a_idx
+                  spans: [/10000 - /10000]
+
+# On the sixth execution a generic query plan will be generated. The cost of the
+# generic plan is less than the average cost of the five custom plans (plus some
+# overhead cost of optimization), so the generic plan is chosen.
+query T
+EXPLAIN ANALYZE EXECUTE p(10000, 20000)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, re-optimized
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: g@g_a_b_idx
+│ equality: (k) = (a)
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: c@c_a_idx
+    │ equality: (k) = (a)
+    │
+    └── • lookup join
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ KV time: 0µs
+        │ KV contention time: 0µs
+        │ KV rows decoded: 0
+        │ KV bytes read: 0 B
+        │ KV gRPC calls: 0
+        │ estimated max memory allocated: 0 B
+        │ table: t@t_pkey
+        │ equality: (k) = (k)
+        │ equality cols are key
+        │ pred: c = "$2"
+        │
+        └── • lookup join
+            │ sql nodes: <hidden>
+            │ kv nodes: <hidden>
+            │ regions: <hidden>
+            │ actual row count: 0
+            │ KV time: 0µs
+            │ KV contention time: 0µs
+            │ KV rows decoded: 0
+            │ KV bytes read: 0 B
+            │ KV gRPC calls: 0
+            │ estimated max memory allocated: 0 B
+            │ table: t@t_a_idx
+            │ equality: ($1) = (a)
+            │
+            └── • values
+                  sql nodes: <hidden>
+                  regions: <hidden>
+                  actual row count: 1
+                  size: 2 columns, 1 row
+
+# On the seventh execution the generic plan is reused.
+query T
+EXPLAIN ANALYZE EXECUTE p(10000, 20000)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• lookup join
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 0
+│ KV time: 0µs
+│ KV contention time: 0µs
+│ KV rows decoded: 0
+│ KV bytes read: 0 B
+│ KV gRPC calls: 0
+│ estimated max memory allocated: 0 B
+│ table: g@g_a_b_idx
+│ equality: (k) = (a)
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ table: c@c_a_idx
+    │ equality: (k) = (a)
+    │
+    └── • lookup join
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ KV time: 0µs
+        │ KV contention time: 0µs
+        │ KV rows decoded: 0
+        │ KV bytes read: 0 B
+        │ KV gRPC calls: 0
+        │ estimated max memory allocated: 0 B
+        │ table: t@t_pkey
+        │ equality: (k) = (k)
+        │ equality cols are key
+        │ pred: c = "$2"
+        │
+        └── • lookup join
+            │ sql nodes: <hidden>
+            │ kv nodes: <hidden>
+            │ regions: <hidden>
+            │ actual row count: 0
+            │ KV time: 0µs
+            │ KV contention time: 0µs
+            │ KV rows decoded: 0
+            │ KV bytes read: 0 B
+            │ KV gRPC calls: 0
+            │ estimated max memory allocated: 0 B
+            │ table: t@t_a_idx
+            │ equality: ($1) = (a)
+            │
+            └── • values
+                  sql nodes: <hidden>
+                  regions: <hidden>
+                  actual row count: 1
+                  size: 2 columns, 1 row
+
+statement ok
+DEALLOCATE p
+
+# Now use a query with a bad generic query plan.
+statement ok
+PREPARE p AS
+SELECT * FROM g WHERE a = $1 ORDER BY b LIMIT 10
+
+statement ok
+EXECUTE p(1);
+EXECUTE p(10);
+EXECUTE p(100);
+EXECUTE p(1000);
+EXECUTE p(10000);
+
+# The generic plan is generated on the sixth execution, but is more expensive
+# than the average custom plan.
+query T
+EXPLAIN ANALYZE EXECUTE p(10)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• scan
+  sql nodes: <hidden>
+  kv nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  KV time: 0µs
+  KV contention time: 0µs
+  KV rows decoded: 0
+  KV bytes read: 0 B
+  KV gRPC calls: 0
+  estimated max memory allocated: 0 B
+  missing stats
+  table: g@g_a_b_idx
+  spans: [/10 - /10]
+  limit: 10
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+# The generic plan previously generated is reused when forcing a generic plan.
+query T
+EXPLAIN ANALYZE EXECUTE p(10)
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• limit
+│ count: 10
+│
+└── • lookup join
+    │ sql nodes: <hidden>
+    │ kv nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 0
+    │ KV time: 0µs
+    │ KV contention time: 0µs
+    │ KV rows decoded: 0
+    │ KV bytes read: 0 B
+    │ KV gRPC calls: 0
+    │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
+    │ table: g@g_a_b_idx
+    │ equality: ($1) = (a)
+    │
+    └── • values
+          sql nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          size: 1 column, 1 row

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -517,6 +517,17 @@ func (m *Memo) IsOptimized() bool {
 	return ok && rel.RequiredPhysical() != nil
 }
 
+// OptimizationCost returns a rough estimate of the cost of optimization of the
+// memo. It is dependent on the number of tables in the metadata, based on the
+// reasoning that queries with more tables likely have more joins, which tend
+// to be the biggest contributors to optimization overhead.
+func (m *Memo) OptimizationCost() Cost {
+	// This cpuCostFactor is the same as cpuCostFactor in the coster.
+	// TODO(mgartner): Package these constants up in a shared location.
+	const cpuCostFactor = 0.01
+	return Cost(m.Metadata().NumTables()) * 1000 * cpuCostFactor
+}
+
 // NextRank returns a new rank that can be assigned to a scalar expression.
 func (m *Memo) NextRank() opt.ScalarRank {
 	m.curRank++

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -799,6 +799,11 @@ func (md *Metadata) AllTables() []TableMeta {
 	return md.tables
 }
 
+// NumTables returns the number of tables in the metadata.
+func (md *Metadata) NumTables() int {
+	return len(md.tables)
+}
+
 // AddColumn assigns a new unique id to a column within the query and records
 // its alias and type. If the alias is empty, a "column<ID>" alias is created.
 func (md *Metadata) AddColumn(alias string, typ *types.T) ColumnID {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -168,7 +168,7 @@ func (p *planner) prepareUsingOptimizer(
 	}
 
 	// Build the memo. Do not attempt to build a generic plan at PREPARE-time.
-	memo, _, err := opc.buildReusableMemo(ctx, false /* allowGeneric */)
+	memo, _, err := opc.buildReusableMemo(ctx, false /* buildGeneric */)
 	if err != nil {
 		return 0, err
 	}
@@ -408,6 +408,15 @@ func (opc *optPlanningCtx) log(ctx context.Context, msg redact.SafeString) {
 	}
 }
 
+type memoType int
+
+const (
+	memoTypeUnknown memoType = iota
+	memoTypeCustom
+	memoTypeGeneric
+	memoTypeIdealGeneric
+)
+
 // buildReusableMemo builds the statement into a memo that can be stored for
 // prepared statements and can later be used as a starting point for
 // optimization. The returned memo is fully optimized if:
@@ -415,33 +424,33 @@ func (opc *optPlanningCtx) log(ctx context.Context, msg redact.SafeString) {
 //  1. The statement does not contain placeholders nor fold-able stable
 //     operators.
 //  2. Or, the placeholder fast path is used.
-//  3. Or, useGeneric is true and the plan is fully optimized as best as
+//  3. Or, buildGeneric is true and the plan is fully optimized as best as
 //     possible in the presence of placeholders.
 //
 // The returned memo is fully detached from the planner and can be used with
 // reuseMemo independently and concurrently by multiple threads.
 func (opc *optPlanningCtx) buildReusableMemo(
-	ctx context.Context, useGeneric bool,
-) (_ *memo.Memo, generic bool, _ error) {
+	ctx context.Context, buildGeneric bool,
+) (*memo.Memo, memoType, error) {
 	p := opc.p
 
 	_, isCanned := opc.p.stmt.AST.(*tree.CannedOptPlan)
 	if isCanned {
 		if !p.EvalContext().SessionData().AllowPrepareAsOptPlan {
-			return nil, false, pgerror.New(pgcode.InsufficientPrivilege,
+			return nil, memoTypeUnknown, pgerror.New(pgcode.InsufficientPrivilege,
 				"PREPARE AS OPT PLAN is a testing facility that should not be used directly",
 			)
 		}
 
 		if !p.SessionData().User().IsRootUser() {
-			return nil, false, pgerror.New(pgcode.InsufficientPrivilege,
+			return nil, memoTypeUnknown, pgerror.New(pgcode.InsufficientPrivilege,
 				"PREPARE AS OPT PLAN may only be used by root",
 			)
 		}
 	}
 
 	if p.SessionData().SaveTablesPrefix != "" && !p.SessionData().User().IsRootUser() {
-		return nil, false, pgerror.New(pgcode.InsufficientPrivilege,
+		return nil, memoTypeUnknown, pgerror.New(pgcode.InsufficientPrivilege,
 			"sub-expression tables creation may only be used by root",
 		)
 	}
@@ -459,7 +468,7 @@ func (opc *optPlanningCtx) buildReusableMemo(
 		bld.SkipAOST = true
 	}
 	if err := bld.Build(); err != nil {
-		return nil, false, err
+		return nil, memoTypeUnknown, err
 	}
 
 	if bld.DisableMemoReuse {
@@ -473,11 +482,12 @@ func (opc *optPlanningCtx) buildReusableMemo(
 			// We don't support placeholders inside the canned plan. The main reason
 			// is that they would be invisible to the parser (which reports the number
 			// of placeholders, used to initialize the relevant structures).
-			return nil, false, pgerror.Newf(pgcode.Syntax,
+			return nil, memoTypeUnknown, pgerror.Newf(pgcode.Syntax,
 				"placeholders are not supported with PREPARE AS OPT PLAN")
 		}
-		// With a canned plan, we don't want to optimize the memo.
-		return opc.optimizer.DetachMemo(ctx), false, nil
+		// With a canned plan, we don't want to optimize the memo. Since we
+		// won't optimize it, we consider it an ideal generic plan.
+		return opc.optimizer.DetachMemo(ctx), memoTypeIdealGeneric, nil
 	}
 
 	// If the memo doesn't have placeholders and did not encounter any stable
@@ -486,35 +496,36 @@ func (opc *optPlanningCtx) buildReusableMemo(
 	if !f.Memo().HasPlaceholders() && !f.FoldingControl().PreventedStableFold() {
 		opc.log(ctx, "optimizing (no placeholders)")
 		if _, err := opc.optimizer.Optimize(); err != nil {
-			return nil, false, err
+			return nil, memoTypeUnknown, err
 		}
 		opc.flags.Set(planFlagOptimized)
-		return opc.optimizer.DetachMemo(ctx), false, nil
+		return opc.optimizer.DetachMemo(ctx), memoTypeIdealGeneric, nil
 	}
 
 	// If the memo has placeholders, first try the placeholder fast path.
 	_, ok, err := opc.optimizer.TryPlaceholderFastPath()
 	if err != nil {
-		return nil, false, err
+		return nil, memoTypeUnknown, err
 	}
 	if ok {
 		opc.log(ctx, "placeholder fast path")
 		opc.flags.Set(planFlagOptimized)
-	} else if useGeneric {
+		return opc.optimizer.DetachMemo(ctx), memoTypeIdealGeneric, nil
+	} else if buildGeneric {
 		// Build a generic query plan if the placeholder fast path failed and a
 		// generic plan was requested.
 		opc.log(ctx, "optimizing (generic)")
 		if _, err := opc.optimizer.Optimize(); err != nil {
-			return nil, false, err
+			return nil, memoTypeUnknown, err
 		}
 		opc.flags.Set(planFlagOptimized)
-		return opc.optimizer.DetachMemo(ctx), true, nil
+		return opc.optimizer.DetachMemo(ctx), memoTypeGeneric, nil
 	}
 
 	// Detach the prepared memo from the factory and transfer its ownership
 	// to the prepared statement. DetachMemo will re-initialize the optimizer
 	// to an empty memo.
-	return opc.optimizer.DetachMemo(ctx), false, nil
+	return opc.optimizer.DetachMemo(ctx), memoTypeCustom, nil
 }
 
 // reuseMemo returns an optimized memo using a cached memo as a starting point.
@@ -546,7 +557,38 @@ func (opc *optPlanningCtx) reuseMemo(
 		return nil, err
 	}
 	opc.flags.Set(planFlagOptimized)
-	return f.Memo(), nil
+	mem := f.Memo()
+	if prep := opc.p.stmt.Prepared; opc.allowMemoReuse && prep != nil {
+		prep.Costs.AddCustom(mem.RootExpr().(memo.RelExpr).Cost() + mem.OptimizationCost())
+	}
+	return mem, nil
+}
+
+// useGenericPlan returns true if a generic query plan should be used instead of
+// a custom plan.
+func (opc *optPlanningCtx) useGenericPlan() bool {
+	switch opc.p.SessionData().PlanCacheMode {
+	case sessiondatapb.PlanCacheModeForceGeneric:
+		return true
+	case sessiondatapb.PlanCacheModeAuto:
+		prep := opc.p.stmt.Prepared
+		// We need to build CustomPlanThreshold custom plans before considering
+		// a generic plan.
+		if prep.Costs.NumCustom() < CustomPlanThreshold {
+			return false
+		}
+		// A generic plan should be used if we have CustomPlanThreshold custom
+		// plan costs and:
+		//
+		//   1. The generic cost is unknown because a generic plan has not been
+		//      built.
+		//   2. Or, the cost of the generic plan is less than or equal to the
+		//      average cost of the custom plans.
+		//
+		return prep.Costs.Generic() == 0 || prep.Costs.Generic() < prep.Costs.AvgCustom()
+	default:
+		return false
+	}
 }
 
 // chooseValidPreparedMemo returns an optimized memo that is equal to, or built
@@ -554,18 +596,23 @@ func (opc *optPlanningCtx) reuseMemo(
 // selects baseMemo or genericMemo based on the following rules, in order:
 //
 //  1. If baseMemo is fully optimized and not stale, it is returned as-is.
-//  2. If useGeneric is true and genericMemo is not stale, it is returned
-//     as-is.
-//  3. If useGeneric is true and genericMemo is stale or nil, nil is returned.
-//     The caller is responsible for building a new generic memo.
-//  4. If baseMemo is not stale and unoptimized, optimize and return it.
-//  5. Otherwise, nil is returned. The caller is responsible for building a new
-//     memo.
+//  2. If plan_cache_mode=force_generic_plan is true then genericMemo is
+//     returned as-is if it is not stale.
+//  3. If plan_cache_mode=auto, there have been at least 5 custom plans
+//     generated, and the cost of the generic memo is less than the average cost
+//     of the custom plans, then the generic memo is returned as-is if it is not
+//     stale. If the cost of the generic memo is greater than or equal to the
+//     average cost of the custom plans, then the baseMemo is returned if it is
+//     not stale.
+//  4. If plan_cache_mode=force_custom_plan, baseMemo is returned if it is not
+//     stale.
+//  5. Otherwise, nil is returned and the caller is responsible for building a
+//     new memo.
 //
 // The logic is structured to avoid unnecessary (*memo.Memo).IsStale calls,
 // since they can be expensive.
 func (opc *optPlanningCtx) chooseValidPreparedMemo(
-	ctx context.Context, baseMemo *memo.Memo, genericMemo *memo.Memo, useGeneric bool,
+	ctx context.Context, baseMemo *memo.Memo, genericMemo *memo.Memo,
 ) (*memo.Memo, error) {
 	// First check for a fully optimized, non-stale, base memo.
 	if baseMemo != nil && baseMemo.IsOptimized() {
@@ -577,24 +624,37 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(
 		}
 	}
 
+	prep := opc.p.stmt.Prepared
+	reuseGeneric := opc.useGenericPlan()
+
 	// Next check for a non-stale, generic memo.
-	if useGeneric && genericMemo != nil {
+	if reuseGeneric && genericMemo != nil {
 		isStale, err := genericMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
 		if err != nil {
 			return nil, err
 		} else if !isStale {
 			return genericMemo, nil
+		} else {
+			// Clear the generic cost if the memo is stale. DDL or new stats
+			// could drastically change the cost of generic and custom plans, so
+			// we should re-consider which to use.
+			prep.Costs.ClearGeneric()
 		}
 	}
 
-	// Next, check for a non-stale, normalized memo, if a generic memo is
-	// not allowed.
-	if !useGeneric && baseMemo != nil && !baseMemo.IsOptimized() {
+	// Next, check for a non-stale, normalized memo, if a generic memo should
+	// not be reused.
+	if !reuseGeneric && baseMemo != nil && !baseMemo.IsOptimized() {
 		isStale, err := baseMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
 		if err != nil {
 			return nil, err
 		} else if !isStale {
 			return baseMemo, nil
+		} else {
+			// Clear the custom costs if the memo is stale. DDL or new stats
+			// could drastically change the cost of generic and custom plans, so
+			// we should re-consider which to use.
+			prep.Costs.ClearCustom()
 		}
 	}
 
@@ -619,9 +679,11 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(
 //     The BaseMemo will be used if it is fully optimized. Otherwise, the
 //     GenericMemo will be used.
 //
-//   - auto: This currently behaves the same as force_custom_plan.
-//
-// TODO(mgartner): Implement "auto".
+//   - auto: A "custom plan" will be optimized for first five executions of the
+//     prepared statement. On the sixth execution, a "generic plan" will be
+//     generated. If its cost is less than the average cost of the custom plans
+//     (plus some optimization overhead cost), then the generic plan will be
+//     used. Otherwise, a custom plan will be used.
 func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo, err error) {
 	p := opc.p
 	prep := p.stmt.Prepared
@@ -629,11 +691,9 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 		return nil, nil
 	}
 
-	useGeneric := opc.p.SessionData().PlanCacheMode == sessiondatapb.PlanCacheModeForceGeneric
-
 	// If the statement was previously prepared, check for a reusable memo.
 	// First check for a valid (non-stale) memo.
-	validMemo, err := opc.chooseValidPreparedMemo(ctx, prep.BaseMemo, prep.GenericMemo, useGeneric)
+	validMemo, err := opc.chooseValidPreparedMemo(ctx, prep.BaseMemo, prep.GenericMemo)
 	if err != nil {
 		return nil, err
 	}
@@ -648,17 +708,35 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 	// build a generic memo from it instead of building the memo from
 	// scratch.
 	opc.log(ctx, "rebuilding cached memo")
-	newMemo, generic, err := opc.buildReusableMemo(ctx, useGeneric)
+	buildGeneric := opc.useGenericPlan()
+	newMemo, typ, err := opc.buildReusableMemo(ctx, buildGeneric)
 	if err != nil {
 		return nil, err
 	}
-	if generic {
-		// TODO(mgartner): Add the generic memo to the query cache so that it
-		// can be reused by future prepared statements.
-		prep.GenericMemo = newMemo
-	} else {
+	switch typ {
+	case memoTypeIdealGeneric:
+		// If we have an "ideal" generic memo, store it as a base memo. It will
+		// always be used regardless of plan_cache_mode, so there is no need to
+		// set GenericCost.
 		prep.BaseMemo = newMemo
+	case memoTypeGeneric:
+		prep.GenericMemo = newMemo
+		prep.Costs.SetGeneric(newMemo.RootExpr().(memo.RelExpr).Cost())
+		// Now that the cost of the generic plan is known, we need to
+		// re-evaluate the decision to use a generic or custom plan.
+		if !opc.useGenericPlan() {
+			// The generic plan that we just built is too expensive, so we need
+			// to build a custom plan. We recursively call fetchPreparedMemo in
+			// case we have a custom plan that can be reused as a starting point
+			// for optimization. The function should not recurse more than once.
+			return opc.fetchPreparedMemo(ctx)
+		}
+	case memoTypeCustom:
+		prep.BaseMemo = newMemo
+	default:
+		return nil, errors.AssertionFailedf("unexpected memo type %v", typ)
 	}
+
 	// Re-optimize the memo, if necessary.
 	return opc.reuseMemo(ctx, newMemo)
 }
@@ -679,7 +757,7 @@ func (opc *optPlanningCtx) fetchPreparedMemoLegacy(ctx context.Context) (_ *memo
 			return nil, err
 		} else if isStale {
 			opc.log(ctx, "rebuilding cached memo")
-			prepared.BaseMemo, _, err = opc.buildReusableMemo(ctx, false /* useGeneric */)
+			prepared.BaseMemo, _, err = opc.buildReusableMemo(ctx, false /* buildGeneric */)
 			if err != nil {
 				return nil, err
 			}
@@ -736,7 +814,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 				return nil, err
 			} else if isStale {
 				opc.log(ctx, "query cache hit but needed update")
-				cachedData.Memo, _, err = opc.buildReusableMemo(ctx, false /* allowGeneric */)
+				cachedData.Memo, _, err = opc.buildReusableMemo(ctx, false /* buildGeneric */)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -56,9 +56,16 @@ type PreparedStatement struct {
 	querycache.PrepareMetadata
 
 	// BaseMemo is the memoized data structure constructed by the cost-based
-	// optimizer during prepare of a SQL statement. It may be a fully-optimized
-	// memo if the prepared statement has no placeholders and no fold-able
-	// stable expressions. Otherwise, it is an unoptimized, normalized memo.
+	// optimizer during prepare of a SQL statement.
+	//
+	// It may be a fully-optimized memo if it contains an "ideal generic plan"
+	// that is guaranteed to be optimal across all executions of the prepared
+	// statement. Ideal generic plans are generated when the statement has no
+	// placeholders nor fold-able stable expressions, or when the placeholder
+	// fast-path is utilized.
+	//
+	// If it is not an ideal generic plan, it is an unoptimized, normalized
+	// memo that is used as a starting point for optimization of custom plans.
 	BaseMemo *memo.Memo
 
 	// GenericMemo, if present, is a fully-optimized memo that can be executed
@@ -66,6 +73,9 @@ type PreparedStatement struct {
 	// TODO(mgartner): Put all fully-optimized plans in the GenericMemo field to
 	// reduce confusion.
 	GenericMemo *memo.Memo
+
+	// Costs tracks the costs of previously optimized custom and generic plans.
+	Costs planCosts
 
 	// refCount keeps track of the number of references to this PreparedStatement.
 	// New references are registered through incRef().
@@ -115,6 +125,75 @@ func (p *PreparedStatement) incRef(ctx context.Context) {
 		log.Fatal(ctx, "corrupt PreparedStatement refcount")
 	}
 	p.refCount++
+}
+
+const (
+	// CustomPlanThreshold is the maximum number of custom plan costs tracked by
+	// planCosts. It is also the number of custom plans executed when
+	// plan_cache_mode=auto before attempting to generate a generic plan.
+	CustomPlanThreshold = 5
+)
+
+// planCosts tracks costs of generic and custom plans.
+type planCosts struct {
+	generic memo.Cost
+	custom  struct {
+		nextIdx int
+		length  int
+		costs   [CustomPlanThreshold]memo.Cost
+	}
+}
+
+// Generic returns the cost of the generic plan.
+func (p *planCosts) Generic() memo.Cost {
+	return p.generic
+}
+
+// SetGeneric sets the cost of the generic plan.
+func (p *planCosts) SetGeneric(cost memo.Cost) {
+	p.generic = cost
+}
+
+// AddCustom adds a custom plan cost to the planCosts, evicting the oldest cost
+// if necessary.
+func (p *planCosts) AddCustom(cost memo.Cost) {
+	p.custom.costs[p.custom.nextIdx] = cost
+	p.custom.nextIdx++
+	if p.custom.nextIdx >= CustomPlanThreshold {
+		p.custom.nextIdx = 0
+	}
+	if p.custom.length < CustomPlanThreshold {
+		p.custom.length++
+	}
+}
+
+// NumCustom returns the number of custom plan costs in the planCosts.
+func (p *planCosts) NumCustom() int {
+	return p.custom.length
+}
+
+// AvgCustom returns the average cost of all the custom plan costs in planCosts.
+// If there are no custom plan costs, it returns 0.
+func (p *planCosts) AvgCustom() memo.Cost {
+	if p.custom.length == 0 {
+		return 0
+	}
+	var sum memo.Cost
+	for i := 0; i < p.custom.length; i++ {
+		sum += p.custom.costs[i]
+	}
+	return sum / memo.Cost(p.custom.length)
+}
+
+// ClearGeneric clears the generic cost.
+func (p *planCosts) ClearGeneric() {
+	p.generic = 0
+}
+
+// ClearCustom clears any previously added custom costs.
+func (p *planCosts) ClearCustom() {
+	p.custom.nextIdx = 0
+	p.custom.length = 0
 }
 
 // preparedStatementsAccessor gives a planner access to a session's collection

--- a/pkg/sql/prepared_stmt_test.go
+++ b/pkg/sql/prepared_stmt_test.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestPlanCosts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type testCase struct {
+		input       []memo.Cost
+		expectedNum int
+		expectedAvg memo.Cost
+	}
+	testCases := []testCase{
+		{input: []memo.Cost{}, expectedNum: 0, expectedAvg: 0},
+		{input: []memo.Cost{0, 0}, expectedNum: 2, expectedAvg: 0},
+		{input: []memo.Cost{1, 1}, expectedNum: 2, expectedAvg: 1},
+		{input: []memo.Cost{1, 2, 3, 4, 5}, expectedNum: 5, expectedAvg: 3},
+		{input: []memo.Cost{1, 2, 3, 4, 5, 6}, expectedNum: 5, expectedAvg: 4},
+		{input: []memo.Cost{9, 9, 9, 9, 9, 1, 2, 3, 4, 5}, expectedNum: 5, expectedAvg: 3},
+	}
+	var pc planCosts
+	for _, tc := range testCases {
+		pc.ClearCustom()
+		for _, cost := range tc.input {
+			pc.AddCustom(cost)
+		}
+		if pc.NumCustom() != tc.expectedNum {
+			t.Errorf("expected Len() to be %d, got %d", tc.expectedNum, pc.NumCustom())
+		}
+		if pc.AvgCustom() != tc.expectedAvg {
+			t.Errorf("expected Avg() to be %f, got %f", tc.expectedAvg, pc.AvgCustom())
+		}
+	}
+}


### PR DESCRIPTION
#### sql: implement plan_cache_mode=auto

The `plan_cache_mode=auto` session setting has been implemented which
instructs the database to pick generic query plans for prepared
statements when they have a cost less than or equal to custom plans.

The current strategy matches Postgres's strategy quite closely. Under
`plan_cache_mode=auto`, custom query plans will be generated for the
first five executions of a prepared statement. On the sixth execution, a
generic query plan will be generated. If the cost of the generic query
plan is less than the average cost of the custom plans (plus some
overhead for re-optimization), then the generic query plan will be used.

Epic: CRDB-37712

Release note (sql change): The session setting `plan_cache_mode=auto`
can now be used to instruct the system to automatically determine
whether to use "custom" or "generic" query plans for the execution of a
prepared statement. Custom query plans are optimized on every execution,
while generic plans are optimized once and reused on future executions
as-is. Generic query plans are beneficial in cases where query
optimization contributes significant overhead to the total cost of
executing a query.

#### rfc: minor edits to generic query plans RFC

The term "absolute generic plan" has been replaced with "ideal generic
query plan".

Release note: None
