### PR TITLE
github: fix check-pebble-dep action

### DIFF
--- a/.github/workflows/check-pebble-dep.yml
+++ b/.github/workflows/check-pebble-dep.yml
@@ -10,6 +10,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Check Pebble deps
         shell: bash


### PR DESCRIPTION
The action is failing with
`invalid object name 'origin/release-23.1'`

This commit adds `fetch-depth: 0` which enables use of all branches.

Epic: none
Release note: None