### PR TITLE
workload/schemachange: create composite type in RSW

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -420,7 +420,12 @@ func makeRenameIndex(s *Smither) (tree.Statement, bool) {
 
 func makeCreateType(s *Smither) (tree.Statement, bool) {
 	name := s.name("typ")
-	return randgen.RandCreateType(s.rnd, string(name), letters), true
+
+	if s.coin() {
+		return randgen.RandCreateEnumType(s.rnd, string(name), letters), true
+	}
+
+	return randgen.RandCreateCompositeType(s.rnd, string(name), letters), true
 }
 
 func makeDropType(s *Smither) (tree.Statement, bool) {

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -150,8 +150,13 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 	numTypes := r.Intn(5) + 1
 	for i := 0; i < numTypes; i++ {
 		name := fmt.Sprintf("rand_typ_%d", i)
-		stmt := randgen.RandCreateType(r, name, letters)
-		stmts = append(stmts, stmt.String())
+		if r.Intn(2) == 0 {
+			stmt := randgen.RandCreateEnumType(r, name, letters)
+			stmts = append(stmts, stmt.String())
+		} else {
+			stmt := randgen.RandCreateCompositeType(r, name, letters)
+			stmts = append(stmts, stmt.String())
+		}
 	}
 	return stmts
 }

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -49,15 +49,15 @@ func MakeSchemaName(ifNotExists bool, schema string, authRole tree.RoleSpec) *tr
 	}
 }
 
-// RandCreateType creates a random CREATE TYPE statement. The resulting
-// type's name will be name, and if the type is an enum, the members will
+// RandCreateEnumType creates a random CREATE TYPE <type_name> AS ENUM statement.
+// The resulting type's name will be name, the enum members will
 // be random strings generated from alphabet.
-func RandCreateType(rng *rand.Rand, name, alphabet string) tree.Statement {
+func RandCreateEnumType(rng *rand.Rand, name, alphabet string) tree.Statement {
 	numLabels := rng.Intn(6) + 1
 	labels := make(tree.EnumValueList, numLabels)
 	labelsMap := make(map[string]struct{})
-	i := 0
-	for i < numLabels {
+
+	for i := 0; i < numLabels; {
 		s := util.RandString(rng, rng.Intn(6)+1, alphabet)
 		if _, ok := labelsMap[s]; !ok {
 			labels[i] = tree.EnumValue(s)
@@ -65,6 +65,7 @@ func RandCreateType(rng *rand.Rand, name, alphabet string) tree.Statement {
 			i++
 		}
 	}
+
 	un, err := tree.NewUnresolvedObjectName(1, [3]string{name}, 0)
 	if err != nil {
 		panic(err)
@@ -73,6 +74,35 @@ func RandCreateType(rng *rand.Rand, name, alphabet string) tree.Statement {
 		TypeName:   un,
 		Variety:    tree.Enum,
 		EnumLabels: labels,
+	}
+}
+
+// RandCreateCompositeType creates a random composite type statement.
+func RandCreateCompositeType(rng *rand.Rand, name, alphabet string) tree.Statement {
+	var compositeTypeList []tree.CompositeTypeElem
+
+	numTypes := rng.Intn(6) + 1
+	uniqueNames := make(map[string]struct{})
+
+	for i := 0; i < numTypes; {
+		randomName := util.RandString(rng, rng.Intn(6)+1, alphabet)
+		randomType := RandTypeFromSlice(rng, types.Scalar)
+
+		if _, ok := uniqueNames[randomName]; !ok {
+			compositeTypeList = append(compositeTypeList, tree.CompositeTypeElem{Label: tree.Name(randomName), Type: randomType})
+			uniqueNames[randomName] = struct{}{}
+			i++
+		}
+	}
+
+	un, err := tree.NewUnresolvedObjectName(1, [3]string{name}, 0)
+	if err != nil {
+		panic(err)
+	}
+	return &tree.CreateType{
+		TypeName:          un,
+		Variety:           tree.Composite,
+		CompositeTypeList: compositeTypeList,
 	}
 }
 

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -117,14 +117,15 @@ const (
 
 	// CREATE ...
 
-	createTypeEnum // CREATE TYPE <type> ENUM AS <def>
-	createIndex    // CREATE INDEX <index> ON <table> <def>
-	createSchema   // CREATE SCHEMA <schema>
-	createSequence // CREATE SEQUENCE <sequence> <def>
-	createTable    // CREATE TABLE <table> <def>
-	createTableAs  // CREATE TABLE <table> AS <def>
-	createView     // CREATE VIEW <view> AS <def>
-	createFunction // CREATE FUNCTION <function> ...
+	createTypeEnum      // CREATE TYPE <type> ENUM AS <def>
+	createTypeComposite // CREATE TYPE <type> AS <def>
+	createIndex         // CREATE INDEX <index> ON <table> <def>
+	createSchema        // CREATE SCHEMA <schema>
+	createSequence      // CREATE SEQUENCE <sequence> <def>
+	createTable         // CREATE TABLE <table> <def>
+	createTableAs       // CREATE TABLE <table> AS <def>
+	createView          // CREATE VIEW <view> AS <def>
+	createFunction      // CREATE FUNCTION <function> ...
 
 	// COMMENT ON ...
 
@@ -237,6 +238,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	createTable:                       (*operationGenerator).createTable,
 	createTableAs:                     (*operationGenerator).createTableAs,
 	createTypeEnum:                    (*operationGenerator).createEnum,
+	createTypeComposite:               (*operationGenerator).createCompositeType,
 	createView:                        (*operationGenerator).createView,
 	dropFunction:                      (*operationGenerator).dropFunction,
 	dropIndex:                         (*operationGenerator).dropIndex,
@@ -287,6 +289,7 @@ var opWeights = []int{
 	createTable:                       1,
 	createTableAs:                     1,
 	createTypeEnum:                    1,
+	createTypeComposite:               1,
 	createView:                        1,
 	dropFunction:                      1,
 	dropIndex:                         1,

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -39,20 +39,21 @@ func _() {
 	_ = x[alterTableSetColumnNotNull-28]
 	_ = x[alterTypeDropValue-29]
 	_ = x[createTypeEnum-30]
-	_ = x[createIndex-31]
-	_ = x[createSchema-32]
-	_ = x[createSequence-33]
-	_ = x[createTable-34]
-	_ = x[createTableAs-35]
-	_ = x[createView-36]
-	_ = x[createFunction-37]
-	_ = x[commentOn-38]
-	_ = x[dropFunction-39]
-	_ = x[dropIndex-40]
-	_ = x[dropSchema-41]
-	_ = x[dropSequence-42]
-	_ = x[dropTable-43]
-	_ = x[dropView-44]
+	_ = x[createTypeComposite-31]
+	_ = x[createIndex-32]
+	_ = x[createSchema-33]
+	_ = x[createSequence-34]
+	_ = x[createTable-35]
+	_ = x[createTableAs-36]
+	_ = x[createView-37]
+	_ = x[createFunction-38]
+	_ = x[commentOn-39]
+	_ = x[dropFunction-40]
+	_ = x[dropIndex-41]
+	_ = x[dropSchema-42]
+	_ = x[dropSequence-43]
+	_ = x[dropTable-44]
+	_ = x[dropView-45]
 }
 
 func (i opType) String() string {
@@ -119,6 +120,8 @@ func (i opType) String() string {
 		return "alterTypeDropValue"
 	case createTypeEnum:
 		return "createTypeEnum"
+	case createTypeComposite:
+		return "createTypeComposite"
 	case createIndex:
 		return "createIndex"
 	case createSchema:


### PR DESCRIPTION
This is the addition of missing tests with composite types, with the newly added COMMENT ON TYPE functionality we now test for comment on composite types as well with the RSW (Random Schemachanger Workload).

Fixes: #126007

Release note: None