### PR TITLE
crosscluster: rework how the change in plan is measured

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -249,10 +249,14 @@ func getNodes(plan *sql.PhysicalPlan) (src, dst map[string]struct{}, nodeCount i
 			// Skip other processors in the plan (like the Frontier processor).
 			continue
 		}
-		dst[proc.SQLInstanceID.String()] = struct{}{}
-		count += 1
-		src[proc.Spec.Core.LogicalReplicationWriter.PartitionSpec.PartitionID] = struct{}{}
-		count += 1
+		if _, ok := dst[proc.SQLInstanceID.String()]; !ok {
+			dst[proc.SQLInstanceID.String()] = struct{}{}
+			count += 1
+		}
+		if _, ok := src[proc.Spec.Core.LogicalReplicationWriter.PartitionSpec.SrcInstanceID.String()]; !ok {
+			src[proc.Spec.Core.LogicalReplicationWriter.PartitionSpec.SrcInstanceID.String()] = struct{}{}
+			count += 1
+		}
 	}
 	return src, dst, count
 }

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_dist.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_dist.go
@@ -594,11 +594,15 @@ func getNodes(plan *sql.PhysicalPlan) (src, dst map[string]struct{}, nodeCount i
 			// Skip other processors in the plan (like the Frontier processor).
 			continue
 		}
-		dst[proc.SQLInstanceID.String()] = struct{}{}
-		count += 1
-		for id := range proc.Spec.Core.StreamIngestionData.PartitionSpecs {
-			src[id] = struct{}{}
+		if _, ok := dst[proc.SQLInstanceID.String()]; !ok {
+			dst[proc.SQLInstanceID.String()] = struct{}{}
 			count += 1
+		}
+		for id := range proc.Spec.Core.StreamIngestionData.PartitionSpecs {
+			if _, ok := src[id]; !ok {
+				src[id] = struct{}{}
+				count += 1
+			}
 		}
 	}
 	return src, dst, count

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_dist_test.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_dist_test.go
@@ -54,25 +54,6 @@ func TestMeasurePlanChange(t *testing.T) {
 		return plan
 	}
 
-	getNodes := func(plan *sql.PhysicalPlan) (src, dst map[string]struct{}, nodeCount int) {
-		dst = make(map[string]struct{})
-		src = make(map[string]struct{})
-		count := 0
-		for _, proc := range plan.Processors {
-			if proc.Spec.Core.StreamIngestionData == nil {
-				// Skip other processors in the plan (like the Frontier processor).
-				continue
-			}
-			dst[proc.SQLInstanceID.String()] = struct{}{}
-			count += 1
-			for id := range proc.Spec.Core.StreamIngestionData.PartitionSpecs {
-				src[id] = struct{}{}
-				count += 1
-			}
-		}
-		return src, dst, count
-	}
-
 	for _, tc := range []struct {
 		name   string
 		before sql.PhysicalPlan
@@ -144,6 +125,12 @@ func TestMeasurePlanChange(t *testing.T) {
 			before: makePlan(makeProc(1, []int{1}), makeProc(2, []int{2})),
 			after:  makePlan(makeProc(1, []int{2}), makeProc(2, []int{1})),
 			frac:   0,
+		},
+		{
+			name:   "lots of processors",
+			before: makePlan(makeProc(1, []int{1}), makeProc(1, []int{1}), makeProc(1, []int{1})),
+			after:  makePlan(makeProc(1, []int{1}), makeProc(1, []int{1}), makeProc(1, []int{1}), makeProc(2, []int{1})),
+			frac:   0.5,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The prior implementation of MeasurePlanChange was inaccurate at calculating the change between the current plan and a proposed new plan. This led to the scenario where a node being added to a cluster wouldn't be considered for any crosscluster replication. This change reworks the calculation to only count each unique node once and comparing the new plan count to the old one. If this value is seen to be higher than the threshold cluster setting, trigger an ingestion retry and subsequent replan.

Proof from roachprod:
![image](https://github.com/user-attachments/assets/d9047404-6864-49dd-9cd1-ed2d14b71f37)


Fixes: #127022
Release note: none