### PR TITLE
delegate: show privileges inherited through public role

### DIFF
--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -495,10 +495,16 @@ func (d *delegator) addWithClause(
 	source := specifics.source
 	cond := specifics.cond
 	nameCols := specifics.nameCols
-
 	implicitGranteeIn := "true"
+	publicRoleQuery := ""
+
 	if n.Grantees != nil {
 		params = params[:0]
+		// By default, every user/role inherits privileges from the implicit `public` role.
+		// To surface these inherited privileges, we query for all privileges inherited through the `public` role
+		// for all show grants statements except for ones which explicitly contain the `public`
+		// role, for e.g. SHOW GRANTS FOR PUBLIC.
+		addPublicAsImplicitGrantee := true
 		grantees, err := decodeusername.FromRoleSpecList(
 			d.evalCtx.SessionData(), username.PurposeValidation, n.Grantees,
 		)
@@ -506,7 +512,31 @@ func (d *delegator) addWithClause(
 			return nil, err
 		}
 		for _, grantee := range grantees {
+			if grantee.IsPublicRole() {
+				// If the public role is explicitly specified as a target within the SHOW GRANTS statement,
+				// no need to implicitly query for permissions on the public role.
+				addPublicAsImplicitGrantee = false
+			}
 			params = append(params, lexbase.EscapeSQLString(grantee.Normalized()))
+		}
+		if addPublicAsImplicitGrantee {
+			schemaNameFilter := ""
+			if strings.Contains(nameCols, "schema_name") {
+				// As the `public` role also contains permissions on virtual schemas like `crdb_internal`,
+				// we filter out the virtual schemas when we add privileges inherited through public to avoid noise.
+				// In all other cases, we don't filter out virtual schemas.
+				schemaNameFilter = "AND schema_name NOT IN ('crdb_internal', 'information_schema', 'pg_catalog', 'pg_extension')"
+			}
+			// The `publicRoleQuery` adds a lookup to retrieve privileges inherited implicitly through the public role.
+			publicRoleQuery = fmt.Sprintf(`
+				UNION ALL 
+					SELECT 
+						%s grantee, privilege_type, is_grantable
+					FROM 
+						r 
+					WHERE 
+						grantee = 'public' %s`,
+				nameCols, schemaNameFilter)
 		}
 		implicitGranteeIn = fmt.Sprintf("implicit_grantee IN (%s)", strings.Join(params, ","))
 	}
@@ -528,9 +558,10 @@ FROM
 	j
 WHERE
 	%s
+%s
 ORDER BY
 	%s grantee, privilege_type, is_grantable
-	`, source, cond, nameCols, implicitGranteeIn, nameCols)
+	`, source, cond, nameCols, implicitGranteeIn, publicRoleQuery, nameCols)
 	// Terminate on invalid users.
 	for _, p := range n.Grantees {
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -45,8 +45,9 @@ a  test-user  ALL      true
 query TTTB rowsort
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
-a  readwrite  ALL  true
-a  test-user  ALL  true
+a  public     CONNECT  false
+a  readwrite  ALL      true
+a  test-user  ALL      true
 
 statement ok
 REVOKE CONNECT ON DATABASE a FROM "test-user",readwrite
@@ -71,6 +72,7 @@ a  test-user  ZONECONFIG  true
 query TTTB rowsort
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
+a  public     CONNECT     false
 a  readwrite  BACKUP      true
 a  readwrite  CREATE      true
 a  readwrite  DROP        true
@@ -107,6 +109,7 @@ REVOKE ALL PRIVILEGES ON DATABASE a FROM "test-user"
 query TTTB rowsort
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
+a  public     CONNECT     false
 a  readwrite  BACKUP      true
 a  readwrite  CREATE      true
 a  readwrite  DROP        true
@@ -126,6 +129,7 @@ a  root    ALL      true
 query TTTB
 SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
+a  public  CONNECT  false
 
 # Usage privilege should not be grantable on databases.
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_inherited
+++ b/pkg/sql/logictest/testdata/logic_test/grant_inherited
@@ -61,11 +61,12 @@ meeter     granter  false
 statement ok
 GRANT ALL ON DATABASE defaultdb TO meeter WITH GRANT OPTION
 
-query TTTB colnames
+query TTTB colnames,rowsort
 SHOW GRANTS ON DATABASE defaultdb FOR alice
 ----
 database_name  grantee  privilege_type  is_grantable
 defaultdb      meeter   ALL             true
+defaultdb      public   CONNECT         false
 
 statement ok
 CREATE SCHEMA sc
@@ -73,7 +74,7 @@ CREATE SCHEMA sc
 statement ok
 GRANT ALL ON SCHEMA sc TO meeter WITH GRANT OPTION
 
-query TTTTB colnames
+query TTTTB colnames,rowsort
 SHOW GRANTS ON SCHEMA sc FOR alice
 ----
 database_name  schema_name  grantee  privilege_type  is_grantable
@@ -85,7 +86,7 @@ CREATE SEQUENCE sq
 statement ok
 GRANT ALL ON SEQUENCE sq TO meeter WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON SEQUENCE sq FOR alice
 ----
 database_name  schema_name  table_name  grantee  privilege_type  is_grantable
@@ -97,7 +98,7 @@ CREATE TABLE tbl (i INT PRIMARY KEY);
 statement ok
 GRANT ALL ON TABLE tbl TO meeter WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON TABLE tbl FOR alice
 ----
 database_name  schema_name  table_name  grantee  privilege_type  is_grantable
@@ -109,11 +110,12 @@ CREATE TYPE typ AS ENUM ('a', 'b')
 statement ok
 GRANT ALL ON TYPE typ TO meeter WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON TYPE typ FOR alice
 ----
 database_name  schema_name  type_name  grantee  privilege_type  is_grantable
 test           public       typ        meeter   ALL             true
+test           public       typ        public   USAGE           false
 
 statement ok
 CREATE FUNCTION fn(IN x INT)
@@ -127,11 +129,12 @@ $$
 statement ok
 GRANT EXECUTE ON FUNCTION fn TO meeter WITH GRANT OPTION
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS ON FUNCTION fn FOR alice
 ----
-database_name  schema_name  routine_id   routine_signature   grantee  privilege_type  is_grantable
-test           public       100111       fn(int8)            meeter   EXECUTE         true
+database_name  schema_name  routine_id  routine_signature  grantee  privilege_type  is_grantable
+test           public       100111      fn(int8)           meeter   EXECUTE         true
+test           public       100111      fn(int8)           public   EXECUTE         false
 
 statement ok
 CREATE EXTERNAL CONNECTION conn AS 'nodelocal://1/foo';
@@ -139,7 +142,7 @@ CREATE EXTERNAL CONNECTION conn AS 'nodelocal://1/foo';
 statement ok
 GRANT ALL ON EXTERNAL CONNECTION conn TO meeter WITH GRANT OPTION
 
-query TTTB colnames
+query TTTB colnames,rowsort
 SHOW GRANTS ON EXTERNAL CONNECTION conn FOR alice
 ----
 connection_name  grantee  privilege_type  is_grantable
@@ -148,8 +151,41 @@ conn             meeter   ALL             true
 statement ok
 GRANT SYSTEM ALL TO meeter WITH GRANT OPTION
 
-query TTB colnames
+query TTB colnames,rowsort
 SHOW SYSTEM GRANTS FOR alice
 ----
 grantee  privilege_type  is_grantable
 meeter   ALL             true
+
+# Verify that privileges inherited implicitly through public are listed
+# for a role.
+
+statement ok
+CREATE ROLE parent
+
+statement ok
+CREATE ROLE child
+
+statement ok
+GRANT parent TO child
+
+statement ok
+CREATE SCHEMA test_schema
+
+statement ok
+GRANT USAGE ON SCHEMA test_schema TO public
+
+statement ok
+GRANT CREATE ON SCHEMA test_schema TO parent
+
+query TTTTTTB colnames,rowsort
+SHOW GRANTS FOR child
+----
+database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public   CREATE          false
+test           public       NULL         schema       public   USAGE           false
+test           public       _typ         type         public   USAGE           false
+test           public       fn(int8)     routine      public   EXECUTE         false
+test           public       typ          type         public   USAGE           false
+test           test_schema  NULL         schema       parent   CREATE          false
+test           test_schema  NULL         schema       public   USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_sequences_in_schema
@@ -9,10 +9,12 @@ CREATE SCHEMA s2;
 statement ok
 GRANT SELECT ON ALL SEQUENCES IN SCHEMA s TO testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public   CREATE          false
+test           public       NULL         schema       public   USAGE           false
 
 statement ok
 CREATE SEQUENCE s.q;
@@ -46,6 +48,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public    CREATE          false
+test           public       NULL         schema       public    USAGE           false
 test           s            q            sequence     testuser  SELECT          false
 test           s            t            table        testuser  BACKUP          false
 
@@ -56,6 +60,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public    CREATE          false
+test           public       NULL         schema       public    USAGE           false
 test           s            q            sequence     testuser  SELECT          false
 test           s            q            sequence     testuser  USAGE           false
 test           s            t            table        testuser  BACKUP          false
@@ -67,6 +73,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            q            sequence     testuser   SELECT          false
 test           s            q            sequence     testuser   USAGE           false
 test           s            q            sequence     testuser2  SELECT          false
@@ -81,6 +89,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            q            sequence     testuser   ALL             false
 test           s            q            sequence     testuser2  ALL             false
 test           s            t            table        testuser   BACKUP          false
@@ -98,6 +108,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser3
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s2           q            sequence     testuser3  ALL             false
 test           s2           t            table        testuser3  ALL             false
 
@@ -114,6 +126,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            q            sequence     testuser   ALL             false
 test           s            q            sequence     testuser2  ALL             false
 test           s            t            table        testuser   BACKUP          false
@@ -126,6 +140,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser3
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s2           q            sequence     testuser3  ALL             false
 test           s2           t            table        testuser3  ALL             false
 test           s3           q            sequence     testuser3  USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
@@ -9,10 +9,12 @@ CREATE SCHEMA s2;
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public   CREATE          false
+test           public       NULL         schema       public   USAGE           false
 
 statement ok
 CREATE TABLE s.t();
@@ -21,10 +23,12 @@ CREATE TABLE s2.t();
 statement ok
 GRANT SELECT ON ALL TABLES IN SCHEMA s TO testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public    CREATE          false
+test           public       NULL         schema       public    USAGE           false
 test           s            t            table        testuser  SELECT          false
 
 statement ok
@@ -34,6 +38,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            t            table        testuser   SELECT          false
 test           s            t            table        testuser2  SELECT          false
 test           s2           t            table        testuser   SELECT          false
@@ -46,6 +52,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            t            table        testuser   ALL             false
 test           s            t            table        testuser2  ALL             false
 test           s2           t            table        testuser   ALL             false
@@ -58,6 +66,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            t            table        testuser   BACKUP          false
 test           s            t            table        testuser   CHANGEFEED      false
 test           s            t            table        testuser   CREATE          false
@@ -94,10 +104,12 @@ test           s2           t            table        testuser2  ZONECONFIG     
 statement ok
 REVOKE ALL ON ALL TABLES IN SCHEMA s, s2 FROM testuser, testuser2
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser, testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public   CREATE          false
+test           public       NULL         schema       public   USAGE           false
 
 # Verify that the database name is resolved correctly if specified.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -66,6 +66,8 @@ SHOW GRANTS FOR testuser2
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
 test           public       t            table        testuser2  INSERT          false
 test           public       t            table        testuser2  SELECT          false
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 
 user testuser2
 
@@ -78,6 +80,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser2  INSERT          false
 test           public       t            table        testuser2  SELECT          false
 
@@ -111,9 +115,12 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser2  DELETE          true
 test           public       t            table        testuser2  SELECT          true
 test           public       t            table        testuser2  UPDATE          true
+
 
 statement ok
 REVOKE GRANT OPTION FOR SELECT ON TABLE t FROM testuser2
@@ -123,6 +130,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser2  DELETE          true
 test           public       t            table        testuser2  SELECT          false
 test           public       t            table        testuser2  UPDATE          true
@@ -162,10 +171,12 @@ REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser2
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public    CREATE          false
+test           public       NULL         schema       public    USAGE           false
 test           public       t            table        testuser  ALL             false
 
 user testuser
@@ -178,10 +189,12 @@ user root
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 
 statement ok
 GRANT UPDATE, DELETE ON TABLE t to testuser WITH GRANT OPTION
@@ -190,6 +203,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser  DELETE          true
 test           public       t            table        testuser  UPDATE          true
 
@@ -197,10 +212,12 @@ test           public       t            table        testuser  UPDATE          
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t to testuser WITH GRANT OPTION
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public    CREATE          false
+test           public       NULL         schema       public    USAGE           false
 test           public       t            table        testuser  ALL             true
 
 user testuser
@@ -213,10 +230,12 @@ user root
 statement ok
 REVOKE GRANT OPTION FOR UPDATE, DELETE ON TABLE t FROM testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser  ALL             false
 
 user testuser
@@ -234,6 +253,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser2  DELETE          false
 test           public       t            table        testuser2  SELECT          true
 test           public       t            table        testuser2  UPDATE          false
@@ -279,6 +300,8 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           public       t            table        testuser  BACKUP          true
 test           public       t            table        testuser  CHANGEFEED      true
 test           public       t            table        testuser  CREATE          true
@@ -318,10 +341,12 @@ GRANT ALL PRIVILEGES ON TABLE t TO testuser WITH GRANT OPTION
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 
 #
 # Wipe everything so far and briefly test databases, schemas, types
@@ -335,15 +360,19 @@ REVOKE ALL PRIVILEGES ON TABLE t FROM testuser
 statement ok
 REVOKE ALL PRIVILEGES ON TABLE t FROM testuser2
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 
 statement ok
 CREATE SCHEMA s
@@ -351,10 +380,12 @@ CREATE SCHEMA s
 statement ok
 GRANT ALL PRIVILEGES ON SCHEMA s TO testuser WITH GRANT OPTION
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            NULL         schema       testuser  ALL             true
 
 user testuser
@@ -364,19 +395,23 @@ GRANT CREATE ON SCHEMA s TO testuser2 WITH GRANT OPTION
 
 user root
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser2
 ----
 database_name  schema_name  object_name  object_type  grantee    privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            NULL         schema       testuser2  CREATE          true
 
 statement ok
 REVOKE GRANT OPTION FOR ALL PRIVILEGES ON SCHEMA s FROM testuser
 
-query TTTTTTB colnames
+query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR testuser
 ----
 database_name  schema_name  object_name  object_type  grantee   privilege_type  is_grantable
+test           public       NULL         schema       public     CREATE          false
+test           public       NULL         schema       public     USAGE           false
 test           s            NULL         schema       testuser  ALL             false
 
 user testuser
@@ -600,7 +635,7 @@ CREATE USER grant_ordering_user
 statement ok
 GRANT ALL ON TABLE grant_ordering_table TO grant_ordering_user WITH GRANT OPTION
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON grant_ordering_table FOR grant_ordering_user
 ----
 database_name  schema_name  table_name            grantee              privilege_type  is_grantable
@@ -609,7 +644,7 @@ test           public       grant_ordering_table  grant_ordering_user  ALL      
 statement ok
 REVOKE GRANT OPTION FOR ALL ON TABLE grant_ordering_table FROM grant_ordering_user
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON grant_ordering_table FOR grant_ordering_user
 ----
 database_name  schema_name  table_name            grantee              privilege_type  is_grantable
@@ -628,7 +663,7 @@ test           public       grant_ordering_table  grant_ordering_user  SELECT   
 statement ok
 REVOKE GRANT OPTION FOR ALL ON TABLE grant_ordering_table FROM grant_ordering_user
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON grant_ordering_table FOR grant_ordering_user
 ----
 database_name  schema_name  table_name            grantee              privilege_type  is_grantable
@@ -695,8 +730,14 @@ SHOW GRANTS FOR roach
 ----
 database_name  schema_name  object_name    object_type          grantee  privilege_type  is_grantable
 NULL           NULL         connection1    external_connection  roach    USAGE           true
+test           public       NULL           schema               public   CREATE          false
+test           public       NULL           schema               public   USAGE           false
+test           public       _mood          type                 public   USAGE           false
+test           public       _type1         type                 public   USAGE           false
+test           public       mood           type                 public   USAGE           false
 test           public       mood           type                 roach    USAGE           false
 test           public       test_sequence  sequence             roach    SELECT          false
+test           public       type1          type                 public   USAGE           false
 
 # Verify that only system grants appear in SHOW SYSTEM GRANTS. Previously,
 # there was a bug that would cause external connection privileges to appear

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -214,12 +214,26 @@ SELECT description FROM [SHOW JOBS] WHERE description LIKE  '%updating privilege
 ----
 
 query TTTTTTB colnames,rowsort
-SHOW GRANTS FOR roach
+WITH roach_grants AS (
+  SHOW GRANTS FOR roach
+)
+SELECT database_name,
+  IF(schema_name LIKE 'pg_temp%', 'pg_temp', schema_name) AS schema_name,
+  object_name,
+  object_type,
+  grantee,
+  privilege_type,
+  is_grantable
+FROM roach_grants
 ----
-database_name  schema_name   object_name  object_type  grantee  privilege_type  is_grantable
-test           roachhouse    NULL         schema       roach    ALL             false
-test           roachlayer    NULL         schema       roach    ALL             false
-test           roachstation  NULL         schema       roach    ALL             false
+database_name  schema_name                    object_name  object_type  grantee  privilege_type  is_grantable
+test           pg_temp                        NULL         schema       public   CREATE          false
+test           pg_temp                        NULL         schema       public   USAGE           false
+test           public                         NULL         schema       public   CREATE          false
+test           public                         NULL         schema       public   USAGE           false
+test           roachhouse                     NULL         schema       roach    ALL             false
+test           roachlayer                     NULL         schema       roach    ALL             false
+test           roachstation                   NULL         schema       roach    ALL             false
 
 subtest has_*_privilege_works_for_public
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -805,6 +805,8 @@ test           pg_catalog   void            type         admin    ALL           
 test           pg_catalog   void            type         root     ALL             false
 test           public       NULL            schema       admin    ALL             true
 test           public       NULL            schema       root     ALL             true
+test           public       NULL            schema       public   CREATE          false
+test           public       NULL            schema       public   USAGE           false
 
 # With no database set, we show the grants everywhere
 statement ok
@@ -1420,6 +1422,8 @@ a              pg_catalog   vector[]                         type         root  
 a              pg_catalog   void                             type         admin    ALL             false
 a              pg_catalog   void                             type         root     ALL             false
 a              public       NULL                             schema       admin    ALL             true
+a              public       NULL                             schema       public   CREATE          false
+a              public       NULL                             schema       public   USAGE           false
 a              public       NULL                             schema       root     ALL             true
 defaultdb      NULL         NULL                             database     admin    ALL             true
 defaultdb      NULL         NULL                             database     root     ALL             true
@@ -1600,6 +1604,8 @@ defaultdb      pg_catalog   vector[]                         type         root  
 defaultdb      pg_catalog   void                             type         admin    ALL             false
 defaultdb      pg_catalog   void                             type         root     ALL             false
 defaultdb      public       NULL                             schema       admin    ALL             true
+defaultdb      public       NULL                             schema       public   CREATE          false
+defaultdb      public       NULL                             schema       public   USAGE           false
 defaultdb      public       NULL                             schema       root     ALL             true
 postgres       NULL         NULL                             database     admin    ALL             true
 postgres       NULL         NULL                             database     root     ALL             true
@@ -1780,6 +1786,8 @@ postgres       pg_catalog   vector[]                         type         root  
 postgres       pg_catalog   void                             type         admin    ALL             false
 postgres       pg_catalog   void                             type         root     ALL             false
 postgres       public       NULL                             schema       admin    ALL             true
+postgres       public       NULL                             schema       public   CREATE          false
+postgres       public       NULL                             schema       public   USAGE           false
 postgres       public       NULL                             schema       root     ALL             true
 system         NULL         NULL                             database     admin    CONNECT         true
 system         NULL         NULL                             database     root     CONNECT         true
@@ -1960,11 +1968,14 @@ system         pg_catalog   vector[]                         type         root  
 system         pg_catalog   void                             type         admin    ALL             false
 system         pg_catalog   void                             type         root     ALL             false
 system         public       NULL                             schema       admin    ALL             true
+system         public       NULL                             schema       public   CREATE          false
+system         public       NULL                             schema       public   USAGE           false
 system         public       NULL                             schema       root     ALL             true
 system         public       comments                         table        admin    DELETE          true
 system         public       comments                         table        admin    INSERT          true
 system         public       comments                         table        admin    SELECT          true
 system         public       comments                         table        admin    UPDATE          true
+system         public       comments                         table        public   SELECT          false
 system         public       comments                         table        root     DELETE          true
 system         public       comments                         table        root     INSERT          true
 system         public       comments                         table        root     SELECT          true
@@ -2520,7 +2531,10 @@ test           pg_catalog   vector[]                         type         root  
 test           pg_catalog   void                             type         admin    ALL             false
 test           pg_catalog   void                             type         root     ALL             false
 test           public       NULL                             schema       admin    ALL             true
+test           public       NULL                             schema       public   CREATE          false
+test           public       NULL                             schema       public   USAGE           false
 test           public       NULL                             schema       root     ALL             true
+
 
 statement error pgcode 42P01 relation "a.t" does not exist
 SHOW GRANTS ON a.t
@@ -2787,6 +2801,8 @@ query TTTTTTB rowsort
 SHOW GRANTS FOR readwrite, "test-user"
 ----
 a  NULL    NULL  database  readwrite  ALL         false
+a  public  NULL  schema    public     CREATE      false
+a  public  NULL  schema    public     USAGE       false
 a  public  v     table     readwrite  BACKUP      false
 a  public  v     table     readwrite  CHANGEFEED  false
 a  public  v     table     readwrite  CREATE      false
@@ -2810,14 +2826,16 @@ SHOW GRANTS ON v
 a  public  v  admin  ALL  true
 a  public  v  root   ALL  true
 
-query TTTTTB
+query TTTTTB rowsort
 SHOW GRANTS ON v FOR readwrite, "test-user"
 ----
 
-query TTTTTTB
+query TTTTTTB rowsort
 SHOW GRANTS FOR readwrite, "test-user"
 ----
-a  NULL  NULL  database  readwrite  ALL  false
+a  NULL    NULL  database  readwrite  ALL     false
+a  public  NULL  schema    public     CREATE  false
+a  public  NULL  schema    public     USAGE   false
 
 # Verify that the DB privileges have not changed.
 query TTTB colnames,rowsort
@@ -2946,7 +2964,7 @@ b              public       t2          root     ALL             true
 statement ok
 CREATE DATABASE empty
 
-query TTTTTB colnames
+query TTTTTB colnames,rowsort
 SHOW GRANTS ON empty.*
 ----
 database_name  schema_name  table_name  grantee  privilege_type  is_grantable
@@ -3022,5 +3040,7 @@ query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR roach
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+db             public       NULL         schema       public   CREATE          false
+db             public       NULL         schema       public   USAGE           false
 db             public       table1       table        roach    ALL             false
 db             public       table2       table        roach    ALL             false

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -42,15 +42,25 @@ query TTTTTB colnames,rowsort
 SHOW GRANTS ON TYPE schema_a.enum_b, enum_a, int4 FOR user1
 ----
 database_name  schema_name  type_name  grantee  privilege_type  is_grantable
+test           public       enum_a     public   USAGE           false
 test           public       enum_a     user1    USAGE           false
+test           schema_a     enum_b     public   USAGE           false
 test           schema_a     enum_b     user1    ALL             false
 
 query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR user1
 ----
 database_name  schema_name  object_name  object_type  grantee  privilege_type  is_grantable
+test           public       NULL         schema       public   CREATE          false
+test           public       NULL         schema       public   USAGE           false
+test           public       _enum_a      type         public   USAGE           false
+test           public       _enum_a+b    type         public   USAGE           false
+test           public       enum_a       type         public   USAGE           false
 test           public       enum_a       type         user1    USAGE           false
+test           public       enum_a+b     type         public   USAGE           false
 test           public       enum_a+b     type         user1    USAGE           false
+test           schema_a     _enum_b      type         public   USAGE           false
+test           schema_a     enum_b       type         public   USAGE           false
 test           schema_a     enum_b       type         user1    ALL             false
 
 statement error type "non_existent" does not exist
@@ -71,10 +81,11 @@ other  public  typ  public  USAGE  false
 other  public  typ  root    ALL    true
 other  public  typ  user1   ALL    false
 
-query TTTTTB
+query TTTTTB rowsort
 SHOW GRANTS ON TYPE other.typ FOR user1
 ----
-other  public  typ  user1  ALL  false
+other  public  typ  public  USAGE  false
+other  public  typ  user1   ALL    false
 
 # Verify that owner and child of owner have is_grantable implicitly.
 
@@ -145,7 +156,23 @@ select description from [show jobs] where description LIKE '%type%'
 query TTTTTTB colnames,rowsort
 SHOW GRANTS FOR roach
 ----
-database_name  schema_name  object_name   object_type  grantee  privilege_type  is_grantable
-test           public       custom_type1  type         roach    ALL             false
-test           public       custom_type2  type         roach    ALL             false
-test           public       custom_type3  type         roach    ALL             false
+database_name  schema_name  object_name          object_type  grantee  privilege_type  is_grantable
+test           public       NULL                 schema       public   CREATE          false
+test           public       NULL                 schema       public   USAGE           false
+test           public       _custom_type1        type         public   USAGE           false
+test           public       _custom_type2        type         public   USAGE           false
+test           public       _custom_type3        type         public   USAGE           false
+test           public       _enum_a              type         public   USAGE           false
+test           public       _enum_a+b            type         public   USAGE           false
+test           public       _owner_grant_option  type         public   USAGE           false
+test           public       custom_type1         type         public   USAGE           false
+test           public       custom_type1         type         roach    ALL             false
+test           public       custom_type2         type         public   USAGE           false
+test           public       custom_type2         type         roach    ALL             false
+test           public       custom_type3         type         public   USAGE           false
+test           public       custom_type3         type         roach    ALL             false
+test           public       enum_a               type         public   USAGE           false
+test           public       enum_a+b             type         public   USAGE           false
+test           public       owner_grant_option   type         public   USAGE           false
+test           schema_a     _enum_b              type         public   USAGE           false
+test           schema_a     enum_b               type         public   USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/procedure_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_privileges
@@ -664,14 +664,24 @@ SELECT * FROM [
 ----
 database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
 test           sc_test_show_grants  100116      p_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100116      p_test_show_grants(int8)             public              EXECUTE         false
+test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  public              EXECUTE         false
 test           sc_test_show_grants  100117      p_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS FOR u_test_show_grants] ORDER BY object_name
 ----
 database_name  schema_name          object_name                          object_type  grantee             privilege_type  is_grantable
+test           public               NULL                                 schema       public              CREATE          false
+test           public               NULL                                 schema       public              USAGE           false
+test           sc_test_show_grants  p_test_show_grants(int8)             routine      public              EXECUTE         false
 test           sc_test_show_grants  p_test_show_grants(int8)             routine      u_test_show_grants  EXECUTE         false
 test           sc_test_show_grants  p_test_show_grants(int8, text, oid)  routine      u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  p_test_show_grants(int8, text, oid)  routine      public              EXECUTE         false
+test           sc_test_show_grants  test_priv_f()                        routine      public              EXECUTE         false
+test           public               test_priv_p1()                       routine      public              EXECUTE         false
+test           public               test_priv_p2(int8)                   routine      public              EXECUTE         false
+test           test_priv_sc1        test_priv_p3()                       routine      public              EXECUTE         false
 
 statement ok
 SET search_path = public;

--- a/pkg/sql/logictest/testdata/logic_test/udf_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/udf_privileges
@@ -634,16 +634,26 @@ SELECT * FROM [
   SHOW GRANTS ON FUNCTION f_test_show_grants(INT), f_test_show_grants(INT, string, OID) FOR u_test_show_grants
 ] ORDER BY routine_id
 ----
-database_name  schema_name          routine_id  routine_signature                   grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100116       f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100117       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+database_name  schema_name          routine_id  routine_signature                    grantee             privilege_type  is_grantable
+test           sc_test_show_grants  100116      f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100116      f_test_show_grants(int8)             public              EXECUTE         false
+test           sc_test_show_grants  100117      f_test_show_grants(int8, text, oid)  public              EXECUTE         false
+test           sc_test_show_grants  100117      f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS FOR u_test_show_grants] ORDER BY object_name
 ----
 database_name  schema_name          object_name                          object_type  grantee             privilege_type  is_grantable
+test           public               NULL                                 schema       public              CREATE          false
+test           public               NULL                                 schema       public              USAGE           false
+test           sc_test_show_grants  f_test_show_grants(int8)             routine      public              EXECUTE         false
 test           sc_test_show_grants  f_test_show_grants(int8)             routine      u_test_show_grants  EXECUTE         false
 test           sc_test_show_grants  f_test_show_grants(int8, text, oid)  routine      u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  f_test_show_grants(int8, text, oid)  routine      public              EXECUTE         false
+test           public               test_priv_f1()                       routine      public              EXECUTE         false
+test           public               test_priv_f2(int8)                   routine      public              EXECUTE         false
+test           test_priv_sc1        test_priv_f3()                       routine      public              EXECUTE         false
+test           sc_test_show_grants  test_priv_p()                        routine      public              EXECUTE         false
 
 statement ok
 SET search_path = public;


### PR DESCRIPTION
This PR updates the SHOW GRANTS FOR <role> output to also contain grants inherited through the public role. public is an implicit role in every cluster. Every role/user within the cluster inherits all privileges from the public role. However, the public role is assigned privileges on all virtual schemas such as crdb_internal. To make the output more meaningful for SHOW GRANTS, we filter out grants related to virtual schemas but include all other grants inherited through the public role. The grants on virtual schemas as listed when the public role is explicitly queried as a target role in a SHOW GRANTS statement.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/122204 
Release note (sql change): SHOW GRANTS for a role shows grants inherited through the implicitly defined public role.