### PR TITLE
execinfra: fix up recent improvement

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -288,7 +288,9 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 }
 
 func (bp *backupDataProcessor) close() {
-	bp.cancelAndWaitForWorker()
+	if bp.cancelAndWaitForWorker != nil {
+		bp.cancelAndWaitForWorker()
+	}
 	if bp.InternalClose() {
 		bp.aggTimer.Stop()
 		bp.memAcc.Close(bp.Ctx())

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -393,7 +393,9 @@ func (gssp *generativeSplitAndScatterProcessor) ConsumerClosed() {
 // runs into an error and stops consuming scattered entries to make sure we
 // don't leak goroutines.
 func (gssp *generativeSplitAndScatterProcessor) close() {
-	gssp.cancelScatterAndWaitForWorker()
+	if gssp.cancelScatterAndWaitForWorker != nil {
+		gssp.cancelScatterAndWaitForWorker()
+	}
 	gssp.InternalClose()
 }
 

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -667,7 +667,9 @@ func (rd *restoreDataProcessor) ConsumerClosed() {
 	if rd.Closed {
 		return
 	}
-	rd.cancelWorkersAndWait()
+	if rd.cancelWorkersAndWait != nil {
+		rd.cancelWorkersAndWait()
+	}
 
 	rd.qp.Close(rd.Ctx())
 	rd.aggTimer.Stop()

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -123,7 +123,7 @@ type RowSource interface {
 
 	// Start prepares the RowSource for future Next() calls and takes in the
 	// context in which these future calls should operate. Start needs to be
-	// called before Next/ConsumerDone/ConsumerClosed.
+	// called before Next and ConsumerDone.
 	//
 	// RowSources that consume other RowSources are expected to Start() their
 	// inputs.
@@ -169,7 +169,8 @@ type RowSource interface {
 
 	// ConsumerClosed informs the source that the consumer is done and will not
 	// make any more calls to Next(). Must be called at least once on a given
-	// RowSource and can be called multiple times.
+	// RowSource and can be called multiple times. Implementations must support
+	// the case when Start was never called.
 	//
 	// Like ConsumerDone(), if the consumer of the source stops consuming rows
 	// before Next indicates that there are no more rows, ConsumerDone() and/or

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -238,7 +238,9 @@ func (idp *readImportDataProcessor) close() {
 		return
 	}
 
-	idp.cancel()
+	if idp.cancel != nil {
+		idp.cancel()
+	}
 	_ = idp.wg.Wait()
 
 	idp.InternalClose()


### PR DESCRIPTION
In f397730f867b6741bc04493f70a157ada512543b we recently merged a change to call `ConsumerClosed` on all processors in a flow on the flow cleanup. That change audited all processors to ensure that the implementations of `ConsumerClosed` were ok to be called multiple times, but there is another condition we need to add - that it's possible for `Start` to not have been called. This commit fixes that oversight - it adjusts the interface comments as well as a handful implementations. The bug isn't a big deal because this could only occur when the server is being shutdown.

Fixes: #127715.

Release note: None