### PR TITLE
release-24.2: crosscluster: consolidate mutation type enum

### DIFF
--- a/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
@@ -185,7 +185,7 @@ func TestDLQClient(t *testing.T) {
 		tableDesc    catalog.TableDescriptor
 		kv           streampb.StreamEvent_KV
 		dlqReason    retryEligibility
-		mutationType ReplicationMutationType
+		mutationType replicationMutationType
 		applyError   error
 	}
 
@@ -195,28 +195,28 @@ func TestDLQClient(t *testing.T) {
 			jobID:        1,
 			tableDesc:    tableNameToDesc["defaultdb.public.foo"],
 			dlqReason:    noSpace,
-			mutationType: Insert,
+			mutationType: insertMutation,
 		},
 		{
 			name:         "insert dlq fallback row for default.baz.foo",
 			jobID:        1,
 			tableDesc:    tableNameToDesc["defaultdb.baz.foo"],
 			dlqReason:    tooOld,
-			mutationType: Insert,
+			mutationType: insertMutation,
 		},
 		{
 			name:         "insert dlq fallback row for a.public.bar",
 			jobID:        1,
 			tableDesc:    tableNameToDesc["a.public.bar"],
 			dlqReason:    noSpace,
-			mutationType: Insert,
+			mutationType: insertMutation,
 		},
 		{
 			name:         "insert dlq fallback row for a.baz.foo",
 			jobID:        1,
 			tableDesc:    tableNameToDesc["a.baz.foo"],
 			dlqReason:    tooOld,
-			mutationType: Insert,
+			mutationType: insertMutation,
 		},
 		{
 			name:           "expect error when given nil cdcEventRow",

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -10,6 +10,7 @@ package logical
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
@@ -680,6 +681,27 @@ func (r retryEligibility) String() string {
 		return "not retryable"
 	}
 	return "unknown"
+}
+
+type replicationMutationType int
+
+const (
+	insertMutation replicationMutationType = iota
+	deleteMutation
+	updateMutation
+)
+
+func (t replicationMutationType) String() string {
+	switch t {
+	case insertMutation:
+		return "insert"
+	case deleteMutation:
+		return "delete"
+	case updateMutation:
+		return "update"
+	default:
+		return fmt.Sprintf("Unrecognized replicationMutationType(%d)", int(t))
+	}
 }
 
 // flushChunk is the per-thread body of flushBuffer; see flushBuffer's contract.

--- a/pkg/ccl/crosscluster/logical/udf_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor.go
@@ -45,14 +45,6 @@ const (
 	upsertSpecified applierDecision = "upsert_specified"
 )
 
-type mutationType string
-
-const (
-	insertMutation mutationType = "insert"
-	updateMutation mutationType = "update"
-	deleteMutation mutationType = "delete"
-)
-
 const (
 	insertQuery = 0
 	updateQuery = 1
@@ -214,7 +206,7 @@ func (aq *applierQuerier) processRow(
 	ie isql.Executor,
 	row cdcevent.Row,
 	prevRow *cdcevent.Row,
-	mutType mutationType,
+	mutType replicationMutationType,
 ) (batchStats, error) {
 	var kvTxn *kv.Txn
 	if txn != nil {
@@ -231,7 +223,7 @@ func (aq *applierQuerier) applyUDF(
 	ctx context.Context,
 	txn *kv.Txn,
 	ie isql.Executor,
-	mutType mutationType,
+	mutType replicationMutationType,
 	row cdcevent.Row,
 	prevRow *cdcevent.Row,
 ) (applierDecision, tree.Datums, error) {
@@ -469,7 +461,7 @@ func makeApplierApplyQueries(
 	joinClause := makeApplierJoinClause(td.TableDesc().PrimaryIndex.KeyColumnNames)
 
 	statements := make([]statements.Statement[tree.Statement], 3)
-	for statementIdx, mutType := range map[int]mutationType{
+	for statementIdx, mutType := range map[int]replicationMutationType{
 		insertQuery: insertMutation,
 		updateQuery: updateMutation,
 		deleteQuery: deleteMutation,


### PR DESCRIPTION
Backport 1/1 commits from #127470.

/cc @cockroachdb/release

---

Previously, DLQ and udf processor defined their own mutation type constants separately. Since the constants share the same values, in this PR we created `replicationMutationType` in
`logical_replication_writer_processor` to replace the mutation type constants in DLQ and udf processor.

Part of: https://cockroachlabs.atlassian.net/browse/DOC-10483
Epic: CRDB-38992
Release note: None

Release justification: LDR only
