### PR TITLE
roachtest: use aws spot vm for running roachtest nightlies.

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -343,7 +343,7 @@ func (r *testRunner) Run(
 			}
 			//  TODO(bhaskar): remove this once we have more usage details
 			//  and more convinced about using spot VMs for all the runs.
-			if roachtestflags.Cloud == spec.GCE &&
+			if (roachtestflags.Cloud == spec.GCE || roachtestflags.Cloud == spec.AWS) &&
 				tests[i].Benchmark &&
 				!tests[i].Suites.Contains(registry.Weekly) &&
 				!tests[i].IsLastFailurePreempt() &&


### PR DESCRIPTION
Currently 80% of benchmark tests are running on spot vm on gce. Adding support to run 80% of benchmark tests running on aws to use spot vms.

Epic: none
Fixes: #127690

Release note: None