### PR TITLE
cli: update TestZipSpecialNames test execution conditions

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -435,6 +435,9 @@ func TestZipSpecialNames(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderShort(t)
+	skip.UnderRace(t)
+
 	dir, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 


### PR DESCRIPTION
Previously, `TestZipSpecialNames` test was timing it out after 15m. This change adds a low timeout for test & mark test as skipped during timeout.

Task: CRDB-39949
Fixes: #126501
Release note: None