### PR TITLE
kv: add DeadlockTimeout option to BatchRequest

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2962,8 +2962,21 @@ message Header {
   reserved 7, 10, 12, 14, 20;
 
   WriteOptions write_options = 35;
-   
-  // Next ID: 36
+
+  // DeadlockTimeout specifies the amount of time that a request will wait on a
+  // lock before pushing the lock holder transaction to detect deadlocks.
+  //
+  // DeadlockTimeout, if set, takes precedence over the
+  // kv.lock_table.deadlock_detection_push_delay cluster setting. If unset,
+  // the cluster setting is used instead.
+  //
+  // This differs from kv.lock_table.deadlock_detection_push_delay in that it
+  // gets applied at a finer granularity, where
+  // kv.lock_table.deadlock_detection_push_delay is a a cluster wide setting.
+  google.protobuf.Duration deadlock_timeout = 36 [(gogoproto.nullable) = false,
+    (gogoproto.stdduration) = true];
+
+  // Next ID: 37
 }
 
 message WriteOptions {

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -895,6 +895,9 @@ func (ba *BatchRequest) SafeFormat(s redact.SafePrinter, verb rune) {
 	if ba.LockTimeout != 0 {
 		s.Printf(", [lock-timeout: %s]", ba.LockTimeout)
 	}
+	if ba.DeadlockTimeout != 0 {
+		s.Printf(", [deadlock-timeout: %s]", ba.DeadlockTimeout)
+	}
 	if ba.AmbiguousReplayProtection {
 		s.Printf(", [protect-ambiguous-replay]")
 	}

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -437,6 +437,10 @@ type Request struct {
 	// The SafeFormatter capable of formatting the request. This is used to enrich
 	// logging with request level information when latches conflict.
 	BaFmt redact.SafeFormatter
+
+	// DeadlockTimeout is the amount of time that the request will wait on a lock
+	// before pushing the lock holder's transaction for deadlock detection.
+	DeadlockTimeout time.Duration
 }
 
 // Guard is returned from Manager.SequenceReq. The guard is passed back in to

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -201,7 +201,11 @@ func (w *lockTableWaiterImpl) WaitOn(
 				// transaction (one that's acquired a claim but not the lock).
 				delay := time.Duration(math.MaxInt64)
 				if deadlockOrLivenessPush {
-					delay = LockTableDeadlockOrLivenessDetectionPushDelay.Get(&w.st.SV)
+					if req.DeadlockTimeout == 0 {
+						delay = LockTableDeadlockOrLivenessDetectionPushDelay.Get(&w.st.SV)
+					} else {
+						delay = req.DeadlockTimeout
+					}
 				}
 				if timeoutPush {
 					// Only reset the lock timeout deadline if this is the first time

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -1160,3 +1160,150 @@ reset namespace
 ----
 
 subtest end
+
+# -------------------------------------------------------------
+# Deadlock due to lock ordering detected after request's deadlock timeout.
+#
+# Class: lock holder aborted while pushing lock holder.
+#
+# Setup: txn1, txn2 acquire locks a, b
+#
+# Test:  set the cluster's deadlock timeout to 1h (debug-disable-txn-pushes)
+#        set the requests' deadlock timeout to 1ns (deadlock-timeout=1ns)
+#        txn1, txn2 write b, a
+#        txn1 is aborted to break deadlock
+#        txn2 proceeds and commits
+# -------------------------------------------------------------
+
+subtest granular_deadlock_timeout
+
+debug-disable-txn-pushes
+----
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-request name=req1w txn=txn1 ts=10,1 deadlock-timeout=1ns
+  put key=a value=v
+----
+
+new-request name=req2w txn=txn2 ts=10,1 deadlock-timeout=1ns
+  put key=b value=v
+----
+
+sequence req=req1w
+----
+[1] sequence req1w: sequencing request
+[1] sequence req1w: acquiring latches
+[1] sequence req1w: scanning lock table for conflicting locks
+[1] sequence req1w: sequencing complete, returned guard
+
+sequence req=req2w
+----
+[2] sequence req2w: sequencing request
+[2] sequence req2w: acquiring latches
+[2] sequence req2w: scanning lock table for conflicting locks
+[2] sequence req2w: sequencing complete, returned guard
+
+on-lock-acquired req=req1w key=a
+----
+[-] acquire lock: txn 00000001 @ ‹a›
+
+on-lock-acquired req=req2w key=b
+----
+[-] acquire lock: txn 00000002 @ ‹b›
+
+finish req=req1w
+----
+[-] finish req1w: finishing request
+
+finish req=req2w
+----
+[-] finish req2w: finishing request
+
+debug-lock-table
+----
+num=2
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+new-request name=req3w txn=txn1 ts=10,1 deadlock-timeout=1ns
+  put key=b value=v
+----
+
+new-request name=req4w txn=txn2 ts=10,1 deadlock-timeout=1ns
+  put key=a value=v
+----
+
+sequence req=req3w
+----
+[3] sequence req3w: sequencing request
+[3] sequence req3w: acquiring latches
+[3] sequence req3w: scanning lock table for conflicting locks
+[3] sequence req3w: waiting in lock wait-queues
+[3] sequence req3w: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3w: pushing after 1ns for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req3w: pushing txn 00000002 to abort
+[3] sequence req3w: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+sequence req=req4w
+----
+[3] sequence req3w: dependency cycle detected 00000001->00000002->00000001
+[4] sequence req4w: sequencing request
+[4] sequence req4w: acquiring latches
+[4] sequence req4w: scanning lock table for conflicting locks
+[4] sequence req4w: waiting in lock wait-queues
+[4] sequence req4w: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4w: pushing after 1ns for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[4] sequence req4w: pushing txn 00000001 to abort
+[4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
+[4] sequence req4w: dependency cycle detected 00000002->00000001->00000002
+
+debug-lock-table
+----
+num=2
+ lock: "a"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 35, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+ lock: "b"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 34, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
+
+# Break the deadlock by aborting txn1.
+on-txn-updated txn=txn1 status=aborted
+----
+[-] update txn: aborting txn1
+[3] sequence req3w: detected pusher aborted
+[3] sequence req3w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[3] sequence req3w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
+[4] sequence req4w: resolving intent ‹"a"› for txn 00000001 with ABORTED status
+[4] sequence req4w: lock wait-queue event: done waiting
+[4] sequence req4w: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req4w: acquiring latches
+[4] sequence req4w: scanning lock table for conflicting locks
+[4] sequence req4w: sequencing complete, returned guard
+
+# Txn2 can proceed and eventually commit.
+finish req=req4w
+----
+[-] finish req4w: finishing request
+
+on-txn-updated txn=txn2 status=committed
+----
+[-] update txn: committing txn2
+
+reset namespace
+----
+
+subtest end

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -462,6 +462,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 			ReadConsistency: ba.ReadConsistency,
 			WaitPolicy:      ba.WaitPolicy,
 			LockTimeout:     ba.LockTimeout,
+			DeadlockTimeout: ba.DeadlockTimeout,
 			AdmissionHeader: ba.AdmissionHeader,
 			PoisonPolicy:    pp,
 			Requests:        ba.Requests,


### PR DESCRIPTION
This PR introduces a new `deadlock_timeout` field to the BatchRequest
Header struct. If set, it will be used as the time to wait on a lock
before pushing the lock holder for deadlock detection. If not set,
the cluster-wide setting:
kv.lock_table.deadlock_detection_push_delay will be used as the timeout.

A future PR will make this configurable at a session granularity.

References: https://github.com/cockroachdb/cockroach/issues/116305

Epic: None

Release note: None