### PR TITLE
roachprod: add dns-host command

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -162,6 +162,9 @@ func initFlags() {
 				providerOptsContainer[providerName].ConfigureClusterFlags(cmd.Flags(), vm.AcceptMultipleProjects)
 			}
 
+			// set up dns flags for dnsHostCmd
+			providerOptsContainer[providerName].ConfigureDNSHostFlags(dnsHostCmd.Flags())
+
 			// createCmd only accepts a single GCE project, as opposed to all the other
 			// commands.
 			providerOptsContainer[providerName].ConfigureClusterFlags(createCmd.Flags(), vm.SingleProject)

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1927,6 +1927,20 @@ var opentelemetryStopCmd = &cobra.Command{
 	}),
 }
 
+var dnsHostCmd = &cobra.Command{
+	Use:   "dns-host <cluster> <sync|delete> [flags]",
+	Short: "manages dns host for the cluster",
+	Long: `Manages dns host for the cluster.
+The command creates, updates or deletes the DNS record sets base on the action:
+sync:   creates the record if it does not exist, or it updates the same.
+delete: deletes the record.
+`,
+	Args: cobra.ExactArgs(2),
+	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
+		return roachprod.ConfigureDNSHost(context.Background(), config.Logger, args[0], args[1])
+	}),
+}
+
 func main() {
 	_ = roachprod.InitProviders()
 	providerOptsContainer = vm.CreateProviderOptionsContainer()
@@ -1944,6 +1958,7 @@ func main() {
 		loadBalancerCmd,
 		listCmd,
 		syncCmd,
+		dnsHostCmd,
 		gcCmd,
 		setupSSHCmd,
 		statusCmd,

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2473,6 +2473,28 @@ func DestroyDNS(ctx context.Context, l *logger.Logger, clusterName string) error
 	})
 }
 
+// ConfigureDNSHost creates, updates or deletes the DNS host records
+func ConfigureDNSHost(ctx context.Context, l *logger.Logger, clusterName, action string) error {
+	c, err := getClusterFromCache(l, clusterName)
+	if err != nil {
+		return err
+	}
+	// all DNS host configuration is in GCE
+	p, ok := vm.Providers[gce.ProviderName]
+	if !ok {
+		return errors.Errorf("provider %s is not present", gce.ProviderName)
+	}
+	dnsProvider, ok := p.(vm.DNSProvider)
+	if !ok {
+		return errors.Errorf("provider %s is not a DNS provider", gce.ProviderName)
+	}
+	dnsInfos := make([]vm.DNSInfo, 0)
+	for _, v := range c.VMs {
+		dnsInfos = append(dnsInfos, vm.DNSInfo{PublicDNS: v.PublicDNS, PublicIP: v.PublicIP})
+	}
+	return dnsProvider.ConfigureDNSHost(ctx, action, dnsInfos)
+}
+
 // StorageCollectionPerformAction either starts or stops workload collection on
 // a target cluster.
 //

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -516,6 +516,10 @@ func (o *ProviderOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
 		"AWS account ids as a comma-separated string")
 }
 
+// ConfigureDNSHostFlags is part of ProviderOpts. This implementation is a no-op.
+func (o *ProviderOpts) ConfigureDNSHostFlags(_ *pflag.FlagSet) {
+}
+
 // CleanSSH is part of vm.Provider.  This implementation is a no-op,
 // since we depend on the user's local identity file.
 func (p *Provider) CleanSSH(l *logger.Logger) error {

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -93,3 +93,7 @@ func (o *ProviderOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjects
 // ConfigureClusterCleanupFlags is part of ProviderOpts. This implementation is a no-op.
 func (o *ProviderOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
 }
+
+// ConfigureDNSHostFlags is part of ProviderOpts. This implementation is a no-op.
+func (o *ProviderOpts) ConfigureDNSHostFlags(_ *pflag.FlagSet) {
+}

--- a/pkg/roachprod/vm/dns.go
+++ b/pkg/roachprod/vm/dns.go
@@ -33,6 +33,14 @@ const (
 	SRV DNSType = "SRV"
 )
 
+// DNSInfo provides the information for DNS configuration
+type DNSInfo struct {
+	// Public DNS of the VM
+	PublicDNS string
+	// Public IP of the VM
+	PublicIP string
+}
+
 // DNSRecord represents a DNS record.
 type DNSRecord struct {
 	// Name is the name of the DNS record.
@@ -63,6 +71,10 @@ type DNSProvider interface {
 	DeleteRecordsByName(ctx context.Context, names ...string) error
 	// Domain returns the domain name (zone) of the DNS provider.
 	Domain() string
+	// ConfigureDNSHost creates, updates, delete the DNS host records based on the action as
+	// sync:   creates the record if it does not exist, or it updates the same.
+	// delete: deletes the record.
+	ConfigureDNSHost(ctx context.Context, action string, dnsInfo []DNSInfo) error
 }
 
 // FanOutDNS collates a collection of VMs by their DNS providers and invoke the

--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -439,3 +439,95 @@ func (p *dnsProvider) syncPublicDNS(l *logger.Logger, vms vm.List) (err error) {
 		cmd, output, zoneBuilder.String(),
 	)
 }
+
+// ConfigureDNSHost configures the DNS host for the cluster based on the action
+func (p *dnsProvider) ConfigureDNSHost(
+	ctx context.Context, action string, dnsInfos []vm.DNSInfo,
+) error {
+	switch action {
+	case "delete":
+		return p.deleteDNSHostRecords(ctx, dnsInfos)
+	case "sync":
+		return p.syncDNSHostRecords(ctx, dnsInfos)
+	}
+	return errors.Newf("invalid action <%s> for configuring dns host. Expected values are delete or sync.", action)
+}
+
+func (p *dnsProvider) syncDNSHostRecords(ctx context.Context, dnsInfos []vm.DNSInfo) error {
+	for _, dnsInfo := range dnsInfos {
+		name := fmt.Sprintf("%s.", dnsInfo.PublicDNS)
+		task := "create"
+		existingRecords, err := listRecordSets(ctx, p.dnsProject, name, p.publicZone)
+		if err != nil {
+			return err
+		}
+		if len(existingRecords) > 0 {
+			// update as record is already present
+			// checking for more than one record is not necessary as these records
+			// are created by the same code
+			task = "update"
+		}
+		if err = createOrUpdateRecord(ctx, p.dnsProject, name, p.publicZone, task, dnsInfo.PublicIP); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *dnsProvider) deleteDNSHostRecords(ctx context.Context, dnsInfos []vm.DNSInfo) error {
+	for _, dnsInfo := range dnsInfos {
+		if err := deleteRecord(ctx, p.dnsProject, fmt.Sprintf("%s.", dnsInfo.PublicDNS), p.publicZone); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createOrUpdateRecord(ctx context.Context, dnsProject, name, zone, action, ip string) error {
+	args := []string{"--project", dnsProject, "dns", "record-sets", action, name,
+		"--type", "A",
+		"--ttl", "60",
+		"--zone", zone,
+		"--rrdatas", ip,
+	}
+	cmd := exec.CommandContext(ctx, "gcloud", args...)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrap(err, "failed to list dns records")
+	}
+	return nil
+}
+
+func listRecordSets(ctx context.Context, dnsProject, name, zone string) ([]vm.DNSRecord, error) {
+	args := []string{"--project", dnsProject, "dns", "record-sets", "list",
+		"--limit", strconv.Itoa(dnsMaxResults),
+		"--page-size", strconv.Itoa(dnsMaxResults),
+		"--zone", zone,
+		"--filter", name,
+		"--format", "json",
+	}
+	cmd := exec.CommandContext(ctx, "gcloud", args...)
+	res, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list dns records")
+	}
+	var jsonList []vm.DNSRecord
+	err = json.Unmarshal(res, &jsonList)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unlarshall dns records")
+	}
+	return jsonList, nil
+}
+
+func deleteRecord(ctx context.Context, dnsProject, name, zone string) error {
+	args := []string{"--project", dnsProject, "dns", "record-sets", "delete", name,
+		"--type", "A",
+		"--zone", zone,
+	}
+	cmd := exec.CommandContext(ctx, "gcloud", args...)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "failed to list dns records")
+	}
+	return nil
+}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1097,27 +1097,12 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, opt vm.Multip
 		fmt.Sprintf("use the shared user %q for ssh rather than your user %q",
 			config.SharedUser, config.OSUser.Username))
 
+	o.ConfigureDNSHostFlags(flags)
+
 	// Flags about DNS override the default values in
 	// providerInstance.dnsProvider.
 
 	dnsProviderInstance := providerInstance.dnsProvider
-	flags.StringVar(
-		&dnsProviderInstance.dnsProject, ProviderName+"-dns-project",
-		dnsProviderInstance.dnsProject,
-		"project to use to set up DNS",
-	)
-	flags.StringVar(
-		&dnsProviderInstance.publicZone,
-		ProviderName+"-dns-zone",
-		dnsProviderInstance.publicZone,
-		"zone file in gcloud project to use to set up public DNS records",
-	)
-	flags.StringVar(
-		&dnsProviderInstance.publicDomain,
-		ProviderName+"-dns-domain",
-		dnsProviderInstance.publicDomain,
-		"zone domian in gcloud project to use to set up public DNS records",
-	)
 	flags.StringVar(
 		&dnsProviderInstance.managedZone,
 		ProviderName+"managed-dns-zone",
@@ -1143,6 +1128,28 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, opt vm.Multip
 		&providerInstance.defaultProject, ProviderName+"-default-project",
 		providerInstance.defaultProject,
 		"google cloud project to use to run core roachprod services",
+	)
+}
+
+// ConfigureDNSHostFlags implements vm.ProviderFlags.
+func (o *ProviderOpts) ConfigureDNSHostFlags(flags *pflag.FlagSet) {
+	dnsProviderInstance := providerInstance.dnsProvider
+	flags.StringVar(
+		&dnsProviderInstance.dnsProject, ProviderName+"-dns-project",
+		dnsProviderInstance.dnsProject,
+		"project to use to set up DNS",
+	)
+	flags.StringVar(
+		&dnsProviderInstance.publicZone,
+		ProviderName+"-dns-zone",
+		dnsProviderInstance.publicZone,
+		"zone file in gcloud project to use to set up public DNS records",
+	)
+	flags.StringVar(
+		&dnsProviderInstance.publicDomain,
+		ProviderName+"-dns-domain",
+		dnsProviderInstance.publicDomain,
+		"zone domian in gcloud project to use to set up public DNS records",
 	)
 }
 

--- a/pkg/roachprod/vm/local/dns.go
+++ b/pkg/roachprod/vm/local/dns.go
@@ -189,3 +189,8 @@ func (n *dnsProvider) dnsFileName() string {
 func dnsKey(record vm.DNSRecord) string {
 	return fmt.Sprintf("%s:%s:%s", record.Name, record.Type, record.Data)
 }
+
+// ConfigureDNSHost is a no-op for local
+func (n *dnsProvider) ConfigureDNSHost(_ context.Context, _ string, _ []vm.DNSInfo) error {
+	return nil
+}

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -194,6 +194,10 @@ func (o *providerOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjects
 func (o *providerOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
 }
 
+// ConfigureDNSHostFlags is part of ProviderOpts. This implementation is a no-op.
+func (o *providerOpts) ConfigureDNSHostFlags(_ *pflag.FlagSet) {
+}
+
 // CleanSSH is part of the vm.Provider interface.  This implementation is a no-op.
 func (p *Provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -362,6 +362,9 @@ type ProviderOpts interface {
 	// ConfigureClusterCleanupFlags configures a FlagSet with any options relevant to
 	// commands (`gc`)
 	ConfigureClusterCleanupFlags(*pflag.FlagSet)
+	// ConfigureDNSHostFlags configures a FlagSet with any options relevant to
+	// commands (`dns-host`)
+	ConfigureDNSHostFlags(*pflag.FlagSet)
 }
 
 // VolumeSnapshot is an abstract representation of a specific volume snapshot.


### PR DESCRIPTION
There is no way to configure dns host via rochprod for a project other than cockroach-ephemeral.
This is because the current `--gce-dns-zone` option available in `roachprod create` put the whole zone
file in the specified zone. This zone file contains all the clusters from cockroach-ephemeral.

This PR adds the capability in roachprod to create, update or delete dns hosts records in any project and zone.

 Fixes: #126926
 Epic: None