### PR TITLE
sql: cannot drop enum values if referenced in index expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -693,6 +693,7 @@ ALTER TYPE typ_110827 DROP VALUE 'a';
 statement error pgcode 2BP01 could not remove enum value "b" as it is being used by table ".*t_110827"
 ALTER TYPE typ_110827 DROP VALUE 'b';
 
+
 subtest end
 
 # We accidentally introduced a regression formatting dependent rows out,
@@ -709,5 +710,25 @@ INSERT INTO t_127136 VALUES (1, 'a');
 
 statement error pgcode 2BP01 could not remove enum value "a" as it is being used by "t_127136" in row: x=1, y='a'
 ALTER TYPE typ_127136 DROP VALUE 'a';
+
+subtest end
+
+# Previously, we did not properly handle scanning index expressions for type
+# references when removing an enum value (#127147).
+subtest validate_type_in_index_expr
+
+statement ok
+CREATE TYPE typ_127147 AS ENUM ('a', 'b', 'c');
+CREATE TABLE t (x TEXT PRIMARY KEY, INDEX ((x::typ_127147)));
+INSERT INTO t VALUES ('a');
+
+statement error pgcode 2BP01 could not remove enum value "a" as it is being used by "t" in row: x='a'
+ALTER TYPE typ_127147 DROP VALUE 'a';
+
+statement ok
+TRUNCATE TABLE t;
+
+statement ok
+ALTER TYPE typ_127147 DROP VALUE 'a';
 
 subtest end

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -837,6 +837,19 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromTable(
 		}
 	}
 
+	// If the descriptor has any inaccessible columns, we need to scan those.
+	var syntheticDescs []catalog.Descriptor
+	if len(desc.AccessibleColumns()) != len(desc.PublicColumns()) {
+		descBuilder := desc.NewBuilder()
+		fullyAccessibleDesc := descBuilder.BuildExistingMutable().(*tabledesc.Mutable)
+		for colIdx := range fullyAccessibleDesc.Columns {
+			if col := &fullyAccessibleDesc.Columns[colIdx]; col.Inaccessible {
+				col.Inaccessible = false
+			}
+		}
+		syntheticDescs = []catalog.Descriptor{descBuilder.BuildImmutable().(catalog.TableDescriptor)}
+	}
+
 	var query strings.Builder
 	colSelectors := tabledesc.ColumnsSelectors(desc.AccessibleColumns())
 	columns := tree.AsStringWithFlags(&colSelectors, tree.FmtSerializable)
@@ -984,7 +997,12 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromTable(
 			User:     username.NodeUserName(),
 			Database: dbDesc.GetName(),
 		}
-		rows, err := txn.QueryRowEx(ctx, "count-value-usage", txn.KV(), override, query.String())
+		var rows tree.Datums
+		err = txn.WithSyntheticDescriptors(syntheticDescs, func() error {
+			var err error
+			rows, err = txn.QueryRowEx(ctx, "count-value-usage", txn.KV(), override, query.String())
+			return err
+		})
 		if err != nil {
 			return errors.Wrapf(err, validationErr, member.LogicalRepresentation)
 		}


### PR DESCRIPTION
Previously, the logic to detect if an enum value was in use assumed that
all public columns would be accessible. As a result it would select from
inaccessible columns and run into errors. To address this, this patch
uses synthetic descriptors to make inaccessible columns public to scan
them for the enum value being dropped.

Fixes: #127147

Release note (bug fix): Dropping enum types values which were referenced by
index expressions could fail with an error.


Note: This is a stacked PR and the first commit should be ignored, since that will be merged seprately.