### PR TITLE
roachtest: bump mixed_version_sql_stats timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -179,7 +179,7 @@ type sqlStatsRequestHelper struct {
 func createSQLStatsRequestHelper(
 	cluster cluster.Cluster, logger *logger.Logger,
 ) *sqlStatsRequestHelper {
-	client := roachtestutil.DefaultHTTPClient(cluster, logger)
+	client := roachtestutil.DefaultHTTPClient(cluster, logger, roachtestutil.HTTPTimeout(15*time.Second))
 	return &sqlStatsRequestHelper{
 		cluster: cluster,
 		logger:  logger,


### PR DESCRIPTION
sql-stats/mixed-version uses an http client witha default timeout of 3 seconds. This commit bumps the timeout to 15 seconds to prevent flaky tests.

Fixes: #126993
Epic: None
Release note: None