### PR TITLE
rpc: deflake TestRemoteOffsetUnhealthy, further 

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -391,6 +391,9 @@ func (r RemoteOffset) isHealthy(ctx context.Context, toleratedOffset time.Durati
 }
 
 func (r RemoteOffset) isStale(ttl time.Duration, now time.Time) bool {
+	if ttl == 0 {
+		return false // ttl disabled
+	}
 	return r.measuredAt().Add(ttl).Before(now)
 }
 

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -837,7 +837,7 @@ func TestOffsetMeasurement(t *testing.T) {
 	clientClock := &AdvancingClock{time: timeutil.Unix(0, 10)}
 	clientMaxOffset := time.Duration(0)
 	clientCtx := newTestContext(clusterID, clientClock, clientMaxOffset, stopper)
-	clientCtx.RemoteClocks.offsetTTL = 5 * clientClock.getAdvancementInterval()
+	clientCtx.RemoteClocks.offsetTTL = 1 * time.Nanosecond
 	if _, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID, DefaultClass).Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -1104,7 +1104,8 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 		clock := timeutil.NewManualTime(timeutil.Unix(0, start.Add(nodeCtxs[i].offset).UnixNano()))
 		nodeCtxs[i].errChan = make(chan error, 1)
 		nodeCtxs[i].ctx = newTestContext(clusterID, clock, maxOffset, stopper)
-		nodeCtxs[i].ctx.RPCHeartbeatInterval = maxOffset
+		// Make the test faster.
+		nodeCtxs[i].ctx.RPCHeartbeatInterval = 10 * time.Millisecond
 		// Disable RPC heartbeat timeouts to avoid flakiness in the test. If a
 		// heartbeat were to time out, its RPC connection would be closed and its
 		// clock offset information would be lost.


### PR DESCRIPTION
In 449b3d4f, we dropped the RPC heartbeat timeout in the test. This eliminated one source of flakiness, but introduced another, which was exacerbated by also dropping the heartbeat interval (temporarily reverted in 321e900c). Specifically, it caused the remote offset TTL to drop to zero - it is set to 10x the timeout, for some reason which I don't plan on touching. This caused the test, which uses a manual clock, to occasionally hit the TTL and fail.

This commit fixes the TTL to properly handle being set to zero. Instead of considering zero to mean "everything is expired", we now consider zero to mean "nothing is expired".

I've confirmed that this now passes over an hour of stress.

Informs #127322.
Release note: None