### PR TITLE
sql/schemachanger: add TTL dependency checking for ALTER TYPE in DSC

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -78,7 +78,7 @@ func AlterColumnType(
 			)
 		}
 	}
-	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, tableDesc.GetRowLevelTTL(), col); err != nil {
+	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, tableDesc.GetRowLevelTTL(), col, tn, op); err != nil {
 		return err
 	}
 	if err := schemaexpr.ValidateComputedColumnExpressionDoesNotDependOnColumn(tableDesc, col, objType, op); err != nil {

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -471,7 +471,11 @@ func SanitizeVarFreeExpr(
 // ValidateTTLExpressionDoesNotDependOnColumn verifies that the
 // ttl_expiration_expression, if any, does not reference the given column.
 func ValidateTTLExpressionDoesNotDependOnColumn(
-	tableDesc catalog.TableDescriptor, rowLevelTTL *catpb.RowLevelTTL, col catalog.Column,
+	tableDesc catalog.TableDescriptor,
+	rowLevelTTL *catpb.RowLevelTTL,
+	col catalog.Column,
+	tn *tree.TableName,
+	op string,
 ) error {
 	if rowLevelTTL == nil || !rowLevelTTL.HasExpirationExpr() {
 		return nil
@@ -480,11 +484,7 @@ func ValidateTTLExpressionDoesNotDependOnColumn(
 	if hasRef, err := validateExpressionDoesNotDependOnColumn(tableDesc, string(expirationExpr), col.GetID()); err != nil {
 		return err
 	} else if hasRef {
-		return pgerror.Newf(
-			pgcode.InvalidColumnReference,
-			"column %q is referenced by row-level TTL expiration expression %q",
-			col.ColName(), expirationExpr,
-		)
+		return sqlerrors.NewAlterDependsOnExpirationExprError(op, "column", string(col.ColName()), tn.Object(), string(expirationExpr))
 	}
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -845,5 +845,31 @@ DROP FUNCTION F1;
 statement ok
 DROP TABLE T_FOR_FUNCTION;
 
-subtest end
+subtest ttl
 
+statement ok
+CREATE TABLE t_ttl_w_expire_at (c1 int, expire_at TIMESTAMPTZ) WITH (ttl_expiration_expression = 'expire_at');
+
+statement error pq: cannot alter type of column "expire_at" referenced by row-level TTL expiration expression "expire_at"\nHINT: use ALTER TABLE.*
+ALTER TABLE t_ttl_w_expire_at ALTER COLUMN expire_at set data type timestamptz;
+
+statement ok
+ALTER TABLE t_ttl_w_expire_at ADD COLUMN new_expire_at TIMESTAMPTZ;
+
+statement ok
+ALTER TABLE t_ttl_w_expire_at SET (ttl_expiration_expression = new_expire_at);
+
+statement ok
+ALTER TABLE t_ttl_w_expire_at ALTER COLUMN expire_at set data type timestamptz;
+
+statement ok
+CREATE TABLE T_TTL_W_DEFAULT (C1 INT PRIMARY KEY) WITH (ttl_expire_after='10 minutes');
+
+statement error pq: cannot alter.* column crdb_internal_expiration while ttl_expire_after is set\nHINT: use ALTER TABLE .* RESET \(ttl\) instead
+ALTER TABLE T_TTL_W_DEFAULT ALTER COLUMN crdb_internal_expiration SET DATA TYPE TIMESTAMPTZ;
+
+statement ok
+DROP TABLE T_TTL_W_EXPIRE_AT;
+DROP TABLE T_TTL_W_DEFAULT;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -903,7 +903,7 @@ ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
 statement ok
 SET use_declarative_schema_changer = 'off'
 
-statement error column "expire_at" is referenced by row-level TTL expiration expression "expire_at"
+statement error cannot drop column "expire_at" referenced by row-level TTL expiration expression "expire_at"\nHINT: use ALTER TABLE .*
 ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
 
 statement ok
@@ -912,7 +912,7 @@ SET use_declarative_schema_changer = 'on'
 statement ok
 SET enable_experimental_alter_column_type_general = 'on'
 
-statement error column "expire_at" is referenced by row-level TTL expiration expression "expire_at"
+statement error cannot alter type of column "expire_at" referenced by row-level TTL expiration expression "expire_at"\nHINT: use ALTER TABLE .*
 ALTER TABLE tbl_alter_table_ttl_expiration_expression ALTER expire_at TYPE TIMESTAMP USING (expire_at AT TIME ZONE 'UTC')
 
 statement ok

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_set_not_null.go
@@ -12,10 +12,9 @@ package scbuildstmt
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 )
 
 func alterTableSetNotNull(
@@ -43,11 +42,7 @@ func alterColumnPreChecks(b BuildCtx, tn *tree.TableName, tbl *scpb.Table, colum
 		_ scpb.Status, _ scpb.TargetStatus, e *scpb.RowLevelTTL,
 	) {
 		if columnName == catpb.TTLDefaultExpirationColumnName && e.HasDurationExpr() {
-			panic(pgerror.Newf(
-				pgcode.InvalidTableDefinition,
-				`cannot alter column %s while ttl_expire_after is set`,
-				columnName,
-			))
+			panic(sqlerrors.NewAlterDependsOnDurationExprError("alter", "column", columnName.String(), tn.Object()))
 		}
 	})
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -1107,7 +1107,7 @@ func checkIfColumnCanBeDropped(b BuildCtx, columnToDrop *scpb.Column) bool {
 		return false
 	}
 	canBeDropped := true
-	walkColumnDependencies(b, columnToDrop, "drop", "column", func(e scpb.Element) {
+	walkColumnDependencies(b, columnToDrop, "drop", "column", func(e scpb.Element, op, objType string) {
 		if !canBeDropped {
 			return
 		}

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -391,9 +391,16 @@ func (w *walkCtx) walkRelation(tbl catalog.TableDescriptor) {
 			w.walkIndex(tbl, idx)
 		}
 		if ttl := tbl.GetRowLevelTTL(); ttl != nil {
+			// We pull out the TTL expression so that we can build proper column
+			// dependencies with whatever column is used.
+			ttlExpr, err := w.newExpression(string(ttl.GetTTLExpr()))
+			if err != nil {
+				panic(err)
+			}
 			w.ev(scpb.Status_PUBLIC, &scpb.RowLevelTTL{
 				TableID:     tbl.GetID(),
 				RowLevelTTL: *ttl,
+				TTLExpr:     ttlExpr,
 			})
 		}
 	}

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -521,6 +521,11 @@ message IndexPartitioning {
 message RowLevelTTL {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   cockroach.sql.catalog.catpb.RowLevelTTL row_level_ttl = 2 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // The expression for the TTL column. It represents either the custom
+  // expression specified in ExpirationExpr, or the default expression if
+  // ExpirationExpr is not set. This expression is used to establish column
+  // dependencies.
+  Expression ttl_expr = 3 [(gogoproto.customname) = "TTLExpr"];
 }
 
 message ColumnName {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -269,6 +269,7 @@ object RowLevelTTL
 
 RowLevelTTL :  TableID
 RowLevelTTL :  RowLevelTTL
+RowLevelTTL :  TTLExpr
 
 object Schema
 


### PR DESCRIPTION
This extracts the TTL expression, whether user-defined or system-defined, into a declarative schema changer (DSC) Expression element. This allows us to correctly establish column dependencies for the column used in the TTL expression. By doing so, we can traverse these column dependencies to return appropriate errors when attempting to alter a column that the TTL expression depends on.

Previously, checking the TTL expression was an outstanding TODO in the new alter type code. The new dependency checking I added allows us to address that TODO.

Using column dependencies in DSC elements is more manageable than the previous method, which was in `checkRowLevelTTLColumn`. Therefore, this update also modifies the drop column functionality to use column dependencies, allowing us to get rid of that function.

Additionally, this update standardizes the error messages for attempts to alter a column dependent on the TTL expression. I opted for more verbose error messages with hints, leading to updates in some of the errors checked in logic tests.

Epic: CRDB-25314
Closes: #126143
Release note: None