### PR TITLE
schematelemetry: don't redact object ID or validation error in logs

### DIFF
--- a/pkg/sql/catalog/schematelemetry/BUILD.bazel
+++ b/pkg/sql/catalog/schematelemetry/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/catalog/schematelemetry/schema_telemetry_test.go
+++ b/pkg/sql/catalog/schematelemetry/schema_telemetry_test.go
@@ -186,7 +186,7 @@ UPDATE system.namespace SET id = %d WHERE id = %d;
 
 	// Ensure that a log line is emitted for each invalid object, with a loose
 	// enforcement of the log structure.
-	errorRE := regexp.MustCompile(`found invalid object with ID \d+: ".+"`)
+	errorRE := regexp.MustCompile(`found invalid object with ID \d+: .+`)
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1000, errorRE, log.SelectEditMode(false, false))
 	require.NoError(t, err)
 	require.Len(t, entries, 9)


### PR DESCRIPTION
fixes: #126584
Release note: None