### PR TITLE
pkg/cli: Add support for uploading debug zip logs to datadog

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -216,6 +216,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/strutil",
         "//pkg/util/syncutil",
+        "//pkg/util/system",
         "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
@@ -261,10 +262,13 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_cobra//doc",
         "@com_github_spf13_pflag//:pflag",
+        "@com_google_cloud_go_storage//:storage",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_golang_google_api//option",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_oauth2//google",
         "@org_golang_x_sync//errgroup",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1576,6 +1576,10 @@ func init() {
 	f = debugZipUploadCmd.Flags()
 	f.StringVar(&debugZipUploadOpts.ddAPIKey, "dd-api-key", "",
 		"Datadog API key to use to send debug.zip artifacts to datadog")
+	f.StringVar(&debugZipUploadOpts.ddAPPKey, "dd-app-key", "",
+		"Datadog APP key to use to send debug.zip artifacts to datadog")
+	f.StringVar(&debugZipUploadOpts.ddSite, "dd-site", defaultDDSite,
+		"Datadog site to use to send debug.zip artifacts to datadog")
 	f.StringSliceVar(&debugZipUploadOpts.include, "include", nil,
 		"The debug zip artifacts to include. Possible values: "+strings.Join(zipArtifactTypes, ", "))
 	f.StringSliceVar(&debugZipUploadOpts.tags, "tags", nil,
@@ -1583,6 +1587,12 @@ func init() {
 			"\nExample: --tags \"env:prod,customer:xyz\"")
 	f.StringVar(&debugZipUploadOpts.clusterName, "cluster", "",
 		"Name of the cluster to associate with the debug zip artifacts. This can be used to identify data in the upstream observability tool.")
+	f.Var(&debugZipUploadOpts.from, "from", "oldest timestamp to include (inclusive)")
+	f.Var(&debugZipUploadOpts.to, "to", "newest timestamp to include (inclusive)")
+	f.StringVar(&debugZipUploadOpts.logFormat, "log-format", "",
+		"log format of the input files")
+	f.StringVar(&debugZipUploadOpts.gcpProjectID, "gcp-project-id",
+		defaultGCPProjectID, "GCP project ID to use to send debug.zip logs to GCS")
 
 	f = debugDecodeKeyCmd.Flags()
 	f.Var(&decodeKeyOptions.encoding, "encoding", "key argument encoding")

--- a/pkg/cli/testdata/upload/logs
+++ b/pkg/cli/testdata/upload/logs
@@ -1,0 +1,86 @@
+# Single-node
+upload-logs
+{
+  "nodes": {
+    "1": {
+      "logs": [
+        {
+          "name": "cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log",
+          "lines": [
+            "I240716 17:51:44.661864 100 server/node.go:533 ⋮ [T1,n1] 24 initialized store s1",
+            "W240716 17:51:44.667017 100 server/env_sampler.go:125 ⋮ [T1,n1] 33 failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: ‹/proc/self/cgroup›: open ‹/proc/self/cgroup›: no such file or directory"
+          ]
+        }
+      ]
+    }
+  }
+}
+----
+ABC/123/dt=20240716/hour=17:
+Upload ID: 123
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v1
+{"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+
+
+# single-node with wrong log format
+upload-logs log-format=crdb-v2
+{
+  "nodes": {
+    "1": {
+      "logs": [
+        {
+          "name": "cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log",
+          "lines": [
+            "I240716 17:51:44.661864 100 server/node.go:533 ⋮ [T1,n1] 24 initialized store s1",
+            "W240716 17:51:44.667017 100 server/env_sampler.go:125 ⋮ [T1,n1] 33 failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: ‹/proc/self/cgroup›: open ‹/proc/self/cgroup›: no such file or directory"
+          ]
+        }
+      ]
+    }
+  }
+}
+----
+Failed to upload logs: decoding on line 2: malformed log entry
+Upload ID: 123
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v2
+
+
+# multi-node
+upload-logs
+{
+  "nodes": {
+    "1": {
+      "logs": [
+        {
+          "name": "cockroach.node1.username.2024-07-16T17_51_43Z.048498.log",
+          "lines": [
+            "I240716 17:51:44.661864 100 server/node.go:533 ⋮ [T1,n1] 24 initialized store s1",
+            "W240716 17:51:44.667017 100 server/env_sampler.go:125 ⋮ [T1,n1] 33 failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: ‹/proc/self/cgroup›: open ‹/proc/self/cgroup›: no such file or directory"
+          ]
+        }
+      ]
+    },
+    "2": {
+      "logs": [
+        {
+          "name": "cockroach.node2.username.2024-07-16T17_51_43Z.048498.log",
+          "lines": [
+            "I240716 17:51:44.797342 916 sql/sqlliveness/slstorage/slstorage.go:540 ⋮ [T1,n1] 43 inserted sqlliveness session 01018071445fbd54a44ee88e906efb311d7193",
+            "I240716 17:51:44.797530 916 sql/sqlliveness/slinstance/slinstance.go:258 ⋮ [T1,n1] 44 created new SQL liveness session 01018071445fbd54a44ee88e906efb311d7193"
+          ]
+        }
+      ]
+    }
+  }
+}
+----
+ABC/123/dt=20240716/hour=17:
+Upload ID: 123
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v1
+{"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"created new SQL liveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:2","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slinstance/slinstance.go","line":258,"counter":44,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"inserted sqlliveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:2","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slstorage/slstorage.go","line":540,"counter":43,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}

--- a/pkg/cli/testdata/upload/profiles
+++ b/pkg/cli/testdata/upload/profiles
@@ -1,104 +1,123 @@
 # Single-node - both profiles
 upload-profiles
 {
-    "1": [
-        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
-        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
-    ]
+  "nodes": {
+    "1": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718972610, "duration": 20},
+        {"type": "heap", "timestamp": 1718974401, "duration": 20}
+      ]
+    }
+  }
 }
 ----
-Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=upload_id:123
 Upload ID: 123
-Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof)
-debug zip upload debugDir --dd-api-key=dd-api-key --cluster=ABC
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,upload_id:123","family":"go","version":"4"}
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=profiles
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
 
 
 # Multi-node - both profiles
 upload-profiles tags=foo:bar
 {
-    "1": [
-        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
-        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
-    ],
-    "2": [
-        { "type": "cpu", "timestamp": 1718974543, "duration": 20 },
-        { "type": "heap", "timestamp": 1718974535, "duration": 20 }
-    ]
+  "nodes": {
+    "1": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718972610, "duration": 20},
+        {"type": "heap", "timestamp": 1718974401, "duration": 20}
+      ]
+    },
+    "2": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718974543, "duration": 20},
+        {"type": "heap", "timestamp": 1718974535, "duration": 20}
+      ]
+    }
+  }
 }
 ----
-Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=upload_id:123
-Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=upload_id:123
 Upload ID: 123
-Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof)
-Uploaded profiles of node 2 to datadog (debugDir/nodes/2/cpu.pprof, debugDir/nodes/2/heap.pprof)
-debug zip upload debugDir --dd-api-key=dd-api-key --tags=foo:bar --cluster=ABC
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:1,service:CRDB-SH,upload_id:123","family":"go","version":"4"}
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:2,service:CRDB-SH,upload_id:123","family":"go","version":"4"}
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=foo:bar --cluster=ABC --include=profiles
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:2,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
 
 
 # Single-node - only CPU profile
 upload-profiles tags=customer:user-given-name,cluster:XYZ
 {
-    "1": [
-        { "type": "cpu", "timestamp": 1718972610, "duration": 20 }
-    ]
+  "nodes": {
+    "1": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718972610, "duration": 20}
+      ]
+    }
+  }
 }
 ----
-Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=upload_id:123
 Upload ID: 123
-Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof)
-debug zip upload debugDir --dd-api-key=dd-api-key --tags=customer:user-given-name,cluster:XYZ --cluster=ABC
-{"start":"","end":"","attachments":["cpu.pprof"],"tags_profiler":"cluster:XYZ,customer:user-given-name,env:debug,foo:bar,node_id:1,service:CRDB-SH,upload_id:123","family":"go","version":"4"}
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=customer:user-given-name,cluster:XYZ --cluster=ABC --include=profiles
+{"start":"","end":"","attachments":["cpu.pprof"],"tags_profiler":"cluster:XYZ,customer:user-given-name,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
 
 
 # Single-node - no profiles found
 upload-profiles
 {
-    "1": []
+  "nodes": {
+    "1": {}
+  }
 }
 ----
 Upload ID: 123
-debug zip upload debugDir --dd-api-key=dd-api-key --cluster=ABC
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=profiles
 
 
 # Colliding tags - env provided by the user should take precedence
 upload-profiles tags=env:SH
 {
-    "1": [
-        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
-        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
-    ]
+  "nodes": {
+    "1": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718972610, "duration": 20},
+        {"type": "heap", "timestamp": 1718974401, "duration": 20}
+      ]
+    }
+  }
 }
 ----
-Explore this profile on datadog: https://{{ datadog domain }}/profiling/explorer?query=upload_id:123
 Upload ID: 123
-Uploaded profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof)
-debug zip upload debugDir --dd-api-key=dd-api-key --tags=env:SH --cluster=ABC
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:SH,node_id:1,service:CRDB-SH,upload_id:123","family":"go","version":"4"}
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=env:SH --cluster=ABC --include=profiles
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:SH,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
 
 
 # Single-node - both profiles
 upload-profiles tags=ERR
 {
-    "1": [
-        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
-        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
-    ]
+  "nodes": {
+    "1": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718972610, "duration": 20},
+        {"type": "heap", "timestamp": 1718974401, "duration": 20}
+      ]
+    }
+  }
 }
 ----
-ERROR: Failed to upload profiles of node 1 to datadog (debugDir/nodes/1/cpu.pprof, debugDir/nodes/1/heap.pprof): 'runtime' is a required field
-debug zip upload debugDir --dd-api-key=dd-api-key --tags=ERR --cluster=ABC
+Failed to upload profiles: failed to upload profiles of node 1: status: 400, body: 'runtime' is a required field
+Upload ID: 123
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=ERR --cluster=ABC --include=profiles
 
 
 # Customer name not provided by the user
 upload-profiles tags=foo:bar skip-cluster-name=true
 {
-    "1": [
-        { "type": "cpu", "timestamp": 1718972610, "duration": 20 },
-        { "type": "heap", "timestamp": 1718974401, "duration": 20 }
-    ]
+  "nodes": {
+    "1": {
+      "profiles": [
+        {"type": "cpu", "timestamp": 1718972610, "duration": 20},
+        {"type": "heap", "timestamp": 1718974401, "duration": 20}
+      ]
+    }
+  }
 }
 ----
 ERROR: cluster name is required for uploading profiles
-debug zip upload debugDir --dd-api-key=dd-api-key --tags=foo:bar
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=foo:bar --include=profiles

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -12,24 +12,35 @@ package cli
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 )
 
 type profileUploadEvent struct {
@@ -44,43 +55,76 @@ type profileUploadEvent struct {
 type uploadZipArtifactFunc func(ctx context.Context, uuid string, debugDirPath string) error
 
 const (
-	datadogAPIKeyHeader  = "DD-API-KEY"
-	zippedProfilePattern = "nodes/*/*.pprof"
-	profileFamily        = "go"
-	profileFormat        = "pprof"
+	// default flag values
+	defaultDDSite       = "us5"
+	defaultGCPProjectID = "arjun-sandbox-424904" // TODO: change this project ID
 
-	// this is not the pprof version, but the version of the profile upload format supported by datadog
+	// datadog HTTP headers
+	datadogAPIKeyHeader = "DD-API-KEY"
+	datadogAppKeyHeader = "DD-APPLICATION-KEY"
+
+	// the path pattern to search for specific artifacts in the debug zip directory
+	zippedProfilePattern = "nodes/*/*.pprof"
+	zippedLogsPattern    = "nodes/*/logs/*"
+
+	// this is not the pprof version, but the version of the profile
+	// upload format supported by datadog
 	profileVersion = "4"
+	profileFamily  = "go"
 
 	// names of mandatory tag
 	nodeIDTag   = "node_id"
 	uploadIDTag = "upload_id"
 	clusterTag  = "cluster"
+
+	// datadog endpoint URLs
+	datadogProfileUploadURLTmpl = "https://intake.profile.%s/v1/input"
+	datadogCreateArchiveURLTmpl = "https://%s/api/v2/logs/config/archives"
+
+	// datadog archive attributes
+	ddArchiveType            = "archives"
+	ddArchiveDestinationType = "gcs"
+	ddArchiveQuery           = "-*" // will make sure to not archive any live logs
+	ddArchiveBucketName      = "debugzip-archives"
+	ddArchiveDefaultClient   = "datadog-archive" // TODO(arjunmahishi): make this a flag also
 )
 
 var debugZipUploadOpts = struct {
-	include            []string
-	ddAPIKey           string
-	ddProfileUploadURL string
-	clusterName        string
-	tags               []string
+	include              []string
+	ddAPIKey             string
+	ddAPPKey             string
+	ddSite               string
+	clusterName          string
+	gcpProjectID         string
+	tags                 []string
+	from, to             timestampValue
+	logFormat            string
+	maxConcurrentUploads int
+	reporter             *zipUploadReporter
 }{
-	ddProfileUploadURL: "https://intake.profile.datadoghq.com/v1/input",
+	maxConcurrentUploads: system.NumCPU(),
+	reporter:             newReporter(os.Stderr),
 }
 
 // This is the list of all supported artifact types. The "possible values" part
 // in the help text is generated from this list. So, make sure to keep this updated
-var zipArtifactTypes = []string{"profiles"}
+// var zipArtifactTypes = []string{"profiles", "logs"}
+// TODO(arjunmahishi): Removing the profiles upload for now. It has started
+// failing for some reason. Will fix this later
+var zipArtifactTypes = []string{"logs"}
 
 // uploadZipArtifactFuncs is a registry of handler functions for each artifact type.
 // While adding/removing functions from here, make sure to update
 // the zipArtifactTypes list as well
 var uploadZipArtifactFuncs = map[string]uploadZipArtifactFunc{
 	"profiles": uploadZipProfiles,
+	"logs":     uploadZipLogs,
 }
 
-// default tags
-var ddProfileTags = []string{"service:CRDB-SH", "env:debug"}
+// default datadog tags. Source has to be "cockroachdb" for the logs to be
+// ingested correctly. This will make sure that the logs pass through the right
+// pipeline which enriches the logs with more fields.
+var defaultDDTags = []string{"service:CRDB-SH", "env:debug", "source:cockroachdb"}
 
 func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 	if err := validateZipUploadReadiness(); err != nil {
@@ -96,11 +140,12 @@ func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 		artifactsToUpload = debugZipUploadOpts.include
 	}
 
-	// run the upload functions
-	// TODO(arjunmahishi): Make this concurrent once there are multiple artifacts to upload
+	// run the upload functions for each artifact type. This can run sequentially.
+	// All the concurrency is contained within the upload functions.
 	for _, artType := range artifactsToUpload {
 		if err := uploadZipArtifactFuncs[artType](cmd.Context(), uploadID, args[0]); err != nil {
-			return err
+			// Log the error and continue with the next artifact
+			fmt.Printf("Failed to upload %s: %s\n", artType, err)
 		}
 	}
 
@@ -109,6 +154,24 @@ func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 }
 
 func validateZipUploadReadiness() error {
+	var (
+		includeLookup     = map[string]struct{}{}
+		artifactsToUpload = zipArtifactTypes
+	)
+
+	if len(debugZipUploadOpts.include) > 0 {
+		artifactsToUpload = debugZipUploadOpts.include
+	}
+	for _, inc := range artifactsToUpload {
+		if _, ok := includeLookup[inc]; ok {
+			// if the artifact type is already included, ignore the duplicate and
+			// continue
+			continue
+		}
+
+		includeLookup[inc] = struct{}{}
+	}
+
 	if debugZipUploadOpts.ddAPIKey == "" {
 		return fmt.Errorf("datadog API key is required for uploading profiles")
 	}
@@ -121,6 +184,24 @@ func validateZipUploadReadiness() error {
 	for _, artType := range debugZipUploadOpts.include {
 		if _, ok := uploadZipArtifactFuncs[artType]; !ok {
 			return fmt.Errorf("unsupported artifact type '%s'", artType)
+		}
+	}
+
+	// validate the datadog site name
+	if _, ok := ddSiteToHostMap[debugZipUploadOpts.ddSite]; !ok {
+		return fmt.Errorf("unsupported datadog site '%s'", debugZipUploadOpts.ddSite)
+	}
+
+	// special validations when logs are to be uploaded
+	_, ok := log.FormatParsers[debugZipUploadOpts.logFormat]
+	_, shouldUploadLogs := includeLookup["logs"]
+	if shouldUploadLogs {
+		if !ok {
+			return fmt.Errorf("unsupported log format '%s'", debugZipUploadOpts.logFormat)
+		}
+
+		if debugZipUploadOpts.ddAPPKey == "" {
+			return fmt.Errorf("datadog APP key is required for uploading logs")
 		}
 	}
 
@@ -147,7 +228,7 @@ func uploadZipProfiles(ctx context.Context, uploadID string, debugDirPath string
 		req, err := newProfileUploadReq(
 			ctx, paths, appendUserTags(
 				append(
-					ddProfileTags, makeDDTag(nodeIDTag, nodeID), makeDDTag(uploadIDTag, uploadID),
+					defaultDDTags, makeDDTag(nodeIDTag, nodeID), makeDDTag(uploadIDTag, uploadID),
 					makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
 				), // system generated tags
 				debugZipUploadOpts.tags..., // user provided tags
@@ -157,36 +238,13 @@ func uploadZipProfiles(ctx context.Context, uploadID string, debugDirPath string
 			return err
 		}
 
-		resp, err := doUploadProfileReq(req)
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				fmt.Println("failed to close response body:", err)
-			}
-		}()
-
-		if resp.StatusCode != http.StatusOK {
-			errMsg := fmt.Sprintf(
-				"Failed to upload profiles of node %s to datadog (%s)",
-				nodeID, (strings.Join(paths, ", ")),
-			)
-			if resp.Body != nil {
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-
-				return fmt.Errorf("%s: %s", errMsg, string(body))
-			}
-
-			return fmt.Errorf("%s: %s", errMsg, resp.Status)
+		if _, err := doUploadReq(req); err != nil {
+			return fmt.Errorf("failed to upload profiles of node %s: %w", nodeID, err)
 		}
 
-		fmt.Printf("Uploaded profiles of node %s to datadog (%s)\n", nodeID, strings.Join(paths, ", "))
-		fmt.Printf("Explore this profile on datadog: "+
-			"https://{{ datadog domain }}/profiling/explorer?query=upload_id:%s\n", uploadID)
+		fmt.Fprintf(os.Stderr, "Uploaded profiles of node %s to datadog (%s)\n", nodeID, strings.Join(paths, ", "))
+		fmt.Fprintf(os.Stderr, "Explore the profiles on datadog: "+
+			"https://{{ datadog domain }}/profiling/explorer?query=%s:%s\n", uploadIDTag, uploadID)
 	}
 
 	return nil
@@ -248,7 +306,7 @@ func newProfileUploadReq(
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, debugZipUploadOpts.ddProfileUploadURL, &body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, makeDDURL(datadogProfileUploadURLTmpl), &body)
 	if err != nil {
 		return nil, err
 	}
@@ -256,6 +314,323 @@ func newProfileUploadReq(
 	req.Header.Set(httputil.ContentTypeHeader, mw.FormDataContentType())
 	req.Header.Set(datadogAPIKeyHeader, debugZipUploadOpts.ddAPIKey)
 	return req, nil
+}
+
+func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) error {
+	paths, err := expandPatterns([]string{path.Join(debugDirPath, zippedLogsPattern)})
+	if err != nil {
+		return err
+	}
+
+	filePattern := regexp.MustCompile(logFilePattern)
+	files, err := findLogFiles(
+		paths, filePattern, nil, groupIndex(filePattern, "program"),
+	)
+	if err != nil {
+		return err
+	}
+
+	// chunkMap holds the mapping of target path names to the chunks of log lines
+	chunkMap := make(map[string][][]byte)
+	firstEventTime, lastEventTime := time.Time{}, time.Time{}
+	gcsPathPrefix := path.Join(debugZipUploadOpts.clusterName, uploadID)
+	for _, file := range files {
+		pathParts := strings.Split(strings.TrimPrefix(file.path, debugDirPath), "/")
+		inputEditMode := log.SelectEditMode(false /* redactable */, false /* redactInput */)
+		stream, err := newFileLogStream(
+			file, time.Time(debugZipUploadOpts.from), time.Time(debugZipUploadOpts.to),
+			inputEditMode, debugZipUploadOpts.logFormat,
+		)
+		if err != nil {
+			return err
+		}
+
+		for e, ok := stream.peek(); ok; e, ok = stream.peek() {
+			if firstEventTime.IsZero() {
+				firstEventTime = timeutil.Unix(0, e.Time) // from the first log entry
+			}
+			lastEventTime = timeutil.Unix(0, e.Time) // from the last log entry
+
+			// The target path is constructed like this: <cluster-name>/<upload-id>/dt=20210901/hour=15
+			targetPath := path.Join(
+				gcsPathPrefix, timeutil.Unix(0, e.Time).Format("dt=20060102/hour=15"),
+			)
+			rawLine, err := logEntryToJSON(e, appendUserTags(
+				append(
+					defaultDDTags, makeDDTag(uploadIDTag, uploadID), makeDDTag(nodeIDTag, pathParts[2]),
+					makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
+				), // system generated tags
+				debugZipUploadOpts.tags..., // user provided tags
+			))
+			if err != nil {
+				return err
+			}
+
+			if _, ok := chunkMap[targetPath]; !ok {
+				chunkMap[targetPath] = [][]byte{}
+			}
+
+			// TODO(arjunmahishi): Can this map hold all the data? We might be able
+			// to start the upload here itself. So that we don't have to keep
+			// everything in memory. But since we are running this on our mac books
+			// for now, we can afford to keep everything in memory.
+			chunkMap[targetPath] = append(chunkMap[targetPath], rawLine)
+			stream.pop()
+		}
+
+		if err := stream.error(); err != nil {
+			if err.Error() == "EOF" {
+				continue
+			}
+			return err
+		}
+	}
+
+	if err := writeLogsToGCS(ctx, chunkMap); err != nil {
+		return err
+	}
+
+	if err := setupDDArchive(ctx, gcsPathPrefix, uploadID); err != nil {
+		return errors.Wrap(err, "failed to setup datadog archive")
+	}
+
+	printRehydrationSteps(uploadID, uploadID, firstEventTime, lastEventTime)
+	return nil
+}
+
+type ddArchivePayload struct {
+	Type       string              `json:"type"`
+	Attributes ddArchiveAttributes `json:"attributes"`
+}
+
+type ddArchiveAttributes struct {
+	Name        string               `json:"name"`
+	Query       string               `json:"query"`
+	Destination ddArchiveDestination `json:"destination"`
+}
+
+type ddArchiveDestination struct {
+	Type        string               `json:"type"`
+	Path        string               `json:"path"`
+	Bucket      string               `json:"bucket"`
+	Integration ddArchiveIntegration `json:"integration"`
+}
+
+type ddArchiveIntegration struct {
+	ProjectID   string `json:"project_id"`
+	ClientEmail string `json:"client_email"`
+}
+
+func setupDDArchive(ctx context.Context, pathPrefix, archiveName string) error {
+	rawPayload, err := json.Marshal(struct {
+		Data ddArchivePayload `json:"data"`
+	}{
+		Data: ddArchivePayload{
+			Type: ddArchiveType,
+			Attributes: ddArchiveAttributes{
+				Name:  archiveName,
+				Query: ddArchiveQuery,
+				Destination: ddArchiveDestination{
+					Type:   ddArchiveDestinationType,
+					Bucket: ddArchiveBucketName,
+					Path:   pathPrefix,
+					Integration: ddArchiveIntegration{
+						ProjectID: debugZipUploadOpts.gcpProjectID,
+						ClientEmail: fmt.Sprintf(
+							"%s@%s.iam.gserviceaccount.com",
+							ddArchiveDefaultClient, debugZipUploadOpts.gcpProjectID,
+						),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, makeDDURL(datadogCreateArchiveURLTmpl), bytes.NewReader(rawPayload),
+	)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set(httputil.ContentTypeHeader, httputil.JSONContentType)
+	req.Header.Set(datadogAPIKeyHeader, debugZipUploadOpts.ddAPIKey)
+	req.Header.Set(datadogAppKeyHeader, debugZipUploadOpts.ddAPPKey)
+
+	if _, err := doUploadReq(req); err != nil {
+		return fmt.Errorf("failed to create datadog archive: %w", err)
+	}
+
+	return nil
+}
+
+type gcsWorkerSig struct {
+	key  string
+	data []byte
+}
+
+// writeLogsToGCS is a function that concurrently writes the logs to GCS.
+// The chunkMap is expected to be a map of time-base paths to luist of log lines.
+//
+//	Example: {
+//	  "dt=20210901/hour=15": [[]byte, []byte, ...],
+//	}
+//
+// Each path will be uploaded as a separate file. The final file name will be
+// randomly generated just be for uploading.
+var writeLogsToGCS = func(ctx context.Context, chunkMap map[string][][]byte) error {
+	gcsClient, closeGCSClient, err := newGCSClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeGCSClient()
+
+	// The concurrency can be easily managed with something like sync/errors.Group
+	// But using channels gives us two advantages:
+	// 1. We can fail fast i.e exit as soon as one upload fails
+	// 2. We can monitor the progress as the uploads happen and report it to the
+	// CLI user (this seem like a non-feature but this is super useful when the
+	// upload times are long)
+	workChan := make(chan gcsWorkerSig, len(chunkMap))
+	doneChan := make(chan error, len(chunkMap))
+	for key, lines := range chunkMap {
+		workChan <- gcsWorkerSig{key, bytes.Join(lines, []byte("\n"))}
+	}
+
+	// we can aggressively schedule the number of workers. Because this is a
+	// network IO bound workload. We will be waiting for the GCS API to complete
+	// the upload most of the time
+	noOfWorkers := min(system.NumCPU()*4, len(chunkMap))
+	for i := 0; i < noOfWorkers; i++ {
+		go func() {
+			for sig := range workChan {
+				filename := path.Join(sig.key, fmt.Sprintf(
+					"archive_%s_%s_%s.json.gz",
+					newRandStr(6, true /* numericOnly */), newRandStr(4, true), newRandStr(22, false),
+				))
+
+				objectWriter := gcsClient.Bucket(ddArchiveBucketName).Object(filename).NewWriter(ctx)
+				w := gzip.NewWriter(objectWriter)
+				_, err := w.Write(sig.data)
+				if err != nil {
+					doneChan <- err
+					return
+				}
+
+				if err := w.Close(); err != nil {
+					doneChan <- err
+					return
+				}
+
+				if err := objectWriter.Close(); err != nil {
+					doneChan <- err
+					return
+				}
+
+				doneChan <- nil
+			}
+		}()
+	}
+
+	report := newReporter(os.Stderr).newReport("logs")
+	doneCount := 0.0
+	for i := 0; i < len(chunkMap); i++ {
+		if err := <-doneChan; err != nil {
+			// stop everything and return the error
+			close(workChan)
+			close(doneChan)
+			return err
+		}
+
+		doneCount++
+		report((doneCount / float64(len(chunkMap))) * 100)
+	}
+
+	close(workChan)
+	close(doneChan)
+	return nil
+}
+
+func newGCSClient(ctx context.Context) (*storage.Client, func(), error) {
+	tokenSource, err := google.DefaultTokenSource(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gcsClient, err := storage.NewClient(ctx, option.WithTokenSource(tokenSource))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return gcsClient, func() {
+		// return a function that already handles the closing error
+		if err := gcsClient.Close(); err != nil {
+			fmt.Println(err)
+		}
+	}, nil
+}
+
+type ddLogEntry struct {
+	logpb.Entry
+
+	Date      string `json:"date"`
+	Timestamp int64  `json:"timestamp"`
+	Channel   string `json:"channel"`
+	Severity  string `json:"severity"`
+
+	// fields to be omitted
+	Message any    `json:"message,omitempty"`
+	Time    string `json:"time,omitempty"`
+	Tags    string `json:"tags,omitempty"`
+}
+
+// logEntryToJSON converts a logpb.Entry to a JSON byte slice and also
+// transform a few fields to use the correct types. The JSON format is based on
+// the specification provided by datadog.
+// Refer: https://gist.github.com/ckelner/edc0e4efe4fa110f6b6b61f69d580171
+func logEntryToJSON(e logpb.Entry, tags []string) ([]byte, error) {
+	var message any = e.Message
+	if strings.HasPrefix(e.Message, "{") {
+		// If the message is already a JSON object, we don't want to escape it
+		// by wrapping it in quotes. Instead, we want to include it as a nested
+		// object in the final JSON output. So, we can override the Message field
+		// with the json.RawMessage instead of string. This will prevent the
+		// message from being escaped.
+		message = json.RawMessage(e.Message)
+	}
+
+	date := timeutil.Unix(0, e.Time).Format(time.RFC3339)
+	timestamp := e.Time / 1e9
+
+	return json.Marshal(struct {
+		// override the following fields in the embedded logpb.Entry struct
+		Timestamp  int64      `json:"timestamp"`
+		Date       string     `json:"date"`
+		Message    any        `json:"message"`
+		Tags       []string   `json:"tags"`
+		ID         string     `json:"_id"`
+		Attributes ddLogEntry `json:"attributes"`
+	}{
+		Timestamp: timestamp,
+		Date:      date,
+		Message:   message,
+		Tags:      tags,
+		ID:        newRandStr(24, false /* numericOnly */),
+		Attributes: ddLogEntry{
+			Entry:     e,
+			Date:      date,
+			Timestamp: timestamp,
+			Channel:   e.Channel.String(),
+			Severity:  e.Severity.String(),
+
+			// remove the below fields via the omitempty tag
+			Time: "",
+			Tags: "",
+		},
+	})
 }
 
 // appendUserTags will make sure there are no duplicates in the final list of tags.
@@ -302,10 +677,32 @@ func makeDDTag(key, value string) string {
 	return fmt.Sprintf("%s:%s", key, value)
 }
 
-// doUploadProfileReq is a variable that holds the function that literally just sends the request.
-// This is useful to mock the datadog API's response in tests.
-var doUploadProfileReq = func(req *http.Request) (*http.Response, error) {
-	return http.DefaultClient.Do(req)
+// doUploadReq is a variable that holds the function that makes the actual HTTP request.
+// There is also some error handling logic in this function. This is a variable so that
+// we can mock this function in the tests.
+var doUploadReq = func(req *http.Request) ([]byte, error) {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Println("failed to close response body:", err)
+		}
+	}()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// treat all non-2xx status codes as errors
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("status code: %s, err message: %s", resp.Status, string(rawBody))
+	}
+
+	return rawBody, nil
 }
 
 // a wrapper around uuid.MakeV4().String() to make the tests more deterministic.
@@ -318,4 +715,118 @@ var newUploadID = func(cluster string) string {
 			fmt.Sprintf("%s-%s", cluster, uuid.NewV4().Short()), " ", "-",
 		),
 	)
+}
+
+// newRandStr generates a random alphanumeric string of the given length. This is used
+// for the _id field in the log entries and for the name of the archives
+var newRandStr = func(length int, numericOnly bool) string {
+	charSet := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	if numericOnly {
+		charSet = "0123456789"
+	}
+
+	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charSet[r.Intn(len(charSet))]
+	}
+	return string(b)
+}
+
+func printRehydrationSteps(uploadID, archiveName string, from, to time.Time) {
+	msg := `
+The logs have been added to an archive and are ready for rehydration (ingestion). This has to be
+triggered manually for now. This will be automated as soon as the datadog API supports it.
+
+Follow these steps to trigger rehydration:
+
+  1. Open this link in your browser: https://us5.datadoghq.com/logs/pipelines/historical-views/add
+  2. In "Select Time Range" section, select the time range from "%s" to "%s" or a subset of it
+  3. In "Select Archive" section, select the archive "%s"
+  4. In "Name Historical Index", enter the name "%s"
+  5. Click on "Rehydrate From Archive"
+
+You will receive an email notification once the rehydration is complete.
+`
+
+	// Month data year
+	timeFormat := "Jan 2 2006"
+	from = from.Truncate(time.Hour)            // round down to the nearest hour
+	to = to.Add(time.Hour).Truncate(time.Hour) // round up to the nearest hour
+	fmt.Fprintf(
+		os.Stderr, msg, from.Format(timeFormat), to.Format(timeFormat), archiveName, uploadID,
+	)
+}
+
+// makeDDURL constructe the final datadog URL by replacing the site
+// placeholder in the template. This is a simple convenience
+// function. It assumes that the site is valid. This assumption is
+// fine because we are validating the site early on in the flow.
+func makeDDURL(tmpl string) string {
+	return fmt.Sprintf(tmpl, ddSiteToHostMap[debugZipUploadOpts.ddSite])
+}
+
+// zipUploadReporter is a simple concurrency-safe logger that can be used to
+// report the progress on the upload of each artifact type in the debug zip.
+// The log printed by this is updated in-place as the progress changes.
+// Usage pattern:
+//
+//	reporter := newReporter(os.Stderr)
+//	report := reporter.newReport("profiles")
+//	report(50) // 50% progress
+//	report(75) // 50% progress
+//	report(100) // 100% progress
+type zipUploadReporter struct {
+	syncutil.RWMutex
+	reports   map[string]float64
+	output    string
+	logWriter io.Writer
+}
+
+func (r *zipUploadReporter) print() {
+	r.RLock()
+	defer r.RUnlock()
+
+	// move the cursor to the top
+	currentLines := strings.Count(r.output, "\n")
+	if currentLines > 0 {
+		fmt.Fprintf(r.logWriter, "\033[%dA", currentLines)
+	}
+
+	reports := []string{}
+	for name := range r.reports {
+		reports = append(reports, name)
+	}
+	sort.Strings(reports)
+
+	var outputBuilder strings.Builder
+	for _, name := range reports {
+		progress := r.reports[name]
+		outputBuilder.WriteString(fmt.Sprintf("%s upload progress: %.2f%%\n", name, progress))
+	}
+
+	r.output = outputBuilder.String()
+	fmt.Fprint(r.logWriter, r.output)
+}
+
+func (r *zipUploadReporter) newReport(name string) func(float64) {
+	r.Lock()
+	defer r.print()
+	defer r.Unlock()
+
+	r.reports[name] = 0
+	return func(progress float64) {
+		r.Lock()
+		defer r.print()
+		defer r.Unlock()
+
+		r.reports[name] = progress
+	}
+}
+
+func newReporter(logWriter io.Writer) *zipUploadReporter {
+	return &zipUploadReporter{
+		reports:   make(map[string]float64),
+		logWriter: logWriter,
+	}
 }

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
 	"github.com/google/pprof/profile"
@@ -35,37 +37,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type zipUploadTestContents struct {
+	Nodes map[int]struct {
+		Profiles []uploadProfileReq `json:"profiles"`
+		Logs     []uploadLogsReq    `json:"logs"`
+	} `json:"nodes"`
+}
+
+type uploadLogsReq struct {
+	Name  string   `json:"name"`
+	Lines []string `json:"lines"`
+}
+
 type uploadProfileReq struct {
 	Type      string `json:"type"`
 	Timestamp int64  `json:"timestamp"`
 	Duration  int64  `json:"duration"`
 }
 
-func setupZipDirWithProfiles(t *testing.T, inputs map[int][]uploadProfileReq) (string, func()) {
+func setupZipDir(t *testing.T, inputs zipUploadTestContents) (string, func()) {
 	t.Helper()
 
 	// make sure that the debug directory name is unique. Or the tests will be flaky.
 	debugDir := path.Join(os.TempDir(), fmt.Sprintf("debug-%s/", uuid.MakeV4().String()))
 
-	for nodeID, nodeInputs := range inputs {
-		// create a subdirectory for each node
+	for nodeID, nodeInputs := range inputs.Nodes {
+		// setup profiles
 		profDir := path.Join(debugDir, fmt.Sprintf("nodes/%d/", nodeID))
 		require.NoError(t, os.MkdirAll(profDir, 0755))
 
-		for _, i := range nodeInputs {
+		for _, prof := range nodeInputs.Profiles {
 			p := &profile.Profile{
-				TimeNanos:     time.Unix(i.Timestamp, 0).UnixNano(),
-				DurationNanos: i.Duration,
+				TimeNanos:     time.Unix(prof.Timestamp, 0).UnixNano(),
+				DurationNanos: prof.Duration,
 				SampleType: []*profile.ValueType{
-					{Type: i.Type},
+					{Type: prof.Type},
 				},
 			}
 
 			file, err := os.Create(
-				path.Join(profDir, fmt.Sprintf("%s.pprof", i.Type)),
+				path.Join(profDir, fmt.Sprintf("%s.pprof", prof.Type)),
 			)
 			require.NoError(t, err)
 			require.NoError(t, p.Write(file))
+			require.NoError(t, file.Close())
+		}
+
+		// setup logs
+		logDir := path.Join(debugDir, fmt.Sprintf("nodes/%d/logs", nodeID))
+		require.NoError(t, os.MkdirAll(logDir, 0755))
+
+		for _, log := range nodeInputs.Logs {
+			var logBuilder bytes.Buffer
+			for _, line := range log.Lines {
+				logBuilder.WriteString(line)
+				logBuilder.WriteString("\n")
+			}
+
+			file, err := os.Create(
+				path.Join(logDir, log.Name),
+			)
+			require.NoError(t, err)
+
+			_, err = file.Write(logBuilder.Bytes())
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
 		}
 	}
 
@@ -74,109 +110,103 @@ func setupZipDirWithProfiles(t *testing.T, inputs map[int][]uploadProfileReq) (s
 	}
 }
 
-func TestUploadZipProfiles(t *testing.T) {
+func TestUploadZipEndToEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer testutils.TestingHook(&newUploadID, func(string) string {
 		return "123"
 	})()
+	defer testutils.TestingHook(&newRandStr, func(l int, n bool) string {
+		if n {
+			return "123"
+		}
+		return "a1b2c3"
+	})()
 
-	defer testutils.TestingHook(&doUploadProfileReq,
-		func(req *http.Request) (*http.Response, error) {
+	defer testutils.TestingHook(&doUploadReq,
+		func(req *http.Request) ([]byte, error) {
 			defer req.Body.Close()
 
-			_, params, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
-			reader := multipart.NewReader(req.Body, params["boundary"])
-
-			// find the "event" part in the multipart request and copy it to the final output
-			for {
-				part, err := reader.NextPart()
-				if err == io.EOF {
-					break
-				}
-
-				if part.FormName() == "event" {
-					var event profileUploadEvent
-					require.NoError(t, json.NewDecoder(part).Decode(&event))
-
-					if strings.Contains(event.Tags, "ERR") {
-						// this is a test to simulate a client error
-						return &http.Response{
-							StatusCode: 400,
-							Body:       io.NopCloser(strings.NewReader("'runtime' is a required field")),
-						}, nil
-					}
-
-					// validate the timestamps outside the data-driven test framework
-					// to keep the test deterministic.
-					start, err := time.Parse(time.RFC3339Nano, event.Start)
-					require.NoError(t, err)
-
-					end, err := time.Parse(time.RFC3339Nano, event.End)
-					require.NoError(t, err)
-
-					require.Equal(t, time.Second*5, end.Sub(start))
-					event.Start = ""
-					event.End = ""
-
-					// require.NoError(t, json.NewEncoder(&finaloutput).Encode(event))
-					rawEvent, err := json.Marshal(event)
-					require.NoError(t, err)
-
-					// print the event so that it gets captured as a part of RunWithCapture
-					fmt.Println(string(rawEvent))
-				}
+			switch req.URL.Path {
+			case "/v1/input":
+				return uploadProfileHook(t, req)
+			case "/api/v2/logs/config/archives":
+				return setupDDArchiveHook(t, req)
+			default:
+				return nil, fmt.Errorf(
+					"unexpected request is being made to datadog: %s", req.URL.Path,
+				)
 			}
-
-			return &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(strings.NewReader("200 OK")),
-			}, nil
 		},
 	)()
 
-	datadriven.RunTest(t, "testdata/upload/profiles", func(t *testing.T, d *datadriven.TestData) string {
-		c := NewCLITest(TestCLIParams{})
-		defer c.Cleanup()
+	defer testutils.TestingHook(&writeLogsToGCS, writeLogsToGCSHook)()
 
-		var finaloutput bytes.Buffer
+	datadriven.Walk(t, "testdata/upload", func(t *testing.T, path string) {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			c := NewCLITest(TestCLIParams{})
+			defer c.Cleanup()
+			debugZipUploadOpts.include = nil
 
-		var testInput map[int][]uploadProfileReq
-		require.NoError(t, json.Unmarshal([]byte(d.Input), &testInput))
+			var finaloutput bytes.Buffer
 
-		var tags string
-		if d.HasArg("tags") {
-			d.ScanArgs(t, "tags", &tags)
-			tags = fmt.Sprintf("--tags=%s", tags)
-		} else {
-			debugZipUploadOpts.tags = nil
-		}
+			var testInput zipUploadTestContents
+			require.NoError(t, json.Unmarshal([]byte(d.Input), &testInput))
 
-		clusterNameArg := "--cluster=ABC"
-		if d.HasArg("skip-cluster-name") {
-			debugZipUploadOpts.clusterName = ""
-			clusterNameArg = ""
-		}
+			var tags string
+			if d.HasArg("tags") {
+				d.ScanArgs(t, "tags", &tags)
+				tags = fmt.Sprintf("--tags=%s", tags)
+			} else {
+				debugZipUploadOpts.tags = nil
+			}
 
-		debugDir, cleanup := setupZipDirWithProfiles(t, testInput)
-		defer cleanup()
+			clusterNameArg := "--cluster=ABC"
+			if d.HasArg("skip-cluster-name") {
+				debugZipUploadOpts.clusterName = ""
+				clusterNameArg = ""
+			}
 
-		stdout, err := c.RunWithCapture(
-			fmt.Sprintf("debug zip upload %s --dd-api-key=dd-api-key %s %s", debugDir, tags, clusterNameArg),
-		)
-		require.NoError(t, err)
+			var includeFlag string // no include flag by default
+			switch d.Cmd {
+			case "upload-profiles":
+				includeFlag = "--include=profiles"
+			case "upload-logs":
+				var logFormat string
+				if d.HasArg("log-format") {
+					d.ScanArgs(t, "log-format", &logFormat)
+				}
 
-		// also write the STDOUT output to the finaloutput buffer. So, both the
-		// API request made to Datadog and the STDOUT output are validated.
-		_, err = finaloutput.WriteString(stdout)
-		require.NoError(t, err)
+				if logFormat == "" {
+					logFormat = "crdb-v1"
+				}
 
-		// sort the lines to avoid flakiness in the test
-		lines := strings.Split(finaloutput.String(), "\n")
-		sort.Strings(lines)
+				includeFlag = fmt.Sprintf("--include=logs --log-format=%s", logFormat)
+			}
 
-		// replace the debugDir with a constant string to avoid flakiness in the test
-		return strings.ReplaceAll(strings.TrimSpace(strings.Join(lines, "\n")), debugDir, "debugDir")
+			debugDir, cleanup := setupZipDir(t, testInput)
+			defer cleanup()
+
+			stdout, err := c.RunWithCapture(fmt.Sprintf(
+				"debug zip upload %s --dd-api-key=dd-api-key --dd-app-key=dd-app-key %s %s %s",
+				debugDir, tags, clusterNameArg, includeFlag,
+			))
+			require.NoError(t, err)
+
+			// also write the STDOUT output to the finaloutput buffer. So, both the
+			// API request made to Datadog and the STDOUT output are validated.
+			_, err = finaloutput.WriteString(stdout)
+			require.NoError(t, err)
+
+			lines := strings.Split(finaloutput.String(), "\n")
+			// if d.Cmd == "upload-profiles" {
+			// sort the lines to avoid flakiness in the test
+			sort.Strings(lines)
+			// }
+
+			// replace the debugDir with a constant string to avoid flakiness in the test
+			return strings.ReplaceAll(strings.TrimSpace(strings.Join(lines, "\n")), debugDir, "debugDir")
+		})
 	})
 }
 
@@ -236,4 +266,108 @@ func TestZipUploadArtifactTypes(t *testing.T) {
 			artifactType,
 		)
 	}
+}
+
+func uploadProfileHook(t *testing.T, req *http.Request) ([]byte, error) {
+	t.Helper()
+
+	_, params, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	reader := multipart.NewReader(req.Body, params["boundary"])
+
+	// find the "event" part in the multipart request and copy it to the final output
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+
+		if part.FormName() == "event" {
+			var event profileUploadEvent
+			require.NoError(t, json.NewDecoder(part).Decode(&event))
+
+			if strings.Contains(event.Tags, "ERR") {
+				// this is a test to simulate a client error
+				return nil, fmt.Errorf("status: 400, body: 'runtime' is a required field")
+			}
+
+			// validate the timestamps outside the data-driven test framework
+			// to keep the test deterministic.
+			start, err := time.Parse(time.RFC3339Nano, event.Start)
+			require.NoError(t, err)
+
+			end, err := time.Parse(time.RFC3339Nano, event.End)
+			require.NoError(t, err)
+
+			require.Equal(t, time.Second*5, end.Sub(start))
+			event.Start = ""
+			event.End = ""
+
+			// require.NoError(t, json.NewEncoder(&finaloutput).Encode(event))
+			rawEvent, err := json.Marshal(event)
+			require.NoError(t, err)
+
+			// print the event so that it gets captured as a part of RunWithCapture
+			fmt.Println(string(rawEvent))
+		}
+	}
+
+	return []byte("200 OK"), nil
+}
+
+func setupDDArchiveHook(t *testing.T, req *http.Request) ([]byte, error) {
+	t.Helper()
+
+	var body bytes.Buffer
+	_, err := body.ReadFrom(req.Body)
+	require.NoError(t, err)
+
+	// print the request bidy so that it gets captured as a part of
+	// RunWithCapture
+	fmt.Println(body.String())
+	return []byte("200 OK"), nil
+}
+
+func writeLogsToGCSHook(ctx context.Context, chunkMap map[string][][]byte) error {
+	out := strings.Builder{}
+	for k, v := range chunkMap {
+		out.WriteString(fmt.Sprintf("%s:\n", k))
+		for _, chunk := range v {
+			out.WriteString(fmt.Sprintf("%s\n", string(chunk)))
+		}
+	}
+
+	// print the logs so that it gets captured as a part of RunWithCapture
+	fmt.Println(out.String())
+	return nil
+}
+
+func TestLogEntryToJSON(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// set the maxConcurrentUploads to 1 to avoid flakiness in the test
+	origConc := debugZipUploadOpts.maxConcurrentUploads
+	debugZipUploadOpts.maxConcurrentUploads = 1
+	defer func() {
+		debugZipUploadOpts.maxConcurrentUploads = origConc
+	}()
+
+	raw, err := logEntryToJSON(logpb.Entry{
+		Severity: logpb.Severity_INFO,
+		Channel:  logpb.Channel_STORAGE,
+		Time:     time.Date(2024, time.August, 2, 0, 0, 0, 0, time.UTC).UnixNano(),
+		Message:  "something happend",
+	}, []string{})
+	require.NoError(t, err)
+
+	t.Log(string(raw))
+
+	raw, err = logEntryToJSON(logpb.Entry{
+		Severity: logpb.Severity_INFO,
+		Channel:  logpb.Channel_STORAGE,
+		Time:     time.Date(2024, time.August, 2, 0, 0, 0, 0, time.UTC).UnixNano(),
+		Message:  `{"foo": "bar"}`,
+	}, []string{})
+	require.NoError(t, err)
+
+	t.Log(string(raw))
 }

--- a/pkg/util/log/formats.go
+++ b/pkg/util/log/formats.go
@@ -32,7 +32,8 @@ type logFormatter interface {
 	contentType() string
 }
 
-var formatParsers = map[string]string{
+// FormatParsers maps the user facing format names to the internal representation.
+var FormatParsers = map[string]string{
 	"crdb-v1":             "v1",
 	"crdb-v1-count":       "v1",
 	"crdb-v1-tty":         "v1",

--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -78,7 +78,7 @@ func NewEntryDecoderWithFormat(
 		}
 		in = io.MultiReader(read, in)
 	}
-	f, ok := formatParsers[format]
+	f, ok := FormatParsers[format]
 	if !ok {
 		return nil, errors.Newf("unknown log file format: %s", format)
 	}


### PR DESCRIPTION
Currently, the "debug zip upload" is capable of uploading CPU and HEAP
profiles to datadog. This commit extends that by adding support to
upload logs as well.

Datadog doesn't support ingesting historical logs by default. So, we are
working around that by reverse engineering the log rehydration feature.

Datadog has the ability to archive logs after a certain retention period
has passed. These archives live in cloud storage services like S3/GCS
etc. Datadog allows you to "rehydrate" logs from these archives on
demand. This is the [Rehydration feature](https://docs.datadoghq.com/logs/log_configuration/rehydrating/?tab=amazons3).

This commit leverages that ability to ingest historical logs. Instead of
datadog creating the archive, we artificially create an archive with the
logs we want to ingest - using a format that datadog recognises. Then as
mentioned above, we can ingest these logs into datadog by "Rehydrating"
them.

One of the caveats of this approach is, there is no API to trigger
rehydration. It has to be triggered manually on the UI. So, the user
running this automation will see instructions printed on STDERR. This
will contain easy to follow steps to complete the ingestion.

---
Usage

```shell
./cockroach debug zip upload <debug zip dir>  \
  --dd-api-key=<DD API key>) \
  --dd-app-key=<DD APP key> \
  --cluster="<cluster name>" \
  --log-format "crdb-v1" 
``` 

---

Epic: CC-27712
Part of: CC-28517
Release note: None