### PR TITLE
logictest: retry relocate stmt in a couple of places

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -12,8 +12,9 @@ statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, FAMILY (k, v));
 INSERT INTO t SELECT i, i FROM generate_series(1, 6) AS g(i)
 
-# Upreplicate the table's range.
-statement ok
+# Upreplicate the table's range. We need a retry to guarantee that the
+# capability has been picked up.
+statement ok retry
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1, 2, 3], 0)
 
 # Split the ranges in the table.

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -12,8 +12,9 @@ user root
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, FAMILY (k, v))
 
-# Upreplicate the table's range.
-statement ok
+# Upreplicate the table's range. We need a retry to guarantee that the
+# capability has been picked up.
+statement ok retry
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1, 2, 3], 0)
 
 # Split the ranges in the table.


### PR DESCRIPTION
The capabilities are propagated asynchronously, so previously we could try to relocate ranges in the secondary tenant before the necessary capability was picked up. This was recently changed in 5f2a4f8af18dc83957ceb3c24cf9c6d7c79ee9e4.

Fixes: #127659.

Release note: None