### PR TITLE
kv: don't propose lease acquisition if raft leader is unknown, by default

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -464,13 +464,8 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	v.perturbation.startTargetNode(ctx, t.L(), v)
 
 	func() {
-		// TODO(baptist): Remove this block once #120073 is fixed.
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
-		if _, err := db.Exec(
-			`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true`); err != nil {
-			t.Fatal(err)
-		}
 		// This isn't strictly necessary, but it would be nice if this test passed at 10s (or lower).
 		if _, err := db.Exec(
 			`SET CLUSTER SETTING server.time_after_store_suspect = '10s'`); err != nil {

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1792,13 +1792,12 @@ func getStreamIngestionJobInfo(db *gosql.DB, jobID int) (jobInfo, error) {
 func srcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
-		`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true;`)
+	)
 }
 
 func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration time.Duration) {
 	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
-		`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
 	)
 

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -25,6 +25,7 @@ import (
 var (
 	repl1 = roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1}
 	repl2 = roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2, ReplicaID: 2}
+	repl3 = roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3}
 	desc  = roachpb.RangeDescriptor{InternalReplicas: []roachpb.ReplicaDescriptor{repl1, repl2}}
 	cts10 = hlc.ClockTimestamp{WallTime: 10}
 	cts20 = hlc.ClockTimestamp{WallTime: 20}
@@ -175,7 +176,7 @@ func defaultSettings() Settings {
 	return Settings{
 		UseExpirationLeases:        false,
 		TransferExpirationLeases:   true,
-		RejectLeaseOnLeaderUnknown: false,
+		RejectLeaseOnLeaderUnknown: true,
 		ExpToEpochEquiv:            true,
 		MinExpirationSupported:     true,
 		RangeLeaseDuration:         20,

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -547,6 +547,10 @@ func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 				},
 				Store: &kvserver.StoreTestingKnobs{
 					DisableConsistencyQueue: true,
+					// We set AllowLeaseRequestProposalsWhenNotLeader to true so that the
+					// lease acquisition request (TestingAcquireLease) can be proposed
+					// regardless of the raft state.
+					AllowLeaseRequestProposalsWhenNotLeader: true,
 					EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
 						TestingPostEvalFilter: func(args kvserverbase.FilterArgs) *kvpb.Error {
 							blockWrites(args)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -146,14 +146,11 @@ var LeaseCheckPreferencesOnAcquisitionEnabled = settings.RegisterBoolSetting(
 
 // RejectLeaseOnLeaderUnknown controls whether a replica that does not know the
 // current raft leader rejects a lease request.
-//
-// TODO(pav-kv): flip the default to true, and remove this setting when this
-// becomes the only behaviour.
 var RejectLeaseOnLeaderUnknown = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lease.reject_on_leader_unknown.enabled",
 	"reject lease requests on a replica that does not know the raft leader",
-	false,
+	true,
 )
 
 // leaseRequestHandle is a handle to an asynchronous lease request.


### PR DESCRIPTION
Fixes #118435.
Fixes #120073.

This commit updates the `kv.lease.reject_on_leader_unknown.enabled` cluster setting added in 282d9532 to be enabled by default. This setting instructs a Raft follower who is not aware of the current Raft leader to reject lease acquisitions immediately, rather than waiting for the local replica establishing connectivity to its quorum (which may never happen).

In cases where a range truly has no leader, we now rely on the client to retry requests (with backoff) until a new leader has been established.

This behavior is is still configurable with the cluster setting, so we can disable it if we find that it causes issues.

Release note: None