### PR TITLE
release-23.1: colexec: fix IS NOT NULL filter for tuples with NULLs

### DIFF
--- a/pkg/sql/colexec/is_null_ops.eg.go
+++ b/pkg/sql/colexec/is_null_ops.eg.go
@@ -288,8 +288,10 @@ func (o *isTupleNullSelOp) Next() coldata.Batch {
 		if sel := batch.Selection(); sel != nil {
 			sel = sel[:n]
 			for _, i := range sel {
-				selectTuple := nulls.NullAt(i) != o.negate
-				if !selectTuple {
+				var selectTuple bool
+				if nulls.NullAt(i) {
+					selectTuple = !o.negate
+				} else {
 					selectTuple = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 				if selectTuple {
@@ -302,8 +304,10 @@ func (o *isTupleNullSelOp) Next() coldata.Batch {
 			batch.SetSelection(true)
 			sel := batch.Selection()[:n]
 			for i := range sel {
-				selectTuple := nulls.NullAt(i) != o.negate
-				if !selectTuple {
+				var selectTuple bool
+				if nulls.NullAt(i) {
+					selectTuple = !o.negate
+				} else {
 					selectTuple = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 				}
 				if selectTuple {

--- a/pkg/sql/colexec/is_null_ops_tmpl.go
+++ b/pkg/sql/colexec/is_null_ops_tmpl.go
@@ -244,8 +244,10 @@ func _MAYBE_SELECT(
 	// {{define "maybeSelect" -}}
 
 	// {{if .IsTuple}}
-	selectTuple := nulls.NullAt(i) != o.negate
-	if !selectTuple {
+	var selectTuple bool
+	if nulls.NullAt(i) {
+		selectTuple = !o.negate
+	} else {
 		selectTuple = isTupleNull(datums.Get(i).(tree.Datum), o.negate)
 	}
 	if selectTuple {

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1255,3 +1255,28 @@ SELECT (ROW() AS a) IS NOT UNKNOWN
 
 statement error pgcode 42601 mismatch in tuple definition: 0 expressions, 1 labels
 SELECT CASE WHEN False THEN ROW() ELSE (ROW() AS a) END
+
+# Regression test for incorrect handling of IS NOT NULL filter in the vectorized
+# engine (#126769).
+query T
+SELECT * FROM (SELECT (NULL, NULL) AS a) AS b WHERE a IS NOT NULL;
+----
+
+query T
+SELECT * FROM (SELECT (1, NULL) AS a) AS b WHERE a IS NOT NULL;
+----
+
+query T
+SELECT * FROM (SELECT (1, 2) AS a) AS b WHERE a IS NOT NULL;
+----
+(1,2)
+
+query B
+SELECT ROW() IS NULL;
+----
+true
+
+query B
+SELECT ROW() IS NOT NULL;
+----
+true

--- a/pkg/sql/sem/eval/eval_test/BUILD.bazel
+++ b/pkg/sql/sem/eval/eval_test/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/parser",
-        "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/eval",


### PR DESCRIPTION
Backport 1/1 commits from #126901.

/cc @cockroachdb/release

---

This commit fixes `isTupleNullSelOp` (which handles IS NOT NULL filter expression). Previously, we incorrectly short-circuited the filter evaluation whenever the tuple is non-NULL - all such tuples were passed by the filter even though only tuples that don't have any NULL elements should pass. This is now fixed by bringing the logic inline with how row-by-row engine does it as well as the `isTupleNullProjOp` does it.

This commit additionally extends an existing vectorized eval test (which currently runs all projections) to also run filtering (i.e. "selection" operators) on expressions of the boolean type. This would have caught the bug.

Fixes: #126769.

Release note (bug fix): Previously, CockroachDB could incorrectly evaluate `IS NOT NULL` filter if it was applied to non-NULL tuples that had NULL elements (like `(1, NULL)` or `(NULL, NULL)`). The bug is present since 20.2 version and is now fixed.

Release justification: bug fix.