### PR TITLE
roachtest: export tpce perf data to roachperf

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -11,8 +11,11 @@
 package tests
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -159,6 +162,7 @@ type tpceOptions struct {
 	activeCustomers  int                             // --active-customers in the workload
 	threads          int                             // overrides the number of threads used
 	skipCleanup      bool                            // passes --skip-cleanup to the tpc-e workload
+	exportMetrics    bool                            // exports metrics to stats.json used by roachperf
 	during           func(ctx context.Context) error // invoked concurrently with the workload
 }
 type tpceSetupType int
@@ -261,6 +265,10 @@ func runTPCE(ctx context.Context, t test.Test, c cluster.Cluster, opts tpceOptio
 		if strings.Contains(result.Stdout, "Reported tpsE :    --   (not between 80% and 100%)") {
 			return errors.New("invalid tpsE fraction")
 		}
+
+		if opts.exportMetrics {
+			return exportTPCEResults(t, result.Stdout)
+		}
 		return nil
 	})
 	if opts.during != nil {
@@ -272,14 +280,16 @@ func runTPCE(ctx context.Context, t test.Test, c cluster.Cluster, opts tpceOptio
 func registerTPCE(r registry.Registry) {
 	// Nightly, small scale configuration.
 	smallNightly := tpceOptions{
-		customers: 5_000,
-		nodes:     3,
-		cpus:      4,
-		ssds:      1,
+		customers:     5_000,
+		nodes:         3,
+		cpus:          4,
+		ssds:          1,
+		exportMetrics: true,
 	}
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("tpce/c=%d/nodes=%d", smallNightly.customers, smallNightly.nodes),
 		Owner:            registry.OwnerTestEng,
+		Benchmark:        true,
 		Timeout:          4 * time.Hour,
 		Cluster:          r.MakeClusterSpec(smallNightly.nodes+1, spec.CPU(smallNightly.cpus), spec.SSD(smallNightly.ssds)),
 		CompatibleClouds: registry.OnlyGCE,
@@ -294,10 +304,11 @@ func registerTPCE(r registry.Registry) {
 
 	// Weekly, large scale configuration.
 	largeWeekly := tpceOptions{
-		customers: 100_000,
-		nodes:     5,
-		cpus:      32,
-		ssds:      2,
+		customers:     100_000,
+		nodes:         5,
+		cpus:          32,
+		ssds:          2,
+		exportMetrics: true,
 	}
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("tpce/c=%d/nodes=%d", largeWeekly.customers, largeWeekly.nodes),
@@ -305,10 +316,73 @@ func registerTPCE(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
-		Timeout:          36 * time.Hour,
+		Timeout:          8 * time.Hour,
 		Cluster:          r.MakeClusterSpec(largeWeekly.nodes+1, spec.CPU(largeWeekly.cpus), spec.SSD(largeWeekly.ssds)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCE(ctx, t, c, largeWeekly)
 		},
 	})
+}
+
+type tpceMetrics struct {
+	AvgLatency  string `json:"AvgLatency"`
+	P50Latency  string `json:"p50Latency"`
+	P90Latency  string `json:"p90Latency"`
+	P99Latency  string `json:"p99Latency"`
+	PMaxLatency string `json:"pMaxLatency"`
+}
+
+// exportTPCEResults parses the output of `tpce` into a JSON file
+// and writes it to the perf directory that roachperf expects. TPCE
+// is an open-loop workload with a fixed rate of transactions, so
+// we want roachperf to plot the latency. There are too many transaction
+// types to plot, so we isolate just `TradeResult`:
+//
+// The Measured Throughput is computed as the total number of Valid Trade-Result Transactions
+// within the Measurement Interval divided by the duration of the Measurement Interval in seconds.
+func exportTPCEResults(t test.Test, result string) error {
+	// Filter out everything but the TradeResult transaction metrics.
+	//
+	// Example output of TPCE:
+	// _Transaction_______|__pass_mix___pass_lat__|______txns______txns/s_______mix__________avg__________p50__________p90__________p99_________pMax
+	//  ...
+	//  TradeResult       |     false       true  |     72114       10.02    9.926%     41.918ms     37.796ms     57.525ms    104.819ms    299.538ms
+	s := bufio.NewScanner(strings.NewReader(result))
+	for s.Scan() {
+		if !strings.HasPrefix(s.Text(), " TradeResult") {
+			continue
+		}
+
+		fields := strings.Fields(s.Text())
+		if len(fields) != 13 {
+			return errors.Errorf("exportTPCEResults: unexpected format of metrics")
+		}
+
+		removeUnits := func(s string) string {
+			s, _ = strings.CutSuffix(s, "ms")
+			return s
+		}
+
+		metrics := tpceMetrics{
+			AvgLatency:  removeUnits(fields[8]),
+			P50Latency:  removeUnits(fields[9]),
+			P90Latency:  removeUnits(fields[10]),
+			P99Latency:  removeUnits(fields[11]),
+			PMaxLatency: removeUnits(fields[12]),
+		}
+		metricBytes, err := json.Marshal(metrics)
+		if err != nil {
+			return err
+		}
+
+		// Copy the metrics to the artifacts directory, so it can be exported to roachperf.
+		// Assume single node artifacts, since the metrics we get are aggregated amongst the cluster.
+		perfDir := fmt.Sprintf("%s/1.perf", t.ArtifactsDir())
+		if err = os.MkdirAll(perfDir, 0755); err != nil {
+			return err
+		}
+
+		return os.WriteFile(fmt.Sprintf("%s/stats.json", perfDir), metricBytes, 0666)
+	}
+	return errors.Errorf("exportTPCEResults: found no lines starting with TradeResult")
 }


### PR DESCRIPTION
This changes the tpce/c=* tests to export TradeResult transaction latencies to a stats.json that is uploaded to roachperf.

Fixes: #127035
Release note: none
Epic: none

------------------

For the roachperf PR see: https://github.com/cockroachdb/roachperf/pull/168

<img width="949" alt="image" src="https://github.com/user-attachments/assets/0ef8f6e7-6fe0-45bc-b21c-87359d5b52a5">

Note the latency fluctuated so much because I only ran the workload for 1 minute to save time/money.