### PR TITLE
sql: fix out-of-bounds exception in insert fast path

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -1051,6 +1051,23 @@ INSERT INTO t115377 VALUES (2, 0, 0, 'east')
 statement error pgcode 23505 duplicate key value violates unique constraint \"unique_k\"
 INSERT INTO t115377 VALUES (2, 1, 1, 'east')
 
+# Regression test for #126988.
+statement ok
+CREATE TABLE t126988 (
+  k INT PRIMARY KEY,
+  j INT,
+  i INT,
+  v INT AS (i) VIRTUAL,
+  UNIQUE WITHOUT INDEX (i, j),
+  INDEX (j, v) STORING (i)
+)
+
+statement ok
+INSERT INTO t126988 VALUES (1, 10, 200)
+
+statement error pgcode 23505 duplicate key value violates unique constraint \"unique_i_j\"\nDETAIL: Key \(10, 200\) already exists.
+INSERT INTO t126988 VALUES (1, 10, 200)
+
 subtest end
 
 # Regression test for hitting a nil pointer in the insert fast path when seeing


### PR DESCRIPTION
This commit fixes a rare out-of-bounds exception in the insert fast
path that would crash the gateway node. The bug could occur when
generating a duplicate key error message for `UNIQUE WITHOUT INDEX`
constraints during a fast-path insert.

Previously the code incorrectly looped over all the lookup index's
columns to find a column corresponding to a constraint column. This was
problematic because 1) there are cases where the column cannot be found
and 2) the index column ordinals could exceed the length of `keyVals` and no
bounds checking is performed before access.

This commit makes the code safer by:
  1. Adding bounds-checking for access to `keyVals`.
  2. Looping over only the indexes key columns—there should be at least
     'len(keyVals)` key columns.
  3. Falling-back to a simpler error message that omits column names
     when the unique constraint column cannot be matched to a key value.

Informs #126988

Release note (bug fix): A bug causing gateway nodes to crash while
executing `INSERT` statements in `REGIONAL BY ROW` tables has been
fixed. This bug has been present since version 23.2.
