### PR TITLE
mixedversion: don't find all predecessors if skip version is not available

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -737,8 +737,10 @@ func (t *Test) choosePreviousReleases() ([]*clusterupgrade.Version, error) {
 		}
 
 		// If skip-version upgrades are not enabled, the only possible
-		// predecessor is the immediate predecessor release.
-		if !skipVersions {
+		// predecessor is the immediate predecessor release. If the
+		// predecessor doesn't support skip versions, then its predecessor
+		// won't either. Don't attempt to find it.
+		if !skipVersions || !pred.AtLeast(minSupportedSkipVersionUpgrade) {
 			return []*clusterupgrade.Version{pred}, nil
 		}
 


### PR DESCRIPTION
In order to enable skip version upgrades, the planner finds all possible predecessors a single version can have. However, we only keep release data from 21.2 and after.

This change now checks first that skip version upgrades are available before finding a predecessor's predecessor.

Fixes: #127357
Release note: none
Epic: none