### PR TITLE
workload/schemachange: get drop column ready, increase opweight of create table

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/lexbase",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -501,7 +501,7 @@ WHERE
 		return err
 	}
 
-	allowed, err := og.scanBool(
+	isIndexDropping, err := og.scanBool(
 		ctx,
 		tx,
 		`
@@ -518,7 +518,7 @@ SELECT count(*) > 0
 	if err != nil {
 		return err
 	}
-	if !allowed {
+	if isIndexDropping {
 		return ErrSchemaChangesDisallowedDueToPkSwap
 	}
 	return nil

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -1571,7 +1572,7 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 	// the table.
 	stmt.potentialExecErrors.add(pgcode.InvalidColumnReference)
 
-	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN "%s"`, tableName, columnName)
+	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, tableName, lexbase.EscapeSQLIdent(columnName))
 	return stmt, nil
 }
 

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -269,7 +269,7 @@ var opWeights = []int{
 	alterTableAddConstraintUnique:     0,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
 	alterTableAlterPrimaryKey:         1,
-	alterTableDropColumn:              0,
+	alterTableDropColumn:              1,
 	alterTableDropColumnDefault:       1,
 	alterTableDropConstraint:          1,
 	alterTableDropNotNull:             1,
@@ -284,7 +284,7 @@ var opWeights = []int{
 	createIndex:                       1,
 	createSchema:                      1,
 	createSequence:                    1,
-	createTable:                       1,
+	createTable:                       10,
 	createTableAs:                     1,
 	createTypeEnum:                    1,
 	createView:                        1,


### PR DESCRIPTION
### workload/schemachange: fix tableHasPrimaryKeySwapActive check
Previously, our workload did not generate any interesting
drop column operations. This was due to the fact that instead
of generating an error (`ErrSchemaChangesDisallowedDueToPkSwap`)
when the primary key was being dropped, it generated an error
if the primary key was **not** being dropped. This patch fixes
this behavior.

Informs: https://github.com/cockroachdb/cockroach/issues/122249
Fixes: https://github.com/cockroachdb/cockroach/issues/126962

Release note: None

---

### workload/schemachange: cannot drop col ref by computed col
This patch adds an expected error case for cols we want to
drop that are referenced by computed cols. For computed
columns that are internal, we put a potentional error code
for now.

Informs:  https://github.com/cockroachdb/cockroach/issues/122249
Fixes: https://github.com/cockroachdb/cockroach/issues/126963

Release note: None

---

### workload/schemachange: enable dropColumn, bump up table creation
Let's make it more likely for us to have tables in the workload
so that we can do more interesting things.
Enabling drop column while I'm at it.

Informs: https://github.com/cockroachdb/cockroach/issues/122249

Release note: None