### PR TITLE
multiregionccl: split up TestRegionAddDropWithConcurrentBackupOps and TestMultiRegionDataDriven

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -47,7 +47,31 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// TestMultiRegionDataDriven is a data-driven test to test various multi-region
+func TestMultiRegionDataDriven_global_tables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testMultiRegionDataDriven(t, "global_tables")
+}
+
+func TestMultiRegionDataDriven_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testMultiRegionDataDriven(t, "regional_by_row")
+}
+
+func TestMultiRegionDataDriven_regional_by_table(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testMultiRegionDataDriven(t, "regional_by_table")
+}
+
+func TestMultiRegionDataDriven_secondary_region(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testMultiRegionDataDriven(t, "secondary_region")
+}
+
+// testMultiRegionDataDriven is a data-driven test to test various multi-region
 // invariants at a high level. This is accomplished by allowing custom cluster
 // configurations when creating the test cluster and providing directives to
 // assert expectations in query traces.
@@ -112,10 +136,7 @@ import (
 //
 // "cleanup-cluster": destroys the cluster. Must be done before creating a new
 // cluster.
-func TestMultiRegionDataDriven(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
+func testMultiRegionDataDriven(t *testing.T, testPath string) {
 	// This test speeds up replication changes by proactively enqueuing replicas
 	// into various queues. This has the benefit of reducing the time taken after
 	// zone config changes, however the downside of added overhead. Disable the
@@ -124,7 +145,7 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	skip.UnderRace(t, "flaky test")
 	skip.UnderDeadlock(t, "flaky test")
 	ctx := context.Background()
-	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
+	datadriven.Walk(t, datapathutils.TestDataPath(t, testPath), func(t *testing.T, path string) {
 		ds := datadrivenTestState{}
 		defer ds.cleanup(ctx)
 		var mu syncutil.Mutex

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -847,7 +847,67 @@ CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2" PLACEMENT R
 	}
 }
 
-// TestRegionAddDropEnclosingBackupOps tests adding/dropping regions
+func TestDropRegionFailWithConcurrentBackupOps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testRegionAddDropWithConcurrentBackupOps(t, struct {
+		cmd                string
+		shouldSucceed      bool
+		expectedPartitions []string
+	}{
+		cmd:                `ALTER DATABASE db DROP REGION "us-east3"`,
+		shouldSucceed:      false,
+		expectedPartitions: []string{"us-east1", "us-east2", "us-east3"},
+	})
+}
+
+func TestDropRegionSucceedWithConcurrentBackupOps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testRegionAddDropWithConcurrentBackupOps(t, struct {
+		cmd                string
+		shouldSucceed      bool
+		expectedPartitions []string
+	}{
+		cmd:                `ALTER DATABASE db DROP REGION "us-east3"`,
+		shouldSucceed:      true,
+		expectedPartitions: []string{"us-east1", "us-east2"},
+	})
+}
+
+func TestAddRegionFailWithConcurrentBackupOps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testRegionAddDropWithConcurrentBackupOps(t, struct {
+		cmd                string
+		shouldSucceed      bool
+		expectedPartitions []string
+	}{
+		cmd:                `ALTER DATABASE db ADD REGION "us-east4"`,
+		shouldSucceed:      false,
+		expectedPartitions: []string{"us-east1", "us-east2", "us-east3"},
+	})
+}
+
+func TestAddRegionSucceedWithConcurrentBackupOps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testRegionAddDropWithConcurrentBackupOps(t, struct {
+		cmd                string
+		shouldSucceed      bool
+		expectedPartitions []string
+	}{
+		cmd:                `ALTER DATABASE db ADD REGION "us-east4"`,
+		shouldSucceed:      true,
+		expectedPartitions: []string{"us-east1", "us-east2", "us-east3", "us-east4"},
+	})
+}
+
+// testRegionAddDropWithConcurrentBackupOps tests adding/dropping regions
 // (which may or may not succeed) with a concurrent backup operation
 // The sketch of the test is as follows:
 // - Client 1 performs an ALTER ADD / DROP REGION. Let the user txn commit.
@@ -858,43 +918,15 @@ CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2" PLACEMENT R
 // - Restore the database, block in the schema changer.
 // - Fail or succeed the schema change job.
 // - Validate that the database and its tables look as expected.
-func TestRegionAddDropWithConcurrentBackupOps(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	skip.UnderRace(t, "times out under race")
-
-	regionAlterCmds := []struct {
-		name               string
+func testRegionAddDropWithConcurrentBackupOps(
+	t *testing.T,
+	regionAlterCmd struct {
 		cmd                string
 		shouldSucceed      bool
 		expectedPartitions []string
-	}{
-		{
-			name:               "drop-region-fail",
-			cmd:                `ALTER DATABASE db DROP REGION "us-east3"`,
-			shouldSucceed:      false,
-			expectedPartitions: []string{"us-east1", "us-east2", "us-east3"},
-		},
-		{
-			name:               "drop-region-succeed",
-			cmd:                `ALTER DATABASE db DROP REGION "us-east3"`,
-			shouldSucceed:      true,
-			expectedPartitions: []string{"us-east1", "us-east2"},
-		},
-		{
-			name:               "add-region-fail",
-			cmd:                `ALTER DATABASE db ADD REGION "us-east4"`,
-			shouldSucceed:      false,
-			expectedPartitions: []string{"us-east1", "us-east2", "us-east3"},
-		},
-		{
-			name:               "add-region-succeed",
-			cmd:                `ALTER DATABASE db ADD REGION "us-east4"`,
-			shouldSucceed:      true,
-			expectedPartitions: []string{"us-east1", "us-east2", "us-east3", "us-east4"},
-		},
-	}
+	},
+) {
+	skip.UnderRace(t, "times out under race")
 
 	testCases := []struct {
 		name      string
@@ -909,158 +941,156 @@ func TestRegionAddDropWithConcurrentBackupOps(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		for _, regionAlterCmd := range regionAlterCmds {
-			t.Run(regionAlterCmd.name+"-"+tc.name, func(t *testing.T) {
-				var mu syncutil.Mutex
-				typeChangeStarted := make(chan struct{})
-				typeChangeFinished := make(chan struct{})
-				backupOpFinished := make(chan struct{})
-				waitInTypeSchemaChangerDuringBackup := true
+		t.Run(tc.name, func(t *testing.T) {
+			var mu syncutil.Mutex
+			typeChangeStarted := make(chan struct{})
+			typeChangeFinished := make(chan struct{})
+			backupOpFinished := make(chan struct{})
+			waitInTypeSchemaChangerDuringBackup := true
 
-				backupKnobs := base.TestingKnobs{
-					SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-						RunBeforeEnumMemberPromotion: func(ctx context.Context) error {
-							mu.Lock()
-							defer mu.Unlock()
-							if waitInTypeSchemaChangerDuringBackup {
-								waitInTypeSchemaChangerDuringBackup = false
-								close(typeChangeStarted)
-								<-backupOpFinished
-							}
-							// Always return success here. The goal of this test isn't to
-							// fail during the backup, but to do so during the restore.
-							return nil
-						},
+			backupKnobs := base.TestingKnobs{
+				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+					RunBeforeEnumMemberPromotion: func(ctx context.Context) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if waitInTypeSchemaChangerDuringBackup {
+							waitInTypeSchemaChangerDuringBackup = false
+							close(typeChangeStarted)
+							<-backupOpFinished
+						}
+						// Always return success here. The goal of this test isn't to
+						// fail during the backup, but to do so during the restore.
+						return nil
 					},
-					// Decrease the adopt loop interval so that retries happen quickly.
-					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
-				}
+				},
+				// Decrease the adopt loop interval so that retries happen quickly.
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			}
 
-				tempExternalIODir, tempDirCleanup := testutils.TempDir(t)
-				defer tempDirCleanup()
+			tempExternalIODir, tempDirCleanup := testutils.TempDir(t)
+			defer tempDirCleanup()
 
-				_, sqlDBBackup, cleanupBackup := multiregionccltestutils.TestingCreateMultiRegionCluster(
-					t,
-					4, /* numServers */
-					backupKnobs,
-					multiregionccltestutils.WithBaseDirectory(tempExternalIODir),
-				)
-				defer cleanupBackup()
+			_, sqlDBBackup, cleanupBackup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+				t,
+				4, /* numServers */
+				backupKnobs,
+				multiregionccltestutils.WithBaseDirectory(tempExternalIODir),
+			)
+			defer cleanupBackup()
 
-				_, err := sqlDBBackup.Exec(`
+			_, err := sqlDBBackup.Exec(`
 DROP DATABASE IF EXISTS db;
 CREATE DATABASE db WITH PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3";
 USE db;
 CREATE TABLE db.rbr(k INT PRIMARY KEY, v INT NOT NULL) LOCALITY REGIONAL BY ROW;
 INSERT INTO db.rbr VALUES (1,1),(2,2),(3,3);
 `)
-				require.NoError(t, err)
+			require.NoError(t, err)
 
-				go func(cmd string) {
-					defer func() {
-						close(typeChangeFinished)
-					}()
-					_, err := sqlDBBackup.Exec(cmd)
-					if err != nil {
-						t.Errorf("expected success, got %v when executing %s", err, cmd)
-					}
-				}(regionAlterCmd.cmd)
-
-				<-typeChangeStarted
-
-				_, err = sqlDBBackup.Exec(tc.backupOp)
-				close(backupOpFinished)
-				require.NoError(t, err)
-
-				<-typeChangeFinished
-
-				restoreKnobs := base.TestingKnobs{
-					SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
-						RunBeforeEnumMemberPromotion: func(context.Context) error {
-							mu.Lock()
-							defer mu.Unlock()
-							if !regionAlterCmd.shouldSucceed {
-								// Trigger a roll-back.
-								return jobs.MarkAsPermanentJobError(errors.New("nope"))
-							}
-							// Trod on.
-							return nil
-						},
-					},
-					// Decrease the adopt loop interval so that retries happen quickly.
-					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			go func(cmd string) {
+				defer func() {
+					close(typeChangeFinished)
+				}()
+				_, err := sqlDBBackup.Exec(cmd)
+				if err != nil {
+					t.Errorf("expected success, got %v when executing %s", err, cmd)
 				}
+			}(regionAlterCmd.cmd)
 
-				// Start a new cluster (with new testing knobs) for restore.
-				_, sqlDBRestore, cleanupRestore := multiregionccltestutils.TestingCreateMultiRegionCluster(
-					t,
-					4, /* numServers */
-					restoreKnobs,
-					multiregionccltestutils.WithBaseDirectory(tempExternalIODir),
-				)
-				defer cleanupRestore()
+			<-typeChangeStarted
 
-				_, err = sqlDBRestore.Exec(tc.restoreOp)
-				require.NoError(t, err)
+			_, err = sqlDBBackup.Exec(tc.backupOp)
+			close(backupOpFinished)
+			require.NoError(t, err)
 
-				// First ensure that the data was restored correctly.
-				numRows := sqlDBRestore.QueryRow(`SELECT count(*) from db.rbr`)
-				require.NoError(t, numRows.Err())
-				var count int
-				err = numRows.Scan(&count)
-				require.NoError(t, err)
-				if count != 3 {
-					t.Logf("unexpected number of rows after restore: expected 3, found %d", count)
-				}
+			<-typeChangeFinished
 
-				// Now validate that the background job has completed and the
-				// regions are in the expected state.
-				testutils.SucceedsSoon(t, func() error {
-					dbRegions := make([]string, 0, len(regionAlterCmd.expectedPartitions))
-					rowsRegions, err := sqlDBRestore.Query("SELECT region FROM [SHOW REGIONS FROM DATABASE db]")
-					require.NoError(t, err)
-					defer func() {
-						require.NoError(t, rowsRegions.Close())
-					}()
-					for {
-						done := rowsRegions.Next()
-						if !done {
-							require.NoError(t, rowsRegions.Err())
-							break
+			restoreKnobs := base.TestingKnobs{
+				SQLTypeSchemaChanger: &sql.TypeSchemaChangerTestingKnobs{
+					RunBeforeEnumMemberPromotion: func(context.Context) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if !regionAlterCmd.shouldSucceed {
+							// Trigger a roll-back.
+							return jobs.MarkAsPermanentJobError(errors.New("nope"))
 						}
-						var region string
-						err := rowsRegions.Scan(&region)
-						require.NoError(t, err)
-						dbRegions = append(dbRegions, region)
+						// Trod on.
+						return nil
+					},
+				},
+				// Decrease the adopt loop interval so that retries happen quickly.
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			}
+
+			// Start a new cluster (with new testing knobs) for restore.
+			_, sqlDBRestore, cleanupRestore := multiregionccltestutils.TestingCreateMultiRegionCluster(
+				t,
+				4, /* numServers */
+				restoreKnobs,
+				multiregionccltestutils.WithBaseDirectory(tempExternalIODir),
+			)
+			defer cleanupRestore()
+
+			_, err = sqlDBRestore.Exec(tc.restoreOp)
+			require.NoError(t, err)
+
+			// First ensure that the data was restored correctly.
+			numRows := sqlDBRestore.QueryRow(`SELECT count(*) from db.rbr`)
+			require.NoError(t, numRows.Err())
+			var count int
+			err = numRows.Scan(&count)
+			require.NoError(t, err)
+			if count != 3 {
+				t.Logf("unexpected number of rows after restore: expected 3, found %d", count)
+			}
+
+			// Now validate that the background job has completed and the
+			// regions are in the expected state.
+			testutils.SucceedsSoon(t, func() error {
+				dbRegions := make([]string, 0, len(regionAlterCmd.expectedPartitions))
+				rowsRegions, err := sqlDBRestore.Query("SELECT region FROM [SHOW REGIONS FROM DATABASE db]")
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, rowsRegions.Close())
+				}()
+				for {
+					done := rowsRegions.Next()
+					if !done {
+						require.NoError(t, rowsRegions.Err())
+						break
 					}
-					if len(dbRegions) != len(regionAlterCmd.expectedPartitions) {
-						return errors.Newf("unexpected number of regions, expected: %v found %v",
+					var region string
+					err := rowsRegions.Scan(&region)
+					require.NoError(t, err)
+					dbRegions = append(dbRegions, region)
+				}
+				if len(dbRegions) != len(regionAlterCmd.expectedPartitions) {
+					return errors.Newf("unexpected number of regions, expected: %v found %v",
+						regionAlterCmd.expectedPartitions,
+						dbRegions,
+					)
+				}
+				for i, expectedRegion := range regionAlterCmd.expectedPartitions {
+					if expectedRegion != dbRegions[i] {
+						return errors.Newf("unexpected regions, expected: %v found %v",
 							regionAlterCmd.expectedPartitions,
 							dbRegions,
 						)
 					}
-					for i, expectedRegion := range regionAlterCmd.expectedPartitions {
-						if expectedRegion != dbRegions[i] {
-							return errors.Newf("unexpected regions, expected: %v found %v",
-								regionAlterCmd.expectedPartitions,
-								dbRegions,
-							)
-						}
-					}
-					return nil
-				})
-
-				// Finally, confirm that all of the tables were repartitioned
-				// correctly by the above ADD/DROP region job.
-				testutils.SucceedsSoon(t, func() error {
-					return multiregionccltestutils.TestingEnsureCorrectPartitioning(
-						sqlDBRestore,
-						"db",
-						"rbr",
-						[]string{"rbr@rbr_pkey"},
-					)
-				})
+				}
+				return nil
 			})
-		}
+
+			// Finally, confirm that all of the tables were repartitioned
+			// correctly by the above ADD/DROP region job.
+			testutils.SucceedsSoon(t, func() error {
+				return multiregionccltestutils.TestingEnsureCorrectPartitioning(
+					sqlDBRestore,
+					"db",
+					"rbr",
+					[]string{"rbr@rbr_pkey"},
+				)
+			})
+		})
 	}
 }


### PR DESCRIPTION
Both of these tests had 4 expensive subtests. By splitting them up into separate
test functions, the work can be sharded more effectively.

fixes https://github.com/cockroachdb/cockroach/issues/126956
fixes https://github.com/cockroachdb/cockroach/issues/125830
fixes https://github.com/cockroachdb/cockroach/issues/126928

Release note: None