### PR TITLE
roachprod: add PCR support to `start-sql`

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -246,9 +246,30 @@ func initFlags() {
 
 	startInstanceCmd.Flags().StringVarP(&storageCluster, "storage-cluster", "S", "", "storage cluster")
 	_ = startInstanceCmd.MarkFlagRequired("storage-cluster")
-	startInstanceCmd.Flags().IntVar(&startOpts.SQLInstance,
-		"sql-instance", 0, "specific SQL/HTTP instance to connect to (this is a roachprod abstraction for separate-process deployments distinct from the internal instance ID)")
-	startInstanceCmd.Flags().StringVar(&startOpts.VirtualClusterLocation, "external-nodes", startOpts.VirtualClusterLocation, "if set, starts service in external mode, as a separate process in the given nodes")
+	startInstanceCmd.Flags().IntVar(
+		&startOpts.SQLInstance,
+		"sql-instance",
+		0,
+		"specific SQL/HTTP instance to connect to (this is a roachprod abstraction for separate-process deployments distinct from the internal instance ID)",
+	)
+	startInstanceCmd.Flags().StringVar(
+		&startOpts.VirtualClusterLocation,
+		"external-nodes",
+		startOpts.VirtualClusterLocation,
+		"if set, starts service in external mode, as a separate process in the given nodes",
+	)
+	startInstanceCmd.Flags().StringVar(
+		&startOpts.PCRSourceCluster,
+		"pcr-cluster",
+		startOpts.PCRSourceCluster,
+		"if starting a PCR cluster, this should be the name of the virtual cluster on the source",
+	)
+	startInstanceCmd.Flags().StringVar(
+		&startOpts.PCRSourcePGURL,
+		"pcr-pgurl",
+		startOpts.PCRSourcePGURL,
+		"if starting a PCR cluster, this should be the pgurl of the system tenant on the source",
+	)
 
 	// Flags for processes that stop (kill) processes.
 	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd, deployCmd} {

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -446,7 +446,7 @@ func initFlags() {
 		_ = cmd.Flags().MarkDeprecated("scp", "always true")
 	}
 
-	for _, cmd := range []*cobra.Command{startCmd, sqlCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, sqlCmd} {
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -694,6 +694,10 @@ default. To start an external process instance, pass the
 --external-cluster flag indicating where the SQL server processes
 should be started.
 
+In shared-process mode, it is possible to start the virtual cluster
+using the Physical Cluster Replication (PCR) feature. The --pcr-cluster
+and --pcr-pgurl can be used to configure the replication.
+
 Nodes are started in secure mode by default and there is a one time
 initialization for the cluster to create and distribute the certs.
 Note that running some modes in secure mode and others in insecure

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -595,9 +595,6 @@ Note that running some modes in secure mode and others in insecure
 mode is not a supported Cockroach configuration. To start nodes in
 insecure mode, use the --insecure flag.
 
-As a debugging aid, the --sequential flag starts the nodes sequentially so node
-IDs match hostnames. Otherwise nodes are started in parallel.
-
 The --binary flag specifies the remote binary to run. It is up to the roachprod
 user to ensure this binary exists, usually via "roachprod put". Note that no
 cockroach software is installed by default on a newly created cluster.
@@ -702,9 +699,6 @@ initialization for the cluster to create and distribute the certs.
 Note that running some modes in secure mode and others in insecure
 mode is not a supported Cockroach configuration. To start nodes in
 insecure mode, use the --insecure flag.
-
-As a debugging aid, the --sequential flag starts the services
-sequentially; otherwise services are started in parallel.
 
 The --binary flag specifies the remote binary to run, if starting
 external services. It is up to the roachprod user to ensure this

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -79,12 +79,17 @@ func StartVirtualClusterOpts(name string, nodes NodeListOption, opts ...StartSto
 	return startOpts
 }
 
-// DefaultStartSharedVirtualClusterOpts returns StartOpts for starting a shared
+// StartSharedVirtualClusterOpts returns StartOpts for starting a shared
 // process virtual cluster with the given name.
-func StartSharedVirtualClusterOpts(name string) StartOpts {
+func StartSharedVirtualClusterOpts(name string, opts ...StartStopOption) StartOpts {
 	startOpts := DefaultStartOpts()
 	startOpts.RoachprodOpts.Target = install.StartSharedProcessForVirtualCluster
 	startOpts.RoachprodOpts.VirtualClusterName = name
+
+	for _, opt := range opts {
+		opt(&startOpts)
+	}
+
 	return startOpts
 }
 
@@ -180,6 +185,19 @@ func StorageCluster(nodes NodeListOption) StartStopOption {
 		switch opts := opts.(type) {
 		case *StartOpts:
 			opts.SeparateProcessStorageNodes = nodes
+		}
+	}
+}
+
+// PCR enables Physical Cluster Replication on the virtual cluster
+// being created. Note that this option should only be used on the
+// destination cluster, when creating a shared-process tenant.
+func PCR(virtualCluster, systemPGURL string) StartStopOption {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StartOpts:
+			opts.RoachprodOpts.PCRSourceCluster = virtualCluster
+			opts.RoachprodOpts.PCRSourcePGURL = systemPGURL
 		}
 	}
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -163,9 +163,6 @@ const (
 	// StartServiceForVirtualCluster starts a SQL/HTTP-only server
 	// process for a virtual cluster.
 	StartServiceForVirtualCluster
-	// StartRoutingProxy starts the SQL proxy process to route
-	// connections to multiple virtual clusters.
-	StartRoutingProxy
 )
 
 const (
@@ -182,9 +179,9 @@ const (
 
 func (st StartTarget) String() string {
 	return [...]string{
-		StartDefault:                  "default",
-		StartServiceForVirtualCluster: "SQL/HTTP instance for virtual cluster",
-		StartRoutingProxy:             "SQL proxy for multiple tenants",
+		StartDefault:                        "default",
+		StartSharedProcessForVirtualCluster: "shared-process virtual cluster instance",
+		StartServiceForVirtualCluster:       "SQL/HTTP instance for virtual cluster",
 	}[st]
 }
 
@@ -353,10 +350,6 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 // `start-single-node` (this was written to provide a short hand to start a
 // single node cluster with a replication factor of one).
 func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts StartOpts) error {
-	if startOpts.Target == StartRoutingProxy {
-		return fmt.Errorf("start SQL proxy not implemented")
-	}
-
 	// Determine if custom ports were specified in the start options.
 	customPortsSpecified := func() bool {
 		if startOpts.SQLPort != 0 && startOpts.SQLPort != config.DefaultSQLPort {
@@ -941,10 +934,6 @@ func (c *SyncedCluster) generateStartArgs(
 
 	case StartServiceForVirtualCluster:
 		args = []string{"mt", "start-sql"}
-
-	case StartRoutingProxy:
-		// args = []string{"mt", "start-proxy"}
-		panic("unimplemented")
 
 	default:
 		return nil, errors.Errorf("unsupported start target %v", startOpts.Target)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -151,6 +151,35 @@ func (s *StartOpts) IsVirtualCluster() bool {
 	return s.Target == StartSharedProcessForVirtualCluster || s.Target == StartServiceForVirtualCluster
 }
 
+// customPortsSpecified determines if custom ports were passed in
+// the start options (via command line or otherwise).
+func (s *StartOpts) customPortsSpecified() bool {
+	if s.SQLPort != 0 && s.SQLPort != config.DefaultSQLPort {
+		return true
+	}
+	if s.AdminUIPort != 0 && s.AdminUIPort != config.DefaultAdminUIPort {
+		return true
+	}
+	return false
+}
+
+// validate checks that the start options are valid to be used in a
+// cluster with the given properties. Returns an error describing the
+// problem if the options are invalid.
+func (s *StartOpts) validate(isLocal, supportsRegistration bool) error {
+	// Local clusters do not support specifying ports. An error is returned if we
+	// detect that they were set.
+	if isLocal && s.customPortsSpecified() {
+		return fmt.Errorf("local clusters do not support specifying ports")
+	}
+
+	if !supportsRegistration && s.customPortsSpecified() {
+		return fmt.Errorf("service registration is not supported for this cluster, but custom ports were specified")
+	}
+
+	return nil
+}
+
 // StartTarget identifies what flavor of cockroach we are starting.
 type StartTarget int
 
@@ -350,26 +379,12 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 // `start-single-node` (this was written to provide a short hand to start a
 // single node cluster with a replication factor of one).
 func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts StartOpts) error {
-	// Determine if custom ports were specified in the start options.
-	customPortsSpecified := func() bool {
-		if startOpts.SQLPort != 0 && startOpts.SQLPort != config.DefaultSQLPort {
-			return true
-		}
-		if startOpts.AdminUIPort != 0 && startOpts.AdminUIPort != config.DefaultAdminUIPort {
-			return true
-		}
-		return false
+	if err := startOpts.validate(c.IsLocal(), c.allowServiceRegistration()); err != nil {
+		return err
 	}
 
-	// Local clusters do not support specifying ports. An error is returned if we
-	// detect that they were set.
 	if c.IsLocal() {
-		if customPortsSpecified() {
-			return fmt.Errorf("local clusters do not support specifying ports")
-		}
-		// We don't need to return an error if the ports are the default values
-		// specified in DefaultStartOps, as these have not been specified explicitly
-		// by the user.
+		// We find open ports dynamically in local mode.
 		startOpts.SQLPort = 0
 		startOpts.AdminUIPort = 0
 	}
@@ -379,16 +394,13 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		// ports, or for local cluster port management to avoid collisions. The
 		// lookup logic will automatically fall back to the default ports if the
 		// service is not found (or has not been registered).
-		if customPortsSpecified() || c.IsLocal() || startOpts.Target != StartDefault {
+		if startOpts.customPortsSpecified() || c.IsLocal() || startOpts.Target != StartDefault {
 			err := c.maybeRegisterServices(ctx, l, startOpts, c.FindOpenPorts)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
-		if customPortsSpecified() {
-			return fmt.Errorf("service registration is not supported for this cluster, but custom ports were specified")
-		}
 		l.Printf(strings.Join([]string{
 			"WARNING: Service registration and custom ports are not supported for this cluster.",
 			fmt.Sprintf("Setting ports to default SQL Port: %d, and Admin UI Port: %d.", config.DefaultSQLPort, config.DefaultAdminUIPort),


### PR DESCRIPTION
This changes the `start-sql` command so that it is now able to
configure Physical Cluster Replication (PCR) between two virtual
clusters. This is achieved by the use of two new flags:
`--pcr-cluster` (the name of the virtual cluster on the source) and
`--pcr-pgurl` (the pgurl of the system tenant on the source).

We also add a correspoding option so that this can be easily consumed
in roachtests.

Epic: none

Release note: None