### PR TITLE
changefeedccl: add log messages for when a core changefeed retries/fails

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -355,12 +355,14 @@ func coreChangefeed(
 			err = knobs.HandleDistChangefeedError(err)
 		}
 
-		if err = changefeedbase.AsTerminalError(ctx, p.ExecCfg().LeaseManager, err); err != nil {
+		if err := changefeedbase.AsTerminalError(ctx, p.ExecCfg().LeaseManager, err); err != nil {
+			log.Infof(ctx, "core changefeed failed due to error: %s", err)
 			return err
 		}
 
 		// All other errors retry; but we'll use an up-to-date progress
 		// information which is saved in the localState.
+		log.Infof(ctx, "core changefeed retrying due to transient error: %s", err)
 	}
 	return ctx.Err() // retry loop exits when context cancels.
 }


### PR DESCRIPTION
Epic: CRDB-37337

Release note: None