### PR TITLE
roachtest: fix broken failover test naming

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -64,19 +64,21 @@ var rangeLeaseRenewalDuration = func() time.Duration {
 // https://github.com/cockroachdb/cockroach/issues/103654
 func registerFailover(r registry.Registry) {
 	for _, leases := range []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases} {
-		var suffix string
+		var leasesStr string
 		if leases == registry.ExpirationLeases {
-			suffix = "/lease=expiration"
+			leasesStr = "/lease=expiration"
 		}
 
 		for _, readOnly := range []bool{false, true} {
+			var readOnlyStr string
 			if readOnly {
-				suffix = "/read-only" + suffix
+				readOnlyStr = "/read-only"
 			} else {
-				suffix = "/read-write" + suffix
+				readOnlyStr = "/read-write"
 			}
+
 			r.Add(registry.TestSpec{
-				Name:                "failover/chaos" + suffix,
+				Name:                "failover/chaos" + readOnlyStr + leasesStr,
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             90 * time.Minute,
@@ -92,7 +94,7 @@ func registerFailover(r registry.Registry) {
 		}
 
 		r.Add(registry.TestSpec{
-			Name:             "failover/partial/lease-gateway" + suffix,
+			Name:             "failover/partial/lease-gateway" + leasesStr,
 			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			Timeout:          30 * time.Minute,
@@ -104,7 +106,7 @@ func registerFailover(r registry.Registry) {
 		})
 
 		r.Add(registry.TestSpec{
-			Name:             "failover/partial/lease-leader" + suffix,
+			Name:             "failover/partial/lease-leader" + leasesStr,
 			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			Timeout:          30 * time.Minute,
@@ -116,7 +118,7 @@ func registerFailover(r registry.Registry) {
 		})
 
 		r.Add(registry.TestSpec{
-			Name:             "failover/partial/lease-liveness" + suffix,
+			Name:             "failover/partial/lease-liveness" + leasesStr,
 			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			Timeout:          30 * time.Minute,
@@ -145,7 +147,7 @@ func registerFailover(r registry.Registry) {
 				clouds = registry.OnlyGCE
 			}
 			r.Add(registry.TestSpec{
-				Name:                fmt.Sprintf("failover/non-system/%s%s", failureMode, suffix),
+				Name:                fmt.Sprintf("failover/non-system/%s%s", failureMode, leasesStr),
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             30 * time.Minute,
@@ -159,7 +161,7 @@ func registerFailover(r registry.Registry) {
 				},
 			})
 			r.Add(registry.TestSpec{
-				Name:                fmt.Sprintf("failover/liveness/%s%s", failureMode, suffix),
+				Name:                fmt.Sprintf("failover/liveness/%s%s", failureMode, leasesStr),
 				Owner:               registry.OwnerKV,
 				CompatibleClouds:    registry.AllExceptAWS,
 				Suites:              registry.Suites(registry.Weekly),
@@ -173,7 +175,7 @@ func registerFailover(r registry.Registry) {
 				},
 			})
 			r.Add(registry.TestSpec{
-				Name:                fmt.Sprintf("failover/system-non-liveness/%s%s", failureMode, suffix),
+				Name:                fmt.Sprintf("failover/system-non-liveness/%s%s", failureMode, leasesStr),
 				Owner:               registry.OwnerKV,
 				CompatibleClouds:    registry.AllExceptAWS,
 				Suites:              registry.Suites(registry.Weekly),


### PR DESCRIPTION
failover roachtest names were recently broken by 04e093f2, which unintentionally introduced variable aliasing and caused the "/read-only" and "/read-write" strings to be appended to every test name. This commit fixes the names and avoids the variable shadowing to make the code less error-prone.

The roachtest names are now fixed:
```sh
➜ roachtest list ^failover
Listing tests which match regex "^failover" and are compatible with cloud "gce".

failover/chaos/read-only [kv]
failover/chaos/read-only/lease=expiration [kv]
failover/chaos/read-write [kv]
failover/chaos/read-write/lease=expiration [kv]
failover/liveness/blackhole [kv]
failover/liveness/blackhole-recv [kv]
failover/liveness/blackhole-recv/lease=expiration [kv]
failover/liveness/blackhole-send [kv]
failover/liveness/blackhole-send/lease=expiration [kv]
failover/liveness/blackhole/lease=expiration [kv]
failover/liveness/crash [kv]
failover/liveness/crash/lease=expiration [kv]
failover/liveness/deadlock [kv]
failover/liveness/deadlock/lease=expiration [kv]
failover/liveness/disk-stall [kv]
failover/liveness/disk-stall/lease=expiration [kv]
failover/liveness/pause [kv]
failover/liveness/pause/lease=expiration [kv]
failover/non-system/blackhole [kv]
failover/non-system/blackhole-recv [kv]
failover/non-system/blackhole-recv/lease=expiration [kv]
failover/non-system/blackhole-send [kv]
failover/non-system/blackhole-send/lease=expiration [kv]
failover/non-system/blackhole/lease=expiration [kv]
failover/non-system/crash [kv]
failover/non-system/crash/lease=expiration [kv]
failover/non-system/deadlock [kv]
failover/non-system/deadlock/lease=expiration [kv]
failover/non-system/disk-stall [kv]
failover/non-system/disk-stall/lease=expiration [kv]
failover/non-system/pause [kv]
failover/non-system/pause/lease=expiration [kv]
failover/partial/lease-gateway [kv]
failover/partial/lease-gateway/lease=expiration [kv]
failover/partial/lease-leader [kv]
failover/partial/lease-leader/lease=expiration [kv]
failover/partial/lease-liveness [kv]
failover/partial/lease-liveness/lease=expiration [kv]
failover/system-non-liveness/blackhole [kv]
failover/system-non-liveness/blackhole-recv [kv]
failover/system-non-liveness/blackhole-recv/lease=expiration [kv]
failover/system-non-liveness/blackhole-send [kv]
failover/system-non-liveness/blackhole-send/lease=expiration [kv]
failover/system-non-liveness/blackhole/lease=expiration [kv]
failover/system-non-liveness/crash [kv]
failover/system-non-liveness/crash/lease=expiration [kv]
failover/system-non-liveness/deadlock [kv]
failover/system-non-liveness/deadlock/lease=expiration [kv]
failover/system-non-liveness/disk-stall [kv]
failover/system-non-liveness/disk-stall/lease=expiration [kv]
failover/system-non-liveness/pause [kv]
failover/system-non-liveness/pause/lease=expiration [kv]
```

Epic: None
Release note: None