### PR TITLE
crosscluster/logical: a couple optimizations for ingestion

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
         "//pkg/util/ctxgroup",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -550,6 +550,7 @@ go_library(
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/fsm",
+        "//pkg/util/growstack",
         "//pkg/util/grpcutil",
         "//pkg/util/grunning",
         "//pkg/util/hlc",

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -69,13 +69,19 @@ type InternalExecutorOverride struct {
 	// being emitted for changes to data made in a session. It is illegal to set
 	// this option when using the internal executor with an outer txn.
 	DisableChangefeedReplication bool
-
 	// OriginIDForLogicalDataReplication is an identifier for the cluster that
 	// originally wrote the data that are being written in this session. An
 	// originID of 0 (the default) identifies a local write, 1 identifies a remote
 	// write of unspecified origin, and 2+ are reserved to identify remote writes
 	// from specific clusters.
 	OriginIDForLogicalDataReplication uint32
+	// PlanCacheMode, if set, overrides the plan_cache_mode session variable.
+	PlanCacheMode *sessiondatapb.PlanCacheMode
+	// GrowStackSize, if true, indicates that the connExecutor goroutine stack
+	// should be grown to 32KiB right away.
+	GrowStackSize bool
+	// DisablePlanGists, if true, overrides the disable_plan_gists session var.
+	DisablePlanGists bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not


### PR DESCRIPTION
This commit applies a couple more optimizations for the ingestion queries:
- we now use the generic query plans for INSERTs and DELETEs. Under assumption that these queries are simple we don't benefit from having the custom plans, so we now force usage of the generic plans.
- it has been observed in the CPU profiles that the goroutine stack of the connExecutor goroutine (that is spun up by the Internal Executor to evaluate a single query) grows multiple times and takes up on the order of 4% of CPU out of 16% attributed to the IE, so we now will use the grow stack hack specifically for the ingestion queries to go around this.
- we now disable plan gist generation too (which has almost negligible overhead, yet we don't really get any benefits from it).

Epic: None

Release note: None