### PR TITLE
sqlliveness: detect and handle invalid SessionIDs

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1936,6 +1936,13 @@ func TestTenantLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestTenantLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestTenantLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -1709,8 +1709,8 @@ func TestLeaseCountDetailSessionBased(t *testing.T) {
 		version := 1
 		region := enum.One
 		_, err := executor.Exec(ctx, "add-rows-for-test", nil,
-			fmt.Sprintf("INSERT INTO system.lease VALUES (%d, %d, %s, '%s', '\\x%x')",
-				descID, version, nodeID, session.ID(), region))
+			fmt.Sprintf("INSERT INTO system.lease VALUES (%d, %d, %s, '\\x%x', '\\x%x')",
+				descID, version, nodeID, session.ID().UnsafeBytes(), region))
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/sqlliveness
+++ b/pkg/sql/logictest/testdata/logic_test/sqlliveness
@@ -1,0 +1,36 @@
+# Validate that invalid sessionID's are always
+# considered dead.
+subtest invalid_sessions
+
+# Legacy non-RBR format
+query B
+select crdb_internal.sql_liveness_is_alive(x'1f915e98f96145a5baa9f3a42c378eb6');
+----
+false
+
+# Wrong length
+query B
+select crdb_internal.sql_liveness_is_alive(x'deadbeef');
+----
+false
+
+subtest end
+
+
+subtest valid_sessions
+
+# Sanity: All sessions are alive in sqlliveness.
+query I
+SELECT count(*) FROM system.sqlliveness WHERE crdb_internal.sql_liveness_is_alive(session_id) = false;
+----
+0
+
+query B
+SELECT count(*) > 0 FROM system.sqlliveness WHERE crdb_internal.sql_liveness_is_alive(session_id) = true;
+----
+true
+
+subtest end
+
+
+

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1919,6 +1919,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1919,6 +1919,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1933,6 +1933,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1912,6 +1912,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -1926,6 +1926,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1940,6 +1940,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2136,6 +2136,13 @@ func TestLogic_sqllite(
 	runLogicTest(t, "sqllite")
 }
 
+func TestLogic_sqlliveness(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "sqlliveness")
+}
+
 func TestLogic_sqlsmith(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1648,6 +1648,11 @@ func TestSchemaChangeComparator_sqllite(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sqllite"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_sqlliveness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sqlliveness"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_sqlsmith(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/sqlsmith"

--- a/pkg/sql/sqlliveness/slstorage/key_encoder.go
+++ b/pkg/sql/sqlliveness/slstorage/key_encoder.go
@@ -24,6 +24,7 @@ import (
 type keyCodec interface {
 	encode(sid sqlliveness.SessionID) (roachpb.Key, string, error)
 	decode(key roachpb.Key) (sqlliveness.SessionID, error)
+	validate(session sqlliveness.SessionID) error
 
 	// indexPrefix returns the prefix for an encoded key. encode() will return
 	// something with the prefix and decode will expect a key with this prefix.
@@ -35,6 +36,10 @@ type keyCodec interface {
 
 type rbrEncoder struct {
 	rbrIndex roachpb.Key
+}
+
+func (e *rbrEncoder) validate(session sqlliveness.SessionID) error {
+	return ValidateSessionID(session)
 }
 
 func (e *rbrEncoder) encode(session sqlliveness.SessionID) (roachpb.Key, string, error) {


### PR DESCRIPTION
Previously, the code for checking if sessions are alive supported non-RBR-encoded session IDs. However, in version 24.1, we removed this support without adding proper handling for invalid IDs, potentially leading to finalization failures during upgrades (if stale session IDs existed). This patch adds logic to treat invalid session IDs, which will allow upgrades to occur if stale session IDs exist.s

Fixes: #127061

Release note: None