### PR TITLE
roachtest/cdc: bump cdc/mixed-versions timeout to 2h

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -72,7 +72,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 		Name:             "cdc/mixed-versions",
 		Owner:            registry.OwnerCDC,
 		Cluster:          r.MakeClusterSpec(5, spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
-		Timeout:          60 * time.Minute,
+		Timeout:          120 * time.Minute,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,


### PR DESCRIPTION
This patch bumps cdc/mixed-version timeout to 2h to fix issues address issues
where some runs call the wait and validate functions more frequently than
others, resulting in longer test durations.

Fixes: #124742, #127051
Release note: none