### PR TITLE
workload/schemachange: take care of formatting

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/lexbase",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -916,7 +917,7 @@ func (og *operationGenerator) columnContainsNull(
 		SELECT %s
 		  FROM %s
 	   WHERE %s IS NULL
-	)`, columnName, tableName.String(), columnName))
+	)`, lexbase.EscapeSQLIdent(columnName), tableName.String(), lexbase.EscapeSQLIdent(columnName)))
 }
 
 func (og *operationGenerator) constraintIsPrimary(

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -501,7 +501,7 @@ WHERE
 		return err
 	}
 
-	allowed, err := og.scanBool(
+	isIndexDropping, err := og.scanBool(
 		ctx,
 		tx,
 		`
@@ -518,7 +518,7 @@ SELECT count(*) > 0
 	if err != nil {
 		return err
 	}
-	if !allowed {
+	if isIndexDropping {
 		return ErrSchemaChangesDisallowedDueToPkSwap
 	}
 	return nil

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -1571,7 +1572,7 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 	// the table.
 	stmt.potentialExecErrors.add(pgcode.InvalidColumnReference)
 
-	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN "%s"`, tableName, columnName)
+	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, tableName, lexbase.EscapeSQLIdent(columnName))
 	return stmt, nil
 }
 

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -269,7 +269,7 @@ var opWeights = []int{
 	alterTableAddConstraintUnique:     0,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
 	alterTableAlterPrimaryKey:         1,
-	alterTableDropColumn:              0,
+	alterTableDropColumn:              1,
 	alterTableDropColumnDefault:       1,
 	alterTableDropConstraint:          1,
 	alterTableDropNotNull:             1,
@@ -284,7 +284,7 @@ var opWeights = []int{
 	createIndex:                       1,
 	createSchema:                      1,
 	createSequence:                    1,
-	createTable:                       1,
+	createTable:                       10,
 	createTableAs:                     1,
 	createTypeEnum:                    1,
 	createView:                        1,


### PR DESCRIPTION
### This PR is stacked on top of others!

Please consider reviewing those PRs first. This message will be removed once prerequisite PRs are merged and this one is rebased.

* first three commits are from #126965

---

### workload/schemachange: take care of formatting
This patch ensures that:
1. for adding a column, the column name is
quote_ident-ed and the actual AST is not
quoted any more than it needs to be (quoting
our type name generated from SQLString is
invalid)
2. for creating an index, we do not over-quote
column names since `getTableColumns` already
does this for us
3. in places where we query by columnName, we
`EscapeSQLIdent` to ensure proper quotations for
special chars

Informs: https://github.com/cockroachdb/cockroach/issues/122249

Release note: None