### PR TITLE
colexec: fix incorrect eager cancellation in parallel unordered sync

### DIFF
--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -65,6 +65,13 @@ func convertToVecTree(
 	)
 	fuseOpt := flowinfra.FuseNormally
 	if flowCtx.Local && !execinfra.HasParallelProcessors(flow) {
+		// TODO(yuzefovich): this check doesn't exactly match what we have on
+		// the main code path where we use !LocalState.MustUseLeafTxn() in the
+		// conditional. Concretely, it means that if we choose to use the
+		// Streamer at the execution time, we will use FuseNormally, yet here
+		// we'd pick FuseAggressively. The issue is minor though since we do
+		// capture the correct vectorized plan in the stmt bundle, so only
+		// explicit EXPLAIN (VEC) is affected.
 		fuseOpt = flowinfra.FuseAggressively
 	}
 	opChains, _, err = creator.setupFlow(ctx, flow.Processors, fuseOpt)

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -678,3 +678,25 @@ SELECT a, b AS b1, b AS b2 FROM abc INTERSECT SELECT a, c, b FROM abc ORDER by a
 1  1  1
 1  2  2
 2  2  2
+
+# Regression test for #127043 where eager cancellation of the parallel unordered
+# synchronizer was causing spurious errors on queries with LIMIT.
+statement ok
+CREATE TABLE t127043_1 (k1 INT, v1 INT, INDEX (k1));
+INSERT INTO t127043_1 VALUES (1, 1);
+CREATE TABLE t127043_2 (k2 INT, v2 INT, INDEX (k2));
+INSERT INTO t127043_2 VALUES (1, 1);
+CREATE TABLE t127043_3 (k3 INT, v3 INT, INDEX (k3));
+INSERT INTO t127043_3 VALUES (1, 1);
+CREATE VIEW v127043 (k, v) AS
+  SELECT
+    k1 AS k, v1 AS v FROM t127043_1@t127043_1_k1_idx
+  UNION SELECT
+    k2 AS k, v2 AS v FROM t127043_2@t127043_2_k2_idx
+  UNION SELECT
+    k3 AS k, v3 AS v FROM t127043_3@t127043_3_k3_idx;
+
+query II
+SELECT k, v FROM v127043 WHERE k = 1 LIMIT 1;
+----
+1  1


### PR DESCRIPTION
As of 2a928d0d0d8cbe5e2f86224b404bdbbbcfb23f49 we have eager cancellation of work in the parallel unordered sync for local plans. This is an optimization to cancel outstanding work in some inputs whenever the sync is being drained as a whole (and is needed to power the locality-optimized search feature). The cancellation is achieved by cancelling the contexts of all inputs and then ignoring all errors from those inputs.

However, if we have multiple parallel unordered syncs in the plan, then eager cancellation in the ancestor can "poison" the execution of the descendant because the latter cannot distinguish between benign errors (that happened because of the eager cancellation) and true query errors. (The sync that performs the eager cancellation distinguishes between the two by checking whether its "root" context is canceled or not.) Other operators don't have this issue since they all run within a single goroutine, with the exception of the lookup and index joins that use the streamer, but there the main "read" goroutine is the same one as for other operators that use a single goroutine, so the parallel sync can correctly filter out benign errors.

This commit fixes an issue of spurious context cancellation errors during valid query execution by allowing eager cancellation on drain only in "leaf" parallel syncs. This should be sufficient for the locality-optimized search feature where we have multiple table readers at the same level combined by the sync (and table readers themselves are always leaf operators).

Fixes: #127043.

Release note (bug fix): CockroachDB previously could encounter spurious `(error encountered after some results were delivered)` `ERROR: context canceled` errors when evaluating some queries in rare cases. Most likely conditions are:
- the query has to be executed locally
- have a LIMIT
- have at least two UNION clauses
- have some lookup / index joins in the UNION branches.

The bug is present since 22.2 and is now fixed.