### PR TITLE
rowexec: minor improvement around stats processors

### DIFF
--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -13,7 +13,6 @@ package execinfra
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
@@ -206,7 +205,7 @@ func Run(ctx context.Context, src RowSource, dst RowReceiver) {
 				// the other portal, i.e. we leave the current portal open.
 				return
 			case DrainRequested:
-				DrainAndForwardMetadata(ctx, src, dst)
+				drainAndForwardMetadata(ctx, src, dst)
 				dst.ProducerDone()
 				return
 			case ConsumerClosed:
@@ -221,16 +220,16 @@ func Run(ctx context.Context, src RowSource, dst RowReceiver) {
 	}
 }
 
-// DrainAndForwardMetadata calls src.ConsumerDone() (thus asking src for
+// drainAndForwardMetadata calls src.ConsumerDone() (thus asking src for
 // draining metadata) and then forwards all the metadata to dst.
 //
 // When this returns, src has been properly closed (regardless of the presence
 // or absence of an error). dst, however, has not been closed; someone else must
 // call dst.ProducerDone() when all producers have finished draining.
 //
-// It is OK to call DrainAndForwardMetadata() multiple times concurrently on the
+// It is OK to call drainAndForwardMetadata() multiple times concurrently on the
 // same dst (as RowReceiver.Push() is guaranteed to be thread safe).
-func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver) {
+func drainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver) {
 	src.ConsumerDone()
 	for {
 		row, meta := src.Next()
@@ -314,47 +313,23 @@ func GetLeafTxnFinalState(ctx context.Context, txn *kv.Txn) *roachpb.LeafTxnFina
 	return txnMeta
 }
 
-// DrainAndClose is a version of DrainAndForwardMetadata that drains multiple
-// sources. These sources are assumed to be the only producers left for dst, so
-// dst is closed once they're all exhausted (this is different from
-// DrainAndForwardMetadata).
+// DrainAndClose drains and closes the source and then closes the dst too. It
+// also propagates the tracing metadata if there is any in the context. src is
+// assumed to be the only producer for dst.
 //
 // If cause is specified, it is forwarded to the consumer before all the drain
 // metadata. This is intended to have been the error, if any, that caused the
 // draining.
-//
-// pushTrailingMeta is called after draining the sources and before calling
-// dst.ProducerDone(). It gives the caller the opportunity to push some trailing
-// metadata (e.g. tracing information and txn updates, if applicable).
-//
-// srcs can be nil.
-//
-// All errors are forwarded to the producer.
 func DrainAndClose(
-	ctx context.Context,
-	dst RowReceiver,
-	cause error,
-	pushTrailingMeta func(context.Context, RowReceiver),
-	srcs ...RowSource,
+	ctx context.Context, flowCtx *FlowCtx, src RowSource, dst RowReceiver, cause error,
 ) {
 	if cause != nil {
 		// We ignore the returned ConsumerStatus and rely on the
-		// DrainAndForwardMetadata() calls below to close srcs in all cases.
+		// drainAndForwardMetadata() call below to close the source.
 		_ = dst.Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: cause})
 	}
-	if len(srcs) > 0 {
-		var wg sync.WaitGroup
-		for _, input := range srcs[1:] {
-			wg.Add(1)
-			go func(input RowSource) {
-				DrainAndForwardMetadata(ctx, input, dst)
-				wg.Done()
-			}(input)
-		}
-		DrainAndForwardMetadata(ctx, srcs[0], dst)
-		wg.Wait()
-	}
-	pushTrailingMeta(ctx, dst)
+	drainAndForwardMetadata(ctx, src, dst)
+	SendTraceData(ctx, flowCtx, dst)
 	dst.ProducerDone()
 }
 

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -302,9 +302,7 @@ func (sp *csvWriter) Run(ctx context.Context, output execinfra.RowReceiver) {
 		return nil
 	}()
 
-	// TODO(dt): pick up tracing info in trailing meta
-	execinfra.DrainAndClose(
-		ctx, output, err, func(context.Context, execinfra.RowReceiver) {} /* pushTrailingMeta */, sp.input)
+	execinfra.DrainAndClose(ctx, sp.flowCtx, sp.input, output, err)
 }
 
 // Resume is part of the execinfra.Processor interface.

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -250,9 +250,7 @@ func (sp *parquetWriterProcessor) Run(ctx context.Context, output execinfra.RowR
 		return nil
 	}()
 
-	// TODO(dt): pick up tracing info in trailing meta
-	execinfra.DrainAndClose(
-		ctx, output, err, func(context.Context, execinfra.RowReceiver) {} /* pushTrailingMeta */, sp.input)
+	execinfra.DrainAndClose(ctx, sp.flowCtx, sp.input, output, err)
 }
 
 // Resume is part of the execinfra.Processor interface.

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -106,6 +106,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "//pkg/util/tracing/tracingpb",
         "@com_github_axiomhq_hyperloglog//:hyperloglog",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -435,7 +436,7 @@ func (s *sampleAggregator) sampleRow(
 func (s *sampleAggregator) writeResults(ctx context.Context) error {
 	// Turn off tracing so these writes don't affect the results of EXPLAIN
 	// ANALYZE.
-	if span := tracing.SpanFromContext(ctx); span != nil && span.IsVerbose() {
+	if span := tracing.SpanFromContext(ctx); span != nil && span.RecordingType() != tracingpb.RecordingOff {
 		// TODO(rytaft): this also hides writes in this function from SQL session
 		// traces.
 		ctx = tracing.ContextWithSpan(ctx, nil)


### PR DESCRIPTION
**rowexec: properly exclude some things in stats job from EXPLAIN ANALYZE**

This commit fixes a minor issue where we attempt to exclude the write into the system table in the stats collection job from EXPLAIN ANALYZE output. The bug is that we did so only for verbose tracing which is now only used for EXPLAIN ANALYZE (DEBUG) whereas "vanilla" EXPLAIN ANALYZE uses the structured recording (as of the last couple of years), so we need a fresh tracing span in that case too.

**execinfra: clean up some helpers a bit**

This should be mostly a no-op change. The only addition is propagating the trace metadata for a couple of export processors.

Epic: None

Release note: None