### PR TITLE
tree: allow implicit casting of enums to strings in function calls

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -195,6 +195,14 @@ SELECT concat('RoacH', NULL)
 ----
 RoacH
 
+statement ok
+CREATE TYPE concat_enum AS ENUM ('foo', 'bar', 'baz')
+
+query T
+SELECT concat('foo'::concat_enum, ' ', 'bar'::concat_enum, ' ', 'baz'::concat_enum)
+----
+foo bar baz
+
 statement error unknown signature: concat\(string, bool, decimal, bool\)
 SELECT concat('RoacH', false, 64.532, TRUE)
 
@@ -4304,6 +4312,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
 ORDER BY 1, 2;
 ----
 Schema  Name             Description
+public  concat_enum      ·
 public  custom_typ       ·
 public  roach_dwellings  ·
 public  testenum         ·

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1194,6 +1194,8 @@ func AsDString(e Expr) (DString, bool) {
 	switch t := e.(type) {
 	case *DString:
 		return *t, true
+	case *DEnum:
+		return DString(t.LogicalRep), true
 	case *DOidWrapper:
 		return AsDString(t.Wrapped)
 	}

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1042,6 +1042,9 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		}
 		rt := typ.ResolvedType()
 		filter := makeFilter(i, func(params TypeList, ordinal int) bool {
+			if rt.Family() == types.EnumFamily && params.MatchAt(types.String, ordinal) {
+				return true
+			}
 			return params.MatchAt(rt, ordinal)
 		})
 		s.overloadIdxs = filterParams(s.overloadIdxs, s.overloads, s.params, filter)


### PR DESCRIPTION
PostgreSQL allows the use of enumerated types as parameters to functions that take string arguments whereas Cockroach previously did not. This patch changes the typecheck logic and runtime to accept enumerated types as arguments to functions that need string arguments.

Fixes: #125025
Release note (bug fix): Enumerated types may now be used as arguments to functions that require strings.