### PR TITLE
colexecdisk: create disk-backed operators lazily

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -139,7 +139,8 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	require.True(t, spilled)
 	require.Zero(t, sem.GetCount(), "sem still reports open FDs")
 
-	externalSorter := colexec.MaybeUnwrapInvariantsChecker(sorter).(*diskSpillerBase).diskBackedOp.(*externalSorter)
+	ds := colexec.MaybeUnwrapInvariantsChecker(sorter).(*diskSpillerBase)
+	externalSorter := ds.getDiskBackedOp(false /* createIfNotExistent */).(*externalSorter)
 	numPartitionsCreated := externalSorter.currentPartitionIdx
 	// This maximum can be achieved when we have minimum required number of FDs
 	// as follows: we expect that each newly created partition contains about


### PR DESCRIPTION
This commit adjust the disk spilling infrastructure so that the disk-backed operators are created lazily, when we spill to disk for the first time. This should avoid some allocations in the common case when we actually don't spill.

TODO: figure out the closer count testing.

Epic: None

Release note: None