### PR TITLE
kvserver: gate new manual split rangefeed cancellation reason on 24.1

### DIFF
--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
@@ -314,7 +315,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// that overlap with the new range of the split and keep registrations that
 		// are only interested in keys that are still on the original range running.
 		reason := kvpb.RangeFeedRetryError_REASON_RANGE_SPLIT
-		if res.Split.SplitTrigger.ManualSplit {
+		if res.Split.SplitTrigger.ManualSplit && b.r.Version().AtLeast(clusterversion.V24_1.Version()) {
 			reason = kvpb.RangeFeedRetryError_REASON_MANUAL_RANGE_SPLIT
 		}
 		b.r.disconnectRangefeedWithReason(


### PR DESCRIPTION
Previously, if a 24.1 replica sent the new manual split reason to cancel a rangefeed to a rangefeed client on 23.2, the client node would crash. With this patch, the new error will only get sent if the replica has fully migrated to 24.1, implying that all nodes are running 24.1 code and will never run code < 24.1 again.

Informs #127029

Release note: none