### PR TITLE
sql: make datum compare safe to use with nil eval contexts

### DIFF
--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -110,6 +110,7 @@ go_test(
     srcs = [
         "cast_map_test.go",
         "cast_test.go",
+        "compare_test.go",
         "eval_internal_test.go",
         "eval_test.go",
         "like_test.go",
@@ -149,10 +150,12 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/stop",
+        "//pkg/util/timeofday",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_lib_pq//oid",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sem/eval/compare_test.go
+++ b/pkg/sql/sem/eval/compare_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package eval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that we can compare random datums with a nil eval context.
+func TestNilEvalContextCompareRandom(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var cmpCtx *eval.Context
+	rng, _ := randutil.NewTestRand()
+
+	for trial := 0; trial < 40; trial++ {
+		typ := randgen.RandType(rng)
+		left := randgen.RandDatum(rng, typ, true /* nullOk */)
+		right := randgen.RandDatum(rng, typ, true /* nullOk */)
+		_, err := left.Compare(ctx, cmpCtx, right)
+		assert.NoError(t, err)
+
+		// Also test comparing a random datum to itself with a nil eval context.
+		var res int
+		res, err = left.Compare(ctx, cmpCtx, left)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, res)
+	}
+}
+
+// Test that we can compare two equal TimeTZ datums with a nil eval context.
+func TestNilEvalContextCompareTimeTZ(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var cmpCtx *eval.Context
+
+	time := timeofday.New(22, 0, 0, 0)
+	res, err := tree.NewDTimeTZFromOffset(time, 0).Compare(
+		ctx,
+		cmpCtx,
+		tree.NewDTimeTZFromOffset(time, 0),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, res)
+}

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -711,6 +711,9 @@ func TimestampToInexactDTimestamp(ts hlc.Timestamp) *tree.DTimestamp {
 
 // GetRelativeParseTime implements ParseContext.
 func (ec *Context) GetRelativeParseTime() time.Time {
+	if ec == nil {
+		return timeutil.Now()
+	}
 	ret := ec.TxnTimestamp
 	if ret.IsZero() {
 		ret = timeutil.Now()

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -115,7 +115,9 @@ type Datum interface {
 	AmbiguousFormat() bool
 
 	// Compare returns -1 if the receiver is less than other, 0 if receiver is
-	// equal to other and +1 if receiver is greater than 'other'.
+	// equal to other and +1 if receiver is greater than 'other'. Compare is safe
+	// to use with a nil eval.Context and results in default behavior, except for
+	// when comparing tree.Placeholder datums.
 	Compare(ctx context.Context, cmpCtx CompareContext, other Datum) (int, error)
 
 	// Prev returns the previous datum and true, if one exists, or nil and false.


### PR DESCRIPTION
This commit adds a nil check to the `eval.Context` implementation of `GetRelativeParseTime()`. This change makes the datum `.Compare()` function safe to use with nil eval contexts, which is useful in places such as the histogram merging code called by the stat cache where we don't have an eval context.

Fixes: #126856

See also: #125950

Release note: None