### PR TITLE
fix: allow dots in cluster name

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -209,7 +209,7 @@ var errClusterNameInvalidFormat = errors.New(`cluster name must contain only let
 // clusterNameRe matches valid cluster names.
 // For example, "a", "a123" and "a-b" are OK,
 // but "0123", "a-" and "123a" are not OK.
-var clusterNameRe = regexp.MustCompile(`^[a-zA-Z](?:[-a-zA-Z0-9]*[a-zA-Z0-9]|)$`)
+var clusterNameRe = regexp.MustCompile(`^[a-zA-Z](?:[-.a-zA-Z0-9]*[a-zA-Z0-9]|)$`)
 
 const maxClusterNameLength = 256
 

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -90,6 +90,8 @@ func TestClusterNameFlag(t *testing.T) {
 	}{
 		{"abc", ""},
 		{"a-b", ""},
+		{"a.b", ""},
+		{"ab.c", ""},
 		{"a123", ""},
 		{"", "cluster name cannot be empty"},
 		{fmt.Sprintf("%*s", 1000, "a"), "cluster name can contain at most 256 characters"},


### PR DESCRIPTION
fixes: #126604 
- Update regex expression to allow dots in the cluster name