### PR TITLE
sql: fix column formatting in inverted index backfill

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -395,10 +395,9 @@ func setupMultiRegionDatabase(t test.Test, conn *gosql.DB, rnd *rand.Rand, logSt
 	}
 
 	execStmt := func(stmt string) {
+		logStmt(stmt)
 		if _, err := conn.Exec(stmt); err != nil {
 			t.Fatal(err)
-		} else {
-			logStmt(stmt)
 		}
 	}
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1796,9 +1796,10 @@ func countExpectedRowsForInvertedIndex(
 	if col.IsExpressionIndexColumn() {
 		colNameOrExpr = col.GetComputeExpr()
 	} else {
-		// Wrap the column name in double-quotes because it might
-		// contain special characters, like "-".
-		colNameOrExpr = fmt.Sprintf("%q", col.ColName())
+		// Format the column name so that it can be parsed if it has special
+		// characters, like "-" or a newline.
+		name := col.ColName()
+		colNameOrExpr = tree.AsStringWithFlags(&name, tree.FmtParsable)
 	}
 
 	var expectedCount int64

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -2060,3 +2060,16 @@ WHERE
         OR (ARRAY ['str2'] && t.links AND ARRAY ['str3'] && t.links)
     );
 ----
+
+# Regression test for #126444. The backfill should not fail when the indexed
+# column has special characters, like a newline.
+statement ok
+CREATE TABLE t126444 (
+  a INT PRIMARY KEY,
+  "b
+c" STRING
+)
+
+statement ok
+CREATE INVERTED INDEX ON t126444 ("b
+c" gin_trgm_ops)


### PR DESCRIPTION
#### sqlsmith: unconditionally log multi-region setup statements

Prior to this commit, SQL statements for setting up multi-region schemas
were not logged if they resulted in an error. This made it difficult to
reproduce test failures, such as in #126444. The setup statements are
now logged unconditionally.

Release note: None

#### sql: fix column formatting in inverted index backfill

Fixes #126444

Release note (bug fix): A bug has been fixed that could cause
`CREATE INVERTED INDEX` and `ALTER TABLE ... SET LOCALITY REGIONAL BY
ROW` statements to fail if the corresponding tables contained columns
with non-standard characters in their name, like tabs or newlines. This
bug was present since inverted indexes were introduced in version 2.0.
