### PR TITLE
crosscluster/logical: remove 'conflcit' from DLQ table name

### DIFF
--- a/pkg/ccl/crosscluster/logical/dead_letter_queue.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// TODO(azhu): create table and enum in the db to be replicated into instead of defaultdb.
-	dlqBaseTableName = "defaultdb.crdb_replication_conflict_dlq_%d"
+	dlqBaseTableName = "defaultdb.crdb_replication_dlq_%d"
 	writeEnumStmt    = `CREATE TYPE IF NOT EXISTS defaultdb.crdb_replication_mutation_type AS ENUM (
 			'insert', 'update', 'delete'
 	)`


### PR DESCRIPTION
Any failure to apply an update that doesn't fail the stream needs to be recorded, not just a conflict-caused failure, so naming it 'conflict' is misleading.

Release note: none.
Epic: none.