### PR TITLE
ui: add Leader lease observability

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -108,6 +108,33 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Lease Types"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      tooltip={`Details about the types of leases in use by ranges in the
+                system. A cluster is expected to have a mix of lease types.
+                In the node view, shows details about leases the node is
+                responsible for. In the cluster view, shows details about
+                leases all across the cluster.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis label="leases">
+        <Metric
+          name="cr.store.leases.expiration"
+          title="Expiration Leases"
+        />
+        <Metric
+          name="cr.store.leases.epoch"
+          title="Epoch Leases"
+        />
+        <Metric
+          name="cr.store.leases.leader"
+          title="Leader Leases"
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Lease Preferences"
       sources={storeSources}
       tenantSource={tenantSource}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/lease.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/lease.ts
@@ -15,6 +15,11 @@ export function IsLeaseEpoch(lease: protos.cockroach.roachpb.ILease) {
   return !FixLong(lease.epoch).eq(0);
 }
 
+export function IsLeaseLeader(lease: protos.cockroach.roachpb.ILease) {
+  return !FixLong(lease.term).eq(0);
+}
+
 export default {
   IsEpoch: IsLeaseEpoch,
+  IsLeader: IsLeaseLeader,
 };


### PR DESCRIPTION
Fixes #125240.

This PR add observability for Leader leases to the DB console.

First, it adds information about Leader leases to the range details page.

<img width="796" alt="Screenshot 2024-07-17 at 5 06 34 PM" src="https://github.com/user-attachments/assets/860f8f67-dd58-4e48-b3ed-3cba1645cdae">
<img width="794" alt="Screenshot 2024-07-17 at 5 07 20 PM" src="https://github.com/user-attachments/assets/bae77afa-66e1-4a8b-b5a6-681260a194f2">

Next, it adds a "Lease Types" graph to Replication dashboard.

<img width="1004" alt="Screenshot 2024-07-18 at 11 45 00 AM" src="https://github.com/user-attachments/assets/dd5ae6ed-81fb-40bf-9dc1-11bf34971466">

Release note: None