### PR TITLE
sql/opt: add session setting to disable merged partial stats use in opt

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3295,6 +3295,10 @@ func (m *sessionDataMutator) SetOptimizerUseForecasts(val bool) {
 	m.data.OptimizerUseForecasts = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseMergedPartialStatistics(val bool) {
+	m.data.OptimizerUseMergedPartialStatistics = val
+}
+
 func (m *sessionDataMutator) SetOptimizerUseHistograms(val bool) {
 	m.data.OptimizerUseHistograms = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6184,6 +6184,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on
 optimizer_use_improved_zigzag_join_costing                 on
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
+optimizer_use_merged_partial_statistics                    off
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 optimizer_use_polymorphic_parameter_fix                    on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2918,6 +2918,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on                  N
 optimizer_use_improved_zigzag_join_costing                 on                  NULL      NULL        NULL        string
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL      NULL        NULL        string
 optimizer_use_lock_op_for_serializable                     off                 NULL      NULL        NULL        string
+optimizer_use_merged_partial_statistics                    off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                          off                 NULL      NULL        NULL        string
 optimizer_use_polymorphic_parameter_fix                    on                  NULL      NULL        NULL        string
@@ -3106,6 +3107,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on                  N
 optimizer_use_improved_zigzag_join_costing                 on                  NULL  user     NULL      on                  on
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL  user     NULL      on                  on
 optimizer_use_lock_op_for_serializable                     off                 NULL  user     NULL      off                 off
+optimizer_use_merged_partial_statistics                    off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                          off                 NULL  user     NULL      off                 off
 optimizer_use_polymorphic_parameter_fix                    on                  NULL  user     NULL      on                  on
@@ -3282,6 +3284,7 @@ optimizer_merge_joins_enabled                              NULL    NULL     NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
 optimizer_push_offset_into_index_join                      NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
+optimizer_use_merged_partial_statistics                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_disjunction_stats                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -140,6 +140,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on
 optimizer_use_improved_zigzag_join_costing                 on
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
+optimizer_use_merged_partial_statistics                    off
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 optimizer_use_polymorphic_parameter_fix                    on

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -756,6 +756,8 @@ WHERE stat->>'name' = '__merged__';
     "row_count": 9
 }
 
+statement ok
+SET optimizer_use_merged_partial_statistics = on
 
 query T
 EXPLAIN (OPT, VERBOSE) SELECT * FROM i WHERE i = 6 OR i <= -1
@@ -1365,3 +1367,70 @@ ka_partialstat   {a}           3          2               2
 
 statement ok
 RESET CLUSTER SETTING sql.stats.histogram_samples.count
+
+# Verify that optimizer_use_merged_partial_statistics can be used to enable and
+# disable merged stat usage in the optimizer.
+statement ok
+RESET optimizer_use_merged_partial_statistics
+
+statement ok
+DELETE FROM ka
+
+statement ok
+INSERT INTO ka SELECT x, x FROM generate_series(0, 9) as g(x)
+
+statement ok
+CREATE STATISTICS ka_fullstat ON a FROM ka
+
+statement ok
+INSERT INTO ka VALUES (10, 10)
+
+statement ok
+CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
+
+query T
+EXPLAIN SELECT * FROM ka WHERE a > 5
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 4 (36% of the table; stats collected <hidden> ago)
+  table: ka@ka_a_idx
+  spans: [/6 - ]
+
+query T
+EXPLAIN SELECT * FROM ka WHERE a = 10
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
+  table: ka@ka_a_idx
+  spans: [/10 - /10]
+
+statement ok
+SET optimizer_use_merged_partial_statistics = on
+
+query T
+EXPLAIN SELECT * FROM ka WHERE a > 5
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 5 (45% of the table; stats collected <hidden> ago)
+  table: ka@ka_a_idx
+  spans: [/6 - ]
+
+query T
+EXPLAIN SELECT * FROM ka WHERE a = 10
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 1 (9.1% of the table; stats collected <hidden> ago)
+  table: ka@ka_a_idx
+  spans: [/10 - /10]

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -152,6 +152,7 @@ type Memo struct {
 	reorderJoinsLimit                          int
 	zigzagJoinEnabled                          bool
 	useForecasts                               bool
+	useMergedPartialStatistics                 bool
 	useHistograms                              bool
 	useMultiColStats                           bool
 	useNotVisibleIndex                         bool
@@ -237,6 +238,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		reorderJoinsLimit:                          int(evalCtx.SessionData().ReorderJoinsLimit),
 		zigzagJoinEnabled:                          evalCtx.SessionData().ZigzagJoinEnabled,
 		useForecasts:                               evalCtx.SessionData().OptimizerUseForecasts,
+		useMergedPartialStatistics:                 evalCtx.SessionData().OptimizerUseMergedPartialStatistics,
 		useHistograms:                              evalCtx.SessionData().OptimizerUseHistograms,
 		useMultiColStats:                           evalCtx.SessionData().OptimizerUseMultiColStats,
 		useNotVisibleIndex:                         evalCtx.SessionData().OptimizerUseNotVisibleIndexes,
@@ -400,6 +402,7 @@ func (m *Memo) IsStale(
 	if m.reorderJoinsLimit != int(evalCtx.SessionData().ReorderJoinsLimit) ||
 		m.zigzagJoinEnabled != evalCtx.SessionData().ZigzagJoinEnabled ||
 		m.useForecasts != evalCtx.SessionData().OptimizerUseForecasts ||
+		m.useMergedPartialStatistics != evalCtx.SessionData().OptimizerUseMergedPartialStatistics ||
 		m.useHistograms != evalCtx.SessionData().OptimizerUseHistograms ||
 		m.useMultiColStats != evalCtx.SessionData().OptimizerUseMultiColStats ||
 		m.useNotVisibleIndex != evalCtx.SessionData().OptimizerUseNotVisibleIndexes ||

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -220,6 +220,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseForecasts = false
 	notStale()
 
+	// Stale optimizer merged partial statistics usage enable.
+	evalCtx.SessionData().OptimizerUseMergedPartialStatistics = true
+	stale()
+	evalCtx.SessionData().OptimizerUseMergedPartialStatistics = false
+	notStale()
+
 	// Stale optimizer histogram usage enable.
 	evalCtx.SessionData().OptimizerUseHistograms = true
 	stale()

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -651,6 +651,7 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 	var first int
 	for first < tab.StatisticCount() &&
 		(tab.Statistic(first).IsPartial() ||
+			tab.Statistic(first).IsMerged() && !sb.evalCtx.SessionData().OptimizerUseMergedPartialStatistics ||
 			tab.Statistic(first).IsForecast() && !sb.evalCtx.SessionData().OptimizerUseForecasts) {
 		first++
 	}
@@ -674,6 +675,9 @@ func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Stati
 		for i := first; i < tab.StatisticCount(); i++ {
 			stat := tab.Statistic(i)
 			if stat.IsPartial() {
+				continue
+			}
+			if stat.IsMerged() && !sb.evalCtx.SessionData().OptimizerUseMergedPartialStatistics {
 				continue
 			}
 			if stat.IsForecast() && !sb.evalCtx.SessionData().OptimizerUseForecasts {

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -537,6 +537,10 @@ message LocalOnlySessionData {
   // EnableCreateStatsUsingExtremesBoolEnum, when true, allows the use of CREATE
   // STATISTICS .. USING EXTREMES on bool and enum columns.
   bool enable_create_stats_using_extremes_bool_enum = 136;
+  // OptimizerUseMergedPartialStatistics indicates whether we should use
+  // statistics merged from partial and full statistics for cardinality
+  // estimation in the optimizer.
+  bool optimizer_use_merged_partial_statistics = 137;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -846,8 +846,6 @@ ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
 		return nil, nil, err
 	}
 
-	// TODO(faizaanmadhani): Wrap merging behind a boolean so
-	// that it can be turned off.
 	merged := MergedStatistics(ctx, statsList, st)
 	statsList = append(merged, statsList...)
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -827,6 +827,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_use_merged_partial_statistics`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_merged_partial_statistics`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_merged_partial_statistics", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseMergedPartialStatistics(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseMergedPartialStatistics), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`optimizer_use_histograms`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_histograms`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Previously, any merged stats created from existing partial stats would always be used by the optimizer. Adds the
`optimizer_use_merged_partial_statistics` session setting, which can be used to disable merged stat usage in the optimizer. This is now disabled by default. Merged stats will still be created in the stats cache if partial stats exist, and the creation of partial stats can be controlled using the `enable_create_stats_using_extremes` session setting.

Fixes: #95233

See also: #125950

Release note (sql change): Added a session setting, `optimizer_use_merged_partial_statistics`, which can be set to true to enable usage of existing partial statistics merged with full statistics when optimizing a query, which is disabled by default.