### PR TITLE
drt: update drtprod start for drt-large

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -27,7 +27,9 @@ fi
 
 case $1 in
   "start")
-    if [[ "$*" != *"--restart"* ]]; then
+    cluster="$2"
+    # This is to avoid the command to have --restart and --restart=false both in case of drt-large
+    if [[ $cluster != "drt-large" && "$*" != *"--restart"* ]]; then
       # implied for long-lived DRT clusters; avoid on init w/ --restart=false.
       shift
       set -- start "--enable-fluent-sink" "--restart" "$@"
@@ -40,12 +42,14 @@ case $1 in
       shift
       set -- start "--enable-fluent-sink" "--sql-port" "26257" "$@"
     fi
-    ;;
-  "sql")
-    if [[ "$*" != *"--secure"* ]]; then
-      shift
-      set -- sql --secure "$@"
-    fi
+    case $cluster in
+      "drt-large")
+        set -- start "--binary" "./cockroach" --args="--log=\"file-defaults: {dir: 'logs', max-group-size: 1GiB}\"" --store-count=16 --restart=false "$@"
+        roachprod run $cluster -- "\"sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh\""
+        ;;
+      *)
+        ;;
+    esac
     ;;
   "side-eye")
     shift


### PR DESCRIPTION
Previously, to start `drt-large` we had to run
```
./scripts/drtprod start drt-large --binary ./cockroach
--args=--log="file-defaults: {dir: 'logs',
max-group-size: 1GiB}" --store-count=16 --restart=false
```
This was inadequate for the uninitiated since it's unlikely for them to know all these arguments. To address this, this patch checks in the flags as default for `drt-large`

Epic: none
Release note: None