### PR TITLE
changefeedccl: fix data race in kafka sink v2 partitioner

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -542,10 +542,10 @@ var _ kgo.Logger = kgoLogAdapter{}
 // recommended sarama compat approach to pass thru record partitions when key is
 // nil, like the v1 implementation.
 func newKgoChangefeedPartitioner() kgo.Partitioner {
-	hasher := fnv.New32a()
 	return &kgoChangefeedPartitioner{
 		inner: kgo.StickyKeyPartitioner(kgo.SaramaCompatHasher(func(bs []byte) uint32 {
-			hasher.Reset()
+			// Make a new hasher each time, as the partitioner may be called concurrently.
+			hasher := fnv.New32a()
 			_, _ = hasher.Write(bs)
 			return hasher.Sum32()
 		})),


### PR DESCRIPTION
The partitioner passed to kgo may be called
concurrently, so we need to create a new Hasher on
each hash call. Thanks @twmb for the find!

Release note: None
