### PR TITLE
release-24.1: ui: add loading skeletons to databases and tables pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
@@ -30,6 +30,15 @@
   &__no-result {
     @include text--body-strong;
   }
+
+  &__cell-error {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    svg {
+      fill: $colors--warning;
+    }
+  }
 }
 
 .sorted-table {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -59,7 +59,7 @@ import {
   TableSchemaDetailsRow,
   TableSpanStatsRow,
 } from "../api";
-import { checkInfoAvailable } from "../databases";
+import { LoadingCell } from "../databases";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { ViewMode } from "./types";
 
@@ -561,12 +561,16 @@ export class DatabaseDetailsPage extends React.Component<
               Ranges
             </Tooltip>
           ),
-          cell: table =>
-            checkInfoAvailable(
-              table.requestError,
-              table.details.spanStats?.error,
-              table.details.spanStats?.range_count,
-            ),
+          cell: table => (
+            <LoadingCell
+              requestError={table.requestError}
+              queryError={table.details.spanStats?.error}
+              loading={table.loading}
+              errorClassName={cx("database-table__cell-error")}
+            >
+              {table.details.spanStats?.range_count}
+            </LoadingCell>
+          ),
           sort: table => table.details.spanStats?.range_count,
           className: cx("database-table__col-range-count"),
           name: "rangeCount",
@@ -580,12 +584,16 @@ export class DatabaseDetailsPage extends React.Component<
               Columns
             </Tooltip>
           ),
-          cell: table =>
-            checkInfoAvailable(
-              table.requestError,
-              table.details.schemaDetails?.error,
-              table.details.schemaDetails?.columns?.length,
-            ),
+          cell: table => (
+            <LoadingCell
+              requestError={table.requestError}
+              queryError={table.details.schemaDetails?.error}
+              loading={table.loading}
+              errorClassName={cx("database-table__cell-error")}
+            >
+              {table.details.schemaDetails?.columns?.length}
+            </LoadingCell>
+          ),
           sort: table => table.details.schemaDetails?.columns?.length,
           className: cx("database-table__col-column-count"),
           name: "columnCount",
@@ -618,15 +626,19 @@ export class DatabaseDetailsPage extends React.Component<
               Regions
             </Tooltip>
           ),
-          cell: table =>
-            checkInfoAvailable(
-              table.requestError,
-              null,
-              table.details.nodesByRegionString &&
-                table.details.nodesByRegionString.length > 0
+          cell: table => (
+            <LoadingCell
+              requestError={table.requestError}
+              queryError={null}
+              loading={table.loading}
+              errorClassName={cx("database-table__cell-error")}
+            >
+              {table.details.nodesByRegionString &&
+              table.details.nodesByRegionString.length > 0
                 ? table.details.nodesByRegionString
-                : null,
-            ),
+                : null}
+            </LoadingCell>
+          ),
           sort: table => table.details.nodesByRegionString,
           className: cx("database-table__col--regions"),
           name: "regions",
@@ -651,16 +663,19 @@ export class DatabaseDetailsPage extends React.Component<
               % of Live Data
             </Tooltip>
           ),
-          cell: table =>
-            checkInfoAvailable(
-              table.requestError,
-              table.details.spanStats?.error,
-              table.details.spanStats ? (
+          cell: table => (
+            <LoadingCell
+              requestError={table.requestError}
+              queryError={table.details.spanStats?.error}
+              loading={table.loading}
+              errorClassName={cx("database-table__cell-error")}
+            >
+              {table.details.spanStats ? (
                 <MVCCInfoCell details={table.details} />
-              ) : null,
-            ),
+              ) : null}
+            </LoadingCell>
+          ),
           sort: table => table.details.spanStats?.live_percentage,
-          className: cx("database-table__col-column-count"),
           name: "livePercentage",
         },
         {
@@ -672,16 +687,20 @@ export class DatabaseDetailsPage extends React.Component<
               Table Stats Last Updated <Timezone />
             </Tooltip>
           ),
-          cell: table =>
-            checkInfoAvailable(
-              table.requestError,
-              table.details.statsLastUpdated?.error,
+          cell: table => (
+            <LoadingCell
+              requestError={table.requestError}
+              queryError={table.details.statsLastUpdated?.error}
+              loading={table.loading}
+              errorClassName={cx("database-table__cell-error")}
+            >
               <Timestamp
                 time={table.details.statsLastUpdated?.stats_last_created_at}
                 format={DATE_FORMAT}
                 fallback={"No table statistics found"}
-              />,
-            ),
+              />
+            </LoadingCell>
+          ),
           sort: table => table.details.statsLastUpdated,
           className: cx("database-table__col--table-stats"),
           name: "tableStatsUpdated",
@@ -720,12 +739,16 @@ export class DatabaseDetailsPage extends React.Component<
             Users
           </Tooltip>
         ),
-        cell: table =>
-          checkInfoAvailable(
-            table.requestError,
-            table.details.grants?.error,
-            table.details.grants?.roles.length,
-          ),
+        cell: table => (
+          <LoadingCell
+            requestError={table.requestError}
+            queryError={table.details.grants?.error}
+            loading={table.loading}
+            errorClassName={cx("database-table__cell-error")}
+          >
+            {table.details.grants?.roles.length}
+          </LoadingCell>
+        ),
         sort: table => table.details.grants?.roles.length,
         className: cx("database-table__col-user-count"),
         name: "userCount",
@@ -736,12 +759,16 @@ export class DatabaseDetailsPage extends React.Component<
             Roles
           </Tooltip>
         ),
-        cell: table =>
-          checkInfoAvailable(
-            table.requestError,
-            table.details.grants?.error,
-            table.details.grants?.roles.join(", "),
-          ),
+        cell: table => (
+          <LoadingCell
+            requestError={table.requestError}
+            queryError={table.details.grants?.error}
+            loading={table.loading}
+            errorClassName={cx("database-table__cell-error")}
+          >
+            {table.details.grants?.roles.join(", ")}
+          </LoadingCell>
+        ),
         sort: table => table.details.grants?.roles.join(", "),
         className: cx("database-table__col-roles"),
         name: "roles",
@@ -752,12 +779,16 @@ export class DatabaseDetailsPage extends React.Component<
             Grants
           </Tooltip>
         ),
-        cell: table =>
-          checkInfoAvailable(
-            table.requestError,
-            table.details.grants?.error,
-            table.details.grants?.privileges.join(", "),
-          ),
+        cell: table => (
+          <LoadingCell
+            requestError={table.requestError}
+            queryError={table.details.grants?.error}
+            loading={table.loading}
+            errorClassName={cx("database-table__cell-error")}
+          >
+            {table.details.grants?.privileges.join(", ")}
+          </LoadingCell>
+        ),
         sort: table => table.details.grants?.privileges?.join(", "),
         className: cx("database-table__col-grants"),
         name: "grants",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
@@ -32,7 +32,7 @@ import * as format from "../util/format";
 import { Breadcrumbs } from "../breadcrumbs";
 import { CaretRight } from "../icon/caretRight";
 import { CockroachCloudContext } from "../contexts";
-import { checkInfoAvailable, getNetworkErrorMessage } from "../databases";
+import { LoadingCell, getNetworkErrorMessage } from "../databases";
 import { ViewMode } from "./types";
 
 const cx = classNames.bind(styles);
@@ -44,13 +44,18 @@ export const DiskSizeCell = ({
 }): JSX.Element => {
   return (
     <>
-      {checkInfoAvailable(
-        table.requestError,
-        table.details?.spanStats?.error,
-        table.details?.spanStats?.approximate_disk_bytes
-          ? format.Bytes(table.details?.spanStats?.approximate_disk_bytes)
-          : null,
-      )}
+      {
+        <LoadingCell
+          requestError={table.requestError}
+          queryError={table.details?.spanStats?.error}
+          loading={table.loading}
+          errorClassName={cx("database-table__cell-error")}
+        >
+          {table.details?.spanStats?.approximate_disk_bytes
+            ? format.Bytes(table.details?.spanStats?.approximate_disk_bytes)
+            : null}
+        </LoadingCell>
+      }
     </>
   );
 };
@@ -110,11 +115,16 @@ export const IndexesCell = ({
 }): JSX.Element => {
   const elem = (
     <>
-      {checkInfoAvailable(
-        table.requestError,
-        table.details?.schemaDetails?.error,
-        table.details?.schemaDetails?.indexes?.length,
-      )}
+      {
+        <LoadingCell
+          requestError={table.requestError}
+          queryError={table.details?.schemaDetails?.error}
+          loading={table.loading}
+          errorClassName={cx("database-table__cell-error")}
+        >
+          {table.details?.schemaDetails?.indexes?.length}
+        </LoadingCell>
+      }
     </>
   );
   // If index recommendations are not enabled or we don't have any index recommendations,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -40,6 +40,15 @@
     @include text--body;
     overflow-wrap: anywhere;
   }
+
+  &__error-cell{
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    svg {
+      fill: $colors--warning;
+    }
+  }
 }
 
 .icon {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -68,7 +68,7 @@ import {
   TableSchemaDetailsRow,
   TableSpanStatsRow,
 } from "../api";
-import { checkInfoAvailable } from "../databases";
+import { LoadingCell } from "../databases";
 
 const cx = classNames.bind(styles);
 const booleanSettingCx = classnames.bind(booleanSettingStyles);
@@ -473,55 +473,82 @@ export class DatabaseTablePage extends React.Component<
                         <SummaryCard className={cx("summary-card")}>
                           <SummaryCardItem
                             label="Size"
-                            value={checkInfoAvailable(
-                              details.requestError,
-                              details.spanStats?.error,
-                              details.spanStats?.approximate_disk_bytes
-                                ? format.Bytes(
-                                    details.spanStats?.approximate_disk_bytes,
-                                  )
-                                : null,
-                            )}
+                            value={
+                              <LoadingCell
+                                requestError={details.requestError}
+                                queryError={details.spanStats?.error}
+                                loading={details.loading}
+                                errorClassName={cx("summary-card__error-cell")}
+                              >
+                                {details.spanStats?.approximate_disk_bytes
+                                  ? format.Bytes(
+                                      details.spanStats?.approximate_disk_bytes,
+                                    )
+                                  : null}
+                              </LoadingCell>
+                            }
                           />
                           <SummaryCardItem
                             label="Replicas"
-                            value={checkInfoAvailable(
-                              details.requestError,
-                              details.replicaData?.error,
-                              details.replicaData?.replicaCount,
-                            )}
+                            value={
+                              <LoadingCell
+                                requestError={details.requestError}
+                                queryError={details.replicaData?.error}
+                                loading={details.loading}
+                                errorClassName={cx("summary-card__error-cell")}
+                              >
+                                {details.replicaData?.replicaCount}
+                              </LoadingCell>
+                            }
                           />
                           <SummaryCardItem
                             label="Ranges"
-                            value={checkInfoAvailable(
-                              details.requestError,
-                              details.spanStats?.error,
-                              details.spanStats?.range_count,
-                            )}
+                            value={
+                              <LoadingCell
+                                requestError={details.requestError}
+                                queryError={details.spanStats?.error}
+                                loading={details.loading}
+                                errorClassName={cx("summary-card__error-cell")}
+                              >
+                                {details.spanStats?.range_count}
+                              </LoadingCell>
+                            }
                           />
                           <SummaryCardItem
                             label="% of Live Data"
-                            value={checkInfoAvailable(
-                              details.requestError,
-                              details.spanStats?.error,
-                              <FormatMVCCInfo details={details} />,
-                            )}
+                            value={
+                              <LoadingCell
+                                requestError={details.requestError}
+                                queryError={details.spanStats?.error}
+                                loading={details.loading}
+                                errorClassName={cx("summary-card__error-cell")}
+                              >
+                                <FormatMVCCInfo details={details} />
+                              </LoadingCell>
+                            }
                           />
                           {details.statsLastUpdated && (
                             <SummaryCardItem
                               label="Table Stats Last Updated"
-                              value={checkInfoAvailable(
-                                details.requestError,
-                                details.statsLastUpdated?.error,
-                                <Timestamp
-                                  time={
-                                    details.statsLastUpdated
-                                      ?.stats_last_created_at
-                                  }
-                                  format={DATE_FORMAT_24_TZ}
-                                  fallback={"No table statistics found"}
-                                />,
-                              )}
+                              value={
+                                <LoadingCell
+                                  requestError={details.requestError}
+                                  queryError={details.statsLastUpdated?.error}
+                                  loading={details.loading}
+                                  errorClassName={cx(
+                                    "summary-card__error-cell",
+                                  )}
+                                >
+                                  <Timestamp
+                                    time={
+                                      details.statsLastUpdated
+                                        ?.stats_last_created_at
+                                    }
+                                    format={DATE_FORMAT_24_TZ}
+                                    fallback={"No table statistics found"}
+                                  />
+                                </LoadingCell>
+                              }
                             />
                           )}
                           {this.props.automaticStatsCollectionEnabled !=
@@ -556,14 +583,21 @@ export class DatabaseTablePage extends React.Component<
                           {this.props.showNodeRegionsSection && (
                             <SummaryCardItem
                               label="Regions/Nodes"
-                              value={checkInfoAvailable(
-                                details.requestError,
-                                null,
-                                details.nodesByRegionString &&
+                              value={
+                                <LoadingCell
+                                  requestError={details.requestError}
+                                  queryError={null}
+                                  loading={details.loading}
+                                  errorClassName={cx(
+                                    "summary-card__error-cell",
+                                  )}
+                                >
+                                  {details.nodesByRegionString &&
                                   details.nodesByRegionString?.length
-                                  ? details.nodesByRegionString
-                                  : null,
-                              )}
+                                    ? details.nodesByRegionString
+                                    : null}
+                                </LoadingCell>
+                              }
                             />
                           )}
                           <SummaryCardItem
@@ -572,11 +606,16 @@ export class DatabaseTablePage extends React.Component<
                           />
                           <SummaryCardItem
                             label="Indexes"
-                            value={checkInfoAvailable(
-                              details.requestError,
-                              details.indexData?.error,
-                              details.indexData?.indexes?.join(", "),
-                            )}
+                            value={
+                              <LoadingCell
+                                requestError={details.requestError}
+                                queryError={details.indexData?.error}
+                                loading={details.loading}
+                                errorClassName={cx("summary-card__error-cell")}
+                              >
+                                {details.indexData?.indexes?.join(", ")}
+                              </LoadingCell>
+                            }
                             className={cx(
                               "database-table-page__indexes--value",
                             )}

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.spec.tsx
@@ -8,6 +8,9 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import React from "react";
+import { render } from "@testing-library/react";
+
 import { INodeStatus } from "../util";
 import {
   Nodes,
@@ -16,6 +19,7 @@ import {
   getNodeIdsFromStoreIds,
   normalizePrivileges,
   normalizeRoles,
+  LoadingCell,
 } from "./util";
 
 describe("Getting nodes by region string", () => {
@@ -171,5 +175,76 @@ describe("Normalize roles", () => {
     const roles = ["public", "admin", "admin"];
     const result = normalizeRoles(roles);
     expect(result).toEqual(["admin", "public"]);
+  });
+});
+
+describe("LoadingCell", () => {
+  it("renders empty data", () => {
+    const { getByText } = render(
+      <LoadingCell requestError={null} loading={false} errorClassName={""}>
+        {null}
+      </LoadingCell>,
+    );
+
+    expect(getByText("No data")).not.toBeNull();
+  });
+  it("renders with undefined children", () => {
+    const { getByText } = render(
+      <LoadingCell
+        requestError={null}
+        loading={false}
+        errorClassName={""}
+      ></LoadingCell>,
+    );
+
+    expect(getByText("No data")).not.toBeNull();
+  });
+  it("renders skeleton heading when loading", () => {
+    const { getByRole } = render(
+      <LoadingCell requestError={null} loading={true} errorClassName={""}>
+        {null}
+      </LoadingCell>,
+    );
+
+    expect(getByRole("heading")).not.toBeNull();
+  });
+  it("renders error name and status icon", () => {
+    const { getByRole } = render(
+      <LoadingCell
+        requestError={{ name: "error name", message: "error message" }}
+        loading={false}
+        errorClassName={"error-class"}
+      >
+        {null}
+      </LoadingCell>,
+    );
+
+    // TODO(davidh): rendering of antd Tooltip component doesn't work
+    // here and hence can't be directly tested to contain the error
+    // name.
+    expect(getByRole("status")).not.toBeNull();
+  });
+  it("renders children with no error", () => {
+    const { getByText } = render(
+      <LoadingCell requestError={null} loading={false} errorClassName={""}>
+        <div>inner data</div>
+      </LoadingCell>,
+    );
+
+    expect(getByText("inner data")).not.toBeNull();
+  });
+  it("renders children with error together", () => {
+    const { getByText, getByRole } = render(
+      <LoadingCell
+        requestError={{ name: "error name", message: "error message" }}
+        loading={false}
+        errorClassName={""}
+      >
+        <div>inner data</div>
+      </LoadingCell>,
+    );
+
+    expect(getByRole("status")).not.toBeNull();
+    expect(getByText("inner data")).not.toBeNull();
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/databases/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/util.tsx
@@ -10,8 +10,11 @@
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import React from "react";
-import { Tooltip } from "antd";
+import { Skeleton, Tooltip } from "antd";
 import "antd/lib/tooltip/style";
+import "antd/lib/skeleton/style";
+import { Caution } from "@cockroachlabs/icons";
+
 import {
   isMaxSizeError,
   isPrivilegeError,
@@ -240,34 +243,56 @@ export function buildIndexStatToRecommendationsMap(
   return recommendationsMap;
 }
 
-export function checkInfoAvailable(
-  requestError: Error,
-  queryError: Error,
-  cell: React.ReactNode,
-): React.ReactNode {
+interface LoadingCellProps {
+  requestError: Error;
+  queryError?: Error;
+  loading: boolean;
+  errorClassName: string;
+}
+
+export const LoadingCell: React.FunctionComponent<LoadingCellProps> = ({
+  loading,
+  requestError,
+  queryError,
+  errorClassName,
+  children,
+}) => {
+  if (loading) {
+    return (
+      <Skeleton loading={true} active={true} paragraph={false} title={true} />
+    );
+  }
+
   let tooltipMsg = "";
   if (requestError) {
     tooltipMsg = `Encountered a network error fetching data for this cell: ${requestError.name}`;
   } else if (queryError) {
     tooltipMsg = getQueryErrorMessage(queryError);
-  } else if (cell == null) {
-    tooltipMsg = "Empty result";
   }
+
+  let childrenOrNoData = <>{children}</>;
+  if (children == null) {
+    childrenOrNoData = <>{"No data"}</>;
+  }
+
   // If we encounter an error gathering data for this cell,
-  // render it "unavailable" with a tooltip message for the error.
+  // render a warning icon with a tooltip message for the error.
   if (tooltipMsg !== "") {
     return (
       <Tooltip
         overlayStyle={{ whiteSpace: "pre-line" }}
         placement="bottom"
         title={tooltipMsg}
+        className={errorClassName}
       >
-        (unavailable)
+        <Caution role={"status"} />
+        {childrenOrNoData}
       </Tooltip>
     );
+  } else {
+    return childrenOrNoData;
   }
-  return cell;
-}
+};
 
 export const getNetworkErrorMessage = (requestError: Error): string => {
   return `Encountered a network error: ${requestError.message}`;

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databaseTableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databaseTableCells.tsx
@@ -20,7 +20,7 @@ import { Link } from "react-router-dom";
 import { StackIcon } from "../icon/stackIcon";
 import { CockroachCloudContext } from "../contexts";
 import {
-  checkInfoAvailable,
+  LoadingCell,
   getNetworkErrorMessage,
   getQueryErrorMessage,
 } from "../databases";
@@ -33,19 +33,18 @@ interface CellProps {
   database: DatabasesPageDataDatabase;
 }
 
-export const DiskSizeCell = ({ database }: CellProps): JSX.Element => {
-  return (
-    <>
-      {checkInfoAvailable(
-        database.spanStatsRequestError,
-        database.spanStats?.error,
-        database.spanStats?.approximate_disk_bytes
-          ? format.Bytes(database.spanStats?.approximate_disk_bytes)
-          : null,
-      )}
-    </>
-  );
-};
+export const DiskSizeCell = ({ database }: CellProps) => (
+  <LoadingCell
+    requestError={database.spanStatsRequestError}
+    queryError={database.spanStats?.error}
+    loading={database.spanStatsLoading}
+    errorClassName={cx("databases-table__cell-error")}
+  >
+    {database.spanStats?.approximate_disk_bytes
+      ? format.Bytes(database.spanStats?.approximate_disk_bytes)
+      : null}
+  </LoadingCell>
+);
 
 export const IndexRecCell = ({ database }: CellProps): JSX.Element => {
   const text =

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.module.scss
@@ -31,6 +31,15 @@
   &__no-result {
     @include text--body-strong;
   }
+
+  &__cell-error {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    svg {
+      fill: $colors--warning;
+    }
+  }
 }
 
 .sorted-table {

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -57,8 +57,8 @@ import {
   SqlApiQueryResponse,
   SqlExecutionErrorMessage,
 } from "../api";
+import { LoadingCell } from "../databases";
 import { InlineAlert } from "@cockroachlabs/ui-components";
-import { checkInfoAvailable } from "../databases";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -562,12 +562,16 @@ export class DatabasesPage extends React.Component<
             Tables
           </Tooltip>
         ),
-        cell: database =>
-          checkInfoAvailable(
-            database.detailsRequestError,
-            database.tables?.error,
-            database.tables?.tables?.length,
-          ),
+        cell: database => (
+          <LoadingCell
+            requestError={database.detailsRequestError}
+            queryError={database.tables?.error}
+            loading={database.detailsLoading}
+            errorClassName={cx("databases-table__cell-error")}
+          >
+            {database.tables?.tables?.length}
+          </LoadingCell>
+        ),
         sort: database => database.tables?.tables.length ?? 0,
         className: cx("databases-table__col-table-count"),
         name: "tableCount",
@@ -581,12 +585,16 @@ export class DatabasesPage extends React.Component<
             Range Count
           </Tooltip>
         ),
-        cell: database =>
-          checkInfoAvailable(
-            database.spanStatsRequestError,
-            database.spanStats?.error,
-            database.spanStats?.range_count,
-          ),
+        cell: database => (
+          <LoadingCell
+            requestError={database.spanStatsRequestError}
+            queryError={database.spanStats?.error}
+            loading={database.spanStatsLoading}
+            errorClassName={cx("databases-table__cell-error")}
+          >
+            {database.spanStats?.range_count}
+          </LoadingCell>
+        ),
         sort: database => database.spanStats?.range_count,
         className: cx("databases-table__col-range-count"),
         name: "rangeCount",
@@ -600,12 +608,15 @@ export class DatabasesPage extends React.Component<
             {this.props.isTenant ? "Regions" : "Regions/Nodes"}
           </Tooltip>
         ),
-        cell: database =>
-          checkInfoAvailable(
-            database.detailsRequestError,
-            null,
-            database.nodesByRegionString ? database.nodesByRegionString : null,
-          ),
+        cell: database => (
+          <LoadingCell
+            requestError={database.detailsRequestError}
+            loading={database.detailsLoading}
+            errorClassName={cx("databases-table__cell-error")}
+          >
+            {database.nodesByRegionString ? database.nodesByRegionString : null}
+          </LoadingCell>
+        ),
         sort: database => database.nodesByRegionString,
         className: cx("databases-table__col-node-regions"),
         name: "nodeRegions",


### PR DESCRIPTION
Backport 1/1 commits from #127075.

/cc @cockroachdb/release

---

The databases and tables pages can take a long time to load data on
clusters with large sizes. The current user experience did not clearly
signal which pieces of information were in progress or missing. This
change updates each cell to show a skeleton as it waits for data from
the backend. If there's no data returned we will show the text "No
Data" instead of "(unavailable)".

The `checkInfoAvailable` helper function is converted into a
functional React component for ease of testing and code uniformity.

Also removes the narrow styling of the "% of Live Data" column.

Resolves: https://github.com/cockroachdb/cockroach/issues/124153
Epic: CRDB-37558

Release note (ui change): The databases and tables pages in the DB
Console will show a loading state while loading information for
databases and tables including size and range counts.
