### PR TITLE
release-24.2: crosscluster: add dlq tests and refactor

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -130,6 +130,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/span",
         "//pkg/util/syncutil",

--- a/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
@@ -22,16 +22,24 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	defaultDbName = "defaultdb"
+	publicScName  = "public"
 )
 
 func TestLoggingDLQClient(t *testing.T) {
@@ -47,7 +55,7 @@ func TestLoggingDLQClient(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT)`)
 
 	tableName := "foo"
-	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), defaultDbName, tableName)
 	familyDesc := &descpb.ColumnFamilyDescriptor{
 		ID:   descpb.FamilyID(1),
 		Name: "",
@@ -56,9 +64,8 @@ func TestLoggingDLQClient(t *testing.T) {
 	ed, err := cdcevent.NewEventDescriptor(tableDesc, familyDesc, false, false, hlc.Timestamp{})
 	require.NoError(t, err)
 
-	tableID := int32(tableDesc.GetID())
 	dlqClient := InitLoggingDeadLetterQueueClient()
-	require.NoError(t, dlqClient.Create(ctx, []int32{tableID}))
+	require.NoError(t, dlqClient.Create(ctx))
 
 	type testCase struct {
 		name           string
@@ -111,45 +118,105 @@ func TestDLQClient(t *testing.T) {
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE TABLE foo (a INT)`)
+	sqlDB.Exec(t, `CREATE SCHEMA baz`)
+	sqlDB.Exec(t, `CREATE TABLE baz.foo (a INT)`)
 
-	tableName := "foo"
-	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
+	sqlDB.Exec(t, `CREATE DATABASE a`)
+	sqlDB.Exec(t, `CREATE SCHEMA a.baz`)
+	sqlDB.Exec(t, `CREATE TABLE a.public.bar (a INT)`)
+	sqlDB.Exec(t, `CREATE TABLE a.baz.foo (a INT)`)
+
+	dbAName := "a"
+
+	tableNames := []fullyQualifiedTableName{
+		{
+			database: defaultDbName,
+			schema:   publicScName,
+			table:    "foo",
+		},
+		{
+			database: defaultDbName,
+			schema:   "baz",
+			table:    "foo",
+		},
+		{
+			database: dbAName,
+			schema:   publicScName,
+			table:    "bar",
+		},
+		{
+			database: dbAName,
+			schema:   "baz",
+			table:    "foo",
+		},
+	}
+
+	tableNameToDesc := make(map[string]catalog.TableDescriptor)
+	tableIDToName := make(map[int32]fullyQualifiedTableName)
+
+	for _, name := range tableNames {
+		desc := desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), name.database, name.schema, name.table)
+		tableIDToName[int32(desc.GetID())] = name
+		tableNameToDesc[fmt.Sprintf("%s.%s.%s", name.database, name.schema, name.table)] = desc
+	}
+
+	// Build family desc for cdc event row
 	familyDesc := &descpb.ColumnFamilyDescriptor{
 		ID:   descpb.FamilyID(1),
 		Name: "",
 	}
 
-	ed, err := cdcevent.NewEventDescriptor(tableDesc, familyDesc, false, false, hlc.Timestamp{})
-	require.NoError(t, err)
+	dlqClient := InitDeadLetterQueueClient(ie, tableIDToName)
+	require.NoError(t, dlqClient.Create(ctx))
 
-	tableID := int32(tableDesc.GetID())
-	dlqClient := InitDeadLetterQueueClient(ie)
-	require.NoError(t, dlqClient.Create(ctx, []int32{tableID}))
-
-	var tableNameQueryResult string
-	sqlDB.QueryRow(t, `SELECT table_name FROM [SHOW TABLES FROM defaultdb]`).Scan(&tableNameQueryResult)
-	require.Equal(t, tableName, tableNameQueryResult)
+	enumRow := [][]string{
+		{dlqSchemaName, "mutation_type", "{insert,update,delete}"},
+	}
+	sqlDB.CheckQueryResults(t,
+		fmt.Sprintf(`SELECT schema, name, values FROM [SHOW ENUMS FROM %s.%s]`, defaultDbName, dlqSchemaName), enumRow)
+	sqlDB.CheckQueryResults(t,
+		fmt.Sprintf(`SELECT schema, name, values FROM [SHOW ENUMS FROM %s.%s]`, dbAName, dlqSchemaName), enumRow)
 
 	type testCase struct {
 		name           string
 		expectedErrMsg string
 
-		jobID       int64
-		tableID     int32
-		tableName   string
-		kv          streampb.StreamEvent_KV
-		cdcEventRow cdcevent.Row
-		applyError  error
-		dlqReason   retryEligibility
+		jobID        int64
+		tableDesc    catalog.TableDescriptor
+		kv           streampb.StreamEvent_KV
+		dlqReason    retryEligibility
+		mutationType ReplicationMutationType
+		applyError   error
 	}
 
 	testCases := []testCase{
 		{
-			name:        "insert row into dlq table",
-			cdcEventRow: cdcevent.Row{EventDescriptor: ed},
-			tableID:     tableID,
-			tableName:   tableName,
-			dlqReason:   noSpace,
+			name:         "insert dlq fallback row for default.public.foo",
+			jobID:        1,
+			tableDesc:    tableNameToDesc["defaultdb.public.foo"],
+			dlqReason:    noSpace,
+			mutationType: Insert,
+		},
+		{
+			name:         "insert dlq fallback row for default.baz.foo",
+			jobID:        1,
+			tableDesc:    tableNameToDesc["defaultdb.baz.foo"],
+			dlqReason:    tooOld,
+			mutationType: Insert,
+		},
+		{
+			name:         "insert dlq fallback row for a.public.bar",
+			jobID:        1,
+			tableDesc:    tableNameToDesc["a.public.bar"],
+			dlqReason:    noSpace,
+			mutationType: Insert,
+		},
+		{
+			name:         "insert dlq fallback row for a.baz.foo",
+			jobID:        1,
+			tableDesc:    tableNameToDesc["a.baz.foo"],
+			dlqReason:    tooOld,
+			mutationType: Insert,
 		},
 		{
 			name:           "expect error when given nil cdcEventRow",
@@ -157,14 +224,64 @@ func TestDLQClient(t *testing.T) {
 		},
 	}
 
+	type dlqRow struct {
+		jobID        int64
+		tableID      int32
+		dlqReason    string
+		mutationType string
+		kv           []byte
+		incomingRow  *tree.DJSON
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.applyError == nil {
 				tc.applyError = errors.New("some error")
 			}
-			err := dlqClient.Log(ctx, tc.jobID, tc.kv, tc.cdcEventRow, tc.dlqReason)
+
+			var cdcEventRow cdcevent.Row
+			if tc.expectedErrMsg == "" {
+				ed, err := cdcevent.NewEventDescriptor(tc.tableDesc, familyDesc, false, false, hlc.Timestamp{})
+				require.NoError(t, err)
+				cdcEventRow = cdcevent.Row{EventDescriptor: ed}
+			}
+
+			err := dlqClient.Log(ctx, tc.jobID, tc.kv, cdcEventRow, tc.dlqReason)
 			if tc.expectedErrMsg == "" {
 				require.NoError(t, err)
+
+				tableID := int32(tc.tableDesc.GetID())
+				name, ok := tableIDToName[tableID]
+				require.True(t, ok)
+
+				actualRow := dlqRow{}
+				sqlDB.QueryRow(t, fmt.Sprintf(`SELECT
+						ingestion_job_id,
+						table_id,
+						dlq_reason,
+						mutation_type,
+						key_value_bytes,
+						incoming_row
+				FROM %s`, fmt.Sprintf(dlqBaseTableName, name.database, dlqSchemaName, name.schema, name.table))).Scan(
+					&actualRow.jobID,
+					&actualRow.tableID,
+					&actualRow.dlqReason,
+					&actualRow.mutationType,
+					&actualRow.kv,
+					&actualRow.incomingRow,
+				)
+
+				bytes, err := protoutil.Marshal(&tc.kv)
+				require.NoError(t, err)
+
+				expectedRow := dlqRow{
+					jobID:        tc.jobID,
+					tableID:      tableID,
+					dlqReason:    tc.dlqReason.String(),
+					mutationType: tc.mutationType.String(),
+					kv:           bytes,
+				}
+				require.Equal(t, expectedRow, actualRow)
 			} else {
 				require.ErrorContains(t, err, tc.expectedErrMsg)
 			}
@@ -211,8 +328,14 @@ func TestDLQJSONQuery(t *testing.T) {
 	defer cleanup()
 
 	tableID := int32(tableDesc.GetID())
-	dlqClient := InitDeadLetterQueueClient(ie)
-	require.NoError(t, dlqClient.Create(ctx, []int32{tableID}))
+	dlqClient := InitDeadLetterQueueClient(ie, map[int32]fullyQualifiedTableName{
+		tableID: {
+			database: defaultDbName,
+			schema:   publicScName,
+			table:    "foo",
+		},
+	})
+	require.NoError(t, dlqClient.Create(ctx))
 
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'hello')`)
 	row := popRow(t)
@@ -224,7 +347,7 @@ func TestDLQJSONQuery(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, dlqClient.Log(ctx, 1, streampb.StreamEvent_KV{KeyValue: kv}, updatedRow, noSpace))
 
-	dlqtableName := fmt.Sprintf(dlqBaseTableName, tableID)
+	dlqtableName := fmt.Sprintf(dlqBaseTableName, defaultDbName, dlqSchemaName, publicScName, "foo")
 
 	var (
 		a     int

--- a/pkg/ccl/crosscluster/logical/logical_replication_dist.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_dist.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,7 +32,7 @@ func constructLogicalReplicationWriterSpecs(
 	initialScanTimestamp hlc.Timestamp,
 	previousReplicatedTimestamp hlc.Timestamp,
 	checkpoint jobspb.StreamIngestionCheckpoint,
-	tableDescs map[int32]descpb.TableDescriptor,
+	tableMd map[int32]execinfrapb.TableReplicationMetadata,
 	jobID jobspb.JobID,
 	streamID streampb.StreamID,
 ) (map[base.SQLInstanceID][]execinfrapb.LogicalReplicationWriterSpec, error) {
@@ -45,7 +44,7 @@ func constructLogicalReplicationWriterSpecs(
 		InitialScanTimestamp:        initialScanTimestamp,
 		Checkpoint:                  checkpoint, // TODO: Only forward relevant checkpoint info
 		StreamAddress:               string(streamAddress),
-		TableDescriptors:            tableDescs,
+		TableMetadata:               tableMd,
 	}
 
 	writerSpecs := make(map[base.SQLInstanceID][]execinfrapb.LogicalReplicationWriterSpec, len(destSQLInstances))

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -794,7 +794,7 @@ func (m mockBatchHandler) SetSyntheticFailurePercent(_ uint32) {}
 
 type mockDLQ int
 
-func (m *mockDLQ) Create(_ context.Context, _ []int32) error {
+func (m *mockDLQ) Create(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -561,8 +561,8 @@ func (s *LogicalReplicationWriterSpec) summary() (string, []string) {
 	const spanLimit = 9
 
 	tableNames := []string{}
-	for _, desc := range s.TableDescriptors {
-		tableNames = append(tableNames, desc.Name)
+	for _, table := range s.TableMetadata {
+		tableNames = append(tableNames, table.SourceDescriptor.Name)
 	}
 
 	annotations := []string{

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -480,6 +480,13 @@ message CloudStorageTestSpec {
   // NEXT ID: 3;
 }
 
+message TableReplicationMetadata {
+  optional cockroach.sql.sqlbase.TableDescriptor source_descriptor = 1 [(gogoproto.nullable) = false];
+  optional string destination_parent_database_name = 2 [(gogoproto.nullable) = false];
+  optional string destination_parent_schema_name = 3 [(gogoproto.nullable) = false];
+  optional string destination_table_name = 4 [(gogoproto.nullable) = false];
+}
+
 message LogicalReplicationWriterSpec {
     // JobID of the job that ran the replicationWriterProcessor.
     optional int64 job_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID"];
@@ -511,7 +518,7 @@ message LogicalReplicationWriterSpec {
     // Checkpoint stores a set of resolved spans denoting completed progress.
     optional jobs.jobspb.StreamIngestionCheckpoint checkpoint = 7 [(gogoproto.nullable) = false];
 
-    // TableDescriptors is a map from destination table IDs to the source table
-    // descriptors.
-    map<int32, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 8 [(gogoproto.nullable) = false];
+    // TableReplicationMetadata is a map from destination table IDs to metadata
+    // containing source table descriptors and fully qualified destination table names.
+    map<int32, TableReplicationMetadata> table_metadata = 8 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
Backport 1/1 commits from #127024.

/cc @cockroachdb/release

---

Followup PR to #126914. Changes included in this PR:

- Create dlq table with fully qualified prefixes instead of `defaultdb`
- Added unit tests to verify create dlq table & insert behave as expected
- Minor refactoring

Part of: https://cockroachlabs.atlassian.net/browse/DOC-10483
Epic: CRDB-38992
Release note: None

Release Justification: LDR only change
