### PR TITLE
storage: per-store categorized write metrics

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -4098,7 +4098,7 @@ func (m *pebbleCategoryIterMetricsContainer) update(stats []sstable.CategoryStat
 }
 
 type pebbleCategoryDiskWriteMetrics struct {
-	BytesWritten *metric.Gauge
+	BytesWritten *metric.Counter
 }
 
 func makePebbleCategorizedWriteMetrics(
@@ -4110,7 +4110,7 @@ func makePebbleCategorizedWriteMetrics(
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
-	return &pebbleCategoryDiskWriteMetrics{BytesWritten: metric.NewGauge(metaDiskBytesWritten)}
+	return &pebbleCategoryDiskWriteMetrics{BytesWritten: metric.NewCounter(metaDiskBytesWritten)}
 }
 
 // MetricStruct implements the metric.Struct interface.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -717,7 +717,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// Set up the DistSQL temp engine.
 
 	useStoreSpec := cfg.TempStorageConfig.Spec
-	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.TempStorageConfig, useStoreSpec, cfg.DiskWriteStatsCollector)
+	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.TempStorageConfig, useStoreSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating temp storage")
 	}

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -289,12 +289,7 @@ func makeExternalWALDir(
 // WALFailover configures automatic failover of the engine's write-ahead log to
 // another volume in the event the WAL becomes blocked on a write that does not
 // complete within a reasonable duration.
-func WALFailover(
-	walCfg base.WALFailoverConfig,
-	storeEnvs fs.Envs,
-	defaultFS vfs.FS,
-	statsCollector *vfs.DiskWriteStatsCollector,
-) ConfigOption {
+func WALFailover(walCfg base.WALFailoverConfig, storeEnvs fs.Envs, defaultFS vfs.FS) ConfigOption {
 	// The set of options available in single-store versus multi-store
 	// configurations vary. This is in part due to the need to store the multiple
 	// stores' WALs separately. When WALFailoverExplicitPath is provided, we have
@@ -310,7 +305,7 @@ func WALFailover(
 			// We need to add the explicilt path to WALRecoveryDirs.
 			if walCfg.PrevPath.IsSet() {
 				return func(cfg *engineConfig) error {
-					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath, defaultFS, statsCollector)
+					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath, defaultFS, storeEnvs[0].StatsCollector)
 					if err != nil {
 						return err
 					}
@@ -327,13 +322,13 @@ func WALFailover(
 		case base.WALFailoverExplicitPath:
 			// The user has provided an explicit path to which we should fail over WALs.
 			return func(cfg *engineConfig) error {
-				walDir, err := makeExternalWALDir(cfg, walCfg.Path, defaultFS, statsCollector)
+				walDir, err := makeExternalWALDir(cfg, walCfg.Path, defaultFS, storeEnvs[0].StatsCollector)
 				if err != nil {
 					return err
 				}
 				cfg.opts.WALFailover = makePebbleWALFailoverOptsForDir(cfg.settings, walDir)
 				if walCfg.PrevPath.IsSet() {
-					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath, defaultFS, statsCollector)
+					walDir, err := makeExternalWALDir(cfg, walCfg.PrevPath, defaultFS, storeEnvs[0].StatsCollector)
 					if err != nil {
 						return err
 					}

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -24,12 +24,9 @@ import (
 // NewTempEngine creates a new engine for DistSQL processors to use when
 // the working set is larger than can be stored in memory.
 func NewTempEngine(
-	ctx context.Context,
-	tempStorage base.TempStorageConfig,
-	storeSpec base.StoreSpec,
-	statsCollector *vfs.DiskWriteStatsCollector,
+	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
 ) (diskmap.Factory, vfs.FS, error) {
-	return NewPebbleTempEngine(ctx, tempStorage, storeSpec, statsCollector)
+	return NewPebbleTempEngine(ctx, tempStorage, storeSpec)
 }
 
 type pebbleTempEngine struct {
@@ -58,19 +55,13 @@ func (r *pebbleTempEngine) NewSortedDiskMultiMap() diskmap.SortedDiskMap {
 // NewPebbleTempEngine creates a new Pebble engine for DistSQL processors to use
 // when the working set is larger than can be stored in memory.
 func NewPebbleTempEngine(
-	ctx context.Context,
-	tempStorage base.TempStorageConfig,
-	storeSpec base.StoreSpec,
-	statsCollector *vfs.DiskWriteStatsCollector,
+	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
 ) (diskmap.Factory, vfs.FS, error) {
-	return newPebbleTempEngine(ctx, tempStorage, storeSpec, statsCollector)
+	return newPebbleTempEngine(ctx, tempStorage, storeSpec)
 }
 
 func newPebbleTempEngine(
-	ctx context.Context,
-	tempStorage base.TempStorageConfig,
-	storeSpec base.StoreSpec,
-	statsCollector *vfs.DiskWriteStatsCollector,
+	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
 ) (*pebbleTempEngine, vfs.FS, error) {
 	var baseFS vfs.FS
 	var dir string
@@ -82,6 +73,7 @@ func newPebbleTempEngine(
 		baseFS = vfs.Default
 		dir = tempStorage.Path
 	}
+	statsCollector := vfs.NewDiskWriteStatsCollector()
 	env, err := fs.InitEnv(ctx, baseFS, dir, fs.EnvConfig{
 		RW: fs.ReadWrite,
 		// Adopt the encryption options of the provided store spec so that


### PR DESCRIPTION
Previously, we were using a single `DiskWriteStatsCollector` for all stores. This inaccurately inflated metrics in multi-store deployments.

This patch uses a separate `DiskWriteStatsCollector` for each engine.

Fixes #126431.

Release note: None