### PR TITLE
cast: only allow vector to array cast for float arrays

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/vector
+++ b/pkg/ccl/logictestccl/testdata/logic_test/vector
@@ -72,11 +72,11 @@ query error pgcode 22000 infinite value not allowed in vector
 select '[3,-Inf]'::vector
 
 statement ok
-CREATE TABLE x (a float[], b real[])
+CREATE TABLE x (a float[], b real[], c float4[])
 
 # Test implicit cast from vector to array.
 statement ok
-INSERT INTO x VALUES('[1,2]'::vector, '[3,4]'::vector)
+INSERT INTO x VALUES('[1,2]'::vector, '[3,4]'::vector, '[5,6]'::vector)
 
 statement ok
 CREATE TABLE v3 (v1 vector(1), v2 vector(1));
@@ -107,3 +107,18 @@ query T
 SELECT json_build_object('[1, 2]':::VECTOR, 1);
 ----
 {"[1,2]": 1}
+
+# Regression test for incorrectly supporting VECTOR -> TEXT[] cast (#126964).
+statement error pgcode 42846 invalid cast: vector -> string\[\]
+SELECT '[0]'::VECTOR::TEXT[];
+
+# Casts to FLOAT4[] and FLOAT8[] are supported.
+query T
+SELECT '[1,2,3]'::VECTOR::FLOAT4[];
+----
+{1,2,3}
+
+query T
+SELECT '[1,2,3]'::VECTOR::FLOAT8[];
+----
+{1,2,3}

--- a/pkg/sql/sem/cast/cast.go
+++ b/pkg/sql/sem/cast/cast.go
@@ -257,8 +257,11 @@ func LookupCast(src, tgt *types.T) (Cast, bool) {
 			Volatility: volatility.Stable,
 		}, true
 	}
-
-	if srcFamily == types.PGVectorFamily && tgtFamily == types.ArrayFamily {
+	if srcFamily == types.PGVectorFamily && tgtFamily == types.ArrayFamily &&
+		tgt.ArrayContents().Family() == types.FloatFamily {
+		// Note that postgres only allows casts to FLOAT4[], but given that
+		// under the hood FLOAT8 and FLOAT4 represented exactly the same way in
+		// CRDB we'll allow both.
 		return Cast{
 			MaxContext: ContextAssignment,
 			Volatility: volatility.Stable,


### PR DESCRIPTION
Postgres supports only VECTOR -> FLOAT4[] cast while we incorrectly added casts to arrays of any type which would lead to internal errors later. This commit fixes this issue by allowing casts to arrays of FLOAT4 and FLOAT8 types (since both have the same internal representation in CRDB).

There is no release note given that we haven't had a beta yet.

Fixes: #126964.

Release note: None