### PR TITLE
workflow: add cockroach-microbench-ci step in github actions

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -17,6 +17,7 @@ status = [
        "macos_arm64_build",
        "unit_tests",
        "windows_build",
+       "cockroach-microbench-ci"
 ]
 
 # List of commit statuses that must not be failing on the PR commit when it is

--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -344,3 +344,33 @@ jobs:
       - name: clean up
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
+  cockroach-microbench-ci:
+    runs-on: [ self-hosted, basic_runner_group ]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - name: Check for perf regression label
+        id: check_perf_regression_label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const labelName = 'perf-regression-expected';
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            if (labels.includes(labelName)) {
+              core.setOutput('label_found', 'true');
+            } else {
+              core.setOutput('label_found', 'false');
+            }
+      - name: run scripts
+        run: ./build/github/cockroach-microbench-ci.sh
+        env:
+          COMPARE_THRESHOLD: "5.00"
+          PUSH_STEP: ${{ github.event_name == 'push' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKIP_COMPARISON: ${{ steps.check_perf_regression_label.outputs.label_found == 'true' }}
+      - name: clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        if: always()
+

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Directories and file names
+output_dir="./artifacts/microbench"
+cleaned_current_dir="$output_dir/current"
+cleaned_base_dir="$output_dir/base"
+
+# hardcoded the file name as of now since `compare` requires a particular format for the file name.
+benchmark_file_name="pkg_sql-report.log"
+log_output_file_path="$output_dir/microbench.log"
+
+storage_bucket_url="gs://cockroach-microbench-ci"
+
+# Threshold for comparison
+threshold=$COMPARE_THRESHOLD
+exit_status=0
+
+# Configure Bazel and dev tooling
+cat <<EOF > ./.bazelrc.user
+build --config nolintonbuild
+build --remote_cache=http://127.0.0.1:9867
+test --test_tmpdir=/tmp/cockroach
+test --config crosslinux
+EOF
+
+# Exit early if SKIP_COMPARISON is true and not a push step
+if $SKIP_COMPARISON && ! $PUSH_STEP; then
+  echo "Exiting since skip comparison is enabled and this is not a push step."
+  exit $exit_status
+fi
+
+./dev doctor
+./dev build roachprod-microbench
+
+# Run benchmarks and clean output
+mkdir -p "$output_dir"
+
+# running 4 here because that's the minumum required for a comparison
+./dev bench pkg/sql/tests '--filter=^BenchmarkKV$' --count 4 --verbose --bench-mem > "$log_output_file_path"
+./bin/roachprod-microbench clean "$log_output_file_path" "$cleaned_current_dir/$benchmark_file_name"
+
+# Push artifact if this is a base merge and skip comparison
+if $PUSH_STEP; then
+  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_HEAD_REF/$GITHUB_SHA.log"
+  echo "Skipping comparison since this is a base merge."
+  exit $exit_status
+fi
+
+# Compare benchmarks
+if ! gcloud storage cp "$storage_bucket_url/$GITHUB_BASE_REF/$BASE_SHA.log" "$cleaned_base_dir/$benchmark_file_name"; then
+  echo "Couldn't download base bench file, exiting."
+  exit $exit_status
+fi
+
+if ! ./bin/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold "$threshold"; then
+  echo "There is an error during comparison. If it's a perf regression, please fix it. If a regression is expected, add [PERF_REGRESSION_EXPECTED] in the PR head title."
+  exit 1
+fi
+
+rm -rf $output_dir
+exit $exit_status


### PR DESCRIPTION

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-29662

This change intends to add a new CI step which will run `BenchmarkKV` microbenchmark for the current commit and compares the result with that of the base commit's results which is stored in a cloud bucket.

This is needed to avoid minor perf regressions so that any regression is caught in the PR itself. The current threshold is set to 5%.

There are highly 3 steps
1. Run benchmarks
2. If this is PR branch, download the base commit's bench results from the cloud storage and compare the results. If there's a regression fail here itself
3. If it is a release/master branch, push the result to the cloud storage with the current commit sha.

In cases that a regression is expected, the developers can add `perf-regression-expected` label which skips the comparison step for the PR. However it will still run the microbenchmarks and upload the results during PR push.