### PR TITLE
syncutil: add and use concurrent Set type

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -721,7 +721,7 @@ type DistSender struct {
 	dontConsiderConnHealth bool
 
 	// Currently executing range feeds.
-	activeRangeFeeds syncutil.Map[*rangeFeedRegistry, struct{}]
+	activeRangeFeeds syncutil.Set[*rangeFeedRegistry]
 }
 
 var _ kv.Sender = &DistSender{}

--- a/pkg/kv/kvserver/rangefeed/scheduler.go
+++ b/pkg/kv/kvserver/rangefeed/scheduler.go
@@ -154,7 +154,7 @@ type Scheduler struct {
 	// separate shards to reduce mutex contention. Allocation is modulo
 	// processors, with shard 0 reserved for priority processors.
 	shards      []*schedulerShard // 1 + id%(len(shards)-1)
-	priorityIDs syncutil.Map[int64, struct{}]
+	priorityIDs syncutil.Set[int64]
 	wg          sync.WaitGroup
 }
 
@@ -282,10 +282,10 @@ func (s *Scheduler) register(id int64, f Callback, priority bool) error {
 	// Make sure we register the priority ID before registering the callback,
 	// since we can otherwise race with enqueues, using the wrong shard.
 	if priority {
-		s.priorityIDs.Store(id, new(struct{}))
+		s.priorityIDs.Add(id)
 	}
 	if err := s.shards[shardIndex(id, len(s.shards), priority)].register(id, f); err != nil {
-		s.priorityIDs.Delete(id)
+		s.priorityIDs.Remove(id)
 		return err
 	}
 	return nil
@@ -300,9 +300,9 @@ func (s *Scheduler) register(id int64, f Callback, priority bool) error {
 // Any attempts to enqueue events for processor after this call will return an
 // error.
 func (s *Scheduler) unregister(id int64) {
-	_, priority := s.priorityIDs.Load(id)
+	priority := s.priorityIDs.Contains(id)
 	s.shards[shardIndex(id, len(s.shards), priority)].unregister(id)
-	s.priorityIDs.Delete(id)
+	s.priorityIDs.Remove(id)
 }
 
 func (s *Scheduler) Stop() {
@@ -328,7 +328,7 @@ func (s *Scheduler) stopProcessor(id int64) {
 // Enqueue event for existing callback. The event is ignored if the processor
 // does not exist.
 func (s *Scheduler) enqueue(id int64, evt processorEventType) {
-	_, priority := s.priorityIDs.Load(id)
+	priority := s.priorityIDs.Contains(id)
 	s.shards[shardIndex(id, len(s.shards), priority)].enqueue(id, evt)
 }
 
@@ -583,7 +583,7 @@ type SchedulerBatch struct {
 	priorityIDs map[int64]bool
 }
 
-func newSchedulerBatch(numShards int, priorityIDs *syncutil.Map[int64, struct{}]) *SchedulerBatch {
+func newSchedulerBatch(numShards int, priorityIDs *syncutil.Set[int64]) *SchedulerBatch {
 	b := schedulerBatchPool.Get().(*SchedulerBatch)
 	if cap(b.ids) >= numShards {
 		b.ids = b.ids[:numShards]
@@ -595,7 +595,7 @@ func newSchedulerBatch(numShards int, priorityIDs *syncutil.Map[int64, struct{}]
 	}
 	// Cache the priority range IDs in an owned map, since we expect this to be
 	// very small or empty and we do a lookup for every Add() call.
-	priorityIDs.Range(func(id int64, _ *struct{}) bool {
+	priorityIDs.Range(func(id int64) bool {
 		b.priorityIDs[id] = true
 		return true
 	})

--- a/pkg/util/syncutil/BUILD.bazel
+++ b/pkg/util/syncutil/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "mutex_sync.go",  # keep
         "mutex_sync_race.go",  # keep
         "mutex_tracing.go",
+        "set.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/syncutil",
     visibility = ["//visibility:public"],
@@ -27,6 +28,7 @@ go_test(
         "map_test.go",
         "mutex_sync_race_test.go",  # keep
         "mutex_tracing_test.go",
+        "set_test.go",
     ],
     embed = [":syncutil"],
     deps = ["@com_github_stretchr_testify//require"],

--- a/pkg/util/syncutil/map.go
+++ b/pkg/util/syncutil/map.go
@@ -37,7 +37,7 @@ import (
 // separate Mutex or RWMutex.
 //
 // Nil values are not supported; to use an Map as a set store a dummy non-nil
-// pointer instead of nil.
+// pointer instead of nil. The Set type is provided for this purpose.
 //
 // The zero Map is valid and empty.
 //

--- a/pkg/util/syncutil/map.go
+++ b/pkg/util/syncutil/map.go
@@ -167,6 +167,8 @@ func (e *entry[V]) load() (value *V, ok bool) {
 
 // Store sets the value for a key.
 func (m *Map[K, V]) Store(key K, value *V) {
+	m.assertNotNil(value)
+
 	read := m.loadReadOnly()
 	if e, ok := read.m[key]; ok && e.tryStore(value) {
 		return
@@ -192,6 +194,15 @@ func (m *Map[K, V]) Store(key K, value *V) {
 			m.read.Store(&readOnly[K, V]{m: read.m, amended: true})
 		}
 		m.dirty[key] = newEntry(value)
+	}
+}
+
+// assertNotNil asserts that a provided value to store is non-nil. Map does not
+// support nil values because nil is used to indicate that an entry has been
+// deleted. Callers should use a dummy non-nil pointer instead of nil.
+func (*Map[K, V]) assertNotNil(v *V) {
+	if v == nil {
+		panic("syncutil.Map: store with a nil value is unsupported")
 	}
 }
 
@@ -230,6 +241,8 @@ func (e *entry[V]) storeLocked(v *V) {
 // Otherwise, it stores and returns the given value.
 // The loaded result is true if the value was loaded, false if stored.
 func (m *Map[K, V]) LoadOrStore(key K, value *V) (actual *V, loaded bool) {
+	m.assertNotNil(value)
+
 	// Avoid locking if it's a clean hit.
 	read := m.loadReadOnly()
 	if e, ok := read.m[key]; ok {

--- a/pkg/util/syncutil/map_test.go
+++ b/pkg/util/syncutil/map_test.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"testing/quick"
+
+	"github.com/stretchr/testify/require"
 )
 
 type intMapInterface mapInterface[int64, int64]
@@ -302,4 +304,13 @@ func TestMapCheckPtr(t *testing.T) {
 			panic("invalid mapOp")
 		}
 	}
+}
+
+// TestMapStoreNilValue tests that storing a nil value in a Map is not allowed.
+func TestMapStoreNilValue(t *testing.T) {
+	var m Map[int64, struct{}]
+	require.Panics(t, func() { m.Store(1, nil) })
+	require.Panics(t, func() { m.LoadOrStore(1, nil) })
+	require.NotPanics(t, func() { m.Store(1, &struct{}{}) })
+	require.NotPanics(t, func() { m.LoadOrStore(1, &struct{}{}) })
 }

--- a/pkg/util/syncutil/set.go
+++ b/pkg/util/syncutil/set.go
@@ -1,0 +1,62 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+// Set is like a Go map[V]struct{} but is safe for concurrent use by multiple
+// goroutines without additional locking or coordination.
+// Loads, stores, and deletes run in amortized constant time.
+//
+// See the Map type for more details.
+type Set[V comparable] struct {
+	m Map[V, struct{}]
+}
+
+// Contains returns whether the value is stored in the set.
+//
+// Both Add and Remove return whether the value previously existed in the set,
+// so Contains is typically not needed when later calling one of those methods.
+// In fact, its use in logic that later mutates the set may be racy if not
+// carefully considered, as there is no synchronization between the Contains
+// call and the subsequent Add or Remove call.
+func (s *Set[V]) Contains(value V) bool {
+	_, ok := s.m.Load(value)
+	return ok
+}
+
+// dummyValue is a placeholder value for all values in the map.
+var dummyValue = new(struct{})
+
+// Add adds the value to the set.
+//
+// Returns whether the value was added (true) or was already present (false).
+func (s *Set[V]) Add(value V) bool {
+	_, loaded := s.m.LoadOrStore(value, dummyValue)
+	return !loaded
+}
+
+// Remove removes the value from the set.
+//
+// Returns whether the value was present and removed (true) or was not present
+// and not removed (false).
+func (s *Set[V]) Remove(value V) bool {
+	_, loaded := s.m.LoadAndDelete(value)
+	return loaded
+}
+
+// Range calls f sequentially for each value present in the set.
+// If f returns false, range stops the iteration.
+//
+// See Map.Range for more details.
+func (s *Set[V]) Range(f func(value V) bool) {
+	s.m.Range(func(value V, _ *struct{}) bool {
+		return f(value)
+	})
+}

--- a/pkg/util/syncutil/set_test.go
+++ b/pkg/util/syncutil/set_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func (s *Set[V]) asSlice() []V {
+	var res []V
+	s.Range(func(v V) bool {
+		res = append(res, v)
+		return true
+	})
+	return res
+}
+
+func TestSetBasic(t *testing.T) {
+	var s Set[int]
+
+	require.Nil(t, s.asSlice())
+	require.False(t, s.Contains(1))
+	require.False(t, s.Remove(1))
+
+	require.True(t, s.Add(1))
+	require.False(t, s.Add(1))
+	require.True(t, s.Add(2))
+	require.ElementsMatch(t, []int{1, 2}, s.asSlice())
+	require.True(t, s.Contains(1))
+	require.True(t, s.Contains(2))
+	require.False(t, s.Contains(3))
+
+	require.True(t, s.Remove(1))
+	require.False(t, s.Remove(1))
+	require.False(t, s.Remove(3))
+	require.ElementsMatch(t, []int{2}, s.asSlice())
+	require.False(t, s.Contains(1))
+	require.True(t, s.Contains(2))
+	require.False(t, s.Contains(3))
+}
+
+func TestSetPointerValue(t *testing.T) {
+	var s Set[*int]
+	ptr1, ptr2, ptr3 := new(int), new(int), new(int)
+
+	require.Nil(t, s.asSlice())
+	require.False(t, s.Contains(nil))
+	require.False(t, s.Contains(ptr1))
+	require.False(t, s.Remove(nil))
+	require.False(t, s.Remove(ptr1))
+
+	require.True(t, s.Add(nil))
+	require.False(t, s.Add(nil))
+	require.True(t, s.Add(ptr1))
+	require.False(t, s.Add(ptr1))
+	require.True(t, s.Add(ptr2))
+	require.ElementsMatch(t, []*int{nil, ptr1, ptr2}, s.asSlice())
+	require.True(t, s.Contains(nil))
+	require.True(t, s.Contains(ptr1))
+	require.True(t, s.Contains(ptr2))
+	require.False(t, s.Contains(ptr3))
+
+	require.True(t, s.Remove(nil))
+	require.False(t, s.Remove(nil))
+	require.True(t, s.Remove(ptr1))
+	require.False(t, s.Remove(ptr1))
+	require.False(t, s.Remove(ptr3))
+	require.ElementsMatch(t, []*int{ptr2}, s.asSlice())
+	require.False(t, s.Contains(nil))
+	require.False(t, s.Contains(ptr1))
+	require.True(t, s.Contains(ptr2))
+	require.False(t, s.Contains(ptr3))
+}


### PR DESCRIPTION
First 14 commits from https://github.com/cockroachdb/cockroach/pull/127079, only the last 3 are new.

This PR adds a new type, `syncutil.Set`, which is a slim wrapper around `syncutil.Map` that provides a set-like API and avoids a footgun with nil values.

The PR then replaces `syncutil.Map` with `syncutil.Set`, where appropriate.

Release note: None