### PR TITLE
release-23.2: sql: allow DISCARD in read-only transactions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -158,3 +158,65 @@ SELECT count(*) FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%'
 
 statement ok
 UNLISTEN temp
+
+# Check that DISCARD still works in read-only mode.
+
+query T
+SET search_path = bar, public; SHOW search_path
+----
+bar, public
+
+query T
+SET timezone = 'Europe/Amsterdam'; SHOW timezone
+----
+Europe/Amsterdam
+
+statement ok
+PREPARE a AS SELECT 1
+
+statement ok
+CREATE SEQUENCE discard_seq START WITH 10
+
+statement ok
+CREATE TEMP TABLE tempy (a int);
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
+----
+tempy
+
+statement ok
+SET default_transaction_read_only = on
+
+statement error cannot execute DROP TABLE in a read-only transaction
+DROP TABLE tempy
+
+# DISCARD should be allowed, even though it drops temporary tables.
+statement ok
+DISCARD ALL
+
+# The DISCARD ALL should have reset default_transaction_read_only.
+query T
+SHOW default_transaction_read_only
+----
+off
+
+query T
+SHOW search_path
+----
+"$user", public
+
+query T
+SHOW timezone
+----
+UTC
+
+statement error prepared statement \"a\" does not exist
+DEALLOCATE a
+
+statement error pgcode 55000 pq: currval\(\): currval of sequence "test.public.discard_seq" is not yet defined in this session
+SELECT currval('discard_seq')
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
+----

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -178,8 +178,14 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 		b.flags.Set(exec.PlanFlagContainsMutation)
 		// Raise error if mutation op is part of a read-only transaction.
 		if b.evalCtx.TxnReadOnly {
-			return execPlan{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
-				"cannot execute %s in a read-only transaction", b.statementTag(e))
+			switch tag := b.statementTag(e); tag {
+			// DISCARD can drop temp tables but is still allowed in read-only
+			// transactions for PG compatibility.
+			case "DISCARD ALL", "DISCARD":
+			default:
+				return execPlan{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
+					"cannot execute %s in a read-only transaction", tag)
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #127298.

/cc @cockroachdb/release

---

To match PostgreSQL, allow DISCARD in read-only transactions.

Fixes: #124150

Release note (sql change): Fix a bug in which the DISCARD statement was disallowed with `default_transaction_read_only = on`.

---

Release justification: low-risk fix for ORM-breaking issue.