### PR TITLE
kvserver: prefer BasicStatus over Status

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1580,6 +1580,14 @@ func (r *Replica) RaftStatus() *raft.Status {
 	return r.raftStatusRLocked()
 }
 
+// RaftBasicStatus returns the current raft basic status of the replica. An empty
+// BasicStatus is returned if the Raft group hasn't been initialized.
+func (r *Replica) RaftBasicStatus() raft.BasicStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.raftBasicStatusRLocked()
+}
+
 // raftStatusRLocked returns the current raft status of the replica, or
 // nil if the Raft group has not been initialized yet.
 //

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -163,8 +163,8 @@ func replicaIsSuspect(repl *Replica) bool {
 	// because it has probably already been removed from its raft group but
 	// doesn't know it. Without this, node decommissioning can stall on such
 	// dormant ranges.
-	raftStatus := repl.RaftStatus()
-	if raftStatus == nil {
+	raftStatus := repl.RaftBasicStatus()
+	if raftStatus.Empty() {
 		liveness, ok := repl.store.cfg.NodeLiveness.Self()
 		return ok && !liveness.Membership.Active()
 	}

--- a/pkg/raft/status.go
+++ b/pkg/raft/status.go
@@ -51,6 +51,11 @@ type SparseStatus struct {
 	Progress map[pb.PeerID]tracker.Progress
 }
 
+// Empty returns true if the receiver is empty.
+func (b BasicStatus) Empty() bool {
+	return b == BasicStatus{}
+}
+
 // withProgress calls the supplied visitor to introspect the progress for the
 // supplied raft group. Cannot be used to introspect p.Inflights.
 func withProgress(r *raft, visitor func(id pb.PeerID, typ ProgressType, pr tracker.Progress)) {


### PR DESCRIPTION
BasicStatus is cheaper than Status as it doesn't allocate. This patch switches a few places that could do with BasicStatus instead of Status to do so.

Epic: none

Release note: None