### PR TITLE
execinfra: ensure all processors are properly cleaned up on shutdown

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -696,7 +696,8 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 	return ib.init(evalCtx, predicates, colExprs, mon)
 }
 
-// Close releases the resources used by the IndexBackfiller.
+// Close releases the resources used by the IndexBackfiller. It can be called
+// multiple times.
 func (ib *IndexBackfiller) Close(ctx context.Context) {
 	if ib.mon != nil {
 		func() {
@@ -705,6 +706,7 @@ func (ib *IndexBackfiller) Close(ctx context.Context) {
 			ib.muBoundAccount.boundAccount.Close(ctx)
 		}()
 		ib.mon.Stop(ctx)
+		ib.mon = nil
 	}
 }
 

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -503,6 +503,9 @@ func (ibm *IndexBackfillMerger) Resume(output execinfra.RowReceiver) {
 	panic("not implemented")
 }
 
+// Close is part of the execinfra.Processor interface.
+func (*IndexBackfillMerger) Close(context.Context) {}
+
 // NewIndexBackfillMerger creates a new IndexBackfillMerger.
 func NewIndexBackfillMerger(
 	flowCtx *execinfra.FlowCtx, processorID int32, spec execinfrapb.IndexBackfillMergerSpec,

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -57,6 +57,11 @@ type Processor interface {
 	// NB: this method doesn't take the context as parameter because the context
 	// was already captured on Run().
 	Resume(output RowReceiver)
+
+	// Close releases the resources of the processor and possibly its inputs.
+	// Must be called at least once on a given Processor and can be called
+	// multiple times.
+	Close(context.Context)
 }
 
 // DoesNotUseTxn is an interface implemented by some processors to mark that
@@ -733,6 +738,11 @@ func (pb *ProcessorBaseNoHelper) Resume(output RowReceiver) {
 		panic("processor output is not provided for emitting rows")
 	}
 	Run(pb.ctx, pb.self, output)
+}
+
+// Close is part of the Processor interface.
+func (pb *ProcessorBaseNoHelper) Close(context.Context) {
+	pb.self.ConsumerClosed()
 }
 
 // ProcStateOpts contains fields used by the ProcessorBase's family of functions

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -672,17 +672,14 @@ func (f *FlowBase) Cleanup(ctx context.Context) {
 
 	// Ensure that all processors are closed. Usually this is done automatically
 	// (when a processor is exhausted or at the end of execinfra.Run loop), but
-	// in edge cases we need to do it here. ConsumerClosed can be called
-	// multiple times.
+	// in edge cases we need to do it here. Close can be called multiple times.
 	//
-	// Note that ConsumerClosed is not thread-safe, but at this point if the
-	// processor wasn't fused and ran in its own goroutine, that goroutine must
-	// have exited since Cleanup is called after having waited for all started
+	// Note that Close is not thread-safe, but at this point if the processor
+	// wasn't fused and ran in its own goroutine, that goroutine must have
+	// exited since Cleanup is called after having waited for all started
 	// goroutines to exit.
 	for _, proc := range f.processors {
-		if rs, ok := proc.(execinfra.RowSource); ok {
-			rs.ConsumerClosed()
-		}
+		proc.Close(ctx)
 	}
 
 	// Release any descriptors accessed by this flow.

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -312,6 +312,9 @@ func (sp *csvWriter) Resume(output execinfra.RowReceiver) {
 	panic("not implemented")
 }
 
+// Close is part of the execinfra.Processor interface.
+func (*csvWriter) Close(context.Context) {}
+
 func init() {
 	rowexec.NewCSVWriterProcessor = newCSVWriterProcessor
 }

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -260,6 +260,9 @@ func (sp *parquetWriterProcessor) Resume(output execinfra.RowReceiver) {
 	panic("not implemented")
 }
 
+// Close is part of the execinfra.Processor interface.
+func (*parquetWriterProcessor) Close(context.Context) {}
+
 // Resume is part of the execinfra.Processor interface.
 func (sp *parquetWriterProcessor) testingKnobsOrNil() *ExportTestingKnobs {
 	if sp.flowCtx.TestingKnobs().Export == nil {

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -110,6 +110,9 @@ func (*columnBackfiller) Resume(output execinfra.RowReceiver) {
 	panic("not implemented")
 }
 
+// Close is part of the execinfra.Processor interface.
+func (*columnBackfiller) Close(context.Context) {}
+
 func (cb *columnBackfiller) doRun(ctx context.Context) *execinfrapb.ProducerMetadata {
 	finishedSpans, err := cb.mainLoop(ctx)
 	if err != nil {

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -438,3 +438,8 @@ func (ib *indexBackfiller) buildIndexEntryBatch(
 func (ib *indexBackfiller) Resume(output execinfra.RowReceiver) {
 	panic("not implemented")
 }
+
+// Close is part of the execinfra.Processor interface.
+func (ib *indexBackfiller) Close(ctx context.Context) {
+	ib.IndexBackfiller.Close(ctx)
+}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -213,6 +213,12 @@ func (s *sampleAggregator) Run(ctx context.Context, output execinfra.RowReceiver
 	s.MoveToDraining(nil /* err */)
 }
 
+// Close is part of the execinfra.Processor interface.
+func (s *sampleAggregator) Close(context.Context) {
+	s.input.ConsumerClosed()
+	s.close()
+}
+
 func (s *sampleAggregator) close() {
 	if s.InternalClose() {
 		s.memAcc.Close(s.Ctx())

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -488,6 +488,12 @@ func (s *samplerProcessor) sampleRow(
 	return false, nil
 }
 
+// Close is part of the execinfra.Processor interface.
+func (s *samplerProcessor) Close(context.Context) {
+	s.input.ConsumerClosed()
+	s.close()
+}
+
 func (s *samplerProcessor) close() {
 	if s.InternalClose() {
 		s.memAcc.Close(s.Ctx())


### PR DESCRIPTION
This commit extends `Processor` interface to introduce `Close` method which must be called at least once. For processors that implement `RowSource` interface this has already been the case with `ConsumerClosed` method, but a handful of processors (sampler, sample aggregator, and index backfiller) didn't have a way to release its resources in case the flow is set up but never ran (which can happen on the server shutdown). This issue is now fixed.

Fixes: #126744.

Release note: None