### PR TITLE
cluster-ui: remove quotes in table name in db details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
@@ -25,7 +25,11 @@ import * as format from "../util/format";
 import { Breadcrumbs } from "../breadcrumbs";
 import { CaretRight } from "../icon/caretRight";
 import { CockroachCloudContext } from "../contexts";
-import { checkInfoAvailable, getNetworkErrorMessage } from "../databases";
+import {
+  checkInfoAvailable,
+  formatSQLTableName,
+  getNetworkErrorMessage,
+} from "../databases";
 import { DatabaseIcon } from "../icon/databaseIcon";
 
 import styles from "./databaseDetailsPage.module.scss";
@@ -94,10 +98,11 @@ export const TableNameCell = ({
       </Tooltip>
     );
   }
+  const displayName = formatSQLTableName(table.name);
   return (
     <Link to={linkURL} className={cx("icon__container")}>
       {icon}
-      {table.name}
+      {displayName}
     </Link>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.ts
@@ -17,6 +17,7 @@ import {
   getNodeIdsFromStoreIds,
   normalizePrivileges,
   normalizeRoles,
+  formatSQLTableName,
 } from "./util";
 
 describe("Getting nodes by region string", () => {
@@ -173,4 +174,39 @@ describe("Normalize roles", () => {
     const result = normalizeRoles(roles);
     expect(result).toEqual(["admin", "public"]);
   });
+});
+
+describe("formatSQLTableName", () => {
+  const tests = [
+    {
+      input: `"db"."table"`,
+      expected: `db.table`,
+    },
+    {
+      input: `"db"."schema"."table"`,
+      expected: `db.schema.table`,
+    },
+    {
+      input: `"a234ajf"."ojir__931a"`,
+      expected: `a234ajf.ojir__931a`,
+    },
+    {
+      input: `"public.hello.world"."table"`,
+      expected: `"public.hello.world".table`,
+    },
+    {
+      input: `"public"."my table"`,
+      expected: `public."my table"`,
+    },
+    {
+      input: `"db"."public. hello . world"."my.table"`,
+      expected: `db."public. hello . world"."my.table"`,
+    },
+  ];
+  it.each(tests)(
+    `removes double quotes from table name parts unless it contains a space or period`,
+    tc => {
+      expect(formatSQLTableName(tc.input)).toBe(tc.expected);
+    },
+  );
 });

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.tsx
@@ -298,3 +298,21 @@ const checkPrivilegeError = (
   // If the error message includes any mention of privilege, consider it a privilege error.
   return err.message.includes("privilege");
 };
+
+// formatSQLTableName formats a SQL table name to a more readable format by
+// removing double quotes around the name parts if that 'part' does not contain
+// any spaces or periods.
+// e.g.
+//  "public"."table" -> public.table
+//  "public"."table" -> public.table
+//  "public"."table with space" -> public."table with space"
+//  "public"."table.with.period" -> public."table.with.period"
+export const formatSQLTableName = (tableName: string): string => {
+  return tableName.replace(/"([^"]+)"/g, (_, part) => {
+    // If it has a space or period keep it in quotes.
+    if (part.match(/[\s.]/)) {
+      return `"${part}"`;
+    }
+    return part;
+  });
+};


### PR DESCRIPTION
Table names were displayed with quotes around their name parts, e.g. "public"."job_info". Now we strip the quotes from the name part unless the part contains a space or period in it.

Epic: none
Fixes: #126823

Release note: None


<img width="491" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/40ed392a-c490-4703-8961-d4063dbf29dd">
<img width="376" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/c62bffa1-f4d9-4fa5-b2ba-3e1ddbe533d8">

