### PR TITLE
sql: add cache invalidation builtin functions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/builtins
+++ b/pkg/ccl/logictestccl/testdata/logic_test/builtins
@@ -1,5 +1,9 @@
 # LogicTest: local
 
+statement ok
+CREATE TABLE xy (x INT, y INT);
+INSERT INTO xy VALUES (1, 2);
+
 subtest protect_mvcc_history
 
 user root
@@ -49,3 +53,170 @@ select crdb_internal.protect_mvcc_history(1709131929793796000.0000000000, '10ms'
 query TTT retry
 select ts as timestamp, meta_type, crdb_internal.pb_to_json( 'cockroach.protectedts.Target', target ) from system.protected_ts_records
 ----
+
+subtest clear_query_plan_cache
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM xy;
+
+statement ok
+SET TRACING = "off";
+
+# The first execution should miss the query cache.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache miss
+query cache add
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM xy;
+
+statement ok
+SET TRACING = "off";
+
+# The second execution should hit the query cache.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache hit
+
+statement ok
+SELECT crdb_internal.clear_query_plan_cache();
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM xy;
+
+statement ok
+SET TRACING = "off";
+
+# After running the builtin, the query cache should be cleared.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%query cache%';
+----
+query cache miss
+query cache add
+
+subtest clear_table_stats_cache
+
+# Add a fresh set of table stats.
+statement ok
+ALTER TABLE xy INJECT STATISTICS '[
+    {
+        "columns": [ "x" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 20000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 60000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 20000,
+                "num_eq": 20000,
+                "num_range": 20000,
+                "upper_bound": "40000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "columns": [ "y" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 7000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 7000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 7000,
+                "num_eq": 86000,
+                "num_range": 7000,
+                "upper_bound": "10000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "columns": [ "x", "y" ],
+        "created_at": "2021-07-13 14:04:42.014148",
+        "distinct_count": 20000,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 100000
+    }
+]';
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM xy;
+
+statement ok
+SET TRACING = "off";
+
+# The first execution should miss the stats cache.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%reading statistics%';
+----
+reading statistics for table 106
+finished reading statistics for table 106
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM xy;
+
+statement ok
+SET TRACING = "off";
+
+# The second execution should hit the stats cache.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%reading statistics%';
+----
+
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
+statement ok
+SET TRACING = "on", cluster;
+
+statement ok
+SELECT * FROM xy;
+
+statement ok
+SET TRACING = "off";
+
+# After executing the builtin, the last execution should miss the stats cache.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%reading statistics%';
+----
+reading statistics for table 106
+finished reading statistics for table 106
+
+subtest end

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -570,6 +570,12 @@ func (ep *DummyEvalPlanner) InsertTemporarySchema(
 
 }
 
+// ClearQueryPlanCache is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) ClearQueryPlanCache() {}
+
+// ClearTableStatsCache is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) ClearTableStatsCache() {}
+
 // DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
 type DummyPrivilegedAccessor struct{}
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -992,6 +992,20 @@ func (p *planner) AutoCommit() bool {
 	return p.autoCommit
 }
 
+// ClearQueryPlanCache is part of the eval.Planner interface.
+func (p *planner) ClearQueryPlanCache() {
+	if p.execCfg.QueryCache != nil {
+		p.execCfg.QueryCache.Clear()
+	}
+}
+
+// ClearTableStatsCache is part of the eval.Planner interface.
+func (p *planner) ClearTableStatsCache() {
+	if p.execCfg.TableStatsCache != nil {
+		p.execCfg.TableStatsCache.Clear()
+	}
+}
+
 // mustUseLeafTxn returns true if inner plans must use a leaf transaction.
 func (p *planner) mustUseLeafTxn() bool {
 	return atomic.LoadInt32(&p.atomic.innerPlansMustUseLeafTxn) >= 1

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8792,6 +8792,38 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			Volatility: volatility.Volatile,
 		},
 	),
+	"crdb_internal.clear_query_plan_cache": makeBuiltin(
+		tree.FunctionProperties{
+			Category:     builtinconstants.CategorySystemRepair,
+			Undocumented: true,
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				evalCtx.Planner.ClearQueryPlanCache()
+				return tree.DVoidDatum, nil
+			},
+			Info:       `This function is used to clear the query plan cache on the gateway node`,
+			Volatility: volatility.Volatile,
+		},
+	),
+	"crdb_internal.clear_table_stats_cache": makeBuiltin(
+		tree.FunctionProperties{
+			Category:     builtinconstants.CategorySystemRepair,
+			Undocumented: true,
+		},
+		tree.Overload{
+			Types:      tree.ParamTypes{},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				evalCtx.Planner.ClearTableStatsCache()
+				return tree.DVoidDatum, nil
+			},
+			Info:       `This function is used to clear the table statistics cache on the gateway node`,
+			Volatility: volatility.Volatile,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2605,6 +2605,8 @@ var builtinOidsArray = []string{
 	2637: `crdb_internal.start_logical_replication_job(conn_str: string, table_names: string[]) -> int`,
 	2638: `crdb_internal.plan_logical_replication(req: bytes) -> bytes`,
 	2639: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
+	2640: `crdb_internal.clear_query_plan_cache() -> void`,
+	2641: `crdb_internal.clear_table_stats_cache() -> void`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -451,6 +451,12 @@ type Planner interface {
 	InsertTemporarySchema(
 		tempSchemaName string, databaseID descpb.ID, schemaID descpb.ID,
 	)
+
+	// ClearQueryPlanCache removes all entries from the node's query plan cache.
+	ClearQueryPlanCache()
+
+	// ClearTableStatsCache removes all entries from the node's table stats cache.
+	ClearTableStatsCache()
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -135,6 +135,13 @@ func NewTableStatisticsCache(
 	return tableStatsCache
 }
 
+// Clear removes all entries from the stats cache.
+func (sc *TableStatisticsCache) Clear() {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.mu.cache.Clear()
+}
+
 // Start begins watching for updates in the stats table.
 func (sc *TableStatisticsCache) Start(
 	ctx context.Context, codec keys.SQLCodec, rangeFeedFactory *rangefeed.Factory,


### PR DESCRIPTION
This commit adds builtin functions that can be used to invalidate the query plan cache and table statistics cache. This is useful for preventing test flakes due to asynchronous cache updates, as well as for tests that involve the caches in general.

Fixes #122543

Release note: None