### PR TITLE
kvserver/rangefeed: fix error handling in intent scanner

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -135,18 +135,23 @@ type Processor interface {
 	// It is ok to start registering streams before background initialization
 	// completes.
 	//
-	// The provided iterator is used to initialize the rangefeed's resolved
-	// timestamp. It must obey the contract of an iterator used for an
-	// initResolvedTSScan. The Processor promises to clean up the iterator by
-	// calling its Close method when it is finished.
+	// The provided IntentScannerConstructor is used to construct a lock table
+	// iterator which will be used to initialize rangefeed's resolved timestamp.
+	// It must be called under the same raftMu lock as first registration to
+	// ensure that there would be no missing events. For LegacyProcessor, this is
+	// currently achieved by Register function synchronizing with the work loop
+	// before the lock is released. For ScheduledProcessor, this is achieved by
+	// calling IntentScannerConstructor synchronously during Start.
 	//
-	// Note that newRtsIter must be called under the same lock as first
-	// registration to ensure that all there would be no missing events.
-	// This is currently achieved by Register function synchronizing with
-	// the work loop before the lock is released.
+	// If IntentScannerConstructor returns a non-nil error, the processor will be
+	// stopped. Otherwise, the intent scanner is successfully initialized. It must
+	// obey the contract of an iterator used for an initResolvedTSScan. The
+	// processor promises to clean up the iterator by calling its Close method when
+	// it's finished.
 	//
-	// If the iterator is nil then no initialization scan will be performed and
-	// the resolved timestamp will immediately be considered initialized.
+	// If the provided IntentScannerConstructor itself is nil then no
+	// initialization scan will be performed and the resolved timestamp will
+	// immediately be considered initialized. This is only possible in tests.
 	Start(stopper *stop.Stopper, newRtsIter IntentScannerConstructor) error
 	// Stop processor and close all registrations.
 	//
@@ -302,4 +307,4 @@ type logicalOpMetadata struct {
 // IntentScannerConstructor is used to construct an IntentScanner. It
 // should be called from underneath a stopper task to ensure that the
 // engine has not been closed.
-type IntentScannerConstructor func() IntentScanner
+type IntentScannerConstructor func() (IntentScanner, error)

--- a/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
@@ -283,8 +283,8 @@ func withMetrics(m *Metrics) option {
 func withRtsScanner(scanner IntentScanner) option {
 	return func(config *testConfig) {
 		if scanner != nil {
-			config.isc = func() IntentScanner {
-				return scanner
+			config.isc = func() (IntentScanner, error) {
+				return scanner, nil
 			}
 		}
 	}

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -499,19 +499,13 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	p = rangefeed.NewProcessor(cfg)
 
 	// Start it with an iterator to initialize the resolved timestamp.
-	rtsIter := func() rangefeed.IntentScanner {
+	rtsIter := func() (rangefeed.IntentScanner, error) {
 		// Assert that we still hold the raftMu when this is called to ensure
 		// that the rtsIter reads from the current snapshot. The replica
 		// synchronizes with the rangefeed Processor calling this function by
 		// waiting for the Register call below to return.
 		r.raftMu.AssertHeld()
-
-		scanner, err := rangefeed.NewSeparatedIntentScanner(streamCtx, r.store.TODOEngine(), desc.RSpan())
-		if err != nil {
-			stream.Disconnect(kvpb.NewError(err))
-			return nil
-		}
-		return scanner
+		return rangefeed.NewSeparatedIntentScanner(streamCtx, r.store.TODOEngine(), desc.RSpan())
 	}
 
 	// NB: This only errors if the stopper is stopping, and we have to return here


### PR DESCRIPTION
Previously, when `IntentScannerConstructor` returned an error, only the first
rangefeed registration on the replica was disconnected as part of the error
handling. This worked because `IntentScannerConstructor` was called before the
first `Register` function finished to avoid missing events. But this feels like
a brittle assumption.

Additionally, we should not continue running `initialSan.Run` when the
constructor returns an error as this could lead to nil pointer panics.

Comments also incorrectly stated that the resolved timestamp is considered
immediately initialized if the provided iterator is nil. We actually check for
`IntentScannerConstructor`, not the iterator itself. Passing a nil
`IntentScannerConstructor` should only be possible in tests, and it shouldn't be
possible for `IntentScannerConstructor` to return a nil `IntentScanner` without
an error.

This patch fixes these issues by updating the comments and stopping the entire
processor when the constructor returns an error.

Epic: none

Release note: Fixed a rare bug introduced in v20.2 that could cause panics if
the intent scanner failed to construct during processor initialization.