### PR TITLE
kv: fix check in WaitForLeaseUpgrade for leader leases

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1136,7 +1136,7 @@ func (tc *TestCluster) WaitForLeaseUpgrade(
 		li, _, err := tc.FindRangeLeaseEx(ctx, desc, nil)
 		require.NoError(t, err)
 		l = li.Current()
-		if l.Type() != roachpb.LeaseEpoch {
+		if l.Type() == roachpb.LeaseExpiration {
 			return errors.Errorf("lease still an expiration based lease")
 		}
 		require.Equal(t, int64(1), l.Epoch)


### PR DESCRIPTION
Wait for the lease to switch away from being expiration-based, not to switch to being epoch-based.

Epic: None
Release note: None