### PR TITLE
crosscluter/logical: fix source-side table name parsing 

### DIFF
--- a/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
@@ -263,10 +263,15 @@ func setupTwoDBUDFTestCluster(
 	_, err = sqlDB.Exec("CREATE DATABASE b")
 	require.NoError(t, err)
 
+	sysSQL := srv.SystemLayer().SQLConn(t)
 	sqlA := s.SQLConn(t, serverutils.DBName("a"))
 	sqlB := s.SQLConn(t, serverutils.DBName("b"))
 	for _, s := range testClusterSettings {
 		_, err := sqlA.Exec(s)
+		require.NoError(t, err)
+	}
+	for _, s := range testClusterSystemSettings {
+		_, err = sysSQL.Exec(s)
 		require.NoError(t, err)
 	}
 	defaultSQLProcessor = udfApplierProcessor

--- a/pkg/ccl/crosscluster/producer/BUILD.bazel
+++ b/pkg/ccl/crosscluster/producer/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/clusterunique",
         "//pkg/sql/isql",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",

--- a/pkg/ccl/crosscluster/producer/event_stream.go
+++ b/pkg/ccl/crosscluster/producer/event_stream.go
@@ -74,14 +74,14 @@ type eventStream struct {
 }
 
 var quantize = settings.RegisterDurationSettingWithExplicitUnit(
-	settings.SystemOnly,
+	settings.ApplicationLevel,
 	"physical_replication.producer.timestamp_granularity",
 	"the granularity at which replicated times are quantized to make tracking more efficient",
 	5*time.Second,
 )
 
 var emitMetadata = settings.RegisterBoolSetting(
-	settings.SystemOnly,
+	settings.ApplicationLevel,
 	"physical_replication.producer.emit_metadata.enabled",
 	"whether to emit metadata events",
 	true,

--- a/pkg/ccl/crosscluster/producer/event_stream.go
+++ b/pkg/ccl/crosscluster/producer/event_stream.go
@@ -538,13 +538,6 @@ func streamPartition(
 	if err := protoutil.Unmarshal(opaqueSpec, &spec); err != nil {
 		return nil, errors.Wrapf(err, "invalid partition spec for stream %d", streamID)
 	}
-	if !evalCtx.SessionData().AvoidBuffering {
-		return nil, errors.New("partition streaming requires 'SET avoid_buffering = true' option")
-	}
-	if !evalCtx.TxnImplicit {
-		return nil, pgerror.Newf(pgcode.InvalidParameterValue,
-			"crdb_internal.stream_partition not allowed in explicit transaction")
-	}
 	if len(spec.Spans) == 0 {
 		return nil, errors.AssertionFailedf("expected at least one span, got none")
 	}

--- a/pkg/ccl/crosscluster/producer/event_stream.go
+++ b/pkg/ccl/crosscluster/producer/event_stream.go
@@ -541,6 +541,10 @@ func streamPartition(
 	if !evalCtx.SessionData().AvoidBuffering {
 		return nil, errors.New("partition streaming requires 'SET avoid_buffering = true' option")
 	}
+	if !evalCtx.TxnImplicit {
+		return nil, pgerror.Newf(pgcode.InvalidParameterValue,
+			"crdb_internal.stream_partition not allowed in explicit transaction")
+	}
 	if len(spec.Spans) == 0 {
 		return nil, errors.AssertionFailedf("expected at least one span, got none")
 	}

--- a/pkg/ccl/crosscluster/producer/replication_manager.go
+++ b/pkg/ccl/crosscluster/producer/replication_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -81,8 +82,7 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 	spans := make([]roachpb.Span, 0, len(req.TableNames))
 	tableDescs := make(map[string]descpb.TableDescriptor, len(req.TableNames))
 	for _, name := range req.TableNames {
-		un := tree.MakeUnresolvedName(name)
-		uon, err := un.ToUnresolvedObjectName(tree.NoAnnotation)
+		uon, err := parser.ParseTableName(name)
 		if err != nil {
 			return streampb.ReplicationProducerSpec{}, err
 		}

--- a/pkg/ccl/crosscluster/producer/stream_lifetime.go
+++ b/pkg/ccl/crosscluster/producer/stream_lifetime.go
@@ -48,7 +48,7 @@ import (
 const defaultExpirationWindow = time.Hour * 24
 
 var streamMaxProcsPerPartition = settings.RegisterIntSetting(
-	settings.SystemOnly,
+	settings.ApplicationLevel,
 	"stream_replication.ingest_processor_parallelism",
 	"controls the maximum number of ingest processors to assign to each source-planned partition",
 	8,

--- a/pkg/ccl/crosscluster/settings.go
+++ b/pkg/ccl/crosscluster/settings.go
@@ -17,7 +17,7 @@ import (
 // StreamReplicationStreamLivenessTrackFrequency controls frequency to check
 // the liveness of a streaming replication producer job.
 var StreamReplicationStreamLivenessTrackFrequency = settings.RegisterDurationSetting(
-	settings.SystemOnly,
+	settings.ApplicationLevel,
 	"stream_replication.stream_liveness_track_frequency",
 	"controls how frequent we check for the liveness of a replication stream producer job",
 	time.Minute,
@@ -27,7 +27,7 @@ var StreamReplicationStreamLivenessTrackFrequency = settings.RegisterDurationSet
 // StreamReplicationMinCheckpointFrequency controls the minimum frequency the stream replication
 // source cluster sends checkpoints to destination cluster.
 var StreamReplicationMinCheckpointFrequency = settings.RegisterDurationSetting(
-	settings.SystemOnly,
+	settings.ApplicationLevel,
 	"stream_replication.min_checkpoint_frequency",
 	"controls minimum frequency the stream replication source cluster sends checkpoints "+
 		"to the destination cluster",

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -243,6 +243,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 					return nil, err
 				}
 				return mgr.StreamPartition(
+					ctx,
 					streampb.StreamID(tree.MustBeDInt(args[0])),
 					[]byte(tree.MustBeDBytes(args[1])),
 				)

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -892,6 +892,7 @@ type ReplicationStreamManager interface {
 	// by opaqueSpec which contains serialized streampb.StreamPartitionSpec protocol message and
 	// returns a value generator which yields events for the specified partition.
 	StreamPartition(
+		ctx context.Context,
 		streamID streampb.StreamID,
 		opaqueSpec []byte,
 	) (ValueGenerator, error)


### PR DESCRIPTION
Previously, we were not correctly parsing the schema name on the
source cluster.

Fixes https://github.com/cockroachdb/cockroach/issues/127194
Release note: None