### PR TITLE
release-23.1: changefeedccl: add log messages for when a core changefeed retries/fails

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -238,11 +238,13 @@ func changefeedPlanHook(
 					}
 				}
 
-				if err = changefeedbase.AsTerminalError(ctx, p.ExecCfg().LeaseManager, err); err != nil {
+				if err := changefeedbase.AsTerminalError(ctx, p.ExecCfg().LeaseManager, err); err != nil {
+					log.Infof(ctx, "core changefeed failed due to error: %s", err)
 					break
 				}
 
 				// All other errors retry.
+				log.Infof(ctx, "core changefeed retrying due to transient error: %s", err)
 				progress = p.ExtendedEvalContext().ChangefeedState.(*coreChangefeedProgress).progress
 			}
 			// TODO(yevgeniy): This seems wrong -- core changefeeds always terminate


### PR DESCRIPTION
Backport 1/1 commits from #127530.

/cc @cockroachdb/release

---

Epic: CRDB-37337

Release note: None

---

Release justification: adding useful logging