### PR TITLE
opt: fix SKIP LOCKED under Read Committed isolation

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
@@ -75,7 +75,6 @@ COMMIT;
 ----
 20 200 2000
 
-
 # Shared reads block on exclusive locks but not on shared locks.
 
 query III async,rowsort q00
@@ -562,3 +561,45 @@ COMMIT
 user root
 
 awaitquery q18
+
+subtest skip_locked
+
+statement ok
+CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT, INDEX (y), FAMILY (x, y, z))
+
+statement ok
+GRANT ALL ON xyz TO testuser
+
+statement ok
+INSERT INTO xyz VALUES (1, 10, 100), (2, 10, 100)
+
+user testuser
+
+statement ok
+BEGIN ISOLATION LEVEL SERIALIZABLE
+
+# Lock the first row.
+
+query III
+SELECT * FROM xyz WHERE x = 1 FOR UPDATE
+----
+1  10  100
+
+user root
+
+# A limited SKIP LOCKED should be able to skip over the locked first row without
+# stopping early or blocking.
+
+query III
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM xyz@xyz_y_idx WHERE y = 10 ORDER BY y, x LIMIT 1 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+2  10  100
+
+user testuser
+
+statement ok
+COMMIT
+
+user root

--- a/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
@@ -597,6 +597,17 @@ COMMIT;
 ----
 2  10  100
 
+# The unlocked reads in SKIP LOCKED should not block on locks, either, even
+# under serializable isolation.
+
+statement ok
+SET optimizer_use_lock_op_for_serializable = true
+
+query III
+SELECT * FROM xyz WHERE z = 100 ORDER BY x FOR UPDATE SKIP LOCKED
+----
+2  10  100
+
 user testuser
 
 statement ok

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -273,7 +273,7 @@ func constructVirtualScan(
 	if params.NeededCols.Contains(0) {
 		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
 	}
-	if params.Locking.IsLocking() {
+	if params.Locking.IsNonZeroLocking() {
 		// We shouldn't have allowed SELECT FOR UPDATE for a virtual table.
 		return nil, errors.AssertionFailedf("locking cannot be used with virtual table")
 	}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1227,7 +1227,7 @@ func (b *Builder) buildLock(lock *memo.LockExpr) (_ execPlan, outputCols colOrdM
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	if !locking.IsLocking() {
+	if !locking.IsNonZeroLocking() {
 		return b.buildRelational(lock.Input)
 	}
 

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -42,6 +42,8 @@ type Locking struct {
 	//   SKIP LOCKED
 	//   NOWAIT
 	//
+	// Note that SKIP LOCKED can be requested without a locking strength, which
+	// signifies skipping over locks without taking any additional locks.
 	WaitPolicy tree.LockingWaitPolicy
 
 	// The third property is the form of locking, either record locking or
@@ -84,4 +86,13 @@ func (l Locking) Max(l2 Locking) Locking {
 // locking mode.
 func (l Locking) IsLocking() bool {
 	return l.Strength != tree.ForNone
+}
+
+// IsNonZeroLocking returns true if the locking properties somehow differ from
+// the zero value locking properties. This can mean a row-level locking mode is
+// set (i.e. l.Strength != tree.ForNone) or the SKIP LOCKED wait policy is in
+// use even if no locking mode is set (i.e. l.WaitPolicy ==
+// tree.LockWaitSkipLocked).
+func (l Locking) IsNonZeroLocking() bool {
+	return l != Locking{}
 }

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1629,12 +1629,13 @@ func (f *ExprFmtCtx) formatLocking(tp treeprinter.Node, locking opt.Locking) {
 func (f *ExprFmtCtx) formatLockingWithPrefix(
 	tp treeprinter.Node, labelPrefix string, locking opt.Locking,
 ) {
-	if !locking.IsLocking() {
+	if !locking.IsNonZeroLocking() {
 		return
 	}
 	strength := ""
 	switch locking.Strength {
 	case tree.ForNone:
+		strength = "none"
 	case tree.ForKeyShare:
 		strength = "for-key-share"
 	case tree.ForShare:

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -81,7 +81,7 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 	// Side Effects
 	// ------------
 	// A Locking option is a side-effect (we don't want to elide this scan).
-	if scan.Locking.IsLocking() {
+	if scan.Locking.IsNonZeroLocking() {
 		rel.VolatilitySet.AddVolatile()
 	}
 

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "join_funcs.go",
         "limit_funcs.go",
         "list_sorter.go",
+        "lock_funcs.go",
         "mutation_funcs.go",
         "ordering_funcs.go",
         "project_builder.go",

--- a/pkg/sql/opt/norm/lock_funcs.go
+++ b/pkg/sql/opt/norm/lock_funcs.go
@@ -1,0 +1,22 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package norm
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// LockUsesSkipLocked returns true if the Lock expression uses the SKIP LOCKED
+// wait policy.
+func (c *CustomFuncs) LockUsesSkipLocked(private *memo.LockPrivate) bool {
+	return private.Locking.WaitPolicy == tree.LockWaitSkipLocked
+}

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -343,3 +343,27 @@ $input
     $limitValue
     $limitOrdering
 )
+
+# PushLimitIntoLock pushes the Limit operator into its Lock input, as long as
+# the Lock does not use a SKIP LOCKED wait policy. This helps minimize the
+# number of rows locked.
+[PushLimitIntoLock, Normalize]
+(Limit
+    (Lock $input:* $private:*) & ^(LockUsesSkipLocked $private)
+    $limit:*
+    $ordering:*
+)
+=>
+(Lock (Limit $input $limit $ordering) $private)
+
+# PushOffsetIntoLock pushes the Offset operator into its Lock input, as long as
+# the Lock does not use a SKIP LOCKED wait policy. This helps minimize the
+# number of rows locked.
+[PushOffsetIntoLock, Normalize]
+(Offset
+    (Lock $input:* $private:*) & ^(LockUsesSkipLocked $private)
+    $offset:*
+    $ordering:*
+)
+=>
+(Lock (Offset $input $offset $ordering) $private)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1659,11 +1659,15 @@ limit
  │    ├── limit hint: 1.00
  │    └── index-join abcde
  │         ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │         ├── locking: none,skip-locked
+ │         ├── volatile
  │         ├── key: (1)
  │         ├── fd: ()-->(4), (1)-->(2,3,5)
  │         ├── limit hint: 1.00
  │         └── scan abcde@abcde_c_idx,partial
  │              ├── columns: a:1!null c:3!null
+ │              ├── locking: none,skip-locked
+ │              ├── volatile
  │              ├── key: (1)
  │              ├── fd: (1)-->(3)
  │              └── limit hint: 1.00
@@ -1683,13 +1687,17 @@ offset
  │    ├── key: (1)
  │    └── project
  │         ├── columns: a:1!null
+ │         ├── volatile
  │         ├── key: (1)
  │         └── project
  │              ├── columns: d:4 a:1!null
+ │              ├── volatile
  │              ├── key: (1)
  │              ├── fd: ()-->(4)
  │              ├── scan abcde@abcde_c_idx,partial
  │              │    ├── columns: a:1!null
+ │              │    ├── locking: none,skip-locked
+ │              │    ├── volatile
  │              │    └── key: (1)
  │              └── projections
  │                   └── CAST(NULL AS TIMESTAMP) [as=d:4]
@@ -1761,11 +1769,15 @@ limit
  │    ├── limit hint: 1.00
  │    └── index-join abcde
  │         ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │         ├── locking: none,skip-locked
+ │         ├── volatile
  │         ├── key: (1)
  │         ├── fd: ()-->(4), (1)-->(2,3,5)
  │         ├── limit hint: 1.00
  │         └── scan abcde@abcde_c_idx,partial
  │              ├── columns: a:1!null c:3!null
+ │              ├── locking: none,skip-locked
+ │              ├── volatile
  │              ├── key: (1)
  │              ├── fd: (1)-->(3)
  │              └── limit hint: 1.00
@@ -1787,10 +1799,14 @@ offset
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
  │    └── index-join abcde
  │         ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │         ├── locking: none,skip-locked
+ │         ├── volatile
  │         ├── key: (1)
  │         ├── fd: ()-->(4), (1)-->(2,3,5)
  │         └── scan abcde@abcde_c_idx,partial
  │              ├── columns: a:1!null c:3!null
+ │              ├── locking: none,skip-locked
+ │              ├── volatile
  │              ├── key: (1)
  │              └── fd: (1)-->(3)
  └── 1

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1573,3 +1573,224 @@ distinct-on
       │    └── column1
       └── first-agg
            └── "?column?"
+
+# ----------------------------------------------------
+# PushLimitIntoLock and PushOffsetIntoLock
+# ----------------------------------------------------
+
+# Check that we push down LIMIT and OFFSET under SFU locking, except when using
+# SKIP LOCKED.
+
+exec-ddl
+CREATE TABLE abcde (
+  a UUID NOT NULL DEFAULT gen_random_uuid(),
+  b STRING NULL,
+  c TIMESTAMP NOT NULL DEFAULT current_timestamp():::TIMESTAMP,
+  d TIMESTAMP NULL,
+  e STRING NULL,
+  PRIMARY KEY (a),
+  INDEX (c) WHERE d IS NULL
+)
+----
+
+# Serializable, without SKIP LOCKED.
+
+opt set=optimizer_use_lock_op_for_serializable=true expect=PushLimitIntoLock
+SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE
+----
+lock abcde
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── locking: for-update
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── index-join abcde
+      ├── columns: a:1!null b:2 c:3!null d:4 e:5
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1-5)
+      └── scan abcde@abcde_c_idx,partial
+           ├── columns: a:1!null c:3!null
+           ├── limit: 1
+           ├── key: ()
+           └── fd: ()-->(1,3)
+
+opt set=optimizer_use_lock_op_for_serializable=true expect=PushOffsetIntoLock
+SELECT * FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE
+----
+lock abcde
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── locking: for-update
+ ├── volatile, mutations
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
+ └── index-join abcde
+      ├── columns: a:1!null b:2 c:3!null d:4 e:5
+      ├── key: (1)
+      ├── fd: ()-->(4), (1)-->(2,3,5)
+      └── offset
+           ├── columns: a:1!null c:3!null
+           ├── key: (1)
+           ├── fd: (1)-->(3)
+           ├── scan abcde@abcde_c_idx,partial
+           │    ├── columns: a:1!null c:3!null
+           │    ├── key: (1)
+           │    └── fd: (1)-->(3)
+           └── 1
+
+# Serializable, with SKIP LOCKED.
+
+opt set=optimizer_use_lock_op_for_serializable=true expect-not=PushLimitIntoLock
+SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+limit
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── lock abcde
+ │    ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile, mutations
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5)
+ │    ├── limit hint: 1.00
+ │    └── index-join abcde
+ │         ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │         ├── key: (1)
+ │         ├── fd: ()-->(4), (1)-->(2,3,5)
+ │         ├── limit hint: 1.00
+ │         └── scan abcde@abcde_c_idx,partial
+ │              ├── columns: a:1!null c:3!null
+ │              ├── key: (1)
+ │              ├── fd: (1)-->(3)
+ │              └── limit hint: 1.00
+ └── 1
+
+opt set=optimizer_use_lock_op_for_serializable=true expect-not=PushOffsetIntoLock
+SELECT a FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE SKIP LOCKED
+----
+offset
+ ├── columns: a:1!null
+ ├── volatile, mutations
+ ├── key: (1)
+ ├── lock abcde
+ │    ├── columns: a:1!null
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile, mutations
+ │    ├── key: (1)
+ │    └── project
+ │         ├── columns: a:1!null
+ │         ├── key: (1)
+ │         └── project
+ │              ├── columns: d:4 a:1!null
+ │              ├── key: (1)
+ │              ├── fd: ()-->(4)
+ │              ├── scan abcde@abcde_c_idx,partial
+ │              │    ├── columns: a:1!null
+ │              │    └── key: (1)
+ │              └── projections
+ │                   └── CAST(NULL AS TIMESTAMP) [as=d:4]
+ └── 1
+
+# Read committed, without SKIP LOCKED.
+
+opt isolation=ReadCommitted expect=PushLimitIntoLock
+SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE
+----
+lock abcde
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── locking: for-update,durability-guaranteed
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── index-join abcde
+      ├── columns: a:1!null b:2 c:3!null d:4 e:5
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1-5)
+      └── scan abcde@abcde_c_idx,partial
+           ├── columns: a:1!null c:3!null
+           ├── limit: 1
+           ├── key: ()
+           └── fd: ()-->(1,3)
+
+opt isolation=ReadCommitted expect=PushOffsetIntoLock
+SELECT * FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE
+----
+lock abcde
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── locking: for-update,durability-guaranteed
+ ├── volatile, mutations
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
+ └── index-join abcde
+      ├── columns: a:1!null b:2 c:3!null d:4 e:5
+      ├── key: (1)
+      ├── fd: ()-->(4), (1)-->(2,3,5)
+      └── offset
+           ├── columns: a:1!null c:3!null
+           ├── key: (1)
+           ├── fd: (1)-->(3)
+           ├── scan abcde@abcde_c_idx,partial
+           │    ├── columns: a:1!null c:3!null
+           │    ├── key: (1)
+           │    └── fd: (1)-->(3)
+           └── 1
+
+# Read committed, with SKIP LOCKED.
+
+opt isolation=ReadCommitted expect-not=PushLimitIntoLock
+SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+limit
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── lock abcde
+ │    ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │    ├── locking: for-update,skip-locked,durability-guaranteed
+ │    ├── volatile, mutations
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5)
+ │    ├── limit hint: 1.00
+ │    └── index-join abcde
+ │         ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │         ├── key: (1)
+ │         ├── fd: ()-->(4), (1)-->(2,3,5)
+ │         ├── limit hint: 1.00
+ │         └── scan abcde@abcde_c_idx,partial
+ │              ├── columns: a:1!null c:3!null
+ │              ├── key: (1)
+ │              ├── fd: (1)-->(3)
+ │              └── limit hint: 1.00
+ └── 1
+
+opt isolation=ReadCommitted expect-not=PushOffsetIntoLock
+SELECT * FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE SKIP LOCKED
+----
+offset
+ ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── volatile, mutations
+ ├── key: (1)
+ ├── fd: ()-->(4), (1)-->(2,3,5)
+ ├── lock abcde
+ │    ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │    ├── locking: for-update,skip-locked,durability-guaranteed
+ │    ├── volatile, mutations
+ │    ├── key: (1)
+ │    ├── fd: ()-->(4), (1)-->(2,3,5)
+ │    └── index-join abcde
+ │         ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │         ├── key: (1)
+ │         ├── fd: ()-->(4), (1)-->(2,3,5)
+ │         └── scan abcde@abcde_c_idx,partial
+ │              ├── columns: a:1!null c:3!null
+ │              ├── key: (1)
+ │              └── fd: (1)-->(3)
+ └── 1

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1203,10 +1203,6 @@ func (b *Builder) buildSelectStmtWithoutParens(
 		outScope = projectionsScope
 	}
 
-	if limit != nil {
-		b.buildLimit(limit, inScope, outScope)
-	}
-
 	// Remove locking items from scope, validate that they were found within the
 	// FROM clause, and build them.
 	for range lockingClause {
@@ -1216,6 +1212,10 @@ func (b *Builder) buildSelectStmtWithoutParens(
 			// TODO(michae2): Combine multiple buildLock calls for the same table.
 			b.buildLocking(item, outScope)
 		}
+	}
+
+	if limit != nil {
+		b.buildLimit(limit, inScope, outScope)
 	}
 
 	// TODO(rytaft): Support FILTER expression.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -168,7 +168,20 @@ func (b *Builder) buildDataSource(
 				}
 			}
 			if b.shouldBuildLockOp() {
-				locking = nil
+				// If we're implementing FOR UPDATE / FOR SHARE with a Lock operator on
+				// top of the plan, then this can be an unlocked scan. But if the
+				// locking uses SKIP LOCKED then we still need this scan to skip over
+				// locks even if it does not take any locks itself.
+				if locking.get().WaitPolicy == tree.LockWaitSkipLocked {
+					// Create a dummy lockingSpec to get just the skip locked behavior.
+					locking = lockingSpec{&lockingItem{
+						item: &tree.LockingItem{
+							WaitPolicy: tree.LockWaitSkipLocked,
+						},
+					}}
+				} else {
+					locking = nil
+				}
 			}
 			return b.buildScan(
 				tabMeta,
@@ -504,7 +517,20 @@ func (b *Builder) buildScanFromTableRef(
 		}
 	}
 	if b.shouldBuildLockOp() {
-		locking = nil
+		// If we're implementing FOR UPDATE / FOR SHARE with a Lock operator on top
+		// of the plan, then this can be an unlocked scan. But if the locking uses
+		// SKIP LOCKED then we still need this scan to skip over locks even if it
+		// does not take any locks itself.
+		if locking.get().WaitPolicy == tree.LockWaitSkipLocked {
+			// Create a dummy lockingSpec to get just the skip locked behavior.
+			locking = lockingSpec{&lockingItem{
+				item: &tree.LockingItem{
+					WaitPolicy: tree.LockWaitSkipLocked,
+				},
+			}}
+		} else {
+			locking = nil
+		}
 	}
 	return b.buildScan(
 		tabMeta, ordinals, indexFlags, locking, inScope, false, /* disableNotVisibleIndex */
@@ -747,7 +773,7 @@ func (b *Builder) buildScan(
 	}
 	if locking.isSet() {
 		private.Locking = locking.get()
-		if b.shouldUseGuaranteedDurability() {
+		if private.Locking.IsLocking() && b.shouldUseGuaranteedDurability() {
 			// Under weaker isolation levels we use fully-durable locks for SELECT FOR
 			// UPDATE statements, SELECT FOR SHARE statements, and constraint checks
 			// (e.g. FK checks), regardless of locking strength and wait policy.

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -3036,7 +3036,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
@@ -3056,7 +3057,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR SHARE SKIP LOCKED
@@ -3076,7 +3078,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE SKIP LOCKED
@@ -3096,7 +3099,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
@@ -3119,7 +3123,8 @@ lock t
       └── project
            ├── columns: a:1!null b:2
            └── scan t
-                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
@@ -3145,7 +3150,8 @@ lock t
            └── project
                 ├── columns: a:1!null b:2
                 └── scan t
-                     └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                     ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                     └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
@@ -3174,7 +3180,8 @@ lock t
                 └── project
                      ├── columns: a:1!null b:2
                      └── scan t
-                          └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                          ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                          └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
@@ -3194,7 +3201,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,skip-locked
 
 build
 SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
@@ -3226,7 +3234,8 @@ lock t
  └── project
       ├── columns: "?column?":5!null a:1!null
       ├── scan t
-      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── locking: none,skip-locked
       └── projections
            └── 1 [as="?column?":5]
 


### PR DESCRIPTION
**opt: do not push LIMIT or OFFSET below locking with SKIP LOCKED**

We were always building the new Lock operator after building Limit
and/or Offset operators in the same SELECT. This is incorrect when the
Lock operator uses SKIP LOCKED, as the Lock might filter out locked rows
that should not count toward a limit or offset.

Instead, build the new Lock operator as input to Limit and/or Offset,
and then use normalization rules to push the Limit and/or Offset below
the Lock if it does not use SKIP LOCKED.

Fixes: #121917

Release note (bug fix): Fix a bug in which SELECT FOR UPDATE or SELECT
FOR SHARE queries using SKIP LOCKED and a LIMIT and/or an OFFSET could
return incorrect results under Read Committed isolation. This bug was
present when support for SKIP LOCKED under Read Committed isolation was
introduced in v24.1.0.

---

**opt: add skip-locked to unlocked scans below SKIP LOCKED**

When using the new Lock operator to implement FOR UPDATE and FOR SHARE,
we build unlocked scans that are then followed by a final Lock
operation. If the Lock operator uses SKIP LOCKED, however, these
unlocked scans still need to be flagged with the skip-locked wait policy
to avoid blocking, even if they do not take locks themselves.

Fixes: #121917

Release note (bug fix): Fix a bug in which some SELECT FOR UPDATE or
SELECT FOR SHARE queries using SKIP LOCKED could still block on locked
rows when using optimizer_use_lock_op_for_serializable under
Serializable isolation. This bug was present when
optimizer_use_lock_op_for_serializable was introduced in v23.2.0.