### PR TITLE
stmtdiagnostics: skip TestDiagnosticsRequest under duress

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -46,7 +46,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderShort(t)
-	skip.UnderDeadlock(t, "the test is too slow")
+	skip.UnderDuress(t, "the test is too slow")
 
 	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()


### PR DESCRIPTION
This commit updates the skip on `TestDiagnosticsRequest` from deadlock-only to duress (we've seen a couple of flakes under stress).

Fixes: #126279.

Release note: None