### PR TITLE
roachtest: expose workload duration as env variable

### DIFF
--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -353,4 +354,21 @@ func getListenAddr(ctx context.Context) (string, error) {
 	}
 
 	return ip.Query, nil
+}
+
+// EnvWorkloadDurationFlag - environment variable to override
+// default run time duration of workload set in tests.
+// Usage: ROACHTEST_PERF_WORKLOAD_DURATION="5m".
+const EnvWorkloadDurationFlag = "ROACHTEST_PERF_WORKLOAD_DURATION"
+
+var workloadDurationRegex = regexp.MustCompile(`^\d+[mhsMHS]$`)
+
+// getEnvWorkloadDurationValueOrDefault validates EnvWorkloadDurationFlag and
+// returns value set if valid else returns default duration.
+func getEnvWorkloadDurationValueOrDefault(defaultDuration string) string {
+	envWorkloadDurationFlag := os.Getenv(EnvWorkloadDurationFlag)
+	if envWorkloadDurationFlag != "" && workloadDurationRegex.MatchString(envWorkloadDurationFlag) {
+		return " --duration=" + envWorkloadDurationFlag
+	}
+	return " --duration=" + defaultDuration
 }

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -24,8 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/stretchr/testify/require"
 )
-
-const envYCSBFlags = "ROACHTEST_YCSB_FLAGS"
 
 func registerYCSB(r registry.Registry) {
 	workloads := []string{"A", "B", "C", "D", "E", "F"}
@@ -89,16 +86,15 @@ func registerYCSB(r registry.Registry) {
 		m.Go(func(ctx context.Context) error {
 			var args string
 			args += " --ramp=" + ifLocal(c, "0s", "2m")
-			args += " --duration=" + ifLocal(c, "10s", "30m")
 			if opts.readCommitted {
 				args += " --isolation-level=read_committed"
 			}
 			if opts.uniformDistribution {
 				args += " --request-distribution=uniform"
 			}
-			if envFlags := os.Getenv(envYCSBFlags); envFlags != "" {
-				args += " " + envFlags
-			}
+
+			defaultDuration := ifLocal(c, "10s", "30m")
+			args += getEnvWorkloadDurationValueOrDefault(defaultDuration)
 			cmd := fmt.Sprintf(
 				"./workload run ycsb --init --insert-count=1000000 --workload=%s --concurrency=%d"+
 					" --splits=%d --histograms="+t.PerfArtifactsDir()+"/stats.json"+args+


### PR DESCRIPTION
For workloads run via workload or cockroach binary we can set duration using --duration cli flag, but this is not available for workloads run via roachtest

To alter duration of workload run via roachtest, one had to modify the test script and recompile the binary. The main user of this script is git bisect script.

This change exposes ROACHTEST_PERF_WORKLOAD_DURATION as enviornment variable, which can be used to set duration of the workload run via roachtest without having to recompile the roachtest binary. workload duration can be set by setting this enviornment variable e.g. ROACHTEST_PERF_WORKLOAD_DURATION="--duration 5m" In the workload run method we use this value to override the parameters sent to workload or cockroach binary, whichever is used to run the workload.

Epic: none

Part of: https://github.com/cockroachdb/cockroach/issues/62303#issuecomment-2241025168