### PR TITLE
release-23.2: sql/sem/tree, backupccl, *: sanitize URLs during Format

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -228,15 +228,15 @@ func emitAlteredSchedule(
 ) error {
 	to := make([]string, len(stmt.To))
 	for i, dest := range stmt.To {
-		to[i] = tree.AsStringWithFlags(dest, tree.FmtBareStrings)
+		to[i] = tree.AsStringWithFlags(dest, tree.FmtBareStrings|tree.FmtShowFullURIs)
 	}
 	kmsURIs := make([]string, len(stmt.Options.EncryptionKMSURI))
 	for i, kmsURI := range stmt.Options.EncryptionKMSURI {
-		kmsURIs[i] = tree.AsStringWithFlags(kmsURI, tree.FmtBareStrings)
+		kmsURIs[i] = tree.AsStringWithFlags(kmsURI, tree.FmtBareStrings|tree.FmtShowFullURIs)
 	}
 	incDests := make([]string, len(stmt.Options.IncrementalStorage))
 	for i, incDest := range stmt.Options.IncrementalStorage {
-		incDests[i] = tree.AsStringWithFlags(incDest, tree.FmtBareStrings)
+		incDests[i] = tree.AsStringWithFlags(incDest, tree.FmtBareStrings|tree.FmtShowFullURIs)
 	}
 	if err := emitSchedule(job, stmt, to, nil, /* incrementalFrom */
 		kmsURIs, incDests, resultsCh); err != nil {

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -301,7 +301,9 @@ func backupJobDescription(
 	}
 
 	ann := p.ExtendedEvalContext().Annotations
-	return tree.AsStringWithFQNames(b, ann), nil
+	return tree.AsStringWithFlags(
+		b, tree.FmtAlwaysQualifyTableNames|tree.FmtShowFullURIs, tree.FmtAnnotations(ann),
+	), nil
 }
 
 // annotatedBackupStatement is a tree.Backup, optionally

--- a/pkg/ccl/backupccl/backuppb/backup.go
+++ b/pkg/ccl/backupccl/backuppb/backup.go
@@ -161,7 +161,7 @@ func (m ScheduledBackupExecutionArgs) MarshalJSONPB(marshaller *jsonpb.Marshaler
 		backup.Options.EncryptionPassphrase = tree.NewDString("redacted")
 	}
 
-	m.BackupStatement = backup.String()
+	m.BackupStatement = tree.AsStringWithFlags(backup, tree.FmtShowFullURIs)
 	return json.Marshal(m)
 }
 

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -556,7 +556,7 @@ func emitSchedule(
 		tree.NewDString(status),
 		nextRun,
 		tree.NewDString(sj.ScheduleExpr()),
-		tree.NewDString(tree.AsString(redactedBackupNode)),
+		tree.NewDString(tree.AsStringWithFlags(redactedBackupNode, tree.FmtShowFullURIs)),
 	}
 	return nil
 }

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1163,7 +1163,9 @@ func restoreJobDescription(
 	}
 
 	ann := p.ExtendedEvalContext().Annotations
-	return tree.AsStringWithFQNames(r, ann), nil
+	return tree.AsStringWithFlags(
+		r, tree.FmtAlwaysQualifyTableNames|tree.FmtShowFullURIs, tree.FmtAnnotations(ann),
+	), nil
 }
 
 func restoreTypeCheck(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1021,7 +1021,7 @@ func changefeedJobDescription(
 		return "", err
 	}
 	sort.Slice(c.Options, func(i, j int) bool { return c.Options[i].Key < c.Options[j].Key })
-	return tree.AsString(c), nil
+	return tree.AsStringWithFlags(c, tree.FmtShowFullURIs), nil
 }
 
 func logSanitizedChangefeedDestination(ctx context.Context, destination string) {

--- a/pkg/ccl/changefeedccl/changefeedpb/marshal.go
+++ b/pkg/ccl/changefeedccl/changefeedpb/marshal.go
@@ -40,6 +40,6 @@ func (m ScheduledChangefeedExecutionArgs) MarshalJSONPB(x *jsonpb.Marshaler) ([]
 	}
 	export.SinkURI = tree.NewDString(sinkURI)
 
-	m.ChangefeedStatement = export.String()
+	m.ChangefeedStatement = tree.AsStringWithFlags(export, tree.FmtShowFullURIs)
 	return json.Marshal(m)
 }

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -303,7 +303,7 @@ func (e *externalConnectionFeedFactory) Feed(
 	}
 	createStmt.SinkURI = tree.NewStrVal(`external://` + randomExternalConnectionName)
 
-	return e.TestFeedFactory.Feed(createStmt.String(), args...)
+	return e.TestFeedFactory.Feed(tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...)
 }
 
 func setURI(
@@ -886,7 +886,7 @@ func (f *tableFeedFactory) Feed(
 		return nil, err
 	}
 
-	if err := f.startFeedJob(c.jobFeed, createStmt.String(), args...); err != nil {
+	if err := f.startFeedJob(c.jobFeed, tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -1129,7 +1129,7 @@ func (f *cloudFeedFactory) Feed(
 		dir:            feedDir,
 		isBare:         createStmt.Select != nil && !explicitEnvelope,
 	}
-	if err := f.startFeedJob(c.jobFeed, createStmt.String(), args...); err != nil {
+	if err := f.startFeedJob(c.jobFeed, tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -1827,7 +1827,7 @@ func (k *kafkaFeedFactory) Feed(create string, args ...interface{}) (cdctest.Tes
 		registry:       registry,
 	}
 
-	if err := k.startFeedJob(c.jobFeed, createStmt.String(), args...); err != nil {
+	if err := k.startFeedJob(c.jobFeed, tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...); err != nil {
 		return nil, errors.CombineErrors(err, c.Close())
 	}
 	return c, nil
@@ -2057,7 +2057,7 @@ func (f *webhookFeedFactory) Feed(create string, args ...interface{}) (cdctest.T
 		isBare:         createStmt.Select != nil && !explicitEnvelope,
 		mockSink:       sinkDest,
 	}
-	if err := f.startFeedJob(c.jobFeed, createStmt.String(), args...); err != nil {
+	if err := f.startFeedJob(c.jobFeed, tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...); err != nil {
 		sinkDest.Close()
 		return nil, err
 	}
@@ -2451,7 +2451,7 @@ func (p *pubsubFeedFactory) Feed(create string, args ...interface{}) (cdctest.Te
 		deprecatedClient: deprecatedClient,
 	}
 
-	if err := p.startFeedJob(c.jobFeed, createStmt.String(), args...); err != nil {
+	if err := p.startFeedJob(c.jobFeed, tree.AsStringWithFlags(createStmt, tree.FmtShowPasswords), args...); err != nil {
 		_ = mockServer.Close()
 		return nil, err
 	}

--- a/pkg/ccl/telemetryccl/BUILD.bazel
+++ b/pkg/ccl/telemetryccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sqltestutils",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -246,7 +247,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 			query: fmt.Sprintf(`BACKUP DATABASE mydb INTO '%s'`, nodelocal.MakeLocalStorageURI("test1")),
 			sampleQueryEvent: expectedSampleQueryEvent{
 				eventType: "backup",
-				stmt:      fmt.Sprintf(`BACKUP DATABASE mydb INTO '%s'`, nodelocal.MakeLocalStorageURI("test1")),
+				stmt:      fmt.Sprintf(`BACKUP DATABASE mydb INTO %s`, tree.PasswordSubstitution),
 			},
 			recoveryEvent: expectedRecoveryEvent{
 				numRows:      3,
@@ -258,7 +259,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 			query: fmt.Sprintf(`BACKUP DATABASE mydb INTO '%s' WITH detached`, nodelocal.MakeLocalStorageURI("test1")),
 			sampleQueryEvent: expectedSampleQueryEvent{
 				eventType: "backup",
-				stmt:      fmt.Sprintf(`BACKUP DATABASE mydb INTO '%s' WITH OPTIONS (detached)`, nodelocal.MakeLocalStorageURI("test1")),
+				stmt:      fmt.Sprintf(`BACKUP DATABASE mydb INTO %s WITH OPTIONS (detached)`, tree.PasswordSubstitution),
 			},
 			recoveryEvent: expectedRecoveryEvent{
 				numRows:      3,
@@ -270,7 +271,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 			query: fmt.Sprintf(`RESTORE DATABASE mydb FROM LATEST IN '%s'`, nodelocal.MakeLocalStorageURI("test1")),
 			sampleQueryEvent: expectedSampleQueryEvent{
 				eventType: "restore",
-				stmt:      fmt.Sprintf(`RESTORE DATABASE mydb FROM 'latest' IN '%s'`, nodelocal.MakeLocalStorageURI("test1")),
+				stmt:      fmt.Sprintf(`RESTORE DATABASE mydb FROM 'latest' IN %s`, tree.PasswordSubstitution),
 			},
 			recoveryEvent: expectedRecoveryEvent{
 				numRows:      3,
@@ -282,7 +283,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 			query: fmt.Sprintf(`RESTORE DATABASE mydb FROM LATEST IN '%s' WITH detached`, nodelocal.MakeLocalStorageURI("test1")),
 			sampleQueryEvent: expectedSampleQueryEvent{
 				eventType: "restore",
-				stmt:      fmt.Sprintf(`RESTORE DATABASE mydb FROM 'latest' IN '%s' WITH OPTIONS (detached)`, nodelocal.MakeLocalStorageURI("test1")),
+				stmt:      fmt.Sprintf(`RESTORE DATABASE mydb FROM 'latest' IN %s WITH OPTIONS (detached)`, tree.PasswordSubstitution),
 			},
 			recoveryEvent: expectedRecoveryEvent{
 				numRows:      3,

--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -223,7 +223,9 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 			query: fmt.Sprintf(`IMPORT INTO a CSV DATA ('%s')`, srv.URL),
 			sampleQueryEvent: expectedSampleQueryEvent{
 				eventType: "import",
-				stmt:      fmt.Sprintf(`IMPORT INTO defaultdb.public.a CSV DATA ('%s')`, srv.URL),
+				stmt: fmt.Sprintf(
+					`IMPORT INTO defaultdb.public.a CSV DATA (%s)`, tree.PasswordSubstitution,
+				),
 			},
 			recoveryEvent: expectedRecoveryEvent{
 				numRows:      3,
@@ -235,7 +237,10 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 			query: fmt.Sprintf(`IMPORT INTO a CSV DATA ('%s') WITH detached`, srv.URL),
 			sampleQueryEvent: expectedSampleQueryEvent{
 				eventType: "import",
-				stmt:      fmt.Sprintf(`IMPORT INTO defaultdb.public.a CSV DATA ('%s') WITH OPTIONS (detached)`, srv.URL),
+				stmt: fmt.Sprintf(
+					`IMPORT INTO defaultdb.public.a CSV DATA (%s) WITH OPTIONS (detached)`,
+					tree.PasswordSubstitution,
+				),
 			},
 			recoveryEvent: expectedRecoveryEvent{
 				numRows:      3,

--- a/pkg/cloud/externalconn/record.go
+++ b/pkg/cloud/externalconn/record.go
@@ -177,7 +177,7 @@ func (e *MutableExternalConnection) UnredactedConnectionStatement() string {
 		},
 		As: tree.NewDString(e.rec.ConnectionDetails.UnredactedURI()),
 	}
-	return tree.AsString(ecNode)
+	return tree.AsStringWithFlags(ecNode, tree.FmtShowFullURIs)
 }
 
 // datumToNative is a helper to convert tree.Datum into Go native types.  We

--- a/pkg/sql/importer/import_csv_mark_redaction_test.go
+++ b/pkg/sql/importer/import_csv_mark_redaction_test.go
@@ -31,7 +31,7 @@ func TestMarkRedactionCCLStatement(t *testing.T) {
 	}{
 		{
 			"IMPORT CSV 'file' WITH delimiter = 'foo'",
-			"IMPORT CSV ‹'file'› WITH OPTIONS (delimiter = ‹'foo'›)",
+			"IMPORT CSV ‹'*****'› WITH OPTIONS (delimiter = ‹'foo'›)",
 		},
 	}
 

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -254,7 +254,9 @@ func importJobDescription(
 	}
 	sort.Slice(stmt.Options, func(i, j int) bool { return stmt.Options[i].Key < stmt.Options[j].Key })
 	ann := p.ExtendedEvalContext().Annotations
-	return tree.AsStringWithFQNames(&stmt, ann), nil
+	return tree.AsStringWithFlags(
+		&stmt, tree.FmtAlwaysQualifyTableNames|tree.FmtShowFullURIs, tree.FmtAnnotations(ann),
+	), nil
 }
 
 func logSanitizedImportDestination(ctx context.Context, destination string) {

--- a/pkg/sql/parser/testdata/alter_backup
+++ b/pkg/sql/parser/testdata/alter_backup
@@ -1,63 +1,71 @@
 parse
 ALTER BACKUP 'foo' ADD NEW_KMS = 'a' WITH OLD_KMS = 'b'
 ----
-ALTER BACKUP 'foo' ADD NEW_KMS='a' WITH OLD_KMS='b' -- normalized!
-ALTER BACKUP ('foo') ADD NEW_KMS=('a') WITH OLD_KMS=('b') -- fully parenthesized
+ALTER BACKUP '*****' ADD NEW_KMS='*****' WITH OLD_KMS='*****' -- normalized!
+ALTER BACKUP ('*****') ADD NEW_KMS=('*****') WITH OLD_KMS=('*****') -- fully parenthesized
 ALTER BACKUP '_' ADD NEW_KMS='_' WITH OLD_KMS='_' -- literals removed
-ALTER BACKUP 'foo' ADD NEW_KMS='a' WITH OLD_KMS='b' -- identifiers removed
+ALTER BACKUP '*****' ADD NEW_KMS='*****' WITH OLD_KMS='*****' -- identifiers removed
+ALTER BACKUP 'foo' ADD NEW_KMS='a' WITH OLD_KMS='b' -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' ADD NEW_KMS = ('a', 'b') WITH OLD_KMS = ('c', 'd')
 ----
-ALTER BACKUP 'foo' ADD NEW_KMS=('a', 'b') WITH OLD_KMS=('c', 'd') -- normalized!
-ALTER BACKUP ('foo') ADD NEW_KMS=(('a'), ('b')) WITH OLD_KMS=(('c'), ('d')) -- fully parenthesized
+ALTER BACKUP '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS=('*****', '*****') -- normalized!
+ALTER BACKUP ('*****') ADD NEW_KMS=(('*****'), ('*****')) WITH OLD_KMS=(('*****'), ('*****')) -- fully parenthesized
 ALTER BACKUP '_' ADD NEW_KMS=('_', '_') WITH OLD_KMS=('_', '_') -- literals removed
-ALTER BACKUP 'foo' ADD NEW_KMS=('a', 'b') WITH OLD_KMS=('c', 'd') -- identifiers removed
+ALTER BACKUP '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS=('*****', '*****') -- identifiers removed
+ALTER BACKUP 'foo' ADD NEW_KMS=('a', 'b') WITH OLD_KMS=('c', 'd') -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' ADD NEW_KMS = ('a', 'b') WITH OLD_KMS = 'c'
 ----
-ALTER BACKUP 'foo' ADD NEW_KMS=('a', 'b') WITH OLD_KMS='c' -- normalized!
-ALTER BACKUP ('foo') ADD NEW_KMS=(('a'), ('b')) WITH OLD_KMS=('c') -- fully parenthesized
+ALTER BACKUP '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS='*****' -- normalized!
+ALTER BACKUP ('*****') ADD NEW_KMS=(('*****'), ('*****')) WITH OLD_KMS=('*****') -- fully parenthesized
 ALTER BACKUP '_' ADD NEW_KMS=('_', '_') WITH OLD_KMS='_' -- literals removed
-ALTER BACKUP 'foo' ADD NEW_KMS=('a', 'b') WITH OLD_KMS='c' -- identifiers removed
+ALTER BACKUP '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS='*****' -- identifiers removed
+ALTER BACKUP 'foo' ADD NEW_KMS=('a', 'b') WITH OLD_KMS='c' -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' ADD NEW_KMS = 'a' WITH OLD_KMS = ('b', 'c')
 ----
-ALTER BACKUP 'foo' ADD NEW_KMS='a' WITH OLD_KMS=('b', 'c') -- normalized!
-ALTER BACKUP ('foo') ADD NEW_KMS=('a') WITH OLD_KMS=(('b'), ('c')) -- fully parenthesized
+ALTER BACKUP '*****' ADD NEW_KMS='*****' WITH OLD_KMS=('*****', '*****') -- normalized!
+ALTER BACKUP ('*****') ADD NEW_KMS=('*****') WITH OLD_KMS=(('*****'), ('*****')) -- fully parenthesized
 ALTER BACKUP '_' ADD NEW_KMS='_' WITH OLD_KMS=('_', '_') -- literals removed
-ALTER BACKUP 'foo' ADD NEW_KMS='a' WITH OLD_KMS=('b', 'c') -- identifiers removed
+ALTER BACKUP '*****' ADD NEW_KMS='*****' WITH OLD_KMS=('*****', '*****') -- identifiers removed
+ALTER BACKUP 'foo' ADD NEW_KMS='a' WITH OLD_KMS=('b', 'c') -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' in 'bar' ADD NEW_KMS = 'a' WITH OLD_KMS = 'b'
 ----
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS='a' WITH OLD_KMS='b' -- normalized!
-ALTER BACKUP ('foo') IN ('bar') ADD NEW_KMS=('a') WITH OLD_KMS=('b') -- fully parenthesized
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS='*****' WITH OLD_KMS='*****' -- normalized!
+ALTER BACKUP ('foo') IN ('*****') ADD NEW_KMS=('*****') WITH OLD_KMS=('*****') -- fully parenthesized
 ALTER BACKUP '_' IN '_' ADD NEW_KMS='_' WITH OLD_KMS='_' -- literals removed
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS='a' WITH OLD_KMS='b' -- identifiers removed
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS='*****' WITH OLD_KMS='*****' -- identifiers removed
+ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS='a' WITH OLD_KMS='b' -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' in 'bar' ADD NEW_KMS = ('a', 'b') WITH OLD_KMS = ('c', 'd')
 ----
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS=('a', 'b') WITH OLD_KMS=('c', 'd') -- normalized!
-ALTER BACKUP ('foo') IN ('bar') ADD NEW_KMS=(('a'), ('b')) WITH OLD_KMS=(('c'), ('d')) -- fully parenthesized
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS=('*****', '*****') -- normalized!
+ALTER BACKUP ('foo') IN ('*****') ADD NEW_KMS=(('*****'), ('*****')) WITH OLD_KMS=(('*****'), ('*****')) -- fully parenthesized
 ALTER BACKUP '_' IN '_' ADD NEW_KMS=('_', '_') WITH OLD_KMS=('_', '_') -- literals removed
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS=('a', 'b') WITH OLD_KMS=('c', 'd') -- identifiers removed
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS=('*****', '*****') -- identifiers removed
+ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS=('a', 'b') WITH OLD_KMS=('c', 'd') -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' in 'bar' ADD NEW_KMS = ('a', 'b') WITH OLD_KMS = 'c'
 ----
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS=('a', 'b') WITH OLD_KMS='c' -- normalized!
-ALTER BACKUP ('foo') IN ('bar') ADD NEW_KMS=(('a'), ('b')) WITH OLD_KMS=('c') -- fully parenthesized
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS='*****' -- normalized!
+ALTER BACKUP ('foo') IN ('*****') ADD NEW_KMS=(('*****'), ('*****')) WITH OLD_KMS=('*****') -- fully parenthesized
 ALTER BACKUP '_' IN '_' ADD NEW_KMS=('_', '_') WITH OLD_KMS='_' -- literals removed
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS=('a', 'b') WITH OLD_KMS='c' -- identifiers removed
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS=('*****', '*****') WITH OLD_KMS='*****' -- identifiers removed
+ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS=('a', 'b') WITH OLD_KMS='c' -- passwords exposed
 
 parse
 ALTER BACKUP 'foo' in 'bar' ADD NEW_KMS = 'a' WITH OLD_KMS = ('b', 'c')
 ----
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS='a' WITH OLD_KMS=('b', 'c') -- normalized!
-ALTER BACKUP ('foo') IN ('bar') ADD NEW_KMS=('a') WITH OLD_KMS=(('b'), ('c')) -- fully parenthesized
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS='*****' WITH OLD_KMS=('*****', '*****') -- normalized!
+ALTER BACKUP ('foo') IN ('*****') ADD NEW_KMS=('*****') WITH OLD_KMS=(('*****'), ('*****')) -- fully parenthesized
 ALTER BACKUP '_' IN '_' ADD NEW_KMS='_' WITH OLD_KMS=('_', '_') -- literals removed
-ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS='a' WITH OLD_KMS=('b', 'c') -- identifiers removed
+ALTER BACKUP 'foo' IN '*****' ADD NEW_KMS='*****' WITH OLD_KMS=('*****', '*****') -- identifiers removed
+ALTER BACKUP 'foo' IN 'bar' ADD NEW_KMS='a' WITH OLD_KMS=('b', 'c') -- passwords exposed

--- a/pkg/sql/parser/testdata/alter_changefeed
+++ b/pkg/sql/parser/testdata/alter_changefeed
@@ -99,6 +99,15 @@ ALTER CHANGEFEED _ ADD TABLE foo  SET bar = '_', qux = '_'  DROP TABLE corge -- 
 ALTER CHANGEFEED 123 ADD TABLE _  SET _ = 'baz', _ = 'quux'  DROP TABLE _ -- identifiers removed
 
 parse
+ALTER CHANGEFEED 123 SET sink = 'bar'
+----
+ALTER CHANGEFEED 123 SET sink = '*****' -- normalized!
+ALTER CHANGEFEED (123) SET sink = ('*****') -- fully parenthesized
+ALTER CHANGEFEED _ SET sink = '_' -- literals removed
+ALTER CHANGEFEED 123 SET _ = '*****' -- identifiers removed
+ALTER CHANGEFEED 123 SET sink = 'bar' -- passwords exposed
+
+parse
 ALTER CHANGEFEED 123 UNSET foo
 ----
 ALTER CHANGEFEED 123 UNSET foo

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -1,66 +1,74 @@
 parse
 BACKUP TABLE foo TO 'bar'
 ----
-BACKUP TABLE foo TO 'bar'
-BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo TO '*****' -- normalized!
+BACKUP TABLE (foo) TO ('*****') -- fully parenthesized
 BACKUP TABLE foo TO '_' -- literals removed
-BACKUP TABLE _ TO 'bar' -- identifiers removed
+BACKUP TABLE _ TO '*****' -- identifiers removed
+BACKUP TABLE foo TO 'bar' -- passwords exposed
 
 parse
 BACKUP foo TO 'bar'
 ----
-BACKUP TABLE foo TO 'bar' -- normalized!
-BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo TO '*****' -- normalized!
+BACKUP TABLE (foo) TO ('*****') -- fully parenthesized
 BACKUP TABLE foo TO '_' -- literals removed
-BACKUP TABLE _ TO 'bar' -- identifiers removed
+BACKUP TABLE _ TO '*****' -- identifiers removed
+BACKUP TABLE foo TO 'bar' -- passwords exposed
 
 parse
 BACKUP TO 'bar'
 ----
-BACKUP TO 'bar'
-BACKUP TO ('bar') -- fully parenthesized
+BACKUP TO '*****' -- normalized!
+BACKUP TO ('*****') -- fully parenthesized
 BACKUP TO '_' -- literals removed
-BACKUP TO 'bar' -- identifiers removed
+BACKUP TO '*****' -- identifiers removed
+BACKUP TO 'bar' -- passwords exposed
 
 parse
 BACKUP role TO 'bar'
 ----
-BACKUP TABLE "role" TO 'bar' -- normalized!
-BACKUP TABLE ("role") TO ('bar') -- fully parenthesized
+BACKUP TABLE "role" TO '*****' -- normalized!
+BACKUP TABLE ("role") TO ('*****') -- fully parenthesized
 BACKUP TABLE "role" TO '_' -- literals removed
-BACKUP TABLE _ TO 'bar' -- identifiers removed
+BACKUP TABLE _ TO '*****' -- identifiers removed
+BACKUP TABLE "role" TO 'bar' -- passwords exposed
 
 parse
 BACKUP TABLE foo INTO 'bar'
 ----
-BACKUP TABLE foo INTO 'bar'
-BACKUP TABLE (foo) INTO ('bar') -- fully parenthesized
+BACKUP TABLE foo INTO '*****' -- normalized!
+BACKUP TABLE (foo) INTO ('*****') -- fully parenthesized
 BACKUP TABLE foo INTO '_' -- literals removed
-BACKUP TABLE _ INTO 'bar' -- identifiers removed
+BACKUP TABLE _ INTO '*****' -- identifiers removed
+BACKUP TABLE foo INTO 'bar' -- passwords exposed
 
 parse
 BACKUP TABLE foo INTO LATEST IN 'bar'
 ----
-BACKUP TABLE foo INTO LATEST IN 'bar'
-BACKUP TABLE (foo) INTO LATEST IN ('bar') -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '*****' -- normalized!
+BACKUP TABLE (foo) INTO LATEST IN ('*****') -- fully parenthesized
 BACKUP TABLE foo INTO LATEST IN '_' -- literals removed
-BACKUP TABLE _ INTO LATEST IN 'bar' -- identifiers removed
+BACKUP TABLE _ INTO LATEST IN '*****' -- identifiers removed
+BACKUP TABLE foo INTO LATEST IN 'bar' -- passwords exposed
 
 parse
 BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_location = 'baz'
 ----
-BACKUP TABLE foo INTO LATEST IN 'bar' WITH OPTIONS (incremental_location = 'baz') -- normalized!
-BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH OPTIONS (incremental_location = ('baz')) -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '*****' WITH OPTIONS (incremental_location = '*****') -- normalized!
+BACKUP TABLE (foo) INTO LATEST IN ('*****') WITH OPTIONS (incremental_location = ('*****')) -- fully parenthesized
 BACKUP TABLE foo INTO LATEST IN '_' WITH OPTIONS (incremental_location = '_') -- literals removed
-BACKUP TABLE _ INTO LATEST IN 'bar' WITH OPTIONS (incremental_location = 'baz') -- identifiers removed
+BACKUP TABLE _ INTO LATEST IN '*****' WITH OPTIONS (incremental_location = '*****') -- identifiers removed
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH OPTIONS (incremental_location = 'baz') -- passwords exposed
 
 parse
 BACKUP TABLE foo INTO 'subdir' IN 'bar'
 ----
-BACKUP TABLE foo INTO 'subdir' IN 'bar'
-BACKUP TABLE (foo) INTO ('subdir') IN ('bar') -- fully parenthesized
+BACKUP TABLE foo INTO 'subdir' IN '*****' -- normalized!
+BACKUP TABLE (foo) INTO ('subdir') IN ('*****') -- fully parenthesized
 BACKUP TABLE foo INTO '_' IN '_' -- literals removed
-BACKUP TABLE _ INTO 'subdir' IN 'bar' -- identifiers removed
+BACKUP TABLE _ INTO 'subdir' IN '*****' -- identifiers removed
+BACKUP TABLE foo INTO 'subdir' IN 'bar' -- passwords exposed
 
 parse
 BACKUP TABLE foo INTO $1 IN $2
@@ -73,34 +81,38 @@ BACKUP TABLE _ INTO $1 IN $2 -- identifiers removed
 parse
 BACKUP TABLE foo INTO LATEST IN 'bar' WITH updates_cluster_monitoring_metrics
 ----
-BACKUP TABLE foo INTO LATEST IN 'bar' WITH OPTIONS (updates_cluster_monitoring_metrics = true) -- normalized!
-BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH OPTIONS (updates_cluster_monitoring_metrics = (true)) -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '*****' WITH OPTIONS (updates_cluster_monitoring_metrics = true) -- normalized!
+BACKUP TABLE (foo) INTO LATEST IN ('*****') WITH OPTIONS (updates_cluster_monitoring_metrics = (true)) -- fully parenthesized
 BACKUP TABLE foo INTO LATEST IN '_' WITH OPTIONS (updates_cluster_monitoring_metrics = _) -- literals removed
-BACKUP TABLE _ INTO LATEST IN 'bar' WITH OPTIONS (updates_cluster_monitoring_metrics = true) -- identifiers removed
+BACKUP TABLE _ INTO LATEST IN '*****' WITH OPTIONS (updates_cluster_monitoring_metrics = true) -- identifiers removed
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH OPTIONS (updates_cluster_monitoring_metrics = true) -- passwords exposed
 
 parse
 EXPLAIN BACKUP TABLE foo TO 'bar'
 ----
-EXPLAIN BACKUP TABLE foo TO 'bar'
-EXPLAIN BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+EXPLAIN BACKUP TABLE foo TO '*****' -- normalized!
+EXPLAIN BACKUP TABLE (foo) TO ('*****') -- fully parenthesized
 EXPLAIN BACKUP TABLE foo TO '_' -- literals removed
-EXPLAIN BACKUP TABLE _ TO 'bar' -- identifiers removed
+EXPLAIN BACKUP TABLE _ TO '*****' -- identifiers removed
+EXPLAIN BACKUP TABLE foo TO 'bar' -- passwords exposed
 
 parse
 BACKUP TABLE foo.foo, baz.baz TO 'bar'
 ----
-BACKUP TABLE foo.foo, baz.baz TO 'bar'
-BACKUP TABLE (foo.foo), (baz.baz) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo.foo, baz.baz TO '*****' -- normalized!
+BACKUP TABLE (foo.foo), (baz.baz) TO ('*****') -- fully parenthesized
 BACKUP TABLE foo.foo, baz.baz TO '_' -- literals removed
-BACKUP TABLE _._, _._ TO 'bar' -- identifiers removed
+BACKUP TABLE _._, _._ TO '*****' -- identifiers removed
+BACKUP TABLE foo.foo, baz.baz TO 'bar' -- passwords exposed
 
 parse
 BACKUP foo.foo, baz.baz TO 'bar'
 ----
-BACKUP TABLE foo.foo, baz.baz TO 'bar' -- normalized!
-BACKUP TABLE (foo.foo), (baz.baz) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo.foo, baz.baz TO '*****' -- normalized!
+BACKUP TABLE (foo.foo), (baz.baz) TO ('*****') -- fully parenthesized
 BACKUP TABLE foo.foo, baz.baz TO '_' -- literals removed
-BACKUP TABLE _._, _._ TO 'bar' -- identifiers removed
+BACKUP TABLE _._, _._ TO '*****' -- identifiers removed
+BACKUP TABLE foo.foo, baz.baz TO 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP 'bar'
@@ -252,42 +264,47 @@ SHOW BACKUP $1 IN $2 WITH OPTIONS (encryption_passphrase = 'secret', encryption_
 parse
 BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
 ----
-BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
-BACKUP TABLE (foo) TO ('bar') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP TABLE foo TO '*****' AS OF SYSTEM TIME '1' INCREMENTAL FROM '*****' -- normalized!
+BACKUP TABLE (foo) TO ('*****') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('*****') -- fully parenthesized
 BACKUP TABLE foo TO '_' AS OF SYSTEM TIME '_' INCREMENTAL FROM '_' -- literals removed
-BACKUP TABLE _ TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- identifiers removed
+BACKUP TABLE _ TO '*****' AS OF SYSTEM TIME '1' INCREMENTAL FROM '*****' -- identifiers removed
+BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- passwords exposed
 
 parse
 BACKUP foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
 ----
-BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- normalized!
-BACKUP TABLE (foo) TO ('bar') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP TABLE foo TO '*****' AS OF SYSTEM TIME '1' INCREMENTAL FROM '*****' -- normalized!
+BACKUP TABLE (foo) TO ('*****') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('*****') -- fully parenthesized
 BACKUP TABLE foo TO '_' AS OF SYSTEM TIME '_' INCREMENTAL FROM '_' -- literals removed
-BACKUP TABLE _ TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- identifiers removed
+BACKUP TABLE _ TO '*****' AS OF SYSTEM TIME '1' INCREMENTAL FROM '*****' -- identifiers removed
+BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- passwords exposed
 
 parse
 BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
 ----
-BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
-BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('bar'), ($2), ('baz') -- fully parenthesized
+BACKUP TABLE foo TO $1 INCREMENTAL FROM '*****', $2, '*****' -- normalized!
+BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('*****'), ($2), ('*****') -- fully parenthesized
 BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $1, '_' -- literals removed
-BACKUP TABLE _ TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- identifiers removed
+BACKUP TABLE _ TO $1 INCREMENTAL FROM '*****', $2, '*****' -- identifiers removed
+BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- passwords exposed
 
 parse
 BACKUP foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
 ----
-BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- normalized!
-BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('bar'), ($2), ('baz') -- fully parenthesized
+BACKUP TABLE foo TO $1 INCREMENTAL FROM '*****', $2, '*****' -- normalized!
+BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('*****'), ($2), ('*****') -- fully parenthesized
 BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $1, '_' -- literals removed
-BACKUP TABLE _ TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- identifiers removed
+BACKUP TABLE _ TO $1 INCREMENTAL FROM '*****', $2, '*****' -- identifiers removed
+BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- passwords exposed
 
 parse
 BACKUP DATABASE foo TO 'bar'
 ----
-BACKUP DATABASE foo TO 'bar'
-BACKUP DATABASE foo TO ('bar') -- fully parenthesized
+BACKUP DATABASE foo TO '*****' -- normalized!
+BACKUP DATABASE foo TO ('*****') -- fully parenthesized
 BACKUP DATABASE foo TO '_' -- literals removed
-BACKUP DATABASE _ TO 'bar' -- identifiers removed
+BACKUP DATABASE _ TO '*****' -- identifiers removed
+BACKUP DATABASE foo TO 'bar' -- passwords exposed
 
 parse
 BACKUP DATABASE foo TO ($1)
@@ -300,44 +317,49 @@ BACKUP DATABASE _ TO $1 -- identifiers removed
 parse
 EXPLAIN BACKUP DATABASE foo TO 'bar'
 ----
-EXPLAIN BACKUP DATABASE foo TO 'bar'
-EXPLAIN BACKUP DATABASE foo TO ('bar') -- fully parenthesized
+EXPLAIN BACKUP DATABASE foo TO '*****' -- normalized!
+EXPLAIN BACKUP DATABASE foo TO ('*****') -- fully parenthesized
 EXPLAIN BACKUP DATABASE foo TO '_' -- literals removed
-EXPLAIN BACKUP DATABASE _ TO 'bar' -- identifiers removed
+EXPLAIN BACKUP DATABASE _ TO '*****' -- identifiers removed
+EXPLAIN BACKUP DATABASE foo TO 'bar' -- passwords exposed
 
 parse
 BACKUP DATABASE foo TO bar
 ----
-BACKUP DATABASE foo TO 'bar' -- normalized!
-BACKUP DATABASE foo TO ('bar') -- fully parenthesized
+BACKUP DATABASE foo TO '*****' -- normalized!
+BACKUP DATABASE foo TO ('*****') -- fully parenthesized
 BACKUP DATABASE foo TO '_' -- literals removed
-BACKUP DATABASE _ TO 'bar' -- identifiers removed
+BACKUP DATABASE _ TO '*****' -- identifiers removed
+BACKUP DATABASE foo TO 'bar' -- passwords exposed
 
 
 parse
 BACKUP DATABASE foo, baz TO 'bar'
 ----
-BACKUP DATABASE foo, baz TO 'bar'
-BACKUP DATABASE foo, baz TO ('bar') -- fully parenthesized
+BACKUP DATABASE foo, baz TO '*****' -- normalized!
+BACKUP DATABASE foo, baz TO ('*****') -- fully parenthesized
 BACKUP DATABASE foo, baz TO '_' -- literals removed
-BACKUP DATABASE _, _ TO 'bar' -- identifiers removed
+BACKUP DATABASE _, _ TO '*****' -- identifiers removed
+BACKUP DATABASE foo, baz TO 'bar' -- passwords exposed
 
 parse
 BACKUP DATABASE foo TO "bar.12" INCREMENTAL FROM "baz.34"
 ----
-BACKUP DATABASE foo TO 'bar.12' INCREMENTAL FROM 'baz.34' -- normalized!
-BACKUP DATABASE foo TO ('bar.12') INCREMENTAL FROM ('baz.34') -- fully parenthesized
+BACKUP DATABASE foo TO '*****' INCREMENTAL FROM '*****' -- normalized!
+BACKUP DATABASE foo TO ('*****') INCREMENTAL FROM ('*****') -- fully parenthesized
 BACKUP DATABASE foo TO '_' INCREMENTAL FROM '_' -- literals removed
-BACKUP DATABASE _ TO 'bar.12' INCREMENTAL FROM 'baz.34' -- identifiers removed
+BACKUP DATABASE _ TO '*****' INCREMENTAL FROM '*****' -- identifiers removed
+BACKUP DATABASE foo TO 'bar.12' INCREMENTAL FROM 'baz.34' -- passwords exposed
 
 
 parse
 BACKUP DATABASE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
 ----
-BACKUP DATABASE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'
-BACKUP DATABASE foo TO ('bar') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP DATABASE foo TO '*****' AS OF SYSTEM TIME '1' INCREMENTAL FROM '*****' -- normalized!
+BACKUP DATABASE foo TO ('*****') AS OF SYSTEM TIME ('1') INCREMENTAL FROM ('*****') -- fully parenthesized
 BACKUP DATABASE foo TO '_' AS OF SYSTEM TIME '_' INCREMENTAL FROM '_' -- literals removed
-BACKUP DATABASE _ TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- identifiers removed
+BACKUP DATABASE _ TO '*****' AS OF SYSTEM TIME '1' INCREMENTAL FROM '*****' -- identifiers removed
+BACKUP DATABASE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz' -- passwords exposed
 
 parse
 BACKUP DATABASE foo TO ($1, $2)
@@ -350,94 +372,103 @@ BACKUP DATABASE _ TO ($1, $2) -- identifiers removed
 parse
 BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz'
 ----
-BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz'
-BACKUP DATABASE foo TO (($1), ($2)) INCREMENTAL FROM ('baz') -- fully parenthesized
+BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM '*****' -- normalized!
+BACKUP DATABASE foo TO (($1), ($2)) INCREMENTAL FROM ('*****') -- fully parenthesized
 BACKUP DATABASE foo TO ($1, $1) INCREMENTAL FROM '_' -- literals removed
-BACKUP DATABASE _ TO ($1, $2) INCREMENTAL FROM 'baz' -- identifiers removed
+BACKUP DATABASE _ TO ($1, $2) INCREMENTAL FROM '*****' -- identifiers removed
+BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz' -- passwords exposed
 
 parse
 BACKUP foo TO 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', revision_history, execution locality = 'a=b'
 ----
-BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', execution locality = 'a=b') -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), encryption_passphrase = '*****', execution locality = ('a=b')) -- fully parenthesized
+BACKUP TABLE foo TO '*****' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', execution locality = 'a=b') -- normalized!
+BACKUP TABLE (foo) TO ('*****') WITH OPTIONS (revision_history = (true), encryption_passphrase = '*****', execution locality = ('a=b')) -- fully parenthesized
 BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, encryption_passphrase = '*****', execution locality = '_') -- literals removed
-BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', execution locality = 'a=b') -- identifiers removed
+BACKUP TABLE _ TO '*****' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', execution locality = 'a=b') -- identifiers removed
 BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = 'secret', execution locality = 'a=b') -- passwords exposed
 
 parse
 BACKUP foo TO 'bar' WITH KMS = ('foo', 'bar'), revision_history
 ----
-BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, kms = ('foo', 'bar')) -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), kms = (('foo'), ('bar'))) -- fully parenthesized
+BACKUP TABLE foo TO '*****' WITH OPTIONS (revision_history = true, kms = ('*****', '*****')) -- normalized!
+BACKUP TABLE (foo) TO ('*****') WITH OPTIONS (revision_history = (true), kms = (('*****'), ('*****'))) -- fully parenthesized
 BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, kms = ('_', '_')) -- literals removed
-BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, kms = ('foo', 'bar')) -- identifiers removed
+BACKUP TABLE _ TO '*****' WITH OPTIONS (revision_history = true, kms = ('*****', '*****')) -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, kms = ('foo', 'bar')) -- passwords exposed
 
 parse
 BACKUP foo TO 'bar' WITH OPTIONS (detached, ENCRYPTION_PASSPHRASE = 'secret', revision_history)
 ----
-BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached) -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), encryption_passphrase = '*****', detached) -- fully parenthesized
+BACKUP TABLE foo TO '*****' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached) -- normalized!
+BACKUP TABLE (foo) TO ('*****') WITH OPTIONS (revision_history = (true), encryption_passphrase = '*****', detached) -- fully parenthesized
 BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, encryption_passphrase = '*****', detached) -- literals removed
-BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached) -- identifiers removed
+BACKUP TABLE _ TO '*****' WITH OPTIONS (revision_history = true, encryption_passphrase = '*****', detached) -- identifiers removed
 BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, encryption_passphrase = 'secret', detached) -- passwords exposed
 
 parse
 BACKUP foo TO 'bar' WITH OPTIONS (detached, KMS = ('foo', 'bar'), revision_history)
 ----
-BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, detached, kms = ('foo', 'bar')) -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), detached, kms = (('foo'), ('bar'))) -- fully parenthesized
+BACKUP TABLE foo TO '*****' WITH OPTIONS (revision_history = true, detached, kms = ('*****', '*****')) -- normalized!
+BACKUP TABLE (foo) TO ('*****') WITH OPTIONS (revision_history = (true), detached, kms = (('*****'), ('*****'))) -- fully parenthesized
 BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, detached, kms = ('_', '_')) -- literals removed
-BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, detached, kms = ('foo', 'bar')) -- identifiers removed
+BACKUP TABLE _ TO '*****' WITH OPTIONS (revision_history = true, detached, kms = ('*****', '*****')) -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, detached, kms = ('foo', 'bar')) -- passwords exposed
 
 
 # Regression test for #95235.
 parse
 BACKUP foo TO 'bar' WITH OPTIONS (detached = false)
 ----
-BACKUP TABLE foo TO 'bar' -- normalized!
-BACKUP TABLE (foo) TO ('bar') -- fully parenthesized
+BACKUP TABLE foo TO '*****' -- normalized!
+BACKUP TABLE (foo) TO ('*****') -- fully parenthesized
 BACKUP TABLE foo TO '_' -- literals removed
-BACKUP TABLE _ TO 'bar' -- identifiers removed
+BACKUP TABLE _ TO '*****' -- identifiers removed
+BACKUP TABLE foo TO 'bar' -- passwords exposed
 
 parse
 BACKUP VIRTUAL CLUSTER 36 TO 'bar'
 ----
-BACKUP VIRTUAL CLUSTER 36 TO 'bar'
-BACKUP VIRTUAL CLUSTER 36 TO ('bar') -- fully parenthesized
+BACKUP VIRTUAL CLUSTER 36 TO '*****' -- normalized!
+BACKUP VIRTUAL CLUSTER 36 TO ('*****') -- fully parenthesized
 BACKUP VIRTUAL CLUSTER _ TO '_' -- literals removed
-BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- identifiers removed
+BACKUP VIRTUAL CLUSTER 36 TO '*****' -- identifiers removed
+BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- passwords exposed
 
 parse
 BACKUP TENANT 36 TO 'bar'
 ----
-BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- normalized!
-BACKUP VIRTUAL CLUSTER 36 TO ('bar') -- fully parenthesized
+BACKUP VIRTUAL CLUSTER 36 TO '*****' -- normalized!
+BACKUP VIRTUAL CLUSTER 36 TO ('*****') -- fully parenthesized
 BACKUP VIRTUAL CLUSTER _ TO '_' -- literals removed
-BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- identifiers removed
+BACKUP VIRTUAL CLUSTER 36 TO '*****' -- identifiers removed
+BACKUP VIRTUAL CLUSTER 36 TO 'bar' -- passwords exposed
 
 parse
 RESTORE TABLE foo FROM 'bar'
 ----
-RESTORE TABLE foo FROM 'bar'
-RESTORE TABLE (foo) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM '*****' -- normalized!
+RESTORE TABLE (foo) FROM ('*****') -- fully parenthesized
 RESTORE TABLE foo FROM '_' -- literals removed
-RESTORE TABLE _ FROM 'bar' -- identifiers removed
+RESTORE TABLE _ FROM '*****' -- identifiers removed
+RESTORE TABLE foo FROM 'bar' -- passwords exposed
 
 parse
 EXPLAIN RESTORE TABLE foo FROM 'bar'
 ----
-EXPLAIN RESTORE TABLE foo FROM 'bar'
-EXPLAIN RESTORE TABLE (foo) FROM ('bar') -- fully parenthesized
+EXPLAIN RESTORE TABLE foo FROM '*****' -- normalized!
+EXPLAIN RESTORE TABLE (foo) FROM ('*****') -- fully parenthesized
 EXPLAIN RESTORE TABLE foo FROM '_' -- literals removed
-EXPLAIN RESTORE TABLE _ FROM 'bar' -- identifiers removed
+EXPLAIN RESTORE TABLE _ FROM '*****' -- identifiers removed
+EXPLAIN RESTORE TABLE foo FROM 'bar' -- passwords exposed
 
 parse
 RESTORE foo FROM 'bar'
 ----
-RESTORE TABLE foo FROM 'bar' -- normalized!
-RESTORE TABLE (foo) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM '*****' -- normalized!
+RESTORE TABLE (foo) FROM ('*****') -- fully parenthesized
 RESTORE TABLE foo FROM '_' -- literals removed
-RESTORE TABLE _ FROM 'bar' -- identifiers removed
+RESTORE TABLE _ FROM '*****' -- identifiers removed
+RESTORE TABLE foo FROM 'bar' -- passwords exposed
 
 parse
 RESTORE TABLE foo FROM $1
@@ -467,76 +498,85 @@ RESTORE TABLE _ FROM $2 IN $1 -- identifiers removed
 parse
 RESTORE TABLE foo FROM $1, $2, 'bar'
 ----
-RESTORE TABLE foo FROM $1, $2, 'bar'
-RESTORE TABLE (foo) FROM ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM $1, $2, '*****' -- normalized!
+RESTORE TABLE (foo) FROM ($1), ($2), ('*****') -- fully parenthesized
 RESTORE TABLE foo FROM $1, $1, '_' -- literals removed
-RESTORE TABLE _ FROM $1, $2, 'bar' -- identifiers removed
+RESTORE TABLE _ FROM $1, $2, '*****' -- identifiers removed
+RESTORE TABLE foo FROM $1, $2, 'bar' -- passwords exposed
 
 parse
 RESTORE foo FROM $1, $2, 'bar'
 ----
-RESTORE TABLE foo FROM $1, $2, 'bar' -- normalized!
-RESTORE TABLE (foo) FROM ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM $1, $2, '*****' -- normalized!
+RESTORE TABLE (foo) FROM ($1), ($2), ('*****') -- fully parenthesized
 RESTORE TABLE foo FROM $1, $1, '_' -- literals removed
-RESTORE TABLE _ FROM $1, $2, 'bar' -- identifiers removed
+RESTORE TABLE _ FROM $1, $2, '*****' -- identifiers removed
+RESTORE TABLE foo FROM $1, $2, 'bar' -- passwords exposed
 
 parse
 RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar'
 ----
-RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar'
-RESTORE TABLE (foo) FROM ('abc') IN ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM 'abc' IN $1, $2, '*****' -- normalized!
+RESTORE TABLE (foo) FROM ('abc') IN ($1), ($2), ('*****') -- fully parenthesized
 RESTORE TABLE foo FROM '_' IN $1, $1, '_' -- literals removed
-RESTORE TABLE _ FROM 'abc' IN $1, $2, 'bar' -- identifiers removed
+RESTORE TABLE _ FROM 'abc' IN $1, $2, '*****' -- identifiers removed
+RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar' -- passwords exposed
 
 parse
 RESTORE TABLE foo FROM $4 IN $1, $2, 'bar'
 ----
-RESTORE TABLE foo FROM $4 IN $1, $2, 'bar'
-RESTORE TABLE (foo) FROM ($4) IN ($1), ($2), ('bar') -- fully parenthesized
+RESTORE TABLE foo FROM $4 IN $1, $2, '*****' -- normalized!
+RESTORE TABLE (foo) FROM ($4) IN ($1), ($2), ('*****') -- fully parenthesized
 RESTORE TABLE foo FROM $1 IN $1, $1, '_' -- literals removed
-RESTORE TABLE _ FROM $4 IN $1, $2, 'bar' -- identifiers removed
+RESTORE TABLE _ FROM $4 IN $1, $2, '*****' -- identifiers removed
+RESTORE TABLE foo FROM $4 IN $1, $2, 'bar' -- passwords exposed
 
 parse
 RESTORE TABLE foo, baz FROM 'bar'
 ----
-RESTORE TABLE foo, baz FROM 'bar'
-RESTORE TABLE (foo), (baz) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '*****' -- normalized!
+RESTORE TABLE (foo), (baz) FROM ('*****') -- fully parenthesized
 RESTORE TABLE foo, baz FROM '_' -- literals removed
-RESTORE TABLE _, _ FROM 'bar' -- identifiers removed
+RESTORE TABLE _, _ FROM '*****' -- identifiers removed
+RESTORE TABLE foo, baz FROM 'bar' -- passwords exposed
 
 
 parse
 RESTORE foo, baz FROM 'bar'
 ----
-RESTORE TABLE foo, baz FROM 'bar' -- normalized!
-RESTORE TABLE (foo), (baz) FROM ('bar') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '*****' -- normalized!
+RESTORE TABLE (foo), (baz) FROM ('*****') -- fully parenthesized
 RESTORE TABLE foo, baz FROM '_' -- literals removed
-RESTORE TABLE _, _ FROM 'bar' -- identifiers removed
+RESTORE TABLE _, _ FROM '*****' -- identifiers removed
+RESTORE TABLE foo, baz FROM 'bar' -- passwords exposed
 
 parse
 RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
 ----
-RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
-RESTORE TABLE (foo), (baz) FROM ('bar') AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '*****' AS OF SYSTEM TIME '1' -- normalized!
+RESTORE TABLE (foo), (baz) FROM ('*****') AS OF SYSTEM TIME ('1') -- fully parenthesized
 RESTORE TABLE foo, baz FROM '_' AS OF SYSTEM TIME '_' -- literals removed
-RESTORE TABLE _, _ FROM 'bar' AS OF SYSTEM TIME '1' -- identifiers removed
+RESTORE TABLE _, _ FROM '*****' AS OF SYSTEM TIME '1' -- identifiers removed
+RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1' -- passwords exposed
 
 
 parse
 RESTORE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
 ----
-RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1' -- normalized!
-RESTORE TABLE (foo), (baz) FROM ('bar') AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE TABLE foo, baz FROM '*****' AS OF SYSTEM TIME '1' -- normalized!
+RESTORE TABLE (foo), (baz) FROM ('*****') AS OF SYSTEM TIME ('1') -- fully parenthesized
 RESTORE TABLE foo, baz FROM '_' AS OF SYSTEM TIME '_' -- literals removed
-RESTORE TABLE _, _ FROM 'bar' AS OF SYSTEM TIME '1' -- identifiers removed
+RESTORE TABLE _, _ FROM '*****' AS OF SYSTEM TIME '1' -- identifiers removed
+RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1' -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM 'bar'
 ----
-RESTORE DATABASE foo FROM 'bar'
-RESTORE DATABASE foo FROM ('bar') -- fully parenthesized
+RESTORE DATABASE foo FROM '*****' -- normalized!
+RESTORE DATABASE foo FROM ('*****') -- fully parenthesized
 RESTORE DATABASE foo FROM '_' -- literals removed
-RESTORE DATABASE _ FROM 'bar' -- identifiers removed
+RESTORE DATABASE _ FROM '*****' -- identifiers removed
+RESTORE DATABASE foo FROM 'bar' -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM ($1)
@@ -549,59 +589,66 @@ RESTORE DATABASE _ FROM $1 -- identifiers removed
 parse
 EXPLAIN RESTORE DATABASE foo FROM 'bar'
 ----
-EXPLAIN RESTORE DATABASE foo FROM 'bar'
-EXPLAIN RESTORE DATABASE foo FROM ('bar') -- fully parenthesized
+EXPLAIN RESTORE DATABASE foo FROM '*****' -- normalized!
+EXPLAIN RESTORE DATABASE foo FROM ('*****') -- fully parenthesized
 EXPLAIN RESTORE DATABASE foo FROM '_' -- literals removed
-EXPLAIN RESTORE DATABASE _ FROM 'bar' -- identifiers removed
+EXPLAIN RESTORE DATABASE _ FROM '*****' -- identifiers removed
+EXPLAIN RESTORE DATABASE foo FROM 'bar' -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM bar
 ----
-RESTORE DATABASE foo FROM 'bar' -- normalized!
-RESTORE DATABASE foo FROM ('bar') -- fully parenthesized
+RESTORE DATABASE foo FROM '*****' -- normalized!
+RESTORE DATABASE foo FROM ('*****') -- fully parenthesized
 RESTORE DATABASE foo FROM '_' -- literals removed
-RESTORE DATABASE _ FROM 'bar' -- identifiers removed
+RESTORE DATABASE _ FROM '*****' -- identifiers removed
+RESTORE DATABASE foo FROM 'bar' -- passwords exposed
 
 
 parse
 RESTORE DATABASE foo, baz FROM 'bar'
 ----
-RESTORE DATABASE foo, baz FROM 'bar'
-RESTORE DATABASE foo, baz FROM ('bar') -- fully parenthesized
+RESTORE DATABASE foo, baz FROM '*****' -- normalized!
+RESTORE DATABASE foo, baz FROM ('*****') -- fully parenthesized
 RESTORE DATABASE foo, baz FROM '_' -- literals removed
-RESTORE DATABASE _, _ FROM 'bar' -- identifiers removed
+RESTORE DATABASE _, _ FROM '*****' -- identifiers removed
+RESTORE DATABASE foo, baz FROM 'bar' -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM 'bar' WITH new_db_name = 'baz'
 ----
-RESTORE DATABASE foo FROM 'bar' WITH OPTIONS (new_db_name = 'baz') -- normalized!
-RESTORE DATABASE foo FROM ('bar') WITH OPTIONS (new_db_name = ('baz')) -- fully parenthesized
+RESTORE DATABASE foo FROM '*****' WITH OPTIONS (new_db_name = 'baz') -- normalized!
+RESTORE DATABASE foo FROM ('*****') WITH OPTIONS (new_db_name = ('baz')) -- fully parenthesized
 RESTORE DATABASE foo FROM '_' WITH OPTIONS (new_db_name = '_') -- literals removed
-RESTORE DATABASE _ FROM 'bar' WITH OPTIONS (new_db_name = 'baz') -- identifiers removed
+RESTORE DATABASE _ FROM '*****' WITH OPTIONS (new_db_name = 'baz') -- identifiers removed
+RESTORE DATABASE foo FROM 'bar' WITH OPTIONS (new_db_name = 'baz') -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM 'bar' WITH schema_only
 ----
-RESTORE DATABASE foo FROM 'bar' WITH OPTIONS (schema_only) -- normalized!
-RESTORE DATABASE foo FROM ('bar') WITH OPTIONS (schema_only) -- fully parenthesized
+RESTORE DATABASE foo FROM '*****' WITH OPTIONS (schema_only) -- normalized!
+RESTORE DATABASE foo FROM ('*****') WITH OPTIONS (schema_only) -- fully parenthesized
 RESTORE DATABASE foo FROM '_' WITH OPTIONS (schema_only) -- literals removed
-RESTORE DATABASE _ FROM 'bar' WITH OPTIONS (schema_only) -- identifiers removed
+RESTORE DATABASE _ FROM '*****' WITH OPTIONS (schema_only) -- identifiers removed
+RESTORE DATABASE foo FROM 'bar' WITH OPTIONS (schema_only) -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_location = 'baz'
 ----
-RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH OPTIONS (incremental_location = 'baz') -- normalized!
-RESTORE DATABASE foo FROM ('bar') IN ('latest') WITH OPTIONS (incremental_location = ('baz')) -- fully parenthesized
+RESTORE DATABASE foo FROM 'bar' IN '*****' WITH OPTIONS (incremental_location = '*****') -- normalized!
+RESTORE DATABASE foo FROM ('bar') IN ('*****') WITH OPTIONS (incremental_location = ('*****')) -- fully parenthesized
 RESTORE DATABASE foo FROM '_' IN '_' WITH OPTIONS (incremental_location = '_') -- literals removed
-RESTORE DATABASE _ FROM 'bar' IN 'latest' WITH OPTIONS (incremental_location = 'baz') -- identifiers removed
+RESTORE DATABASE _ FROM 'bar' IN '*****' WITH OPTIONS (incremental_location = '*****') -- identifiers removed
+RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH OPTIONS (incremental_location = 'baz') -- passwords exposed
 
 parse
 RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
 ----
-RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
-RESTORE DATABASE foo, baz FROM ('bar') AS OF SYSTEM TIME ('1') -- fully parenthesized
+RESTORE DATABASE foo, baz FROM '*****' AS OF SYSTEM TIME '1' -- normalized!
+RESTORE DATABASE foo, baz FROM ('*****') AS OF SYSTEM TIME ('1') -- fully parenthesized
 RESTORE DATABASE foo, baz FROM '_' AS OF SYSTEM TIME '_' -- literals removed
-RESTORE DATABASE _, _ FROM 'bar' AS OF SYSTEM TIME '1' -- identifiers removed
+RESTORE DATABASE _, _ FROM '*****' AS OF SYSTEM TIME '1' -- identifiers removed
+RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1' -- passwords exposed
 
 parse
 RESTORE DATABASE foo FROM ($1, $2)
@@ -702,61 +749,66 @@ RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1' -- identifiers removed
 parse
 RESTORE FROM $1, $2, 'bar'
 ----
-RESTORE FROM $1, $2, 'bar'
-RESTORE FROM ($1), ($2), ('bar') -- fully parenthesized
+RESTORE FROM $1, $2, '*****' -- normalized!
+RESTORE FROM ($1), ($2), ('*****') -- fully parenthesized
 RESTORE FROM $1, $1, '_' -- literals removed
-RESTORE FROM $1, $2, 'bar' -- identifiers removed
+RESTORE FROM $1, $2, '*****' -- identifiers removed
+RESTORE FROM $1, $2, 'bar' -- passwords exposed
 
 parse
 RESTORE FROM $4 IN $1, $2, 'bar'
 ----
-RESTORE FROM $4 IN $1, $2, 'bar'
-RESTORE FROM ($4) IN ($1), ($2), ('bar') -- fully parenthesized
+RESTORE FROM $4 IN $1, $2, '*****' -- normalized!
+RESTORE FROM ($4) IN ($1), ($2), ('*****') -- fully parenthesized
 RESTORE FROM $1 IN $1, $1, '_' -- literals removed
-RESTORE FROM $4 IN $1, $2, 'bar' -- identifiers removed
+RESTORE FROM $4 IN $1, $2, '*****' -- identifiers removed
+RESTORE FROM $4 IN $1, $2, 'bar' -- passwords exposed
 
 parse
 RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH skip_missing_foreign_keys
 ----
-RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- normalized!
-RESTORE FROM ($4) IN ($1), ($2), ('bar') AS OF SYSTEM TIME ('1') WITH OPTIONS (skip_missing_foreign_keys) -- fully parenthesized
+RESTORE FROM $4 IN $1, $2, '*****' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- normalized!
+RESTORE FROM ($4) IN ($1), ($2), ('*****') AS OF SYSTEM TIME ('1') WITH OPTIONS (skip_missing_foreign_keys) -- fully parenthesized
 RESTORE FROM $1 IN $1, $1, '_' AS OF SYSTEM TIME '_' WITH OPTIONS (skip_missing_foreign_keys) -- literals removed
-RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- identifiers removed
+RESTORE FROM $4 IN $1, $2, '*****' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- identifiers removed
+RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH OPTIONS (skip_missing_foreign_keys) -- passwords exposed
 
 parse
 RESTORE abc.xzy FROM 'a' WITH into_db = 'foo', skip_missing_foreign_keys
 ----
-RESTORE TABLE abc.xzy FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- normalized!
-RESTORE TABLE (abc.xzy) FROM ('a') WITH OPTIONS (into_db = ('foo'), skip_missing_foreign_keys) -- fully parenthesized
+RESTORE TABLE abc.xzy FROM '*****' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- normalized!
+RESTORE TABLE (abc.xzy) FROM ('*****') WITH OPTIONS (into_db = ('foo'), skip_missing_foreign_keys) -- fully parenthesized
 RESTORE TABLE abc.xzy FROM '_' WITH OPTIONS (into_db = '_', skip_missing_foreign_keys) -- literals removed
-RESTORE TABLE _._ FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- identifiers removed
+RESTORE TABLE _._ FROM '*****' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- identifiers removed
+RESTORE TABLE abc.xzy FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys) -- passwords exposed
 
 parse
 RESTORE FROM 'a' WITH into_db = 'foo', skip_missing_foreign_keys, skip_localities_check
 ----
-RESTORE FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- normalized!
-RESTORE FROM ('a') WITH OPTIONS (into_db = ('foo'), skip_missing_foreign_keys, skip_localities_check) -- fully parenthesized
+RESTORE FROM '*****' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- normalized!
+RESTORE FROM ('*****') WITH OPTIONS (into_db = ('foo'), skip_missing_foreign_keys, skip_localities_check) -- fully parenthesized
 RESTORE FROM '_' WITH OPTIONS (into_db = '_', skip_missing_foreign_keys, skip_localities_check) -- literals removed
-RESTORE FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- identifiers removed
+RESTORE FROM '*****' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- identifiers removed
+RESTORE FROM 'a' WITH OPTIONS (into_db = 'foo', skip_missing_foreign_keys, skip_localities_check) -- passwords exposed
 
 parse
 RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz', debug_pause_on='error',
 skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views, skip_missing_udfs, detached, skip_localities_check)
 ----
-RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- fully parenthesized
+RESTORE TABLE foo FROM '*****' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- normalized!
+RESTORE TABLE (foo) FROM ('*****') WITH OPTIONS (encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- fully parenthesized
 RESTORE TABLE foo FROM '_' WITH OPTIONS (encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- identifiers removed
+RESTORE TABLE _ FROM '*****' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- identifiers removed
 RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check) -- passwords exposed
 
 parse
 RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz, DEBUG_PAUSE_ON='error',
 SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS, SKIP_LOCALITIES_CHECK, SKIP_MISSING_UDFS
 ----
-RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- fully parenthesized
+RESTORE TABLE foo FROM '*****' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- normalized!
+RESTORE TABLE (foo) FROM ('*****') WITH OPTIONS (encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- fully parenthesized
 RESTORE TABLE foo FROM '_' WITH OPTIONS (encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- identifiers removed
+RESTORE TABLE _ FROM '*****' WITH OPTIONS (encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- identifiers removed
 RESTORE TABLE foo FROM 'bar' WITH OPTIONS (encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check) -- passwords exposed
 
 parse
@@ -802,106 +854,119 @@ RESTORE VIRTUAL CLUSTER 36 FROM ($1, $2) WITH OPTIONS (virtual_cluster = '5') --
 parse
 BACKUP TABLE foo TO 'bar' WITH revision_history, detached
 ----
-BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, detached) -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = (true), detached) -- fully parenthesized
+BACKUP TABLE foo TO '*****' WITH OPTIONS (revision_history = true, detached) -- normalized!
+BACKUP TABLE (foo) TO ('*****') WITH OPTIONS (revision_history = (true), detached) -- fully parenthesized
 BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = _, detached) -- literals removed
-BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = true, detached) -- identifiers removed
+BACKUP TABLE _ TO '*****' WITH OPTIONS (revision_history = true, detached) -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = true, detached) -- passwords exposed
 
 parse
 BACKUP TABLE foo TO 'bar' WITH revision_history = $1, detached, execution locality = $2
 ----
-BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- normalized!
-BACKUP TABLE (foo) TO ('bar') WITH OPTIONS (revision_history = ($1), detached, execution locality = ($2)) -- fully parenthesized
+BACKUP TABLE foo TO '*****' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- normalized!
+BACKUP TABLE (foo) TO ('*****') WITH OPTIONS (revision_history = ($1), detached, execution locality = ($2)) -- fully parenthesized
 BACKUP TABLE foo TO '_' WITH OPTIONS (revision_history = $1, detached, execution locality = $1) -- literals removed
-BACKUP TABLE _ TO 'bar' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- identifiers removed
+BACKUP TABLE _ TO '*****' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- identifiers removed
+BACKUP TABLE foo TO 'bar' WITH OPTIONS (revision_history = $1, detached, execution locality = $2) -- passwords exposed
 
 parse
 RESTORE TABLE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences, detached
 ----
-RESTORE TABLE foo FROM 'bar' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- fully parenthesized
+RESTORE TABLE foo FROM '*****' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- normalized!
+RESTORE TABLE (foo) FROM ('*****') WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- fully parenthesized
 RESTORE TABLE foo FROM '_' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- identifiers removed
+RESTORE TABLE _ FROM '*****' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (skip_missing_foreign_keys, skip_missing_sequences, detached) -- passwords exposed
 
 parse
 RESTORE TABLE foo FROM 'bar' WITH remove_regions
 ----
-RESTORE TABLE foo FROM 'bar' WITH OPTIONS (skip_localities_check, remove_regions) -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH OPTIONS (skip_localities_check, remove_regions) -- fully parenthesized
+RESTORE TABLE foo FROM '*****' WITH OPTIONS (skip_localities_check, remove_regions) -- normalized!
+RESTORE TABLE (foo) FROM ('*****') WITH OPTIONS (skip_localities_check, remove_regions) -- fully parenthesized
 RESTORE TABLE foo FROM '_' WITH OPTIONS (skip_localities_check, remove_regions) -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH OPTIONS (skip_localities_check, remove_regions) -- identifiers removed
+RESTORE TABLE _ FROM '*****' WITH OPTIONS (skip_localities_check, remove_regions) -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH OPTIONS (skip_localities_check, remove_regions) -- passwords exposed
 
 parse
 BACKUP INTO 'bar' WITH include_all_virtual_clusters = $1, detached
 ----
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
-BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
+BACKUP INTO ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
 BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- passwords exposed
 
 parse
 BACKUP INTO 'bar' WITH include_all_secondary_tenants = $1, detached
 ----
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
-BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
+BACKUP INTO ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
 BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- passwords exposed
 
 parse
 BACKUP INTO 'bar' WITH include_all_virtual_clusters, detached
 ----
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
-BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+BACKUP INTO ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
 BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- passwords exposed
 
 parse
 BACKUP INTO 'bar' WITH include_all_secondary_tenants, detached
 ----
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
-BACKUP INTO ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+BACKUP INTO ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
 BACKUP INTO '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
-BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+BACKUP INTO '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+BACKUP INTO 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- passwords exposed
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters = $1, detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- normalized!
+RESTORE FROM ('latest') IN ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = ($1)) -- fully parenthesized
 RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1) -- passwords exposed
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters = $1, execution locality = $2, detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = ($1), execution locality = ($2)) -- fully parenthesized
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- normalized!
+RESTORE FROM ('latest') IN ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = ($1), execution locality = ($2)) -- fully parenthesized
 RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $1) -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- identifiers removed
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = $1, execution locality = $2) -- passwords exposed
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_virtual_clusters, detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+RESTORE FROM ('latest') IN ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
 RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- passwords exposed
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants, detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- normalized!
+RESTORE FROM ('latest') IN ('*****') WITH OPTIONS (detached, include_all_virtual_clusters = (true)) -- fully parenthesized
 RESTORE FROM '_' IN '_' WITH OPTIONS (detached, include_all_virtual_clusters = _) -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, include_all_virtual_clusters = true) -- passwords exposed
 
 parse
 RESTORE FROM LATEST IN 'bar' WITH unsafe_restore_incompatible_version, execution locality = 'abc', detached
 ----
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- normalized!
-RESTORE FROM ('latest') IN ('bar') WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = ('abc')) -- fully parenthesized
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- normalized!
+RESTORE FROM ('latest') IN ('*****') WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = ('abc')) -- fully parenthesized
 RESTORE FROM '_' IN '_' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = '_') -- literals removed
-RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- identifiers removed
+RESTORE FROM 'latest' IN '*****' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- identifiers removed
+RESTORE FROM 'latest' IN 'bar' WITH OPTIONS (detached, unsafe_restore_incompatible_version, execution locality = 'abc') -- passwords exposed
 
 error
 BACKUP foo TO 'bar' WITH key1, key2 = 'value'
@@ -1048,10 +1113,11 @@ HINT: try \h RESTORE
 parse
 BACKUP INTO LATEST IN UNLOGGED WITH OPTIONS ( DETACHED = FALSE )
 ----
-BACKUP INTO LATEST IN 'unlogged' -- normalized!
-BACKUP INTO LATEST IN ('unlogged') -- fully parenthesized
+BACKUP INTO LATEST IN '*****' -- normalized!
+BACKUP INTO LATEST IN ('*****') -- fully parenthesized
 BACKUP INTO LATEST IN '_' -- literals removed
-BACKUP INTO LATEST IN 'unlogged' -- identifiers removed
+BACKUP INTO LATEST IN '*****' -- identifiers removed
+BACKUP INTO LATEST IN 'unlogged' -- passwords exposed
 
 # Regression test for https://github.com/cockroachdb/cockroach/issues/110411.
 parse

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -117,92 +117,102 @@ BACKUP TABLE foo.foo, baz.baz TO 'bar' -- passwords exposed
 parse
 SHOW BACKUP 'bar'
 ----
-SHOW BACKUP 'bar'
-SHOW BACKUP ('bar') -- fully parenthesized
+SHOW BACKUP '*****' -- normalized!
+SHOW BACKUP ('*****') -- fully parenthesized
 SHOW BACKUP '_' -- literals removed
-SHOW BACKUP 'bar' -- identifiers removed
+SHOW BACKUP '*****' -- identifiers removed
+SHOW BACKUP 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', CHECK_FILES
 ----
-SHOW BACKUP 'bar' WITH OPTIONS (check_files, encryption_passphrase = '*****') -- normalized!
-SHOW BACKUP ('bar') WITH OPTIONS (check_files, encryption_passphrase = '*****') -- fully parenthesized
+SHOW BACKUP '*****' WITH OPTIONS (check_files, encryption_passphrase = '*****') -- normalized!
+SHOW BACKUP ('*****') WITH OPTIONS (check_files, encryption_passphrase = '*****') -- fully parenthesized
 SHOW BACKUP '_' WITH OPTIONS (check_files, encryption_passphrase = '*****') -- literals removed
-SHOW BACKUP 'bar' WITH OPTIONS (check_files, encryption_passphrase = '*****') -- identifiers removed
+SHOW BACKUP '*****' WITH OPTIONS (check_files, encryption_passphrase = '*****') -- identifiers removed
 SHOW BACKUP 'bar' WITH OPTIONS (check_files, encryption_passphrase = 'secret') -- passwords exposed
 
 parse
 SHOW BACKUP FROM LATEST IN 'bar' WITH incremental_location = 'baz', skip size
 ----
-SHOW BACKUP FROM 'latest' IN 'bar' WITH OPTIONS (incremental_location = 'baz', skip size) -- normalized!
-SHOW BACKUP FROM ('latest') IN ('bar') WITH OPTIONS (incremental_location = ('baz'), skip size) -- fully parenthesized
+SHOW BACKUP FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****', skip size) -- normalized!
+SHOW BACKUP FROM ('latest') IN ('*****') WITH OPTIONS (incremental_location = ('*****'), skip size) -- fully parenthesized
 SHOW BACKUP FROM '_' IN '_' WITH OPTIONS (incremental_location = '_', skip size) -- literals removed
-SHOW BACKUP FROM 'latest' IN 'bar' WITH OPTIONS (incremental_location = 'baz', skip size) -- identifiers removed
+SHOW BACKUP FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****', skip size) -- identifiers removed
+SHOW BACKUP FROM 'latest' IN 'bar' WITH OPTIONS (incremental_location = 'baz', skip size) -- passwords exposed
 
 parse
 SHOW BACKUP FROM LATEST IN ('bar','bar1') WITH KMS = ('foo', 'bar'), incremental_location=('hi','hello')
 ----
-SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH OPTIONS (incremental_location = ('hi', 'hello'), kms = ('foo', 'bar')) -- normalized!
-SHOW BACKUP FROM ('latest') IN (('bar'), ('bar1')) WITH OPTIONS (incremental_location = (('hi'), ('hello')), kms = (('foo'), ('bar'))) -- fully parenthesized
+SHOW BACKUP FROM 'latest' IN ('*****', '*****') WITH OPTIONS (incremental_location = ('*****', '*****'), kms = ('*****', '*****')) -- normalized!
+SHOW BACKUP FROM ('latest') IN (('*****'), ('*****')) WITH OPTIONS (incremental_location = (('*****'), ('*****')), kms = (('*****'), ('*****'))) -- fully parenthesized
 SHOW BACKUP FROM '_' IN ('_', '_') WITH OPTIONS (incremental_location = ('_', '_'), kms = ('_', '_')) -- literals removed
-SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH OPTIONS (incremental_location = ('hi', 'hello'), kms = ('foo', 'bar')) -- identifiers removed
+SHOW BACKUP FROM 'latest' IN ('*****', '*****') WITH OPTIONS (incremental_location = ('*****', '*****'), kms = ('*****', '*****')) -- identifiers removed
+SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH OPTIONS (incremental_location = ('hi', 'hello'), kms = ('foo', 'bar')) -- passwords exposed
 
 
 parse
 EXPLAIN SHOW BACKUP 'bar'
 ----
-EXPLAIN SHOW BACKUP 'bar'
-EXPLAIN SHOW BACKUP ('bar') -- fully parenthesized
+EXPLAIN SHOW BACKUP '*****' -- normalized!
+EXPLAIN SHOW BACKUP ('*****') -- fully parenthesized
 EXPLAIN SHOW BACKUP '_' -- literals removed
-EXPLAIN SHOW BACKUP 'bar' -- identifiers removed
+EXPLAIN SHOW BACKUP '*****' -- identifiers removed
+EXPLAIN SHOW BACKUP 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP RANGES 'bar'
 ----
-SHOW BACKUP RANGES 'bar'
-SHOW BACKUP RANGES ('bar') -- fully parenthesized
+SHOW BACKUP RANGES '*****' -- normalized!
+SHOW BACKUP RANGES ('*****') -- fully parenthesized
 SHOW BACKUP RANGES '_' -- literals removed
-SHOW BACKUP RANGES 'bar' -- identifiers removed
+SHOW BACKUP RANGES '*****' -- identifiers removed
+SHOW BACKUP RANGES 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP FILES 'bar'
 ----
-SHOW BACKUP FILES 'bar'
-SHOW BACKUP FILES ('bar') -- fully parenthesized
+SHOW BACKUP FILES '*****' -- normalized!
+SHOW BACKUP FILES ('*****') -- fully parenthesized
 SHOW BACKUP FILES '_' -- literals removed
-SHOW BACKUP FILES 'bar' -- identifiers removed
+SHOW BACKUP FILES '*****' -- identifiers removed
+SHOW BACKUP FILES 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP CONNECTION 'bar'
 ----
-SHOW BACKUP CONNECTION 'bar'
-SHOW BACKUP CONNECTION ('bar') -- fully parenthesized
+SHOW BACKUP CONNECTION '*****' -- normalized!
+SHOW BACKUP CONNECTION ('*****') -- fully parenthesized
 SHOW BACKUP CONNECTION '_' -- literals removed
-SHOW BACKUP CONNECTION 'bar' -- identifiers removed
+SHOW BACKUP CONNECTION '*****' -- identifiers removed
+SHOW BACKUP CONNECTION 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP CONNECTION 'bar' WITH TRANSFER = '1KiB', TIME = '1h', CONCURRENTLY = 3
 ----
-SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h') -- normalized!
-SHOW BACKUP CONNECTION ('bar') WITH OPTIONS (CONCURRENTLY = (3), TRANSFER = ('1KiB'), TIME = ('1h')) -- fully parenthesized
+SHOW BACKUP CONNECTION '*****' WITH OPTIONS (CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h') -- normalized!
+SHOW BACKUP CONNECTION ('*****') WITH OPTIONS (CONCURRENTLY = (3), TRANSFER = ('1KiB'), TIME = ('1h')) -- fully parenthesized
 SHOW BACKUP CONNECTION '_' WITH OPTIONS (CONCURRENTLY = _, TRANSFER = '_', TIME = '_') -- literals removed
-SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h') -- identifiers removed
+SHOW BACKUP CONNECTION '*****' WITH OPTIONS (CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h') -- identifiers removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (CONCURRENTLY = 3, TRANSFER = '1KiB', TIME = '1h') -- passwords exposed
 
 parse
 SHOW BACKUP CONNECTION 'bar' WITH TRANSFER = $1, CONCURRENTLY = $2, TIME = $3
 ----
-SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (CONCURRENTLY = $2, TRANSFER = $1, TIME = $3) -- normalized!
-SHOW BACKUP CONNECTION ('bar') WITH OPTIONS (CONCURRENTLY = ($2), TRANSFER = ($1), TIME = ($3)) -- fully parenthesized
+SHOW BACKUP CONNECTION '*****' WITH OPTIONS (CONCURRENTLY = $2, TRANSFER = $1, TIME = $3) -- normalized!
+SHOW BACKUP CONNECTION ('*****') WITH OPTIONS (CONCURRENTLY = ($2), TRANSFER = ($1), TIME = ($3)) -- fully parenthesized
 SHOW BACKUP CONNECTION '_' WITH OPTIONS (CONCURRENTLY = $1, TRANSFER = $1, TIME = $1) -- literals removed
-SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (CONCURRENTLY = $2, TRANSFER = $1, TIME = $3) -- identifiers removed
+SHOW BACKUP CONNECTION '*****' WITH OPTIONS (CONCURRENTLY = $2, TRANSFER = $1, TIME = $3) -- identifiers removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (CONCURRENTLY = $2, TRANSFER = $1, TIME = $3) -- passwords exposed
 
 parse
 SHOW BACKUPS IN 'bar'
 ----
-SHOW BACKUPS IN 'bar'
-SHOW BACKUPS IN ('bar') -- fully parenthesized
+SHOW BACKUPS IN '*****' -- normalized!
+SHOW BACKUPS IN ('*****') -- fully parenthesized
 SHOW BACKUPS IN '_' -- literals removed
-SHOW BACKUPS IN 'bar' -- identifiers removed
+SHOW BACKUPS IN '*****' -- identifiers removed
+SHOW BACKUPS IN 'bar' -- passwords exposed
 
 parse
 SHOW BACKUPS IN $1
@@ -215,10 +225,11 @@ SHOW BACKUPS IN $1 -- identifiers removed
 parse
 SHOW BACKUP 'foo' IN 'bar'
 ----
-SHOW BACKUP 'foo' IN 'bar'
-SHOW BACKUP ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP 'foo' IN '*****' -- normalized!
+SHOW BACKUP ('foo') IN ('*****') -- fully parenthesized
 SHOW BACKUP '_' IN '_' -- literals removed
-SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
+SHOW BACKUP 'foo' IN '*****' -- identifiers removed
+SHOW BACKUP 'foo' IN 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP FROM $1 IN $2 WITH privileges
@@ -231,26 +242,29 @@ SHOW BACKUP FROM $1 IN $2 WITH OPTIONS (privileges) -- identifiers removed
 parse
 SHOW BACKUP FILES FROM 'foo' IN 'bar'
 ----
-SHOW BACKUP FILES FROM 'foo' IN 'bar'
-SHOW BACKUP FILES FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP FILES FROM 'foo' IN '*****' -- normalized!
+SHOW BACKUP FILES FROM ('foo') IN ('*****') -- fully parenthesized
 SHOW BACKUP FILES FROM '_' IN '_' -- literals removed
-SHOW BACKUP FILES FROM 'foo' IN 'bar' -- identifiers removed
+SHOW BACKUP FILES FROM 'foo' IN '*****' -- identifiers removed
+SHOW BACKUP FILES FROM 'foo' IN 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP RANGES FROM 'foo' IN 'bar'
 ----
-SHOW BACKUP RANGES FROM 'foo' IN 'bar'
-SHOW BACKUP RANGES FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP RANGES FROM 'foo' IN '*****' -- normalized!
+SHOW BACKUP RANGES FROM ('foo') IN ('*****') -- fully parenthesized
 SHOW BACKUP RANGES FROM '_' IN '_' -- literals removed
-SHOW BACKUP RANGES FROM 'foo' IN 'bar' -- identifiers removed
+SHOW BACKUP RANGES FROM 'foo' IN '*****' -- identifiers removed
+SHOW BACKUP RANGES FROM 'foo' IN 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar'
 ----
-SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar'
-SHOW BACKUP SCHEMAS FROM ('foo') IN ('bar') -- fully parenthesized
+SHOW BACKUP SCHEMAS FROM 'foo' IN '*****' -- normalized!
+SHOW BACKUP SCHEMAS FROM ('foo') IN ('*****') -- fully parenthesized
 SHOW BACKUP SCHEMAS FROM '_' IN '_' -- literals removed
-SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar' -- identifiers removed
+SHOW BACKUP SCHEMAS FROM 'foo' IN '*****' -- identifiers removed
+SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar' -- passwords exposed
 
 parse
 SHOW BACKUP $1 IN $2 WITH ENCRYPTION_PASSPHRASE = 'secret', ENCRYPTION_INFO_DIR = 'long_live_backupper'
@@ -1123,7 +1137,8 @@ BACKUP INTO LATEST IN 'unlogged' -- passwords exposed
 parse
 SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (TIME = '1h')
 ----
-SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (TIME = '1h')
-SHOW BACKUP CONNECTION ('bar') WITH OPTIONS (TIME = ('1h')) -- fully parenthesized
+SHOW BACKUP CONNECTION '*****' WITH OPTIONS (TIME = '1h') -- normalized!
+SHOW BACKUP CONNECTION ('*****') WITH OPTIONS (TIME = ('1h')) -- fully parenthesized
 SHOW BACKUP CONNECTION '_' WITH OPTIONS (TIME = '_') -- literals removed
-SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (TIME = '1h') -- identifiers removed
+SHOW BACKUP CONNECTION '*****' WITH OPTIONS (TIME = '1h') -- identifiers removed
+SHOW BACKUP CONNECTION 'bar' WITH OPTIONS (TIME = '1h') -- passwords exposed

--- a/pkg/sql/parser/testdata/changefeed
+++ b/pkg/sql/parser/testdata/changefeed
@@ -17,42 +17,47 @@ EXPERIMENTAL CHANGEFEED FOR TABLE _ FAMILY _ -- identifiers removed
 parse
 EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO 'sink'
 ----
-EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO 'sink'
-EXPLAIN CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') -- fully parenthesized
+EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO '*****' -- normalized!
+EXPLAIN CREATE CHANGEFEED FOR TABLE (foo) INTO ('*****') -- fully parenthesized
 EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO '_' -- literals removed
-EXPLAIN CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
+EXPLAIN CREATE CHANGEFEED FOR TABLE _ INTO '*****' -- identifiers removed
+EXPLAIN CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- passwords exposed
 
 parse
 CREATE CHANGEFEED FOR foo INTO 'sink'
 ----
-CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- normalized!
-CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo INTO '*****' -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo) INTO ('*****') -- fully parenthesized
 CREATE CHANGEFEED FOR TABLE foo INTO '_' -- literals removed
-CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE _ INTO '*****' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- passwords exposed
 
 parse
 CREATE CHANGEFEED FOR TABLE foo INTO sink
 ----
-CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- normalized!
-CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo INTO '*****' -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo) INTO ('*****') -- fully parenthesized
 CREATE CHANGEFEED FOR TABLE foo INTO '_' -- literals removed
-CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE _ INTO '*****' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- passwords exposed
 
 parse
 CREATE CHANGEFEED FOR TABLE foo, db.bar, foo FAMILY bar, schema.db.foo INTO 'sink'
 ----
-CREATE CHANGEFEED FOR TABLE foo, TABLE db.bar, TABLE foo FAMILY bar, TABLE schema.db.foo INTO 'sink' -- normalized!
-CREATE CHANGEFEED FOR TABLE (foo), TABLE (db.bar), TABLE (foo) FAMILY bar, TABLE (schema.db.foo) INTO ('sink') -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo, TABLE db.bar, TABLE foo FAMILY bar, TABLE schema.db.foo INTO '*****' -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo), TABLE (db.bar), TABLE (foo) FAMILY bar, TABLE (schema.db.foo) INTO ('*****') -- fully parenthesized
 CREATE CHANGEFEED FOR TABLE foo, TABLE db.bar, TABLE foo FAMILY bar, TABLE schema.db.foo INTO '_' -- literals removed
-CREATE CHANGEFEED FOR TABLE _, TABLE _._, TABLE _ FAMILY _, TABLE _._._ INTO 'sink' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE _, TABLE _._, TABLE _ FAMILY _, TABLE _._._ INTO '*****' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo, TABLE db.bar, TABLE foo FAMILY bar, TABLE schema.db.foo INTO 'sink' -- passwords exposed
 
 parse
 CREATE CHANGEFEED FOR TABLE foo INTO 'sink'
 ----
-CREATE CHANGEFEED FOR TABLE foo INTO 'sink'
-CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo INTO '*****' -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo) INTO ('*****') -- fully parenthesized
 CREATE CHANGEFEED FOR TABLE foo INTO '_' -- literals removed
-CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE _ INTO '*****' -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo INTO 'sink' -- passwords exposed
 
 ## TODO(dan): Implement:
 ## CREATE CHANGEFEED FOR TABLE foo VALUES FROM (1) TO (2) INTO 'sink'
@@ -62,10 +67,11 @@ CREATE CHANGEFEED FOR TABLE _ INTO 'sink' -- identifiers removed
 parse
 CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH bar = 'baz'
 ----
-CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH OPTIONS (bar = 'baz') -- normalized!
-CREATE CHANGEFEED FOR TABLE (foo) INTO ('sink') WITH OPTIONS (bar = ('baz')) -- fully parenthesized
+CREATE CHANGEFEED FOR TABLE foo INTO '*****' WITH OPTIONS (bar = 'baz') -- normalized!
+CREATE CHANGEFEED FOR TABLE (foo) INTO ('*****') WITH OPTIONS (bar = ('baz')) -- fully parenthesized
 CREATE CHANGEFEED FOR TABLE foo INTO '_' WITH OPTIONS (bar = '_') -- literals removed
-CREATE CHANGEFEED FOR TABLE _ INTO 'sink' WITH OPTIONS (_ = 'baz') -- identifiers removed
+CREATE CHANGEFEED FOR TABLE _ INTO '*****' WITH OPTIONS (_ = 'baz') -- identifiers removed
+CREATE CHANGEFEED FOR TABLE foo INTO 'sink' WITH OPTIONS (bar = 'baz') -- passwords exposed
 
 parse
 CREATE CHANGEFEED AS SELECT * FROM foo

--- a/pkg/sql/parser/testdata/copy
+++ b/pkg/sql/parser/testdata/copy
@@ -25,10 +25,11 @@ COPY _ FROM STDIN WITH (QUOTE '"') -- identifiers removed
 parse
 COPY crdb_internal.file_upload FROM STDIN WITH destination = 'filename'
 ----
-COPY crdb_internal.file_upload FROM STDIN WITH (DESTINATION 'filename') -- normalized!
-COPY crdb_internal.file_upload FROM STDIN WITH (DESTINATION ('filename')) -- fully parenthesized
+COPY crdb_internal.file_upload FROM STDIN WITH (DESTINATION '*****') -- normalized!
+COPY crdb_internal.file_upload FROM STDIN WITH (DESTINATION ('*****')) -- fully parenthesized
 COPY crdb_internal.file_upload FROM STDIN WITH (DESTINATION '_') -- literals removed
-COPY _._ FROM STDIN WITH (DESTINATION 'filename') -- identifiers removed
+COPY _._ FROM STDIN WITH (DESTINATION '*****') -- identifiers removed
+COPY crdb_internal.file_upload FROM STDIN WITH (DESTINATION 'filename') -- passwords exposed
 
 parse
 COPY t (a, b, c) FROM STDIN WITH BINARY
@@ -41,10 +42,11 @@ COPY _ (_, _, _) FROM STDIN WITH (FORMAT BINARY) -- identifiers removed
 parse
 COPY crdb_internal.file_upload FROM STDIN WITH BINARY destination = 'filename'
 ----
-COPY crdb_internal.file_upload FROM STDIN WITH (FORMAT BINARY, DESTINATION 'filename') -- normalized!
-COPY crdb_internal.file_upload FROM STDIN WITH (FORMAT BINARY, DESTINATION ('filename')) -- fully parenthesized
+COPY crdb_internal.file_upload FROM STDIN WITH (FORMAT BINARY, DESTINATION '*****') -- normalized!
+COPY crdb_internal.file_upload FROM STDIN WITH (FORMAT BINARY, DESTINATION ('*****')) -- fully parenthesized
 COPY crdb_internal.file_upload FROM STDIN WITH (FORMAT BINARY, DESTINATION '_') -- literals removed
-COPY _._ FROM STDIN WITH (FORMAT BINARY, DESTINATION 'filename') -- identifiers removed
+COPY _._ FROM STDIN WITH (FORMAT BINARY, DESTINATION '*****') -- identifiers removed
+COPY crdb_internal.file_upload FROM STDIN WITH (FORMAT BINARY, DESTINATION 'filename') -- passwords exposed
 
 parse
 COPY t (a, b, c) FROM STDIN WITH CSV DELIMITER ',' NULL 'NUL'
@@ -57,10 +59,11 @@ COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', NULL 'NUL') -- iden
 parse
 COPY t (a, b, c) FROM STDIN WITH CSV DELIMITER ',' destination = 'filename'
 ----
-COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', DESTINATION 'filename') -- normalized!
-COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER (','), DESTINATION ('filename')) -- fully parenthesized
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', DESTINATION '*****') -- normalized!
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER (','), DESTINATION ('*****')) -- fully parenthesized
 COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER '_', DESTINATION '_') -- literals removed
-COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', DESTINATION 'filename') -- identifiers removed
+COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', DESTINATION '*****') -- identifiers removed
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ',', DESTINATION 'filename') -- passwords exposed
 
 parse
 COPY t (a, b, c) FROM STDIN BINARY
@@ -73,26 +76,29 @@ COPY _ (_, _, _) FROM STDIN WITH (FORMAT BINARY) -- identifiers removed
 parse
 COPY t (a, b, c) FROM STDIN destination = 'filename' BINARY
 ----
-COPY t (a, b, c) FROM STDIN WITH (FORMAT BINARY, DESTINATION 'filename') -- normalized!
-COPY t (a, b, c) FROM STDIN WITH (FORMAT BINARY, DESTINATION ('filename')) -- fully parenthesized
+COPY t (a, b, c) FROM STDIN WITH (FORMAT BINARY, DESTINATION '*****') -- normalized!
+COPY t (a, b, c) FROM STDIN WITH (FORMAT BINARY, DESTINATION ('*****')) -- fully parenthesized
 COPY t (a, b, c) FROM STDIN WITH (FORMAT BINARY, DESTINATION '_') -- literals removed
-COPY _ (_, _, _) FROM STDIN WITH (FORMAT BINARY, DESTINATION 'filename') -- identifiers removed
+COPY _ (_, _, _) FROM STDIN WITH (FORMAT BINARY, DESTINATION '*****') -- identifiers removed
+COPY t (a, b, c) FROM STDIN WITH (FORMAT BINARY, DESTINATION 'filename') -- passwords exposed
 
 parse
 COPY t (a, b, c) FROM STDIN destination = 'filename' CSV DELIMITER ' '
 ----
-COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION 'filename') -- normalized!
-COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER (' '), DESTINATION ('filename')) -- fully parenthesized
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION '*****') -- normalized!
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER (' '), DESTINATION ('*****')) -- fully parenthesized
 COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER '_', DESTINATION '_') -- literals removed
-COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION 'filename') -- identifiers removed
+COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION '*****') -- identifiers removed
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION 'filename') -- passwords exposed
 
 parse
 COPY t (a, b, c) FROM STDIN destination = 'filename' CSV DELIMITER ' ' ESCAPE 'x' HEADER
 ----
-COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION 'filename', ESCAPE 'x', HEADER true) -- normalized!
-COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER (' '), DESTINATION ('filename'), ESCAPE ('x'), HEADER true) -- fully parenthesized
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION '*****', ESCAPE 'x', HEADER true) -- normalized!
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER (' '), DESTINATION ('*****'), ESCAPE ('x'), HEADER true) -- fully parenthesized
 COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER '_', DESTINATION '_', ESCAPE '_', HEADER true) -- literals removed
-COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION 'filename', ESCAPE 'x', HEADER true) -- identifiers removed
+COPY _ (_, _, _) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION '*****', ESCAPE 'x', HEADER true) -- identifiers removed
+COPY t (a, b, c) FROM STDIN WITH (FORMAT CSV, DELIMITER ' ', DESTINATION 'filename', ESCAPE 'x', HEADER true) -- passwords exposed
 
 parse
 COPY t TO STDOUT

--- a/pkg/sql/parser/testdata/create_external_connection
+++ b/pkg/sql/parser/testdata/create_external_connection
@@ -1,15 +1,17 @@
 parse
 CREATE EXTERNAL CONNECTION 'foo' AS 'bar'
 ----
-CREATE EXTERNAL CONNECTION 'foo' AS 'bar'
-CREATE EXTERNAL CONNECTION ('foo') AS ('bar') -- fully parenthesized
+CREATE EXTERNAL CONNECTION 'foo' AS '*****' -- normalized!
+CREATE EXTERNAL CONNECTION ('foo') AS ('*****') -- fully parenthesized
 CREATE EXTERNAL CONNECTION '_' AS '_' -- literals removed
-CREATE EXTERNAL CONNECTION 'foo' AS 'bar' -- identifiers removed
+CREATE EXTERNAL CONNECTION 'foo' AS '*****' -- identifiers removed
+CREATE EXTERNAL CONNECTION 'foo' AS 'bar' -- passwords exposed
 
 parse
 CREATE EXTERNAL CONNECTION IF NOT EXISTS 'foo' AS 'bar'
 ----
-CREATE EXTERNAL CONNECTION IF NOT EXISTS 'foo' AS 'bar'
-CREATE EXTERNAL CONNECTION IF NOT EXISTS ('foo') AS ('bar') -- fully parenthesized
+CREATE EXTERNAL CONNECTION IF NOT EXISTS 'foo' AS '*****' -- normalized!
+CREATE EXTERNAL CONNECTION IF NOT EXISTS ('foo') AS ('*****') -- fully parenthesized
 CREATE EXTERNAL CONNECTION IF NOT EXISTS '_' AS '_' -- literals removed
-CREATE EXTERNAL CONNECTION IF NOT EXISTS 'foo' AS 'bar' -- identifiers removed
+CREATE EXTERNAL CONNECTION IF NOT EXISTS 'foo' AS '*****' -- identifiers removed
+CREATE EXTERNAL CONNECTION IF NOT EXISTS 'foo' AS 'bar' -- passwords exposed

--- a/pkg/sql/parser/testdata/create_schedule
+++ b/pkg/sql/parser/testdata/create_schedule
@@ -3,66 +3,74 @@
 parse
 CREATE SCHEDULE FOR BACKUP TABLE foo INTO 'bar' RECURRING '@hourly'
 ----
-CREATE SCHEDULE FOR BACKUP TABLE foo INTO 'bar' RECURRING '@hourly'
-CREATE SCHEDULE FOR BACKUP TABLE (foo) INTO ('bar') RECURRING ('@hourly') -- fully parenthesized
+CREATE SCHEDULE FOR BACKUP TABLE foo INTO '*****' RECURRING '@hourly' -- normalized!
+CREATE SCHEDULE FOR BACKUP TABLE (foo) INTO ('*****') RECURRING ('@hourly') -- fully parenthesized
 CREATE SCHEDULE FOR BACKUP TABLE foo INTO '_' RECURRING '_' -- literals removed
-CREATE SCHEDULE FOR BACKUP TABLE _ INTO 'bar' RECURRING '@hourly' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE _ INTO '*****' RECURRING '@hourly' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE foo INTO 'bar' RECURRING '@hourly' -- passwords exposed
 
 parse
 CREATE SCHEDULE 'my schedule' FOR BACKUP TABLE foo INTO 'bar' RECURRING '@daily'
 ----
-CREATE SCHEDULE 'my schedule' FOR BACKUP TABLE foo INTO 'bar' RECURRING '@daily'
-CREATE SCHEDULE ('my schedule') FOR BACKUP TABLE (foo) INTO ('bar') RECURRING ('@daily') -- fully parenthesized
+CREATE SCHEDULE 'my schedule' FOR BACKUP TABLE foo INTO '*****' RECURRING '@daily' -- normalized!
+CREATE SCHEDULE ('my schedule') FOR BACKUP TABLE (foo) INTO ('*****') RECURRING ('@daily') -- fully parenthesized
 CREATE SCHEDULE '_' FOR BACKUP TABLE foo INTO '_' RECURRING '_' -- literals removed
-CREATE SCHEDULE 'my schedule' FOR BACKUP TABLE _ INTO 'bar' RECURRING '@daily' -- identifiers removed
+CREATE SCHEDULE 'my schedule' FOR BACKUP TABLE _ INTO '*****' RECURRING '@daily' -- identifiers removed
+CREATE SCHEDULE 'my schedule' FOR BACKUP TABLE foo INTO 'bar' RECURRING '@daily' -- passwords exposed
 
 parse
 CREATE SCHEDULE FOR BACKUP TABLE foo INTO 'bar' RECURRING '@daily'
 ----
-CREATE SCHEDULE FOR BACKUP TABLE foo INTO 'bar' RECURRING '@daily'
-CREATE SCHEDULE FOR BACKUP TABLE (foo) INTO ('bar') RECURRING ('@daily') -- fully parenthesized
+CREATE SCHEDULE FOR BACKUP TABLE foo INTO '*****' RECURRING '@daily' -- normalized!
+CREATE SCHEDULE FOR BACKUP TABLE (foo) INTO ('*****') RECURRING ('@daily') -- fully parenthesized
 CREATE SCHEDULE FOR BACKUP TABLE foo INTO '_' RECURRING '_' -- literals removed
-CREATE SCHEDULE FOR BACKUP TABLE _ INTO 'bar' RECURRING '@daily' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE _ INTO '*****' RECURRING '@daily' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE foo INTO 'bar' RECURRING '@daily' -- passwords exposed
 
 parse
 CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP ALWAYS
 ----
-CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP ALWAYS
-CREATE SCHEDULE FOR BACKUP TABLE (foo), (bar), (buz) INTO ('bar') RECURRING ('@daily') FULL BACKUP ALWAYS -- fully parenthesized
+CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO '*****' RECURRING '@daily' FULL BACKUP ALWAYS -- normalized!
+CREATE SCHEDULE FOR BACKUP TABLE (foo), (bar), (buz) INTO ('*****') RECURRING ('@daily') FULL BACKUP ALWAYS -- fully parenthesized
 CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO '_' RECURRING '_' FULL BACKUP ALWAYS -- literals removed
-CREATE SCHEDULE FOR BACKUP TABLE _, _, _ INTO 'bar' RECURRING '@daily' FULL BACKUP ALWAYS -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE _, _, _ INTO '*****' RECURRING '@daily' FULL BACKUP ALWAYS -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP ALWAYS -- passwords exposed
 
 parse
 CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP '@weekly'
 ----
-CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP '@weekly'
-CREATE SCHEDULE FOR BACKUP TABLE (foo), (bar), (buz) INTO ('bar') RECURRING ('@daily') FULL BACKUP ('@weekly') -- fully parenthesized
+CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO '*****' RECURRING '@daily' FULL BACKUP '@weekly' -- normalized!
+CREATE SCHEDULE FOR BACKUP TABLE (foo), (bar), (buz) INTO ('*****') RECURRING ('@daily') FULL BACKUP ('@weekly') -- fully parenthesized
 CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO '_' RECURRING '_' FULL BACKUP '_' -- literals removed
-CREATE SCHEDULE FOR BACKUP TABLE _, _, _ INTO 'bar' RECURRING '@daily' FULL BACKUP '@weekly' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE _, _, _ INTO '*****' RECURRING '@daily' FULL BACKUP '@weekly' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' RECURRING '@daily' FULL BACKUP '@weekly' -- passwords exposed
 
 parse
 CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' WITH revision_history RECURRING '@daily' FULL BACKUP '@weekly'
 ----
-CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' -- normalized!
-CREATE SCHEDULE FOR BACKUP TABLE (foo), (bar), (buz) INTO ('bar') WITH revision_history = (true) RECURRING ('@daily') FULL BACKUP ('@weekly') -- fully parenthesized
+CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO '*****' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' -- normalized!
+CREATE SCHEDULE FOR BACKUP TABLE (foo), (bar), (buz) INTO ('*****') WITH revision_history = (true) RECURRING ('@daily') FULL BACKUP ('@weekly') -- fully parenthesized
 CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO '_' WITH revision_history = _ RECURRING '_' FULL BACKUP '_' -- literals removed
-CREATE SCHEDULE FOR BACKUP TABLE _, _, _ INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE _, _, _ INTO '*****' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP TABLE foo, bar, buz INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' -- passwords exposed
 
 parse
 CREATE SCHEDULE FOR BACKUP INTO 'bar' WITH revision_history RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS foo = 'bar'
 ----
-CREATE SCHEDULE FOR BACKUP INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS foo = 'bar' -- normalized!
-CREATE SCHEDULE FOR BACKUP INTO ('bar') WITH revision_history = (true) RECURRING ('@daily') FULL BACKUP ('@weekly') WITH SCHEDULE OPTIONS foo = ('bar') -- fully parenthesized
+CREATE SCHEDULE FOR BACKUP INTO '*****' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS foo = 'bar' -- normalized!
+CREATE SCHEDULE FOR BACKUP INTO ('*****') WITH revision_history = (true) RECURRING ('@daily') FULL BACKUP ('@weekly') WITH SCHEDULE OPTIONS foo = ('bar') -- fully parenthesized
 CREATE SCHEDULE FOR BACKUP INTO '_' WITH revision_history = _ RECURRING '_' FULL BACKUP '_' WITH SCHEDULE OPTIONS foo = '_' -- literals removed
-CREATE SCHEDULE FOR BACKUP INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS _ = 'bar' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP INTO '*****' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS _ = 'bar' -- identifiers removed
+CREATE SCHEDULE FOR BACKUP INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS foo = 'bar' -- passwords exposed
 
 parse
 CREATE SCHEDULE IF NOT EXISTS 'baz' FOR BACKUP INTO 'bar' WITH revision_history RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS first_run = 'now'
 ----
-CREATE SCHEDULE IF NOT EXISTS 'baz' FOR BACKUP INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS first_run = 'now' -- normalized!
-CREATE SCHEDULE IF NOT EXISTS ('baz') FOR BACKUP INTO ('bar') WITH revision_history = (true) RECURRING ('@daily') FULL BACKUP ('@weekly') WITH SCHEDULE OPTIONS first_run = ('now') -- fully parenthesized
+CREATE SCHEDULE IF NOT EXISTS 'baz' FOR BACKUP INTO '*****' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS first_run = 'now' -- normalized!
+CREATE SCHEDULE IF NOT EXISTS ('baz') FOR BACKUP INTO ('*****') WITH revision_history = (true) RECURRING ('@daily') FULL BACKUP ('@weekly') WITH SCHEDULE OPTIONS first_run = ('now') -- fully parenthesized
 CREATE SCHEDULE IF NOT EXISTS '_' FOR BACKUP INTO '_' WITH revision_history = _ RECURRING '_' FULL BACKUP '_' WITH SCHEDULE OPTIONS first_run = '_' -- literals removed
-CREATE SCHEDULE IF NOT EXISTS 'baz' FOR BACKUP INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS _ = 'now' -- identifiers removed
+CREATE SCHEDULE IF NOT EXISTS 'baz' FOR BACKUP INTO '*****' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS _ = 'now' -- identifiers removed
+CREATE SCHEDULE IF NOT EXISTS 'baz' FOR BACKUP INTO 'bar' WITH revision_history = true RECURRING '@daily' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS first_run = 'now' -- passwords exposed
 
 # Scheduled Changefeed Tests
 

--- a/pkg/sql/parser/testdata/import_export
+++ b/pkg/sql/parser/testdata/import_export
@@ -1,66 +1,74 @@
 parse
 IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'
 ----
-IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal://0/foo/bar') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT TABLE foo FROM PGDUMPCREATE '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT TABLE foo FROM PGDUMPCREATE ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT TABLE foo FROM PGDUMPCREATE '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT TABLE _ FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT TABLE _ FROM PGDUMPCREATE '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal://0/foo/bar') WITH temp = 'path/to/temp'
 ----
-IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal://0/foo/bar') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT TABLE foo FROM PGDUMPCREATE '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT TABLE foo FROM PGDUMPCREATE ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT TABLE foo FROM PGDUMPCREATE '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT TABLE _ FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT TABLE _ FROM PGDUMPCREATE '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 IMPORT INTO foo(id, email) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'
 ----
-IMPORT INTO foo(id, email) CSV DATA ('path/to/some/file', $1) WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT INTO foo(id, email) CSV DATA (('path/to/some/file'), ($1)) WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT INTO foo(id, email) CSV DATA ('*****', $1) WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT INTO foo(id, email) CSV DATA (('*****'), ($1)) WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT INTO foo(id, email) CSV DATA ('_', $1) WITH OPTIONS (temp = '_') -- literals removed
-IMPORT INTO _(_, _) CSV DATA ('path/to/some/file', $1) WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT INTO _(_, _) CSV DATA ('*****', $1) WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT INTO foo(id, email) CSV DATA ('path/to/some/file', $1) WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 IMPORT INTO foo CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'
 ----
-IMPORT INTO foo CSV DATA ('path/to/some/file', $1) WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT INTO foo CSV DATA (('path/to/some/file'), ($1)) WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT INTO foo CSV DATA ('*****', $1) WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT INTO foo CSV DATA (('*****'), ($1)) WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT INTO foo CSV DATA ('_', $1) WITH OPTIONS (temp = '_') -- literals removed
-IMPORT INTO _ CSV DATA ('path/to/some/file', $1) WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT INTO _ CSV DATA ('*****', $1) WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT INTO foo CSV DATA ('path/to/some/file', $1) WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'
 ----
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'
 ----
-EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-EXPLAIN IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+EXPLAIN IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+EXPLAIN IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 EXPLAIN IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+EXPLAIN IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH temp = 'path/to/temp'
 ----
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH OPTIONS (temp = 'path/to/temp')
 ----
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
+IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
+IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
 IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
+IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 EXPORT INTO CSV 'a' FROM TABLE a

--- a/pkg/sql/parser/testdata/import_export
+++ b/pkg/sql/parser/testdata/import_export
@@ -73,31 +73,35 @@ IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- pa
 parse
 EXPORT INTO CSV 'a' FROM TABLE a
 ----
-EXPORT INTO CSV 'a' FROM TABLE a
-EXPORT INTO CSV ('a') FROM TABLE a -- fully parenthesized
+EXPORT INTO CSV '*****' FROM TABLE a -- normalized!
+EXPORT INTO CSV ('*****') FROM TABLE a -- fully parenthesized
 EXPORT INTO CSV '_' FROM TABLE a -- literals removed
-EXPORT INTO CSV 'a' FROM TABLE _ -- identifiers removed
+EXPORT INTO CSV '*****' FROM TABLE _ -- identifiers removed
+EXPORT INTO CSV 'a' FROM TABLE a -- passwords exposed
 
 parse
 EXPORT INTO CSV 'a' FROM SELECT * FROM a
 ----
-EXPORT INTO CSV 'a' FROM SELECT * FROM a
-EXPORT INTO CSV ('a') FROM SELECT (*) FROM a -- fully parenthesized
+EXPORT INTO CSV '*****' FROM SELECT * FROM a -- normalized!
+EXPORT INTO CSV ('*****') FROM SELECT (*) FROM a -- fully parenthesized
 EXPORT INTO CSV '_' FROM SELECT * FROM a -- literals removed
-EXPORT INTO CSV 'a' FROM SELECT * FROM _ -- identifiers removed
+EXPORT INTO CSV '*****' FROM SELECT * FROM _ -- identifiers removed
+EXPORT INTO CSV 'a' FROM SELECT * FROM a -- passwords exposed
 
 parse
 EXPORT INTO CSV 's3://my/path/%part%.csv' WITH delimiter = '|' FROM TABLE a
 ----
-EXPORT INTO CSV 's3://my/path/%part%.csv' WITH OPTIONS(delimiter = '|') FROM TABLE a -- normalized!
-EXPORT INTO CSV ('s3://my/path/%part%.csv') WITH OPTIONS(delimiter = ('|')) FROM TABLE a -- fully parenthesized
+EXPORT INTO CSV '*****' WITH OPTIONS(delimiter = '|') FROM TABLE a -- normalized!
+EXPORT INTO CSV ('*****') WITH OPTIONS(delimiter = ('|')) FROM TABLE a -- fully parenthesized
 EXPORT INTO CSV '_' WITH OPTIONS(delimiter = '_') FROM TABLE a -- literals removed
-EXPORT INTO CSV 's3://my/path/%part%.csv' WITH OPTIONS(_ = '|') FROM TABLE _ -- identifiers removed
+EXPORT INTO CSV '*****' WITH OPTIONS(_ = '|') FROM TABLE _ -- identifiers removed
+EXPORT INTO CSV 's3://my/path/%part%.csv' WITH OPTIONS(delimiter = '|') FROM TABLE a -- passwords exposed
 
 parse
 EXPORT INTO CSV 's3://my/path/%part%.csv' WITH delimiter = '|' FROM SELECT a, sum(b) FROM c WHERE d = 1 ORDER BY sum(b) DESC LIMIT 10
 ----
-EXPORT INTO CSV 's3://my/path/%part%.csv' WITH OPTIONS(delimiter = '|') FROM SELECT a, sum(b) FROM c WHERE d = 1 ORDER BY sum(b) DESC LIMIT 10 -- normalized!
-EXPORT INTO CSV ('s3://my/path/%part%.csv') WITH OPTIONS(delimiter = ('|')) FROM SELECT (a), (sum((b))) FROM c WHERE ((d) = (1)) ORDER BY (sum((b))) DESC LIMIT (10) -- fully parenthesized
+EXPORT INTO CSV '*****' WITH OPTIONS(delimiter = '|') FROM SELECT a, sum(b) FROM c WHERE d = 1 ORDER BY sum(b) DESC LIMIT 10 -- normalized!
+EXPORT INTO CSV ('*****') WITH OPTIONS(delimiter = ('|')) FROM SELECT (a), (sum((b))) FROM c WHERE ((d) = (1)) ORDER BY (sum((b))) DESC LIMIT (10) -- fully parenthesized
 EXPORT INTO CSV '_' WITH OPTIONS(delimiter = '_') FROM SELECT a, sum(b) FROM c WHERE d = _ ORDER BY sum(b) DESC LIMIT _ -- literals removed
-EXPORT INTO CSV 's3://my/path/%part%.csv' WITH OPTIONS(_ = '|') FROM SELECT _, _(_) FROM _ WHERE _ = 1 ORDER BY _(_) DESC LIMIT 10 -- identifiers removed
+EXPORT INTO CSV '*****' WITH OPTIONS(_ = '|') FROM SELECT _, _(_) FROM _ WHERE _ = 1 ORDER BY _(_) DESC LIMIT 10 -- identifiers removed
+EXPORT INTO CSV 's3://my/path/%part%.csv' WITH OPTIONS(delimiter = '|') FROM SELECT a, sum(b) FROM c WHERE d = 1 ORDER BY sum(b) DESC LIMIT 10 -- passwords exposed

--- a/pkg/sql/parser/testdata/prepared_stmts
+++ b/pkg/sql/parser/testdata/prepared_stmts
@@ -97,10 +97,11 @@ PREPARE _ (INT8) AS DELETE FROM _ WHERE _ = $1 -- identifiers removed
 parse
 PREPARE a AS BACKUP DATABASE a TO 'b'
 ----
-PREPARE a AS BACKUP DATABASE a TO 'b'
-PREPARE a AS BACKUP DATABASE a TO ('b') -- fully parenthesized
+PREPARE a AS BACKUP DATABASE a TO '*****' -- normalized!
+PREPARE a AS BACKUP DATABASE a TO ('*****') -- fully parenthesized
 PREPARE a AS BACKUP DATABASE a TO '_' -- literals removed
-PREPARE _ AS BACKUP DATABASE _ TO 'b' -- identifiers removed
+PREPARE _ AS BACKUP DATABASE _ TO '*****' -- identifiers removed
+PREPARE a AS BACKUP DATABASE a TO 'b' -- passwords exposed
 
 parse
 PREPARE a (STRING) AS BACKUP DATABASE a TO $1
@@ -113,10 +114,11 @@ PREPARE _ (STRING) AS BACKUP DATABASE _ TO $1 -- identifiers removed
 parse
 PREPARE a AS RESTORE DATABASE a FROM 'b'
 ----
-PREPARE a AS RESTORE DATABASE a FROM 'b'
-PREPARE a AS RESTORE DATABASE a FROM ('b') -- fully parenthesized
+PREPARE a AS RESTORE DATABASE a FROM '*****' -- normalized!
+PREPARE a AS RESTORE DATABASE a FROM ('*****') -- fully parenthesized
 PREPARE a AS RESTORE DATABASE a FROM '_' -- literals removed
-PREPARE _ AS RESTORE DATABASE _ FROM 'b' -- identifiers removed
+PREPARE _ AS RESTORE DATABASE _ FROM '*****' -- identifiers removed
+PREPARE a AS RESTORE DATABASE a FROM 'b' -- passwords exposed
 
 parse
 PREPARE a (STRING) AS RESTORE DATABASE a FROM $1

--- a/pkg/sql/parser/testdata/prepared_stmts
+++ b/pkg/sql/parser/testdata/prepared_stmts
@@ -267,10 +267,11 @@ PREPARE _ (INT8) AS RESUME JOBS SELECT $1 -- identifiers removed
 parse
 PREPARE a AS IMPORT INTO a CSV DATA ('c') WITH temp = 'd'
 ----
-PREPARE a AS IMPORT INTO a CSV DATA ('c') WITH OPTIONS (temp = 'd') -- normalized!
-PREPARE a AS IMPORT INTO a CSV DATA (('c')) WITH OPTIONS (temp = ('d')) -- fully parenthesized
+PREPARE a AS IMPORT INTO a CSV DATA ('*****') WITH OPTIONS (temp = 'd') -- normalized!
+PREPARE a AS IMPORT INTO a CSV DATA (('*****')) WITH OPTIONS (temp = ('d')) -- fully parenthesized
 PREPARE a AS IMPORT INTO a CSV DATA ('_') WITH OPTIONS (temp = '_') -- literals removed
-PREPARE _ AS IMPORT INTO _ CSV DATA ('c') WITH OPTIONS (_ = 'd') -- identifiers removed
+PREPARE _ AS IMPORT INTO _ CSV DATA ('*****') WITH OPTIONS (_ = 'd') -- identifiers removed
+PREPARE a AS IMPORT INTO a CSV DATA ('c') WITH OPTIONS (temp = 'd') -- passwords exposed
 
 parse
 PREPARE a (STRING, STRING, STRING) AS IMPORT INTO a CSV DATA ($2) WITH temp = $3

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -2063,23 +2063,26 @@ SHOW VIRTUAL CLUSTER _ WITH REPLICATION STATUS, CAPABILITIES -- identifiers remo
 parse
 SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privileges, debug_dump_metadata_sst
 ----
-SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH OPTIONS (incremental_location = 'nullif', privileges, debug_dump_metadata_sst) -- normalized!
-SHOW BACKUP ('family') IN (('string'), ('placeholder'), ('placeholder'), ('placeholder'), ('string'), ('placeholder'), ('string'), ('placeholder')) WITH OPTIONS (incremental_location = ('nullif'), privileges, debug_dump_metadata_sst) -- fully parenthesized
+SHOW BACKUP 'family' IN ('*****', '*****', '*****', '*****', '*****', '*****', '*****', '*****') WITH OPTIONS (incremental_location = '*****', privileges, debug_dump_metadata_sst) -- normalized!
+SHOW BACKUP ('family') IN (('*****'), ('*****'), ('*****'), ('*****'), ('*****'), ('*****'), ('*****'), ('*****')) WITH OPTIONS (incremental_location = ('*****'), privileges, debug_dump_metadata_sst) -- fully parenthesized
 SHOW BACKUP '_' IN ('_', '_', '_', '_', '_', '_', '_', '_') WITH OPTIONS (incremental_location = '_', privileges, debug_dump_metadata_sst) -- literals removed
-SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH OPTIONS (incremental_location = 'nullif', privileges, debug_dump_metadata_sst) -- identifiers removed
+SHOW BACKUP 'family' IN ('*****', '*****', '*****', '*****', '*****', '*****', '*****', '*****') WITH OPTIONS (incremental_location = '*****', privileges, debug_dump_metadata_sst) -- identifiers removed
+SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH OPTIONS (incremental_location = 'nullif', privileges, debug_dump_metadata_sst) -- passwords exposed
 
 parse
 SHOW BACKUP 'abc' WITH SKIP SIZE
 ----
-SHOW BACKUP 'abc' WITH OPTIONS (skip size) -- normalized!
-SHOW BACKUP ('abc') WITH OPTIONS (skip size) -- fully parenthesized
+SHOW BACKUP '*****' WITH OPTIONS (skip size) -- normalized!
+SHOW BACKUP ('*****') WITH OPTIONS (skip size) -- fully parenthesized
 SHOW BACKUP '_' WITH OPTIONS (skip size) -- literals removed
-SHOW BACKUP 'abc' WITH OPTIONS (skip size) -- identifiers removed
+SHOW BACKUP '*****' WITH OPTIONS (skip size) -- identifiers removed
+SHOW BACKUP 'abc' WITH OPTIONS (skip size) -- passwords exposed
 
 parse
 SHOW BACKUP 'abc' WITH NOWAIT
 ----
-SHOW BACKUP 'abc' WITH OPTIONS (skip size) -- normalized!
-SHOW BACKUP ('abc') WITH OPTIONS (skip size) -- fully parenthesized
+SHOW BACKUP '*****' WITH OPTIONS (skip size) -- normalized!
+SHOW BACKUP ('*****') WITH OPTIONS (skip size) -- fully parenthesized
 SHOW BACKUP '_' WITH OPTIONS (skip size) -- literals removed
-SHOW BACKUP 'abc' WITH OPTIONS (skip size) -- identifiers removed
+SHOW BACKUP '*****' WITH OPTIONS (skip size) -- identifiers removed
+SHOW BACKUP 'abc' WITH OPTIONS (skip size) -- passwords exposed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
@@ -8,12 +8,12 @@ END
 ----
 DECLARE
 BEGIN
-IMPORT TABLE foo FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql' WITH OPTIONS (max_row_size = '524288');
+IMPORT TABLE foo FROM PGDUMP '*****' WITH OPTIONS (max_row_size = '524288');
 END
  -- normalized!
 DECLARE
 BEGIN
-IMPORT TABLE foo FROM PGDUMP ('userfile://defaultdb.public.userfiles_root/db.sql') WITH OPTIONS (max_row_size = ('524288'));
+IMPORT TABLE foo FROM PGDUMP ('*****') WITH OPTIONS (max_row_size = ('524288'));
 END
  -- fully parenthesized
 DECLARE
@@ -23,9 +23,14 @@ END
  -- literals removed
 DECLARE
 BEGIN
-IMPORT TABLE _ FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql' WITH OPTIONS (_ = '524288');
+IMPORT TABLE _ FROM PGDUMP '*****' WITH OPTIONS (_ = '524288');
 END
  -- identifiers removed
+DECLARE
+BEGIN
+IMPORT TABLE foo FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql' WITH OPTIONS (max_row_size = '524288');
+END
+ -- passwords exposed
 
 parse
 DECLARE

--- a/pkg/sql/sem/tree/alter_backup.go
+++ b/pkg/sql/sem/tree/alter_backup.go
@@ -29,7 +29,7 @@ func (node *AlterBackup) Format(ctx *FmtCtx) {
 		ctx.WriteString(" IN ")
 	}
 
-	ctx.FormatNode(node.Backup)
+	ctx.FormatURI(node.Backup)
 	ctx.FormatNode(&node.Cmds)
 }
 
@@ -64,10 +64,10 @@ type AlterBackupKMS struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterBackupKMS) Format(ctx *FmtCtx) {
 	ctx.WriteString(" ADD NEW_KMS=")
-	ctx.FormatNode(&node.KMSInfo.NewKMSURI)
+	ctx.FormatURIs(node.KMSInfo.NewKMSURI)
 
 	ctx.WriteString(" WITH OLD_KMS=")
-	ctx.FormatNode(&node.KMSInfo.OldKMSURI)
+	ctx.FormatURIs(node.KMSInfo.OldKMSURI)
 }
 
 // BackupKMS represents possible options used when altering a backup KMS

--- a/pkg/sql/sem/tree/alter_backup_schedule.go
+++ b/pkg/sql/sem/tree/alter_backup_schedule.go
@@ -86,7 +86,7 @@ type AlterBackupScheduleSetInto struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterBackupScheduleSetInto) Format(ctx *FmtCtx) {
 	ctx.WriteString("SET INTO ")
-	ctx.FormatNode(&node.Into)
+	ctx.FormatURIs(node.Into)
 }
 
 // AlterBackupScheduleSetWith represents an SET <options> command

--- a/pkg/sql/sem/tree/alter_changefeed.go
+++ b/pkg/sql/sem/tree/alter_changefeed.go
@@ -91,7 +91,15 @@ type AlterChangefeedSetOptions struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterChangefeedSetOptions) Format(ctx *FmtCtx) {
 	ctx.WriteString(" SET ")
-	ctx.FormatNode(&node.Options)
+	node.Options.formatEach(ctx, func(n *KVOption, ctx *FmtCtx) {
+		// The "sink" option is a URL. (Use a literal here to avoid pulling in
+		// changefeedbase as a dependency.)
+		if string(n.Key) == "sink" {
+			ctx.FormatURI(n.Value)
+		} else {
+			ctx.FormatNode(n.Value)
+		}
+	})
 }
 
 // AlterChangefeedUnsetOptions represents an UNSET <options> command

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -101,14 +101,19 @@ func (node *Backup) Format(ctx *FmtCtx) {
 	} else {
 		ctx.WriteString("TO ")
 	}
-	ctx.FormatNode(&node.To)
+	ctx.FormatURIs(node.To)
 	if node.AsOf.Expr != nil {
 		ctx.WriteString(" ")
 		ctx.FormatNode(&node.AsOf)
 	}
 	if node.IncrementalFrom != nil {
 		ctx.WriteString(" INCREMENTAL FROM ")
-		ctx.FormatNode(&node.IncrementalFrom)
+		for i, from := range node.IncrementalFrom {
+			if i > 0 {
+				ctx.WriteString(", ")
+			}
+			ctx.FormatURI(from)
+		}
 	}
 
 	if !node.Options.IsDefault() {
@@ -194,7 +199,7 @@ func (node *Restore) Format(ctx *FmtCtx) {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(&node.From[i])
+		ctx.FormatURIs(node.From[i])
 	}
 	if node.AsOf.Expr != nil {
 		ctx.WriteString(" ")
@@ -301,13 +306,13 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 	if o.EncryptionKMSURI != nil {
 		maybeAddSep()
 		ctx.WriteString("kms = ")
-		ctx.FormatNode(&o.EncryptionKMSURI)
+		ctx.FormatURIs(o.EncryptionKMSURI)
 	}
 
 	if o.IncrementalStorage != nil {
 		maybeAddSep()
 		ctx.WriteString("incremental_location = ")
-		ctx.FormatNode(&o.IncrementalStorage)
+		ctx.FormatURIs(o.IncrementalStorage)
 	}
 
 	if o.ExecutionLocality != nil {
@@ -425,7 +430,7 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 	if o.DecryptionKMSURI != nil {
 		maybeAddSep()
 		ctx.WriteString("kms = ")
-		ctx.FormatNode(&o.DecryptionKMSURI)
+		ctx.FormatURIs(o.DecryptionKMSURI)
 	}
 
 	if o.IntoDB != nil {
@@ -490,7 +495,7 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 	if o.IncrementalStorage != nil {
 		maybeAddSep()
 		ctx.WriteString("incremental_location = ")
-		ctx.FormatNode(&o.IncrementalStorage)
+		ctx.FormatURIs(o.IncrementalStorage)
 	}
 
 	if o.AsTenant != nil {

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -239,6 +239,13 @@ func (o *KVOptions) HasKey(key Name) bool {
 
 // Format implements the NodeFormatter interface.
 func (o *KVOptions) Format(ctx *FmtCtx) {
+	o.formatEach(ctx, func(n *KVOption, ctx *FmtCtx) {
+		ctx.FormatNode(n.Value)
+	})
+}
+
+// formatEach is like Format but allows custom formatting of the value part.
+func (o *KVOptions) formatEach(ctx *FmtCtx, formatValue func(*KVOption, *FmtCtx)) {
 	for i := range *o {
 		n := &(*o)[i]
 		if i > 0 {
@@ -251,7 +258,7 @@ func (o *KVOptions) Format(ctx *FmtCtx) {
 		})
 		if n.Value != nil {
 			ctx.WriteString(` = `)
-			ctx.FormatNode(n.Value)
+			formatValue(n, ctx)
 		}
 	}
 }

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -44,7 +44,7 @@ func (node *CreateChangefeed) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Targets)
 	if node.SinkURI != nil {
 		ctx.WriteString(" INTO ")
-		ctx.FormatNode(node.SinkURI)
+		ctx.FormatURI(node.SinkURI)
 	}
 	if node.Options != nil {
 		ctx.WriteString(" WITH OPTIONS (")

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -129,7 +129,7 @@ func (o *CopyOptions) Format(ctx *FmtCtx) {
 		// by copy_file_upload.go, so this will provide backward
 		// compatibility with older servers.
 		ctx.WriteString("DESTINATION ")
-		ctx.FormatNode(o.Destination)
+		ctx.FormatURI(o.Destination)
 		addSep = true
 	}
 	if o.Escape != nil {

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2176,7 +2176,7 @@ func (node *CreateExternalConnection) Format(ctx *FmtCtx) {
 	ctx.WriteString("CREATE EXTERNAL CONNECTION")
 	ctx.FormatNode(&node.ConnectionLabelSpec)
 	ctx.WriteString(" AS ")
-	ctx.FormatNode(node.As)
+	ctx.FormatURI(node.As)
 }
 
 // CreateTenant represents a CREATE VIRTUAL CLUSTER statement.

--- a/pkg/sql/sem/tree/export.go
+++ b/pkg/sql/sem/tree/export.go
@@ -25,7 +25,7 @@ func (node *Export) Format(ctx *FmtCtx) {
 	ctx.WriteString("EXPORT INTO ")
 	ctx.WriteString(node.FileFormat)
 	ctx.WriteString(" ")
-	ctx.FormatNode(node.File)
+	ctx.FormatURI(node.File)
 	if node.Options != nil {
 		ctx.WriteString(" WITH OPTIONS(")
 		ctx.FormatNode(&node.Options)

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -35,7 +35,7 @@ func (node *Import) Format(ctx *FmtCtx) {
 		}
 		ctx.WriteString(node.FileFormat)
 		ctx.WriteByte(' ')
-		ctx.FormatNode(&node.Files)
+		ctx.FormatURIs(node.Files)
 	} else {
 		if node.Into {
 			ctx.WriteString("INTO ")
@@ -52,9 +52,14 @@ func (node *Import) Format(ctx *FmtCtx) {
 			ctx.FormatNode(node.Table)
 		}
 		ctx.WriteString(node.FileFormat)
-		ctx.WriteString(" DATA (")
-		ctx.FormatNode(&node.Files)
-		ctx.WriteString(")")
+		ctx.WriteString(" DATA ")
+		if len(node.Files) == 1 {
+			ctx.WriteString("(")
+		}
+		ctx.FormatURIs(node.Files)
+		if len(node.Files) == 1 {
+			ctx.WriteString(")")
+		}
 	}
 
 	if node.Options != nil {

--- a/pkg/sql/sem/tree/schedule.go
+++ b/pkg/sql/sem/tree/schedule.go
@@ -60,7 +60,7 @@ func (node *ScheduledBackup) Format(ctx *FmtCtx) {
 	}
 
 	ctx.WriteString(" INTO ")
-	ctx.FormatNode(&node.To)
+	ctx.FormatURIs(node.To)
 
 	if !node.BackupOptions.IsDefault() {
 		ctx.WriteString(" WITH ")

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -113,7 +113,7 @@ type ShowBackup struct {
 func (node *ShowBackup) Format(ctx *FmtCtx) {
 	if node.InCollection != nil && node.Path == nil {
 		ctx.WriteString("SHOW BACKUPS IN ")
-		ctx.FormatNode(&node.InCollection)
+		ctx.FormatURIs(node.InCollection)
 		return
 	}
 	ctx.WriteString("SHOW BACKUP ")
@@ -133,10 +133,12 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.WriteString("FROM ")
 	}
 
-	ctx.FormatNode(node.Path)
 	if node.InCollection != nil {
+		ctx.FormatNode(node.Path)
 		ctx.WriteString(" IN ")
-		ctx.FormatNode(&node.InCollection)
+		ctx.FormatURIs(node.InCollection)
+	} else {
+		ctx.FormatURI(node.Path)
 	}
 	if !node.Options.IsDefault() {
 		ctx.WriteString(" WITH OPTIONS (")
@@ -205,7 +207,7 @@ func (o *ShowBackupOptions) Format(ctx *FmtCtx) {
 	if o.IncrementalStorage != nil {
 		maybeAddSep()
 		ctx.WriteString("incremental_location = ")
-		ctx.FormatNode(&o.IncrementalStorage)
+		ctx.FormatURIs(o.IncrementalStorage)
 	}
 
 	if o.Privileges {
@@ -221,7 +223,7 @@ func (o *ShowBackupOptions) Format(ctx *FmtCtx) {
 	if o.DecryptionKMSURI != nil {
 		maybeAddSep()
 		ctx.WriteString("kms = ")
-		ctx.FormatNode(&o.DecryptionKMSURI)
+		ctx.FormatURIs(o.DecryptionKMSURI)
 	}
 	if o.SkipSize {
 		maybeAddSep()


### PR DESCRIPTION
Backport 9/9 commits from #126970.

/cc @cockroachdb/release

---

Prior to this change, all SQL statements containing URLs would be formatted with the full URL in cleartext, including any secrets such as keys or passwords. These secrets would sometimes show up in the slow query log or sql audit log. This PR adds new functions `tree.(*FmtCtx).FormatURI`and `tree.(*FmtCtx).FormatURIs` which are designed to sanitize URLs during formatting.

See individual commits for details.

Fixes: CRDB-39710, TREQ-284

Epic: None

Release note: None

---

Release justification: fix for security issue.