### PR TITLE
raft: pull out a ElectionTracker 

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -325,8 +325,9 @@ type raft struct {
 	maxMsgSize         entryEncodingSize
 	maxUncommittedSize entryPayloadSize
 
-	config quorum.Config
-	trk    tracker.ProgressTracker
+	config          quorum.Config
+	trk             tracker.ProgressTracker
+	electionTracker tracker.ElectionTracker
 
 	state StateType
 
@@ -433,6 +434,8 @@ func newRaft(c *Config) *raft {
 		storeLiveness:               c.StoreLiveness,
 	}
 	lastID := r.raftLog.lastEntryID()
+
+	r.electionTracker = tracker.MakeVoteTracker(&r.config)
 
 	cfg, progressMap, err := confchange.Restore(confchange.Changer{
 		Config:           quorum.MakeEmptyConfig(),
@@ -760,7 +763,7 @@ func (r *raft) reset(term uint64) {
 
 	r.abortLeaderTransfer()
 
-	r.trk.ResetVotes()
+	r.electionTracker.ResetVotes()
 	r.trk.Visit(func(id pb.PeerID, pr *tracker.Progress) {
 		*pr = tracker.Progress{
 			Match:     0,
@@ -895,7 +898,7 @@ func (r *raft) becomePreCandidate() {
 	// but doesn't change anything else. In particular it does not increase
 	// r.Term or change r.Vote.
 	r.step = stepCandidate
-	r.trk.ResetVotes()
+	r.electionTracker.ResetVotes()
 	r.tick = r.tickElection
 	// TODO(arul): We're forgetting the raft leader here. From the perspective of
 	// leader leases, this is fine, because we wouldn't be here unless we'd
@@ -1055,8 +1058,8 @@ func (r *raft) poll(
 	} else {
 		r.logger.Infof("%x received %s rejection from %x at term %d", r.id, t, id, r.Term)
 	}
-	r.trk.RecordVote(id, v)
-	return r.trk.TallyVotes()
+	r.electionTracker.RecordVote(id, v)
+	return r.electionTracker.TallyVotes()
 }
 
 func (r *raft) Step(m pb.Message) error {

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -159,7 +159,7 @@ func testNonleaderStartElection(t *testing.T, state StateType) {
 
 	assert.Equal(t, uint64(2), r.Term)
 	assert.Equal(t, StateCandidate, r.state)
-	assert.True(t, r.trk.Votes[r.id])
+	assert.True(t, r.electionTracker.TestingGetVotes()[r.id])
 
 	msgs := r.readMessages()
 	sort.Sort(messageSlice(msgs))

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1520,7 +1520,7 @@ func testCandidateSelfVoteAfterLostElection(t *testing.T, preVote bool) {
 	assert.Equal(t, StateFollower, sm.state)
 
 	// Its self-vote does not make its way to its ProgressTracker.
-	granted, _, _ := sm.trk.TallyVotes()
+	granted, _, _ := sm.electionTracker.TallyVotes()
 	assert.Zero(t, granted)
 
 }
@@ -1549,7 +1549,7 @@ func TestCandidateDeliversPreCandidateSelfVoteAfterBecomingCandidate(t *testing.
 	steps = sm.takeMessagesAfterAppend()
 
 	// Its pre-vote self-vote does not make its way to its ProgressTracker.
-	granted, _, _ := sm.trk.TallyVotes()
+	granted, _, _ := sm.electionTracker.TallyVotes()
 	assert.Zero(t, granted)
 
 	// A single vote from n2 does not move n1 to the leader.

--- a/pkg/raft/tracker/BUILD.bazel
+++ b/pkg/raft/tracker/BUILD.bazel
@@ -3,10 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "tracker",
     srcs = [
+        "electiontracker.go",
         "inflights.go",
         "progress.go",
+        "progresstracker.go",
         "state.go",
-        "tracker.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/tracker",
     visibility = ["//visibility:public"],

--- a/pkg/raft/tracker/electiontracker.go
+++ b/pkg/raft/tracker/electiontracker.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tracker
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
+	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+)
+
+// ElectionTracker is used to track votes from the currently active configuration
+// and determine election results.
+type ElectionTracker struct {
+	config *quorum.Config
+
+	votes map[pb.PeerID]bool
+}
+
+func MakeVoteTracker(config *quorum.Config) ElectionTracker {
+	return ElectionTracker{
+		config: config,
+		votes:  map[pb.PeerID]bool{},
+	}
+}
+
+// RecordVote records that the node with the given id voted for this Raft
+// instance if v == true (and declined it otherwise).
+func (e *ElectionTracker) RecordVote(id pb.PeerID, vote bool) {
+	_, ok := e.votes[id]
+	if !ok {
+		e.votes[id] = vote
+	}
+}
+
+// TallyVotes returns the number of granted and rejected Votes, and whether the
+// election outcome is known.
+func (e *ElectionTracker) TallyVotes() (granted int, rejected int, _ quorum.VoteResult) {
+	// Make sure to populate granted/rejected correctly even if the votes slice
+	// contains members no longer part of the configuration. This doesn't really
+	// matter in the way the numbers are used (they're informational), but might
+	// as well get it right.
+	for id, v := range e.votes {
+		if _, isLearner := e.config.Learners[id]; isLearner {
+			continue
+		}
+		if v {
+			granted++
+		} else {
+			rejected++
+		}
+	}
+	result := e.config.Voters.VoteResult(e.votes)
+	return granted, rejected, result
+}
+
+// ResetVotes prepares for a new round of vote counting via recordVote.
+func (e *ElectionTracker) ResetVotes() {
+	clear(e.votes)
+}
+
+// TestingGetVotes exports the votes map for testing.
+func (e *ElectionTracker) TestingGetVotes() map[pb.PeerID]bool {
+	return e.votes
+}

--- a/pkg/raft/tracker/progresstracker.go
+++ b/pkg/raft/tracker/progresstracker.go
@@ -29,7 +29,7 @@ import (
 // configuration. In particular, it tracks the match index for each peer, which
 // in-turn allows for reasoning about the committed index.
 type ProgressTracker struct {
-	Config *quorum.Config
+	config *quorum.Config
 
 	Progress ProgressMap
 }
@@ -37,7 +37,7 @@ type ProgressTracker struct {
 // MakeProgressTracker initializes a ProgressTracker.
 func MakeProgressTracker(config *quorum.Config, progressMap ProgressMap) ProgressTracker {
 	p := ProgressTracker{
-		Config:   config,
+		config:   config,
 		Progress: progressMap,
 	}
 	return p
@@ -59,7 +59,7 @@ func (l matchAckIndexer) AckedIndex(id pb.PeerID) (quorum.Index, bool) {
 // Committed returns the largest log index known to be committed based on what
 // the voting members of the group have acknowledged.
 func (p *ProgressTracker) Committed() uint64 {
-	return uint64(p.Config.Voters.CommittedIndex(matchAckIndexer(p.Progress)))
+	return uint64(p.config.Voters.CommittedIndex(matchAckIndexer(p.Progress)))
 }
 
 // Visit invokes the supplied closure for all tracked progresses in stable order.
@@ -96,12 +96,12 @@ func (p *ProgressTracker) QuorumActive() bool {
 		votes[id] = pr.RecentActive
 	})
 
-	return p.Config.Voters.VoteResult(votes) == quorum.VoteWon
+	return p.config.Voters.VoteResult(votes) == quorum.VoteWon
 }
 
 // VoterNodes returns a sorted slice of voters.
 func (p *ProgressTracker) VoterNodes() []pb.PeerID {
-	m := p.Config.Voters.IDs()
+	m := p.config.Voters.IDs()
 	nodes := make([]pb.PeerID, 0, len(m))
 	for id := range m {
 		nodes = append(nodes, id)
@@ -112,11 +112,11 @@ func (p *ProgressTracker) VoterNodes() []pb.PeerID {
 
 // LearnerNodes returns a sorted slice of learners.
 func (p *ProgressTracker) LearnerNodes() []pb.PeerID {
-	if len(p.Config.Learners) == 0 {
+	if len(p.config.Learners) == 0 {
 		return nil
 	}
-	nodes := make([]pb.PeerID, 0, len(p.Config.Learners))
-	for id := range p.Config.Learners {
+	nodes := make([]pb.PeerID, 0, len(p.config.Learners))
+	for id := range p.config.Learners {
 		nodes = append(nodes, id)
 	}
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })


### PR DESCRIPTION
First 5 commits are from https://github.com/cockroachdb/cockroach/pull/127312.

Previously, the ProgressTracker was responsible for tracking votes and
progress. This patch pulls out a new struct, a VoteTracker, to track
votes instead.

Closes https://github.com/cockroachdb/cockroach/issues/125265

Release note: None