### PR TITLE
changefeedccl: unify the age filter of "SHOW JOBS" and "SHOW CHANGEFEED JOBS"

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -466,7 +466,13 @@ func (u Updater) canceled(ctx context.Context) error {
 			return fmt.Errorf("job with status %s cannot be requested to be canceled", md.Status)
 		}
 		ju.UpdateStatus(StatusCanceled)
-		md.Payload.FinishedMicros = timeutil.ToUnixMicros(u.j.registry.clock.Now().GoTime())
+		var now time.Time
+		if u.j.registry.knobs.StubTimeNow != nil {
+			now = u.j.registry.knobs.StubTimeNow()
+		} else {
+			now = u.j.registry.clock.Now().GoTime()
+		}
+		md.Payload.FinishedMicros = timeutil.ToUnixMicros(now)
 		ju.UpdatePayload(md.Payload)
 		return nil
 	})

--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -83,6 +83,14 @@ type TestingKnobs struct {
 	// BeforeWaitForJobsQuery is called once per invocation of the
 	// poll-show-jobs query in WaitForJobs.
 	BeforeWaitForJobsQuery func(jobs []jobspb.JobID)
+
+	// Jobs updater will use this function to get the current time. If nil,
+	// "registry.clock.Now" will be used.
+	//
+	// TODO (xiaochen): currently only "Updater.canceled" uses this knob,
+	// we may want to extend this to other parts of the jobs package and
+	// give this knob a default value (so it won't be nil).
+	StubTimeNow func() time.Time
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/delegate/show_changefeed_jobs.go
+++ b/pkg/sql/delegate/show_changefeed_jobs.go
@@ -73,8 +73,8 @@ FROM
 	if n.Jobs == nil {
 		// The query intends to present:
 		// - first all the running jobs sorted in order of start time,
-		// - then all completed jobs sorted in order of completion time.
-		//
+		// - then all completed jobs sorted in order of completion time (no more than 12 hours).
+		whereClause = fmt.Sprintf(`WHERE %s`, ageFilter)
 		// The "ORDER BY" clause below exploits the fact that all
 		// running jobs have finished = NULL.
 		orderbyClause = `ORDER BY COALESCE(finished, now()) DESC, started DESC`

--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
+const ageFilter = `(finished IS NULL OR finished > now() - '12h':::interval)`
+
 func constructSelectQuery(n *tree.ShowJobs) string {
 	var baseQuery strings.Builder
 	baseQuery.WriteString(`SELECT job_id, job_type, `)
@@ -75,9 +77,9 @@ func constructSelectQuery(n *tree.ShowJobs) string {
 
 		// The query intends to present:
 		// - first all the running jobs sorted in order of start time,
-		// - then all completed jobs sorted in order of completion time.
+		// - then all completed jobs sorted in order of completion time (no more than 12 hours).
 		whereClause = fmt.Sprintf(
-			`WHERE %s AND (finished IS NULL OR finished > now() - '12h':::interval)`, typePredicate)
+			`WHERE %s AND %s`, typePredicate, ageFilter)
 		// The "ORDER BY" clause below exploits the fact that all
 		// running jobs have finished = NULL.
 		orderbyClause = `ORDER BY COALESCE(finished, now()) DESC, started DESC`


### PR DESCRIPTION
Previously, "SHOW CHANGEFEED JOBS" return jobs from the last 14 days whereas "SHOW JOBS" return jobs from the last 12 hours.

This commit addresses this issue by:

- Use the same "age filter" for these two commands.
- Add a new knob "StubTimeNow" for job updater.

Fixes: #124882

Release note (sql change): Unify the age filter of commands "SHOW JOBS" and "SHOW CHANGEFEED JOBS".