### PR TITLE
release-23.1: changefeedccl: add some debug logging to the test sinkless feed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -823,7 +823,7 @@ func TestChangefeedTenants(t *testing.T) {
 		// kvServer is used here because we require a
 		// TestServerInterface implementor. It is only used as
 		// the return value for f.Server()
-		f := makeSinklessFeedFactory(kvServer, sink, nil)
+		f := makeSinklessFeedFactory(t, kvServer, sink, nil)
 		tenantSQL.Exec(t, `INSERT INTO foo_in_tenant VALUES (1)`)
 		feed := feed(t, f, `CREATE CHANGEFEED FOR foo_in_tenant`)
 		assertPayloads(t, feed, []string{
@@ -8566,7 +8566,7 @@ func TestChangefeedCreateTelemetryLogs(t *testing.T) {
 	t.Run(`core_sink_type`, func(t *testing.T) {
 		coreSink, cleanup := sqlutils.PGUrl(t, s.Server.SQLAddr(), t.Name(), url.User(username.RootUser))
 		defer cleanup()
-		coreFeedFactory := makeSinklessFeedFactory(s.Server, coreSink, nil)
+		coreFeedFactory := makeSinklessFeedFactory(t, s.Server, coreSink, nil)
 
 		beforeCreateSinkless := timeutil.Now()
 		coreFeed := feed(t, coreFeedFactory, `CREATE CHANGEFEED FOR foo`)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -945,7 +945,7 @@ func makeFeedFactoryWithOptions(
 		return f, func() {}
 	case "sinkless":
 		sink, cleanup := pgURLForUser(username.RootUser)
-		f := makeSinklessFeedFactory(s, sink, pgURLForUser)
+		f := makeSinklessFeedFactory(t, s, sink, pgURLForUser)
 		f.(*sinklessFeedFactory).currentDB = func(currentDB *string) error {
 			r := db.QueryRow("SELECT current_database()")
 			return r.Scan(currentDB)


### PR DESCRIPTION
Backport 1/1 commits from #127553.

/cc @cockroachdb/release

---

This patch adds some debug logging to the test sinkless feed to
help with debugging test failures.

Informs #126890

Release note: None

---

Release justification: test-only change
