### PR TITLE
release-23.1: pgwire: unify serialization error handling

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -937,10 +937,10 @@ func (c *conn) bufferRow(ctx context.Context, row tree.Datums, r *commandResult)
 		}
 	}
 	if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
-		return errors.NewAssertionErrorWithWrappedErrf(err, "unexpected err from buffer")
+		return err
 	}
 	if err := c.maybeFlush(r.pos, r.bufferingDisabled); err != nil {
-		return errors.NewAssertionErrorWithWrappedErrf(err, "unexpected err from buffer")
+		return err
 	}
 	c.maybeReallocate()
 	return nil
@@ -982,7 +982,7 @@ func (c *conn) bufferBatch(ctx context.Context, batch coldata.Batch, r *commandR
 				}
 			}
 			if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
-				panic(fmt.Sprintf("unexpected err from buffer: %s", err))
+				return err
 			}
 			if err := c.maybeFlush(r.pos, r.bufferingDisabled); err != nil {
 				return err


### PR DESCRIPTION
Backport 1/3 commits from #118376.

/cc @cockroachdb/release

---

This commit unifies the serialization error handling between `bufferRow` and `bufferBatch` methods. In particular, whenever an error is returned on `finishMsg` or `maybeFlush`, these errors are somewhat expected (so they shouldn't trigger an assertion failure); furthermore, in one spot we straight up panicked with the error. I think the correct way is simply propagating the error higher up, and then it'll become "communication error" which will trigger connection shutdown.

Fixes: #127059.

Release note: None

Release justification: bug fix.
