### PR TITLE
crosscluster: escape dlq table name

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -349,6 +349,7 @@ func (p *logicalReplicationPlanner) generatePlanWithFrontier(
 		return nil, nil, nil, err
 	}
 
+	// TODO(azhu): add a flag to avoid recreating dlq tables during replanning
 	dlqClient := InitDeadLetterQueueClient(p.jobExecCtx.ExecCfg().InternalDB.Executor(), tableIDToName)
 	if err := dlqClient.Create(ctx); err != nil {
 		return nil, nil, nil, errors.Wrap(err, "failed to create dead letter queue")


### PR DESCRIPTION
Use `lexbase.EscapeSQLIdent()` in DLQ table name construction to ensure that table names that require quoting are escaped properly.

Followup to #127024

Part of: https://cockroachlabs.atlassian.net/browse/DOC-10483
Epic: CRDB-38992
Release note: None