### PR TITLE
jwtauthccl: add mapper for issuer url to jwks URI

### DIFF
--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lestrrat_go_jwx//jwk",
         "@com_github_lestrrat_go_jwx//jwt",
+        "@org_golang_x_exp//maps",
     ],
 )
 

--- a/pkg/ccl/jwtauthccl/authentication_jwt.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt.go
@@ -68,7 +68,7 @@ type jwtAuthenticator struct {
 type jwtAuthenticatorConf struct {
 	audience             []string
 	enabled              bool
-	issuers              []string
+	issuersConf          issuerURLConf
 	issuerCA             string
 	jwks                 jwk.Set
 	claim                string
@@ -91,7 +91,7 @@ func (authenticator *jwtAuthenticator) reloadConfigLocked(
 	conf := jwtAuthenticatorConf{
 		audience:             mustParseValueOrArray(JWTAuthAudience.Get(&st.SV)),
 		enabled:              JWTAuthEnabled.Get(&st.SV),
-		issuers:              mustParseValueOrArray(JWTAuthIssuers.Get(&st.SV)),
+		issuersConf:          mustParseJWTIssuersConf(JWTAuthIssuersConfig.Get(&st.SV)),
 		issuerCA:             JWTAuthIssuerCustomCA.Get(&st.SV),
 		jwks:                 mustParseJWKS(JWTAuthJWKS.Get(&st.SV)),
 		claim:                JWTAuthClaim.Get(&st.SV),
@@ -167,25 +167,15 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 	}
 
 	// Check for issuer match against configured issuers.
-	issuerUrl := ""
-	issuerMatch := false
-	for _, issuer := range authenticator.mu.conf.issuers {
-		if issuer == unverifiedToken.Issuer() {
-			issuerMatch = true
-			issuerUrl = issuer
-			break
-		}
-	}
-	if !issuerMatch {
-		return "", errors.WithDetailf(
-			errors.Newf("JWT authentication: invalid issuer"),
-			"token issued by %s", unverifiedToken.Issuer())
+	tokenIssuer := unverifiedToken.Issuer()
+	if err = authenticator.mu.conf.issuersConf.checkIssuerConfigured(tokenIssuer); err != nil {
+		return "", errors.WithDetailf(err, "token issued by %s", tokenIssuer)
 	}
 
 	var jwkSet jwk.Set
-	// If auto-fetch is enabled, fetch the JWKS remotely from the issuer's well known jwks url.
+	// If auto-fetch is enabled, fetch the JWKS remotely from the issuer's well known jwks URI.
 	if authenticator.mu.conf.jwksAutoFetchEnabled {
-		jwkSet, err = authenticator.remoteFetchJWKS(ctx, issuerUrl)
+		jwkSet, err = authenticator.remoteFetchJWKS(ctx, tokenIssuer)
 		if err != nil {
 			return redact.Sprintf("unable to fetch jwks: %v", err),
 				errors.Newf("JWT authentication: unable to validate token")
@@ -288,16 +278,27 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 	return "", nil
 }
 
-// remoteFetchJWKS fetches the JWKS from the provided URI.
+// remoteFetchJWKS fetches the JWKS URI from the provided issuer URL.
 func (authenticator *jwtAuthenticator) remoteFetchJWKS(
-	ctx context.Context, issuerUrl string,
+	ctx context.Context, issuerURL string,
 ) (jwk.Set, error) {
-	jwksUrl, err := authenticator.getJWKSUrl(ctx, issuerUrl)
+	var jwksURI string
+	// if JWKS URI is configured in JWTAuthIssuersConfig use that instead of URL
+	// from issuer's well-known endpoint
+	err := authenticator.mu.conf.issuersConf.checkJWKSConfigured()
 	if err != nil {
-		return nil, err
+		jwksURI, err = authenticator.getJWKSURI(ctx, issuerURL)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		jwksURI, err = authenticator.mu.conf.issuersConf.getJWKSURI(issuerURL)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	body, err := getHttpResponse(ctx, jwksUrl, authenticator)
+	body, err := getHttpResponse(ctx, jwksURI, authenticator)
 	if err != nil {
 		return nil, err
 	}
@@ -308,8 +309,8 @@ func (authenticator *jwtAuthenticator) remoteFetchJWKS(
 	return jwkSet, nil
 }
 
-// getJWKSUrl returns the JWKS URI from the OpenID configuration endpoint.
-func (authenticator *jwtAuthenticator) getJWKSUrl(
+// getJWKSURI returns the JWKS URI from the OpenID configuration endpoint.
+func (authenticator *jwtAuthenticator) getJWKSURI(
 	ctx context.Context, issuerUrl string,
 ) (string, error) {
 	type OIDCConfigResponse struct {
@@ -367,7 +368,7 @@ var ConfigureJWTAuth = func(
 	JWTAuthEnabled.SetOnChange(&st.SV, func(ctx context.Context) {
 		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
 	})
-	JWTAuthIssuers.SetOnChange(&st.SV, func(ctx context.Context) {
+	JWTAuthIssuersConfig.SetOnChange(&st.SV, func(ctx context.Context) {
 		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
 	})
 	JWTAuthIssuerCustomCA.SetOnChange(&st.SV, func(ctx context.Context) {

--- a/pkg/ccl/jwtauthccl/authentication_jwt_test.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt_test.go
@@ -181,7 +181,7 @@ func TestJWTSingleKey(t *testing.T) {
 	jwkPublicKey := serializePublicKey(t, publicKey)
 
 	// Configure issuer as it gets checked even before the token validity check.
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer1)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer1)
 
 	// When JWKSAutoFetchEnabled JWKS fetch should be attempted and  fail for configured issuer.
 	JWKSAutoFetchEnabled.Override(ctx, &s.ClusterSettings().SV, true)
@@ -221,7 +221,7 @@ func TestJWTSingleKeyWithoutKeyAlgorithm(t *testing.T) {
 	jwkPublicKey := serializePublicKey(t, publicKey)
 
 	// Configure issuer as it gets checked even before the token validity check.
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer1)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer1)
 
 	// When JWKSAutoFetchEnabled, JWKS fetch should be attempted and  fail for configured issuer.
 	JWKSAutoFetchEnabled.Override(ctx, &s.ClusterSettings().SV, true)
@@ -251,7 +251,7 @@ func TestJWTMultiKey(t *testing.T) {
 	// Make sure jwt auth is enabled.
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	// Configure issuer as it gets checked even before the token validity check.
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer1)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer1)
 	keySet, key, key2 := createJWKS(t)
 	token := createJWT(t, username1, audience1, issuer1, timeutil.Now().Add(time.Hour), key2, jwa.ES384, "", "")
 	publicKey, err := key.PublicKey()
@@ -292,7 +292,7 @@ func TestExpiredToken(t *testing.T) {
 	// Make sure jwt auth is enabled and accepts valid signing keys.
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	// Configure issuer as it gets checked even before the token validity check.
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer1)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer1)
 	keySet, key, _ := createJWKS(t)
 	token := createJWT(t, username1, audience1, issuer1, timeutil.Now().Add(-1*time.Second), key, jwa.RS256, "", "")
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
@@ -323,7 +323,7 @@ func TestKeyIdMismatch(t *testing.T) {
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
 	// Configure issuer as it gets checked even before the token validity check.
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer1)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer1)
 
 	// When JWKSAutoFetchEnabled the jwks fetch should be attempted and fail.
 	_, err = verifier.ValidateJWTLogin(ctx, s.ClusterSettings(), username.MakeSQLUsernameFromPreNormalizedString(username1), token, identMap)
@@ -364,7 +364,7 @@ func TestIssuerCheck(t *testing.T) {
 	require.ErrorContains(t, err, "JWT authentication: invalid issuer")
 	require.EqualValues(t, "token issued by issuer1", errors.GetAllDetails(err)[0])
 
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 	// Validation fails with an issuer error when the issuer in the token is not in cluster's accepted issuers.
 	_, err = verifier.ValidateJWTLogin(ctx, s.ClusterSettings(), username.MakeSQLUsernameFromPreNormalizedString(invalidUsername), token1, identMap)
 	require.ErrorContains(t, err, "JWT authentication: invalid issuer")
@@ -376,7 +376,7 @@ func TestIssuerCheck(t *testing.T) {
 	require.EqualValues(t, "token issued for [test_user1] and login was for invalid_user", errors.GetAllDetails(err)[0])
 
 	// Set the cluster setting to accept issuer values of either "issuer" or "issuer2".
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, "[\""+issuer1+"\", \""+issuer2+"\"]")
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, "[\""+issuer1+"\", \""+issuer2+"\"]")
 
 	// Validation succeeds when the issuer in the token is an element of the cluster's accepted issuers.
 	_, err = verifier.ValidateJWTLogin(ctx, s.ClusterSettings(), username.MakeSQLUsernameFromPreNormalizedString(invalidUsername), token1, identMap)
@@ -406,7 +406,7 @@ func TestSubjectCheck(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 
 	// Validation fails with a subject error when a user tries to log in with a user named
 	// "invalid" but the token is for the user "test2".
@@ -438,7 +438,7 @@ func TestClaimMissing(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 	JWTAuthClaim.Override(ctx, &s.ClusterSettings().SV, customClaimName)
 
 	// Validation fails with missing claim
@@ -465,7 +465,7 @@ func TestIntegerClaimValue(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 	JWTAuthClaim.Override(ctx, &s.ClusterSettings().SV, customClaimName)
 
 	// the integer claim is implicitly cast to a string
@@ -491,7 +491,7 @@ func TestSingleClaim(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 	JWTAuthClaim.Override(ctx, &s.ClusterSettings().SV, customClaimName)
 
 	// Validation fails with a subject error when a user tries to log in with a user named
@@ -523,7 +523,7 @@ func TestMultipleClaim(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 	JWTAuthClaim.Override(ctx, &s.ClusterSettings().SV, customClaimName)
 
 	// Validation fails with a subject error when a user tries to log in with a user named
@@ -560,7 +560,7 @@ func TestSubjectMappingCheck(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 
 	// Validation fails with a subject error when a user tries to log in when their user is mapped to username2
 	// but they try to log in with username1.
@@ -598,7 +598,7 @@ func TestSubjectReservedUser(t *testing.T) {
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
 	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, "[\""+issuer1+"\", \""+issuer2+"\"]")
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, "[\""+issuer1+"\", \""+issuer2+"\"]")
 
 	// You cannot log in as root or other reserved users using token based auth when mapped to root.
 	_, err = verifier.ValidateJWTLogin(ctx, s.ClusterSettings(), username.MakeSQLUsernameFromPreNormalizedString("root"), token, identMap)
@@ -626,7 +626,7 @@ func TestAudienceCheck(t *testing.T) {
 	// Make sure jwt auth is enabled and accepts jwk1 or jwk2 as valid signing keys.
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer2)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer2)
 
 	// Set audience field to audience2.
 	JWTAuthAudience.Override(ctx, &s.ClusterSettings().SV, audience2)
@@ -681,7 +681,7 @@ func createJWKSFromFile(t *testing.T, fileName string) jwk.Set {
 	return jwkSet
 }
 
-// test that jwks url is used when JWKSAutoFetchEnabled is true.
+// test that jwks URI is used when JWKSAutoFetchEnabled is true.
 func Test_JWKSFetchWorksWhenEnabled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Intercept the call to getHttpResponse and return the mockGetHttpResponse
@@ -699,7 +699,7 @@ func Test_JWKSFetchWorksWhenEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create key from a file. This key will be used to sign the token.
-	// Matching public key available in jwks url is used to verify token.
+	// Matching public key available in jwks URI is used to verify token.
 	keySet := createJWKSFromFile(t, "testdata/www.idp1apis.com_oauth2_v3_certs_private")
 	key, _ := keySet.Get(0)
 	validIssuer := "https://accounts.idp1.com"
@@ -708,7 +708,7 @@ func Test_JWKSFetchWorksWhenEnabled(t *testing.T) {
 	// Make sure jwt auth is enabled and accepts jwk1 or jwk2 as valid signing keys.
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	//JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySet))
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, validIssuer)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, validIssuer)
 
 	// Set audience field to audience2.
 	JWTAuthAudience.Override(ctx, &s.ClusterSettings().SV, audience2)
@@ -735,7 +735,7 @@ func Test_JWKSFetchWorksWhenEnabled(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// test jwks url is used when JWKSAutoFetchEnabled and static jwks ignored.
+// test jwks URI is used when JWKSAutoFetchEnabled and static jwks ignored.
 func Test_JWKSFetchWorksWhenEnabledIgnoresTheStaticJWKS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Intercept the call to getHttpResponse and return the mockGetHttpResponse
@@ -753,7 +753,7 @@ func Test_JWKSFetchWorksWhenEnabledIgnoresTheStaticJWKS(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create key from a file. This key will be used to sign the token.
-	// Matching public key available in jwks url is used to verify token.
+	// Matching public key available in jwks URI is used to verify token.
 	keySetUsedForSigning := createJWKSFromFile(t, "testdata/www.idp1apis.com_oauth2_v3_certs_private")
 	key, _ := keySetUsedForSigning.Get(0)
 	validIssuer := "https://accounts.idp1.com"
@@ -765,7 +765,7 @@ func Test_JWKSFetchWorksWhenEnabledIgnoresTheStaticJWKS(t *testing.T) {
 	// Configure cluster setting with a key that is not used for signing.
 	keySetNotUsedForSigning, _, _ := createJWKS(t)
 	JWTAuthJWKS.Override(ctx, &s.ClusterSettings().SV, serializePublicKeySet(t, keySetNotUsedForSigning))
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, validIssuer)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, validIssuer)
 
 	// Set audience field to audience2.
 	JWTAuthAudience.Override(ctx, &s.ClusterSettings().SV, audience2)
@@ -841,7 +841,7 @@ func TestJWTAuthWithCustomCACert(t *testing.T) {
 				Issuer      string   `json:"issuer"`
 				AuthURL     string   `json:"authorization_endpoint"`
 				TokenURL    string   `json:"token_endpoint"`
-				JWKSURL     string   `json:"jwks_uri"`
+				JWKSURI     string   `json:"jwks_uri"`
 				UserInfoURL string   `json:"userinfo_endpoint"`
 				Algorithms  []string `json:"id_token_signing_alg_values_supported"`
 			}
@@ -851,7 +851,7 @@ func TestJWTAuthWithCustomCACert(t *testing.T) {
 			require.NoError(t, err)
 
 			// We need to update the 'jwks_uri' to point to the local test server.
-			p.JWKSURL = testServerURL + "/jwks"
+			p.JWKSURI = testServerURL + "/jwks"
 
 			updatedBytes, err := json.Marshal(p)
 			require.NoError(t, err)
@@ -895,7 +895,7 @@ func TestJWTAuthWithCustomCACert(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a key to sign the token using testdata.
-	// The same will be fetched through the JWKS URL to verify the token.
+	// The same will be fetched through the JWKS URI to verify the token.
 	keySet := createJWKSFromFile(t, "testdata/www.idp1apis.com_oauth2_v3_certs_private")
 	key, _ := keySet.Get(0)
 	issuer := testServerURL
@@ -903,7 +903,7 @@ func TestJWTAuthWithCustomCACert(t *testing.T) {
 		t, username1, audience1, issuer, timeutil.Now().Add(time.Hour), key, jwa.RS256, "", "")
 
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, issuer)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, issuer)
 	JWKSAutoFetchEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthAudience.Override(ctx, &s.ClusterSettings().SV, audience1)
 
@@ -1014,7 +1014,7 @@ func TestJWTAuthClientTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a key to sign the token using testdata.
-	// The same will be fetched through the JWKS URL to verify the token.
+	// The same will be fetched through the JWKS URI to verify the token.
 	keySet := createJWKSFromFile(t, "testdata/www.idp1apis.com_oauth2_v3_certs_private")
 	key, _ := keySet.Get(0)
 	validIssuer := "https://accounts.idp1.com"
@@ -1022,7 +1022,7 @@ func TestJWTAuthClientTimeout(t *testing.T) {
 		t, username1, audience1, validIssuer, timeutil.Now().Add(time.Hour), key, jwa.RS256, "", "")
 
 	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
-	JWTAuthIssuers.Override(ctx, &s.ClusterSettings().SV, validIssuer)
+	JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, validIssuer)
 	JWKSAutoFetchEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 	JWTAuthAudience.Override(ctx, &s.ClusterSettings().SV, audience1)
 	JWTAuthClientTimeout.Override(ctx, &s.ClusterSettings().SV, time.Millisecond)
@@ -1041,4 +1041,110 @@ func TestJWTAuthClientTimeout(t *testing.T) {
 		errMsg,
 	)
 	require.ErrorContains(t, err, "JWT authentication: unable to validate token")
+}
+
+func TestJWTAuthWithIssuerJWKSConfAutoFetchJWKS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Initiate a test OIDC/JWKS server locally over HTTP.
+	testServer := httptest.NewUnstartedServer(nil)
+	testServerURL := "http://" + testServer.Listener.Addr().String()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"GET /.well-known/openid-configuration",
+		func(w http.ResponseWriter, r *http.Request) {
+			// Serve the response locally mocking openid config.
+			dataBytes := map[string]string{"invalid-key": "invalid-value"}
+			updatedBytes, _ := json.Marshal(dataBytes)
+			_, err := w.Write(updatedBytes)
+			require.NoError(t, err)
+		},
+	)
+	mux.HandleFunc(
+		"GET /jwks",
+		func(w http.ResponseWriter, r *http.Request) {
+			// Serve the JWKS response locally from testdata.
+			dataBytes, err := os.ReadFile("testdata/www.idp1apis.com_oauth2_v3_certs")
+			require.NoError(t, err)
+			_, err = w.Write(dataBytes)
+			require.NoError(t, err)
+		},
+	)
+
+	testServer.Config = &http.Server{
+		Handler: mux,
+	}
+	testServer.Start()
+	defer testServer.Close()
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	// Create a key to sign the token using testdata.
+	// The same will be fetched through the JWKS URI to verify the token.
+	keySet := createJWKSFromFile(t, "testdata/www.idp1apis.com_oauth2_v3_certs_private")
+	key, _ := keySet.Get(0)
+	issuer := testServerURL
+	token := createJWT(
+		t, username1, audience1, issuer, timeutil.Now().Add(time.Hour), key, jwa.RS256, "", "")
+
+	JWTAuthEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+	JWKSAutoFetchEnabled.Override(ctx, &s.ClusterSettings().SV, true)
+	JWTAuthAudience.Override(ctx, &s.ClusterSettings().SV, audience1)
+
+	verifier := ConfigureJWTAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
+	identMapString := ""
+	identMap, err := identmap.From(strings.NewReader(identMapString))
+	require.NoError(t, err)
+
+	for _, testCase := range []struct {
+		testName           string
+		issuerConfSetting  string
+		assertFn           func(t require.TestingT, err error, msgAndArgs ...interface{})
+		expectedErr        string
+		expectedErrDetails string
+		detailedErrMsg     string
+	}{
+		{
+			testName:           "fail if issuer not set",
+			issuerConfSetting:  "",
+			assertFn:           require.Error,
+			expectedErr:        "JWT authentication: invalid issuer",
+			expectedErrDetails: "token issued by " + testServerURL,
+		},
+		{
+			testName:          "fail if issuer provided without JWKS URI mapping",
+			issuerConfSetting: testServerURL,
+			assertFn:          require.Error,
+			expectedErr:       "JWT authentication: unable to validate token",
+			detailedErrMsg:    "unable to fetch jwks: no JWKS URI found in OpenID configuration",
+		},
+		{
+			testName:          "success if issuer to jwks URI provided",
+			issuerConfSetting: "{\"issuer_jwks_map\": {\"" + testServerURL + "\": \"" + testServerURL + "/jwks" + "\"}}",
+			assertFn:          require.NoError,
+		},
+	} {
+		t.Run(testCase.testName, func(t *testing.T) {
+			// set the issuer configuration cluster setting
+			JWTAuthIssuersConfig.Override(ctx, &s.ClusterSettings().SV, testCase.issuerConfSetting)
+			detailedErrMsg, err := verifier.ValidateJWTLogin(
+				ctx,
+				s.ClusterSettings(),
+				username.MakeSQLUsernameFromPreNormalizedString(username1),
+				token,
+				identMap,
+			)
+			testCase.assertFn(t, err)
+			if err != nil {
+				require.Equal(t, testCase.expectedErr, err.Error())
+				require.Equal(t, testCase.expectedErrDetails, errors.FlattenDetails(err))
+				require.Equal(t, detailedErrMsg, redact.RedactableString(testCase.detailedErrMsg))
+			}
+		})
+	}
 }

--- a/pkg/ccl/jwtauthccl/settings.go
+++ b/pkg/ccl/jwtauthccl/settings.go
@@ -12,11 +12,13 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/json"
+	"slices"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/errors"
 	"github.com/lestrrat-go/jwx/jwk"
+	"golang.org/x/exp/maps"
 )
 
 // All cluster settings necessary for the JWT authentication feature.
@@ -30,6 +32,7 @@ const (
 	JWKSAutoFetchEnabledSettingName  = baseJWTAuthSettingName + "jwks_auto_fetch.enabled"
 	jwtAuthIssuerCustomCASettingName = baseJWTAuthSettingName + "issuers.custom_ca"
 	jwtAuthClientTimeoutSettingName  = baseJWTAuthSettingName + "client.timeout"
+	jwtAuthIssuersConfigSettingName  = JWTAuthIssuersSettingName + ".configuration"
 )
 
 // JWTAuthClaim sets the JWT claim that is parsed to get the username.
@@ -68,14 +71,37 @@ var JWTAuthJWKS = settings.RegisterStringSetting(
 	settings.WithValidateString(validateJWTAuthJWKS),
 )
 
-// JWTAuthIssuers is the list of "issuer" values that are accepted for JWT logins over the SQL interface.
-var JWTAuthIssuers = settings.RegisterStringSetting(
+// JWTAuthIssuersConfig contains the configuration of all JWT issuers  whose
+// tokens are allowed for JWT logins over the SQL interface. This can be set to
+// one of the following values:
+// 1. Simple string that Go can parse as a valid issuer URL.
+// 2. String that can be parsed as valid JSON array of issuer URLs list.
+// 3. String that can be parsed as valid JSON and deserialized into a map of
+// issuer URLs to corresponding JWKS URIs.
+// In the third case we will be overriding the JWKS URI present in the issuer's
+// well-known endpoint.
+// Example valid values:
+//   - 'https://accounts.google.com'
+//   - ['example.com/adfs','https://accounts.google.com']
+//   - '{
+//     "issuer_jwks_map": {
+//     "https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs",
+//     "example.com/adfs": "https://example.com/adfs/discovery/keys"
+//     }
+//     }'
+//
+// When issuer_jwks_map is set, we directly use the JWKS URI to get the key set.
+// In all other cases where JWKSAutoFetchEnabled is set we obtain the JWKS URI
+// first from issuer's well-known endpoint and the use this endpoint.
+var JWTAuthIssuersConfig = settings.RegisterStringSetting(
 	settings.ApplicationLevel,
 	JWTAuthIssuersSettingName,
-	"sets accepted issuer values for JWT logins over the SQL interface either as a string or as a JSON "+
-		"string with an array of issuer strings in it",
+	"sets accepted issuer values for JWT logins over the SQL interface which can "+
+		"be a single issuer URL string or a JSON string containing an array of "+
+		"issuer URLs or a JSON object containing map of issuer URLS to JWKS URIs",
 	"",
-	settings.WithValidateString(validateJWTAuthIssuers),
+	settings.WithValidateString(validateJWTAuthIssuersConf),
+	settings.WithName(jwtAuthIssuersConfigSettingName),
 )
 
 // JWTAuthIssuerCustomCA is the custom root CA for verifying certificates while
@@ -90,12 +116,16 @@ var JWTAuthIssuerCustomCA = settings.RegisterStringSetting(
 	settings.WithValidateString(validateJWTAuthIssuerCACert),
 )
 
-// JWKSAutoFetchEnabled enables or disables automatic fetching of JWKs from the issuer's well-known endpoint.
+// JWKSAutoFetchEnabled enables or disables automatic fetching of JWKS either
+// from JWKS URI present in the issuer's well-known endpoint  or value set in
+// JWTAuthIssuersConfig for JWKS URI corresponding to the issuer from presented
+// JWT token for JWT login over SQL interface.
 var JWKSAutoFetchEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	JWKSAutoFetchEnabledSettingName,
-	"enables or disables automatic fetching of JWKs from the issuer's well-known endpoint. "+
-		"If this is enabled, the server.jwt_authentication.jwks will be ignored.",
+	"enables or disables automatic fetching of JWKS from the issuer's well-known "+
+		"endpoint or JWKS URI set in JWTAuthIssuersConfig. If this is enabled, the "+
+		"server.jwt_authentication.jwks will be ignored.",
 	false,
 	settings.WithReportable(true),
 )
@@ -112,20 +142,90 @@ var JWTAuthClientTimeout = settings.RegisterDurationSetting(
 	settings.WithPublic,
 )
 
-func validateJWTAuthIssuers(values *settings.Values, s string) error {
+// getJSONDecoder generates a new decoder from provided json string. This is
+// necessary as currently the offset for decoder can't be reset after Decode().
+func getJSONDecoder(s string) *json.Decoder {
+	decoder := json.NewDecoder(bytes.NewReader([]byte(s)))
+	decoder.DisallowUnknownFields()
+	return decoder
+}
+
+type issuerURLConf struct {
+	ijMap   *issuerJWKSMap
+	issuers []string
+}
+
+func (conf *issuerURLConf) checkIssuerConfigured(issuer string) error {
+	if !slices.Contains(conf.issuers, issuer) {
+		return errors.Newf("JWT authentication: invalid issuer")
+	}
+	return nil
+}
+
+func (conf *issuerURLConf) checkJWKSConfigured() error {
+	if conf.ijMap == nil || len(conf.ijMap.Mappings) == 0 {
+		return errors.Newf("JWT authentication: no jwks mappings configured")
+	}
+	return nil
+}
+
+func (conf *issuerURLConf) getJWKSURI(issuer string) (jwksURI string, err error) {
+	var ok bool
+	if jwksURI, ok = conf.ijMap.Mappings[issuer]; !ok {
+		return "", errors.Newf("JWT authentication: no jwks uri set for issuer")
+	}
+	return jwksURI, nil
+}
+
+// issuerJWKSMap is a struct that defines a valid JSON body for the
+// OIDCRedirectURL cluster setting in multi-region environments.
+type issuerJWKSMap struct {
+	Mappings map[string]string `json:"issuer_jwks_map"`
+}
+
+// mustParseJWTIssuersConf will read in a string that's from the
+// JWTAuthIssuersConfig setting. We know from the validation that runs on that
+// setting that any value that's not valid JSON that deserializes into the
+// issuerJWKSMap struct will be either a list of issuer URLs or a single issuer
+// URL which will populate and return issuerURLConf.
+func mustParseJWTIssuersConf(s string) issuerURLConf {
+	var ijMap = issuerJWKSMap{}
 	var issuers []string
+	decoder := getJSONDecoder(s)
+	err := decoder.Decode(&ijMap)
+	if err == nil {
+		issuers = append(issuers, maps.Keys(ijMap.Mappings)...)
+		return issuerURLConf{ijMap: &ijMap, issuers: issuers}
+	}
+
+	decoder = getJSONDecoder(s)
+	err = decoder.Decode(&issuers)
+	if err == nil {
+		return issuerURLConf{issuers: issuers}
+	}
+	return issuerURLConf{issuers: []string{s}}
+}
+
+func validateJWTAuthIssuersConf(values *settings.Values, s string) error {
+	var issuers []string
+	var ijMap = issuerJWKSMap{}
 
 	var jsonCheck json.RawMessage
 	if json.Unmarshal([]byte(s), &jsonCheck) != nil {
 		// If we know the string is *not* valid JSON, fall back to assuming basic
-		// string to use a single valid issuer
+		// string to use a single valid issuer.
 		return nil
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader([]byte(s)))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&issuers); err != nil {
-		return errors.Wrap(err, "JWT authentication issuers JSON not valid")
+	decoder := getJSONDecoder(s)
+	issuerListErr := decoder.Decode(&issuers)
+	decoder = getJSONDecoder(s)
+	issuerJWKSMapErr := decoder.Decode(&ijMap)
+	if issuerListErr != nil && issuerJWKSMapErr != nil {
+		return errors.Wrap(
+			errors.Join(issuerListErr, issuerJWKSMapErr),
+			"JWT authentication: issuers JSON not valid",
+		)
 	}
 	return nil
 }
@@ -161,7 +261,7 @@ func mustParseValueOrArray(rawString string) []string {
 	var jsonCheck json.RawMessage
 	if json.Unmarshal([]byte(rawString), &jsonCheck) != nil {
 		// If we know the string is *not* valid JSON, fall back to assuming basic
-		// string to use a single valid.
+		// string to use a single valid issuer.
 		return []string{rawString}
 	}
 

--- a/pkg/ccl/jwtauthccl/settings_test.go
+++ b/pkg/ccl/jwtauthccl/settings_test.go
@@ -18,41 +18,53 @@ import (
 func TestValidateAndParseJWTAuthIssuers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tests := []struct {
-		name            string
-		setting         string
-		wantErr         bool
-		expectedIssuers []string
+		name                  string
+		setting               string
+		wantErr               bool
+		expectedIssuers       []string
+		expectedIssuerJWKSMap map[string]string
 	}{
-		{"empty string",
-			"", false,
-			[]string{""}},
-		{"string constant",
-			"issuer1", false,
-			[]string{"issuer1"}},
-		{"odd string constant",
-			"issuer1{}`[]!@#%#^$&*", false,
-			[]string{"issuer1{}`[]!@#%#^$&*"}},
-		{"empty json",
-			"[]", false,
-			[]string{}},
-		{"single element json",
-			"[\"issuer 1\"]", false,
-			[]string{"issuer 1"}},
-		{"multiple element json",
-			"[\"issuer 1\", \"issuer 2\", \"issuer 3\", \"issuer 4\", \"issuer 5\"]", false,
-			[]string{"issuer 1", "issuer 2", "issuer 3", "issuer 4", "issuer 5"}},
-		{"json but invalid in this context",
-			"{\"redirect_urls\": {\"key\":\"http://example.com\"}}", true,
-			nil},
+		{name: "empty string",
+			expectedIssuers: []string{""}},
+		{name: "string constant",
+			setting:         "issuer1",
+			expectedIssuers: []string{"issuer1"}},
+		{name: "odd string constant",
+			setting:         "issuer1{}`[]!@#%#^$&*",
+			expectedIssuers: []string{"issuer1{}`[]!@#%#^$&*"}},
+		{name: "empty json",
+			setting:         "[]",
+			expectedIssuers: []string{}},
+		{name: "single element json",
+			setting:         "[\"issuer 1\"]",
+			expectedIssuers: []string{"issuer 1"}},
+		{name: "multiple element json",
+			setting:         "[\"issuer 1\", \"issuer 2\", \"issuer 3\", \"issuer 4\", \"issuer 5\"]",
+			expectedIssuers: []string{"issuer 1", "issuer 2", "issuer 3", "issuer 4", "issuer 5"}},
+		{name: "json but invalid in this context",
+			setting: "{\"redirect_urls\": {\"key\":\"http://example.com\"}}", wantErr: true},
+		{name: "json object valid in this context single mapping",
+			setting:               "{\"issuer_jwks_map\": {\"https://accounts.google.com\": \"https://www.googleapis.com/oauth2/v3/certs\"}}",
+			expectedIssuers:       []string{"https://accounts.google.com"},
+			expectedIssuerJWKSMap: map[string]string{"https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs"}},
+		{name: "json object valid in this context multiple mapping",
+			setting: "{\"issuer_jwks_map\": {\"https://accounts.google.com\": \"https://www.googleapis.com/oauth2/v3/certs\"" +
+				",\"example.com/adfs\": \"https://example.com/adfs/discovery/keys\"}}",
+			expectedIssuers: []string{"https://accounts.google.com", "example.com/adfs"},
+			expectedIssuerJWKSMap: map[string]string{"https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs",
+				"example.com/adfs": "https://example.com/adfs/discovery/keys"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateJWTAuthIssuers(nil, tt.setting); (err != nil) != tt.wantErr {
+			if err := validateJWTAuthIssuersConf(nil, tt.setting); (err != nil) != tt.wantErr {
 				t.Errorf("validateJWTAuthIssuers() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr {
-				parsedIssuers := mustParseValueOrArray(tt.setting)
-				require.Equal(t, parsedIssuers, tt.expectedIssuers)
+				parsedIssuersConf := mustParseJWTIssuersConf(tt.setting)
+				require.ElementsMatch(t, parsedIssuersConf.issuers, tt.expectedIssuers)
+				if parsedIssuersConf.ijMap != nil {
+					require.Equal(t, parsedIssuersConf.ijMap.Mappings, tt.expectedIssuerJWKSMap)
+				}
 			}
 		})
 	}

--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -532,7 +532,7 @@ func TestOIDCProviderInitialization(t *testing.T) {
 				Issuer      string   `json:"issuer"`
 				AuthURL     string   `json:"authorization_endpoint"`
 				TokenURL    string   `json:"token_endpoint"`
-				JWKSURL     string   `json:"jwks_uri"`
+				JWKSURI     string   `json:"jwks_uri"`
 				UserInfoURL string   `json:"userinfo_endpoint"`
 				Algorithms  []string `json:"id_token_signing_alg_values_supported"`
 			}

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -220,7 +220,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting issuers: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthIssuers.Override(context.Background(), sv, a.Vals[0])
+							jwtauthccl.JWTAuthIssuersConfig.Override(context.Background(), sv, a.Vals[0])
 						case "jwks":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting jwks: %d", len(a.Vals))


### PR DESCRIPTION
For provisioning JWKS auto fetch feature we currently depend on issuer's well-known endpoint. This conflicts for some JWT issuers who either don't have a well-known endpoint or path of the well-known endpoint is non-standard. In such cases, operators require to manually set the JWKS URI mapping for each JWT issuer they are intending to allow JWT login. This is facilitated by this PR by allowing `server.jwt_authentication.issuers.configuration` to now take in json object mapping of issuer URL to JWKS URI.

informs https://github.com/cockroachlabs/support/issues/2956 
fixes https://github.com/cockroachdb/cockroach/issues/124976 
Epic CRDB-39178

Release note(security, ops): The cluster setting
`server.jwt_authentication.issuers` is now changed to client facing name `server.jwt_authentication.issuers.configuration` to be reflective of the value the setting can take. This can be set to one of the following values:
1. Simple string that Go can parse as a valid issuer URL.
2. String that can be parsed as valid JSON array of issuer URLs list.
3. String that can be parsed as valid JSON and deserialized into a map of issuer URLs to corresponding JWKS URIs.
In the third case we will be overriding the JWKS URI present in the issuer's well-known endpoint.

Example valid values:
- 'https://accounts.google.com'
- ['example.com/adfs','https://accounts.google.com']
- '{ "issuer_jwks_map": { "https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs", "example.com/adfs": "https://example.com/adfs/discovery/keys" } }' 

When `issuer_jwks_map` is set, we directly use the JWKS URI to get the key set. In all other cases where JWKSAutoFetchEnabled is set we obtain the JWKS URI first from issuer's well-known endpoint and then use this endpoint.