### PR TITLE
sql: skip TestShowFingerprintsDuringSchemaChange under deadlock

### DIFF
--- a/pkg/sql/show_fingerprints_test.go
+++ b/pkg/sql/show_fingerprints_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -139,6 +140,11 @@ func TestShowFingerprintsDuringSchemaChange(t *testing.T) {
 func TestShowTenantFingerprintsProtectsTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// Under deadlock there isn't enough time for the CREATE TENANT txn to commit
+	// due to the intervals we lower to speed up this test. There is no difference
+	// otherwise when running this test under deadlock
+	skip.UnderDeadlock(t, 121445, "Deadlock makes txns take too long to commit")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This test fails sometimes under the deadlock flag because the CREATE TENANT call doesn't commit its transaction in time. This causes setup to fail and has no bearing on the actual test itself. Test doesn't fail outside of this one scenario, so skipping it.

Release note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/121445