### PR TITLE
roachtest: fix multi-store-remove

### DIFF
--- a/pkg/cmd/roachtest/tests/multi_store_remove.go
+++ b/pkg/cmd/roachtest/tests/multi_store_remove.go
@@ -33,7 +33,6 @@ const (
 func registerMultiStoreRemove(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "multi-store-remove",
-		Skip:              "#123989",
 		Owner:             registry.OwnerStorage,
 		Cluster:           r.MakeClusterSpec(multiStoreNodes, spec.SSD(multiStoreStoresPerNode)),
 		CompatibleClouds:  registry.OnlyGCE,
@@ -144,7 +143,7 @@ func runMultiStoreRemove(ctx context.Context, t test.Test, c cluster.Cluster) {
 		if err := conn.QueryRowContext(ctx,
 			`SELECT
 			    (SELECT count(1) FROM crdB_internal.ranges) AS ranges
-			  , (SELECT count(range_count) FROM crdb_internal.kv_store_status) AS replicas`,
+			  , (SELECT sum(range_count) FROM crdb_internal.kv_store_status) AS replicas`,
 		).Scan(&ranges, &replicas); err != nil {
 			t.Fatalf("replication status: %s", err)
 		}


### PR DESCRIPTION
The intention of the test is to compare the number of ranges (multiplied by the replication factor) to the _sum_ of replicas across all stores. The current implementation is incorrect, as it compares range count to store count.

Fix the test by using a `sum` of replicas across each store, rather than a `count`, which will return the number of stores.

Fix #123989.

Release note: None.