### PR TITLE
changefeedccl: add support for MSK IAM authentication in the v2 kafka sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -113,11 +112,6 @@ func TestChangefeedExternalConnections(t *testing.T) {
 	enableEnterprise()
 	unknownParams := func(sink string, params ...string) string {
 		return fmt.Sprintf(`unknown %s sink query parameters: [%s]`, sink, strings.Join(params, ", "))
-	}
-
-	// TODO(#127536): We disabled testing the Kafka V2 sink here, since it doesnt support MSK yet. Re-enable it.
-	if KafkaV2Enabled.Get(&s.Server.ClusterSettings().SV) {
-		skip.WithIssue(t, 127536, "Kafka V2 sink does not support MSK yet")
 	}
 
 	for _, tc := range []struct {

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -416,6 +417,14 @@ func buildKgoConfig(
 	if dialConfig.saslEnabled {
 		var s sasl.Mechanism
 		switch dialConfig.saslMechanism {
+		// This is a "fake" mechanism we use to signify that we're using AWS MSK
+		// IAM, which is really OAUTHBEARER with a custom token provider.
+		case changefeedbase.SASLTypeAWSMSKIAM:
+			tp, err := newKgoAWSIAMRoleOauthTokenProvider(dialConfig)
+			if err != nil {
+				return nil, err
+			}
+			s = sasloauth.Oauth(tp)
 		// TODO(#126991): Remove this sarama dependency.
 		case sarama.SASLTypeOAuth:
 			tp, err := newKgoOauthTokenProvider(ctx, dialConfig)
@@ -612,6 +621,22 @@ func newKgoOauthTokenProvider(
 			return sasloauth.Auth{}, err
 		}
 		return sasloauth.Auth{Token: tok.AccessToken}, nil
+	}, nil
+}
+
+// newKgoAWSIAMRoleOauthTokenProvider returns a new token provider that uses the
+// AWS MSK IAM signer to generate a SASL Oauth token. Currently only implicit
+// auth & role assumption is supported.
+func newKgoAWSIAMRoleOauthTokenProvider(
+	dialConfig kafkaDialConfig,
+) (func(ctx context.Context) (sasloauth.Auth, error), error) {
+	return func(ctx context.Context) (sasloauth.Auth, error) {
+		token, _, err := signer.GenerateAuthTokenFromRole(
+			ctx, dialConfig.saslAwsRegion, dialConfig.saslAwsIAMRoleArn, dialConfig.saslAwsIAMSessionName)
+		if err != nil {
+			return sasloauth.Auth{}, err
+		}
+		return sasloauth.Auth{Token: token}, nil
 	}, nil
 }
 


### PR DESCRIPTION

Add MSK IAM SASL authentication support to the v2 kafka sink.

Fixes: #127536

Release note (enterprise change): The v2 kafka sink now supports MSK IAM SASL authentication.
