### PR TITLE
roachtest: commandbuilder equals syntax mode

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/commandbuilder.go
+++ b/pkg/cmd/roachtest/roachtestutil/commandbuilder.go
@@ -23,6 +23,7 @@ type Command struct {
 	Binary    string
 	Arguments []string
 	Flags     map[string]*string
+	UseEquals bool
 }
 
 // NewCommand builds a command. The format parameter can take
@@ -40,6 +41,11 @@ func NewCommand(format string, args ...interface{}) *Command {
 		Arguments: parts[1:],
 		Flags:     make(map[string]*string),
 	}
+}
+
+func (c *Command) WithEqualsSyntax() *Command {
+	c.UseEquals = true
+	return c
 }
 
 func (c *Command) Arg(format string, args ...interface{}) *Command {
@@ -103,6 +109,11 @@ func (c *Command) String() string {
 	}
 	sort.Strings(names)
 
+	flagJoinSymbol := " "
+	if c.UseEquals {
+		flagJoinSymbol = "="
+	}
+
 	for _, name := range names {
 		val := c.Flags[name]
 		prefix := "-"
@@ -115,7 +126,7 @@ func (c *Command) String() string {
 		if val != nil {
 			parts = append(parts, *val)
 		}
-		flags = append(flags, strings.Join(parts, " "))
+		flags = append(flags, strings.Join(parts, flagJoinSymbol))
 	}
 
 	cmd := append(

--- a/pkg/cmd/roachtest/roachtestutil/commandbuilder_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/commandbuilder_test.go
@@ -33,6 +33,10 @@ func TestCommand(t *testing.T) {
 	c.Flag("max-ops", 10).Flag("path", "/some/path")
 	require.Equal(t, "./cockroach workload run bank {pgurl:1} --max-ops 10 --path /some/path", c.String())
 
+	c = clone(baseCommand).WithEqualsSyntax()
+	c.Flag("max-ops", 10).Flag("path", "/some/path")
+	require.Equal(t, "./cockroach workload run bank {pgurl:1} --max-ops=10 --path=/some/path", c.String())
+
 	c = clone(baseCommand)
 	c.MaybeFlag(true, "max-ops", 10)     // included
 	c.MaybeFlag(false, "concurrency", 8) // not included
@@ -73,5 +77,6 @@ func clone(cmd *Command) *Command {
 		Binary:    cmd.Binary,
 		Arguments: append([]string{}, cmd.Arguments...),
 		Flags:     flags,
+		UseEquals: cmd.UseEquals,
 	}
 }


### PR DESCRIPTION
Previously, `commandbuilder` would join flag parts with a space. This works well generally, but there is a case when a flag could be both an option (bool) or be assigned a value (e.g., the cockroach `logtostderr` flag can be both a bool or a string).

This change adds the ability to switch the builder into `equals syntax` mode. If enabled, when the command string is built it will use `--flag=value` instead of `--flag value`.

Epic: None
Release note: None