### PR TITLE
githooks: clarify commit message reminder about bug fixes and GitHub issues

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -120,7 +120,7 @@ ${cchar}Release note (performance improvement): \\
 ${cchar}Release note (cluster virtualization): \\
 ${cchar}Release note (bug fix): \\
 ${cchar}              ^-- ensure there is a corresponding GitHub issue labeled \\
-${cchar}                  with C-bug and earliest known release branch \\
+${cchar}                  with C-bug and all known affected release branches \\
 
 ;
 "


### PR DESCRIPTION
This commit updates the commit message reminder for the bug fix category of release notes to clarify that the corresponding GitHub issue should be labeled with *all* known affected release branches, not just the earliest one.

Release note: None