### PR TITLE
roachtest: use enum for cloud value

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -631,7 +631,7 @@ type nodeSelector interface {
 type clusterImpl struct {
 	name  string
 	tag   string
-	cloud string
+	cloud spec.Cloud
 	spec  spec.ClusterSpec
 	t     test.Test
 	f     roachtestutil.Fataler
@@ -936,8 +936,8 @@ func (f *clusterFactory) newCluster(
 		return nil, nil, err
 	}
 	if clusterCloud != spec.Local {
-		providerOptsContainer.SetProviderOpts(clusterCloud, providerOpts)
-		workloadProviderOptsContainer.SetProviderOpts(clusterCloud, workloadProviderOpts)
+		providerOptsContainer.SetProviderOpts(clusterCloud.String(), providerOpts)
+		workloadProviderOptsContainer.SetProviderOpts(clusterCloud.String(), workloadProviderOpts)
 	}
 
 	createFlagsOverride(&createVMOpts)
@@ -1892,11 +1892,11 @@ func (c *clusterImpl) removeLabels(labels []string) error {
 func (c *clusterImpl) ListSnapshots(
 	ctx context.Context, vslo vm.VolumeSnapshotListOpts,
 ) ([]vm.VolumeSnapshot, error) {
-	return roachprod.ListSnapshots(ctx, c.l, c.Cloud(), vslo)
+	return roachprod.ListSnapshots(ctx, c.l, c.Cloud().String(), vslo)
 }
 
 func (c *clusterImpl) DeleteSnapshots(ctx context.Context, snapshots ...vm.VolumeSnapshot) error {
-	return roachprod.DeleteSnapshots(ctx, c.l, c.Cloud(), snapshots...)
+	return roachprod.DeleteSnapshots(ctx, c.l, c.Cloud().String(), snapshots...)
 }
 
 func (c *clusterImpl) CreateSnapshot(
@@ -2929,7 +2929,7 @@ func (c *clusterImpl) MakeNodes(opts ...option.Option) string {
 	return c.name + r.String()
 }
 
-func (c *clusterImpl) Cloud() string {
+func (c *clusterImpl) Cloud() spec.Cloud {
 	return c.cloud
 }
 

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -137,7 +137,7 @@ type Cluster interface {
 
 	Spec() spec.ClusterSpec
 	Name() string
-	Cloud() string
+	Cloud() spec.Cloud
 	IsLocal() bool
 	// IsSecure returns true iff the cluster uses TLS.
 	IsSecure() bool

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -52,7 +52,7 @@ func roachtestPrefix(p string) string {
 
 // generateHelpCommand creates a HelpCommand for createPostRequest
 func generateHelpCommand(
-	testName string, clusterName string, cloud string, start time.Time, end time.Time,
+	testName string, clusterName string, cloud spec.Cloud, start time.Time, end time.Time,
 ) func(renderer *issues.Renderer) {
 	return func(renderer *issues.Renderer) {
 		issues.HelpCommandAsLink(
@@ -246,7 +246,7 @@ func (g *githubIssues) createPostRequest(
 	artifacts := fmt.Sprintf("/%s", testName)
 
 	clusterParams := map[string]string{
-		roachtestPrefix("cloud"):            roachtestflags.Cloud,
+		roachtestPrefix("cloud"):            roachtestflags.Cloud.String(),
 		roachtestPrefix("cpu"):              fmt.Sprintf("%d", spec.Cluster.CPUs),
 		roachtestPrefix("ssd"):              fmt.Sprintf("%d", spec.Cluster.SSDs),
 		roachtestPrefix("metamorphicBuild"): fmt.Sprintf("%t", metamorphicBuild),

--- a/pkg/cmd/roachtest/registry/filter_test.go
+++ b/pkg/cmd/roachtest/registry/filter_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/cockroachdb/datadriven"
 )
@@ -70,7 +71,7 @@ func TestTestFilter(t *testing.T) {
 			for _, arg := range d.CmdArgs {
 				switch arg.Key {
 				case "cloud":
-					options = append(options, WithCloud(arg.Vals[0]))
+					options = append(options, WithCloud(spec.CloudFromString(arg.Vals[0])))
 				case "suite":
 					options = append(options, WithSuite(arg.Vals[0]))
 				case "owner":

--- a/pkg/cmd/roachtest/registry/testdata/filter/errors
+++ b/pkg/cmd/roachtest/registry/testdata/filter/errors
@@ -1,9 +1,5 @@
 # Invalid filters.
 
-filter cloud=badcloud
-----
-error: invalid cloud "badcloud"; valid clouds are local,gce,aws,azure
-
 filter owner=badowner
 ----
 error: invalid owner "badowner"
@@ -12,9 +8,9 @@ filter suite=badsuite
 ----
 error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest,acceptance
 
-filter cloud=badcloud owner=badowner suite=badsuite
+filter owner=badowner suite=badsuite
 ----
-error: invalid cloud "badcloud"; valid clouds are local,gce,aws,azure
+error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest,acceptance
 
 # Filters with one field leading to no matches.
 

--- a/pkg/cmd/roachtest/roachtestflags/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestflags/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/cmd/roachtest/spec",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
     ],
 )

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -21,8 +21,8 @@ import (
 
 // This block defines all roachtest flags (for the list and run/bench commands).
 var (
-	Cloud string = spec.GCE
-	_            = registerListFlag(&Cloud, FlagInfo{
+	Cloud spec.Cloud = spec.GCE
+	_                = registerListFlag(&Cloud, FlagInfo{
 		Name: "cloud",
 		Usage: `List only tests compatible with the given cloud ("local", "gce",
 		        "aws", "azure", or "all")`,

--- a/pkg/cmd/roachtest/slack.go
+++ b/pkg/cmd/roachtest/slack.go
@@ -74,8 +74,8 @@ func postSlackReport(pass, fail, skip map[*testImpl]struct{}) {
 
 	var prefix string
 	switch {
-	case roachtestflags.Cloud != "":
-		prefix = strings.ToUpper(roachtestflags.Cloud)
+	case roachtestflags.Cloud.IsSet():
+		prefix = strings.ToUpper(roachtestflags.Cloud.String())
 	default:
 		prefix = "GCE"
 	}

--- a/pkg/cmd/roachtest/spec/cloud.go
+++ b/pkg/cmd/roachtest/spec/cloud.go
@@ -10,14 +10,73 @@
 
 package spec
 
-const (
-	// AWS stands for Amazon Web Services.
-	AWS = "aws"
-	// GCE stands for Google Compute Engine.
-	GCE = "gce"
-	// Azure is Microsoft's cloud.
-	Azure = "azure"
-	// Local is a faux cloud value assigned to tests that
-	// are run on a local machine.
-	Local = "local"
+import (
+	"fmt"
+	"strings"
 )
+
+// Cloud indicates the cloud provider.
+type Cloud int
+
+const (
+	// AnyCloud is a sentinel value for an unset Cloud value, which in most
+	// contexts means "any cloud".
+	AnyCloud Cloud = iota
+	// Local is a faux cloud value assigned to tests that are run on a local
+	// machine.
+	Local
+	// GCE stands for Google Compute Engine.
+	GCE
+	// AWS stands for Amazon Web Services.
+	AWS
+	// Azure is Microsoft's cloud.
+	Azure
+)
+
+// IsSet returns true if the value is set. The meaning of an unset value depends
+// on the context, but it usually means "any cloud".
+func (c Cloud) IsSet() bool {
+	return c != AnyCloud
+}
+
+func (c Cloud) String() string {
+	switch c {
+	case AWS:
+		return "aws"
+	case GCE:
+		return "gce"
+	case Azure:
+		return "azure"
+	case Local:
+		return "local"
+	default:
+		panic("invalid cloud")
+	}
+}
+
+// CloudFromString parses the cloud provider from a string (e.g. "aws" or
+// "AWS").
+func CloudFromString(s string) Cloud {
+	c, ok := TryCloudFromString(s)
+	if !ok {
+		panic(fmt.Sprintf("invalid cloud %q", s))
+	}
+	return c
+}
+
+// TryCloudFromString parses the cloud provider from a string (e.g. "aws" or
+// "AWS").
+func TryCloudFromString(s string) (_ Cloud, ok bool) {
+	switch strings.ToLower(s) {
+	case "aws":
+		return AWS, true
+	case "gce":
+		return GCE, true
+	case "azure":
+		return Azure, true
+	case "local":
+		return Local, true
+	default:
+		return AnyCloud, false
+	}
+}

--- a/pkg/cmd/roachtest/test_filter.go
+++ b/pkg/cmd/roachtest/test_filter.go
@@ -23,7 +23,7 @@ import (
 func makeTestFilter(regexps []string) (*registry.TestFilter, error) {
 	var options []registry.TestFilterOption
 	if !roachtestflags.ForceCloudCompat {
-		if cloud := roachtestflags.Cloud; cloud != "all" && cloud != "" {
+		if cloud := roachtestflags.Cloud; cloud.IsSet() {
 			options = append(options, registry.WithCloud(cloud))
 		}
 	}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -453,7 +453,7 @@ func (r *testRunner) Run(
 // N.B. currently this value is hardcoded per cloud provider.
 func numConcurrentClusterCreations() int {
 	var res int
-	if roachtestflags.Cloud == "aws" {
+	if roachtestflags.Cloud == spec.AWS {
 		// AWS has ridiculous API calls limits, so we're going to create one cluster
 		// at a time. Internally, roachprod has throttling for the calls required to
 		// create a single cluster.

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -371,7 +371,7 @@ func registerBackup(r registry.Registry) {
 
 	// Skip running on aws because the roachtest env does not have the proper
 	// credentials. See 127062
-	for _, cloudProvider := range []string{spec.GCE} {
+	for _, cloudProvider := range []spec.Cloud{spec.GCE} {
 		r.Add(registry.TestSpec{
 			Name:              fmt.Sprintf("backup/assume-role/%s", cloudProvider),
 			Owner:             registry.OwnerDisasterRecovery,
@@ -449,7 +449,7 @@ func registerBackup(r registry.Registry) {
 		})
 	}
 	KMSSpec := r.MakeClusterSpec(3)
-	for _, cloudProvider := range []string{spec.GCE, spec.AWS} {
+	for _, cloudProvider := range []spec.Cloud{spec.GCE, spec.AWS} {
 		r.Add(registry.TestSpec{
 			Name:              fmt.Sprintf("backup/KMS/%s/%s", cloudProvider, KMSSpec.String()),
 			Owner:             registry.OwnerDisasterRecovery,

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -854,7 +854,7 @@ func (rd *replicationDriver) backupAfterFingerprintMismatch(
 		rd.t.L().Printf("skip taking backups of tenants on azure, bucket not configured yet")
 		return nil
 	}
-	cloudPrefixes := map[string]string{
+	cloudPrefixes := map[spec.Cloud]string{
 		spec.GCE:   "gs",
 		spec.AWS:   "s3",
 		spec.Azure: "azure",

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -516,7 +516,9 @@ type hardwareSpecs struct {
 	zones []string
 }
 
-func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string) spec.ClusterSpec {
+func (hw hardwareSpecs) makeClusterSpecs(
+	r registry.Registry, backupCloud spec.Cloud,
+) spec.ClusterSpec {
 	clusterOpts := make([]spec.Option, 0)
 	clusterOpts = append(clusterOpts, spec.CPU(hw.cpus))
 	if hw.volumeSize != 0 {
@@ -614,7 +616,7 @@ type backupSpecs struct {
 	version string
 
 	// cloud is the cloud storage provider the backup is stored on.
-	cloud string
+	cloud spec.Cloud
 
 	// allowLocal is true if the test should be allowed to run
 	// locally. We don't set this by default to avoid someone
@@ -645,7 +647,7 @@ type backupSpecs struct {
 	customFixtureDir string
 }
 
-func (bs backupSpecs) CloudIsCompatible(cloud string) error {
+func (bs backupSpecs) CloudIsCompatible(cloud spec.Cloud) error {
 	if cloud == spec.Local && bs.allowLocal {
 		return nil
 	}
@@ -705,7 +707,7 @@ func (sp *restoreSpecs) getAostCmd() string {
 }
 
 func makeBackupSpecs(override backupSpecs, specs backupSpecs) backupSpecs {
-	if override.cloud != "" {
+	if override.cloud.IsSet() {
 		specs.cloud = override.cloud
 	}
 	if override.version != "" {
@@ -945,7 +947,7 @@ func (sp *restoreSpecs) String() string {
 
 	var builder strings.Builder
 	builder.WriteString("/" + bs.workload.String())
-	builder.WriteString("/" + bs.cloud)
+	builder.WriteString("/" + bs.cloud.String())
 
 	// Annotate the name with the number of incremental layers we are restoring if
 	// it differs from the default.

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -392,7 +392,7 @@ func tpccMaxRate(warehouses int) int {
 }
 
 func maxSupportedTPCCWarehouses(
-	buildVersion version.Version, cloud string, nodes spec.ClusterSpec,
+	buildVersion version.Version, cloud spec.Cloud, nodes spec.ClusterSpec,
 ) int {
 	var v *version.Version
 	var warehouses int
@@ -1174,7 +1174,7 @@ func registerTPCC(r registry.Registry) {
 	})
 }
 
-func valueForCloud(cloud string, gce, aws, azure int) int {
+func valueForCloud(cloud spec.Cloud, gce, aws, azure int) int {
 	switch cloud {
 	case spec.AWS:
 		return aws
@@ -1280,11 +1280,11 @@ type tpccBenchSpec struct {
 	SharedProcessMT bool
 }
 
-func (s tpccBenchSpec) EstimatedMax(cloud string) int {
+func (s tpccBenchSpec) EstimatedMax(cloud spec.Cloud) int {
 	return valueForCloud(cloud, s.EstimatedMaxGCE, s.EstimatedMaxAWS, s.EstimatedMaxAzure)
 }
 
-func (s tpccBenchSpec) LoadWarehouses(cloud string) int {
+func (s tpccBenchSpec) LoadWarehouses(cloud spec.Cloud) int {
 	return valueForCloud(cloud, s.LoadWarehousesGCE, s.LoadWarehousesAWS, s.LoadWarehousesAzure)
 }
 

--- a/pkg/cmd/roachtest/tests/tpcc_test.go
+++ b/pkg/cmd/roachtest/tests/tpcc_test.go
@@ -21,21 +21,21 @@ import (
 func TestTPCCSupportedWarehouses(t *testing.T) {
 	const expectPanic = -1
 	tests := []struct {
-		cloud        string
+		cloud        spec.Cloud
 		spec         spec.ClusterSpec
 		buildVersion *version.Version
 		expected     int
 	}{
-		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
-		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
-		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
+		{spec.GCE, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
+		{spec.GCE, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
+		{spec.GCE, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
 
-		{"aws", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
-		{"aws", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
+		{spec.AWS, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
+		{spec.AWS, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
 
-		{"nope", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
+		{spec.Local, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
+		{spec.GCE, spec.MakeClusterSpec(5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
+		{spec.GCE, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/testselector/BUILD.bazel
+++ b/pkg/cmd/roachtest/testselector/BUILD.bazel
@@ -6,5 +6,8 @@ go_library(
     embedsrcs = ["snowflake_query.sql"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/testselector",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_snowflakedb_gosnowflake//:gosnowflake"],
+    deps = [
+        "//pkg/cmd/roachtest/spec",
+        "@com_github_snowflakedb_gosnowflake//:gosnowflake",
+    ],
 )

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	sf "github.com/snowflakedb/gosnowflake"
 )
 
@@ -55,16 +56,19 @@ type TestDetails struct {
 
 // SelectTestsReq is the request for CategoriseTests
 type SelectTestsReq struct {
-	ForPastDays, // number of days data to consider for test selection
-	FirstRunOn, // number of days to consider for the first time the test is run
-	LastRunOn, // number of days to consider for the last time the test is run
-	SelectFromSuccessPct int //percentage of tests to be Selected for running from the successful test list sorted by number of runs
-	Cloud, // the cloud where the tests were run
-	Suite string // the test suite for which the selection is done
+	ForPastDays          int // number of days data to consider for test selection
+	FirstRunOn           int // number of days to consider for the first time the test is run
+	LastRunOn            int // number of days to consider for the last time the test is run
+	SelectFromSuccessPct int // percentage of tests to be Selected for running from the successful test list sorted by number of runs
+
+	Cloud spec.Cloud // the cloud where the tests were run
+	Suite string     // the test suite for which the selection is done
 }
 
 // NewDefaultSelectTestsReq returns a new SelectTestsReq with default values populated
-func NewDefaultSelectTestsReq(selectFromSuccessPct int, cloud, suite string) *SelectTestsReq {
+func NewDefaultSelectTestsReq(
+	selectFromSuccessPct int, cloud spec.Cloud, suite string,
+) *SelectTestsReq {
 	return &SelectTestsReq{
 		ForPastDays:          defaultForPastDays,
 		FirstRunOn:           defaultFirstRunOn,

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -88,7 +88,7 @@ func (p *workPool) workRemaining() []testWithCount {
 //
 // cr is used for its information about how many clusters with a given tag currently exist.
 func (p *workPool) selectTestForCluster(
-	ctx context.Context, s spec.ClusterSpec, cr *clusterRegistry, cloud string,
+	ctx context.Context, s spec.ClusterSpec, cr *clusterRegistry, cloud spec.Cloud,
 ) testToRunRes {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -241,7 +241,7 @@ func scoreTestAgainstCluster(tc testWithCount, tag string, cr *clusterRegistry) 
 
 // findCompatibleTestsLocked returns a list of tests compatible with a cluster spec.
 func (p *workPool) findCompatibleTestsLocked(
-	clusterSpec spec.ClusterSpec, cloud string,
+	clusterSpec spec.ClusterSpec, cloud spec.Cloud,
 ) []testWithCount {
 	if _, ok := clusterSpec.ReusePolicy.(spec.ReusePolicyNone); ok {
 		// Cluster cannot be reused, so no tests are compatible.


### PR DESCRIPTION
This commit changes cloud values to an enum instead of a more
error-prone string.

Epic: none
Release note: None