### PR TITLE
crosscluster/logical: add mode option parsing

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -252,6 +252,11 @@ message LogicalReplicationDetails {
     int32 function_id = 2;
   }
   DefaultConflictResolution default_conflict_resolution = 7 [(gogoproto.nullable) = false];
+
+  enum Mode{
+    IMMEDIATE = 0;
+  }
+  Mode mode = 8;
 }
 
 message LogicalReplicationProgress {


### PR DESCRIPTION
This commit allows for the parsing of the mode option. Since we only support a single mode right now, when not provided it is set by default. Any other options other than immediate will result in an error.

Tests are also added to ensure error handling of options is properly returned.

Epic: none
Release note: None