### PR TITLE
roachtest: add operation name as a datadog tag

### DIFF
--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -487,6 +487,9 @@ func maybeEmitDatadogEvent(
 	details := fmt.Sprintf("cluster: %s\n", clusterName)
 	ev := statsd.NewEvent(fmt.Sprintf("op %s %s", opSpec.Name, status), details)
 
+	ev.Tags = append(ev.Tags, fmt.Sprintf("operation-name:%s", opSpec.Name))
+	ev.Tags = append(ev.Tags, fmt.Sprintf("operation-status:%s", status))
+
 	ev.AggregationKey = fmt.Sprintf("operation-%d", operationID)
 	switch eventType {
 	case eventOpStarted:


### PR DESCRIPTION
Roachtest opeartions emits event to datadog. Custom operation related tags are not added to datadog. Added opeation-name and operation-status custom tags.

Epic: none
Fixes: #127635

Release note: None