### PR TITLE
release-23.1: storage: make pebbleLogger.Eventf also log

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "pebble_batch.go",
         "pebble_file_registry.go",
         "pebble_iterator.go",
+        "pebble_logger_and_tracer.go",
         "pebble_merge.go",
         "pebble_mvcc_scanner.go",
         "read_as_of_iterator.go",

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -679,29 +679,6 @@ func wrapFilesystemMiddleware(opts *pebble.Options) (vfs.FS, io.Closer) {
 	return fs, closer
 }
 
-type pebbleLogger struct {
-	ctx   context.Context
-	depth int
-}
-
-var _ pebble.LoggerAndTracer = pebbleLogger{}
-
-func (l pebbleLogger) Infof(format string, args ...interface{}) {
-	log.Storage.InfofDepth(l.ctx, l.depth, format, args...)
-}
-
-func (l pebbleLogger) Fatalf(format string, args ...interface{}) {
-	log.Storage.FatalfDepth(l.ctx, l.depth, format, args...)
-}
-
-func (l pebbleLogger) Eventf(ctx context.Context, format string, args ...interface{}) {
-	log.Eventf(ctx, format, args...)
-}
-
-func (l pebbleLogger) IsTracingEnabled(ctx context.Context) bool {
-	return log.HasSpanOrEvent(ctx)
-}
-
 // PebbleConfig holds all configuration parameters and knobs used in setting up
 // a new Pebble instance.
 type PebbleConfig struct {

--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -132,7 +132,7 @@ func (i *assertionIter) RangeBounds() ([]byte, []byte) {
 		panic(errors.AssertionFailedf("RangeBounds() called on !Valid() pebble.Iterator"))
 	}
 	if _, hasRange := i.Iterator.HasPointAndRange(); !hasRange {
-		panic(errors.AssertionFailedf("RangeBounds() called on pebble.Iterator without range keys"))
+		return nil, nil
 	}
 	// See maybeSaveAndMangleRangeKeyBufs for where these are saved.
 	j := i.rangeKeyBufs.idx


### PR DESCRIPTION
Manual backport of https://github.com/cockroachdb/cockroach/pull/126824

/cc @cockroachdb/release 

----

This is useful when tracing is not enabled, but verbosity of logging can be increased. Also, we currently have gaps in context propagation in tracing which this can help mitigate for scenarios where slowness is reproducible.

Relates to cockroachdb/pebble#3728

Epic: none

Release note: None

----

Release justification: low-risk observability improvement to address customer issue