### PR TITLE
kv: add "leases.leader" metric

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -311,6 +311,7 @@
 <tr><td>STORAGE</td><td>leases.epoch</td><td>Number of replica leaseholders using epoch-based leases</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>leases.error</td><td>Number of failed lease requests</td><td>Lease Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>leases.expiration</td><td>Number of replica leaseholders using expiration-based leases</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>leases.leader</td><td>Number of replica leaseholders using leader leases</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>leases.liveness</td><td>Number of replica leaseholders for the liveness range(s)</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>leases.preferences.less-preferred</td><td>Number of replica leaseholders which satisfy a lease preference which is not the most preferred</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>leases.preferences.violating</td><td>Number of replica leaseholders which violate lease preferences</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -197,12 +197,13 @@ func TestLeaseQueueExpirationLeasesOnly(t *testing.T) {
 		require.NoError(t, db.AdminSplit(ctx, splitKey, hlc.MaxTimestamp))
 	}
 
-	countLeases := func() (epoch int64, expiration int64) {
+	countLeases := func() (epoch, leader, expiration int64) {
 		for i := 0; i < tc.NumServers(); i++ {
 			require.NoError(t, tc.Server(i).GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
 				require.NoError(t, s.ComputeMetrics(ctx))
-				expiration += s.Metrics().LeaseExpirationCount.Value()
 				epoch += s.Metrics().LeaseEpochCount.Value()
+				leader += s.Metrics().LeaseLeaderCount.Value()
+				expiration += s.Metrics().LeaseExpirationCount.Value()
 				return nil
 			}))
 		}
@@ -213,19 +214,20 @@ func TestLeaseQueueExpirationLeasesOnly(t *testing.T) {
 	// meta and liveness ranges require expiration leases. However, it's possible
 	// that there are a few other stray expiration leases too, since lease
 	// transfers use expiration leases as well.
-	epochLeases, expLeases := countLeases()
+	epochLeases, leaderLeases, expLeases := countLeases()
 	require.NotZero(t, epochLeases)
+	require.Zero(t, leaderLeases)
 	require.NotZero(t, expLeases)
 	initialExpLeases := expLeases
-	t.Logf("initial: epochLeases=%d expLeases=%d", epochLeases, expLeases)
+	t.Logf("initial: epochLeases=%d leaderLeases=%d expLeases=%d", epochLeases, leaderLeases, expLeases)
 
 	// Switch to expiration leases and wait for them to change.
 	_, err := sqlDB.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = true`)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		epochLeases, expLeases = countLeases()
-		t.Logf("enabling: epochLeases=%d expLeases=%d", epochLeases, expLeases)
-		return epochLeases == 0 && expLeases > 0
+		epochLeases, leaderLeases, expLeases = countLeases()
+		t.Logf("enabling: epochLeases=%d leaderLeases=%d expLeases=%d", epochLeases, leaderLeases, expLeases)
+		return epochLeases == 0 && leaderLeases == 0 && expLeases > 0
 	}, 30*time.Second, 500*time.Millisecond) // accomodate stress/deadlock builds
 
 	// Run a scan across the ranges, just to make sure they work.
@@ -242,9 +244,9 @@ func TestLeaseQueueExpirationLeasesOnly(t *testing.T) {
 	_, err = sqlDB.ExecContext(ctx, `SET CLUSTER SETTING kv.expiration_leases_only.enabled = false`)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		epochLeases, expLeases = countLeases()
-		t.Logf("disabling: epochLeases=%d expLeases=%d", epochLeases, expLeases)
-		return epochLeases > 0 && expLeases > 0 && expLeases <= initialExpLeases
+		epochLeases, leaderLeases, expLeases = countLeases()
+		t.Logf("disabling: epochLeases=%d leaderLeases=%d expLeases=%d", epochLeases, leaderLeases, expLeases)
+		return epochLeases > 0 && leaderLeases == 0 && expLeases > 0 && expLeases <= initialExpLeases
 	}, 30*time.Second, 500*time.Millisecond)
 }
 

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -165,6 +165,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaLeaseLeaderCount = metric.Metadata{
+		Name:        "leases.leader",
+		Help:        "Number of replica leaseholders using leader leases",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaLeaseLivenessCount = metric.Metadata{
 		Name:        "leases.liveness",
 		Help:        "Number of replica leaseholders for the liveness range(s)",
@@ -2560,6 +2566,7 @@ type StoreMetrics struct {
 	LeaseTransferErrorCount        *metric.Counter
 	LeaseExpirationCount           *metric.Gauge
 	LeaseEpochCount                *metric.Gauge
+	LeaseLeaderCount               *metric.Gauge
 	LeaseLivenessCount             *metric.Gauge
 	LeaseViolatingPreferencesCount *metric.Gauge
 	LeaseLessPreferredCount        *metric.Gauge
@@ -3259,6 +3266,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		LeaseTransferErrorCount:        metric.NewCounter(metaLeaseTransferErrorCount),
 		LeaseExpirationCount:           metric.NewGauge(metaLeaseExpirationCount),
 		LeaseEpochCount:                metric.NewGauge(metaLeaseEpochCount),
+		LeaseLeaderCount:               metric.NewGauge(metaLeaseLeaderCount),
 		LeaseLivenessCount:             metric.NewGauge(metaLeaseLivenessCount),
 		LeaseViolatingPreferencesCount: metric.NewGauge(metaLeaseViolatingPreferencesCount),
 		LeaseLessPreferredCount:        metric.NewGauge(metaLeaseLessPreferredCount),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3188,6 +3188,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		leaseHolderCount               int64
 		leaseExpirationCount           int64
 		leaseEpochCount                int64
+		leaseLeaderCount               int64
 		leaseLivenessCount             int64
 		leaseViolatingPreferencesCount int64
 		leaseLessPreferredCount        int64
@@ -3261,6 +3262,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 				leaseExpirationCount++
 			case roachpb.LeaseEpoch:
 				leaseEpochCount++
+			case roachpb.LeaseLeader:
+				leaseLeaderCount++
 			}
 			if metrics.LivenessLease {
 				leaseLivenessCount++
@@ -3331,6 +3334,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)
+	s.metrics.LeaseLeaderCount.Update(leaseLeaderCount)
 	s.metrics.LeaseViolatingPreferencesCount.Update(leaseViolatingPreferencesCount)
 	s.metrics.LeaseLessPreferredCount.Update(leaseLessPreferredCount)
 	s.metrics.LeaseLivenessCount.Update(leaseLivenessCount)


### PR DESCRIPTION
Fixes #125238.

This commit adds a new metric, `leases.leader`, which tracks the number of replica leaseholders using leader leases. Currently, the metric is always 0.

Release note: None