### PR TITLE
roachprod: add unimplemented error

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -660,11 +660,11 @@ func (p *Provider) Create(
 }
 
 func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) Shrink(*logger.Logger, vm.List, string) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 // waitForIPs waits until AWS reports both internal and external IP addresses
@@ -1638,8 +1638,8 @@ func (p *Provider) CreateVolume(
 	return vol, err
 }
 
-func (p *Provider) DeleteVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) error {
-	panic("unimplemented")
+func (p *Provider) DeleteVolume(l *logger.Logger, volume vm.Volume, _ *vm.VM) error {
+	return vm.UnimplementedError
 }
 
 func (p *Provider) ListVolumes(l *logger.Logger, vm *vm.VM) ([]vm.Volume, error) {
@@ -1693,19 +1693,19 @@ func (p *Provider) CreateVolumeSnapshot(
 func (p *Provider) ListVolumeSnapshots(
 	l *logger.Logger, vslo vm.VolumeSnapshotListOpts,
 ) ([]vm.VolumeSnapshot, error) {
-	panic("unimplemented")
+	return nil, vm.UnimplementedError
 }
 
 func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.VolumeSnapshot) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -123,25 +123,25 @@ func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {
 	// TODO(leon): implement
-	panic("unimplemented")
+	return vm.VolumeSnapshot{}, vm.UnimplementedError
 }
 
 func (p *Provider) ListVolumeSnapshots(
 	l *logger.Logger, vslo vm.VolumeSnapshotListOpts,
 ) ([]vm.VolumeSnapshot, error) {
-	panic("unimplemented")
+	return nil, vm.UnimplementedError
 }
 
 func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.VolumeSnapshot) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) CreateVolume(*logger.Logger, vm.VolumeCreateOpts) (vm.Volume, error) {
-	panic("unimplemented")
+	return vm.Volume{}, vm.UnimplementedError
 }
 
-func (p *Provider) DeleteVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) error {
-	panic("unimplemented")
+func (p *Provider) DeleteVolume(l *logger.Logger, volume vm.Volume, _ *vm.VM) error {
+	return vm.UnimplementedError
 }
 
 func (p *Provider) ListVolumes(l *logger.Logger, vm *vm.VM) ([]vm.Volume, error) {
@@ -149,23 +149,23 @@ func (p *Provider) ListVolumes(l *logger.Logger, vm *vm.VM) ([]vm.Volume, error)
 }
 
 func (p *Provider) AttachVolume(*logger.Logger, vm.Volume, *vm.VM) (string, error) {
-	panic("unimplemented")
+	return "", vm.UnimplementedError
 }
 
 func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) Shrink(*logger.Logger, vm.List, string) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
-	panic("unimplemented")
+	return vm.UnimplementedError
 }
 
 func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -62,6 +62,12 @@ const (
 	DisksInitializedFile = "/mnt/data1/" + InitializedFile
 )
 
+// UnimplementedError is returned when a method is not implemented by a
+// provider. An error is returned instead of panicking to isolate failures to a
+// single test (in the context of `roachtest`), otherwise the entire test run
+// would fail.
+var UnimplementedError = errors.New("unimplemented")
+
 type CPUArch string
 
 // ParseArch parses a string into a CPUArch using a simple, non-exhaustive heuristic.


### PR DESCRIPTION
Previously, providers would panic if an unimplemented method was called. This could prove problematic for roachtest that allow tests to specify a set of compatible clouds. The implementer of the test may be unaware that the method they are planning to invoke is not implemented on certain cloud providers. A panic will end up failing the whole test suite.

In this change we introduce an error that should be used instead of `panic("unimplemented")`.

Fixes: #119857

Release note: None
Epic: None