### PR TITLE
roachtests: fix 5x upreplication with timeseries zonecfg range

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -168,8 +168,9 @@ func runDrainAndDecommission(
 		db := c.Conn(ctx, t.L(), pinnedNode)
 		defer db.Close()
 
-		run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
-		run(fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
+		run(fmt.Sprintf(`ALTER RANGE default    CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
+		run(fmt.Sprintf(`ALTER DATABASE system  CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
+		run(fmt.Sprintf(`ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
 
 		// Speed up the decommissioning.
 		run(`SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='2GiB'`)
@@ -1100,8 +1101,9 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 		defer db.Close()
 
 		// Set the replication factor to 5.
-		run(db, fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
-		run(db, fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+		run(db, fmt.Sprintf(`ALTER RANGE default    CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+		run(db, fmt.Sprintf(`ALTER DATABASE system  CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+		run(db, fmt.Sprintf(`ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
 
 		// Increase the speed of decommissioning.
 		run(db, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='2GiB'`)

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -71,8 +71,9 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 		defer db.Close()
 
 		// Set the replication factor.
-		run(db, fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
-		run(db, fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+		run(db, fmt.Sprintf(`ALTER RANGE default    CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+		run(db, fmt.Sprintf(`ALTER DATABASE system  CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
+		run(db, fmt.Sprintf(`ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
 
 		// Wait for initial up-replication.
 		err := WaitForReplication(ctx, t, t.L(), db, replicationFactor, atLeastReplicationFactor)


### PR DESCRIPTION
Fixes #127496.
Fixes #127497.
Fixes #127500.

This commit fixes the following roachtests, which were all attempting to configure 5x replication on all ranges, and broke due to 59f5cb92:
- `decommission/slow`
- `drain-and-decommission/nodes=9`
- `slow-drain/duration=1m0s`

The fact that tests broke due to that commit deserve some discussion, independent of this fix. Was that an expected result of that change? Do users now need to configure zone configurations differently with the presence of the default `timeseries` zone? Will that breaking change be documented as such? The commit does not have release notes; should it?

Release note: None