### PR TITLE
raft: export LeadSupportStatus method

### DIFF
--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/raft/raftpb",
         "//pkg/raft/raftstoreliveness",
         "//pkg/raft/tracker",
+        "//pkg/util/hlc",
     ],
 )
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -490,6 +490,15 @@ func (rn *RawNode) SparseStatus() SparseStatus {
 	return getSparseStatus(rn.raft)
 }
 
+// LeadSupportStatus returns a LeadSupportStatus. Notably, it only includes
+// leader support information.
+func (rn *RawNode) LeadSupportStatus() LeadSupportStatus {
+	return getLeadSupportStatus(rn.raft)
+}
+
+// TODO(nvanbenschoten): remove this one the method is used.
+var _ = (*RawNode).LeadSupportStatus
+
 // ProgressType indicates the type of replica a Progress corresponds to.
 type ProgressType byte
 


### PR DESCRIPTION
Part of #123847.

This commit adds a new `LeadSupportUntil` timestamp to `Status`. It also adds a `LeadSupportStatus` type, which is a variant of `Status` without `Config` or `Progress`, which are expensive to copy. These will be used when performing verification of leader leases in the future.

Release note: None