### PR TITLE
changefeedccl: add some debug logging to the test sinkless feed

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1019,7 +1019,7 @@ func makeFeedFactoryWithOptions(
 		}
 		sink, cleanup := getInitialSinkForSinklessFactory(t, db, pgURLForUserSinkless)
 		root, cleanupRoot := pgURLForUserSinkless(username.RootUser)
-		f := makeSinklessFeedFactory(s, sink, root, pgURLForUserSinkless)
+		f := makeSinklessFeedFactory(t, s, sink, root, pgURLForUserSinkless)
 		return f, func() {
 			cleanup()
 			cleanupRoot()


### PR DESCRIPTION
This patch adds some debug logging to the test sinkless feed to
help with debugging test failures.

Informs #126890

Release note: None