### PR TITLE
kvserver/rangefeed: skip TestRangeFeedIntentResolutionRace under stress

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1353,8 +1353,7 @@ func TestRangeFeedIntentResolutionRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t) // too slow, times out
-	skip.UnderDeadlock(t)
+	skip.UnderDuress(t) // too slow, times out
 
 	// Use a timeout, to prevent a hung test.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
This patch skips TestRangeFeedIntentResolutionRace under stress. This test is a
known issue.

Informs: https://github.com/cockroachdb/cockroach/issues/119340
Release note: none