### PR TITLE
logical/crosscluster: save checkpoint during initial scan

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -420,17 +420,10 @@ func (rh *rowHandler) handleRow(ctx context.Context, row tree.Datums) error {
 			`unmarshalling resolved timestamp: %x`, raw)
 	}
 
-	advanced := false
 	for _, sp := range resolvedSpans.ResolvedSpans {
-		adv, err := rh.frontier.Forward(sp.Span, sp.Timestamp)
-		if err != nil {
+		if _, err := rh.frontier.Forward(sp.Span, sp.Timestamp); err != nil {
 			return err
 		}
-		advanced = advanced || adv
-	}
-
-	if !advanced {
-		return nil
 	}
 
 	updateFreq := jobCheckpointFrequency.Get(rh.settings)


### PR DESCRIPTION
Only persisting when we advance implies that we also don't persist the checkpoint until the initial scan is done, which means that a restart during the initial scan loses progress.

Epic: none
Release note: None