### PR TITLE
roachtest: include Side-Eye link in GitHub posts

### DIFF
--- a/pkg/cmd/bazci/githubpost/issues/formatter_unit.go
+++ b/pkg/cmd/bazci/githubpost/issues/formatter_unit.go
@@ -49,9 +49,22 @@ func (unitTestFormatterTyp) Body(r *Renderer, data TemplateData) error {
 		data.Commit,
 		data.CommitURL,
 	)
-	r.Escaped(`:
+	if data.SideEyeSnapshotURL != "" {
+		r.Escaped(`. `)
+		msg := "A Side-Eye cluster snapshot was captured: "
+		if data.SideEyeSnapshotMsg != "" {
+			msg = data.SideEyeSnapshotMsg
+		}
+		r.Escaped(msg)
+		r.A(data.SideEyeSnapshotURL, data.SideEyeSnapshotURL)
+		r.Escaped(`.
 
 `)
+	} else {
+		r.Escaped(`:
+
+`)
+	}
 	if fop, ok := data.CondensedMessage.FatalOrPanic(50); ok {
 		if fop.Error != "" {
 			r.Escaped("Fatal error:")

--- a/pkg/cmd/bazci/githubpost/issues/issues.go
+++ b/pkg/cmd/bazci/githubpost/issues/issues.go
@@ -257,6 +257,12 @@ type TemplateData struct {
 	ArtifactsURL string
 	// URL is the link to the failing build.
 	URL string
+	// SideEyeSnapshotURL is the URL for accessing a Side-Eye snapshot associated
+	// with this test failure. Empty if no such snapshot exists.
+	SideEyeSnapshotURL string
+	// SideEyeSnapshotMsg is a message to prepend to the link to the SideEye
+	// snapshot. Empty if SideEyeSnapshotURL is empty.
+	SideEyeSnapshotMsg string
 	// Issues that match this one, except they're on other branches.
 	RelatedIssues []github.Issue
 	// InternalLog contains information about non-critical issues encountered
@@ -556,6 +562,12 @@ type PostRequest struct {
 	// A path to the test artifacts relative to the artifacts root. If nonempty,
 	// allows the poster formatter to construct a direct URL to this directory.
 	Artifacts string
+	// SideEyeSnapshotURL is the URL for accessing a Side-Eye snapshot associated
+	// with this test failure. Empty if no such snapshot exists.
+	SideEyeSnapshotURL string
+	// SideEyeSnapshotMsg is a message to prepend to the link to the SideEye
+	// snapshot. Empty if SideEyeSnapshotURL is empty.
+	SideEyeSnapshotMsg string
 	// MentionOnCreate is a slice of GitHub handles (@foo, @cockroachdb/some-team, etc)
 	// that should be mentioned in the message when creating a new issue. These are
 	// *not* mentioned when posting to an existing issue.

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_16.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_16.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----


### PR DESCRIPTION
This patch makes the links to Side-Eye snapshots for timed-out tests more discoverable by including them in the GitHub issue post, and also in the test's log file. Before this patch, the link was hard to find because it was buried in the `teardown.log` file. I think making these links more visible can make the difference between Side-Eye helping people and nobody knowing about it.

Release note: None
Epic: none