### PR TITLE
schematelemetry: test that logs are redacted correctly

### DIFF
--- a/pkg/sql/catalog/schematelemetry/schema_telemetry_test.go
+++ b/pkg/sql/catalog/schematelemetry/schema_telemetry_test.go
@@ -187,7 +187,14 @@ UPDATE system.namespace SET id = %d WHERE id = %d;
 	// Ensure that a log line is emitted for each invalid object, with a loose
 	// enforcement of the log structure.
 	errorRE := regexp.MustCompile(`found invalid object with ID \d+: .+`)
-	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1000, errorRE, log.SelectEditMode(false, false))
+	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1000, errorRE, log.SelectEditMode(false /* redact */, false /* keepRedactable */))
 	require.NoError(t, err)
 	require.Len(t, entries, 9)
+
+	// Verify that the log entries have redaction markers applied by checking one
+	// of the specific error messages.
+	errorRE = regexp.MustCompile(`found invalid object with ID \d+: relation ‹"nojob"›`)
+	entries, err = log.FetchEntriesFromFiles(0, math.MaxInt64, 1000, errorRE, log.SelectEditMode(false /* redact */, true /* keepRedactable */))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
 }


### PR DESCRIPTION
follow-up from https://github.com/cockroachdb/cockroach/pull/127195
informs: https://github.com/cockroachdb/cockroach/issues/126584
Release note: None