### PR TITLE
rpc: deflake TestRemoteOffsetUnhealthy

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1104,8 +1104,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 		clock := timeutil.NewManualTime(timeutil.Unix(0, start.Add(nodeCtxs[i].offset).UnixNano()))
 		nodeCtxs[i].errChan = make(chan error, 1)
 		nodeCtxs[i].ctx = newTestContext(clusterID, clock, maxOffset, stopper)
-		// Make the test faster.
-		nodeCtxs[i].ctx.RPCHeartbeatInterval = 10 * time.Millisecond
+		nodeCtxs[i].ctx.RPCHeartbeatInterval = maxOffset
 		// Disable RPC heartbeat timeouts to avoid flakiness in the test. If a
 		// heartbeat were to time out, its RPC connection would be closed and its
 		// clock offset information would be lost.


### PR DESCRIPTION
[bors didn't want to listen.](https://github.com/cockroachdb/cockroach/pull/127462#issuecomment-2237645363)

Epic: None
Release note: None