### PR TITLE
release-24.2: crosscluster/logical: set UDF function name from SQL input

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -79,6 +79,7 @@ go_library(
         "@com_github_cockroachdb_errors//issuelink",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_lib_pq//oid",
     ],
 )
 

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/exprutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -196,7 +197,7 @@ func createLogicalReplicationStreamPlanHook(
 
 		if uf, ok := options.GetUserFunctions(); ok {
 			for i, name := range srcTableNames {
-				repPairs[i].SrcFunctionID = uf[name]
+				repPairs[i].DstFunctionID = uf[name]
 			}
 		}
 		// Default conflict resolution if not set will be LWW
@@ -305,8 +306,12 @@ func evalLogicalReplicationOptions(
 		// This case will assume that a function name was passed in
 		// and we will try to resolve it.
 		default:
-			urn := tree.MakeUnresolvedName(defaultFnc)
-			descID, err := lookupFunctionID(ctx, p, urn)
+			urn, err := parser.ParseFunctionName(defaultFnc)
+			if err != nil {
+				return nil, err
+			}
+			un := urn.ToUnresolvedName()
+			descID, err := lookupFunctionID(ctx, p, *un)
 			if err != nil {
 				return nil, err
 			}
@@ -324,8 +329,8 @@ func evalLogicalReplicationOptions(
 				return nil, err
 			}
 
-			urn := tree.MakeUnresolvedName(fnc.String())
-			descID, err := lookupFunctionID(ctx, p, urn)
+			un := fnc.ToUnresolvedObjectName().ToUnresolvedName()
+			descID, err := lookupFunctionID(ctx, p, *un)
 			if err != nil {
 				return nil, err
 			}
@@ -343,14 +348,14 @@ func lookupFunctionID(
 		return 0, err
 	}
 	if len(rf.Overloads) > 1 {
-		return 0, errors.Newf("function '%s' has more than 1 overload", u.String())
+		return 0, errors.Newf("function %q has more than 1 overload", u.String())
 	}
 	fnOID := rf.Overloads[0].Oid
-	var descID int32
-	if descID := typedesc.UserDefinedTypeOIDToID(fnOID); descID == 0 {
-		return 0, errors.Newf("function '%s' is not a user defined type", u.String())
+	descID := typedesc.UserDefinedTypeOIDToID(fnOID)
+	if descID == 0 {
+		return 0, errors.Newf("function %q is not a user defined type", u.String())
 	}
-	return descID, nil
+	return int32(descID), nil
 }
 
 func (r *resolvedLogicalReplicationOptions) GetCursor() (hlc.Timestamp, bool) {

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -101,7 +100,6 @@ func createLogicalReplicationStreamPlanHook(
 		}
 
 		var (
-			targetDatabase     catid.DescID
 			targetsDescription string
 			srcTableNames      = make([]string, len(stmt.From.Tables))
 			repPairs           = make([]jobspb.LogicalReplicationDetails_ReplicationPair, len(stmt.Into.Tables))
@@ -116,11 +114,6 @@ func createLogicalReplicationStreamPlanHook(
 			prefix, td, err := resolver.ResolveMutableExistingTableObject(ctx, p, &dstTableName, true, tree.ResolveRequireTableDesc)
 			if err != nil {
 				return err
-			}
-			if targetDatabase == 0 {
-				targetDatabase = td.ParentID
-			} else if targetDatabase != td.ParentID {
-				return errors.Errorf("cross-database replication job is not allowed")
 			}
 			repPairs[i].DstDescriptorID = int32(td.GetID())
 

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -25,12 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -43,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/lib/pq/oid"
 )
 
 var (
@@ -315,28 +314,9 @@ func (p *logicalReplicationPlanner) generatePlanWithFrontier(
 		return nil, nil, nil, err
 	}
 
-	var (
-		defaultFnDesc catalog.Descriptor
-		defaultFnName string
-	)
+	var defaultFnOID oid.Oid
 	if defaultFnID := p.payload.DefaultConflictResolution.FunctionId; defaultFnID != 0 {
-		if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, descriptors *descs.Collection) error {
-			fnDesc, err := descriptors.ByID(txn.KV()).Get().Desc(ctx, catid.DescID(defaultFnID))
-			if err != nil {
-				return errors.Wrapf(err, "failed to look up function descriptor")
-			}
-			scDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Schema(ctx, fnDesc.GetParentSchemaID())
-			if err != nil {
-				return errors.Wrapf(err, "failed to look up schema descriptor for function %d", fnDesc.GetID())
-			}
-			defaultFnDesc = fnDesc
-			defaultFnName = fmt.Sprintf("%s.%s",
-				lexbase.EscapeSQLIdent(scDesc.GetName()),
-				lexbase.EscapeSQLIdent(fnDesc.GetName()))
-			return nil
-		}); err != nil {
-			return nil, nil, nil, err
-		}
+		defaultFnOID = catid.FuncIDToOID(catid.DescID(defaultFnID))
 	}
 
 	tableIDToName := make(map[int32]fullyQualifiedTableName)
@@ -359,31 +339,11 @@ func (p *logicalReplicationPlanner) generatePlanWithFrontier(
 				return errors.Wrapf(err, "failed to look up schema descriptor for table %d", pair.DstDescriptorID)
 			}
 
-			var fnName string
+			var fnOID oid.Oid
 			if pair.DstFunctionID != 0 {
-				fnDesc, err := descriptors.ByID(txn.KV()).Get().Desc(ctx, catid.DescID(pair.DstFunctionID))
-				if err != nil {
-					return errors.Wrapf(err, "failed to look up function descriptor")
-				}
-				fnScDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Schema(ctx, fnDesc.GetParentSchemaID())
-				if err != nil {
-					return errors.Wrapf(err, "failed to look up schema descriptor for function %d", fnDesc.GetID())
-				}
-				if fnDesc.GetParentID() != dbDesc.GetID() {
-					return errors.Errorf("cross-database function reference not allowed")
-				}
-				// TODO(ssd): Right now we are pushing the
-				// escaped, qualified function name down to the
-				// processors. This makes it a fragile to
-				// renames.
-				fnName = fmt.Sprintf("%s.%s",
-					lexbase.EscapeSQLIdent(fnScDesc.GetName()),
-					lexbase.EscapeSQLIdent(fnDesc.GetName()))
-			} else if defaultFnDesc != nil {
-				if defaultFnDesc.GetParentID() != dbDesc.GetID() {
-					return errors.Errorf("cross-database function reference not allowed")
-				}
-				fnName = defaultFnName
+				fnOID = catid.FuncIDToOID(catid.DescID(pair.DstFunctionID))
+			} else if defaultFnOID != 0 {
+				fnOID = defaultFnOID
 			}
 
 			tablesMd[pair.DstDescriptorID] = execinfrapb.TableReplicationMetadata{
@@ -391,7 +351,7 @@ func (p *logicalReplicationPlanner) generatePlanWithFrontier(
 				DestinationParentDatabaseName: dbDesc.GetName(),
 				DestinationParentSchemaName:   scDesc.GetName(),
 				DestinationTableName:          dstTableDesc.GetName(),
-				DestinationFunctionName:       fnName,
+				DestinationFunctionOID:        uint32(fnOID),
 			}
 			tableIDToName[pair.DstDescriptorID] = fullyQualifiedTableName{
 				database: dbDesc.GetName(),

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -899,32 +899,29 @@ func TestLogicalStreamIngestionJobWithFallbackUDF(t *testing.T) {
 	defer server.Stopper().Stop(ctx)
 
 	lwwFunc := `CREATE OR REPLACE FUNCTION repl_apply(action STRING, proposed tab, existing tab, prev tab, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL,proposed_mvcc_timestamp DECIMAL, proposed_previous_mvcc_timestamp DECIMAL)
-	RETURNS crdb_replication_applier_decision
+	RETURNS string
 	AS $$
 	BEGIN
 	IF existing_origin_timestamp IS NULL THEN
 	    IF existing_mvcc_timestamp < proposed_mvcc_timestamp THEN
 			SELECT crdb_internal.log('case 1');
-			RETURN ('accept_proposed', NULL);
+			RETURN 'accept_proposed';
 		ELSE
 			SELECT crdb_internal.log('case 2');
-			RETURN ('ignore_proposed', NULL);
+			RETURN 'ignore_proposed';
 		END IF;
 	ELSE
 		IF existing_origin_timestamp < proposed_mvcc_timestamp THEN
 			SELECT crdb_internal.log('case 3');
-			RETURN ('accept_proposed', NULL);
+			RETURN 'accept_proposed';
 		ELSE
 			SELECT crdb_internal.log('case 4');
-			RETURN ('ignore_proposed', NULL);
+			RETURN 'ignore_proposed';
 		END IF;
 	END IF;
 	END
 	$$ LANGUAGE plpgsql`
-	// TODO(ssd): We should make this type automatically for people or remove the `upsert_specified action so that we don't need it`
-	dbB.Exec(t, applierTypes)
 	dbB.Exec(t, lwwFunc)
-	dbA.Exec(t, applierTypes)
 	dbA.Exec(t, lwwFunc)
 
 	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -392,6 +392,15 @@ func TestLogicalStreamIngestionErrors(t *testing.T) {
 	}
 
 	dbB.Exec(t, createQ, urlA)
+
+	createBasicTable(t, dbA, "foo1")
+	createBasicTable(t, dbA, "foo2")
+	createBasicTable(t, dbA, "foo3")
+	createBasicTable(t, dbB, "foo1")
+
+	dbB.ExpectErr(t, "cross-database replication job is not allowed",
+		"CREATE LOGICAL REPLICATION STREAM FROM TABLES (foo1, foo2) ON $1 INTO TABLES (b.foo1, a.foo3)", urlA)
+
 }
 
 func TestLogicalStreamIngestionJobWithColumnFamilies(t *testing.T) {

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -392,15 +392,6 @@ func TestLogicalStreamIngestionErrors(t *testing.T) {
 	}
 
 	dbB.Exec(t, createQ, urlA)
-
-	createBasicTable(t, dbA, "foo1")
-	createBasicTable(t, dbA, "foo2")
-	createBasicTable(t, dbA, "foo3")
-	createBasicTable(t, dbB, "foo1")
-
-	dbB.ExpectErr(t, "cross-database replication job is not allowed",
-		"CREATE LOGICAL REPLICATION STREAM FROM TABLES (foo1, foo2) ON $1 INTO TABLES (b.foo1, a.foo3)", urlA)
-
 }
 
 func TestLogicalStreamIngestionJobWithColumnFamilies(t *testing.T) {

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -887,16 +887,17 @@ func TestLogicalStreamIngestionJobWithFallbackUDF(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	s, sqlA, sqlB, cleanup := setupTwoDBUDFTestCluster(t)
-	defer cleanup()
+	ctx := context.Background()
+	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestControlsTenantsExplicitly,
+			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			},
+		},
+	})
+	defer server.Stopper().Stop(ctx)
 
-	// Set the default back to the lww resolver, but leave udfName set.
-	defaultSQLProcessor = lwwProcessor
-
-	dbA := sqlutils.MakeSQLRunner(sqlA)
-	dbB := sqlutils.MakeSQLRunner(sqlB)
-	createBasicTable(t, dbA, "tab")
-	createBasicTable(t, dbB, "tab")
 	lwwFunc := `CREATE OR REPLACE FUNCTION repl_apply(action STRING, proposed tab, existing tab, prev tab, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL,proposed_mvcc_timestamp DECIMAL, proposed_previous_mvcc_timestamp DECIMAL)
 	RETURNS crdb_replication_applier_decision
 	AS $$
@@ -943,8 +944,8 @@ func TestLogicalStreamIngestionJobWithFallbackUDF(t *testing.T) {
 		jobAID jobspb.JobID
 		jobBID jobspb.JobID
 	)
-	dbA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbBURL.String()).Scan(&jobAID)
-	dbB.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbAURL.String()).Scan(&jobBID)
+	dbA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH FUNCTION repl_apply FOR TABLE tab", dbBURL.String()).Scan(&jobAID)
+	dbB.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH FUNCTION repl_apply FOR TABLE tab", dbAURL.String()).Scan(&jobBID)
 
 	now := s.Clock().Now()
 	t.Logf("waiting for replication job %d", jobAID)

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -126,11 +125,16 @@ func newLogicalReplicationWriterProcessor(
 		}
 	}
 
-	tableDescs := make(map[descpb.ID]catalog.TableDescriptor)
+	tableConfigs := make(map[descpb.ID]sqlProcessorTableConfig)
 	tableIDToName := make(map[int32]fullyQualifiedTableName)
 	for tableID, md := range spec.TableMetadata {
 		desc := md.SourceDescriptor
-		tableDescs[descpb.ID(tableID)] = tabledesc.NewBuilder(&desc).BuildImmutableTable()
+		tableConfigs[descpb.ID(tableID)] = sqlProcessorTableConfig{
+			srcDesc:   tabledesc.NewBuilder(&desc).BuildImmutableTable(),
+			dstDBName: md.DestinationParentDatabaseName,
+			dstFnName: md.DestinationFunctionName,
+		}
+
 		tableIDToName[tableID] = fullyQualifiedTableName{
 			database: md.DestinationParentDatabaseName,
 			schema:   md.DestinationParentSchemaName,
@@ -141,7 +145,7 @@ func newLogicalReplicationWriterProcessor(
 	for i := range bhPool {
 
 		rp, err := makeSQLProcessor(
-			ctx, flowCtx.Cfg.Settings, tableDescs,
+			ctx, flowCtx.Cfg.Settings, tableConfigs,
 			// Initialize the executor with a fresh session data - this will
 			// avoid creating a new copy on each executor usage.
 			flowCtx.Cfg.DB.Executor(isql.WithSessionData(sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */))),
@@ -160,8 +164,8 @@ func newLogicalReplicationWriterProcessor(
 	dlqDbExec := flowCtx.Cfg.DB.Executor(isql.WithSessionData(sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */)))
 
 	var numTablesWithSecondaryIndexes int
-	for _, td := range tableDescs {
-		if len(td.NonPrimaryIndexes()) > 0 {
+	for _, tc := range tableConfigs {
+		if len(tc.srcDesc.NonPrimaryIndexes()) > 0 {
 			numTablesWithSecondaryIndexes++
 		}
 	}
@@ -186,7 +190,7 @@ func newLogicalReplicationWriterProcessor(
 			// (Here we have access to the descriptor of the source table, but
 			// for now we assume that the source and the target descriptors are
 			// similar.)
-			if 2*numTablesWithSecondaryIndexes < len(tableDescs) && useImplicitTxns.Get(&flowCtx.Cfg.Settings.SV) {
+			if 2*numTablesWithSecondaryIndexes < len(tableConfigs) && useImplicitTxns.Get(&flowCtx.Cfg.Settings.SV) {
 				return 1
 			}
 			return int(flushBatchSize.Get(&flowCtx.Cfg.Settings.SV))

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -130,9 +130,8 @@ func newLogicalReplicationWriterProcessor(
 	for tableID, md := range spec.TableMetadata {
 		desc := md.SourceDescriptor
 		tableConfigs[descpb.ID(tableID)] = sqlProcessorTableConfig{
-			srcDesc:   tabledesc.NewBuilder(&desc).BuildImmutableTable(),
-			dstDBName: md.DestinationParentDatabaseName,
-			dstFnName: md.DestinationFunctionName,
+			srcDesc: tabledesc.NewBuilder(&desc).BuildImmutableTable(),
+			dstOID:  md.DestinationFunctionOID,
 		}
 
 		tableIDToName[tableID] = fullyQualifiedTableName{

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -48,8 +48,6 @@ const (
 	udfApplierProcessor = "applier-udf"
 )
 
-// TODO(ssd): Thread through from job
-var udfName string
 var defaultSQLProcessor = lwwProcessor
 
 // A sqlRowProcessor is a RowProcessor that handles rows using the
@@ -68,7 +66,7 @@ type sqlRowProcessor struct {
 // A querier handles rows for any table that has previously been added
 // to the querier using the passed isql.Txn and internal executor.
 type querier interface {
-	AddTable(targetDescID int32, td catalog.TableDescriptor) error
+	AddTable(targetDescID int32, tc sqlProcessorTableConfig) error
 	InsertRow(ctx context.Context, txn isql.Txn, ie isql.Executor, row cdcevent.Row, prevRow *cdcevent.Row, likelyInsert bool) (batchStats, error)
 	DeleteRow(ctx context.Context, txn isql.Txn, ie isql.Executor, row cdcevent.Row, prevRow *cdcevent.Row) (batchStats, error)
 	RequiresParsedBeforeRow() bool
@@ -192,17 +190,53 @@ func (q *queryBuffer) ApplierQueryForRow(row cdcevent.Row) (queryBuilder, error)
 	return applierQueryBuilder, nil
 }
 
+type sqlProcessorTableConfig struct {
+	srcDesc   catalog.TableDescriptor
+	dstDBName string
+	dstFnName string
+}
+
+// validateTableConfigs validates assumptions made in the current
+// implementation. Most of these can be lifted in the future but are
+// disallowed for now to reduce churn in this first cut.
+func validateTableConfigs(configs map[descpb.ID]sqlProcessorTableConfig) error {
+	var (
+		first       = true
+		dbName      string
+		hasFunction bool
+	)
+	for _, conf := range configs {
+		if first {
+			dbName = conf.dstDBName
+			hasFunction = conf.dstFnName != ""
+			first = false
+		}
+		if dbName != conf.dstDBName {
+			return errors.Errorf("cross-database replication job is not allowed")
+		}
+		if hasFunction != (conf.dstFnName != "") {
+			return errors.Errorf("function must be specified for all tables")
+		}
+
+	}
+	return nil
+}
+
 func makeSQLProcessor(
 	ctx context.Context,
 	settings *cluster.Settings,
-	tableDescs map[descpb.ID]catalog.TableDescriptor,
+	tableConfigs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
 ) (*sqlRowProcessor, error) {
+	if err := validateTableConfigs(tableConfigs); err != nil {
+		return nil, err
+	}
+
 	switch defaultSQLProcessor {
 	case lwwProcessor:
-		return makeSQLLastWriteWinsHandler(ctx, settings, tableDescs, ie)
+		return makeSQLLastWriteWinsHandler(ctx, settings, tableConfigs, ie)
 	case udfApplierProcessor:
-		return makeUDFApplierProcessor(ctx, settings, tableDescs, ie)
+		return makeUDFApplierProcessor(ctx, settings, tableConfigs, ie)
 	default:
 		return nil, errors.AssertionFailedf("unknown SQL processor: %s", defaultSQLProcessor)
 	}
@@ -211,16 +245,17 @@ func makeSQLProcessor(
 func makeSQLProcessorFromQuerier(
 	ctx context.Context,
 	settings *cluster.Settings,
-	tableDescs map[descpb.ID]catalog.TableDescriptor,
+	tableDescs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
 	querier querier,
 ) (*sqlRowProcessor, error) {
 	cdcEventTargets := changefeedbase.Targets{}
 	tableDescsBySrcID := make(map[descpb.ID]catalog.TableDescriptor, len(tableDescs))
 
-	for descID, desc := range tableDescs {
+	for descID, tabConfig := range tableDescs {
+		desc := tabConfig.srcDesc
 		tableDescsBySrcID[desc.GetID()] = desc
-		if err := querier.AddTable(int32(descID), desc); err != nil {
+		if err := querier.AddTable(int32(descID), tabConfig); err != nil {
 			return nil, err
 		}
 		cdcEventTargets.Add(changefeedbase.Target{
@@ -374,23 +409,29 @@ const (
 func makeSQLLastWriteWinsHandler(
 	ctx context.Context,
 	settings *cluster.Settings,
-	tableDescs map[descpb.ID]catalog.TableDescriptor,
+	tableConfigs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
 ) (*sqlRowProcessor, error) {
+	var hasFunction bool
+	for _, tc := range tableConfigs {
+		hasFunction = tc.dstFnName != ""
+		break
+	}
+
 	var fallbackQuerier querier
-	if udfName != "" {
+	if hasFunction {
 		var err error
-		fallbackQuerier, err = makeApplierQuerier(ctx, settings, tableDescs, ie)
+		fallbackQuerier, err = makeApplierQuerier(ctx, settings, tableConfigs, ie)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	qb := queryBuffer{
-		deleteQueries: make(map[catid.DescID]queryBuilder, len(tableDescs)),
-		insertQueries: make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableDescs)),
+		deleteQueries: make(map[catid.DescID]queryBuilder, len(tableConfigs)),
+		insertQueries: make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
 	}
-	return makeSQLProcessorFromQuerier(ctx, settings, tableDescs, ie,
+	return makeSQLProcessorFromQuerier(ctx, settings, tableConfigs, ie,
 		&lwwQuerier{
 			settings:        settings,
 			queryBuffer:     qb,
@@ -420,7 +461,8 @@ type lwwQuerier struct {
 	fallbackQuerier querier
 }
 
-func (lww *lwwQuerier) AddTable(targetDescID int32, td catalog.TableDescriptor) error {
+func (lww *lwwQuerier) AddTable(targetDescID int32, tc sqlProcessorTableConfig) error {
+	td := tc.srcDesc
 	var err error
 	lww.queryBuffer.insertQueries[td.GetID()], err = makeLWWInsertQueries(targetDescID, td)
 	if err != nil {
@@ -432,7 +474,7 @@ func (lww *lwwQuerier) AddTable(targetDescID int32, td catalog.TableDescriptor) 
 	}
 
 	if lww.fallbackQuerier != nil {
-		if err := lww.fallbackQuerier.AddTable(targetDescID, td); err != nil {
+		if err := lww.fallbackQuerier.AddTable(targetDescID, tc); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -191,9 +191,8 @@ func (q *queryBuffer) ApplierQueryForRow(row cdcevent.Row) (queryBuilder, error)
 }
 
 type sqlProcessorTableConfig struct {
-	srcDesc   catalog.TableDescriptor
-	dstDBName string
-	dstFnName string
+	srcDesc catalog.TableDescriptor
+	dstOID  uint32
 }
 
 func makeSQLProcessor(
@@ -386,17 +385,13 @@ func makeSQLLastWriteWinsHandler(
 	needFallback := false
 	shouldUseFallback := make(map[catid.DescID]bool, len(tableConfigs))
 	for _, tc := range tableConfigs {
-		shouldUseFallback[tc.srcDesc.GetID()] = tc.dstFnName != ""
-		needFallback = needFallback || tc.dstFnName != ""
+		shouldUseFallback[tc.srcDesc.GetID()] = tc.dstOID != 0
+		needFallback = needFallback || tc.dstOID != 0
 	}
 
 	var fallbackQuerier querier
 	if needFallback {
-		var err error
-		fallbackQuerier, err = makeApplierQuerier(ctx, settings, tableConfigs, ie)
-		if err != nil {
-			return nil, err
-		}
+		fallbackQuerier = makeApplierQuerier(ctx, settings, tableConfigs, ie)
 	}
 
 	qb := queryBuffer{

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -196,42 +196,12 @@ type sqlProcessorTableConfig struct {
 	dstFnName string
 }
 
-// validateTableConfigs validates assumptions made in the current
-// implementation. Most of these can be lifted in the future but are
-// disallowed for now to reduce churn in this first cut.
-func validateTableConfigs(configs map[descpb.ID]sqlProcessorTableConfig) error {
-	var (
-		first       = true
-		dbName      string
-		hasFunction bool
-	)
-	for _, conf := range configs {
-		if first {
-			dbName = conf.dstDBName
-			hasFunction = conf.dstFnName != ""
-			first = false
-		}
-		if dbName != conf.dstDBName {
-			return errors.Errorf("cross-database replication job is not allowed")
-		}
-		if hasFunction != (conf.dstFnName != "") {
-			return errors.Errorf("function must be specified for all tables")
-		}
-
-	}
-	return nil
-}
-
 func makeSQLProcessor(
 	ctx context.Context,
 	settings *cluster.Settings,
 	tableConfigs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
 ) (*sqlRowProcessor, error) {
-	if err := validateTableConfigs(tableConfigs); err != nil {
-		return nil, err
-	}
-
 	switch defaultSQLProcessor {
 	case lwwProcessor:
 		return makeSQLLastWriteWinsHandler(ctx, settings, tableConfigs, ie)
@@ -412,14 +382,16 @@ func makeSQLLastWriteWinsHandler(
 	tableConfigs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
 ) (*sqlRowProcessor, error) {
-	var hasFunction bool
+
+	needFallback := false
+	shouldUseFallback := make(map[catid.DescID]bool, len(tableConfigs))
 	for _, tc := range tableConfigs {
-		hasFunction = tc.dstFnName != ""
-		break
+		shouldUseFallback[tc.srcDesc.GetID()] = tc.dstFnName != ""
+		needFallback = needFallback || tc.dstFnName != ""
 	}
 
 	var fallbackQuerier querier
-	if hasFunction {
+	if needFallback {
 		var err error
 		fallbackQuerier, err = makeApplierQuerier(ctx, settings, tableConfigs, ie)
 		if err != nil {
@@ -433,9 +405,10 @@ func makeSQLLastWriteWinsHandler(
 	}
 	return makeSQLProcessorFromQuerier(ctx, settings, tableConfigs, ie,
 		&lwwQuerier{
-			settings:        settings,
-			queryBuffer:     qb,
-			fallbackQuerier: fallbackQuerier,
+			settings:          settings,
+			queryBuffer:       qb,
+			shouldUseFallback: shouldUseFallback,
+			fallbackQuerier:   fallbackQuerier,
 		})
 }
 
@@ -456,9 +429,11 @@ func makeSQLLastWriteWinsHandler(
 //
 // See the design document for possible solutions to both of these problems.
 type lwwQuerier struct {
-	settings        *cluster.Settings
-	queryBuffer     queryBuffer
-	fallbackQuerier querier
+	settings    *cluster.Settings
+	queryBuffer queryBuffer
+
+	shouldUseFallback map[catid.DescID]bool
+	fallbackQuerier   querier
 }
 
 func (lww *lwwQuerier) AddTable(targetDescID int32, tc sqlProcessorTableConfig) error {
@@ -473,12 +448,19 @@ func (lww *lwwQuerier) AddTable(targetDescID int32, tc sqlProcessorTableConfig) 
 		return err
 	}
 
-	if lww.fallbackQuerier != nil {
+	if lww.shouldUseFallbackQuerier(td.GetID()) {
 		if err := lww.fallbackQuerier.AddTable(targetDescID, tc); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (lww *lwwQuerier) shouldUseFallbackQuerier(id catid.DescID) bool {
+	if lww.fallbackQuerier == nil {
+		return false
+	}
+	return lww.shouldUseFallback[id]
 }
 
 func (lww *lwwQuerier) RequiresParsedBeforeRow() bool {
@@ -508,7 +490,7 @@ func (lww *lwwQuerier) InsertRow(
 		return batchStats{}, err
 	}
 
-	fallbackSpecified := lww.fallbackQuerier != nil
+	fallbackSpecified := lww.shouldUseFallbackQuerier(row.TableID)
 	shouldTryOptimisticInsert := likelyInsert && tryOptimisticInsertEnabled.Get(&lww.settings.SV)
 	shouldTryOptimisticInsert = shouldTryOptimisticInsert || fallbackSpecified
 	var optimisticInsertConflicts int64

--- a/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
@@ -82,8 +82,7 @@ func TestLWWInsertQueryGeneration(t *testing.T) {
 		dstDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", tableNameDst)
 		rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[descpb.ID]sqlProcessorTableConfig{
 			dstDesc.GetID(): {
-				srcDesc:   srcDesc,
-				dstDBName: "defaultdb",
+				srcDesc: srcDesc,
 			},
 		}, s.InternalExecutor().(isql.Executor))
 		require.NoError(t, err)
@@ -152,8 +151,7 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
 	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[descpb.ID]sqlProcessorTableConfig{
 		desc.GetID(): {
-			srcDesc:   desc,
-			dstDBName: "defaultdb",
+			srcDesc: desc,
 		},
 	}, s.InternalDB().(isql.DB).Executor(isql.WithSessionData(sd)))
 	require.NoError(b, err)

--- a/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -81,8 +80,11 @@ func TestLWWInsertQueryGeneration(t *testing.T) {
 		tableNameDst := createTable(t, schemaTmpl)
 		srcDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", tableNameSrc)
 		dstDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", tableNameDst)
-		rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[descpb.ID]catalog.TableDescriptor{
-			dstDesc.GetID(): srcDesc,
+		rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[descpb.ID]sqlProcessorTableConfig{
+			dstDesc.GetID(): {
+				srcDesc:   srcDesc,
+				dstDBName: "defaultdb",
+			},
 		}, s.InternalExecutor().(isql.Executor))
 		require.NoError(t, err)
 		return rp, func(datums ...interface{}) roachpb.KeyValue {
@@ -148,8 +150,11 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
 	// Simulate how we set up the row processor on the main code path.
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
-	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[descpb.ID]catalog.TableDescriptor{
-		desc.GetID(): desc,
+	rp, err := makeSQLLastWriteWinsHandler(ctx, s.ClusterSettings(), map[descpb.ID]sqlProcessorTableConfig{
+		desc.GetID(): {
+			srcDesc:   desc,
+			dstDBName: "defaultdb",
+		},
 	}, s.InternalDB().(isql.DB).Executor(isql.WithSessionData(sd)))
 	require.NoError(b, err)
 

--- a/pkg/ccl/crosscluster/logical/udf_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor.go
@@ -40,9 +40,8 @@ const (
 	// or update will be upserted. A delete will be deleted.
 	acceptProposed applierDecision = "accept_proposed"
 	// upsertProposed indicates that an insert or update mutation should be applied.
-	upsertProposed  applierDecision = "upsert_proposed"
-	deleteProposed  applierDecision = "delete_proposed"
-	upsertSpecified applierDecision = "upsert_specified"
+	upsertProposed applierDecision = "upsert_proposed"
+	deleteProposed applierDecision = "delete_proposed"
 )
 
 const (
@@ -52,22 +51,12 @@ const (
 )
 
 const (
-	applierTypes = `
--- crdb_replication_applier_decision is the return type for any user-provided
--- function. The row field is the row to be insert when the decision is upsert_specified.
--- Note that users need to take special care that the columns returned in row are in canonical
--- order. It isn't particularly clear how the user is going to do this easily.
-CREATE TYPE IF NOT EXISTS crdb_replication_applier_decision AS (decision STRING, row RECORD)`
-
 	applierQueryBase = `
 WITH data (%s)
 AS (VALUES (%s))
-SELECT (res).decision, (res).row FROM
-(
-	SELECT %s('%s', data, existing, (%s), existing.crdb_internal_mvcc_timestamp, existing.crdb_replication_origin_timestamp, $%d, $%d) AS res
-	FROM data LEFT JOIN [%d as existing]
-	%s
-)`
+SELECT %s('%s', data, existing, (%s), existing.crdb_internal_mvcc_timestamp, existing.crdb_replication_origin_timestamp, $%d, $%d) AS decision
+FROM data LEFT JOIN [%d as existing]
+%s`
 	applierUpsertQueryBase = `UPSERT INTO [%d as t] (%s) VALUES (%s)`
 	applierDeleteQueryBase = `DELETE FROM [%d as t] WHERE %s`
 )
@@ -202,11 +191,11 @@ func (aq *applierQuerier) processRow(
 	if txn != nil {
 		kvTxn = txn.KV()
 	}
-	decision, decisionRow, err := aq.applyUDF(ctx, kvTxn, ie, mutType, row, prevRow)
+	decision, err := aq.applyUDF(ctx, kvTxn, ie, mutType, row, prevRow)
 	if err != nil {
 		return batchStats{}, err
 	}
-	return aq.applyDecision(ctx, kvTxn, ie, row, decision, decisionRow)
+	return aq.applyDecision(ctx, kvTxn, ie, row, decision)
 }
 
 func (aq *applierQuerier) applyUDF(
@@ -216,16 +205,16 @@ func (aq *applierQuerier) applyUDF(
 	mutType replicationMutationType,
 	row cdcevent.Row,
 	prevRow *cdcevent.Row,
-) (applierDecision, tree.Datums, error) {
+) (applierDecision, error) {
 	applyQueryBuilder, err := aq.queryBuffer.ApplierQueryForRow(row)
 	if err != nil {
-		return noDecision, nil, err
+		return noDecision, err
 	}
 	if err := applyQueryBuilder.AddRowDefaultNull(&row); err != nil {
-		return noDecision, nil, err
+		return noDecision, err
 	}
 	if err := applyQueryBuilder.AddRowDefaultNull(prevRow); err != nil {
-		return noDecision, nil, err
+		return noDecision, err
 	}
 
 	var query int
@@ -240,7 +229,7 @@ func (aq *applierQuerier) applyUDF(
 
 	stmt, datums, err := applyQueryBuilder.Query(query)
 	if err != nil {
-		return noDecision, nil, err
+		return noDecision, err
 	}
 
 	aq.proposedMVCCTs.Decimal = eval.TimestampToDecimal(row.MvccTimestamp)
@@ -251,22 +240,15 @@ func (aq *applierQuerier) applyUDF(
 		append(datums, &aq.proposedMVCCTs, &aq.proposedPrevMVCCTs)...,
 	)
 	if err != nil {
-		return noDecision, nil, err
+		return noDecision, err
 	}
-	if len(decisionRow) < 2 {
-		return noDecision, nil, errors.Errorf("unexpected number of return values from custom UDF: %d", len(decisionRow))
+	if len(decisionRow) != 1 {
+		return noDecision, errors.Errorf("unexpected number of return values from custom UDF: %d", len(decisionRow))
 	}
 	decisionStr, ok := decisionRow[0].(*tree.DString)
 	if !ok {
-		return noDecision, nil, errors.Errorf("unexpected return type for first return value from custom UDF: %v", decisionRow[0])
+		return noDecision, errors.Errorf("unexpected return type for first return value from custom UDF: %v", decisionRow[0])
 	}
-
-	var mutatedDatums tree.Datums
-	mutatedDatumsTuple, ok := decisionRow[1].(*tree.DTuple)
-	if ok {
-		mutatedDatums = mutatedDatumsTuple.D
-	}
-
 	decision := applierDecision(*decisionStr)
 	if decision == acceptProposed {
 		switch mutType {
@@ -276,16 +258,11 @@ func (aq *applierQuerier) applyUDF(
 			decision = upsertProposed
 		}
 	}
-	return decision, mutatedDatums, nil
+	return decision, nil
 }
 
 func (aq *applierQuerier) applyDecision(
-	ctx context.Context,
-	txn *kv.Txn,
-	ie isql.Executor,
-	row cdcevent.Row,
-	decision applierDecision,
-	decisionRow tree.Datums,
+	ctx context.Context, txn *kv.Txn, ie isql.Executor, row cdcevent.Row, decision applierDecision,
 ) (batchStats, error) {
 	switch decision {
 	case ignoreProposed:
@@ -318,29 +295,6 @@ func (aq *applierQuerier) applyDecision(
 		if err != nil {
 			return batchStats{}, err
 		}
-		if err := aq.execParsed(ctx, replicatedInsertOpName, txn, ie, aq.ieoInsert, stmt, datums...); err != nil {
-			return batchStats{}, err
-		}
-		return batchStats{}, nil
-	case upsertSpecified:
-		q, err := aq.queryBuffer.InsertQueryForRow(row)
-		if err != nil {
-			return batchStats{}, err
-		}
-		stmt, _, err := q.Query(defaultQuery)
-		if err != nil {
-			return batchStats{}, err
-		}
-		datums := make([]interface{}, len(decisionRow)+1)
-		for i := range decisionRow {
-			datums[i] = decisionRow[i]
-		}
-		// TODO(ssd): Should we even record an
-		// crdb_replication_origin_timestamp here. Perhaps the UDF mode
-		// should leave this completely to the user and not use this
-		// extra column at all since in the case of upsertSpecfied, the
-		// origin is really the UDF itself, not the remote cluster.
-		datums[len(datums)-1] = &tree.DDecimal{Decimal: eval.TimestampToDecimal(row.MvccTimestamp)}
 		if err := aq.execParsed(ctx, replicatedInsertOpName, txn, ie, aq.ieoInsert, stmt, datums...); err != nil {
 			return batchStats{}, err
 		}

--- a/pkg/ccl/crosscluster/logical/udf_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor.go
@@ -54,7 +54,7 @@ const (
 	applierQueryBase = `
 WITH data (%s)
 AS (VALUES (%s))
-SELECT %s('%s', data, existing, (%s), existing.crdb_internal_mvcc_timestamp, existing.crdb_replication_origin_timestamp, $%d, $%d) AS decision
+SELECT [FUNCTION %d]('%s', data, existing, (%s), existing.crdb_internal_mvcc_timestamp, existing.crdb_replication_origin_timestamp, $%d, $%d) AS decision
 FROM data LEFT JOIN [%d as existing]
 %s`
 	applierUpsertQueryBase = `UPSERT INTO [%d as t] (%s) VALUES (%s)`
@@ -97,32 +97,18 @@ func makeApplierQuerier(
 	settings *cluster.Settings,
 	tableConfigs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
-) (*applierQuerier, error) {
-	qb := queryBuffer{
-		deleteQueries:  make(map[catid.DescID]queryBuilder, len(tableConfigs)),
-		insertQueries:  make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
-		applierQueries: make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
-	}
-
-	var databaseName string
-	for _, t := range tableConfigs {
-		databaseName = t.dstDBName
-		break
-	}
-
-	insertOverride := getIEOverride(replicatedInsertOpName)
-	deleteOverride := getIEOverride(replicatedDeleteOpName)
-	applyUDFOverride := getIEOverride(replicatedApplyUDFOpName)
-	insertOverride.Database = databaseName
-	deleteOverride.Database = databaseName
-	applyUDFOverride.Database = databaseName
+) *applierQuerier {
 	return &applierQuerier{
-		queryBuffer: qb,
+		queryBuffer: queryBuffer{
+			deleteQueries:  make(map[catid.DescID]queryBuilder, len(tableConfigs)),
+			insertQueries:  make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
+			applierQueries: make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
+		},
 		settings:    settings,
-		ieoInsert:   insertOverride,
-		ieoDelete:   deleteOverride,
-		ieoApplyUDF: applyUDFOverride,
-	}, nil
+		ieoInsert:   getIEOverride(replicatedInsertOpName),
+		ieoDelete:   getIEOverride(replicatedDeleteOpName),
+		ieoApplyUDF: getIEOverride(replicatedApplyUDFOpName),
+	}
 }
 
 func makeUDFApplierProcessor(
@@ -131,20 +117,17 @@ func makeUDFApplierProcessor(
 	tableDescs map[descpb.ID]sqlProcessorTableConfig,
 	ie isql.Executor,
 ) (*sqlRowProcessor, error) {
-	aq, err := makeApplierQuerier(ctx, settings, tableDescs, ie)
-	if err != nil {
-		return nil, err
-	}
+	aq := makeApplierQuerier(ctx, settings, tableDescs, ie)
 	return makeSQLProcessorFromQuerier(ctx, settings, tableDescs, ie, aq)
 }
 
 func (aq *applierQuerier) AddTable(targetDescID int32, tc sqlProcessorTableConfig) error {
 	var err error
 	td := tc.srcDesc
-	if tc.dstFnName == "" {
+	if tc.dstOID == 0 {
 		return errors.AssertionFailedf("empty function name")
 	}
-	aq.queryBuffer.applierQueries[td.GetID()], err = makeApplierApplyQueries(targetDescID, td, tc.dstFnName)
+	aq.queryBuffer.applierQueries[td.GetID()], err = makeApplierApplyQueries(targetDescID, td, tc.dstOID)
 	if err != nil {
 		return err
 	}
@@ -376,7 +359,7 @@ func escapedColumnNameList(names []string) string {
 }
 
 func makeApplierApplyQueries(
-	dstTableDescID int32, td catalog.TableDescriptor, udfName string,
+	dstTableDescID int32, td catalog.TableDescriptor, udfOID uint32,
 ) (map[catid.FamilyID]queryBuilder, error) {
 	if td.NumFamilies() > 1 {
 		return nil, errors.Errorf("multiple-column familes not supported by the custom-UDF applier")
@@ -413,7 +396,7 @@ func makeApplierApplyQueries(
 		q := fmt.Sprintf(applierQueryBase,
 			colNames,
 			valStr,
-			udfName,
+			udfOID,
 			mutType,
 			prevValStr,
 			remoteMVCCIdx,

--- a/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
@@ -58,13 +58,12 @@ func TestUDFWithRandomTables(t *testing.T) {
 	t.Logf(stmt)
 	runnerA.Exec(t, stmt)
 	runnerB.Exec(t, stmt)
-	runnerB.Exec(t, applierTypes)
 	runnerB.Exec(t, `
 		CREATE OR REPLACE FUNCTION repl_apply(action STRING, data rand_table, existing rand_table, prev rand_table, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL, proposed_mvcc_timetamp DECIMAL, proposed_previous_mvcc_timestamp DECIMAL)
-		RETURNS crdb_replication_applier_decision
+		RETURNS string
 		AS $$
 		BEGIN
-		RETURN ('accept_proposed', NULL);
+		RETURN 'accept_proposed'
 		END;
 		$$ LANGUAGE plpgsql
 		`)
@@ -93,54 +92,6 @@ func TestUDFWithRandomTables(t *testing.T) {
 	compareReplicatedTables(t, s, "a", "b", tableName, runnerA, runnerB)
 }
 
-func TestUDFApplieSpecified(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	s, sqlA, sqlB, cleanup := setupTwoDBUDFTestCluster(t)
-	defer cleanup()
-
-	runnerA := sqlutils.MakeSQLRunner(sqlA)
-	runnerB := sqlutils.MakeSQLRunner(sqlB)
-
-	tableName := "tallies"
-	stmt := "CREATE TABLE tallies(pk INT PRIMARY KEY, v INT)"
-	runnerA.Exec(t, stmt)
-	runnerA.Exec(t, "INSERT INTO tallies VALUES (1, 10), (2, 22), (3, 33)")
-	runnerB.Exec(t, stmt)
-	runnerB.Exec(t, applierTypes)
-	runnerB.Exec(t, `
-		CREATE OR REPLACE FUNCTION repl_apply(action STRING, proposed tallies, existing tallies, prev tallies, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL, proposed_mvcc_timetamp DECIMAL, proposed_previous_mvcc_timestamp DECIMAL)
-		RETURNS crdb_replication_applier_decision
-		AS $$
-		BEGIN
-		IF action = 'insert' OR action = 'update' THEN
-			RETURN ('upsert_specified', ((proposed).pk, (proposed).v + 1000));
-		END IF;
-		RETURN ('accept_proposed', NULL);
-		END
-		$$ LANGUAGE plpgsql
-		`)
-
-	addCol := fmt.Sprintf(`ALTER TABLE %s `+lwwColumnAdd, tableName)
-	runnerA.Exec(t, addCol)
-	runnerB.Exec(t, addCol)
-
-	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))
-	defer cleanup()
-
-	streamStartStmt := fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE %[1]s ON $1 INTO TABLE %[1]s WITH FUNCTION repl_apply FOR TABLE %[1]s", tableName)
-	var jobBID jobspb.JobID
-	runnerB.QueryRow(t, streamStartStmt, dbAURL.String()).Scan(&jobBID)
-
-	t.Logf("waiting for replication job %d", jobBID)
-	WaitUntilReplicatedTime(t, s.Clock().Now(), runnerB, jobBID)
-	runnerB.CheckQueryResults(t, "SELECT * FROM tallies", [][]string{
-		{"1", "1010"},
-		{"2", "1022"},
-		{"3", "1033"},
-	})
-}
-
 func TestUDFInsertOnly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -154,17 +105,16 @@ func TestUDFInsertOnly(t *testing.T) {
 	runnerA.Exec(t, stmt)
 	runnerA.Exec(t, "INSERT INTO tallies VALUES (1, 10), (2, 22), (3, 33), (4, 44)")
 	runnerB.Exec(t, stmt)
-	runnerB.Exec(t, applierTypes)
 	runnerB.Exec(t, "CREATE SCHEMA funcs")
 	runnerB.Exec(t, `
 		CREATE OR REPLACE FUNCTION funcs.repl_apply(action STRING, proposed tallies, existing tallies, prev tallies, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL, proposed_mvcc_timetamp DECIMAL, proposed_previous_mvcc_timestamp DECIMAL)
-		RETURNS crdb_replication_applier_decision
+		RETURNS string
 		AS $$
 		BEGIN
 		IF action = 'insert' THEN
-			RETURN ('accept_proposed', NULL);
+			RETURN 'accept_proposed';
 		END IF;
-		RETURN ('ignore_proposed', NULL);
+		RETURN 'ignore_proposed';
 		END
 		$$ LANGUAGE plpgsql
 		`)
@@ -210,16 +160,15 @@ func TestUDFPreviousValue(t *testing.T) {
 	runnerA.Exec(t, "INSERT INTO tallies VALUES (1, 10)")
 	runnerB.Exec(t, stmt)
 	runnerB.Exec(t, "INSERT INTO tallies VALUES (1, 20)")
-	runnerB.Exec(t, applierTypes)
 	runnerB.Exec(t, `
 		CREATE OR REPLACE FUNCTION repl_apply(action STRING, proposed tallies, existing tallies, prev tallies, existing_mvcc_timestamp DECIMAL, existing_origin_timestamp DECIMAL, proposed_mvcc_timetamp DECIMAL, proposed_previous_mvcc_timestamp DECIMAL)
-		RETURNS crdb_replication_applier_decision
+		RETURNS string
 		AS $$
 		BEGIN
 		IF action = 'update' THEN
-			RETURN ('upsert_specified', ((proposed).pk, (existing).v + ((proposed).v-(prev).v)));
+                        UPDATE tallies SET v = v + ((proposed).v-(prev).v) WHERE pk = (proposed).pk;
 		END IF;
-		RETURN ('ignore_proposed', NULL);
+		RETURN 'ignore_proposed';
 		END
 		$$ LANGUAGE plpgsql
 		`)

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -223,7 +223,7 @@ message LogicalReplicationDetails {
   message ReplicationPair {
     int32 src_descriptor_id = 1 [(gogoproto.customname) = "SrcDescriptorID"];
     int32 dst_descriptor_id = 2 [(gogoproto.customname) = "DstDescriptorID"];
-    int32 function_id = 3 [(gogoproto.customname) = "SrcFunctionID"];
+    int32 function_id = 3 [(gogoproto.customname) = "DstFunctionID"];
   }
   repeated ReplicationPair replication_pairs = 3 [(gogoproto.nullable) = false];
 
@@ -241,7 +241,7 @@ message LogicalReplicationDetails {
       (gogoproto.nullable) = false,
       (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
       (gogoproto.customname) = "SourceClusterID"];
-  
+
   message DefaultConflictResolution{
     enum DefaultConflictResolution {
       LWW = 0;

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -485,9 +485,9 @@ message TableReplicationMetadata {
   optional string destination_parent_database_name = 2 [(gogoproto.nullable) = false];
   optional string destination_parent_schema_name = 3 [(gogoproto.nullable) = false];
   optional string destination_table_name = 4 [(gogoproto.nullable) = false];
-  // DestinationFunctionName, if non-empty, is the name of the
+  // DestinationFunctionOID, if non-zero, is the OID of the
   // user-defined function that should be used for the table.
-  optional string destination_function_name = 5 [(gogoproto.nullable) = false];
+  optional uint32 destination_function_oid = 5 [(gogoproto.nullable) = false, (gogoproto.customname) = "DestinationFunctionOID"];
 }
 
 message LogicalReplicationWriterSpec {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -485,6 +485,9 @@ message TableReplicationMetadata {
   optional string destination_parent_database_name = 2 [(gogoproto.nullable) = false];
   optional string destination_parent_schema_name = 3 [(gogoproto.nullable) = false];
   optional string destination_table_name = 4 [(gogoproto.nullable) = false];
+  // DestinationFunctionName, if non-empty, is the name of the
+  // user-defined function that should be used for the table.
+  optional string destination_function_name = 5 [(gogoproto.nullable) = false];
 }
 
 message LogicalReplicationWriterSpec {

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -290,6 +290,26 @@ func ParseTableName(sql string) (*tree.UnresolvedObjectName, error) {
 	return rename.Name, nil
 }
 
+// ParseFunctionName parses a function name. The function name must contain one
+// or more name parts, using the full input SQL syntax: each name
+// part containing special characters, or non-lowercase characters,
+// must be enclosed in double quote. The name may not be an invalid
+// function name (the caller is responsible for guaranteeing that only
+// valid function names are provided as input).
+func ParseFunctionName(sql string) (*tree.UnresolvedObjectName, error) {
+	// We wrap the name we want to parse into a dummy statement since our parser
+	// can only parse full statements.
+	stmt, err := ParseOne(fmt.Sprintf("ALTER FUNCTION %s RENAME TO x", sql))
+	if err != nil {
+		return nil, err
+	}
+	rename, ok := stmt.AST.(*tree.AlterRoutineRename)
+	if !ok {
+		return nil, errors.AssertionFailedf("expected an ALTER FUNCTION statement, but found %T", stmt)
+	}
+	return rename.Function.FuncName.ToUnresolvedObjectName(), nil
+}
+
 // ParseTablePattern parses a table pattern. The table name must contain one
 // or more name parts, using the full input SQL syntax: each name
 // part containing special characters, or non-lowercase characters,


### PR DESCRIPTION
Backport 4/4 commits from #127428.

/cc @cockroachdb/release

---

First commit is #127024

See individual commits.

Release justification: LDR feature work.
