### PR TITLE
sql/sessiondatapb: fix parsing/formatting of sql_sequence_cached_node

### DIFF
--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -133,14 +133,20 @@ const (
 	// can impact performance negatively.
 	SerialUsesSQLSequences SerialNormalizationMode = 2
 	// SerialUsesCachedSQLSequences is identical to SerialUsesSQLSequences with
-	// the exception that nodes can cache sequence values. This significantly
+	// the exception that sessions can cache sequence values. This significantly
 	// reduces contention and distributed calls to kv, which results in better
 	// performance. Gaps between sequences may be larger as a result of cached
 	// values being lost to errors and/or node failures.
 	SerialUsesCachedSQLSequences SerialNormalizationMode = 3
 	// SerialUsesUnorderedRowID means use INT NOT NULL DEFAULT unordered_unique_rowid().
-	SerialUsesUnorderedRowID         SerialNormalizationMode = 4
+	SerialUsesUnorderedRowID SerialNormalizationMode = 4
+	// SerialUsesCachedNodeSQLSequences is identical to
+	// SerialUsesCachedSQLSequences, except the sequence values are cached per
+	// node instead of per session.
 	SerialUsesCachedNodeSQLSequences SerialNormalizationMode = 5
+	// maxSerialNormalizationMode should always be one larger than the last
+	// public value.
+	maxSerialNormalizationMode = 6
 )
 
 func (m SerialNormalizationMode) String() string {
@@ -155,6 +161,8 @@ func (m SerialNormalizationMode) String() string {
 		return "sql_sequence"
 	case SerialUsesCachedSQLSequences:
 		return "sql_sequence_cached"
+	case SerialUsesCachedNodeSQLSequences:
+		return "sql_sequence_cached_node"
 	default:
 		return fmt.Sprintf("invalid (%d)", m)
 	}

--- a/pkg/sql/sessiondatapb/session_data_test.go
+++ b/pkg/sql/sessiondatapb/session_data_test.go
@@ -28,3 +28,13 @@ func TestSessionDataJsonCompat(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedSessionData, actualSessionData)
 }
+
+func TestSerialNormalizationRoundTrip(t *testing.T) {
+	for s := range maxSerialNormalizationMode {
+		expectedVal := SerialNormalizationMode(s)
+		str := expectedVal.String()
+		actualVal, ok := SerialNormalizationModeFromString(str)
+		require.True(t, ok)
+		require.Equal(t, expectedVal, actualVal)
+	}
+}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/127667
Release note (bug fix): The sql_sequence_cached_node value of the serial_normalization setting was not correctly formatted. This could lead to errors while connecting to CockroachDB if the default value of serial_normalization was set to serial_normalization. The formatting bug was fixed, which also fixes the errors when connecting.