### PR TITLE
kv: support Leader lease construction and validation

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/lease_status.go
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.go
@@ -45,6 +45,14 @@ func (st LeaseStatus) Expiration() hlc.Timestamp {
 			exp.Forward(st.Liveness.Expiration.ToTimestamp())
 		}
 		return exp
+	case roachpb.LeaseLeader:
+		exp := st.Lease.MinExpiration
+		// The leader support applies to the lease iff the lease term matches the
+		// raft term.
+		if st.Lease.Term == st.LeaderSupport.Term {
+			exp.Forward(st.LeaderSupport.LeadSupportUntil)
+		}
+		return exp
 	default:
 		panic("unexpected")
 	}

--- a/pkg/kv/kvserver/kvserverpb/lease_status.proto
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.proto
@@ -100,4 +100,17 @@ message LeaseStatus {
   // The minimum observed timestamp on a transaction that is respected by this lease.
   util.hlc.Timestamp min_valid_observed_timestamp = 7 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
+  // Raft leadership support, if this is a leader lease for a leader lease's
+  // associated term.
+  RaftLeaderSupport leader_support = 8 [(gogoproto.nullable) = false];
+}
+
+// RaftLeaderSupport holds the leader lease state.
+message RaftLeaderSupport {
+  // Term is the current raft term known to the local replica.
+  uint64 term = 1;
+  // LeadSupportUntil is the timestamp at which the local replica, if leader,
+  // knows it has support to remain leader until. If the leader has not yet
+  // fortified its leadership, this will be the zero timestamp.
+  util.hlc.Timestamp lead_support_until = 2 [(gogoproto.nullable) = false];
 }

--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -152,6 +152,9 @@ func (i BuildInput) validate() error {
 	if i.Now.IsEmpty() {
 		return errors.AssertionFailedf("no clock timestamp provided")
 	}
+	if i.RaftStatus == nil {
+		return errors.AssertionFailedf("no raft status provided")
+	}
 	if i.Remote() {
 		return errors.AssertionFailedf("cannot acquire/extend lease for remote "+
 			"replica: %v -> %v", i.PrevLease, i.NextLeaseHolder)

--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -34,6 +34,9 @@ type Settings struct {
 	// leases that are later upgraded to epoch-based ones or whether we transfer
 	// epoch-based leases directly.
 	TransferExpirationLeases bool
+	// PreferLeaderLeasesOverEpochLeases controls whether leader leases are
+	// preferred over epoch-based leases for this range.
+	PreferLeaderLeasesOverEpochLeases bool
 	// RejectLeaseOnLeaderUnknown controls whether a replica that does not know
 	// the current raft leader rejects a lease request.
 	RejectLeaseOnLeaderUnknown bool
@@ -139,10 +142,17 @@ func (i BuildInput) Remote() bool { return !i.PrevLocal() && !i.NextLocal() }
 
 // PrevLeaseExpiration returns the expiration time of the previous lease.
 func (i BuildInput) PrevLeaseExpiration() hlc.Timestamp {
-	return kvserverpb.LeaseStatus{
+	st := kvserverpb.LeaseStatus{
 		Lease:    i.PrevLease,
 		Liveness: i.PrevLeaseNodeLiveness,
-	}.Expiration()
+	}
+	if i.PrevLease.Replica.StoreID == i.LocalStoreID {
+		st.LeaderSupport = kvserverpb.RaftLeaderSupport{
+			Term:             i.RaftStatus.Term,
+			LeadSupportUntil: i.RaftStatus.LeadSupportUntil,
+		}
+	}
+	return st.Expiration()
 }
 
 func (i BuildInput) validate() error {
@@ -301,6 +311,9 @@ func build(st Settings, nl NodeLiveness, i BuildInput) (Output, error) {
 		nextLeaseLiveness = &l.Liveness
 
 		nextLease.MinExpiration = leaseMinTimestamp(st, i, nextLeaseType)
+	case roachpb.LeaseLeader:
+		nextLease.Term = leaseTerm(i, nextLeaseType)
+		nextLease.MinExpiration = leaseMinTimestamp(st, i, nextLeaseType)
 	default:
 		panic("unexpected")
 	}
@@ -326,12 +339,16 @@ func build(st Settings, nl NodeLiveness, i BuildInput) (Output, error) {
 }
 
 func leaseType(st Settings, i BuildInput) roachpb.LeaseType {
-	if st.UseExpirationLeases || (i.Transfer() && st.TransferExpirationLeases) {
+	if st.UseExpirationLeases {
+		// If the range should use expiration-based leases, construct one.
+		return roachpb.LeaseExpiration
+	}
+	if i.Transfer() && (st.TransferExpirationLeases || st.PreferLeaderLeasesOverEpochLeases) {
 		// In addition to ranges that should be using expiration-based leases
 		// (typically the meta and liveness ranges), we also use them during lease
 		// transfers for all other ranges. After acquiring these expiration based
 		// leases, the leaseholders are expected to upgrade them to the more
-		// efficient epoch-based ones. But by transferring an expiration-based
+		// efficient epoch/leader leases. But by transferring an expiration-based
 		// lease, we can limit the effect of an ill-advised lease transfer since the
 		// incoming leaseholder needs to recognize itself as such within a few
 		// seconds; if it doesn't (we accidentally sent the lease to a replica in
@@ -340,9 +357,33 @@ func leaseType(st Settings, i BuildInput) roachpb.LeaseType {
 		// leaseholder that's delayed in applying the lease transfer to maintain its
 		// lease (assuming the node it's on is able to heartbeat its liveness
 		// record).
+		//
+		// This safety concern is not a problem with leader leases. However, at the
+		// time of initiating a lease transfer, the target is (typically) not the
+		// raft leader, so we have no term to associate a leader lease with, so we
+		// have no choice but to transfer an expiration-based lease and let the
+		// recipient upgrade it to a leader lease when it becomes leader.
 		return roachpb.LeaseExpiration
 	}
-	return roachpb.LeaseEpoch
+	if !st.PreferLeaderLeasesOverEpochLeases {
+		// If this range is not preferring leader leases over epoch leases, we
+		// construct an epoch-based lease.
+		return roachpb.LeaseEpoch
+	}
+	if i.RaftStatus.RaftState != raft.StateLeader {
+		// If this range wants to use a leader lease, but it is not currently the
+		// raft leader, we construct an expiration-based lease. It is highly likely
+		// that the lease acquisition will be rejected before being proposed by the
+		// lease safety checks in verifyAcquisition. If not (e.g. because the
+		// kv.lease.reject_on_leader_unknown.enabled setting is set to a non-default
+		// value of false), we may end up with an expiration-based lease, which is
+		// safe and can be upgraded to a leader lease when the range becomes the
+		// leader.
+		return roachpb.LeaseExpiration
+	}
+	// We're the leader and we prefer leader leases, so we construct a leader
+	// lease associated with the current raft term.
+	return roachpb.LeaseLeader
 }
 
 func leaseReplica(i BuildInput) roachpb.ReplicaDescriptor {
@@ -427,22 +468,61 @@ func leaseEpoch(
 }
 
 func leaseMinTimestamp(st Settings, i BuildInput, nextType roachpb.LeaseType) hlc.Timestamp {
-	if nextType != roachpb.LeaseEpoch {
-		panic("leaseMinTimestamp called for non-epoch lease")
-	}
-	if !st.MinExpirationSupported {
+	switch nextType {
+	case roachpb.LeaseEpoch:
+		if !st.MinExpirationSupported {
+			return hlc.Timestamp{}
+		}
+		// If we are promoting an expiration-based lease to an epoch-based lease, we
+		// must make sure the expiration does not regress. Do so by assigning a
+		// minimum expiration time to the new lease, which sets a lower bound for the
+		// lease's expiration, independent of the expiration stored indirectly in the
+		// liveness record.
+		expPromo := i.Extension() && i.PrevLease.Type() == roachpb.LeaseExpiration
+		if expPromo {
+			return *i.PrevLease.Expiration
+		}
 		return hlc.Timestamp{}
+	case roachpb.LeaseLeader:
+		if !st.MinExpirationSupported {
+			panic("cannot construct leader lease without minimum expiration support")
+		}
+		// If we are constructing a leader lease, always set a minimum expiration
+		// time, regardless of whether this is a promotion from an expiration-based
+		// lease or not. This provides a lower bound for the lease's expiration,
+		// independent of the leader fortification.
+		//
+		// This is necessary for correctness during promotion from expiration-based
+		// leases, where the previous lease has not yet expired. In these cases, not
+		// assigning a minimum expiration time could allow the new lease to have a
+		// lower expiration time than the previous lease, which could lead to
+		// violations of the Lease Disjointness property if the new lease is never
+		// extended.
+		//
+		// This is not necessary for correctness during normal leader lease
+		// acquisition. In these cases, the previous lease has already expired, so
+		// there's no chance of an expiration regression. Still, it is still useful
+		// to set a minimum expiration time so that the new lease is guaranteed to
+		// have some validity period, even if the raft leader is unable to fortify.
+		minExp := i.Now.ToTimestamp().Add(int64(st.RangeLeaseDuration), 0)
+		minExp.Forward(i.PrevLeaseExpiration())
+		return minExp
+	default:
+		panic("leaseMinTimestamp called for non-epoch and non-leader lease")
 	}
-	// If we are promoting an expiration-based lease to an epoch-based lease, we
-	// must make sure the expiration does not regress. Do so by assigning a
-	// minimum expiration time to the new lease, which sets a lower bound for the
-	// lease's expiration, independent of the expiration stored indirectly in the
-	// liveness record.
-	expPromo := i.Extension() && i.PrevLease.Type() == roachpb.LeaseExpiration
-	if expPromo {
-		return *i.PrevLease.Expiration
+}
+
+func leaseTerm(i BuildInput, nextType roachpb.LeaseType) uint64 {
+	if nextType != roachpb.LeaseLeader {
+		panic("leaseTerm called for non-leader lease")
 	}
-	return hlc.Timestamp{}
+	if i.RaftStatus.RaftState != raft.StateLeader {
+		panic("leaseTerm called when not leader")
+	}
+	if i.RaftStatus.Term == 0 {
+		panic("leaseTerm called with term 0")
+	}
+	return i.RaftStatus.Term
 }
 
 func leaseDeprecatedStartStasis(i BuildInput, nextExpiration *hlc.Timestamp) *hlc.Timestamp {
@@ -538,6 +618,7 @@ var leaseValidationFuncs = []func(i BuildInput, nextLease roachpb.Lease) error{
 	validateExpiration,
 	validateAcquisitionType,
 	validateSequence,
+	validateMinExpiration,
 }
 
 func validateReplica(_ BuildInput, nextLease roachpb.Lease) error {
@@ -584,6 +665,10 @@ func validateExpiration(_ BuildInput, nextLease roachpb.Lease) error {
 		if nextLease.Expiration != nil {
 			return errors.AssertionFailedf("expiration assigned to epoch-based lease")
 		}
+	case roachpb.LeaseLeader:
+		if nextLease.Expiration != nil {
+			return errors.AssertionFailedf("expiration assigned to leader lease")
+		}
 	default:
 		panic("unexpected")
 	}
@@ -596,6 +681,24 @@ func validateAcquisitionType(_ BuildInput, nextLease roachpb.Lease) error {
 
 func validateSequence(_ BuildInput, nextLease roachpb.Lease) error {
 	return validateNonZero(nextLease.Sequence, "sequence")
+}
+
+func validateMinExpiration(_ BuildInput, nextLease roachpb.Lease) error {
+	switch nextLease.Type() {
+	case roachpb.LeaseExpiration:
+		if !nextLease.MinExpiration.IsEmpty() {
+			return errors.AssertionFailedf("minimum expiration assigned to expiration-based lease")
+		}
+	case roachpb.LeaseEpoch:
+		// Epoch-based leases may or may not have a minimum expiration time set.
+	case roachpb.LeaseLeader:
+		if nextLease.MinExpiration.IsEmpty() {
+			return errors.AssertionFailedf("minimum expiration not assigned to leader lease")
+		}
+	default:
+		panic("unexpected")
+	}
+	return nil
 }
 
 func validateNonZero[T comparable](field T, name string) error {

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -54,6 +54,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:    repl1.StoreID,
 				Now:             cts20,
+				RaftStatus:      &raft.Status{},
 				PrevLease:       roachpb.Lease{Replica: repl2, Expiration: &ts30},
 				NextLeaseHolder: repl2,
 			},
@@ -64,6 +65,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:     repl1.StoreID,
 				Now:              cts20,
+				RaftStatus:       &raft.Status{},
 				PrevLease:        roachpb.Lease{Replica: repl2, Epoch: 3},
 				PrevLeaseExpired: true,
 				NextLeaseHolder:  repl1,
@@ -75,6 +77,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:          repl1.StoreID,
 				Now:                   cts20,
+				RaftStatus:            &raft.Status{},
 				PrevLease:             roachpb.Lease{Replica: repl2, Expiration: &ts30},
 				PrevLeaseNodeLiveness: defaultNodeLivenessRecord(repl2.NodeID).Liveness,
 				PrevLeaseExpired:      true,
@@ -87,6 +90,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:     repl1.StoreID,
 				Now:              cts20,
+				RaftStatus:       &raft.Status{},
 				PrevLease:        roachpb.Lease{Replica: repl2, Expiration: &ts30},
 				PrevLeaseExpired: true,
 				NextLeaseHolder:  repl1,
@@ -98,6 +102,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:     repl1.StoreID,
 				Now:              cts20,
+				RaftStatus:       &raft.Status{},
 				PrevLease:        roachpb.Lease{Replica: repl2, Expiration: &ts10},
 				PrevLeaseExpired: false,
 				NextLeaseHolder:  repl1,
@@ -109,6 +114,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:     repl1.StoreID,
 				Now:              cts20,
+				RaftStatus:       &raft.Status{},
 				PrevLease:        roachpb.Lease{Replica: repl2, Expiration: &ts30},
 				PrevLeaseExpired: false,
 				NextLeaseHolder:  repl1,
@@ -120,6 +126,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:       repl1.StoreID,
 				Now:                cts20,
+				RaftStatus:         &raft.Status{},
 				PrevLease:          roachpb.Lease{Replica: repl2, Expiration: &ts10},
 				PrevLeaseExpired:   true,
 				NextLeaseHolder:    repl1,
@@ -132,6 +139,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:     repl1.StoreID,
 				Now:              cts20,
+				RaftStatus:       &raft.Status{},
 				PrevLease:        roachpb.Lease{Replica: repl2, Expiration: &ts10},
 				PrevLeaseExpired: true,
 				NextLeaseHolder:  repl1,
@@ -143,6 +151,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:    repl1.StoreID,
 				Now:             cts20,
+				RaftStatus:      &raft.Status{},
 				PrevLease:       roachpb.Lease{Replica: repl1, Expiration: &ts30},
 				NextLeaseHolder: repl1,
 			},
@@ -153,6 +162,7 @@ func TestInputValidation(t *testing.T) {
 			input: BuildInput{
 				LocalStoreID:    repl1.StoreID,
 				Now:             cts20,
+				RaftStatus:      &raft.Status{},
 				PrevLease:       roachpb.Lease{Replica: repl1, Expiration: &ts30},
 				NextLeaseHolder: repl2,
 			},

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -184,12 +185,13 @@ func TestInputValidation(t *testing.T) {
 
 func defaultSettings() Settings {
 	return Settings{
-		UseExpirationLeases:        false,
-		TransferExpirationLeases:   true,
-		RejectLeaseOnLeaderUnknown: true,
-		ExpToEpochEquiv:            true,
-		MinExpirationSupported:     true,
-		RangeLeaseDuration:         20,
+		UseExpirationLeases:               false,
+		TransferExpirationLeases:          true,
+		PreferLeaderLeasesOverEpochLeases: false,
+		RejectLeaseOnLeaderUnknown:        true,
+		ExpToEpochEquiv:                   true,
+		MinExpirationSupported:            true,
+		RangeLeaseDuration:                20,
 	}
 }
 
@@ -197,6 +199,27 @@ func useExpirationSettings() Settings {
 	st := defaultSettings()
 	st.UseExpirationLeases = true
 	return st
+}
+
+func useLeaderSettings() Settings {
+	st := defaultSettings()
+	st.PreferLeaderLeasesOverEpochLeases = true
+	return st
+}
+
+func raftStatusFollower(replicaID roachpb.ReplicaID) *raft.Status {
+	s := &raft.Status{}
+	s.ID = raftpb.PeerID(replicaID)
+	s.Term = 5
+	s.RaftState = raft.StateFollower
+	return s
+}
+
+func raftStatusLeader(replicaID roachpb.ReplicaID) *raft.Status {
+	s := raftStatusFollower(replicaID)
+	s.RaftState = raft.StateLeader
+	s.LeadSupportUntil = ts30
+	return s
 }
 
 // mockNodeLiveness implements the NodeLiveness interface.
@@ -249,6 +272,7 @@ func TestBuild(t *testing.T) {
 				if nl == nil {
 					nl = defaultNodeLiveness()
 				}
+				require.NoError(t, tt.input.validate())
 				out, err := build(st, nl, tt.input)
 				if tt.expErr == "" {
 					require.NoError(t, err)
@@ -266,6 +290,7 @@ func TestBuild(t *testing.T) {
 		defaultInput := BuildInput{
 			LocalStoreID: repl1.StoreID,
 			Now:          cts20,
+			RaftStatus:   raftStatusLeader(repl1.ReplicaID),
 			PrevLease: roachpb.Lease{
 				Replica:  repl2,
 				Epoch:    2,
@@ -390,6 +415,82 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			{
+				name:  "acquire leader lease",
+				st:    useLeaderSettings(),
+				input: defaultInput,
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:         repl1,
+						Start:           cts20,
+						ProposedTS:      cts20,
+						Term:            5,
+						Sequence:        8,
+						AcquisitionType: roachpb.LeaseAcquisitionType_Request,
+						MinExpiration:   ts40,
+					},
+				},
+			},
+			{
+				name:  "replace expiration, acquire leader lease",
+				st:    useLeaderSettings(),
+				input: expirationInput,
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica: repl1,
+						// Start time backdated to the expiration of the previous lease.
+						Start:           hlc.ClockTimestamp{WallTime: 10, Logical: 1},
+						ProposedTS:      cts20,
+						Term:            5,
+						Sequence:        8,
+						AcquisitionType: roachpb.LeaseAcquisitionType_Request,
+						MinExpiration:   ts40,
+					},
+				},
+			},
+			{
+				name: "acquire leader lease, as raft follower",
+				st:   useLeaderSettings(),
+				input: func() BuildInput {
+					i := defaultInput
+					i.RaftStatus = raftStatusFollower(repl1.ReplicaID)
+					return i
+				}(),
+				// The replica is a follower, so it gets an expiration-based lease.
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:               repl1,
+						Start:                 cts20,
+						ProposedTS:            cts20,
+						Expiration:            &ts40,
+						DeprecatedStartStasis: &ts40,
+						Sequence:              8,
+						AcquisitionType:       roachpb.LeaseAcquisitionType_Request,
+					},
+				},
+			},
+			{
+				name: "replace expiration, acquire leader lease, as raft follower",
+				st:   useLeaderSettings(),
+				input: func() BuildInput {
+					i := expirationInput
+					i.RaftStatus = raftStatusFollower(repl1.ReplicaID)
+					return i
+				}(),
+				// The replica is a follower, so it gets an expiration-based lease.
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica: repl1,
+						// Start time backdated to the expiration of the previous lease.
+						Start:                 hlc.ClockTimestamp{WallTime: 10, Logical: 1},
+						ProposedTS:            cts20,
+						Expiration:            &ts40,
+						DeprecatedStartStasis: &ts40,
+						Sequence:              8,
+						AcquisitionType:       roachpb.LeaseAcquisitionType_Request,
+					},
+				},
+			},
+			{
 				name:   "missing node liveness",
 				nl:     missingNodeLiveness(),
 				input:  defaultInput,
@@ -402,6 +503,7 @@ func TestBuild(t *testing.T) {
 		defaultInput := BuildInput{
 			LocalStoreID: repl1.StoreID,
 			Now:          cts20,
+			RaftStatus:   raftStatusLeader(repl1.ReplicaID),
 			PrevLease: roachpb.Lease{
 				Replica:  repl1,
 				Start:    cts10,
@@ -414,6 +516,14 @@ func TestBuild(t *testing.T) {
 		expirationInput := func() BuildInput {
 			i := defaultInput
 			i.PrevLease.Expiration = &ts30
+			i.PrevLease.Epoch = 0
+			i.PrevLeaseNodeLiveness = livenesspb.Liveness{}
+			return i
+		}()
+		leaderInput := func() BuildInput {
+			i := defaultInput
+			i.PrevLease.Term = 5
+			i.PrevLease.MinExpiration = ts30
 			i.PrevLease.Epoch = 0
 			i.PrevLeaseNodeLiveness = livenesspb.Liveness{}
 			return i
@@ -540,6 +650,44 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			{
+				name:  "promote expiration to leader lease",
+				st:    useLeaderSettings(),
+				input: expirationInput,
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:         repl1,
+						Start:           cts10,
+						ProposedTS:      cts20,
+						Term:            5,
+						Sequence:        7, // sequence not changed
+						AcquisitionType: roachpb.LeaseAcquisitionType_Request,
+						MinExpiration:   ts40,
+					},
+				},
+			},
+			{
+				name: "promote expiration to leader lease, as raft follower",
+				st:   useLeaderSettings(),
+				input: func() BuildInput {
+					i := expirationInput
+					i.RaftStatus = raftStatusFollower(repl1.ReplicaID)
+					return i
+				}(),
+				// The replica is a follower, so it gets an (extended) expiration-based
+				// lease.
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:               repl1,
+						Start:                 cts10,
+						ProposedTS:            cts20,
+						Expiration:            &ts40,
+						DeprecatedStartStasis: &ts40,
+						Sequence:              7, // sequence not changed
+						AcquisitionType:       roachpb.LeaseAcquisitionType_Request,
+					},
+				},
+			},
+			{
 				name:  "extend expiration",
 				st:    useExpirationSettings(),
 				input: expirationInput,
@@ -576,6 +724,89 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			{
+				name:  "extend leader lease",
+				st:    useLeaderSettings(),
+				input: leaderInput,
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:         repl1,
+						Start:           cts10,
+						ProposedTS:      cts20,
+						Term:            5,
+						Sequence:        7, // sequence not changed
+						AcquisitionType: roachpb.LeaseAcquisitionType_Request,
+						MinExpiration:   ts40,
+					},
+				},
+			},
+			{
+				name: "extend leader lease, avoid shortening",
+				st:   useLeaderSettings(),
+				input: func() BuildInput {
+					i := leaderInput
+					i.PrevLease.MinExpiration = ts50
+					return i
+				}(),
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:         repl1,
+						Start:           cts10,
+						ProposedTS:      cts20,
+						Term:            5,
+						Sequence:        7, // sequence not changed
+						AcquisitionType: roachpb.LeaseAcquisitionType_Request,
+						MinExpiration:   ts50,
+					},
+				},
+			},
+			{
+				name: "extend leader lease, avoid shortening, as follower",
+				st:   useLeaderSettings(),
+				input: func() BuildInput {
+					i := leaderInput
+					i.PrevLease.MinExpiration = ts50
+					i.RaftStatus = raftStatusFollower(repl1.ReplicaID)
+					return i
+				}(),
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:               repl1,
+						Start:                 cts10,
+						ProposedTS:            cts20,
+						Expiration:            &ts50,
+						DeprecatedStartStasis: &ts50,
+						Sequence:              8, // sequence not changed
+						AcquisitionType:       roachpb.LeaseAcquisitionType_Request,
+					},
+				},
+			},
+			{
+				name: "extend leader lease, avoid shortening, as follower with remaining lead support",
+				st:   useLeaderSettings(),
+				input: func() BuildInput {
+					i := leaderInput
+					i.PrevLease.MinExpiration = ts40
+					// NOTE: even though the replica is a follower, it still has remaining
+					// lead support from when it was the leader. It has stepped down and
+					// is waiting out the remainder of its lead support before campaigning
+					// at a later term.
+					i.RaftStatus = raftStatusFollower(repl1.ReplicaID)
+					i.RaftStatus.LeadSupportUntil = ts50
+					return i
+				}(),
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:               repl1,
+						Start:                 cts10,
+						ProposedTS:            cts20,
+						Expiration:            &ts50,
+						DeprecatedStartStasis: &ts50,
+						Sequence:              8, // sequence not changed
+						AcquisitionType:       roachpb.LeaseAcquisitionType_Request,
+					},
+				},
+			},
+			{
 				name: "min proposed timestamp",
 				input: func() BuildInput {
 					i := defaultInput
@@ -606,6 +837,7 @@ func TestBuild(t *testing.T) {
 		defaultInput := BuildInput{
 			LocalStoreID: repl1.StoreID,
 			Now:          cts20,
+			RaftStatus:   raftStatusLeader(repl1.ReplicaID),
 			PrevLease: roachpb.Lease{
 				Replica:  repl1,
 				Start:    cts10,
@@ -618,6 +850,14 @@ func TestBuild(t *testing.T) {
 		expirationInput := func() BuildInput {
 			i := defaultInput
 			i.PrevLease.Expiration = &ts30
+			i.PrevLease.Epoch = 0
+			i.PrevLeaseNodeLiveness = livenesspb.Liveness{}
+			return i
+		}()
+		leaderInput := func() BuildInput {
+			i := defaultInput
+			i.PrevLease.Term = 5
+			i.PrevLease.MinExpiration = ts30
 			i.PrevLease.Epoch = 0
 			i.PrevLeaseNodeLiveness = livenesspb.Liveness{}
 			return i
@@ -641,6 +881,20 @@ func TestBuild(t *testing.T) {
 			{
 				name:  "transfer from expiration",
 				input: expirationInput,
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:         repl2,
+						Start:           cts20,
+						ProposedTS:      cts20,
+						Expiration:      &ts40,
+						Sequence:        8,
+						AcquisitionType: roachpb.LeaseAcquisitionType_Transfer,
+					},
+				},
+			},
+			{
+				name:  "transfer from leader lease",
+				input: leaderInput,
 				expOutput: Output{
 					NextLease: roachpb.Lease{
 						Replica:         repl2,
@@ -681,6 +935,28 @@ func TestBuild(t *testing.T) {
 				nl:     missingNodeLiveness(),
 				input:  expirationInput,
 				expErr: "liveness record not found in cache",
+			},
+			{
+				name: "cannot transfer to leader lease",
+				st: func() Settings {
+					st := defaultSettings()
+					st.TransferExpirationLeases = false
+					st.PreferLeaderLeasesOverEpochLeases = true
+					return st
+				}(),
+				input: defaultInput,
+				// PreferLeaderLeasesOverEpochLeases takes precedence over
+				// TransferExpirationLeases. We never transfer to a leader lease.
+				expOutput: Output{
+					NextLease: roachpb.Lease{
+						Replica:         repl2,
+						Start:           cts20,
+						ProposedTS:      cts20,
+						Expiration:      &ts40,
+						Sequence:        8,
+						AcquisitionType: roachpb.LeaseAcquisitionType_Transfer,
+					},
+				},
 			},
 		})
 	})

--- a/pkg/kv/kvserver/leases/status.go
+++ b/pkg/kv/kvserver/leases/status.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,6 +30,9 @@ type StatusInput struct {
 	MaxOffset          time.Duration
 	MinProposedTs      hlc.ClockTimestamp
 	MinValidObservedTs hlc.ClockTimestamp
+
+	// Information about raft.
+	RaftStatus raft.LeadSupportStatus
 
 	// The current time and the time of the request to evaluate the lease for.
 	Now       hlc.ClockTimestamp
@@ -113,7 +117,10 @@ func Status(ctx context.Context, nl NodeLiveness, i StatusInput) kvserverpb.Leas
 		RequestTime:               i.RequestTs,
 		MinValidObservedTimestamp: i.MinValidObservedTs,
 	}
-	if lease.Type() == roachpb.LeaseEpoch {
+	switch lease.Type() {
+	case roachpb.LeaseExpiration:
+		// lease.Expiration is the only field we need to evaluate the lease.
+	case roachpb.LeaseEpoch:
 		// For epoch-based leases, retrieve the node liveness record associated with
 		// the lease.
 		l, ok := nl.GetLiveness(lease.Replica.NodeID)
@@ -141,6 +148,57 @@ func Status(ctx context.Context, nl NodeLiveness, i StatusInput) kvserverpb.Leas
 		// liveness record's expiration to determine the expiration of the lease. If
 		// not, the lease is likely expired, but its minimum expiration may still be
 		// in the future (also consulted in status.Expiration), so we check below.
+	case roachpb.LeaseLeader:
+		// For leader leases, evaluate the Raft leader support information
+		// associated with the lease.
+		if lease.OwnedBy(i.LocalStoreID) {
+			// If the leader lease is held locally, we compare the term of the lease
+			// to the term of the Raft leader below in the call to status.Expiration
+			// to determine whether the current LeadSupportUntil contributes to the
+			// lease's expiration.
+			status.LeaderSupport = kvserverpb.RaftLeaderSupport{
+				Term:             i.RaftStatus.Term,
+				LeadSupportUntil: i.RaftStatus.LeadSupportUntil,
+			}
+		} else {
+			// If the leader lease is not held locally, we first consult the minimum
+			// expiration. This can quickly determine that the lease is valid if the
+			// minimum expiration is in the future, all without consulting raft leader
+			// support. If so, we fall through to below, where the minimum expiration
+			// is consulted in status.Expiration.
+			knownNotExpired := i.Now.ToTimestamp().Less(lease.MinExpiration)
+			if !knownNotExpired {
+				// Otherwise, the remote leader lease's validity depends on raft leader
+				// support. We can't infer the leader support status of the lease unless
+				// we know of a raft leader at a later term (which may be ourselves).
+				// Knowledge of a raft leader at a later term proves that the support
+				// for this earlier term (which the lease is associated with) has been
+				// lost, otherwise no new leader could have been elected.
+				//
+				// If we do not know of a leader at a later term, the leader's term may
+				// still be supported and the lease may still be valid. We cannot say
+				// for sure. In cases where the leaseholder crashes, we must wait for
+				// raft to elect a new leader before any other replica (typically the
+				// new leader) can determine the (in)validity of the old lease and go on
+				// to replace it.
+				knownSuccessor := i.RaftStatus.Term > lease.Term && i.RaftStatus.Lead != raft.None
+				if !knownSuccessor {
+					// TODO(nvanbenschoten): we could introduce a new INDETERMINATE state
+					// for this case, instead of using ERROR. This would look a bit less
+					// unexpected.
+					status.State = kvserverpb.LeaseState_ERROR
+					status.ErrInfo = "leader lease is not held locally, cannot determine validity"
+					return status
+				}
+				// We know of a newer raft leader. We still don't know the exact extent
+				// of the leader support that the lease had, but we know that leader
+				// support has either already expired or was never even established due
+				// to a failure of the raft leader to fortify. Either way, the leader of
+				// lease.Term cannot think this lease's leader support is in the future.
+			}
+		}
+	default:
+		panic("unexpected lease type")
 	}
 	expiration := status.Expiration()
 	maxOffset := i.MaxOffset

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1620,6 +1620,13 @@ func (r *Replica) raftBasicStatusRLocked() raft.BasicStatus {
 	return raft.BasicStatus{}
 }
 
+func (r *Replica) raftLeadSupportStatusRLocked() raft.LeadSupportStatus {
+	if rg := r.mu.internalRaftGroup; rg != nil {
+		return rg.LeadSupportStatus()
+	}
+	return raft.LeadSupportStatus{}
+}
+
 // State returns a copy of the internal state of the Replica, along with some
 // auxiliary information.
 func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -76,14 +76,15 @@ import (
 
 var TransferExpirationLeasesFirstEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
-	"kv.transfer_expiration_leases_first.enabled",
+	"kv.lease.transfer_expiration_leases_first.enabled",
 	"controls whether we transfer expiration-based leases that are later upgraded to epoch-based ones",
 	true,
+	settings.WithRetiredName("kv.transfer_expiration_leases_first.enabled"),
 )
 
 var ExpirationLeasesOnly = settings.RegisterBoolSetting(
 	settings.SystemOnly,
-	"kv.expiration_leases_only.enabled",
+	"kv.lease.expiration_leases_only.enabled",
 	"only use expiration-based leases never epoch-based ones "+
 		"when there are less than kv.lease.expiration_max_replicas_per_node on the node, "+
 		"(experimental, affects performance)",
@@ -91,7 +92,15 @@ var ExpirationLeasesOnly = settings.RegisterBoolSetting(
 	// builds because TestClusters are usually so slow that they're unable
 	// to maintain leases/leadership/liveness.
 	!syncutil.DeadlockEnabled &&
-		metamorphic.ConstantWithTestBool("kv.expiration_leases_only.enabled", false),
+		metamorphic.ConstantWithTestBool("kv.lease.expiration_leases_only.enabled", false),
+	settings.WithRetiredName("kv.expiration_leases_only.enabled"),
+)
+
+var PreferLeaderLeasesOverEpochLeases = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.lease.prefer_leader_leases_over_epoch_leases.enabled",
+	"controls whether leader leases are preferred over epoch-based leases",
+	envutil.EnvOrDefaultBool("COCKROACH_LEADER_LEASES", false),
 )
 
 // ExpirationLeasesMaxReplicasPerNode converts from expiration back to epoch
@@ -695,6 +704,14 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		RequestTs:          reqTS,
 		Lease:              *r.mu.state.Lease,
 	}
+	// TODO(nvanbenschoten): evaluate whether this is too expensive to compute for
+	// every lease status request. We may need to cache this result. If, at that
+	// time, we determine that it is sufficiently cheap, we should either compute
+	// it unconditionally, regardless of the lease type or let leases.Status
+	// decide when to compute it. See #125255.
+	if in.Lease.Type() == roachpb.LeaseLeader {
+		in.RaftStatus = r.raftLeadSupportStatusRLocked()
+	}
 	return leases.Status(ctx, r.store.cfg.NodeLiveness, in)
 }
 
@@ -719,6 +736,7 @@ func (r *Replica) leaseSettings(ctx context.Context) leases.Settings {
 	return leases.Settings{
 		UseExpirationLeases:                       r.shouldUseExpirationLeaseRLocked(),
 		TransferExpirationLeases:                  TransferExpirationLeasesFirstEnabled.Get(&r.store.ClusterSettings().SV),
+		PreferLeaderLeasesOverEpochLeases:         PreferLeaderLeasesOverEpochLeases.Get(&r.store.ClusterSettings().SV),
 		RejectLeaseOnLeaderUnknown:                RejectLeaseOnLeaderUnknown.Get(&r.store.ClusterSettings().SV),
 		DisableAboveRaftLeaseTransferSafetyChecks: r.store.cfg.TestingKnobs.DisableAboveRaftLeaseTransferSafetyChecks,
 		AllowLeaseProposalWhenNotLeader:           r.store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader,
@@ -1189,6 +1207,10 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 					msg = "lease state could not be determined"
 				}
 				log.VEventf(ctx, 2, "%s", msg)
+				// TODO(nvanbenschoten): now that leader leases are going to return an
+				// ERROR status on follower replicas instead of a VALID status, we will
+				// hit this path more. Do we need to add the lease to this
+				// NotLeaseHolder error to ensure fast redirection?
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
 					kvpb.NewNotLeaseHolderError(roachpb.Lease{}, r.store.StoreID(), r.mu.state.Desc, msg))
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2058,7 +2058,13 @@ func (l Lease) Equivalent(newL Lease, expToEpochEquiv bool) bool {
 			if l.GetExpiration().LessEq(newL.GetExpiration()) {
 				l.Expiration, newL.Expiration = nil, nil
 			}
+
+		default:
+			panic("unexpected lease type")
 		}
+
+	default:
+		panic("unexpected lease type")
 	}
 	return l == newL
 }


### PR DESCRIPTION
Part of #123847.
Part of #125237.
The remaining work for these issues is to test the integration with Raft once leader fortification is hooked up to `raft.Status.LeadSupportUntil`.

This commit adds the ability to construct a Leader lease and the ability to evaluate the validity of a Leader lease.

Construction of a Leader lease is straightforward. The Raft leader (fortified or not) is allowed to propose a Lease with a Term field set to the Leader's current term. This will bind the lease to the leadership term and permit the lease to inherit leader fortification support as its expiration (in addition to a minimum expiration). The lease remains valid for as long as the leader retains support from its quorum, which is all indirectly coordinated through Store Liveness.

Validation of a Leader lease is more complex due to an information asymmetry. The Raft leader knows its own term and its leader fortification support, so it can evaluate the lease's validity without ambiguity.

However, follower replicas do not have this information. Instead, they must rely on observing raft leadership changes to infer leader support. Specifically, a follower replica (during the lease's term) can not determine the leader support status of the lease unless it knows of a Raft leader at a later term (which may be itself). Knowledge of a Raft leader at a later term proves that the support for this earlier term (which the lease is associated with) has been lost, otherwise no new leader could have been elected. The ability to make this inference builds on the Raft leader fortification safety property.

If the follower replica (during the lease's term) does not know of a Raft leader at a later term, the leader's term may still be supported and the lease may still be valid. We cannot say for sure, so we must assume the lease is still valid and respect it. In cases where the leaseholder crashes, follower replicas must wait for raft to elect a new leader before any other replica (typically the new leader) can determine the (in)validity of the old lease and replace it.

Release note: None