### PR TITLE
release-23.2: roachtest: skip pgjdbc and hibernate test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -249,6 +249,8 @@ func registerActiveRecord(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
+		Skip:             "https://github.com/cockroachdb/activerecord-cockroachdb-adapter/pull/333",
+		SkipDetails:      "upstream test suite is flaky",
 		Name:             "activerecord",
 		Owner:            registry.OwnerSQLFoundations,
 		Timeout:          5 * time.Hour,

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -249,6 +249,8 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 	}
 
 	r.Add(registry.TestSpec{
+		Skip:             `https://github.com/cockroachdb/cockroach/issues/127206#issuecomment-2234146075`,
+		SkipDetails:      `a test dependency was pulled from the upstream package repository`,
 		Name:             opt.testName,
 		Owner:            registry.OwnerSQLFoundations,
 		Cluster:          r.MakeClusterSpec(1),

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -220,6 +220,8 @@ func registerPgjdbc(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
+		Skip:             `https://github.com/cockroachdb/cockroach/issues/127209#issuecomment-2233446488`,
+		SkipDetails:      `a test dependency was pulled from the upstream package repository`,
 		Name:             "pgjdbc",
 		Owner:            registry.OwnerSQLFoundations,
 		Cluster:          r.MakeClusterSpec(1),


### PR DESCRIPTION
A dependency was pulled from the package repository. On the master branch we are updating the pgjdbc version under test so it doesn't use this package, but for older branches that creates a lot of extra work, so we'll just skip it instead.

fixes https://github.com/cockroachdb/cockroach/issues/127261
fixes https://github.com/cockroachdb/cockroach/issues/127341
fixes https://github.com/cockroachdb/cockroach/issues/127257
fixes https://github.com/cockroachdb/cockroach/issues/127237
Release justification: test only change
Release note: None