### PR TITLE
release-24.2: crosscluster: heartbeat retained time to source cluster

### DIFF
--- a/pkg/ccl/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/ccl/crosscluster/physical/alter_replication_job_test.go
@@ -55,11 +55,7 @@ func TestAlterTenantCompleteToTime(t *testing.T) {
 
 	var cutoverTime time.Time
 	c.DestSysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
-
-	var cutoverStr string
-	c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
-		args.DestTenantName, cutoverTime).Scan(&cutoverStr)
-	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
+	cutoverOutput := c.Cutover(ctx, producerJobID, ingestionJobID, cutoverTime, false)
 	require.Equal(t, cutoverTime, cutoverOutput.GoTime())
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 }
@@ -67,7 +63,6 @@ func TestAlterTenantCompleteToTime(t *testing.T) {
 func TestAlterTenantCompleteToLatest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
 
@@ -84,9 +79,7 @@ func TestAlterTenantCompleteToLatest(t *testing.T) {
 	c.WaitUntilReplicatedTime(targetReplicatedTime, jobspb.JobID(ingestionJobID))
 
 	var emptyCutoverTime time.Time
-	cutoverStr := c.Cutover(ctx, producerJobID, ingestionJobID, emptyCutoverTime, false)
-
-	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
+	cutoverOutput := c.Cutover(ctx, producerJobID, ingestionJobID, emptyCutoverTime, false)
 	require.GreaterOrEqual(t, cutoverOutput.GoTime(), targetReplicatedTime.GoTime())
 	require.LessOrEqual(t, cutoverOutput.GoTime(), c.SrcCluster.Server(0).Clock().Now().GoTime())
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_job_test.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_job_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -205,10 +206,24 @@ func TestTenantStreamingFailback(t *testing.T) {
 	var ts1 string
 	sqlA.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&ts1)
 
-	t.Log("waiting for initial scan on g")
-	replicationtestutils.WaitUntilStartTimeReached(t, sqlB, jobspb.JobID(consumerGJobID))
-	t.Log("completing replication on g to latest")
-	sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO LATEST")
+	// Randomize query execution to verify fast failback works for both
+	// `COMPLETE REPLICATION TO LATEST` and `COMPLETE REPLICATION TO SYSTEM TIME`
+	rng, _ := randutil.NewPseudoRand()
+	if rng.Intn(2) == 0 {
+		t.Logf("waiting for g@%s", ts1)
+		replicationtestutils.WaitUntilReplicatedTime(t,
+			replicationtestutils.DecimalTimeToHLC(t, ts1),
+			sqlB,
+			jobspb.JobID(consumerGJobID))
+
+		t.Logf("completing replication on g@%s", ts1)
+		sqlB.Exec(t, fmt.Sprintf("ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO SYSTEM TIME '%s'", ts1))
+	} else {
+		t.Log("waiting for initial scan on g")
+		replicationtestutils.WaitUntilStartTimeReached(t, sqlB, jobspb.JobID(consumerGJobID))
+		t.Log("completing replication on g to latest")
+		sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO LATEST")
+	}
 
 	jobutils.WaitForJobToSucceed(t, sqlB, jobspb.JobID(consumerGJobID))
 	compareAtTimetamp(ts1)

--- a/pkg/ccl/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/testutils.go
@@ -264,28 +264,39 @@ ORDER BY created DESC LIMIT 1`, c.Args.DestTenantName)
 // the latest replicated time.
 func (c *TenantStreamingClusters) Cutover(
 	ctx context.Context, producerJobID, ingestionJobID int, cutoverTime time.Time, async bool,
-) string {
+) hlc.Timestamp {
 	// Cut over the ingestion job and the job will stop eventually.
 	var cutoverStr string
+	var cutoverOutput hlc.Timestamp
+
 	if cutoverTime.IsZero() {
 		c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO LATEST`,
 			c.Args.DestTenantName).Scan(&cutoverStr)
-		cutoverOutput := DecimalTimeToHLC(c.T, cutoverStr)
-		protectedTimestamp := replicationutils.TestingGetPTSFromReplicationJob(c.T, ctx, c.SrcSysSQL, c.SrcSysServer, producerJobID)
-		require.LessOrEqual(c.T, protectedTimestamp.GoTime(), cutoverOutput.GoTime())
+		cutoverOutput = DecimalTimeToHLC(c.T, cutoverStr)
 	} else {
 		c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
 			c.Args.DestTenantName, cutoverTime).Scan(&cutoverStr)
-		cutoverOutput := DecimalTimeToHLC(c.T, cutoverStr)
+		cutoverOutput = DecimalTimeToHLC(c.T, cutoverStr)
 		require.Equal(c.T, cutoverTime, cutoverOutput.GoTime())
 	}
+
+	protectedTimestamp := replicationutils.TestingGetPTSFromReplicationJob(c.T, ctx, c.SrcSysSQL, c.SrcSysServer, producerJobID)
+	require.LessOrEqual(c.T, protectedTimestamp.GoTime(), cutoverOutput.GoTime())
+
+	// PTS should be less than or equal to retained time as a result of heartbeats.
+	var retainedTime time.Time
+	c.DestSysSQL.QueryRow(c.T,
+		`SELECT retained_time FROM [SHOW TENANT $1 WITH REPLICATION STATUS]`,
+		c.Args.DestTenantName).Scan(&retainedTime)
+
+	require.LessOrEqual(c.T, protectedTimestamp.GoTime(), retainedTime)
 
 	if !async {
 		jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 		c.WaitForPostCutoverRetentionJob()
 	}
 
-	return cutoverStr
+	return cutoverOutput
 }
 
 // StartStreamReplication producer job ID and ingestion job ID.


### PR DESCRIPTION
Backport 1/1 commits from #125966.

/cc @cockroachdb/release

---

Previously, the destination cluster heartbeats replicated time
- the upper bound of the time window for which users can cutover
to. By heartbeating the replicated time, the PTS on the source
cluster can advance above cutover timestamps issued by users,
causing fast failback to fail. In This PR, we heartbeat the
retained time, which is the lower bound of the cutover window,
instead of the replicated time. This guarantees that PTS on the
source cluster will always be less than or equal to cutover
timestamp issued within the cutover window.

In addition, we also take the maximum of previous retained time and
replication start time to be the updated retained time, since we
don't need to protect anything below replication start time.

Epic: none
Release note (bug fix): This patch fixes a known limitation in
which fast failback could fail. It leads us to protect data for
the default protection window of 4 hours on both the source and
the destination.

----

Release justification: PCR bug fix