### PR TITLE
workload: stop skipping split/scatter on tenants

### DIFF
--- a/pkg/workload/workloadsql/workloadsql.go
+++ b/pkg/workload/workloadsql/workloadsql.go
@@ -103,31 +103,8 @@ func Split(ctx context.Context, db *gosql.DB, table workload.Table, concurrency 
 		return err
 	}
 
-	// Check to see if we're allowed to perform any splits - if we're in a tenant,
-	// we can't perform splits.
-	_, err := db.Exec("SHOW RANGES FROM TABLE system.descriptor")
-	if err != nil {
-		if strings.Contains(err.Error(), "not fully contained in tenant") ||
-			strings.Contains(err.Error(), errorutil.UnsupportedUnderClusterVirtualizationMessage) {
-			log.Infof(ctx, `skipping workload splits; can't split on tenants'`)
-			//nolint:returnerrcheck
-			return nil
-		}
-		return err
-	}
-
 	if table.Splits.NumBatches <= 0 {
 		return nil
-	}
-
-	// Test that we can actually perform a scatter.
-	if _, err := db.Exec("ALTER TABLE system.jobs SCATTER"); err != nil {
-		if strings.Contains(err.Error(), "operation is disabled within a virtual cluster") {
-			log.Infof(ctx, `skipping workload splits; can't scatter on tenants'`)
-			//nolint:returnerrcheck
-			return nil
-		}
-		return err
 	}
 
 	splitPoints := make([][]interface{}, 0, table.Splits.NumBatches)


### PR DESCRIPTION
Tenants have been able to perform `SPLIT` and `SCATTER` out of the box since 24.1. As such, silently skipping these operations and matching on error messages is no longer necessary.

Epic: none

Release note: None