### PR TITLE
spanconfig: log spanconfig changes

### DIFF
--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -185,6 +185,18 @@ func (s *Store) getFallbackConfig() roachpb.SpanConfig {
 func (s *Store) Apply(
 	ctx context.Context, dryrun bool, updates ...spanconfig.Update,
 ) (deleted []spanconfig.Target, added []spanconfig.Record) {
+
+	// Log the potential span config changes.
+	if !dryrun {
+		for _, update := range updates {
+			err := s.maybeLogUpdate(ctx, &update)
+			if err != nil {
+				log.KvDistribution.Warningf(ctx, "attempted to log a spanconfig update to "+
+					"target:%+v, but got the following error:%+v", update.GetTarget(), err)
+			}
+		}
+	}
+
 	deleted, added, err := s.applyInternal(ctx, dryrun, updates...)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
@@ -314,4 +326,51 @@ func (s *Store) Iterate(f func(spanconfig.Record) error) error {
 			}
 			return f(record)
 		})
+}
+
+// maybeLogUpdate logs the SpanConfig changes to the distribution channel. It
+// also logs changes to the span boundaries. It doesn't log the changes to the
+// SpanConfig for high churn fields like protected timestamps.
+func (s *Store) maybeLogUpdate(ctx context.Context, update *spanconfig.Update) error {
+	nextSC := update.GetConfig()
+	target := update.GetTarget()
+
+	// Return early from SystemTarget updates because they correspond to PTS
+	// updates.
+	if !target.IsSpanTarget() {
+		return nil
+	}
+
+	rKey, err := keys.Addr(target.GetSpan().Key)
+	if err != nil {
+		return err
+	}
+
+	var curSpanConfig roachpb.SpanConfig
+	var curSpan roachpb.Span
+	var found bool
+	func() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		curSpanConfig, curSpan, found = s.mu.spanConfigStore.getSpanConfigForKey(ctx, rKey)
+	}()
+
+	// Check if the span bounds have changed.
+	if found &&
+		(!curSpan.Key.Equal(target.GetSpan().Key) ||
+			!curSpan.EndKey.Equal(target.GetSpan().EndKey)) {
+		log.KvDistribution.Infof(ctx,
+			"changing the span boundaries for span:%+v from:[%+v:%+v) to:[%+v:%+v) "+
+				"with config: %+v", target, curSpan.Key, curSpan.EndKey, target.GetSpan().Key,
+			target.GetSpan().EndKey, nextSC)
+	}
+
+	// Log if there is a SpanConfig change in any field other than
+	// ProtectedTimestamps to avoid logging PTS updates.
+	if found && curSpanConfig.HasConfigurationChange(nextSC) {
+		log.KvDistribution.Infof(ctx,
+			"changing the spanconfig for span:%+v from:%+v to:%+v",
+			target, curSpanConfig, nextSC)
+	}
+	return nil
 }


### PR DESCRIPTION
Whenever there is a SpanConfig change, log it to the distribution channel. Note that we only log changes if it modifies something in the SpanConfig other than the ProtectedTimestamps to reduce the number of things to log.

Commands used:

```
CREATE TABLE test1 (a int, b int);
ALTER TABLE test1 CONFIGURE ZONE USING num_replicas = 5;
```

OUTPUT

```
I240725 19:06:57.232300 1261 13@spanconfig/spanconfigstore/store.go:373 ⋮ [T1,Vsystem,n1,job=‹AUTO SPAN CONFIG RECONCILIATION id=989147442139496449›] 2124  Changing the SpanConfig for Span:‹/Table/10{4-5}› From:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:3 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false} To:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:07:03.237846 618 13@spanconfig/spanconfigstore/store.go:373 ⋮ [T1,Vsystem,n1] 2125  Changing the SpanConfig for Span:‹/Table/10{4-5}› From:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:3 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false} To:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
```

Continuing the commands:

```
CREATE INDEX test1index ON test1(b); 
ALTER INDEX test1@test1index CONFIGURE ZONE USING num_replicas = 4;  
```

Output

```
 I240725 19:08:09.255002 1261 13@spanconfig/spanconfigstore/store.go:364 ⋮ [T1,Vsystem,n1,job=‹AUTO SPAN CONFIG RECONCILIATION id=989147442139496449›] 2127  Changing the span boundaries for Span:‹/Table/104{-/2}› From:[/Table/104:/Table/105) To:[/Table/104:/Table/104/2) With config: {RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:08:09.255056 1261 13@spanconfig/spanconfigstore/store.go:364 ⋮ [T1,Vsystem,n1,job=‹AUTO SPAN CONFIG RECONCILIATION id=989147442139496449›] 2128  Changing the span boundaries for Span:‹/Table/104/{2-3}› From:[/Table/104:/Table/105) To:[/Table/104/2:/Table/104/3) With config: {RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:4 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:08:09.255076 1261 13@spanconfig/spanconfigstore/store.go:373 ⋮ [T1,Vsystem,n1,job=‹AUTO SPAN CONFIG RECONCILIATION id=989147442139496449›] 2129  Changing the SpanConfig for Span:‹/Table/104/{2-3}› From:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false} To:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:4 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:08:09.255096 1261 13@spanconfig/spanconfigstore/store.go:364 ⋮ [T1,Vsystem,n1,job=‹AUTO SPAN CONFIG RECONCILIATION id=989147442139496449›] 2130  Changing the span boundaries for Span:‹/Table/10{4/3-5}› From:[/Table/104:/Table/105) To:[/Table/104/3:/Table/105) With config: {RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:08:15.236237 618 13@spanconfig/spanconfigstore/store.go:364 ⋮ [T1,Vsystem,n1] 2131  Changing the span boundaries for Span:‹/Table/104{-/2}› From:[/Table/104:/Table/105) To:[/Table/104:/Table/104/2) With config: {RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:08:15.236321 618 13@spanconfig/spanconfigstore/store.go:364 ⋮ [T1,Vsystem,n1] 2132  Changing the span boundaries for Span:‹/Table/104/{2-3}› From:[/Table/104/2:/Table/105) To:[/Table/104/2:/Table/104/3) With config: {RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:4 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
I240725 19:08:15.236346 618 13@spanconfig/spanconfigstore/store.go:373 ⋮ [T1,Vsystem,n1] 2133  Changing the SpanConfig for Span:‹/Table/104/{2-3}› From:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:5 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false} To:{RangeMinBytes:134217728 RangeMaxBytes:536870912 GCPolicy:{TTLSeconds:14400 ProtectionPolicies:[] IgnoreStrictEnforcement:false} GlobalReads:false NumReplicas:4 NumVoters:0 Constraints:[] VoterConstraints:[] LeasePreferences:[] RangefeedEnabled:false ExcludeDataFromBackup:false}
```

Fixes: #127171

Release note: None