### PR TITLE
sql/parser: fix memory leak of scanned comments

### DIFF
--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -98,6 +98,7 @@ func (s *Scanner) Init(str string) {
 // where we reuse a Scanner).
 func (s *Scanner) Cleanup() {
 	s.bytesPrealloc = nil
+	s.Comments = nil
 }
 
 func (s *Scanner) allocBytes(length int) []byte {


### PR DESCRIPTION
This commit fixes a memory leak that cause a session's
`scanner.Scanner`, which is embedded in a `pgwire.conn` via a
`parser.Parser`, to retain previously scanned SQL comments in all parsed
SQL statements. The scanner's slice of comments would continue to grow
as it parsed new SQL strings with comments, as long as the session
remained open. Also, the slice of comments holds references to the bytes
in `pgwire` read buffers, preventing those buffers from being GC'd.

Fixes #127710

Release note (bug fix): A bug has been fixed that caused a memory leak
when executing SQL statements with comments, for example,
`SELECT /* comment */ 1;`. Memory owned by a SQL session would continue
to grow as these types of statements were executed. The memory would
only be released when closing the SQL session. This bug has been present
since version 23.1.
