### PR TITLE
release-23.2: roachtest: skip clearrange/zfs/checks=true

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -59,6 +59,8 @@ func registerClearRange(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runClearRange(ctx, t, c, true /* checks */)
 		},
+		Skip:        "#126777",
+		SkipDetails: "Issue setting up ZFS filesystem.",
 	})
 }
 


### PR DESCRIPTION
Skip the ZFS variant of the clearrange roachtest.

Epic: none
Informs: #126777
Release note: none
Release justification: test-only changes