### PR TITLE
sql: skip populating some fields in SetupFlowRequest in local plans

### DIFF
--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -30,6 +30,7 @@ message SetupFlowRequest {
   reserved 1, 2;
 
   optional util.tracing.tracingpb.TraceInfo trace_info = 11;
+  // JobTag is only populated in distributed flows.
   optional string job_tag = 13 [(gogoproto.nullable) = false];
 
   // LeafTxnInputState is the input parameter for the *kv.Txn needed for
@@ -46,6 +47,8 @@ message SetupFlowRequest {
 
   optional FlowSpec flow = 3 [(gogoproto.nullable) = false];
 
+  // EvalContext contains a subset of the eval.Context that needs to be sent to
+  // remote nodes for proper execution.
   optional EvalContext eval_context = 6 [(gogoproto.nullable) = false];
 
   optional bool trace_kv = 8 [(gogoproto.nullable) = false,


### PR DESCRIPTION
If we have a local plan, then some of the fields in `SetupFlowRequest` don't need to be populated, so we can skip some allocations. Additionally, this commit speeds up how we retrieve the job tag for distributed plan.

Epic: None

Release note: None