### PR TITLE
syntheticprivilegecache: use correct context when reading the table

### DIFF
--- a/pkg/sql/syntheticprivilegecache/cache.go
+++ b/pkg/sql/syntheticprivilegecache/cache.go
@@ -90,7 +90,7 @@ func (c *Cache) Get(
 	}
 	privDesc, err := c.c.LoadValueOutsideOfCacheSingleFlight(ctx, fmt.Sprintf("%s-%d", spo.GetPath(), desc.GetVersion()),
 		func(loadCtx context.Context) (_ interface{}, retErr error) {
-			return c.readFromStorage(ctx, txn, spo)
+			return c.readFromStorage(loadCtx, txn, spo)
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, we incorrectly used the captured context in `readFromStorage` invocation which happens in a separate goroutine which might outlive its creator. This in turn could lead to a "span use after Finish" problem and is now fixed.

Fixes: #126979.

Release note: None