### PR TITLE
release-23.1: ui: fix query fetching store ids for db/tables and remove quotes around table names

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -370,8 +370,12 @@ const getDatabaseReplicasAndRegions: DatabaseDetailsQuery<DatabaseReplicasRegion
     ) => {
       if (txn_result.error) {
         resp.stats.replicaData.error = txn_result.error;
+        // We don't expect to have any rows for this query on error.
+        return;
       }
-      resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
+      if (!txnResultIsEmpty(txn_result)) {
+        resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
+      }
     },
     handleMaxSizeError: (_dbName, _response, _dbDetail) => {
       return Promise.resolve(false);

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -177,6 +177,7 @@ const UPGRADE_RELATED_ERRORS = [
 ];
 
 export function isUpgradeError(message: string): boolean {
+  if (message == null) return false;
   return UPGRADE_RELATED_ERRORS.some(err => message.search(err) !== -1);
 }
 
@@ -195,6 +196,10 @@ export function isUpgradeError(message: string): boolean {
  * @param message
  */
 export function sqlApiErrorMessage(message: string): string {
+  if (!message) {
+    return "";
+  }
+
   if (isUpgradeError(message)) {
     return "This page may not be available during an upgrade.";
   }

--- a/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
@@ -463,12 +463,16 @@ const getTableReplicaStoreIDs: TableDetailsQuery<TableReplicasRow> = {
   ) => {
     if (txn_result.error) {
       resp.stats.replicaData.error = txn_result.error;
+      // We don't expect to have any rows for this query on error.
+      return;
     }
 
     // TODO #118957 (xinhaoz) Store IDs and node IDs cannot be used interchangeably.
-    resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
-    resp.stats.replicaData.replicaCount =
-      txn_result?.rows[0]?.replica_count ?? 0;
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
+      resp.stats.replicaData.replicaCount =
+        txn_result?.rows[0]?.replica_count ?? 0;
+    }
   },
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
@@ -33,7 +33,11 @@ import * as format from "../util/format";
 import { Breadcrumbs } from "../breadcrumbs";
 import { CaretRight } from "../icon/caretRight";
 import { CockroachCloudContext } from "../contexts";
-import { checkInfoAvailable, getNetworkErrorMessage } from "../databases";
+import {
+  checkInfoAvailable,
+  formatSQLTableName,
+  getNetworkErrorMessage,
+} from "../databases";
 
 const cx = classNames.bind(styles);
 
@@ -93,10 +97,11 @@ export const TableNameCell = ({
       </Tooltip>
     );
   }
+  const displayName = formatSQLTableName(table.name);
   return (
     <Link to={linkURL} className={cx("icon__container")}>
       {icon}
-      {table.name}
+      {displayName}
     </Link>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.ts
@@ -16,6 +16,7 @@ import {
   getNodeIdsFromStoreIds,
   normalizePrivileges,
   normalizeRoles,
+  formatSQLTableName,
 } from "./util";
 
 describe("Getting nodes by region string", () => {
@@ -172,4 +173,39 @@ describe("Normalize roles", () => {
     const result = normalizeRoles(roles);
     expect(result).toEqual(["admin", "public"]);
   });
+});
+
+describe("formatSQLTableName", () => {
+  const tests = [
+    {
+      input: `"db"."table"`,
+      expected: `db.table`,
+    },
+    {
+      input: `"db"."schema"."table"`,
+      expected: `db.schema.table`,
+    },
+    {
+      input: `"a234ajf"."ojir__931a"`,
+      expected: `a234ajf.ojir__931a`,
+    },
+    {
+      input: `"public.hello.world"."table"`,
+      expected: `"public.hello.world".table`,
+    },
+    {
+      input: `"public"."my table"`,
+      expected: `public."my table"`,
+    },
+    {
+      input: `"db"."public. hello . world"."my.table"`,
+      expected: `db."public. hello . world"."my.table"`,
+    },
+  ];
+  it.each(tests)(
+    `removes double quotes from table name parts unless it contains a space or period`,
+    tc => {
+      expect(formatSQLTableName(tc.input)).toBe(tc.expected);
+    },
+  );
 });

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.tsx
@@ -298,3 +298,21 @@ const checkPrivilegeError = (
   // If the error message includes any mention of privilege, consider it a privilege error.
   return err.message.includes("privilege");
 };
+
+// formatSQLTableName formats a SQL table name to a more readable format by
+// removing double quotes around the name parts if that 'part' does not contain
+// any spaces or periods.
+// e.g.
+//  "public"."table" -> public.table
+//  "public"."table" -> public.table
+//  "public"."table with space" -> public."table with space"
+//  "public"."table.with.period" -> public."table.with.period"
+export const formatSQLTableName = (tableName: string): string => {
+  return tableName.replace(/"([^"]+)"/g, (_, part) => {
+    // If it has a space or period keep it in quotes.
+    if (part.match(/[\s.]/)) {
+      return `"${part}"`;
+    }
+    return part;
+  });
+};

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -22,8 +22,7 @@ import {
   REMOTE_DEBUGGING_ERROR_TEXT,
   indexUnusedDuration,
 } from "src/util/constants";
-import Severity = protos.cockroach.util.log.Severity;
-import { stubSqlApiCall } from "src/util/fakeApi";
+import { mockExecSQLErrors, stubSqlApiCall } from "src/util/fakeApi";
 
 const { ZoneConfig } = cockroach.config.zonepb;
 const { ZoneConfigurationLevel } = cockroach.server.serverpb;
@@ -285,6 +284,20 @@ describe("rest api", function () {
           done();
         });
     });
+
+    it("should not error when any query fails", async () => {
+      const req = { database, csIndexUnusedDuration: indexUnusedDuration };
+      const mockResults = mockExecSQLErrors<clusterUiApi.DatabaseDetailsRow>(6);
+      stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+        clusterUiApi.createDatabaseDetailsReq(req),
+        mockResults,
+      );
+
+      // This call should not throw.
+      const result = await clusterUiApi.getDatabaseDetails(req);
+      expect(result.results).toBeDefined();
+      expect(result.results.error).toBeDefined();
+    });
   });
 
   describe("table details request", function () {
@@ -478,6 +491,27 @@ describe("rest api", function () {
           expect(_.startsWith(e.message, "Promise timed out")).toBeTruthy();
           done();
         });
+    });
+
+    it("should not error when any query fails", async () => {
+      const mockResults = mockExecSQLErrors<clusterUiApi.TableDetailsRow>(10);
+      stubSqlApiCall<clusterUiApi.TableDetailsRow>(
+        clusterUiApi.createTableDetailsReq(
+          dbName,
+          tableName,
+          indexUnusedDuration,
+        ),
+        mockResults,
+      );
+
+      // This call should not throw.
+      const result = await clusterUiApi.getTableDetails({
+        database: dbName,
+        table: tableName,
+        csIndexUnusedDuration: indexUnusedDuration,
+      });
+      expect(result.results).toBeDefined();
+      expect(result.results.error).toBeDefined();
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import * as $protobuf from "protobufjs";
+import { SqlTxnResult } from "@cockroachlabs/cluster-ui/dist/types/api";
 
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import { cockroach } from "src/js/protos";
@@ -106,7 +107,17 @@ export function stubSqlApiCall<T>(
   mockTxnResults: mockSqlTxnResult<T>[],
   times: number = 1,
 ) {
-  const response = buildSqlExecutionResponse(mockTxnResults);
+  const firstError = mockTxnResults.find(mock => mock.error != null)?.error;
+  let err: clusterUiApi.SqlExecutionErrorMessage;
+  if (firstError != null) {
+    err = {
+      message: firstError.message,
+      code: "123",
+      severity: "ERROR",
+      source: { file: "myfile.go", line: 111, function: "myFn" },
+    };
+  }
+  const response = buildSqlExecutionResponse(mockTxnResults, err);
   fetchMock.mock({
     headers: {
       Accept: "application/json",
@@ -185,3 +196,23 @@ function buildSqlTxnResult<RowType>(
     error: mock.error,
   };
 }
+
+const mockStmtExecErrorResponse = <T>(
+  res: Partial<SqlTxnResult<T>>,
+): SqlTxnResult<T> => ({
+  statement: res?.statement ?? 1,
+  tag: "SELECT",
+  start: "2022-01-01T00:00:00Z",
+  end: "2022-01-01T00:00:01Z",
+  error: new Error("error"),
+  rows_affected: 0,
+  ...res,
+});
+
+export const mockExecSQLErrors = <T>(
+  statements: number,
+): mockSqlTxnResult<T>[] => {
+  return Array.from({ length: statements }, (_, i) =>
+    mockStmtExecErrorResponse<T>({ statement: i + 1 }),
+  );
+};


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: fix query fetching store ids for db/tables" (#126419)
  * 1/1 commits from "cluster-ui: remove quotes in table name in db details" (#126961)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: bug fix