### PR TITLE
mixedversion: pass in cluster settings when restarting binary

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -422,7 +422,7 @@ func (p *testPlanner) changeVersionSteps(
 	for j, node := range previousVersionNodes {
 		steps = append(steps, p.newSingleStep(
 			restartWithNewBinaryStep{
-				version: to, node: node, rt: p.rt,
+				version: to, node: node, rt: p.rt, settings: p.clusterSettings(),
 			},
 		))
 		err := p.currentContext.System.changeVersion(node, to)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -80,6 +80,7 @@ func TestTestPlanner(t *testing.T) {
 	}()
 
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "planner"), func(t *testing.T, path string) {
+		defer withTestBuildVersion("v24.3.0")()
 		resetMutators()
 		// Unless specified, treat every test as a non-UA deployment
 		// test. Tests can use the deployment-mode option in the

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
@@ -23,12 +23,12 @@ ok
 
 plan
 ----
-Upgrades:           v24.1.1 → <current>
+Upgrades:           v24.2.2 → <current>
 Deployment mode:    system-only
 Plan:
-├── install fixtures for version "v24.1.1" (1)
-├── start cluster at version "v24.1.1" (2)
-├── wait for system tenant on nodes :1-4 to reach cluster version '24.1' (3)
+├── install fixtures for version "v24.2.2" (1)
+├── start cluster at version "v24.2.2" (2)
+├── wait for system tenant on nodes :1-4 to reach cluster version '24.2' (3)
 ├── run startup hooks concurrently
 │   ├── run "initialize bank workload", after 0s delay (4)
 │   └── run "initialize rand workload", after 0s delay (5)
@@ -36,9 +36,9 @@ Plan:
 │   ├── run "bank workload", after 5s delay (6)
 │   ├── run "rand workload", after 500ms delay (7)
 │   └── run "csv server", after 0s delay (8)
-└── upgrade cluster from "v24.1.1" to "<current>"
+└── upgrade cluster from "v24.2.2" to "<current>"
    ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (9)
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
    │   ├── restart node 1 with binary version <current> (10)
    │   ├── restart node 3 with binary version <current> (11)
    │   ├── run mixed-version hooks concurrently
@@ -46,15 +46,15 @@ Plan:
    │   │   └── run "mixed-version 2", after 500ms delay (13)
    │   ├── restart node 2 with binary version <current> (14)
    │   └── restart node 4 with binary version <current> (15)
-   ├── downgrade nodes :1-4 from "<current>" to "v24.1.1"
-   │   ├── restart node 4 with binary version v24.1.1 (16)
+   ├── downgrade nodes :1-4 from "<current>" to "v24.2.2"
+   │   ├── restart node 4 with binary version v24.2.2 (16)
    │   ├── run mixed-version hooks concurrently
    │   │   ├── run "mixed-version 1", after 100ms delay (17)
    │   │   └── run "mixed-version 2", after 0s delay (18)
-   │   ├── restart node 1 with binary version v24.1.1 (19)
-   │   ├── restart node 2 with binary version v24.1.1 (20)
-   │   └── restart node 3 with binary version v24.1.1 (21)
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+   │   ├── restart node 1 with binary version v24.2.2 (19)
+   │   ├── restart node 2 with binary version v24.2.2 (20)
+   │   └── restart node 3 with binary version v24.2.2 (21)
+   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
    │   ├── restart node 4 with binary version <current> (22)
    │   ├── restart node 1 with binary version <current> (23)
    │   ├── restart node 2 with binary version <current> (24)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/conflicting_mutators
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/conflicting_mutators
@@ -19,28 +19,28 @@ ok
 
 plan debug=true
 ----
-Upgrades:           v24.1.1 → <current>
+Upgrades:           v24.2.2 → <current>
 Deployment mode:    system-only
 Mutators:           concurrent_user_hooks_mutator, remove_user_hooks_mutator
 Plan:
-├── install fixtures for version "v24.1.1" (1) [stage=cluster-setup]
-├── start cluster at version "v24.1.1" (2) [stage=cluster-setup]
-├── wait for system tenant on nodes :1-4 to reach cluster version '24.1' (3) [stage=cluster-setup]
-└── upgrade cluster from "v24.1.1" to "<current>"
+├── install fixtures for version "v24.2.2" (1) [stage=cluster-setup]
+├── start cluster at version "v24.2.2" (2) [stage=cluster-setup]
+├── wait for system tenant on nodes :1-4 to reach cluster version '24.2' (3) [stage=cluster-setup]
+└── upgrade cluster from "v24.2.2" to "<current>"
    ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (4) [stage=init]
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
    │   ├── restart node 4 with binary version <current> (5) [stage=temporary-upgrade]
    │   ├── testSingleStep (6) [stage=temporary-upgrade]
    │   ├── restart node 3 with binary version <current> (7) [stage=temporary-upgrade]
    │   ├── restart node 2 with binary version <current> (8) [stage=temporary-upgrade]
    │   └── restart node 1 with binary version <current> (9) [stage=temporary-upgrade]
-   ├── downgrade nodes :1-4 from "<current>" to "v24.1.1"
-   │   ├── restart node 2 with binary version v24.1.1 (10) [stage=rollback-upgrade]
-   │   ├── restart node 1 with binary version v24.1.1 (11) [stage=rollback-upgrade]
+   ├── downgrade nodes :1-4 from "<current>" to "v24.2.2"
+   │   ├── restart node 2 with binary version v24.2.2 (10) [stage=rollback-upgrade]
+   │   ├── restart node 1 with binary version v24.2.2 (11) [stage=rollback-upgrade]
    │   ├── testSingleStep (12) [stage=rollback-upgrade]
-   │   ├── restart node 3 with binary version v24.1.1 (13) [stage=rollback-upgrade]
-   │   └── restart node 4 with binary version v24.1.1 (14) [stage=rollback-upgrade]
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+   │   ├── restart node 3 with binary version v24.2.2 (13) [stage=rollback-upgrade]
+   │   └── restart node 4 with binary version v24.2.2 (14) [stage=rollback-upgrade]
+   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
    │   ├── restart node 3 with binary version <current> (15) [stage=last-upgrade]
    │   ├── restart node 1 with binary version <current> (16) [stage=last-upgrade]
    │   ├── restart node 4 with binary version <current> (17) [stage=last-upgrade]

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/mutator_probabilities
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/mutator_probabilities
@@ -15,16 +15,16 @@ ok
 
 plan debug=true
 ----
-Upgrades:           v24.1.1 → <current>
+Upgrades:           v24.2.2 → <current>
 Deployment mode:    system-only
 Mutators:           concurrent_user_hooks_mutator
 Plan:
-├── install fixtures for version "v24.1.1" (1) [stage=cluster-setup]
-├── start cluster at version "v24.1.1" (2) [stage=cluster-setup]
-├── wait for system tenant on nodes :1-4 to reach cluster version '24.1' (3) [stage=cluster-setup]
-└── upgrade cluster from "v24.1.1" to "<current>"
+├── install fixtures for version "v24.2.2" (1) [stage=cluster-setup]
+├── start cluster at version "v24.2.2" (2) [stage=cluster-setup]
+├── wait for system tenant on nodes :1-4 to reach cluster version '24.2' (3) [stage=cluster-setup]
+└── upgrade cluster from "v24.2.2" to "<current>"
    ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (4) [stage=init]
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
    │   ├── restart node 4 with binary version <current> (5) [stage=temporary-upgrade]
    │   ├── run following steps concurrently
    │   │   ├── run "my mixed version feature", after 5s delay (6) [stage=temporary-upgrade]
@@ -32,15 +32,15 @@ Plan:
    │   ├── restart node 3 with binary version <current> (8) [stage=temporary-upgrade]
    │   ├── restart node 2 with binary version <current> (9) [stage=temporary-upgrade]
    │   └── restart node 1 with binary version <current> (10) [stage=temporary-upgrade]
-   ├── downgrade nodes :1-4 from "<current>" to "v24.1.1"
-   │   ├── restart node 2 with binary version v24.1.1 (11) [stage=rollback-upgrade]
-   │   ├── restart node 1 with binary version v24.1.1 (12) [stage=rollback-upgrade]
+   ├── downgrade nodes :1-4 from "<current>" to "v24.2.2"
+   │   ├── restart node 2 with binary version v24.2.2 (11) [stage=rollback-upgrade]
+   │   ├── restart node 1 with binary version v24.2.2 (12) [stage=rollback-upgrade]
    │   ├── run following steps concurrently
    │   │   ├── run "my mixed version feature", after 3m0s delay (13) [stage=rollback-upgrade]
    │   │   └── testSingleStep, after 0s delay (14) [stage=rollback-upgrade]
-   │   ├── restart node 3 with binary version v24.1.1 (15) [stage=rollback-upgrade]
-   │   └── restart node 4 with binary version v24.1.1 (16) [stage=rollback-upgrade]
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+   │   ├── restart node 3 with binary version v24.2.2 (15) [stage=rollback-upgrade]
+   │   └── restart node 4 with binary version v24.2.2 (16) [stage=rollback-upgrade]
+   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
    │   ├── restart node 3 with binary version <current> (17) [stage=last-upgrade]
    │   ├── restart node 1 with binary version <current> (18) [stage=last-upgrade]
    │   ├── restart node 4 with binary version <current> (19) [stage=last-upgrade]


### PR DESCRIPTION
This PR adds back in the propagation of cluster settings in MVT when restarting the binary. This was erroneously deleted in #125869.

It also bumps the build version for the `TestPlanner` tests, in order to test skip version upgrades.

Release note: none
Fixes: https://github.com/cockroachdb/cockroach/issues/127106