### PR TITLE
storage: log on Engine close

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1682,6 +1682,8 @@ func (p *Pebble) Close() {
 	for _, closeFunc := range p.cfg.afterClose {
 		closeFunc()
 	}
+
+	p.logger.Infof("Closed storage engine")
 }
 
 // aggregateIterStats is propagated to all of an engine's iterators, aggregating


### PR DESCRIPTION
Log when the storage engine is closed. This context may help in debugging future failures of #124845 if the Engine continues to be used while the in-memory filesystem is reset to its synced state.

Epic: none
Informs #124845.
Release note: none