### PR TITLE
sql: unskip TestSqlActivityUpdateTopLimitJob

### DIFF
--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -239,7 +239,6 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 120626)
 	skip.UnderRace(t, "test is too slow to run under race")
 
 	stubTime := timeutil.Now().Truncate(time.Hour)


### PR DESCRIPTION
Could not reproduce the failure documented in #120626.

Informs: #120626

Release note: None