### PR TITLE
cli: reset `securityassets` `Loader` after test completion

### DIFF
--- a/pkg/cli/demo_locality_test.go
+++ b/pkg/cli/demo_locality_test.go
@@ -40,6 +40,7 @@ func TestDemoLocality(t *testing.T) {
 	// asset loader that is set by default in tests will not be able to
 	// find the certs that demo sets up.
 	securityassets.ResetLoader()
+	defer ResetTest()
 
 	// Using datadriven allows TESTFLAGS=-rewrite.
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "demo", "test_demo_locality"), func(t *testing.T, td *datadriven.TestData) string {

--- a/pkg/cli/demo_test.go
+++ b/pkg/cli/demo_test.go
@@ -34,6 +34,7 @@ func TestDemo(t *testing.T) {
 	// asset loader that is set by default in tests will not be able to
 	// find the certs that demo sets up.
 	securityassets.ResetLoader()
+	defer ResetTest()
 
 	// Using datadriven allows TESTFLAGS=-rewrite.
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "demo", "test_demo"), func(t *testing.T, td *datadriven.TestData) string {

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package cli_test
+package cli
 
 import (
 	"os"
@@ -24,6 +24,10 @@ import (
 )
 
 func init() {
+	ResetTest()
+}
+
+func ResetTest() {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 }
 


### PR DESCRIPTION
These tests update the global `securityassets` `Loader` for their tests, but then don't reset it back to the previous value afterward. This can cause tests to appear to fail randomly depending on which tests are scheduled on a single shard.

In the future, we should consider avoiding using global mutable state to avoid this kind of thing happening.

Closes #127382.
Epic: none
Release note: None