### PR TITLE
changefeedccl: fix kafka-azure roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2136,9 +2136,10 @@ func registerCDC(r registry.Registry) {
 		Name:             "cdc/kafka-azure",
 		Owner:            `cdc`,
 		CompatibleClouds: registry.OnlyAzure,
-		Cluster:          r.MakeClusterSpec(2),
-		Leases:           registry.MetamorphicLeases,
-		Suites:           registry.Suites(registry.Nightly),
+		// The Azure CLI only packages AMD64 binaries in its deb installer, so lock to AMD64.
+		Cluster: r.MakeClusterSpec(2, spec.Arch(vm.ArchAMD64)),
+		Leases:  registry.MetamorphicLeases,
+		Suites:  registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()


### PR DESCRIPTION
The kafka-azure roachtest has been failing due to
an architecture mismatch. The Azure CLI .deb
package only supports AMD64. In the future we can
look into migrating to installing it via `pip3
install`, but for now lock the architecture to AMD64.

Fixes: #123864

Release note: None
