### PR TITLE
crosscluster: make a redaction-safe processorType enum

### DIFF
--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -38,13 +38,23 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
 	originTimestampColumnName = "crdb_replication_origin_timestamp"
+)
 
-	lwwProcessor        = "last-write-wins"
-	udfApplierProcessor = "applier-udf"
+type processorType string
+
+// SafeValue implements the redact.SafeValue interface.
+func (p processorType) SafeValue() {}
+
+var _ redact.SafeValue = defaultSQLProcessor
+
+const (
+	lwwProcessor        processorType = "last-write-wins"
+	udfApplierProcessor processorType = "applier-udf"
 )
 
 // TODO(ssd): Thread through from job

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -65,6 +65,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"SettingName": {},
 						"ValueOrigin": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/logical": {
+						"processorType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/cli/exit": {
 						"Code": {},
 					},


### PR DESCRIPTION
This will help to make sure the processor type is not redacted if we use it in logs or errors.

Epic: None
Release note: None