### PR TITLE
crosscluster/logical: fix backoff setting default

### DIFF
--- a/pkg/ccl/crosscluster/logical/purgatory.go
+++ b/pkg/ccl/crosscluster/logical/purgatory.go
@@ -30,7 +30,7 @@ var retryQueueBackoff = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"logical_replication.consumer.retry_queue_backoff",
 	"minimum delay between retries of items in the retry queue",
-	time.Minute,
+	time.Second*3,
 )
 
 var retryQueueSizeLimit = settings.RegisterByteSizeSetting(


### PR DESCRIPTION
When I made these settings, I mistakenly used minute for both the expiration and the backoff.

Release note: none.
Epic: none.