### PR TITLE
sql: clean up health checks

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
 )
@@ -154,8 +153,8 @@ func DecodeStoreDescKey(storeKey string) (roachpb.StoreID, error) {
 
 // MakeDistSQLDrainingKey returns the gossip key for the given node's distsql
 // draining state.
-func MakeDistSQLDrainingKey(instanceID base.SQLInstanceID) string {
-	return MakeKey(KeyDistSQLDrainingPrefix, instanceID.String())
+func MakeDistSQLDrainingKey(nodeID roachpb.NodeID) string {
+	return MakeKey(KeyDistSQLDrainingPrefix, nodeID.String())
 }
 
 // removePrefixFromKey removes the key prefix and separator and returns what's

--- a/pkg/rpc/nodedialer/BUILD.bazel
+++ b/pkg/rpc/nodedialer/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/rpc/nodedialer",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/kv/kvbase",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -230,21 +229,6 @@ func (n *Dialer) ConnHealthTryDial(nodeID roachpb.NodeID, class rpc.ConnectionCl
 	// NB: This will always return `ErrNotHeartbeated` since the heartbeat will
 	// not be done by the time `Health` is called since GRPCDialNode is async.
 	return n.rpcContext.GRPCDialNode(addr.String(), nodeID, class).Health()
-}
-
-// ConnHealthTryDialInstance returns nil if we have an open connection of the
-// rpc.DefaultClass to the given sqlinstance that succeeded on its most recent
-// heartbeat. If no healthy connection is found, it will attempt to dial the
-// instance.
-func (n *Dialer) ConnHealthTryDialInstance(id base.SQLInstanceID, addr string) error {
-	if n == nil {
-		return errors.New("no node dialer configured")
-	}
-	if err := n.rpcContext.ConnHealth(
-		addr, roachpb.NodeID(id), rpc.DefaultClass); err == nil {
-		return nil
-	}
-	return n.rpcContext.GRPCDialPod(addr, id, rpc.DefaultClass).Health()
 }
 
 // GetCircuitBreaker retrieves the circuit breaker for connections to the

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
@@ -917,19 +916,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		NodeID:           cfg.nodeIDContainer,
 	}
 
-	var isAvailable func(sqlInstanceID base.SQLInstanceID) bool
-	nodeLiveness, hasNodeLiveness := cfg.nodeLiveness.Optional(47900)
-	if hasNodeLiveness {
-		isAvailable = func(sqlInstanceID base.SQLInstanceID) bool {
-			return nodeLiveness.GetNodeVitalityFromCache(roachpb.NodeID(sqlInstanceID)).IsLive(livenesspb.DistSQL)
-		}
-	} else {
-		// We're on a SQL tenant, so this is the only node DistSQL will ever
-		// schedule on - always returning true is fine.
-		isAvailable = func(sqlInstanceID base.SQLInstanceID) bool {
-			return true
-		}
-	}
+	nodeLiveness, _ := cfg.nodeLiveness.Optional(distsql.MultiTenancyIssueNo)
 
 	// Setup the trace collector that is used to fetch inflight trace spans from
 	// all nodes in the cluster.
@@ -953,6 +940,32 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 				ctx, cfg.Settings, cfg.stopper, &timeutil.DefaultTimeSource{}, rootSQLMemoryMonitor,
 			),
 		)
+	}
+
+	kvNodeAvailable := func(nodeID roachpb.NodeID) bool {
+		return sql.CheckKVNodeHealth(
+			ctx,
+			nodeID,
+			cfg.kvNodeDialer.ConnHealthTryDial,
+			nodeLiveness,
+			cfg.gossip,
+		)
+	}
+
+	// NB: This will return ErrNotHeartbeated on the first call, but that's fine
+	// as we will plan without this node. The connection will still be
+	// established asyncronously and cached in the rpc layer for future calls.
+	//
+	// TODO(baptist): We shouldn't need the addr passed into this function. The
+	// cfg.sqlInstanceDialer used here already has an address resolver. Which
+	// would presumably return the same result. Clean this up and replace calls
+	// to ConnHealthTryDialInstance with ConnHealthTryDial.
+	sqlNodeAvailable := func(sqlInstanceID base.SQLInstanceID, addr string) bool {
+		if err := cfg.sqlInstanceDialer.ConnHealthTryDialInstance(sqlInstanceID, addr); err != nil {
+			log.VEventf(ctx, 2, "sql instance n%d is not available for planning %v", sqlInstanceID, err)
+			return false
+		}
+		return true
 	}
 
 	storageEngineClient := kvserver.NewStorageEngineClient(cfg.kvNodeDialer)
@@ -1024,9 +1037,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.nodeDescs,
 			cfg.gossip,
 			cfg.stopper,
-			isAvailable,
-			cfg.kvNodeDialer.ConnHealthTryDial, // only used by system tenant
-			cfg.sqlInstanceDialer.ConnHealthTryDialInstance,
+			kvNodeAvailable,
+			sqlNodeAvailable,
 			cfg.sqlInstanceDialer,
 			codec,
 			cfg.sqlInstanceReader,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -955,13 +955,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// NB: This will return ErrNotHeartbeated on the first call, but that's fine
 	// as we will plan without this node. The connection will still be
 	// established asyncronously and cached in the rpc layer for future calls.
-	//
-	// TODO(baptist): We shouldn't need the addr passed into this function. The
-	// cfg.sqlInstanceDialer used here already has an address resolver. Which
-	// would presumably return the same result. Clean this up and replace calls
-	// to ConnHealthTryDialInstance with ConnHealthTryDial.
-	sqlNodeAvailable := func(sqlInstanceID base.SQLInstanceID, addr string) bool {
-		if err := cfg.sqlInstanceDialer.ConnHealthTryDialInstance(sqlInstanceID, addr); err != nil {
+	sqlNodeAvailable := func(sqlInstanceID base.SQLInstanceID) bool {
+		if err := cfg.sqlInstanceDialer.ConnHealthTryDial(roachpb.NodeID(sqlInstanceID), rpc.DefaultClass); err != nil {
 			log.VEventf(ctx, 2, "sql instance n%d is not available for planning %v", sqlInstanceID, err)
 			return false
 		}

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -787,6 +787,7 @@ go_test(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
+        "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptstorage",

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -333,9 +333,8 @@ func startConnExecutor(
 			nil, /* nodeDescs */
 			gw,
 			stopper,
-			func(base.SQLInstanceID) bool { return true }, // everybody is available
-			nil, /* connHealthCheckerSystem */
-			nil, /* instanceConnHealthChecker */
+			func(roachpb.NodeID) bool { return true },             // everybody is available
+			func(base.SQLInstanceID, string) bool { return true }, // everybody is available
 			nil, /* sqlInstanceDialer */
 			keys.SystemSQLCodec,
 			nil, /* sqlAddressResolver */

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -333,8 +333,8 @@ func startConnExecutor(
 			nil, /* nodeDescs */
 			gw,
 			stopper,
-			func(roachpb.NodeID) bool { return true },             // everybody is available
-			func(base.SQLInstanceID, string) bool { return true }, // everybody is available
+			func(roachpb.NodeID) bool { return true },     // everybody is available
+			func(base.SQLInstanceID) bool { return true }, // everybody is available
 			nil, /* sqlInstanceDialer */
 			keys.SystemSQLCodec,
 			nil, /* sqlAddressResolver */

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/distsql",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/gossip",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -153,7 +152,7 @@ func (ds *ServerImpl) setDraining(drain bool) error {
 	}
 	if g, ok := ds.ServerConfig.Gossip.Optional(MultiTenancyIssueNo); ok {
 		return g.AddInfoProto(
-			gossip.MakeDistSQLDrainingKey(base.SQLInstanceID(nodeID)),
+			gossip.MakeDistSQLDrainingKey(nodeID),
 			&execinfrapb.DistSQLDrainingInfo{
 				Draining: drain,
 			},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -118,7 +118,7 @@ type DistSQLPlanner struct {
 
 	// sqlNodeAvailable encapsulates the various node health checks to avoid
 	// planning on unhealthy SQL instances.
-	sqlNodeAvailable func(base.SQLInstanceID, string) bool
+	sqlNodeAvailable func(base.SQLInstanceID) bool
 
 	// parallelLocalScansSem is a node-wide semaphore on the number of
 	// additional goroutines that can be used to run concurrent TableReaders
@@ -181,7 +181,7 @@ func NewDistSQLPlanner(
 	gw gossip.OptionalGossip,
 	stopper *stop.Stopper,
 	kvNodeAvailable func(nodeID roachpb.NodeID) bool,
-	sqlNodeAvailable func(base.SQLInstanceID, string) bool,
+	sqlNodeAvailable func(base.SQLInstanceID) bool,
 	sqlInstanceDialer *nodedialer.Dialer,
 	codec keys.SQLCodec,
 	sqlAddressResolver sqlinstance.AddressResolver,
@@ -1566,9 +1566,7 @@ func (dsp *DistSQLPlanner) deprecatedHealthySQLInstanceIDForKVNodeIDSystem(
 // checkInstanceHealth returns the instance health status by dialing the node.
 // It also caches the result to avoid redialing for a query.
 func (dsp *DistSQLPlanner) checkInstanceHealth(
-	instanceID base.SQLInstanceID,
-	instanceRPCAddr string,
-	nodeStatusesCache map[base.SQLInstanceID]NodeStatus,
+	instanceID base.SQLInstanceID, nodeStatusesCache map[base.SQLInstanceID]NodeStatus,
 ) NodeStatus {
 	if nodeStatusesCache != nil {
 		if status, ok := nodeStatusesCache[instanceID]; ok {
@@ -1576,7 +1574,7 @@ func (dsp *DistSQLPlanner) checkInstanceHealth(
 		}
 	}
 	status := NodeOK
-	if !dsp.sqlNodeAvailable(instanceID, instanceRPCAddr) {
+	if !dsp.sqlNodeAvailable(instanceID) {
 		status = NodeUnhealthy
 	}
 
@@ -1608,16 +1606,16 @@ func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeHostedInstanceResolver(
 		log.VEventf(ctx, 2, "all SQL instances available for distributed planning: %v", allInstances)
 	}
 
-	instances := make(map[base.SQLInstanceID]sqlinstance.InstanceInfo, len(allInstances))
+	instances := make(map[base.SQLInstanceID]bool, len(allInstances))
 	for _, n := range allInstances {
-		instances[n.InstanceID] = n
+		instances[n.InstanceID] = true
 	}
 
 	return func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 		sqlInstance := base.SQLInstanceID(nodeID)
-		if n, ok := instances[sqlInstance]; ok {
+		if instances[sqlInstance] {
 			if status := dsp.checkInstanceHealth(
-				sqlInstance, n.InstanceRPCAddr, planCtx.nodeStatuses); status == NodeOK {
+				sqlInstance, planCtx.nodeStatuses); status == NodeOK {
 				return sqlInstance, SpanPartitionReason_TARGET_HEALTHY
 			}
 		}
@@ -1681,7 +1679,7 @@ func (dsp *DistSQLPlanner) filterUnhealthyInstances(
 	for _, n := range instances {
 		// Gateway is always considered healthy
 		if n.InstanceID == dsp.gatewaySQLInstanceID ||
-			dsp.checkInstanceHealth(n.InstanceID, n.InstanceRPCAddr, nodeStatusesCache) == NodeOK {
+			dsp.checkInstanceHealth(n.InstanceID, nodeStatusesCache) == NodeOK {
 			instances[j] = n
 			j++
 		} else {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -111,9 +112,13 @@ type DistSQLPlanner struct {
 	// sqlInstanceDialer handles communication between SQL nodes/pods.
 	sqlInstanceDialer *nodedialer.Dialer
 
-	// nodeHealth encapsulates the various node health checks to avoid planning
-	// on unhealthy nodes.
-	nodeHealth distSQLNodeHealth
+	// kvNodeAvailable encapsulates the various node health checks to avoid
+	// planning on unhealthy nodes.
+	kvNodeAvailable func(nodeID roachpb.NodeID) bool
+
+	// sqlNodeAvailable encapsulates the various node health checks to avoid
+	// planning on unhealthy SQL instances.
+	sqlNodeAvailable func(base.SQLInstanceID, string) bool
 
 	// parallelLocalScansSem is a node-wide semaphore on the number of
 	// additional goroutines that can be used to run concurrent TableReaders
@@ -175,9 +180,8 @@ func NewDistSQLPlanner(
 	nodeDescs kvclient.NodeDescStore,
 	gw gossip.OptionalGossip,
 	stopper *stop.Stopper,
-	isAvailable func(base.SQLInstanceID) bool,
-	connHealthCheckerSystem func(roachpb.NodeID, rpc.ConnectionClass) error, // will only be used by the system tenant
-	instanceConnHealthChecker func(base.SQLInstanceID, string) error,
+	kvNodeAvailable func(nodeID roachpb.NodeID) bool,
+	sqlNodeAvailable func(base.SQLInstanceID, string) bool,
 	sqlInstanceDialer *nodedialer.Dialer,
 	codec keys.SQLCodec,
 	sqlAddressResolver sqlinstance.AddressResolver,
@@ -190,18 +194,14 @@ func NewDistSQLPlanner(
 		distSQLSrv:           distSQLSrv,
 		gossip:               gw,
 		sqlInstanceDialer:    sqlInstanceDialer,
-		nodeHealth: distSQLNodeHealth{
-			gossip:             gw,
-			connHealthSystem:   connHealthCheckerSystem,
-			connHealthInstance: instanceConnHealthChecker,
-			isAvailable:        isAvailable,
-		},
-		distSender:         distSender,
-		nodeDescs:          nodeDescs,
-		rpcCtx:             rpcCtx,
-		sqlAddressResolver: sqlAddressResolver,
-		codec:              codec,
-		clock:              clock,
+		kvNodeAvailable:      kvNodeAvailable,
+		sqlNodeAvailable:     sqlNodeAvailable,
+		distSender:           distSender,
+		nodeDescs:            nodeDescs,
+		rpcCtx:               rpcCtx,
+		sqlAddressResolver:   sqlAddressResolver,
+		codec:                codec,
+		clock:                clock,
 	}
 
 	dsp.parallelLocalScansSem = quotapool.NewIntPool("parallel local scans concurrency",
@@ -1248,77 +1248,78 @@ func MakeSpanPartitionWithRangeCount(
 	}
 }
 
-type distSQLNodeHealth struct {
-	gossip             gossip.OptionalGossip
-	isAvailable        func(base.SQLInstanceID) bool
-	connHealthSystem   func(roachpb.NodeID, rpc.ConnectionClass) error
-	connHealthInstance func(base.SQLInstanceID, string) error
-}
-
-func (h *distSQLNodeHealth) checkSystem(
-	ctx context.Context, sqlInstanceID base.SQLInstanceID,
-) error {
-	{
-		// NB: as of #22658, connHealthSystem does not work as expected; see the
-		// comment within. We still keep this code for now because in
-		// practice, once the node is down it will prevent using this node
-		// 90% of the time (it gets used around once per second as an
-		// artifact of rpcContext's reconnection mechanism at the time of
-		// writing). This is better than having it used in 100% of cases
-		// (until the liveness check below kicks in).
-		if err := h.connHealthSystem(roachpb.NodeID(sqlInstanceID), rpc.DefaultClass); err != nil {
-			// This host isn't known to be healthy. Don't use it (use the gateway
-			// instead). Note: this can never happen for our sqlInstanceID (which
-			// always has its address in the nodeMap).
-			log.VEventf(ctx, 1, "marking n%d as unhealthy for this plan: %v", sqlInstanceID, err)
-			return err
-		}
+// CheckKVNodeHealth returns true if the given nodeID is available for DistSQL
+// planning based on a number of factors. This function checks NodeVitaility,
+// kvConnHealth and if there is DistSQLDrainingInfo in Gossip.
+//
+// TODO(baptist): Move this code into NodeVitality.IsLive for DistSQL.
+func CheckKVNodeHealth(
+	ctx context.Context,
+	nodeID roachpb.NodeID,
+	kvConnHealth func(roachpb.NodeID, rpc.ConnectionClass) error,
+	nodeLiveness livenesspb.NodeVitalityInterface,
+	optGossip gossip.OptionalGossip,
+) bool {
+	// NB: as of #22658, Dialer.ConnHealthTryDial does not work as expected; see
+	// the comment within. We still keep this code for now because in practice,
+	// once the node is down it will prevent using this node 90% of the time (it
+	// gets used around once per second as an artifact of rpcContext's
+	// reconnection mechanism at the time of writing). This is better than
+	// having it used in 100% of cases (until the liveness check below kicks
+	// in).
+	if err := kvConnHealth(nodeID, rpc.DefaultClass); err != nil {
+		// This host isn't known to be healthy. Don't use it (use the gateway
+		// instead). Note: this can never happen for our sqlInstanceID (which
+		// always has its address in the nodeMap).
+		log.VEventf(ctx, 2, "marking n%d as unhealthy for this plan: %v", nodeID, err)
+		return false
 	}
-	if !h.isAvailable(sqlInstanceID) {
-		return pgerror.Newf(pgcode.CannotConnectNow, "not using n%d since it is not available", sqlInstanceID)
+	if nodeLiveness != nil {
+		if !nodeLiveness.GetNodeVitalityFromCache(nodeID).IsLive(livenesspb.DistSQL) {
+			log.VEventf(ctx, 2, "not using n%d since it is not available", nodeID)
+			return false
+		}
 	}
 
 	// Check that the node is not draining.
-	g, ok := h.gossip.Optional(distsql.MultiTenancyIssueNo)
+	g, ok := optGossip.Optional(distsql.MultiTenancyIssueNo)
 	if !ok {
-		return errors.AssertionFailedf("gossip is expected to be available for the system tenant")
+		log.VEventf(ctx, 1, "gossip is expected to be available for dist SQL planning")
+		return false
 	}
 	drainingInfo := &execinfrapb.DistSQLDrainingInfo{}
-	if err := g.GetInfoProto(gossip.MakeDistSQLDrainingKey(sqlInstanceID), drainingInfo); err != nil {
-		// Because draining info has no expiration, an error
-		// implies that we have not yet received a node's
-		// draining information. Since this information is
-		// written on startup, the most likely scenario is
-		// that the node is ready. We therefore return no
-		// error.
+	if err := g.GetInfoProto(gossip.MakeDistSQLDrainingKey(nodeID), drainingInfo); err != nil {
+		// Because draining info has no expiration, an error implies that we
+		// have not yet received a node's draining information. Since this
+		// information is written on startup, the most likely scenario is that
+		// the node is ready. We therefore return no error.
 		// TODO(ajwerner): Determine the expected error types and only filter those.
-		return nil //nolint:returnerrcheck
+		log.VEventf(ctx, 2, "problem getting draining key %v", err)
+		return true
 	}
 
 	if drainingInfo.Draining {
-		err := errors.Newf("not using n%d because it is draining", sqlInstanceID)
-		log.VEventf(ctx, 1, "%v", err)
-		return err
+		log.VEventf(ctx, 2, "not using n%d because it is draining", nodeID)
+		return false
 	}
-
-	return nil
+	return true
 }
 
 // checkInstanceHealthAndVersionSystem returns information about a node's health
 // and compatibility. The info is also recorded in planCtx.nodeStatuses. It
 // should only be used by the system tenant.
 func (dsp *DistSQLPlanner) checkInstanceHealthAndVersionSystem(
-	ctx context.Context, planCtx *PlanningCtx, sqlInstanceID base.SQLInstanceID,
+	ctx context.Context, planCtx *PlanningCtx, nodeID roachpb.NodeID,
 ) NodeStatus {
-	if status, ok := planCtx.nodeStatuses[sqlInstanceID]; ok {
+	if status, ok := planCtx.nodeStatuses[base.SQLInstanceID(nodeID)]; ok {
 		return status
 	}
 
 	status := NodeOK
-	if err := dsp.nodeHealth.checkSystem(ctx, sqlInstanceID); err != nil {
+	if !dsp.kvNodeAvailable(nodeID) {
 		status = NodeUnhealthy
 	}
-	planCtx.nodeStatuses[sqlInstanceID] = status
+	planCtx.nodeStatuses[base.SQLInstanceID(nodeID)] = status
 	return status
 }
 
@@ -1549,7 +1550,7 @@ func (dsp *DistSQLPlanner) deprecatedHealthySQLInstanceIDForKVNodeIDSystem(
 	ctx context.Context, planCtx *PlanningCtx, nodeID roachpb.NodeID,
 ) (base.SQLInstanceID, SpanPartitionReason) {
 	sqlInstanceID := base.SQLInstanceID(nodeID)
-	status := dsp.checkInstanceHealthAndVersionSystem(ctx, planCtx, sqlInstanceID)
+	status := dsp.checkInstanceHealthAndVersionSystem(ctx, planCtx, nodeID)
 	// If the node is unhealthy or its DistSQL version is incompatible, use the
 	// gateway to process this span instead of the unhealthy host. An empty
 	// address indicates an unhealthy host.
@@ -1575,15 +1576,7 @@ func (dsp *DistSQLPlanner) checkInstanceHealth(
 		}
 	}
 	status := NodeOK
-	if err := dsp.nodeHealth.connHealthInstance(instanceID, instanceRPCAddr); err != nil {
-		if errors.Is(err, rpc.ErrNotHeartbeated) {
-			// Consider ErrNotHeartbeated as a temporary error (see its description) and
-			// avoid caching its result, as it can resolve to a more accurate result soon.
-			// It's more reasonable to plan on using this node, and if such a node is
-			// unhealthy, the retry-as-local mechanism would retry the operation on the
-			// gateway.
-			return NodeOK
-		}
+	if !dsp.sqlNodeAvailable(instanceID, instanceRPCAddr) {
 		status = NodeUnhealthy
 	}
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -1351,7 +1351,7 @@ func TestPartitionSpans(t *testing.T) {
 				spanResolver:         tsp,
 				gossip:               gw,
 				kvNodeAvailable:      func(id roachpb.NodeID) bool { return connHealth(int(id)) },
-				sqlNodeAvailable:     func(id base.SQLInstanceID, _ string) bool { return connHealth(int(id)) },
+				sqlNodeAvailable:     func(id base.SQLInstanceID) bool { return connHealth(int(id)) },
 				sqlAddressResolver:   mockInstances,
 				distSQLSrv: &distsql.ServerImpl{
 					ServerConfig: execinfra.ServerConfig{

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1306,7 +1307,7 @@ func TestPartitionSpans(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := mockGossip.AddInfoProto(
-			gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+			gossip.MakeDistSQLDrainingKey(roachpb.NodeID(sqlInstanceID)),
 			&execinfrapb.DistSQLDrainingInfo{Draining: false},
 			0, // ttl - no expiration
 		); err != nil {
@@ -1334,13 +1335,13 @@ func TestPartitionSpans(t *testing.T) {
 
 			gw := gossip.MakeOptionalGossip(mockGossip)
 
-			connHealth := func(nodeId roachpb.NodeID) error {
+			connHealth := func(nodeID int) bool {
 				for _, n := range tc.deadNodes {
-					if int(nodeId) == n {
-						return fmt.Errorf("test node is unhealthy")
+					if nodeID == n {
+						return false
 					}
 				}
-				return nil
+				return true
 			}
 
 			dsp := DistSQLPlanner{
@@ -1349,19 +1350,9 @@ func TestPartitionSpans(t *testing.T) {
 				stopper:              stopper,
 				spanResolver:         tsp,
 				gossip:               gw,
-				nodeHealth: distSQLNodeHealth{
-					gossip: gw,
-					connHealthSystem: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
-						return connHealth(node)
-					},
-					connHealthInstance: func(sqlInstance base.SQLInstanceID, _ string) error {
-						return connHealth(roachpb.NodeID(sqlInstance))
-					},
-					isAvailable: func(base.SQLInstanceID) bool {
-						return true
-					},
-				},
-				sqlAddressResolver: mockInstances,
+				kvNodeAvailable:      func(id roachpb.NodeID) bool { return connHealth(int(id)) },
+				sqlNodeAvailable:     func(id base.SQLInstanceID, _ string) bool { return connHealth(int(id)) },
+				sqlAddressResolver:   mockInstances,
 				distSQLSrv: &distsql.ServerImpl{
 					ServerConfig: execinfra.ServerConfig{
 						NodeID:       base.NewSQLIDContainerForNode(nID),
@@ -1691,7 +1682,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		// would be taken out of the gossip data, but other datums it advertised
 		// are left in place.
 		if err := mockGossip.AddInfoProto(
-			gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+			gossip.MakeDistSQLDrainingKey(roachpb.NodeID(sqlInstanceID)),
 			&execinfrapb.DistSQLDrainingInfo{
 				Draining: false,
 			},
@@ -1714,15 +1705,11 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		stopper:              stopper,
 		spanResolver:         tsp,
 		gossip:               gw,
-		nodeHealth: distSQLNodeHealth{
-			gossip: gw,
-			connHealthSystem: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
-				_, err := mockGossip.GetNodeIDAddress(node)
-				return err
-			},
-			isAvailable: func(base.SQLInstanceID) bool {
-				return true
-			},
+		kvNodeAvailable: func(id roachpb.NodeID) bool {
+			if _, err := mockGossip.GetNodeIDAddress(id); err != nil {
+				return false
+			}
+			return true
 		},
 		codec: keys.SystemSQLCodec,
 	}
@@ -1765,29 +1752,29 @@ func TestCheckNodeHealth(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	const sqlInstanceID = base.SQLInstanceID(5)
+	const nodeID = roachpb.NodeID(5)
 
-	mockGossip := gossip.NewTest(roachpb.NodeID(sqlInstanceID), stopper, metric.NewRegistry())
+	mockGossip := gossip.NewTest(nodeID, stopper, metric.NewRegistry())
 
 	desc := &roachpb.NodeDescriptor{
-		NodeID:  roachpb.NodeID(sqlInstanceID),
+		NodeID:  nodeID,
 		Address: util.UnresolvedAddr{NetworkField: "tcp", AddressField: "testaddr"},
 	}
 	if err := mockGossip.SetNodeDescriptor(desc); err != nil {
 		t.Fatal(err)
 	}
 	if err := mockGossip.AddInfoProto(
-		gossip.MakeDistSQLDrainingKey(sqlInstanceID),
+		gossip.MakeDistSQLDrainingKey(nodeID),
 		&execinfrapb.DistSQLDrainingInfo{Draining: false},
 		0, // ttl - no expiration
 	); err != nil {
 		t.Fatal(err)
 	}
 
-	notAvailable := func(base.SQLInstanceID) bool {
+	notAvailable := func(roachpb.NodeID) bool {
 		return false
 	}
-	available := func(base.SQLInstanceID) bool {
+	available := func(roachpb.NodeID) bool {
 		return true
 	}
 
@@ -1800,44 +1787,53 @@ func TestCheckNodeHealth(t *testing.T) {
 	_ = connUnhealthy
 
 	livenessTests := []struct {
-		isAvailable func(id base.SQLInstanceID) bool
-		exp         string
+		isAvailable func(id roachpb.NodeID) bool
+		exp         bool
 	}{
-		{available, ""},
-		{notAvailable, "not using n5 since it is not available"},
+		{available, true},
+		{notAvailable, false},
 	}
 
 	gw := gossip.MakeOptionalGossip(mockGossip)
 	for _, test := range livenessTests {
 		t.Run("liveness", func(t *testing.T) {
-			h := distSQLNodeHealth{
-				gossip:           gw,
-				connHealthSystem: connHealthy,
-				isAvailable:      test.isAvailable,
+			nodeLiveness := livenesspb.TestCreateNodeVitality()
+			nodeLiveness.AddNode(nodeID)
+			if !test.isAvailable(nodeID) {
+				nodeLiveness.DownNode(nodeID)
 			}
-			if err := h.checkSystem(context.Background(), sqlInstanceID); !testutils.IsError(err, test.exp) {
-				t.Fatalf("expected %v, got %v", test.exp, err)
+			if CheckKVNodeHealth(
+				context.Background(),
+				nodeID,
+				connHealthy,
+				nodeLiveness,
+				gw,
+			) != test.exp {
+				t.Fatalf("expected %v", test.exp)
 			}
 		})
 	}
 
 	connHealthTests := []struct {
 		connHealth func(roachpb.NodeID, rpc.ConnectionClass) error
-		exp        string
+		exp        bool
 	}{
-		{connHealthy, ""},
-		{connUnhealthy, "injected conn health error"},
+		{connHealthy, true},
+		{connUnhealthy, false},
 	}
 
 	for _, test := range connHealthTests {
 		t.Run("connHealth", func(t *testing.T) {
-			h := distSQLNodeHealth{
-				gossip:           gw,
-				connHealthSystem: test.connHealth,
-				isAvailable:      available,
-			}
-			if err := h.checkSystem(context.Background(), sqlInstanceID); !testutils.IsError(err, test.exp) {
-				t.Fatalf("expected %v, got %v", test.exp, err)
+			nodeLiveness := livenesspb.TestCreateNodeVitality()
+			nodeLiveness.AddNode(nodeID)
+			if CheckKVNodeHealth(
+				context.Background(),
+				nodeID,
+				test.connHealth,
+				nodeLiveness,
+				gw,
+			) != test.exp {
+				t.Fatalf("expected %v", test.exp)
 			}
 		})
 	}

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -78,7 +78,7 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningSystem(
 	// populate it.
 	for _, node := range resp.Nodes {
 		if ok, _ := node.Desc.Locality.Matches(localityFilter); ok {
-			_ /* NodeStatus */ = dsp.checkInstanceHealthAndVersionSystem(ctx, planCtx, base.SQLInstanceID(node.Desc.NodeID))
+			_ /* NodeStatus */ = dsp.checkInstanceHealthAndVersionSystem(ctx, planCtx, node.Desc.NodeID)
 		}
 	}
 	nodes := make([]base.SQLInstanceID, 0, len(planCtx.nodeStatuses))


### PR DESCRIPTION
Previously we added health checks to validate the health of SQL pods in addition to KV pods. Ideally the KV checks should be handled by the liveness framework while the SQL-SQL pod checks are outside the scope of the liveness framework. This change makes the code paths more explicit.

Epic: CRDB-39091

Informs: #120774

Release note: None