### PR TITLE
crosscluster/logical: add heuristic for choosing implicit vs explicit

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -23,7 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -122,10 +124,14 @@ func newLogicalReplicationWriterProcessor(
 		}
 	}
 
+	tableDescs := make(map[int32]catalog.TableDescriptor)
+	for dstTableDescID, desc := range spec.TableDescriptors {
+		tableDescs[dstTableDescID] = tabledesc.NewBuilder(&desc).BuildImmutableTable()
+	}
 	bhPool := make([]BatchHandler, maxWriterWorkers)
 	for i := range bhPool {
 		rp, err := makeSQLLastWriteWinsHandler(
-			ctx, flowCtx.Cfg.Settings, spec.TableDescriptors,
+			ctx, flowCtx.Cfg.Settings, tableDescs,
 			// Initialize the executor with a fresh session data - this will
 			// avoid creating a new copy on each executor usage.
 			flowCtx.Cfg.DB.Executor(isql.WithSessionData(sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */))),
@@ -143,10 +149,34 @@ func newLogicalReplicationWriterProcessor(
 
 	dlqDbExec := flowCtx.Cfg.DB.Executor(isql.WithSessionData(sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */)))
 
+	var numTablesWithSecondaryIndexes int
+	for _, td := range tableDescs {
+		if len(td.NonPrimaryIndexes()) > 0 {
+			numTablesWithSecondaryIndexes++
+		}
+	}
+
 	lrw := &logicalReplicationWriterProcessor{
 		spec: spec,
 		getBatchSize: func() int {
-			if useImplicitTxns.Get(&flowCtx.Cfg.Settings.SV) {
+			// We want to decide whether to use implicit txns or not based on
+			// the schema of the target table. Benchmarking has shown that
+			// implicit txns are beneficial on tables with no secondary indexes
+			// whereas explicit txns are beneficial when at least one secondary
+			// index is present.
+			//
+			// Unfortunately, if we have multiple replication pairs, we don't
+			// know which tables will be affected by this batch before deciding
+			// on the batch size, so we'll use a heuristic such that we'll use
+			// the implicit txns if at least half of the target tables are
+			// without the secondary indexes. If we only have a single
+			// replication pair, then this heuristic gives us the precise
+			// recommendation.
+			//
+			// (Here we have access to the descriptor of the source table, but
+			// for now we assume that the source and the target descriptors are
+			// similar.)
+			if 2*numTablesWithSecondaryIndexes < len(tableDescs) && useImplicitTxns.Get(&flowCtx.Cfg.Settings.SV) {
 				return 1
 			}
 			return int(flushBatchSize.Get(&flowCtx.Cfg.Settings.SV))
@@ -648,9 +678,6 @@ func (lrw *logicalReplicationWriterProcessor) flushChunk(
 	ctx context.Context, bh BatchHandler, chunk []streampb.StreamEvent_KV, canRetry retryEligibility,
 ) (flushStats, error) {
 	batchSize := lrw.getBatchSize()
-	// TODO(yuzefovich): we should have a better heuristic for when to use the
-	// implicit vs explicit txns (for example, depending on the presence of the
-	// secondary indexes).
 
 	var stats flushStats
 	// TODO: The batching here in production would need to be much

--- a/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -74,8 +74,8 @@ func TestLWWInsertQueryQuoting(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/insert", tc.name), func(t *testing.T) {
 			tableName := createTable(tc.schemaTmpl)
 			desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", tableName)
-			rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]descpb.TableDescriptor{
-				int32(desc.GetID()): *desc.TableDesc(),
+			rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]catalog.TableDescriptor{
+				int32(desc.GetID()): desc,
 			}, s.InternalExecutor().(isql.Executor))
 			require.NoError(t, err)
 
@@ -89,8 +89,8 @@ func TestLWWInsertQueryQuoting(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/delete", tc.name), func(t *testing.T) {
 			tableName := createTable(tc.schemaTmpl)
 			desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", tableName)
-			rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]descpb.TableDescriptor{
-				int32(desc.GetID()): *desc.TableDesc(),
+			rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]catalog.TableDescriptor{
+				int32(desc.GetID()): desc,
 			}, s.InternalExecutor().(isql.Executor))
 			require.NoError(t, err)
 
@@ -128,8 +128,8 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
 	// Simulate how we set up the row processor on the main code path.
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
-	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]descpb.TableDescriptor{
-		int32(desc.GetID()): *desc.TableDesc(),
+	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[int32]catalog.TableDescriptor{
+		int32(desc.GetID()): desc,
 	}, s.InternalDB().(isql.DB).Executor(isql.WithSessionData(sd)))
 	require.NoError(b, err)
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -511,6 +511,7 @@ message LogicalReplicationWriterSpec {
     // Checkpoint stores a set of resolved spans denoting completed progress.
     optional jobs.jobspb.StreamIngestionCheckpoint checkpoint = 7 [(gogoproto.nullable) = false];
 
-    // TableDescriptors is a map between from destination table IDs to the source table descriptor.
+    // TableDescriptors is a map from destination table IDs to the source table
+    // descriptors.
     map<int32, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 8 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
This commit makes it so that we use implicit txns only on tables that have no secondary indexes and explicit txns for those with secondary indexes (in addition to having the cluster setting enabled). Benchmarking has shown that this way we get the best performance. There is a caveat though, if we have multiple replication pairs and only a subset of tables has secondary indexes, we'll go with the majority of tables' choice for all of them (because we decide which txn to use before we decode the KVs to know which tables are affected).

Epic: None

Release note: None