### PR TITLE
kv: delete unused Store.spanConfigUpdateQueueRateLimiter

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1131,7 +1131,6 @@ type Store struct {
 
 	computeInitialMetrics              sync.Once
 	systemConfigUpdateQueueRateLimiter *quotapool.RateLimiter
-	spanConfigUpdateQueueRateLimiter   *quotapool.RateLimiter
 
 	rangeFeedSlowClosedTimestampNudge *singleflight.Group
 


### PR DESCRIPTION
This has been unused since its introduction in 89f8aba8. For some reason, it's now tripping up `TestLint/TestStaticCheck`.

Epic: None
Release note: None