### PR TITLE
drt: switch to pd-standard for drt-large

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -311,8 +311,9 @@ EOF"
           --gce-use-spot \
           --nodes 15 \
           --gce-machine-type n2-standard-16 \
-          --local-ssd=true \
-          --gce-local-ssd-count 16 \
+          --local-ssd=false
+          --gce-pd-volume-size=6000
+          --gce-pd-volume-type=pd-standard
           --os-volume-size 100 \
           --username drt \
           --lifetime 8760h


### PR DESCRIPTION
Previously, we were attaching local ssds to `drt-large` VMs. This was inadequate because we'd often lose the cluster in case of multi-region preemptions. This patch switches over to `pd-standard` to avoid this.

Epic: none
Release note: None