### PR TITLE
pkg/cli: Include both resolutions (10s and 30min) in tsdump

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -64,10 +64,11 @@ var debugTimeSeriesDumpCmd = &cobra.Command{
 	Use:   "tsdump",
 	Short: "dump all the raw timeseries values in a cluster",
 	Long: `
-Dumps all of the raw timeseries values in a cluster. Only the default resolution
-is retrieved, i.e. typically datapoints older than the value of the
-'timeseries.storage.resolution_10s.ttl' cluster setting will be absent from the
-output.
+Dumps all of the raw timeseries values in a cluster. If the supplied time range
+is within the 'timeseries.storage.resolution_10s.ttl', metrics will be dumped
+as it is with 10s resolution. If the time range extends outside of the TTL, the
+timeseries downsampled to 30m resolution will be dumped for the time beyond
+the TTL.
 
 When an input file is provided instead (as an argument), this input file
 must previously have been created with the --format=raw switch. The command
@@ -153,6 +154,9 @@ will then convert it to the --format requested in the current invocation.
 				StartNanos: time.Time(debugTimeSeriesDumpOpts.from).UnixNano(),
 				EndNanos:   time.Time(debugTimeSeriesDumpOpts.to).UnixNano(),
 				Names:      names,
+				Resolutions: []tspb.TimeSeriesResolution{
+					tspb.TimeSeriesResolution_RESOLUTION_30M, tspb.TimeSeriesResolution_RESOLUTION_10S,
+				},
 			}
 			tsClient := tspb.NewTimeSeriesClient(conn)
 


### PR DESCRIPTION
Previously, only the highest resolution (10s) slabs of the tsdb were fetched while dumping metrics as part of the tsdump command. As a result, the metrics fetched would be no older than `timeseries.storage.resolution_10s.ttl`, even if the time range supplied by the user was bigger. For Example, let's say:

```
ttl = 10 days (configurable in cluster settings)
to_time = NOW (user supplied)
from_time = NOW - 15 days (user supplied)
```

The output of tsdump would not have the data for days 11 to 15. It's not that we don't have the data for days 11 to 15, it's just been rolled up to a lower resolutions. By default, the ts server only fetches the highest resolution data.

This commit fixes that by explicitly asking both the supported resolutions (30min and 10s) while making the `DumpRequest` to the ts server.

---

### Screenshots 

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/48db481d-1ff1-48b9-b2fa-6b9a69a6b054)

</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/e2a72745-f688-43ad-ba92-ec0b6ed51e8b)

</details>

---

Part of: CRDB-39348
Fixes: #125256
Release note (cli change): tsdump to include all the available resolutions in the time range supplied by the user