### PR TITLE
sql: fix incorrect context capture for the internal executor

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -230,7 +230,7 @@ func (ie *InternalExecutor) runWithEx(
 		return err
 	}
 	wg.Add(1)
-	cleanup := func() {
+	cleanup := func(ctx context.Context) {
 		closeMode := normalClose
 		if txn != nil {
 			closeMode = externalTxnClose
@@ -245,7 +245,7 @@ func (ie *InternalExecutor) runWithEx(
 			SpanOpt:  stop.ChildSpan,
 		},
 		func(ctx context.Context) {
-			defer cleanup()
+			defer cleanup(ctx)
 			// TODO(yuzefovich): benchmark whether we should be growing the
 			// stack size unconditionally.
 			if growStackSize {
@@ -265,7 +265,7 @@ func (ie *InternalExecutor) runWithEx(
 	); err != nil {
 		// The goroutine wasn't started, so we need to perform the cleanup
 		// ourselves.
-		cleanup()
+		cleanup(ctx)
 		return err
 	}
 	return nil


### PR DESCRIPTION
In b9680b45d61f497fe996ebefda052d8c4e5b9eb3 we introduced a cleanup function that captured the context incorrectly and this is now fixed.

Fixes: #127597.

Release note: None