### PR TITLE
crosscluster: implement dlq logic

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -92,7 +92,6 @@ go_test(
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl/cdcevent",
-        "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/crosscluster/replicationtestutils",
         "//pkg/ccl/storageccl",
         "//pkg/jobs",

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -130,11 +130,6 @@ func (r *logicalReplicationResumer) ingest(
 	}
 	defer func() { _ = client.Close(ctx) }()
 
-	dlqClient := InitDeadLetterQueueClient()
-	if err := dlqClient.Create(); err != nil {
-		return errors.Wrap(err, "failed to create dead letter queue client")
-	}
-
 	asOf := replicatedTimeAtStart
 	if asOf.IsEmpty() {
 		asOf = payload.ReplicationStartTime
@@ -305,8 +300,15 @@ func (p *logicalReplicationPlanner) generatePlanWithFrontier(
 	}
 
 	dstToSrcDescMap := make(map[int32]descpb.TableDescriptor)
-	for _, pair := range p.payload.ReplicationPairs {
+	tableIDs := make([]int32, len(p.payload.ReplicationPairs))
+	for i, pair := range p.payload.ReplicationPairs {
 		dstToSrcDescMap[pair.DstDescriptorID] = plan.DescriptorMap[pair.SrcDescriptorID]
+		tableIDs[i] = pair.DstDescriptorID
+	}
+
+	dlqClient := InitDeadLetterQueueClient(p.jobExecCtx.ExecCfg().InternalDB.Executor())
+	if err := dlqClient.Create(ctx, tableIDs); err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create dead letter queue")
 	}
 
 	frontier, err := span.MakeFrontierAt(p.replicatedTimeAtStart, plan.SourceSpans...)

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -672,10 +672,12 @@ func (m mockBatchHandler) SetSyntheticFailurePercent(_ uint32) {}
 
 type mockDLQ int
 
-func (m *mockDLQ) Create() error { return nil }
+func (m *mockDLQ) Create(_ context.Context, _ []int32) error {
+	return nil
+}
 
 func (m *mockDLQ) Log(
-	_ context.Context, _ int64, _ streampb.StreamEvent_KV, _ cdcevent.Row, _ error,
+	_ context.Context, _ int64, _ streampb.StreamEvent_KV, _ cdcevent.Row, _ retryEligibility,
 ) error {
 	*m++
 	return nil


### PR DESCRIPTION
In this PR, we implement the logic for dlq client to create dlq tables and insert replication conflict logs into the corresponding dlq table.

Part of: https://cockroachlabs.atlassian.net/browse/DOC-10483
Epic: CRDB-38992
Release note: None