### PR TITLE
internal/sqlsmith: don't generate abs on FLOAT4

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -441,6 +441,13 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 			return nil, false
 		}
 	}
+	if fn.def.Name == "abs" && typ.Identical(types.Float4) {
+		// The 'abs' function is known to return somewhat unpredictable results
+		// on FLOAT4 type (different precision depending on the execution engine
+		// and the optimizer plan), so we choose to never use it in this
+		// context.
+		return nil, false
+	}
 
 	args := make(tree.TypedExprs, 0)
 	for _, argTyp := range fn.overload.Types.Types() {


### PR DESCRIPTION
I just reduced ~three~five failures in the unoptimized query oracle to `abs` function used in the virtual computed columns where the difference appeared to be only in the precision of this column. It seems somewhat expected to me that depending on the execution engine and / or the optimizer plan we'd have some difference here, so without looking too much into this, this commit skips generating the `abs` function on FLOAT4 type altogether (we still will generate it on FLOAT8 type).

Fixes: #126190

Release note: None