### PR TITLE
workflows: run `update_releases` on release-24.2

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -25,7 +25,12 @@ jobs:
     environment: ${{ github.ref_name == 'master' && 'master' || null }}
     strategy:
       matrix:
-        branch: ["master", "release-23.1", "release-23.2", "release-24.1"]
+        branch:
+          - "master"
+          - "release-23.1"
+          - "release-23.2"
+          - "release-24.1"
+          - "release-24.2"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Epic: none
Release note: None