### PR TITLE
sql: add logging for copyfrom roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -96,6 +96,7 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 			break
 		}
 		if pgerror.GetPGCode(err) != pgcode.SerializationFailure {
+			t.L().Printf("err: %v\n", err)
 			t.L().Printf("stdout:\n%v\n", det.Stdout)
 			t.L().Printf("stderr:\n%v\n", det.Stderr)
 			t.Fatal(err)


### PR DESCRIPTION
In #113099 we added a retry loop to the copyfrom roachtest to avoid test flakes due to node overload. However, checking that the error code is `40001` using `pgerror.GetPGCode()` has failed to retry the command in one case. This commit adds some extra logging to try and figure out why a `TransactionRetryWithProtoRefreshError` error would have a code other than `40001`.

Fixes #127144

Release note: None