### PR TITLE
concurrency: delete LockPromotionError

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
-        "//pkg/kv/kvserver/concurrency",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/liveness",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -109,10 +108,6 @@ func exceptAmbiguous(err error) bool { // true if ambiguous result
 
 func exceptDelRangeUsingTombstoneStraddlesRangeBoundary(err error) bool {
 	return errors.Is(err, errDelRangeUsingTombstoneStraddlesRangeBoundary)
-}
-
-func exceptSharedLockPromotionError(err error) bool { // true if lock promotion error
-	return errors.Is(err, &concurrency.LockPromotionError{})
 }
 
 func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -796,10 +796,7 @@ func (v *validator) processOp(op Operation) {
 		//
 		// So we ignore the results of failIfError, calling it only for its side
 		// effect of perhaps registering a failure with the validator.
-		v.failIfError(
-			op, t.Result,
-			exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError,
-		)
+		v.failIfError(op, t.Result, exceptRollback, exceptAmbiguous)
 
 		ops := t.Ops
 		if t.CommitInBatch != nil {
@@ -1390,9 +1387,7 @@ func (v *validator) checkError(
 	op Operation, r Result, extraExceptions ...func(err error) bool,
 ) (ambiguous, hadError bool) {
 	sl := []func(error) bool{
-		exceptAmbiguous, exceptOmitted, exceptRetry,
-		exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
-		exceptSharedLockPromotionError,
+		exceptAmbiguous, exceptOmitted, exceptRetry, exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
 	}
 	sl = append(sl, extraExceptions...)
 	return v.failIfError(op, r, sl...)

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -4683,21 +4683,3 @@ func assert(condition bool, msg string) {
 		panic(msg)
 	}
 }
-
-// LockPromotionError is used to mark lock promotion errors.
-// TODO(arul): Once we've implemented lock promotion generally, we can remove
-// this machinery.
-type LockPromotionError struct{}
-
-func (e *LockPromotionError) Error() string {
-	return "lock promotion error"
-}
-
-// MarkLockPromotionError wraps the given error, if non-nil, as a
-// LockPromotionError.
-func MarkLockPromotionError(cause error) error {
-	if cause == nil {
-		return nil
-	}
-	return errors.Mark(cause, &LockPromotionError{})
-}


### PR DESCRIPTION
Now that we've implemented generalized lock promotion, this is no longer needed.

Epic: none

Release note: None