### PR TITLE
colexec: release in-memory resources after spilling to disk

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -827,7 +827,6 @@ func TestAggregators(t *testing.T) {
 				func(input []colexecop.Operator) (colexecop.Operator, error) {
 					args := &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
-						MemAccount:     testMemAcc,
 						Input:          input[0],
 						InputTypes:     tc.typs,
 						Spec:           tc.spec,
@@ -956,7 +955,6 @@ func TestAggregatorRandom(t *testing.T) {
 					require.NoError(t, err)
 					args := &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
-						MemAccount:     testMemAcc,
 						Input:          source,
 						InputTypes:     tc.typs,
 						Spec:           tc.spec,
@@ -1174,7 +1172,6 @@ func benchmarkAggregateFunction(
 			for i := 0; i < b.N; i++ {
 				a := agg.new(ctx, &colexecagg.NewAggregatorArgs{
 					Allocator:         testAllocator,
-					MemAccount:        testMemAcc,
 					Input:             source,
 					InputTypes:        tc.typs,
 					Spec:              tc.spec,

--- a/pkg/sql/colexec/aggregators_util.go
+++ b/pkg/sql/colexec/aggregators_util.go
@@ -274,7 +274,7 @@ func newDistinctAggregatorHelperBase(
 	b := &distinctAggregatorHelperBase{
 		aggregatorHelperBase: newAggregatorHelperBase(args.Spec, maxBatchSize),
 		inputTypes:           args.InputTypes,
-		arena:                stringarena.Make(args.MemAccount),
+		arena:                stringarena.Make(args.Allocator.Acc()),
 		datumAlloc:           datumAlloc,
 	}
 	var vecIdxsToConvert []int

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -315,6 +315,8 @@ func canWrap(mode sessiondatapb.VectorizeExecMode, core *execinfrapb.ProcessorCo
 // - post describes the post-processing spec of the processor. It will be used
 // to determine whether top K sort can be planned. If you want the general sort
 // operator, then pass in empty struct.
+// - diskBackedReuseMode indicates whether this disk-backed sort can be used
+// multiple times.
 func (r opResult) createDiskBackedSort(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
@@ -328,6 +330,7 @@ func (r opResult) createDiskBackedSort(
 	processorID int32,
 	opNamePrefix redact.RedactableString,
 	factory coldata.ColumnFactory,
+	diskBackedReuseMode colexecop.BufferingOpReuseMode,
 ) colexecop.Operator {
 	var (
 		sorterMemMonitorName redact.RedactableString
@@ -440,6 +443,7 @@ func (r opResult) createDiskBackedSort(
 			r.ToClose = append(r.ToClose, es.(colexecop.Closer))
 			return es
 		},
+		diskBackedReuseMode,
 		args.TestingKnobs.SpillingCallbackFn,
 	)
 	r.ToClose = append(r.ToClose, diskSpiller)
@@ -470,11 +474,15 @@ func (r opResult) makeDiskBackedSorterConstructor(
 			// acquired. The hash-based partitioner will do this up front.
 			sortArgs.FDSemaphore = nil
 		}
+		// Given that this disk-backed sort is created for the fallback strategy
+		// of the hash-based partitioner, it can be reused multiple times (in
+		// the worst case, for each partition).
+		const reuseMode = colexecop.BufferingOpCanReuse
 		return r.createDiskBackedSort(
 			ctx, flowCtx, &sortArgs, input, inputTypes,
 			execinfrapb.Ordering{Columns: orderingCols}, 0, /* limit */
 			0 /* matchLen */, maxNumberPartitions, args.Spec.ProcessorID,
-			opNamePrefix+"-", factory,
+			opNamePrefix+"-", factory, reuseMode,
 		)
 	}
 }
@@ -1059,6 +1067,7 @@ func NewColOperator(
 							result.ToClose = append(result.ToClose, toClose)
 							return eha
 						},
+						colexecop.BufferingOpNoReuse,
 						args.TestingKnobs.SpillingCallbackFn,
 					)
 					result.Root = diskSpiller
@@ -1125,6 +1134,7 @@ func NewColOperator(
 						result.ToClose = append(result.ToClose, toClose)
 						return ed
 					},
+					colexecop.BufferingOpNoReuse,
 					args.TestingKnobs.SpillingCallbackFn,
 				)
 				result.Root = diskSpiller
@@ -1415,7 +1425,7 @@ func NewColOperator(
 			limit := core.Sorter.Limit
 			result.Root = result.createDiskBackedSort(
 				ctx, flowCtx, args, input, result.ColumnTypes, ordering, limit, matchLen, 0, /* maxNumberPartitions */
-				spec.ProcessorID, "" /* opNamePrefix */, factory,
+				spec.ProcessorID, "" /* opNamePrefix */, factory, colexecop.BufferingOpNoReuse,
 			)
 
 		case core.Windower != nil:
@@ -1475,7 +1485,8 @@ func NewColOperator(
 								ctx, flowCtx, args, input, inputTypes,
 								execinfrapb.Ordering{Columns: orderingCols}, 0 /*limit */, 0, /* matchLen */
 								0 /* maxNumberPartitions */, spec.ProcessorID,
-								opNamePrefix, factory)
+								opNamePrefix, factory, colexecop.BufferingOpNoReuse,
+							)
 						},
 					)
 					// Window partitioner will append a boolean column.
@@ -1485,7 +1496,7 @@ func NewColOperator(
 						input = result.createDiskBackedSort(
 							ctx, flowCtx, args, input, result.ColumnTypes,
 							wf.Ordering, 0 /* limit */, 0 /* matchLen */, 0, /* maxNumberPartitions */
-							spec.ProcessorID, opNamePrefix, factory,
+							spec.ProcessorID, opNamePrefix, factory, colexecop.BufferingOpNoReuse,
 						)
 					}
 				}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -698,7 +698,6 @@ func makeNewHashAggregatorArgs(
 		ctx, flowCtx, opName, args.Spec.ProcessorID, 5, /* numAccounts */
 	)
 	newAggArgs.Allocator = colmem.NewLimitedAllocator(ctx, hashAggregatorMemAccount, accounts[0], factory)
-	newAggArgs.MemAccount = hashAggregatorMemAccount
 	return &colexecagg.NewHashAggregatorArgs{
 			NewAggregatorArgs:        newAggArgs,
 			HashTableAllocator:       colmem.NewLimitedAllocator(ctx, hashTableMemAccount, accounts[1], factory),
@@ -998,7 +997,6 @@ func NewColOperator(
 					newAggArgs.Allocator = colmem.NewAllocator(
 						ctx, hashAggregatorUnlimitedMemAccount, factory,
 					)
-					newAggArgs.MemAccount = hashAggregatorUnlimitedMemAccount
 					evalCtx.SingleDatumAggMemAccount = hashAggregatorUnlimitedMemAccount
 					newHashAggArgs := &colexecagg.NewHashAggregatorArgs{
 						NewAggregatorArgs:        newAggArgs,
@@ -1042,7 +1040,6 @@ func NewColOperator(
 							// in-memory hash aggregator fit under the limit, so
 							// we use an unlimited allocator.
 							newAggArgs.Allocator = colmem.NewAllocator(ctx, ehaMemAccount, factory)
-							newAggArgs.MemAccount = ehaMemAccount
 							newAggArgs.Input = input
 							eha, toClose := colexecdisk.NewExternalHashAggregator(
 								ctx,
@@ -1070,7 +1067,6 @@ func NewColOperator(
 			} else {
 				evalCtx.SingleDatumAggMemAccount = getStreamingMemAccount(args, flowCtx)
 				newAggArgs.Allocator = getStreamingAllocator(ctx, args, flowCtx)
-				newAggArgs.MemAccount = getStreamingMemAccount(args, flowCtx)
 				result.Root = colexec.NewOrderedAggregator(ctx, newAggArgs)
 				result.ToClose = append(result.ToClose, result.Root.(colexecop.Closer))
 			}
@@ -1382,7 +1378,6 @@ func NewColOperator(
 					// partitions to process using the in-memory hash aggregator
 					// fit under the limit, so we use an unlimited allocator.
 					newAggArgs.Allocator = colmem.NewAllocator(ctx, ehaMemAccount, factory)
-					newAggArgs.MemAccount = ehaMemAccount
 					newAggArgs.Input = aggInput
 					eha, toClose := colexecdisk.NewExternalHashAggregator(
 						ctx,

--- a/pkg/sql/colexec/colexecagg/BUILD.bazel
+++ b/pkg/sql/colexec/colexecagg/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/duration",
         "//pkg/util/json",  # keep
-        "//pkg/util/mon",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/colexec/colexecagg/aggregators_util.go
+++ b/pkg/sql/colexec/colexecagg/aggregators_util.go
@@ -18,16 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 // NewAggregatorArgs encompasses all arguments necessary to instantiate either
 // of the aggregators.
 type NewAggregatorArgs struct {
-	Allocator *colmem.Allocator
-	// MemAccount should be the same as the one used by Allocator and will be
-	// used by aggregatorHelper to handle DISTINCT clause.
-	MemAccount     *mon.BoundAccount
+	Allocator      *colmem.Allocator
 	Input          colexecop.Operator
 	InputTypes     []*types.T
 	Spec           *execinfrapb.AggregatorSpec

--- a/pkg/sql/colexec/colexecagg/aggregators_util.go
+++ b/pkg/sql/colexec/colexecagg/aggregators_util.go
@@ -23,6 +23,14 @@ import (
 // NewAggregatorArgs encompasses all arguments necessary to instantiate either
 // of the aggregators.
 type NewAggregatorArgs struct {
+	// Allocator will be utilized for miscellaneous allocations in the
+	// aggregators.
+	//
+	// In the in-memory hash aggregator it will be used for:
+	// - aggregateFuncAlloc
+	// - DISTINCT and FILTER helpers
+	// - aggBucketAlloc
+	// - AppendOnlyBufferedBatch for buffered tuples.
 	Allocator      *colmem.Allocator
 	Input          colexecop.Operator
 	InputTypes     []*types.T

--- a/pkg/sql/colexec/colexecdisk/BUILD.bazel
+++ b/pkg/sql/colexec/colexecdisk/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -335,7 +335,7 @@ func (op *hashBasedPartitioner) Init(ctx context.Context) {
 	op.cancelChecker.Init(op.Ctx)
 	op.partitionsToProcessUsingMain = make(map[int]*hbpPartitionInfo)
 	// If we are initializing the hash-based partitioner, it means that we had
-	// to fallback from the in-memory one since the inputs had more tuples that
+	// to fall back from the in-memory one since the inputs had more tuples that
 	// could fit into the memory, and, therefore, it makes sense to instantiate
 	// the batches with maximum capacity.
 	op.scratch.batches = append(op.scratch.batches, op.unlimitedAllocator.NewMemBatchWithFixedCapacity(op.inputTypes[0], coldata.BatchSize()))

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -246,7 +246,6 @@ type hashJoiner struct {
 	}
 
 	exportBufferedState struct {
-		hashTableReleased  bool
 		rightExported      int
 		rightWindowedBatch coldata.Batch
 	}
@@ -709,13 +708,8 @@ func (hj *hashJoiner) ExportBuffered(input colexecop.Operator) coldata.Batch {
 		// point we haven't requested a single batch from the left.
 		return coldata.ZeroBatch
 	} else if hj.InputTwo == input {
-		if hj.exportBufferedState.hashTableReleased {
-			return coldata.ZeroBatch
-		}
-		if hj.exportBufferedState.rightExported == hj.ht.Vals.Length() {
-			// We no longer need the hash table, so we can release it.
-			hj.ht.Release()
-			hj.exportBufferedState.hashTableReleased = true
+		if hj.ht == nil || hj.exportBufferedState.rightExported == hj.ht.Vals.Length() {
+			// The right input has been fully exported.
 			return coldata.ZeroBatch
 		}
 		newRightExported := hj.exportBufferedState.rightExported + coldata.BatchSize()
@@ -740,6 +734,30 @@ func (hj *hashJoiner) ExportBuffered(input colexecop.Operator) coldata.Batch {
 		// This code is unreachable, but the compiler cannot infer that.
 		return nil
 	}
+}
+
+// ReleaseBeforeExport implements the colexecop.BufferingInMemoryOperator
+// interface.
+func (hj *hashJoiner) ReleaseBeforeExport() {}
+
+// ReleaseAfterExport implements the colexecop.BufferingInMemoryOperator
+// interface.
+func (hj *hashJoiner) ReleaseAfterExport(input colexecop.Operator) {
+	if hj.InputOne == input {
+		// We don't have anything to release for the left input.
+		return
+	}
+	if hj.ht == nil {
+		// Resources have already been released.
+		return
+	}
+	// We can only spill to disk while building the hash table (i.e. before the
+	// probing phase), so we only need to release the hash table and the
+	// windowed batch we used for the export (since we haven't allocated any
+	// other resources).
+	hj.ht.Release()
+	hj.ht = nil
+	hj.exportBufferedState.rightWindowedBatch = nil
 }
 
 func (hj *hashJoiner) resetOutput(nResults int) {
@@ -782,13 +800,12 @@ func (hj *hashJoiner) Reset(ctx context.Context) {
 	// complete in build() method.
 	hj.emittingRightState.rowIdx = 0
 	if buildutil.CrdbTestBuild {
-		if hj.exportBufferedState.hashTableReleased {
+		if hj.ht == nil {
 			colexecerror.InternalError(errors.AssertionFailedf(
 				"the hash joiner is being reset after having spilled to disk",
 			))
 		}
 	}
-	hj.exportBufferedState.hashTableReleased = false
 	hj.exportBufferedState.rightExported = 0
 }
 

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -150,7 +150,6 @@ func TestDefaultAggregateFunc(t *testing.T) {
 				colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.UnorderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
 					return agg.new(context.Background(), &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
-						MemAccount:     testMemAcc,
 						Input:          input[0],
 						InputTypes:     tc.typs,
 						Spec:           tc.spec,

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -137,7 +137,6 @@ func TestExternalHashAggregator(t *testing.T) {
 				op, closers, err := createExternalHashAggregator(
 					ctx, flowCtx, &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
-						MemAccount:     testMemAcc,
 						Input:          input[0],
 						InputTypes:     tc.typs,
 						Spec:           tc.spec,

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -434,7 +434,6 @@ func TestHashAggregator(t *testing.T) {
 			func(sources []colexecop.Operator) (colexecop.Operator, error) {
 				args := &colexecagg.NewAggregatorArgs{
 					Allocator:      testAllocator,
-					MemAccount:     testMemAcc,
 					Input:          sources[0],
 					InputTypes:     tc.typs,
 					Spec:           tc.spec,

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -133,6 +133,20 @@ func (op *UnorderedDistinct) ExportBuffered(colexecop.Operator) coldata.Batch {
 	return coldata.ZeroBatch
 }
 
+// ReleaseBeforeExport implements the colexecop.BufferingInMemoryOperator
+// interface.
+func (op *UnorderedDistinct) ReleaseBeforeExport() {
+	// We need to hold onto the hash table to perform the filtering in the
+	// unorderedDistinctFilterer.
+}
+
+// ReleaseAfterExport implements the colexecop.BufferingInMemoryOperator
+// interface.
+func (op *UnorderedDistinct) ReleaseAfterExport(colexecop.Operator) {
+	// We need to hold onto the hash table to perform the filtering in the
+	// unorderedDistinctFilterer.
+}
+
 // Reset resets the UnorderedDistinct.
 func (op *UnorderedDistinct) Reset(ctx context.Context) {
 	if r, ok := op.Input.(colexecop.Resetter); ok {


### PR DESCRIPTION
**colexecagg: remove redundant NewAggregatorArgs.MemAccount field**

This field is supposed to be the same memory account as used by the allocator (which wasn't the case in one spot), but we can easily access the account through the allocator wherever needed.

**colexec: release in-memory resources after spilling to disk**

This commit audits all operators that can spill to disk. In almost all cases, once the export of buffered tuples is complete, we no longer need resources used by the in-memory operator, so this commit eagerly loses references to them while adjusting the memory accounting system accordingly.

There are two exceptions though:
- the unordered distinct keeps on using the in-memory hash table even after having spilled to disk (the hashtable is probed to remove duplicates of the rows that were emitted before disk spilling occurred)
- when the disk-backed sort is used in the fallback strategy in the hash-based partitioner, the sort can be reused multiple times (for each partition in the worst case).

The first exception is very easy to handle, but handling the second one was a bit tricky and required some plumbing. Namely, we now mark each disk-backed operator to indicate what "reuse mode" of the buffering operator is required; if no reuse occurs, then the operator is free to lose all the references; if reuse can happen, then we effectively preserve the behavior before this change.

We extend the `BufferingInMemoryOperator` interface to include two new methods to allow operators to release resources before and after the export.

Fixes: #60022.

Release note: None