### PR TITLE
raft: use last accepted term for log writes

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -247,13 +247,6 @@ func (l *raftLog) hasNextUnstableEnts() bool {
 	return len(l.nextUnstableEnts()) > 0
 }
 
-// hasNextOrInProgressUnstableEnts returns if there are any entries that are
-// available to be written to the local stable log or in the process of being
-// written to the local stable log.
-func (l *raftLog) hasNextOrInProgressUnstableEnts() bool {
-	return len(l.unstable.entries) > 0
-}
-
 // nextCommittedEnts returns all the available entries for execution.
 // Entries can be committed even when the local raft instance has not durably
 // appended them to the local raft log yet. If allowUnstable is true, committed
@@ -407,7 +400,7 @@ func (l *raftLog) acceptApplying(i uint64, size entryEncodingSize, allowUnstable
 		i < l.maxAppliableIndex(allowUnstable)
 }
 
-func (l *raftLog) stableTo(id entryID) { l.unstable.stableTo(id) }
+func (l *raftLog) stableTo(mark logMark) { l.unstable.stableTo(mark) }
 
 func (l *raftLog) stableSnapTo(i uint64) { l.unstable.stableSnapTo(i) }
 

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -591,23 +591,23 @@ func TestStableToWithSnap(t *testing.T) {
 	for _, tt := range []struct {
 		sl   logSlice
 		to   logMark
-		want uint64 // the unstable.offset
+		want uint64 // prev.index
 	}{
 		// out of bounds
-		{sl: snapID.append(), to: logMark{term: 1, index: 2}, want: 6},
-		{sl: snapID.append(), to: logMark{term: 2, index: 6}, want: 6},
-		{sl: snapID.append(), to: logMark{term: 2, index: 7}, want: 6},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 2, index: 4}, want: 6},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 2, index: 10}, want: 6},
+		{sl: snapID.append(), to: logMark{term: 1, index: 2}, want: 5},
+		{sl: snapID.append(), to: logMark{term: 2, index: 6}, want: 5},
+		{sl: snapID.append(), to: logMark{term: 2, index: 7}, want: 5},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 2, index: 4}, want: 5},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 2, index: 10}, want: 5},
 		// successful acknowledgements
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 5}, want: 6},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 6}, want: 7},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 7}, want: 8},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 8}, want: 9},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 5}, want: 5},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 6}, want: 6},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 7}, want: 7},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 8, index: 8}, want: 8},
 		// mismatching accepted term
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 3, index: 6}, want: 6},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 3, index: 7}, want: 6},
-		{sl: snapID.append(6, 6, 8), to: logMark{term: 3, index: 8}, want: 6},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 3, index: 6}, want: 5},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 3, index: 7}, want: 5},
+		{sl: snapID.append(6, 6, 8), to: logMark{term: 3, index: 8}, want: 5},
 	} {
 		t.Run("", func(t *testing.T) {
 			s := NewMemoryStorage()
@@ -616,7 +616,7 @@ func TestStableToWithSnap(t *testing.T) {
 			raftLog := newLog(s, discardLogger)
 			require.True(t, raftLog.append(tt.sl))
 			raftLog.stableTo(tt.to)
-			require.Equal(t, tt.want, raftLog.unstable.prev.index+1)
+			require.Equal(t, tt.want, raftLog.unstable.prev.index)
 		})
 	}
 }

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -472,7 +472,7 @@ func TestUnstableStableTo(t *testing.T) {
 				u.stableSnapTo(u.snapshot.Metadata.Index)
 			}
 			u.checkInvariants(t)
-			u.stableTo(entryID{term: tt.term, index: tt.index})
+			u.stableTo(logMark{term: tt.term, index: tt.index})
 			u.checkInvariants(t)
 			require.Equal(t, tt.wprev, u.prev.index)
 			require.Equal(t, tt.wentryInProgress, u.entryInProgress)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1067,8 +1067,6 @@ func (r *raft) Step(m pb.Message) error {
 	switch {
 	case m.Term == 0:
 		// local message
-	case m.Type == pb.MsgStorageAppendResp:
-		// local message
 	case m.Term > r.Term:
 		if m.Type == pb.MsgVote || m.Type == pb.MsgPreVote {
 			force := bytes.Equal(m.Context, []byte(campaignTransfer))

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1067,6 +1067,8 @@ func (r *raft) Step(m pb.Message) error {
 	switch {
 	case m.Term == 0:
 		// local message
+	case m.Type == pb.MsgStorageAppendResp:
+		// local message
 	case m.Term > r.Term:
 		if m.Type == pb.MsgVote || m.Type == pb.MsgPreVote {
 			force := bytes.Equal(m.Context, []byte(campaignTransfer))
@@ -1133,19 +1135,6 @@ func (r *raft) Step(m pb.Message) error {
 			r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] rejected %s from %x [logterm: %d, index: %d] at term %d",
 				r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term)
 			r.send(pb.Message{To: m.From, Term: r.Term, Type: pb.MsgPreVoteResp, Reject: true})
-		} else if m.Type == pb.MsgStorageAppendResp {
-			if m.Snapshot != nil {
-				// Even if the snapshot applied under a different term, its application
-				// is still valid. Snapshots carry committed (term-independent) state.
-				r.appliedSnap(m.Snapshot)
-			}
-			if m.Index != 0 {
-				// Don't consider the appended log entries to be stable because they may
-				// have been overwritten in the unstable log during a later term. See
-				// the comment in newStorageAppendResp for more about this race.
-				r.logger.Infof("%x [term: %d] ignored entry appends from a %s message with lower term [term: %d]",
-					r.id, r.Term, m.Type, m.Term)
-			}
 		} else {
 			// ignore other cases
 			r.logger.Infof("%x [term: %d] ignored a %s message with lower term from %x [term: %d]",
@@ -1169,7 +1158,7 @@ func (r *raft) Step(m pb.Message) error {
 			r.appliedSnap(m.Snapshot)
 		}
 		if m.Index != 0 {
-			r.raftLog.stableTo(entryID{term: m.LogTerm, index: m.Index})
+			r.raftLog.stableTo(logMark{term: m.LogTerm, index: m.Index})
 		}
 
 	case pb.MsgStorageApplyResp:

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -799,7 +799,7 @@ func commitNoopEntry(r *raft, s *MemoryStorage) {
 	r.readMessages()
 	s.Append(r.raftLog.nextUnstableEnts())
 	r.raftLog.appliedTo(r.raftLog.committed, 0 /* size */)
-	r.raftLog.stableTo(r.raftLog.lastEntryID())
+	r.raftLog.stableTo(r.raftLog.unstable.mark())
 }
 
 func acceptAndReply(m pb.Message) pb.Message {

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -34,7 +34,7 @@ import (
 func nextEnts(r *raft, s *MemoryStorage) (ents []pb.Entry) {
 	// Append unstable entries.
 	s.Append(r.raftLog.nextUnstableEnts())
-	r.raftLog.stableTo(r.raftLog.lastEntryID())
+	r.raftLog.stableTo(r.raftLog.unstable.mark())
 
 	// Run post-append steps.
 	r.advanceMessagesAfterAppend()

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -219,6 +219,10 @@ func newStorageAppendMsg(r *raft, rd Ready) pb.Message {
 		From:    r.id,
 		Entries: rd.Entries,
 	}
+	if ln := len(rd.Entries); ln != 0 {
+		m.LogTerm = r.raftLog.accTerm()
+		m.Index = rd.Entries[ln-1].Index
+	}
 	if !IsEmptyHardState(rd.HardState) {
 		// If the Ready includes a HardState update, assign each of its fields
 		// to the corresponding fields in the Message. This allows clients to

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -201,12 +201,10 @@ func needStorageAppendMsg(r *raft, rd Ready) bool {
 		len(r.msgsAfterAppend) > 0
 }
 
-func needStorageAppendRespMsg(r *raft, rd Ready) bool {
+func needStorageAppendRespMsg(rd Ready) bool {
 	// Return true if raft needs to hear about stabilized entries or an applied
-	// snapshot. See the comment in newStorageAppendRespMsg, which explains why
-	// we check hasNextOrInProgressUnstableEnts instead of len(rd.Entries) > 0.
-	return r.raftLog.hasNextOrInProgressUnstableEnts() ||
-		!IsEmptySnap(rd.Snapshot)
+	// snapshot.
+	return !IsEmptySnap(rd.Snapshot) || len(rd.Entries) != 0
 }
 
 // newStorageAppendMsg creates the message that should be sent to the local
@@ -248,7 +246,7 @@ func newStorageAppendMsg(r *raft, rd Ready) pb.Message {
 	// handling to use a fast-path in r.raftLog.term() before the newly appended
 	// entries are removed from the unstable log.
 	m.Responses = r.msgsAfterAppend
-	if needStorageAppendRespMsg(r, rd) {
+	if needStorageAppendRespMsg(rd) {
 		m.Responses = append(m.Responses, newStorageAppendRespMsg(r, rd))
 	}
 	return m
@@ -266,17 +264,18 @@ func newStorageAppendRespMsg(r *raft, rd Ready) pb.Message {
 		// Dropped after term change, see below.
 		Term: r.Term,
 	}
-	if r.raftLog.hasNextOrInProgressUnstableEnts() {
-		// If the raft log has unstable entries, attach the last index and term of the
-		// append to the response message. This (index, term) tuple will be handed back
-		// and consulted when the stability of those log entries is signaled to the
-		// unstable. If the (index, term) match the unstable log by the time the
-		// response is received (unstable.stableTo), the unstable log can be truncated.
+	if ln := len(rd.Entries); ln != 0 {
+		// If sending unstable entries to storage, attach the last index and last
+		// accepted term to the response message. This (index, term) tuple will be
+		// handed back and consulted when the stability of those log entries is
+		// signaled to the unstable. If the term matches the last accepted term by
+		// the time the response is received (unstable.stableTo), the unstable log
+		// can be truncated up to the given index.
 		//
-		// However, with just this logic, there would be an ABA problem[^1] that could
-		// lead to the unstable log and the stable log getting out of sync temporarily
-		// and leading to an inconsistent view. Consider the following example with 5
-		// nodes, A B C D E:
+		// The last accepted term logic prevents an ABA problem[^1] that could lead
+		// to the unstable log and the stable log getting out of sync temporarily
+		// and leading to an inconsistent view. Consider the following example with
+		// 5 nodes, A B C D E:
 		//
 		//  1. A is the leader.
 		//  2. A proposes some log entries but only B receives these entries.
@@ -305,51 +304,19 @@ func newStorageAppendRespMsg(r *raft, rd Ready) pb.Message {
 		//     that no in-progress appends might overwrite them before removing entries
 		//     from the unstable log.
 		//
-		// To prevent these kinds of problems, we also attach the current term to the
-		// MsgStorageAppendResp (above). If the term has changed by the time the
-		// MsgStorageAppendResp if returned, the response is ignored and the unstable
-		// log is not truncated. The unstable log is only truncated when the term has
-		// remained unchanged from the time that the MsgStorageAppend was sent to the
-		// time that the MsgStorageAppendResp is received, indicating that no-one else
-		// is in the process of truncating the stable log.
+		// If accTerm has changed by the time the MsgStorageAppendResp is returned,
+		// the response is ignored and the unstable log is not truncated. The
+		// unstable log is only truncated when the term has remained unchanged from
+		// the time that the MsgStorageAppend was sent to the time that the response
+		// is received, indicating that no new leader has overwritten the log.
 		//
-		// However, this replaces a correctness problem with a liveness problem. If we
-		// only attempted to truncate the unstable log when appending new entries but
-		// also occasionally dropped these responses, then quiescence of new log entries
-		// could lead to the unstable log never being truncated.
-		//
-		// To combat this, we attempt to truncate the log on all MsgStorageAppendResp
-		// messages where the unstable log is not empty, not just those associated with
-		// entry appends. This includes MsgStorageAppendResp messages associated with an
-		// updated HardState, which occur after a term change.
-		//
-		// In other words, we set Index and LogTerm in a block that looks like:
-		//
-		//  if r.raftLog.hasNextOrInProgressUnstableEnts() { ... }
-		//
-		// not like:
-		//
-		//  if len(rd.Entries) > 0 { ... }
-		//
-		// To do so, we attach r.raftLog.lastIndex() and r.raftLog.lastTerm(), not the
-		// (index, term) of the last entry in rd.Entries. If rd.Entries is not empty,
-		// these will be the same. However, if rd.Entries is empty, we still want to
-		// attest that this (index, term) is correct at the current term, in case the
-		// MsgStorageAppend that contained the last entry in the unstable slice carried
-		// an earlier term and was dropped.
-		//
-		// A MsgStorageAppend with a new term is emitted on each term change. This is
-		// the same condition that causes MsgStorageAppendResp messages with earlier
-		// terms to be ignored. As a result, we are guaranteed that, assuming a bounded
-		// number of term changes, there will eventually be a MsgStorageAppendResp
-		// message that is not ignored. This means that entries in the unstable log
-		// which have been appended to stable storage will eventually be truncated and
-		// dropped from memory.
+		// TODO(pav-kv): unstable entries can be partially released even if the last
+		// accepted term changed, if we track the (term, index) points at which the
+		// log was truncated.
 		//
 		// [^1]: https://en.wikipedia.org/wiki/ABA_problem
-		last := r.raftLog.lastEntryID()
-		m.Index = last.index
-		m.LogTerm = last.term
+		m.LogTerm = r.raftLog.accTerm()
+		m.Index = rd.Entries[ln-1].Index
 	}
 	if !IsEmptySnap(rd.Snapshot) {
 		snap := rd.Snapshot
@@ -411,7 +378,7 @@ func (rn *RawNode) acceptReady(rd Ready) {
 				rn.stepsOnAdvance = append(rn.stepsOnAdvance, m)
 			}
 		}
-		if needStorageAppendRespMsg(rn.raft, rd) {
+		if needStorageAppendRespMsg(rd) {
 			m := newStorageAppendRespMsg(rn.raft, rd)
 			rn.stepsOnAdvance = append(rn.stepsOnAdvance, m)
 		}

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -261,8 +261,6 @@ func newStorageAppendRespMsg(r *raft, rd Ready) pb.Message {
 		Type: pb.MsgStorageAppendResp,
 		To:   r.id,
 		From: LocalAppendThread,
-		// Dropped after term change, see below.
-		Term: r.Term,
 	}
 	if ln := len(rd.Entries); ln != 0 {
 		// If sending unstable entries to storage, attach the last index and last

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -610,9 +610,7 @@ process-ready 1 2 3
   Messages:
   1->2 MsgApp Term:1 Log:1/15 Commit:14
   1->3 MsgApp Term:1 Log:1/15 Commit:14
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Responses:[
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
-  ]
+  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
   ]
@@ -638,7 +636,6 @@ process-ready 1 2 3
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Responses:[
     2->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
@@ -651,7 +648,6 @@ process-ready 1 2 3
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Responses:[
     3->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
@@ -772,13 +768,11 @@ process-append-thread 2 3
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
   Responses:
   2->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
   Responses:
   3->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
 
 process-apply-thread 1 2 3
 ----
@@ -803,11 +797,7 @@ deliver-msgs 1 2 3
 2->1 MsgAppResp Term:1 Log:0/15
 3->1 MsgAppResp Term:1 Log:0/15
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
-INFO entry at index 15 missing from unstable log; ignoring
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
-INFO entry at index 15 missing from unstable log; ignoring
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 
 process-ready 1 2 3
@@ -873,10 +863,6 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1
   Responses:
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
   Processing:
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1
   Responses:
-> 1 receiving messages
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
-  INFO entry at index 15 missing from unstable log; ignoring

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -92,7 +92,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
     1->1 MsgAppResp Term:1 Log:0/11
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/11
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
@@ -103,7 +103,7 @@ stabilize
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:10 Lead:1
@@ -112,7 +112,7 @@ stabilize
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
     2->1 MsgAppResp Term:1 Log:0/11
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/11
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 3 handling Ready
   Ready MustSync=true:
@@ -122,30 +122,30 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
     3->1 MsgAppResp Term:1 Log:0/11
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 1 receiving messages
   1->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/11
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/11
   3->1 MsgAppResp Term:1 Log:0/11
 > 2 receiving messages
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
 > 3 receiving messages
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/11
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:11 Lead:1
@@ -240,7 +240,7 @@ process-ready 1 2 3
   1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
   1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/12
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
   ]
 > 2 handling Ready
   <empty Ready>
@@ -269,7 +269,7 @@ process-ready 1 2 3
   Messages:
   2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/12
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
   ]
 > 3 handling Ready
   Ready MustSync=true:
@@ -278,7 +278,7 @@ process-ready 1 2 3
   Messages:
   3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/12
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
   ]
 
 propose 1 prop_2
@@ -296,7 +296,7 @@ process-ready 1 2 3
   1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
   1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/13
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/13
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
   ]
 > 2 handling Ready
   <empty Ready>
@@ -319,7 +319,7 @@ process-ready 1 2 3
   Messages:
   2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/13
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/13
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
   ]
 > 3 handling Ready
   Ready MustSync=true:
@@ -328,7 +328,7 @@ process-ready 1 2 3
   Messages:
   3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/13
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/13
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
   ]
 
 process-append-thread 1 2 3
@@ -338,28 +338,28 @@ process-append-thread 1 2 3
   1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/12
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/12
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
 
 deliver-msgs 1 2 3
 ----
 1->1 MsgAppResp Term:1 Log:0/12
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 2->1 MsgAppResp Term:1 Log:0/12
 3->1 MsgAppResp Term:1 Log:0/12
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/12
+AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
+AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
 
 status 1
 ----
@@ -387,7 +387,7 @@ process-ready 1 2 3
   1->3 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/14
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/14
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
@@ -419,7 +419,7 @@ process-ready 1 2 3
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/13
     2->1 MsgAppResp Term:1 Log:0/14
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/14
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
@@ -435,7 +435,7 @@ process-ready 1 2 3
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/13
     3->1 MsgAppResp Term:1 Log:0/14
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/14
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:1/14
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
@@ -448,28 +448,28 @@ process-append-thread 1 2 3
   1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/13
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/13
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/13
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/13
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/13
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/13
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
 
 deliver-msgs 1 2 3
 ----
 1->1 MsgAppResp Term:1 Log:0/13
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/13
+AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
 2->1 MsgAppResp Term:1 Log:0/13
 3->1 MsgAppResp Term:1 Log:0/13
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/13
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/13
+AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
+AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
 
 propose 1 prop_4
 ----
@@ -491,7 +491,7 @@ process-ready 1 2 3
   1->3 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
@@ -523,7 +523,7 @@ process-ready 1 2 3
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/14
     2->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
@@ -539,7 +539,7 @@ process-ready 1 2 3
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/14
     3->1 MsgAppResp Term:1 Log:0/15
-    AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
@@ -552,21 +552,21 @@ process-append-thread 1 2 3
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/14
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/14
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/13
   2->1 MsgAppResp Term:1 Log:0/14
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/14
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/13
   3->1 MsgAppResp Term:1 Log:0/14
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/14
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:1/14
 
 process-apply-thread 1 2 3
 ----
@@ -589,15 +589,15 @@ process-apply-thread 1 2 3
 deliver-msgs 1 2 3
 ----
 1->1 MsgAppResp Term:1 Log:0/14
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/14
+AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
 2->1 MsgAppResp Term:1 Log:0/13
 2->1 MsgAppResp Term:1 Log:0/14
 3->1 MsgAppResp Term:1 Log:0/13
 3->1 MsgAppResp Term:1 Log:0/14
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/14
+AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/14
+AppendThread->3 MsgStorageAppendResp Term:0 Log:1/14
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
 
 process-ready 1 2 3
@@ -660,21 +660,21 @@ process-append-thread 1 2 3
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/14
   2->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/14
   3->1 MsgAppResp Term:1 Log:0/15
-  AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
 
 process-apply-thread 1 2 3
 ----
@@ -697,15 +697,15 @@ process-apply-thread 1 2 3
 deliver-msgs 1 2 3
 ----
 1->1 MsgAppResp Term:1 Log:0/15
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/15
+AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
 2->1 MsgAppResp Term:1 Log:0/14
 2->1 MsgAppResp Term:1 Log:0/15
 3->1 MsgAppResp Term:1 Log:0/14
 3->1 MsgAppResp Term:1 Log:0/15
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
-AppendThread->2 MsgStorageAppendResp Term:1 Log:1/15
+AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
-AppendThread->3 MsgStorageAppendResp Term:1 Log:1/15
+AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
 
 process-ready 1 2 3

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -90,7 +90,7 @@ stabilize
   Messages:
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
+  1->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
     1->1 MsgAppResp Term:1 Log:0/11
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
   ]
@@ -100,7 +100,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
+  1->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
@@ -110,7 +110,7 @@ stabilize
   Entries:
   1/11 EntryNormal ""
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
+  2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
     2->1 MsgAppResp Term:1 Log:0/11
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
   ]
@@ -120,7 +120,7 @@ stabilize
   Entries:
   1/11 EntryNormal ""
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
+  3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""] Responses:[
     3->1 MsgAppResp Term:1 Log:0/11
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
   ]
@@ -129,13 +129,13 @@ stabilize
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
+  2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/11
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
+  3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Entries:[1/11 EntryNormal ""]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/11
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
@@ -238,7 +238,7 @@ process-ready 1 2 3
   Messages:
   1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
   1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
+  1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/12
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
   ]
@@ -267,7 +267,7 @@ process-ready 1 2 3
   Entries:
   1/12 EntryNormal "prop_1"
   Messages:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
+  2->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/12
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
   ]
@@ -276,7 +276,7 @@ process-ready 1 2 3
   Entries:
   1/12 EntryNormal "prop_1"
   Messages:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
+  3->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/12
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
   ]
@@ -294,7 +294,7 @@ process-ready 1 2 3
   Messages:
   1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
   1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
+  1->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/13
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
   ]
@@ -317,7 +317,7 @@ process-ready 1 2 3
   Entries:
   1/13 EntryNormal "prop_2"
   Messages:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
+  2->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/13
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
   ]
@@ -326,7 +326,7 @@ process-ready 1 2 3
   Entries:
   1/13 EntryNormal "prop_2"
   Messages:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
+  3->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/13
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
   ]
@@ -335,19 +335,19 @@ process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/12
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  2->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/12
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
+  3->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/12
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
@@ -385,7 +385,7 @@ process-ready 1 2 3
   1->3 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
   1->3 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
+  1->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/14
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
   ]
@@ -416,7 +416,7 @@ process-ready 1 2 3
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
+  2->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/13
     2->1 MsgAppResp Term:1 Log:0/14
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
@@ -432,7 +432,7 @@ process-ready 1 2 3
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
+  3->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/13
     3->1 MsgAppResp Term:1 Log:0/14
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/14
@@ -445,19 +445,19 @@ process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  1->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/13
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  2->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/13
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  3->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/13
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
@@ -489,7 +489,7 @@ process-ready 1 2 3
   1->3 MsgApp Term:1 Log:1/14 Commit:13
   1->2 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
   1->3 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
+  1->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/15
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
   ]
@@ -520,7 +520,7 @@ process-ready 1 2 3
   CommittedEntries:
   1/13 EntryNormal "prop_2"
   Messages:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
+  2->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/14
     2->1 MsgAppResp Term:1 Log:0/15
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
@@ -536,7 +536,7 @@ process-ready 1 2 3
   CommittedEntries:
   1/13 EntryNormal "prop_2"
   Messages:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
+  3->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/14
     3->1 MsgAppResp Term:1 Log:0/15
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
@@ -549,20 +549,20 @@ process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
+  1->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/14
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
+  2->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/13
   2->1 MsgAppResp Term:1 Log:0/14
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
+  3->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/13
   3->1 MsgAppResp Term:1 Log:0/14
@@ -657,20 +657,20 @@ process-append-thread 1 2 3
 ----
 > 1 processing append thread
   Processing:
-  1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
+  1->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
   1->1 MsgAppResp Term:1 Log:0/15
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
 > 2 processing append thread
   Processing:
-  2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
+  2->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
   2->1 MsgAppResp Term:1 Log:0/14
   2->1 MsgAppResp Term:1 Log:0/15
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
 > 3 processing append thread
   Processing:
-  3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
+  3->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
   3->1 MsgAppResp Term:1 Log:0/14
   3->1 MsgAppResp Term:1 Log:0/15

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -394,9 +394,7 @@ Ready MustSync=true:
 HardState Term:3 Commit:11 Lead:4
 Messages:
 1->4 MsgHeartbeatResp Term:3 Log:0/0
-1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Responses:[
-  AppendThread->1 MsgStorageAppendResp Term:3 Log:2/12
-]
+1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11
 
 deliver-msgs 4
 ----
@@ -457,7 +455,7 @@ raft-log 1
 deliver-msgs 1
 ----
 AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
-INFO 1 [term: 3] ignored entry appends from a MsgStorageAppendResp message with lower term [term: 1]
+INFO mark (term,index)=(1,12) mismatched the last accepted term 3 in unstable log; ignoring 
 
 process-append-thread 1
 ----
@@ -476,14 +474,13 @@ raft-log 1
 deliver-msgs 1
 ----
 AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
-INFO 1 [term: 3] ignored entry appends from a MsgStorageAppendResp message with lower term [term: 2]
+INFO mark (term,index)=(2,12) mismatched the last accepted term 3 in unstable log; ignoring 
 
 process-append-thread 1
 ----
 Processing:
 1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11
 Responses:
-AppendThread->1 MsgStorageAppendResp Term:3 Log:2/12
 
 raft-log 1
 ----
@@ -492,8 +489,7 @@ raft-log 1
 
 deliver-msgs 1
 ----
-AppendThread->1 MsgStorageAppendResp Term:3 Log:2/12
-INFO entry at (index,term)=(12,2) mismatched with entry at (12,3) in unstable log; ignoring
+no messages
 
 process-append-thread 1
 ----

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -44,7 +44,7 @@ Messages:
 2->7 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
 2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"] Responses:[
   2->2 MsgAppResp Term:1 Log:0/12
-  AppendThread->2 MsgStorageAppendResp Term:1 Log:1/12
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 ]
 
 deliver-msgs 1 drop=(3,4,5,6,7)
@@ -66,7 +66,7 @@ Entries:
 Messages:
 1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"] Responses:[
   1->2 MsgAppResp Term:1 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 ]
 
 # Step 4: node 3 becomes the leader after getting a vote from nodes 4, 5, and 6.
@@ -197,7 +197,7 @@ Messages:
 3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Entries:[2/12 EntryNormal ""] Responses:[
   3->3 MsgAppResp Term:2 Log:0/12
-  AppendThread->3 MsgStorageAppendResp Term:2 Log:2/12
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:2/12
 ]
 
 deliver-msgs 1 drop=(2,4,5,6,7)
@@ -227,7 +227,7 @@ Messages:
 1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Entries:[2/12 EntryNormal ""] Responses:[
   1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->3 MsgAppResp Term:2 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 ]
 
 # Step 6: node 3 crashes and node 4 becomes leader getting the vote from 5, 6, and 7.
@@ -353,7 +353,7 @@ Messages:
 4->7 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Entries:[3/12 EntryNormal ""] Responses:[
   4->4 MsgAppResp Term:3 Log:0/12
-  AppendThread->4 MsgStorageAppendResp Term:3 Log:3/12
+  AppendThread->4 MsgStorageAppendResp Term:0 Log:3/12
 ]
 
 # Step 7: before the new entries reach node 1, it hears of the term change
@@ -420,7 +420,7 @@ Entries:
 Messages:
 1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""] Responses:[
   1->4 MsgAppResp Term:3 Log:0/12
-  AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12
 ]
 
 # Step 8: The asynchronous log appends from the first Ready complete and the
@@ -437,7 +437,7 @@ Processing:
 1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"]
 Responses:
 1->2 MsgAppResp Term:1 Log:0/12
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 
 raft-log 1
 ----
@@ -454,7 +454,7 @@ raft-log 1
 
 deliver-msgs 1
 ----
-AppendThread->1 MsgStorageAppendResp Term:1 Log:1/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 INFO mark (term,index)=(1,12) mismatched the last accepted term 3 in unstable log; ignoring 
 
 process-append-thread 1
@@ -464,7 +464,7 @@ Processing:
 Responses:
 1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
 1->3 MsgAppResp Term:2 Log:0/12
-AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 
 raft-log 1
 ----
@@ -473,7 +473,7 @@ raft-log 1
 
 deliver-msgs 1
 ----
-AppendThread->1 MsgStorageAppendResp Term:2 Log:2/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 INFO mark (term,index)=(2,12) mismatched the last accepted term 3 in unstable log; ignoring 
 
 process-append-thread 1
@@ -497,7 +497,7 @@ Processing:
 1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""]
 Responses:
 1->4 MsgAppResp Term:3 Log:0/12
-AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12
 
 raft-log 1
 ----
@@ -506,4 +506,4 @@ raft-log 1
 
 deliver-msgs 1
 ----
-AppendThread->1 MsgStorageAppendResp Term:3 Log:3/12
+AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -42,7 +42,7 @@ Messages:
 2->5 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
 2->6 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
 2->7 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
-2->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"] Responses:[
+2->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "init_prop"] Responses:[
   2->2 MsgAppResp Term:1 Log:0/12
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 ]
@@ -64,7 +64,7 @@ Ready MustSync=true:
 Entries:
 1/12 EntryNormal "init_prop"
 Messages:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"] Responses:[
+1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "init_prop"] Responses:[
   1->2 MsgAppResp Term:1 Log:0/12
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 ]
@@ -195,7 +195,7 @@ Messages:
 3->5 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->6 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Entries:[2/12 EntryNormal ""] Responses:[
+3->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Vote:3 Entries:[2/12 EntryNormal ""] Responses:[
   3->3 MsgAppResp Term:2 Log:0/12
   AppendThread->3 MsgStorageAppendResp Term:0 Log:2/12
 ]
@@ -224,7 +224,7 @@ HardState Term:2 Commit:11 Lead:3
 Entries:
 2/12 EntryNormal ""
 Messages:
-1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Entries:[2/12 EntryNormal ""] Responses:[
+1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Entries:[2/12 EntryNormal ""] Responses:[
   1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->3 MsgAppResp Term:2 Log:0/12
   AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
@@ -351,7 +351,7 @@ Messages:
 4->5 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->6 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->7 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Entries:[3/12 EntryNormal ""] Responses:[
+4->AppendThread MsgStorageAppend Term:3 Log:3/12 Commit:11 Vote:4 Entries:[3/12 EntryNormal ""] Responses:[
   4->4 MsgAppResp Term:3 Log:0/12
   AppendThread->4 MsgStorageAppendResp Term:0 Log:3/12
 ]
@@ -418,7 +418,7 @@ Ready MustSync=true:
 Entries:
 3/12 EntryNormal ""
 Messages:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""] Responses:[
+1->AppendThread MsgStorageAppend Term:0 Log:3/12 Entries:[3/12 EntryNormal ""] Responses:[
   1->4 MsgAppResp Term:3 Log:0/12
   AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12
 ]
@@ -434,7 +434,7 @@ raft-log 1
 process-append-thread 1
 ----
 Processing:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[1/12 EntryNormal "init_prop"]
+1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "init_prop"]
 Responses:
 1->2 MsgAppResp Term:1 Log:0/12
 AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
@@ -460,7 +460,7 @@ INFO mark (term,index)=(1,12) mismatched the last accepted term 3 in unstable lo
 process-append-thread 1
 ----
 Processing:
-1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Entries:[2/12 EntryNormal ""]
+1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Entries:[2/12 EntryNormal ""]
 Responses:
 1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
 1->3 MsgAppResp Term:2 Log:0/12
@@ -494,7 +494,7 @@ no messages
 process-append-thread 1
 ----
 Processing:
-1->AppendThread MsgStorageAppend Term:0 Log:0/0 Entries:[3/12 EntryNormal ""]
+1->AppendThread MsgStorageAppend Term:0 Log:3/12 Entries:[3/12 EntryNormal ""]
 Responses:
 1->4 MsgAppResp Term:3 Log:0/12
 AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12


### PR DESCRIPTION
This PR modifies the log write protocol to take advantage of the last accepted term tracked in `raftLog`/`unstable`.

Log entry writes are ordered by the last accepted term (`unstable.term`). Entries in the log can be overwritten only if this term is bumped (when we accept a log write from a higher term leader). If `unstable.term` is unchanged when we receive an acknowledgement from log storage, then the acknowledged entries don't have any overwrites in the write queue, and it is safe to remove them from `unstable`.

Part of #124440