### PR TITLE
pkg/cli: add --locality-file to server start commands

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -125,7 +125,23 @@ including fewer. For example:
 <PRE>
 
   --locality=cloud=gce,region=us-west1,zone=us-west-1b
-  --locality=cloud=aws,region=us-east,zone=us-east-2</PRE>`,
+  --locality=cloud=aws,region=us-east,zone=us-east-2
+
+</PRE>
+This flag is incompatible with --locality-file.`,
+	}
+
+	LocalityFile = FlagInfo{
+		Name: "locality-file",
+		Description: `
+File name to read locality data from. Using this flag has the same effect as
+providing the file's contents directly via the --locality flag. Any leading or
+trailing whitespace characters, as defined by Unicode, will be automatically
+trimmed.
+<PRE>
+
+</PRE>
+This flag is incompatible with --locality.`,
 	}
 
 	Background = FlagInfo{

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -493,8 +493,9 @@ type SQLConfig struct {
 	// The tenant that the SQL server runs on the behalf of.
 	TenantID roachpb.TenantID
 
-	// If set, will to be called at server startup to obtain the tenant id.
-	DelayedSetTenantID func(context.Context) (roachpb.TenantID, error)
+	// If set, will to be called at server startup to obtain the tenant id and
+	// locality.
+	DelayedSetTenantID func(context.Context) (roachpb.TenantID, roachpb.Locality, error)
 
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -297,11 +297,15 @@ func newTenantServer(
 	// case, DelayedSetTenantID will be set and should be used to populate
 	// TenantID in the config. We call it here as we need a valid TenantID below.
 	if sqlCfg.DelayedSetTenantID != nil {
-		cfgTenantID, err := sqlCfg.DelayedSetTenantID(ctx)
+		cfgTenantID, cfgLocality, err := sqlCfg.DelayedSetTenantID(ctx)
 		if err != nil {
 			return nil, err
 		}
+		// We need to update sqlCfg and baseCfg here explicitly since copies
+		// were passed into newTenantServer instead of the original serverCfg
+		// object.
 		sqlCfg.TenantID = cfgTenantID
+		baseCfg.Locality = cfgLocality
 	}
 	log.Ops.Infof(ctx, "server starting for tenant %q", redact.Safe(sqlCfg.TenantID))
 	// Inform the server identity provider that we're operating


### PR DESCRIPTION
Previously, we can only specify locality configurations via the --locality
flag. This commit introduces a new --locality-file flag to all server start
commands (i.e. start, start-single-node, and mt start-sql), and would allow
us to specify locality configurations via a file. Note that for the specified
file, all leading and trailing whitespaces will be trimmed before processing.

This addresses a situation in CockroachDB Cloud where we are unable to access
the locality of the SQL servers during process startup, and we need to
populate this after. CockroachDB Cloud runs SQL pods for Serverless via the
`mt start-sql` subcommand, alongside with the `--tenant-id-file` flag. When
such a flag is specified, we will defer the loading of the locality file until
the tenant ID has been read. This would allow us to populate the locality file
during runtime (i.e. after the cockroach process has fully started).

Epic: none

Release note (cli change): A new `--locality-file` flag has been added to all
server start commands. With this flag, locality configurations can be
specified via a file, and this has the same effect as providing the file's
contents directly via the `--locality` flag.