### PR TITLE
backupccl: deflake backup/assume-role roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -1021,7 +1021,7 @@ func getAWSBackupPath(dest string) (string, error) {
 		AssumeRoleAWSKeyIDEnvVar:     amazon.AWSAccessKeyParam,
 		AssumeRoleAWSSecretKeyEnvVar: amazon.AWSSecretParam,
 		AssumeRoleAWSRoleEnvVar:      amazon.AssumeRoleParam,
-		KMSRegionAEnvVar:             amazon.KMSRegionParam,
+		KMSRegionAEnvVar:             amazon.S3RegionParam,
 	}
 	for env, param := range expect {
 		v := os.Getenv(env)


### PR DESCRIPTION
This patch fixes the region param passed to the s3 uri.

Fixes #126881

Epic: none