### PR TITLE
kv: optimize multi-read lock table conflict check

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -62,14 +62,6 @@ import (
 )
 
 const (
-	// configGossipTTL is the time-to-live for configuration maps.
-
-	// optimizePutThreshold is the minimum length of a contiguous run
-	// of batched puts or conditional puts, after which the constituent
-	// put operations will possibly be optimized by determining whether
-	// the key space being written is starting out empty.
-	optimizePutThreshold = 10
-
 	// Transaction names and operations used for range changes.
 	// Note that those names are used by tests to perform request filtering
 	// in absence of better criteria. If names are changed, tests should be

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -37,6 +37,12 @@ import (
 	"github.com/kr/pretty"
 )
 
+// optimizePutThreshold is the minimum length of a contiguous run
+// of batched puts or conditional puts, after which the constituent
+// put operations will possibly be optimized by determining whether
+// the key space being written is starting out empty.
+const optimizePutThreshold = 10
+
 // optimizePuts searches for contiguous runs of Put & CPut commands in
 // the supplied request union. Any run which exceeds a minimum length
 // threshold employs a full order iterator to determine whether the

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// configGossipTTL is the time-to-live for configuration maps.
 const configGossipTTL = 0 // does not expire
 
 func (r *Replica) gossipFirstRange(ctx context.Context) {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1518,6 +1518,12 @@ func ScanLocks(
 	if bytes.Compare(start, end) >= 0 {
 		return locks, nil
 	}
+	if maxLocks < 0 {
+		return locks, nil
+	}
+	if targetBytes < 0 {
+		return locks, nil
+	}
 
 	ltStart, _ := keys.LockTableSingleKey(start, nil)
 	ltEnd, _ := keys.LockTableSingleKey(end, nil)
@@ -1535,15 +1541,6 @@ func ScanLocks(
 	var lockBytes int64
 	var ok bool
 	for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: ltStart}); ok; ok, err = iter.NextEngineKey() {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if maxLocks != 0 && int64(len(locks)) >= maxLocks {
-			break
-		}
-		if targetBytes != 0 && lockBytes >= targetBytes {
-			break
-		}
 		key, err := iter.EngineKey()
 		if err != nil {
 			return nil, err
@@ -1561,6 +1558,17 @@ func ScanLocks(
 		}
 		locks = append(locks, roachpb.MakeLock(meta.Txn, ltKey.Key, ltKey.Strength))
 		lockBytes += int64(len(ltKey.Key)) + int64(len(v))
+
+		// Check loop termination conditions, ahead of the next pebble iteration.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if maxLocks != 0 && int64(len(locks)) >= maxLocks {
+			break
+		}
+		if targetBytes != 0 && lockBytes >= targetBytes {
+			break
+		}
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds a fast-path for multi-read requests (10+ Gets or Scans) in `canDropLatchesBeforeEval` when checking for conflicting locks. If a read-only batch is large enough, we now perform a single lock table scan from the batch's smallest key to its largest key to check for conflicts. This is more efficient than scanning the lock table for each request in the batch. However, it may encounter false positive conflicts, in which case we fall back to scanning the lock table for each request in the batch.

Example improvement:
```sql
CREATE TABLE t (
  k INT PRIMARY KEY,
  a INT,
  b INT,
  c INT
);

INSERT INTO t
SELECT i, i%50, i*10, i*100
FROM generate_series(1, 50000) AS g(i);

CREATE INDEX ON t (a);


-- 1000 row index join (`SELECT * FROM t WHERE a = 39`):
--- v24.1.2         CRDB | Execution Times (ms): 7.000, 7.000, 7.000
--- v24.1.2 + patch CRDB | Execution Times (ms): 6.000, 6.000, 6.000

-- 4000 row index join (`SELECT * FROM t WHERE a BETWEEN 36 AND 39`):
--- v24.1.2         CRDB | Execution Times (ms): 22.000, 22.000, 23.000
--- v24.1.2 + patch CRDB | Execution Times (ms): 17.000, 16.000, 16.000
```

Epic: None
Release note (performance improvement): Lookup joins that return many rows are up to 25% faster when probing into a table with no row locks.