### PR TITLE
bulitins: rewrite concat() to accept any datum type

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2880,7 +2880,7 @@ Can be used to define the tile bounds required by ST_AsMVTGeom to convert geomet
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="compress"></a><code>compress(data: <a href="bytes.html">bytes</a>, codec: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Compress <code>data</code> with the specified <code>codec</code> (<code>gzip</code>, ‘lz4’, ‘snappy’, 'zstd).</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="concat"></a><code>concat(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
+<tr><td><a name="concat"></a><code>concat(anyelement...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="concat_ws"></a><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -195,8 +195,13 @@ SELECT concat('RoacH', NULL)
 ----
 RoacH
 
-statement error unknown signature: concat\(string, bool, decimal, bool\)
-SELECT concat('RoacH', false, 64.532, TRUE)
+statement ok
+CREATE TYPE concat_enum AS ENUM ('foo', 'bar', 'baz')
+
+query T
+SELECT concat('foo'::concat_enum, ' ', 64.532, ' ', 'baz'::concat_enum, ' ', 42, ' ', 1 = 0, ' ', '{"foo": "bar"}'::json, ' ', '{1, 2, 3}'::int[])
+----
+foo 64.532 baz 42 f {"foo": "bar"} {1,2,3}
 
 query T
 SELECT substr('RoacH', 2, 3)
@@ -4304,6 +4309,7 @@ LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
 ORDER BY 1, 2;
 ----
 Schema  Name             Description
+public  concat_enum      ·
 public  custom_typ       ·
 public  roach_dwellings  ·
 public  testenum         ·

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -826,7 +826,7 @@ var builtinOidsArray = []string{
 	845:  `substring(input: varbit, start_pos: int, length: int) -> varbit`,
 	846:  `substring(input: bytes, start_pos: int) -> bytes`,
 	847:  `substring(input: bytes, start_pos: int, length: int) -> bytes`,
-	848:  `concat(string...) -> string`,
+	848:  `concat(anyelement...) -> string`,
 	849:  `concat_ws(string...) -> string`,
 	850:  `convert_from(str: bytes, enc: string) -> string`,
 	851:  `convert_to(str: string, enc: string) -> bytes`,

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -631,6 +631,9 @@ func (expr *StrVal) ResolveAsType(
 
 	// Typing a string literal constant into some value type.
 	switch typ.Family() {
+	// If we don't care about output type, just pick the low effort conversion.
+	case types.AnyFamily:
+		fallthrough
 	case types.StringFamily:
 		if typ.Oid() == oid.T_name {
 			expr.resString = DString(expr.s)


### PR DESCRIPTION
Previously, CONCAT() would only accept string arguments, which differed from Postgres which will accept and format any data type. This patch changes the implementation to accept any Datum type.

Fixes: #125025
Release note (bug fix): CONCAT() now accepts arguments of any data type.