### PR TITLE
crosscluster/logical: allow replication between different table names

### DIFF
--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -346,7 +346,7 @@ const (
 	insertQueryPessimistic = `
 INSERT INTO [%d AS t] (%s)
 VALUES (%s)
-ON CONFLICT ON CONSTRAINT %s
+ON CONFLICT (%s)
 DO UPDATE SET
 %s
 WHERE (t.crdb_internal_mvcc_timestamp <= excluded.crdb_replication_origin_timestamp
@@ -354,6 +354,23 @@ WHERE (t.crdb_internal_mvcc_timestamp <= excluded.crdb_replication_origin_timest
  OR (t.crdb_replication_origin_timestamp <= excluded.crdb_replication_origin_timestamp
      AND t.crdb_replication_origin_timestamp IS NOT NULL)`
 )
+
+func sqlEscapedJoin(parts []string, sep string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return lexbase.EscapeSQLIdent(parts[0])
+	default:
+		var s strings.Builder
+		s.WriteString(lexbase.EscapeSQLIdent(parts[0]))
+		for _, p := range parts[1:] {
+			s.WriteString(sep)
+			s.WriteString(lexbase.EscapeSQLIdent(p))
+		}
+		return s.String()
+	}
+}
 
 func makeInsertQueries(
 	dstTableDescID int32, td catalog.TableDescriptor,
@@ -434,7 +451,7 @@ func makeInsertQueries(
 			dstTableDescID,
 			columnNames.String(),
 			valueStrings.String(),
-			lexbase.EscapeSQLIdent(td.GetPrimaryIndex().GetName()),
+			sqlEscapedJoin(td.TableDesc().PrimaryIndex.KeyColumnNames, ","),
 			onConflictUpdateClause.String(),
 		))
 		if err != nil {


### PR DESCRIPTION
Previously our on-conflict clause used the name of the primary index from source table descriptor. Most users do not explicitly name the primary index which means that the primary index name is based on the table name. This tied the query to the table name of the _source_.

Here, we use an alternate ON CONFLICT syntax, explicitly listing the primary index columns.

Epic: none
Release note: none