### PR TITLE
roachtest: fix warehouse count increase in disagg-rebalance

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -44,10 +44,13 @@ func registerDisaggRebalance(r registry.Registry) {
 
 			initialWaitDuration := 2 * time.Minute
 			warehouses := 1000
+			activeWarehouses := 20
 
 			t.Status("workload initialization")
+			// Checks are turned off as they take a while for high warehouse counts on
+			// top of disaggregated storage.
 			cmd := fmt.Sprintf(
-				"./cockroach workload fixtures import tpcc --warehouses=%d {pgurl:1}",
+				"./cockroach workload fixtures import tpcc --warehouses=%d --checks=false {pgurl:1}",
 				warehouses,
 			)
 			m := c.NewMonitor(ctx, c.Range(1, 3))
@@ -62,8 +65,8 @@ func registerDisaggRebalance(r registry.Registry) {
 				t.Status("run tpcc")
 
 				cmd := fmt.Sprintf(
-					"./cockroach workload run tpcc --warehouses=%d --duration=10m {pgurl:1-3}",
-					warehouses,
+					"./cockroach workload run tpcc --warehouses=%d --active-warehouses=%d --duration=10m {pgurl:1-3}",
+					warehouses, activeWarehouses,
 				)
 
 				return c.RunE(ctx, option.WithNodes(c.Node(1)), cmd)


### PR DESCRIPTION
Previously, we increased the warehouse count in the disagg-rebalance roachtest to make it less flaky. However this greatly increased the amount of time it takes for TPCC consistency checks to run, especially on top of disaggregated storage. This change disables those checks and reduces the active warehouse count back down to reduce the amount of foreground resource utilization while leaving the imported warehouse count be larger.

Fixes #127507.

Epic: none

Release note: None