### PR TITLE
*: replace sync.Map with syncutil.Map, forbid use of sync.Map

### DIFF
--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -304,8 +304,8 @@ func (p *deprecatedPubsubSink) Topics() []string {
 }
 
 func (p *deprecatedGcpPubsubClient) cacheTopicLocked(name string, topic *pubsub.Topic) {
-	//TODO (zinger): Investigate whether changing topics to a sync.Map would be
-	//faster here, I think it would.
+	// TODO(zinger): Investigate whether changing topics to a syncutil.Map would
+	// be faster here, I think it would.
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.mu.topics[name] = topic

--- a/pkg/ccl/multitenantccl/tenantcostclient/metrics_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/metrics_test.go
@@ -32,7 +32,7 @@ func TestMetrics_getEstimatedReplicationBytes(t *testing.T) {
 
 	assertCachedPathMetricsSize := func(size int) {
 		count := 0
-		m.cachedPathMetrics.Range(func(key, value any) bool {
+		m.cachedPathMetrics.Range(func(_ networkPath, _ *networkPathMetrics) bool {
 			count++
 			return true
 		})

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -241,13 +241,14 @@ func getLicense(st *cluster.Settings) (*licenseccl.License, error) {
 	}
 	cacheKey := licenseCacheKey(str)
 	if cachedLicense, ok := st.Cache.Load(cacheKey); ok {
-		return cachedLicense.(*licenseccl.License), nil
+		return (*cachedLicense).(*licenseccl.License), nil
 	}
 	license, err := decode(str)
 	if err != nil {
 		return nil, err
 	}
-	st.Cache.Store(cacheKey, license)
+	licenseBox := any(license)
+	st.Cache.Store(cacheKey, &licenseBox)
 	return license, nil
 }
 

--- a/pkg/jobs/helpers.go
+++ b/pkg/jobs/helpers.go
@@ -30,5 +30,5 @@ func ResetConstructors() func() {
 // TestingWrapResumerConstructor injects a wrapper around resumer creation for
 // the specified job type.
 func (r *Registry) TestingWrapResumerConstructor(typ jobspb.Type, wrap func(Resumer) Resumer) {
-	r.creationKnobs.Store(typ, wrap)
+	r.creationKnobs.Store(typ, &wrap)
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -16,7 +16,6 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -721,7 +721,7 @@ type DistSender struct {
 	dontConsiderConnHealth bool
 
 	// Currently executing range feeds.
-	activeRangeFeeds sync.Map // // map[*rangeFeedRegistry]nil
+	activeRangeFeeds syncutil.Map[*rangeFeedRegistry, struct{}]
 }
 
 var _ kv.Sender = &DistSender{}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -617,7 +616,7 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 		}, 10*time.Second)
 	}
 
-	var observedStreams sync.Map
+	var observedStreams syncutil.Map[int64, struct{}]
 	var capturedSender atomic.Value
 
 	ignoreValues := func(event kvcoord.RangeFeedMessage) {}
@@ -634,7 +633,7 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 			func(ctx context.Context, s roachpb.Span, streamID int64, event *kvpb.RangeFeedEvent) (skip bool, _ error) {
 				switch t := event.GetValue().(type) {
 				case *kvpb.RangeFeedCheckpoint:
-					observedStreams.Store(streamID, nil)
+					observedStreams.Store(streamID, &struct{}{})
 					_, err := frontier.Forward(t.Span, t.ResolvedTS)
 					if err != nil {
 						return true, err
@@ -677,8 +676,7 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 		initialClosed := numRestartStreams.Load()
 		numToCancel := 1 + rand.Int31n(3)
 		var numCancelled int32 = 0
-		observedStreams.Range(func(key any, _ any) bool {
-			streamID := key.(int64)
+		observedStreams.Range(func(streamID int64, _ *struct{}) bool {
 			if _, wasCancelled := cancelledStreams[streamID]; wasCancelled {
 				return true // try another stream.
 			}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -671,8 +671,8 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 		// we know the rangefeed is started, all ranges are running.
 		expectFrontierAdvance()
 
-		// Pick some number of streams to close. Since sync.Map iteration order is non-deterministic,
-		// we'll pick few random streams.
+		// Pick some number of streams to close. Since syncutil.Map iteration order
+		// is non-deterministic, we'll pick few random streams.
 		initialClosed := numRestartStreams.Load()
 		numToCancel := 1 + rand.Int31n(3)
 		var numCancelled int32 = 0

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -4449,7 +4450,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 
 	waitForInitialPuts := makeBarrier(2)
 	waitForInitialMeta2Scans := makeBarrier(2)
-	var queriedMetaKeys sync.Map
+	var queriedMetaKeys syncutil.Map[string, struct{}]
 	var ds *DistSender
 	testFn := func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
 		rs, err := keys.Range(ba.Requests)
@@ -4508,7 +4509,7 @@ func TestEvictionTokenCoalesce(t *testing.T) {
 				return br, nil
 			}
 		}
-		queriedMetaKeys.Store(string(rs.Key), struct{}{})
+		queriedMetaKeys.Store(string(rs.Key), &struct{}{})
 		return br, nil
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -42,7 +41,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -488,14 +489,14 @@ func TestTxnCoordSenderCommitCanceled(t *testing.T) {
 	// blockCommits is used to block commit responses for a given txn. The key is
 	// a txn ID, and the value is a ready channel (chan struct) that will be
 	// closed when the commit has been received and blocked.
-	var blockCommits sync.Map
+	var blockCommits syncutil.Map[uuid.UUID, chan struct{}]
 	responseFilter := func(_ context.Context, ba *kvpb.BatchRequest, _ *kvpb.BatchResponse) *kvpb.Error {
 		if arg, ok := ba.GetArg(kvpb.EndTxn); ok && ba.Txn != nil {
 			et := arg.(*kvpb.EndTxnRequest)
 			readyC, ok := blockCommits.Load(ba.Txn.ID)
 			if ok && et.Commit && len(et.InFlightWrites) == 0 {
-				close(readyC.(chan struct{})) // notify test that commit is received and blocked
-				<-ctx.Done()                  // wait for test to complete (NB: not the passed context)
+				close(*readyC) // notify test that commit is received and blocked
+				<-ctx.Done()   // wait for test to complete (NB: not the passed context)
 			}
 		}
 		return nil
@@ -526,7 +527,7 @@ func TestTxnCoordSenderCommitCanceled(t *testing.T) {
 	// Commit the transaction, but ask the response filter to block the final
 	// async commit sent by txnCommitter to make the implicit commit explicit.
 	readyC := make(chan struct{})
-	blockCommits.Store(txn.ID(), readyC)
+	blockCommits.Store(txn.ID(), &readyC)
 	require.NoError(t, txn.Commit(ctx))
 	<-readyC
 

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
@@ -72,14 +73,14 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		var allowSplits atomic.Value
 		allowSplits.Store(true)
 		unblockCh := make(chan struct{}, 1)
-		var rangesBlocked sync.Map
+		var rangesBlocked syncutil.Map[roachpb.RangeID, struct{}]
 		args = base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
 						TestingRequestFilter: func(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
 							if ba.Header.Txn != nil && ba.Header.Txn.Name == "split" && !allowSplits.Load().(bool) {
-								rangesBlocked.Store(ba.Header.RangeID, true)
+								rangesBlocked.Store(ba.Header.RangeID, &struct{}{})
 								defer rangesBlocked.Delete(ba.Header.RangeID)
 								select {
 								case <-unblockCh:

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"encoding/binary"
 	"math"
 	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -202,11 +202,11 @@ func TestReliableIntentCleanup(t *testing.T) {
 		// abortHeartbeats is used to abort txn heartbeats, returning
 		// TransactionAbortedError. Key is txn anchor key, value is a chan
 		// struct{} that will be closed when the next heartbeat aborts.
-		var abortHeartbeats sync.Map
+		var abortHeartbeats syncutil.Map[string, chan struct{}]
 
 		abortHeartbeat := func(t *testing.T, txnKey roachpb.Key) <-chan struct{} {
 			abortedC := make(chan struct{})
-			abortHeartbeats.Store(string(txnKey), abortedC)
+			abortHeartbeats.Store(string(txnKey), &abortedC)
 			t.Cleanup(func() {
 				abortHeartbeats.Delete(string(txnKey))
 			})
@@ -217,11 +217,11 @@ func TestReliableIntentCleanup(t *testing.T) {
 		// a txn anchor key, and the value is a chan chan<- struct{} that, when
 		// the Put is ready, will be used to send an unblock channel. The
 		// unblock channel can be closed to unblock the Put.
-		var blockPuts sync.Map
+		var blockPuts syncutil.Map[string, chan chan<- struct{}]
 
 		blockPut := func(t *testing.T, txnKey roachpb.Key) <-chan chan<- struct{} {
 			readyC := make(chan chan<- struct{})
-			blockPuts.Store(string(txnKey), readyC)
+			blockPuts.Store(string(txnKey), &readyC)
 			t.Cleanup(func() {
 				blockPuts.Delete(string(txnKey))
 			})
@@ -233,11 +233,11 @@ func TestReliableIntentCleanup(t *testing.T) {
 		// chan<- struct{} that, when the Put is ready, will be used to send an
 		// unblock channel. The unblock channel can be closed to unblock the
 		// Put.
-		var blockPutEvals sync.Map
+		var blockPutEvals syncutil.Map[string, chan chan<- struct{}]
 
 		blockPutEval := func(t *testing.T, txnKey roachpb.Key) <-chan chan<- struct{} {
 			readyC := make(chan chan<- struct{})
-			blockPutEvals.Store(string(txnKey), readyC)
+			blockPutEvals.Store(string(txnKey), &readyC)
 			t.Cleanup(func() {
 				blockPutEvals.Delete(string(txnKey))
 			})
@@ -249,7 +249,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 			// close the aborted channel and return an error response.
 			if _, ok := ba.GetArg(kvpb.HeartbeatTxn); ok && ba.Txn != nil {
 				if abortedC, ok := abortHeartbeats.LoadAndDelete(string(ba.Txn.Key)); ok {
-					close(abortedC.(chan struct{}))
+					close(*abortedC)
 					return kvpb.NewError(kvpb.NewTransactionAbortedError(
 						kvpb.ABORT_REASON_NEW_LEASE_PREVENTS_TXN))
 				}
@@ -264,7 +264,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 			if put, ok := args.Req.(*kvpb.PutRequest); ok && args.Hdr.Txn != nil {
 				if bytes.HasPrefix(put.Key, prefix) {
 					if ch, ok := blockPutEvals.LoadAndDelete(string(args.Hdr.Txn.Key)); ok {
-						readyC := ch.(chan chan<- struct{})
+						readyC := *ch
 						unblockC := make(chan struct{})
 						readyC <- unblockC
 						close(readyC)
@@ -282,7 +282,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 			if arg, ok := ba.GetArg(kvpb.Put); ok && ba.Txn != nil {
 				if bytes.HasPrefix(arg.(*kvpb.PutRequest).Key, prefix) {
 					if ch, ok := blockPuts.LoadAndDelete(string(ba.Txn.Key)); ok {
-						readyC := ch.(chan chan<- struct{})
+						readyC := *ch
 						unblockC := make(chan struct{})
 						readyC <- unblockC
 						close(readyC)

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_metrics.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_metrics.go
@@ -160,8 +160,7 @@ func newMetrics(c *Controller) *metrics {
 			annotateMetricTemplateWithWorkClass(wc, flowTokensAvailable),
 			func() int64 {
 				sum := int64(0)
-				c.mu.buckets.Range(func(key, value any) bool {
-					b := value.(*bucket)
+				c.mu.buckets.Range(func(_ kvflowcontrol.Stream, b *bucket) bool {
 					sum += int64(b.tokens(wc))
 					return true
 				})
@@ -233,10 +232,7 @@ func newMetrics(c *Controller) *metrics {
 				// TODO(sumeer): this cap is not ideal. Consider dynamically reducing
 				// the logging frequency to maintain a mean of 400 log entries/10min.
 				const streamStatsCountCap = 20
-				c.mu.buckets.Range(func(key, value any) bool {
-					stream := key.(kvflowcontrol.Stream)
-					b := value.(*bucket)
-
+				c.mu.buckets.Range(func(stream kvflowcontrol.Stream, b *bucket) bool {
 					if b.tokens(wc) <= 0 {
 						count++
 

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/kvflowdispatch.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/kvflowdispatch.go
@@ -35,7 +35,7 @@ type Dispatch struct {
 		// TODO(irfansharif,aaditya): On kv0/enc=false/nodes=3/cpu=96 this mutex
 		// is responsible for ~3.7% of the mutex contention. Look to address it
 		// as part of #104154. Perhaps shard this mutex by node ID? Or use a
-		// sync.Map instead?
+		// syncutil.Map instead?
 		syncutil.Mutex
 		// outbox maintains pending dispatches on a per-node basis.
 		outbox map[roachpb.NodeID]dispatches

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -4074,21 +4074,19 @@ func (m *pebbleCategoryIterMetrics) update(stats sstable.CategoryStats) {
 }
 
 type pebbleCategoryIterMetricsContainer struct {
-	registry *metric.Registry
-	// sstable.Category => *pebbleCategoryIterMetrics
-	metricsMap sync.Map
+	registry   *metric.Registry
+	metricsMap syncutil.Map[sstable.Category, pebbleCategoryIterMetrics]
 }
 
 func (m *pebbleCategoryIterMetricsContainer) update(stats []sstable.CategoryStatsAggregate) {
 	for _, s := range stats {
-		val, ok := m.metricsMap.Load(s.Category)
+		cm, ok := m.metricsMap.Load(s.Category)
 		if !ok {
-			val, ok = m.metricsMap.LoadOrStore(s.Category, makePebbleCategorizedIterMetrics(s.Category))
+			cm, ok = m.metricsMap.LoadOrStore(s.Category, makePebbleCategorizedIterMetrics(s.Category))
 			if !ok {
-				m.registry.AddMetricStruct(val)
+				m.registry.AddMetricStruct(cm)
 			}
 		}
-		cm := val.(*pebbleCategoryIterMetrics)
 		cm.update(s.CategoryStats)
 	}
 }

--- a/pkg/settings/cluster/BUILD.bazel
+++ b/pkg/settings/cluster/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/settings",
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -12,7 +12,6 @@ package cluster
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -20,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -53,7 +53,7 @@ type Settings struct {
 
 	// Cache can be used for arbitrary caching, e.g. to cache decoded
 	// enterprises licenses for utilccl.CheckEnterpriseEnabled().
-	Cache sync.Map
+	Cache syncutil.Map[any, any]
 
 	// OverridesInformer can be nil.
 	OverridesInformer OverridesInformer

--- a/pkg/util/syncutil/map_test.go
+++ b/pkg/util/syncutil/map_test.go
@@ -262,7 +262,7 @@ func TestMapRangeNestedCall(t *testing.T) { // Issue 46399
 	})
 
 	if length != 0 {
-		t.Fatalf("Unexpected sync.Map size, got %v want %v", length, 0)
+		t.Fatalf("Unexpected syncutil.Map size, got %v want %v", length, 0)
 	}
 }
 


### PR DESCRIPTION
This commit performs a series of refactors that were unlocked by https://github.com/cockroachdb/cockroach/pull/120604 to replace all uses of `sync.Map` with `syncutil.Map`. `syncutil.Map` is more efficient, it cuts down on heap allocations, and it provides more type safety than `sync.Map`, so there's no reason to use `sync.Map` anymore.

Release note: None