### PR TITLE
raft: update leader's Next when appending entries

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -817,6 +817,11 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 	} else if !r.raftLog.append(app) {
 		r.logger.Panicf("%x leader could not append to its log", r.id)
 	}
+
+	// On appending entries, the leader is effectively "sending" a MsgApp to its
+	// local "acceptor". Since we don't actually send this self-MsgApp, update the
+	// progress here as if it was sent.
+	r.trk.Progress[r.id].Next = app.lastIndex() + 1
 	// The leader needs to self-ack the entries just appended once they have
 	// been durably persisted (since it doesn't send an MsgApp to itself). This
 	// response message will be added to msgsAfterAppend and delivered back to

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -246,6 +246,13 @@ process-ready 1 2 3
 > 3 handling Ready
   <empty Ready>
 
+# TODO(pav-kv): leader's next should be updated.
+status 1
+----
+1: StateReplicate match=11 next=12
+2: StateReplicate match=11 next=13 inflight=1
+3: StateReplicate match=11 next=13 inflight=1
+
 deliver-msgs 1 2 3
 ----
 1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
@@ -353,6 +360,12 @@ AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
 3->1 MsgAppResp Term:1 Log:0/12
 AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
 AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+
+status 1
+----
+1: StateReplicate match=12 next=13
+2: StateReplicate match=12 next=14 inflight=1
+3: StateReplicate match=12 next=14 inflight=1
 
 propose 1 prop_3
 ----

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -246,10 +246,9 @@ process-ready 1 2 3
 > 3 handling Ready
   <empty Ready>
 
-# TODO(pav-kv): leader's next should be updated.
 status 1
 ----
-1: StateReplicate match=11 next=12
+1: StateReplicate match=11 next=13
 2: StateReplicate match=11 next=13 inflight=1
 3: StateReplicate match=11 next=13 inflight=1
 
@@ -363,7 +362,7 @@ AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
 
 status 1
 ----
-1: StateReplicate match=12 next=13
+1: StateReplicate match=12 next=14
 2: StateReplicate match=12 next=14 inflight=1
 3: StateReplicate match=12 next=14 inflight=1
 

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -97,7 +97,7 @@ ok
 # In-flight tracking to nodes 2 and 3 is saturated, but node 3 is behind.
 status 1
 ----
-1: StateReplicate match=14 next=15
+1: StateReplicate match=14 next=18
 2: StateReplicate match=14 next=18 paused inflight=3[full]
 3: StateReplicate match=11 next=15 paused inflight=3[full]
 


### PR DESCRIPTION
This PR makes the leader update its `Progress.Next` when it appends entries to its log. This makes the `Progress.Next` updates symmetric.

Previously, we only updated `Next` for followers, when sending a `MsgApp` to them, but updated `Match` symmetrically when getting `MsgAppResp` (both from the leader self-directed messages, and from followers). The leader is a special case: it doesn't send `MsgApp`s to itself. But there is an implicit `MsgApp` that happens in `appendEntry` function. We update `Next` accordingly.

On the leader, `Next` is always equal to `log.lastIndex + 1`. This is consistent with the fact that no more `MsgApp`s need to be sent to the local Acceptor.

Epic: none
Release note: none