### PR TITLE
release-24.1: ui: fix query fetching store ids for db/tables

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -379,8 +379,12 @@ const getDatabaseReplicasAndRegions: DatabaseDetailsQuery<DatabaseReplicasRegion
     ) => {
       if (txn_result.error) {
         resp.stats.replicaData.error = txn_result.error;
+        // We don't expect to have any rows for this query on error.
+        return;
       }
-      resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
+      if (!txnResultIsEmpty(txn_result)) {
+        resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
+      }
     },
     handleMaxSizeError: (_dbName, _response, _dbDetail) => {
       return Promise.resolve(false);

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -178,6 +178,7 @@ const UPGRADE_RELATED_ERRORS = [
 ];
 
 export function isUpgradeError(message: string): boolean {
+  if (message == null) return false;
   return UPGRADE_RELATED_ERRORS.some(err => message.search(err) !== -1);
 }
 
@@ -196,6 +197,10 @@ export function isUpgradeError(message: string): boolean {
  * @param message
  */
 export function sqlApiErrorMessage(message: string): string {
+  if (!message) {
+    return "";
+  }
+
   if (isUpgradeError(message)) {
     return "This page may not be available during an upgrade.";
   }

--- a/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
@@ -463,12 +463,16 @@ const getTableReplicaStoreIDs: TableDetailsQuery<TableReplicasRow> = {
   ) => {
     if (txn_result.error) {
       resp.stats.replicaData.error = txn_result.error;
+      // We don't expect to have any rows for this query on error.
+      return;
     }
 
     // TODO #118957 (xinhaoz) Store IDs and node IDs cannot be used interchangeably.
-    resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
-    resp.stats.replicaData.replicaCount =
-      txn_result?.rows[0]?.replica_count ?? 0;
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
+      resp.stats.replicaData.replicaCount =
+        txn_result?.rows[0]?.replica_count ?? 0;
+    }
   },
 };
 

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -23,7 +23,7 @@ import {
   indexUnusedDuration,
 } from "src/util/constants";
 import Severity = protos.cockroach.util.log.Severity;
-import { stubSqlApiCall } from "src/util/fakeApi";
+import { mockExecSQLErrors, stubSqlApiCall } from "src/util/fakeApi";
 
 const { ZoneConfig } = cockroach.config.zonepb;
 const { ZoneConfigurationLevel } = cockroach.server.serverpb;
@@ -302,6 +302,20 @@ describe("rest api", function () {
           done();
         });
     });
+
+    it("should not error when any query fails", async () => {
+      const req = { database, csIndexUnusedDuration: indexUnusedDuration };
+      const mockResults = mockExecSQLErrors<clusterUiApi.DatabaseDetailsRow>(6);
+      stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+        clusterUiApi.createDatabaseDetailsReq(req),
+        mockResults,
+      );
+
+      // This call should not throw.
+      const result = await clusterUiApi.getDatabaseDetails(req);
+      expect(result.results).toBeDefined();
+      expect(result.results.error).toBeDefined();
+    });
   });
 
   describe("table details request", function () {
@@ -495,6 +509,27 @@ describe("rest api", function () {
           expect(_.startsWith(e.message, "Promise timed out")).toBeTruthy();
           done();
         });
+    });
+
+    it("should not error when any query fails", async () => {
+      const mockResults = mockExecSQLErrors<clusterUiApi.TableDetailsRow>(10);
+      stubSqlApiCall<clusterUiApi.TableDetailsRow>(
+        clusterUiApi.createTableDetailsReq(
+          dbName,
+          tableName,
+          indexUnusedDuration,
+        ),
+        mockResults,
+      );
+
+      // This call should not throw.
+      const result = await clusterUiApi.getTableDetails({
+        database: dbName,
+        table: tableName,
+        csIndexUnusedDuration: indexUnusedDuration,
+      });
+      expect(result.results).toBeDefined();
+      expect(result.results.error).toBeDefined();
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import * as $protobuf from "protobufjs";
+import { SqlTxnResult } from "@cockroachlabs/cluster-ui/dist/types/api";
 
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import { cockroach } from "src/js/protos";
@@ -106,7 +107,17 @@ export function stubSqlApiCall<T>(
   mockTxnResults: mockSqlTxnResult<T>[],
   times: number = 1,
 ) {
-  const response = buildSqlExecutionResponse(mockTxnResults);
+  const firstError = mockTxnResults.find(mock => mock.error != null)?.error;
+  let err: clusterUiApi.SqlExecutionErrorMessage;
+  if (firstError != null) {
+    err = {
+      message: firstError.message,
+      code: "123",
+      severity: "ERROR",
+      source: { file: "myfile.go", line: 111, function: "myFn" },
+    };
+  }
+  const response = buildSqlExecutionResponse(mockTxnResults, err);
   fetchMock.mock({
     headers: {
       Accept: "application/json",
@@ -185,3 +196,23 @@ function buildSqlTxnResult<RowType>(
     error: mock.error,
   };
 }
+
+const mockStmtExecErrorResponse = <T>(
+  res: Partial<SqlTxnResult<T>>,
+): SqlTxnResult<T> => ({
+  statement: res?.statement ?? 1,
+  tag: "SELECT",
+  start: "2022-01-01T00:00:00Z",
+  end: "2022-01-01T00:00:01Z",
+  error: new Error("error"),
+  rows_affected: 0,
+  ...res,
+});
+
+export const mockExecSQLErrors = <T>(
+  statements: number,
+): mockSqlTxnResult<T>[] => {
+  return Array.from({ length: statements }, (_, i) =>
+    mockStmtExecErrorResponse<T>({ statement: i + 1 }),
+  );
+};


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: fix query fetching store ids for db/tables" (#126419)

cc @cockroachdb/release 

---------------

These queries were updated in #118904 to make them more performant. In that change we mistakenly removed the null check before reading the `rows` field, causing pages using this request to crash if this query fails.

Epic: none
Fixes: #126348

Release note (bug fix): Database overview and db details pages should not crash if the range information is not available.

Release justification: bug fix