### PR TITLE
streamingest: rework how the change in plan is measured

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -594,11 +594,15 @@ func measurePlanChange(before, after *sql.PhysicalPlan) float64 {
 				// Skip other processors in the plan (like the Frontier processor).
 				continue
 			}
-			dst[proc.SQLInstanceID.String()] = struct{}{}
-			count += 1
-			for id := range proc.Spec.Core.StreamIngestionData.PartitionSpecs {
-				src[id] = struct{}{}
+			if _, ok := dst[proc.SQLInstanceID.String()]; !ok {
+				dst[proc.SQLInstanceID.String()] = struct{}{}
 				count += 1
+			}
+			for id := range proc.Spec.Core.StreamIngestionData.PartitionSpecs {
+				if _, ok := src[id]; !ok {
+					src[id] = struct{}{}
+					count += 1
+				}
 			}
 		}
 		return src, dst, count

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist_test.go
@@ -127,6 +127,12 @@ func TestMeasurePlanChange(t *testing.T) {
 			after:  makePlan(makeProc(1, []int{2}), makeProc(2, []int{1})),
 			frac:   0,
 		},
+		{
+			name:   "lots of processors",
+			before: makePlan(makeProc(1, []int{1}), makeProc(1, []int{1}), makeProc(1, []int{1})),
+			after:  makePlan(makeProc(1, []int{1}), makeProc(1, []int{1}), makeProc(1, []int{1}), makeProc(2, []int{1})),
+			frac:   0.5,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			frac := measurePlanChange(&tc.before, &tc.after)


### PR DESCRIPTION
The prior implementation of MeasurePlanChange was inaccurate at calculating the change between the current plan and a proposed new plan. This led to the scenario where a node being added to a cluster wouldn't be considered for PCR. This change reworks the calculation to only count each unique node once.

See https://github.com/cockroachdb/cockroach/pull/127259 which this was backported from.