### PR TITLE
crosscluster/logical: adjust observability of ingestion queries

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/asof",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -298,8 +299,7 @@ func (srp *sqlRowProcessor) SetSyntheticFailurePercent(rate uint32) {
 
 var (
 	forceGenericPlan = sessiondatapb.PlanCacheModeForceGeneric
-	ieOverrides      = sessiondata.InternalExecutorOverride{
-		AttributeToUser: true,
+	ieOverrideBase   = sessiondata.InternalExecutorOverride{
 		// The OriginIDForLogicalDataReplication session variable will bind the
 		// origin ID 1 to each per-statement batch request header sent by the
 		// internal executor. This metadata will be plumbed to the MVCCValueHeader
@@ -325,7 +325,33 @@ var (
 		DisablePlanGists: true,
 		QualityOfService: &sessiondatapb.UserLowQoS,
 	}
+	// Have a separate override for each of the replicated queries.
+	ieOverrideOptimisticInsert, ieOverrideInsert, ieOverrideDelete sessiondata.InternalExecutorOverride
 )
+
+const (
+	replicatedOptimisticInsertOpName = "replicated-optimistic-insert"
+	replicatedInsertOpName           = "replicated-insert"
+	replicatedDeleteOpName           = "replicated-delete"
+	replicatedApplyUDFOpName         = "replicated-apply-udf"
+)
+
+func getIEOverride(opName string) sessiondata.InternalExecutorOverride {
+	o := ieOverrideBase
+	// We want the ingestion queries to show up on the SQL Activity page
+	// alongside with the foreground traffic by default. We can achieve this
+	// by using the same naming scheme as AttributeToUser feature of the IE
+	// override (effectively, we opt out of using the "external" metrics for
+	// the ingestion queries).
+	o.ApplicationName = catconstants.AttributedToUserInternalAppNamePrefix + "-" + opName
+	return o
+}
+
+func init() {
+	ieOverrideOptimisticInsert = getIEOverride(replicatedOptimisticInsertOpName)
+	ieOverrideInsert = getIEOverride(replicatedInsertOpName)
+	ieOverrideDelete = getIEOverride(replicatedDeleteOpName)
+}
 
 var tryOptimisticInsertEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
@@ -450,7 +476,7 @@ func (lww *lwwQuerier) InsertRow(
 		if err != nil {
 			return batchStats{}, err
 		}
-		if _, err = ie.ExecParsed(ctx, "replicated-optimistic-insert", kvTxn, ieOverrides, stmt, datums...); err != nil {
+		if _, err = ie.ExecParsed(ctx, replicatedOptimisticInsertOpName, kvTxn, ieOverrideOptimisticInsert, stmt, datums...); err != nil {
 			// If the optimistic insert failed with unique violation, we have to
 			// fall back to the pessimistic path. If we got a different error,
 			// then we bail completely.
@@ -478,7 +504,7 @@ func (lww *lwwQuerier) InsertRow(
 	if err != nil {
 		return batchStats{}, err
 	}
-	if _, err = ie.ExecParsed(ctx, "replicated-insert", kvTxn, ieOverrides, stmt, datums...); err != nil {
+	if _, err = ie.ExecParsed(ctx, replicatedInsertOpName, kvTxn, ieOverrideInsert, stmt, datums...); err != nil {
 		log.Warningf(ctx, "replicated insert failed (query: %s): %s", stmt.SQL, err.Error())
 		return batchStats{}, err
 	}
@@ -506,7 +532,7 @@ func (lww *lwwQuerier) DeleteRow(
 		return batchStats{}, err
 	}
 
-	if _, err := ie.ExecParsed(ctx, "replicated-delete", kvTxn, ieOverrides, stmt, datums...); err != nil {
+	if _, err := ie.ExecParsed(ctx, replicatedDeleteOpName, kvTxn, ieOverrideDelete, stmt, datums...); err != nil {
 		log.Warningf(ctx, "replicated delete failed (query: %s): %s", stmt.SQL, err.Error())
 		return batchStats{}, err
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -763,7 +763,7 @@ func (ie *InternalExecutor) QueryRowEx(
 	return rows, err
 }
 
-// QueryRowEx is like QueryRowExParssed, but takes a parsed statement.
+// QueryRowExParsed is like QueryRowEx, but takes a parsed statement.
 func (ie *InternalExecutor) QueryRowExParsed(
 	ctx context.Context,
 	opName string,

--- a/pkg/sql/isql/isql_db.go
+++ b/pkg/sql/isql/isql_db.go
@@ -125,8 +125,8 @@ type Executor interface {
 		qargs ...interface{},
 	) (tree.Datums, error)
 
-	// QueryRowExParsed is like QueryRowEd, but allows the caller to provide an already
-	// parsed statement.
+	// QueryRowExParsed is like QueryRowEx, but allows the caller to provide an
+	// already parsed statement.
 	QueryRowExParsed(
 		ctx context.Context,
 		opName string,


### PR DESCRIPTION
This commit makes it so that we no longer use `AttributeToUser` functionality of the internal executor (which includes the internal queries to show up on the SQL Activity page and in the "external" metrics) for the ingestion queries since we found the metrics part to be quite confusing. The SQL Activity part is useful, so that part is preserved by explicitly setting the ApplicationName in the IE override struct (we need a separate override struct for each of 3 ingestion queries) - this way these queries will show on the SQL Activity page without having to enable a separate cluster setting that would include all internal queries.

Epic: None

Release note: None