### PR TITLE
release-24.1: metric: improve Counter

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/file_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/file_test.go
@@ -508,7 +508,7 @@ func TestParsingErrorHandling(t *testing.T) {
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "error when creating access controller from file")
-		errorCount := errorCountMetric.Snapshot().Value()
+		errorCount := errorCountMetric.Value()
 		require.Equal(t, int64(0), errorCount)
 	})
 
@@ -524,7 +524,7 @@ func TestParsingErrorHandling(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, next)
-		require.Equal(t, int64(0), errorCountMetric.Snapshot().Value())
+		require.Equal(t, int64(0), errorCountMetric.Value())
 		allowlist := controller.(*Allowlist)
 		require.Equal(t, map[string]AllowEntry{
 			"tenant": {
@@ -544,7 +544,7 @@ func TestParsingErrorHandling(t *testing.T) {
 				// We need to return something to make the compiler happy, but t.Fatal will end execution.
 				return nil
 			default:
-				errorCount := errorCountMetric.Snapshot().Value()
+				errorCount := errorCountMetric.Value()
 				// If error count isn't one, then it hasn't happened yet.
 				if errorCount != 1 {
 					return fmt.Errorf("Expected error count to be 1 but got %d", errorCount)
@@ -560,7 +560,7 @@ func TestParsingErrorHandling(t *testing.T) {
 			select {
 			case controller := <-next:
 				// error count should go down
-				require.Equal(t, int64(0), errorCountMetric.Snapshot().Value())
+				require.Equal(t, int64(0), errorCountMetric.Value())
 				allowlist := controller.(*Allowlist)
 				require.Equal(t, map[string]AllowEntry{
 					"tenant": {

--- a/pkg/cmd/roachtest/tests/multiregion_leasing.go
+++ b/pkg/cmd/roachtest/tests/multiregion_leasing.go
@@ -141,7 +141,7 @@ func runSchemaChangeMultiRegionBenchmarkLeasing(
 			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), defaultOpts)
 
 			grp := ctxgroup.WithContext(ctx)
-			totalTimeSeconds := syncutil.AtomicFloat64(0.0)
+			var totalTimeSeconds syncutil.AtomicFloat64
 			// Start one thread per-node that will execute the cockroach sql command
 			// with a script that selects from each table. The number of tables that
 			// we have is high so the lease manager can't keep everything refreshed
@@ -181,7 +181,7 @@ func runSchemaChangeMultiRegionBenchmarkLeasing(
 							"session_based_leasing=%t node=%d iteration=%d completed in %.2f",
 							sessionBasedLeasingEnabled, nodeIdx, iter, realExecTimeSeconds,
 						))
-						syncutil.AddFloat64(&totalTimeSeconds, realExecTimeSeconds)
+						totalTimeSeconds.Add(realExecTimeSeconds)
 					}
 					return nil
 				})
@@ -189,7 +189,7 @@ func runSchemaChangeMultiRegionBenchmarkLeasing(
 			if err := grp.Wait(); err != nil {
 				t.Fatal(err)
 			}
-			durations[modeIdx] = time.Duration(syncutil.LoadFloat64(&totalTimeSeconds) * float64(time.Second))
+			durations[modeIdx] = time.Duration(totalTimeSeconds.Load() * float64(time.Second))
 			t.Status(fmt.Sprintf("benchmark completed for session_based_leasing=%t in %d", sessionBasedLeasingEnabled, durations[modeIdx]))
 		}()
 	}

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -259,7 +259,7 @@ func (n *Network) IsNetworkConnected() bool {
 func (n *Network) infosSent() int {
 	var count int64
 	for _, node := range n.Nodes {
-		count += node.Gossip.GetNodeMetrics().InfosSent.Counter.Count()
+		count += node.Gossip.GetNodeMetrics().InfosSent.Count()
 	}
 	return int(count)
 }
@@ -269,7 +269,7 @@ func (n *Network) infosSent() int {
 func (n *Network) infosReceived() int {
 	var count int64
 	for _, node := range n.Nodes {
-		count += node.Gossip.GetNodeMetrics().InfosReceived.Counter.Count()
+		count += node.Gossip.GetNodeMetrics().InfosReceived.Count()
 	}
 	return int(count)
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1769,6 +1769,7 @@ func TestLint(t *testing.T) {
 			"syscall":                                     "sysutil",
 			"errors":                                      "github.com/cockroachdb/errors",
 			"oserror":                                     "github.com/cockroachdb/errors/oserror",
+			"go.uber.org/atomic":                          "sync/atomic",
 			"github.com/pkg/errors":                       "github.com/cockroachdb/errors",
 			"github.com/cockroachdb/errors/assert":        "github.com/cockroachdb/errors",
 			"github.com/cockroachdb/errors/barriers":      "github.com/cockroachdb/errors",

--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_prometheus_prometheus//promql/parser",
-        "@com_github_rcrowley_go_metrics//:go-metrics",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -239,5 +239,5 @@ func (g *CounterFloat64) Inc(i float64) {
 // UpdateIfHigher sets the counter's value only if it's higher
 // than the currently set one. It's assumed the caller holds
 func (g *CounterFloat64) UpdateIfHigher(i float64) {
-	g.value.UpdateIfHigher(i)
+	g.value.Update(i)
 }

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/tick"
@@ -24,7 +25,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	prometheusgo "github.com/prometheus/client_model/go"
-	"github.com/rcrowley/go-metrics"
 )
 
 const (
@@ -722,22 +722,53 @@ func deepCopy(source prometheusgo.Histogram) *prometheusgo.Histogram {
 // A Counter holds a single mutable atomic value.
 type Counter struct {
 	Metadata
-	metrics.Counter
+
+	count atomic.Int64
 }
 
 // NewCounter creates a counter.
 func NewCounter(metadata Metadata) *Counter {
-	return &Counter{metadata, metrics.NewCounter()}
+	return &Counter{Metadata: metadata}
 }
 
-// Dec overrides the metric.Counter method. This method should NOT be
-// used and serves only to prevent misuse of the metric type.
-func (c *Counter) Dec(int64) {
-	// From https://prometheus.io/docs/concepts/metric_types/#counter
-	// > Counters should not be used to expose current counts of items
-	// > whose number can also go down, e.g. the number of currently
-	// > running goroutines. Use gauges for this use case.
-	panic("Counter should not be decremented, use a Gauge instead")
+// Clear resets the counter to zero.
+func (c *Counter) Clear() {
+	c.count.Store(0)
+}
+
+// Inc atomically increments the counter by the given value.
+func (c *Counter) Inc(v int64) {
+	if buildutil.CrdbTestBuild && v < 0 {
+		panic("Counters should not be decremented")
+	}
+	c.count.Add(v)
+}
+
+// Update atomically sets the current value of the counter, unless the current
+// value is already greater.
+//
+// Update is intended to be used when the counter itself is not the source of
+// truth; instead it is a (periodically updated) copy of a counter that is
+// maintained elsewhere.
+//
+// Update conservatively guards against setting the counter to a lower value
+// because some synchronization bugs in this release have been observed to
+// violate monotonicity.
+func (c *Counter) Update(val int64) {
+	for {
+		old := c.count.Load()
+		if old > val {
+			return
+		}
+		if c.count.CompareAndSwap(old, val) {
+			return
+		}
+	}
+}
+
+// Count returns the current value of the counter.
+func (c *Counter) Count() int64 {
+	return c.count.Load()
 }
 
 // GetType returns the prometheus type enum for this metric.
@@ -745,18 +776,18 @@ func (c *Counter) GetType() *prometheusgo.MetricType {
 	return prometheusgo.MetricType_COUNTER.Enum()
 }
 
-// Inspect calls the given closure with the empty string and itself.
+// Inspect calls the given closure with itself.
 func (c *Counter) Inspect(f func(interface{})) { f(c) }
 
 // MarshalJSON marshals to JSON.
 func (c *Counter) MarshalJSON() ([]byte, error) {
-	return json.Marshal(c.Counter.Count())
+	return json.Marshal(c.Count())
 }
 
 // ToPrometheusMetric returns a filled-in prometheus metric of the right type.
 func (c *Counter) ToPrometheusMetric() *prometheusgo.Metric {
 	return &prometheusgo.Metric{
-		Counter: &prometheusgo.Counter{Value: proto.Float64(float64(c.Counter.Count()))},
+		Counter: &prometheusgo.Counter{Value: proto.Float64(float64(c.Count()))},
 	}
 }
 
@@ -782,24 +813,37 @@ func (c *CounterFloat64) GetMetadata() Metadata {
 }
 
 func (c *CounterFloat64) Clear() {
-	syncutil.StoreFloat64(&c.count, 0)
+	c.count.Store(0)
 }
 
 func (c *CounterFloat64) Count() float64 {
-	return syncutil.LoadFloat64(&c.count)
+	return c.count.Load()
 }
 
 func (c *CounterFloat64) Inc(i float64) {
-	syncutil.AddFloat64(&c.count, i)
+	if buildutil.CrdbTestBuild && i < 0 {
+		panic("Counters should not be decremented")
+	}
+	c.count.Add(i)
 }
 
-func (c *CounterFloat64) UpdateIfHigher(i float64) {
-	syncutil.StoreFloat64IfHigher(&c.count, i)
+// Update atomically sets the current value of the counter, unless the current
+// value is already greater.
+//
+// Update is intended to be used when the counter itself is not the source of
+// truth; instead it is a (periodically updated) copy of a counter that is
+// maintained elsewhere.
+//
+// Update conservatively guards against setting the counter to a lower value
+// because some synchronization bugs in this release have been observed to
+// violate monotonicity.
+func (c *CounterFloat64) Update(val float64) {
+	c.count.StoreIfHigher(val)
 }
 
 func (c *CounterFloat64) Snapshot() *CounterFloat64 {
 	newCounter := NewCounterFloat64(c.Metadata)
-	syncutil.StoreFloat64(&newCounter.count, c.Count())
+	newCounter.count.Store(c.Count())
 	return newCounter
 }
 
@@ -831,13 +875,13 @@ func NewCounterFloat64(metadata Metadata) *CounterFloat64 {
 // A Gauge atomically stores a single integer value.
 type Gauge struct {
 	Metadata
-	value *int64
+	value atomic.Int64
 	fn    func() int64
 }
 
 // NewGauge creates a Gauge.
 func NewGauge(metadata Metadata) *Gauge {
-	return &Gauge{metadata, new(int64), nil}
+	return &Gauge{Metadata: metadata}
 }
 
 // NewFunctionalGauge creates a Gauge metric whose value is determined when
@@ -845,17 +889,12 @@ func NewGauge(metadata Metadata) *Gauge {
 // Note that Update, Inc, and Dec should NOT be called on a Gauge returned
 // from NewFunctionalGauge.
 func NewFunctionalGauge(metadata Metadata, f func() int64) *Gauge {
-	return &Gauge{metadata, nil, f}
-}
-
-// Snapshot returns a read-only copy of the gauge.
-func (g *Gauge) Snapshot() metrics.Gauge {
-	return metrics.GaugeSnapshot(g.Value())
+	return &Gauge{Metadata: metadata, fn: f}
 }
 
 // Update updates the gauge's value.
 func (g *Gauge) Update(v int64) {
-	atomic.StoreInt64(g.value, v)
+	g.value.Store(v)
 }
 
 // Value returns the gauge's current value.
@@ -863,17 +902,17 @@ func (g *Gauge) Value() int64 {
 	if g.fn != nil {
 		return g.fn()
 	}
-	return atomic.LoadInt64(g.value)
+	return g.value.Load()
 }
 
 // Inc increments the gauge's value.
 func (g *Gauge) Inc(i int64) {
-	atomic.AddInt64(g.value, i)
+	g.value.Add(i)
 }
 
 // Dec decrements the gauge's value.
 func (g *Gauge) Dec(i int64) {
-	atomic.AddInt64(g.value, -i)
+	g.value.Add(-i)
 }
 
 // GetType returns the prometheus type enum for this metric.
@@ -907,43 +946,32 @@ func (g *Gauge) GetMetadata() Metadata {
 // A GaugeFloat64 atomically stores a single float64 value.
 type GaugeFloat64 struct {
 	Metadata
-	bits *uint64
+	value syncutil.AtomicFloat64
 }
 
 // NewGaugeFloat64 creates a GaugeFloat64.
 func NewGaugeFloat64(metadata Metadata) *GaugeFloat64 {
-	return &GaugeFloat64{metadata, new(uint64)}
-}
-
-// Snapshot returns a read-only copy of the gauge.
-func (g *GaugeFloat64) Snapshot() metrics.GaugeFloat64 {
-	return metrics.GaugeFloat64Snapshot(g.Value())
+	return &GaugeFloat64{Metadata: metadata}
 }
 
 // Update updates the gauge's value.
 func (g *GaugeFloat64) Update(v float64) {
-	atomic.StoreUint64(g.bits, math.Float64bits(v))
+	g.value.Store(v)
 }
 
 // Value returns the gauge's current value.
 func (g *GaugeFloat64) Value() float64 {
-	return math.Float64frombits(atomic.LoadUint64(g.bits))
+	return g.value.Load()
 }
 
 // Inc increments the gauge's value.
 func (g *GaugeFloat64) Inc(delta float64) {
-	for {
-		oldBits := atomic.LoadUint64(g.bits)
-		newBits := math.Float64bits(math.Float64frombits(oldBits) + delta)
-		if atomic.CompareAndSwapUint64(g.bits, oldBits, newBits) {
-			return
-		}
-	}
+	g.value.Add(delta)
 }
 
 // Dec decrements the gauge's value.
 func (g *GaugeFloat64) Dec(delta float64) {
-	g.Inc(-delta)
+	g.value.Add(-delta)
 }
 
 // GetType returns the prometheus type enum for this metric.

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -98,7 +98,7 @@ func TestCounter(t *testing.T) {
 
 func TestCounterFloat64(t *testing.T) {
 	g := NewCounterFloat64(emptyMetadata)
-	g.UpdateIfHigher(10)
+	g.Update(10)
 	if v := g.Count(); v != 10 {
 		t.Fatalf("unexpected value: %f", v)
 	}
@@ -116,7 +116,7 @@ func TestCounterFloat64(t *testing.T) {
 
 	for i := int64(55); i < 65; i++ {
 		wg.Add(1)
-		go func(i int64) { g.UpdateIfHigher(float64(i)); wg.Done() }(i)
+		go func(i int64) { g.Update(float64(i)); wg.Done() }(i)
 	}
 	wg.Wait()
 	if v := g.Count(); math.Abs(v-64.0) > 0.001 {

--- a/pkg/util/syncutil/atomic_test.go
+++ b/pkg/util/syncutil/atomic_test.go
@@ -32,18 +32,18 @@ func TestAtomicFloat64(t *testing.T) {
 		i      AtomicFloat64
 		after  AtomicFloat64
 	}
-	x.before = magic64
-	x.after = magic64
+	x.before.val.Store(magic64)
+	x.after.val.Store(magic64)
 	for delta := float64(1); delta+delta > delta; delta += delta {
 		e := delta
-		StoreFloat64(&x.i, e)
-		a := LoadFloat64(&x.i)
+		x.i.Store(e)
+		a := x.i.Load()
 		if a != e {
 			t.Fatalf("stored=%f got=%f", e, a)
 		}
 	}
-	if x.before != magic64 || x.after != magic64 {
-		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before, x.after, uint64(magic64), uint64(magic64))
+	if x.before.val.Load() != magic64 || x.after.val.Load() != magic64 {
+		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before.val.Load(), x.after.val.Load(), uint64(magic64), uint64(magic64))
 	}
 }
 
@@ -54,27 +54,27 @@ func TestAtomicStoreFloat64IfHigher(t *testing.T) {
 		i      AtomicFloat64
 		after  AtomicFloat64
 	}
-	x.before = magic64
-	x.after = magic64
+	x.before.val.Store(magic64)
+	x.after.val.Store(magic64)
 
 	// Roughly half the time we will have to store a larger value.
-	StoreFloat64(&x.i, math.MaxFloat64/math.Pow(2, 500))
+	x.i.Store(math.MaxFloat64 / math.Pow(2, 500))
 	for delta := float64(1); delta+delta > delta; delta += delta {
 		e := delta
-		cur := LoadFloat64(&x.i)
+		cur := x.i.Load()
 		shouldStore := e > cur
-		StoreFloat64IfHigher(&x.i, e)
-		afterStore := LoadFloat64(&x.i)
+		x.i.StoreIfHigher(e)
+		afterStore := x.i.Load()
 		if shouldStore && e != afterStore {
 			t.Fatalf("should store: expected=%f got=%f", e, afterStore)
 		}
 		if !shouldStore && cur != afterStore {
 			t.Fatalf("should not store: expected=%f got=%f", cur, afterStore)
 		}
-		StoreFloat64(&x.i, math.MaxFloat64/math.Pow(2, 500))
+		x.i.Store(math.MaxFloat64 / math.Pow(2, 500))
 	}
-	if x.before != magic64 || x.after != magic64 {
-		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before, x.after, uint64(magic64), uint64(magic64))
+	if x.before.val.Load() != magic64 || x.after.val.Load() != magic64 {
+		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before.val.Load(), x.after.val.Load(), uint64(magic64), uint64(magic64))
 	}
 }
 
@@ -85,19 +85,19 @@ func TestAtomicAddFloat64(t *testing.T) {
 		i      AtomicFloat64
 		after  AtomicFloat64
 	}
-	x.before = magic64
-	x.after = magic64
-	j := LoadFloat64(&x.i)
+	x.before.val.Store(magic64)
+	x.after.val.Store(magic64)
+	j := x.i.Load()
 	for delta := float64(1); delta+delta > delta; delta += delta {
-		AddFloat64(&x.i, delta)
+		x.i.Add(delta)
 		j += delta
-		got := LoadFloat64(&x.i)
-		if j != LoadFloat64(&x.i) {
+		got := x.i.Load()
+		if j != x.i.Load() {
 			t.Fatalf("expected=%f got=%f", j, got)
 		}
 	}
-	if x.before != magic64 || x.after != magic64 {
-		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before, x.after, uint64(magic64), uint64(magic64))
+	if x.before.val.Load() != magic64 || x.after.val.Load() != magic64 {
+		t.Fatalf("wrong magic: %#x _ %#x != %#x _ %#x", x.before.val.Load(), x.after.val.Load(), uint64(magic64), uint64(magic64))
 	}
 }
 


### PR DESCRIPTION
This is a 24.1 backport of #125611, with the adjustment of making `Update` guard against monotonicity violations (and omitting `UpdateIfHigher`).

----

This change improves `metric.Counter` to use an atomic directly instead of `go-metrics.Counter`. This allows us to add an `Update` method. The lack of these methods led to widespread use of gauges instead of counters (whenever the counter was maintained in a lower layer).

We also improve the implementation and interface of `syncutil.AtomicFloat64`.

Fixes: #99922
Release note: None
Release justification: Fixes a disruptive observability bug.