### PR TITLE
sql/schemachange: Fix drop database degradation

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_type.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_type.go
@@ -46,13 +46,13 @@ func init() {
 			to(scpb.Status_ABSENT,
 				revertible(false),
 				emit(func(this *scpb.ColumnType, md *opGenContext) *scop.RemoveDroppedColumnType {
-					// Make this a no-op if the column type already exists. The
-					// RemoveDroppedColumnType op is meant to be emitted only for columns
-					// that were dropped.
-					if checkIfColumnTypeExists(this.TableID, this.ColumnID, md) {
-						return nil
-					}
 					if ids := referencedTypeIDs(this); len(ids) > 0 {
+						// Make this a no-op if the column type already exists. The
+						// RemoveDroppedColumnType op is meant to be emitted only for columns
+						// that were dropped.
+						if checkIfColumnTypeExists(this.TableID, this.ColumnID, md) {
+							return nil
+						}
 						return &scop.RemoveDroppedColumnType{
 							TableID:  this.TableID,
 							ColumnID: this.ColumnID,


### PR DESCRIPTION
This fixes a recent issue with dropping databases introduced in commit 52c12c0. That change added initial DSC support for ALTER TABLE ALTER COLUMN ... TYPE operations. It was modeled in the DSC elements as a drop followed by an add of ColumnType elements. ColumnType was an existing element with its own rules for dropping a column, table, or database, and would emit the RemoveDroppedColumnType operation. However, I didn't want to emit this when altering the type of the column.

To achieve this, I checked all the targets to see if a ColumnType is being added for the same column. This can be quite expensive, especially for a large database, because for each column being removed, it loops through all the elements involved in the operation to see if we are also adding a ColumnType of the same type.

Fortunately, RemoveDroppedColumnType is only emitted when removing a column that references a user-defined type, which is rare. So, in this commit I optimized the checks by first verifying if we are removing a column that references type IDs, which is relatively cheap to detect, and then checking if it’s a column that we are altering.

No release note is required for this because the degradation only went in a week ago.

Closes: #127747
Release note: None