### PR TITLE
release-23.1: sql: alter type drop value can crash formatting out dependent rows

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -666,3 +666,20 @@ CREATE VIEW bar_view AS (SELECT ARRAY['b'::bar])
 
 statement error pq: could not remove enum value "b" as it is being used in view "bar_view"
 ALTER TYPE bar DROP VALUE 'b'
+
+# We accidentally introduced a regression formatting dependent rows out,
+# which contain a reference to the type, so validate that the formatting logic
+# works correctly when inaccessible columns exist. (#127136)
+subtest validate_type_dependent_row
+
+statement ok
+CREATE TYPE typ_127136 AS ENUM('a', 'b', 'c');
+CREATE TABLE t_127136 (x INT PRIMARY KEY);
+CREATE INDEX foo ON t_127136((x*10));
+ALTER TABLE t_127136 ADD COLUMN y typ_127136;
+INSERT INTO t_127136 VALUES (1, 'a');
+
+statement error pgcode 2BP01 could not remove enum value "a" as it is being used by "t_127136" in row: x=1, y='a'
+ALTER TYPE typ_127136 DROP VALUE 'a';
+
+subtest end

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -925,7 +925,7 @@ func (t *typeSchemaChanger) canRemoveEnumValue(
 			if len(rows) > 0 {
 				return pgerror.Newf(pgcode.DependentObjectsStillExist,
 					"could not remove enum value %q as it is being used by %q in row: %s",
-					member.LogicalRepresentation, desc.GetName(), labeledRowValues(desc.PublicColumns(), rows))
+					member.LogicalRepresentation, desc.GetName(), labeledRowValues(desc.AccessibleColumns(), rows))
 			}
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #127245.

/cc @cockroachdb/release

---

Previously, we modified drop type to only select accessible columns of a given index when detecting rows still using enum values. We unfortunately, did not corrects update logic that formats out the error message to map the names correctly to visible accessible columns only. To address this, this patch updates error logic to use the accessible columns.


Fixes: #127136
Release justification: fix a crash
Release note: None
