### PR TITLE
kv: terminate retryable errors from other txns

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1087,7 +1087,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 					// TransactionRetryWithProtoRefreshError if the closure ran another
 					// transaction internally and let the error propagate upwards instead
 					// of handling it.
-					return errors.Wrapf(err, "retryable error from another txn")
+					return errors.Wrap(errors.Opaque(err), "retryable error from another txn")
 				}
 				if txn.isClientFinalized() {
 					// We've already committed or rolled back, so we can't retry. The


### PR DESCRIPTION
Previously, this wasn't happening because we were wrapping the error, which retains the retryable error as part of the error cause stack. The comment indicates the intention was not to do so; we fix this by eschewing wrapping.

Epic: none

Release note: None