### PR TITLE
workload/tpcc: fix hang on error or when the workload gets interrupted

### DIFF
--- a/pkg/workload/tpcc/BUILD.bazel
+++ b/pkg/workload/tpcc/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/bufalloc",
+        "//pkg/util/ctxgroup",
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -157,7 +157,7 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		)
 
 		// Starting the background goroutine which will reset the w_ytd values periodically in warehouseWytdResetPeriod
-		go p.startResetValueWorker(ctx)
+		go p.startResetValueWorker()
 	}
 
 	if err := p.sr.Init(ctx, "payment", mcp); err != nil {
@@ -167,45 +167,44 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 	return p, nil
 }
 
-func (p *payment) startResetValueWorker(ctx context.Context) {
-	ticker := time.NewTicker(warehouseWytdResetPeriod)
-	defer ticker.Stop()
+func (p *payment) startResetValueWorker() {
+	p.config.resetTableGrp.GoCtx(func(ctx context.Context) error {
+		ticker := time.NewTicker(warehouseWytdResetPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
 
-	p.config.resetTableWg.Add(1)
-	defer p.config.resetTableWg.Done()
+				// Creating batches of maxRowsToUpdateTxn to avoid long-running txns
+				for startRange := 0; startRange < p.config.warehouses; startRange += maxRowsToUpdateTxn {
+					endRange := min(p.config.warehouses, startRange+maxRowsToUpdateTxn)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+					if _, err := p.config.executeTx(
+						ctx, p.mcp.Get(),
+						func(tx pgx.Tx) error {
+							if _, err := p.resetWarehouse.ExecTx(
+								ctx, tx, wYtd, startRange, endRange,
+							); err != nil {
+								return errors.Wrap(err, "reset warehouse failed")
+							}
 
-			// Creating batches of maxRowsToUpdateTxn to avoid long-running txns
-			for startRange := 0; startRange < p.config.warehouses; startRange += maxRowsToUpdateTxn {
-				endRange := min(p.config.warehouses, startRange+maxRowsToUpdateTxn)
+							if _, err := p.resetDistrict.ExecTx(
+								ctx, tx, ytd, startRange, endRange,
+							); err != nil {
+								return errors.Wrap(err, "reset district failed")
+							}
 
-				if _, err := p.config.executeTx(
-					ctx, p.mcp.Get(),
-					func(tx pgx.Tx) error {
-						if _, err := p.resetWarehouse.ExecTx(
-							ctx, tx, wYtd, startRange, endRange,
-						); err != nil {
-							return errors.Wrap(err, "reset warehouse failed")
-						}
-
-						if _, err := p.resetDistrict.ExecTx(
-							ctx, tx, ytd, startRange, endRange,
-						); err != nil {
-							return errors.Wrap(err, "reset district failed")
-						}
-
-						return nil
-					}); err != nil {
-					log.Errorf(ctx, "%v", err)
+							return nil
+						}); err != nil {
+						log.Errorf(ctx, "%v", err)
+					}
 				}
 			}
 		}
-	}
+	})
+
 }
 
 func (p *payment) run(ctx context.Context, wID int) (interface{}, time.Duration, error) {

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -24,6 +24,7 @@ import (
 	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -131,8 +132,9 @@ type tpcc struct {
 	// In that case, we reset w_ytd & d_ytd periodically and skip 3.3.2.1 and 3.3.2.8 consistency checks.
 	isLongDurationWorkload bool
 
-	// wait group for any background reset table operation to avoid goroutine leaks during long duration workloads
-	resetTableWg sync.WaitGroup
+	// context group for any background reset table operation to avoid goroutine leaks during long duration workloads
+	resetTableGrp      ctxgroup.Group
+	resetTableCancelFn context.CancelFunc
 }
 
 type waitSetter struct {
@@ -305,7 +307,6 @@ var tpccMeta = workload.Meta{
 		g.flags.StringVar(&g.txnPreambleFile, "txn-preamble-file", "", "queries that will be injected before each txn")
 		RandomSeed.AddFlag(&g.flags)
 		g.connFlags = workload.NewConnFlags(&g.flags)
-
 		// Hardcode this since it doesn't seem like anyone will want to change
 		// it and it's really noisy in the generated fixture paths.
 		g.nowString = []byte(`2006-01-02 15:04:05`)
@@ -835,6 +836,10 @@ func (w *tpcc) Ops(
 		}
 	}
 
+	var resetTableCtx context.Context
+	resetTableCtx, w.resetTableCancelFn = context.WithCancel(ctx)
+	w.resetTableGrp = ctxgroup.WithContext(resetTableCtx)
+
 	if duration, err := w.flags.GetDuration("duration"); err == nil {
 		if duration == 0 || duration >= longDurationWorkloadThreshold {
 			log.Warningf(ctx,
@@ -1029,7 +1034,7 @@ func (w *tpcc) Ops(
 	}
 
 	// Close idle connections.
-	ql.Close = func(context context.Context) error {
+	ql.Close = func(_ context.Context) error {
 		for _, conn := range conns {
 			if err := conn.Close(ctx); err != nil {
 				log.Warningf(ctx, "%v", err)
@@ -1041,8 +1046,10 @@ func (w *tpcc) Ops(
 			}
 		}
 
-		w.resetTableWg.Wait()
-
+		w.resetTableCancelFn()
+		if err := w.resetTableGrp.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+			log.Warningf(ctx, "%v", err)
+		}
 		return nil
 	}
 	return ql, nil


### PR DESCRIPTION
Previously, we added logic to clean up reset w_ytd and d_ytd periodically as a part of #124259, this logic did not use the appropriate context, so the workload could hang waiting on the go routines introduced by the change. To address this, this patch introduces a new cancellable context and ctxgroup for these routines, so the workload always terminates gracefully.

Fixes: #127212

Release note: None