### PR TITLE
changefeedccl: fix cdc/kafka-chaos-single-row roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1682,9 +1682,10 @@ func registerCDC(r registry.Registry) {
 				_ = conn2.Close()
 			}()
 
+			const testDuration = 30 * time.Minute
 			// Repeatedly update a single row in a table in order to create a large
 			// number of events with the same key that will span multiple batches.
-			for i := 0; i < 1000000; i++ {
+			for start, i := timeutil.Now(), 0; i < 1000000 && timeutil.Since(start) < testDuration; i++ {
 				stmt := fmt.Sprintf(`UPDATE t SET x = %d WHERE id = 1;`, i)
 				if i%2 == 0 {
 					_, err = conn1.ExecContext(ctx, stmt)


### PR DESCRIPTION
The test was timing out after 3 hours, since it
was previously not intended to succeed. This PR
makes it finish after 30 minutes.

Epic: None

Release note: None
