### PR TITLE
storage: fix storage.value_blocks.enabled usage in MakeIngestionWrite…

### DIFF
--- a/pkg/kv/kvnemesis/testdata/TestOperationsFormat/4
+++ b/pkg/kv/kvnemesis/testdata/TestOperationsFormat/4
@@ -1,6 +1,6 @@
 echo
 ----
-···db0.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1144 bytes (as writes)
+···db0.AddSSTable(ctx, tk(1), tk(4), ... /* @s1 */) // 1114 bytes (as writes)
 ···// ^-- tk(1) -> sv(s1): /Table/100/"0000000000000001"/0.000000001,0 -> /BYTES/v1
 ···// ^-- tk(2) -> sv(s1): /Table/100/"0000000000000002"/0.000000001,0 -> /<empty>
 ···// ^-- [tk(3), tk(4)) -> sv(s1): /Table/100/"000000000000000{3"-4"} -> /<empty>

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -91,8 +91,9 @@ var MaxSyncDurationFatalOnExceeded = settings.RegisterBoolSetting(
 // ValueBlocksEnabled controls whether older versions of MVCC keys in the same
 // sstable will have their values written to value blocks. This only affects
 // sstables that will be written in the future, as part of flushes or
-// compactions, and does not eagerly change the encoding of existing sstables.
-// Reads can correctly read both kinds of sstables.
+// compactions inside Pebble, and for ingestions (outside Pebble), and does
+// not eagerly change the encoding of existing sstables. Reads can correctly
+// read both kinds of sstables.
 var ValueBlocksEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel, // used for temp storage in virtual cluster servers
 	"storage.value_blocks.enabled",

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -91,6 +91,15 @@ func TestMakeIngestionWriterOptions(t *testing.T) {
 			}(),
 			want: sstable.TableFormatPebblev4,
 		},
+		{
+			name: "disable value blocks",
+			st: func() *cluster.Settings {
+				st := cluster.MakeTestingClusterSettings()
+				ValueBlocksEnabled.Override(context.Background(), &st.SV, false)
+				return st
+			}(),
+			want: sstable.TableFormatPebblev2,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
…rOptions

This will allow the existing cluster setting to be used to disable value blocks even for ingestion, as was intended.

Informs #127678

Epic: none

Release note: None