### PR TITLE
roachtest: direct mixedversion planning errors to test-eng

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -375,7 +375,12 @@ func boolP(b bool) *bool {
 func testPredecessorFunc(
 	rng *rand.Rand, v *clusterupgrade.Version,
 ) (*clusterupgrade.Version, error) {
-	return testPredecessorMapping[release.VersionSeries(&v.Version)], nil
+	pred, ok := testPredecessorMapping[release.VersionSeries(&v.Version)]
+	if !ok {
+		return nil, fmt.Errorf("no known predecessor for %q", v)
+	}
+
+	return pred, nil
 }
 
 // createDataDrivenMixedVersionTest creates a `*Test` instance based


### PR DESCRIPTION
Mixedversion planning failures are always internal errors and therefore shouldn't lead to issues being assigned to the team that owns the test. We fix that in this commit.

Epic: none

Release note: None