### PR TITLE
release-24.2: cluster-ui: db details page should show user-friendly table names

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -161,9 +161,21 @@ const getDatabaseGrantsQuery: DatabaseDetailsQuery<DatabaseGrantsRow> = {
   },
 };
 
+export type TableNameParts = {
+  // Raw unquoted, unescaped schema name.
+  schema: string;
+  // Raw unquoted, unescaped table name.
+  table: string;
+
+  // qualifiedNameWithSchemaAndTable is the qualifed
+  // table name containing escaped, quoted schema and
+  // table name parts.
+  qualifiedNameWithSchemaAndTable: string;
+};
+
 // Database Tables
 export type DatabaseTablesResponse = {
-  tables: string[];
+  tables: TableNameParts[];
 };
 
 type DatabaseTablesRow = {
@@ -197,7 +209,11 @@ const getDatabaseTablesQuery: DatabaseDetailsQuery<DatabaseTablesRow> = {
           row.table_schema,
           row.table_name,
         ]).sqlString();
-        return resp.tablesResp.tables.push(escTableName);
+        resp.tablesResp.tables.push({
+          schema: row.table_schema,
+          table: row.table_name,
+          qualifiedNameWithSchemaAndTable: escTableName,
+        });
       });
     }
     if (txnResult.error) {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
@@ -80,3 +80,7 @@
   font-weight: $font-weight--extra-bold;
   color: $colors--neutral-8;
 }
+
+.schema-name {
+  color: $colors--neutral-5;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -118,7 +118,12 @@ function createTable(): DatabaseDetailsPageDataTable {
     loaded: true,
     requestError: null,
     queryError: undefined,
-    name: randomName(),
+    name: {
+      qualifiedNameWithSchemaAndTable: "public.table",
+      schema: "public",
+      table: "table",
+    },
+    qualifiedDisplayName: "public.table",
     details: {
       grants: {
         roles,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -43,6 +43,7 @@ import {
   SqlExecutionErrorMessage,
   TableHeuristicDetailsRow,
   TableIndexUsageStats,
+  TableNameParts,
   TableSchemaDetailsRow,
   TableSpanStatsRow,
 } from "../api";
@@ -128,7 +129,9 @@ export interface DatabaseDetailsPageData {
 }
 
 export interface DatabaseDetailsPageDataTable {
-  name: string;
+  name: TableNameParts;
+  // Display name containing unquoted, unescaped schema and table name parts.
+  qualifiedDisplayName: string;
   loading: boolean;
   loaded: boolean;
   // Request error when getting table details.
@@ -195,7 +198,7 @@ function filterBySearchQuery(
   table: DatabaseDetailsPageDataTable,
   search: string,
 ): boolean {
-  const matchString = table.name.toLowerCase();
+  const matchString = table.qualifiedDisplayName.toLowerCase();
 
   if (search.startsWith('"') && search.endsWith('"')) {
     search = search.substring(1, search.length - 1);
@@ -352,7 +355,7 @@ export class DatabaseDetailsPage extends React.Component<
       if (!table.loaded && !table.loading && table.requestError === undefined) {
         this.props.refreshTableDetails(
           this.props.name,
-          table.name,
+          table.name.qualifiedNameWithSchemaAndTable,
           this.props.csIndexUnusedDuration,
         );
       }
@@ -702,16 +705,19 @@ export class DatabaseDetailsPage extends React.Component<
         cell: table => (
           <Link
             to={
-              EncodeDatabaseTableUri(this.props.name, table.name) +
-              `?tab=grants`
+              EncodeDatabaseTableUri(
+                this.props.name,
+                table.name.qualifiedNameWithSchemaAndTable,
+              ) + `?tab=grants`
             }
             className={cx("icon__container")}
           >
             <DatabaseIcon className={cx("icon--s")} />
-            {table.name}
+            <span className={cx("schema-name")}>{table.name.schema}.</span>
+            <span>{table.name.table}</span>
           </Link>
         ),
-        sort: table => table.name,
+        sort: table => table.qualifiedDisplayName,
         className: cx("database-table__col-name"),
         name: "name",
       },

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
@@ -68,12 +68,15 @@ export const TableNameCell = ({
   if (isCockroachCloud) {
     linkURL = `${location.pathname}/${EncodeUriName(
       getMatchParamByName(dbDetails.match, schemaNameAttr),
-    )}/${EncodeUriName(table.name)}`;
+    )}/${EncodeUriName(table.name.qualifiedNameWithSchemaAndTable)}`;
     if (dbDetails.viewMode === ViewMode.Grants) {
       linkURL += `?viewMode=${ViewMode.Grants}`;
     }
   } else {
-    linkURL = EncodeDatabaseTableUri(dbDetails.name, table.name);
+    linkURL = EncodeDatabaseTableUri(
+      dbDetails.name,
+      table.name.qualifiedNameWithSchemaAndTable,
+    );
     if (dbDetails.viewMode === ViewMode.Grants) {
       linkURL += `?tab=grants`;
     }
@@ -97,7 +100,8 @@ export const TableNameCell = ({
   return (
     <Link to={linkURL} className={cx("icon__container")}>
       {icon}
-      {table.name}
+      <span className={cx("schema-name")}>{table.name.schema}.</span>
+      <span>{table.name.table}</span>
     </Link>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
@@ -22,7 +22,7 @@ import { generateTableID, longToInt, TimestampToMoment } from "../util";
 import { DatabaseTablePageDataDetails, IndexStat } from "../databaseTablePage";
 import { IndexStatsState } from "../store/indexStats";
 import { DatabasesPageDataDatabase } from "../databasesPage";
-import { DatabasesListResponse } from "../api";
+import { DatabasesListResponse, TableNameParts } from "../api";
 import { RecommendationType as RecType } from "../indexDetailsPage";
 
 import {
@@ -125,7 +125,7 @@ const deriveDatabaseDetails = (
 
 interface DerivedTableDetailsParams {
   dbName: string;
-  tables: string[];
+  tables: TableNameParts[];
   tableDetails: Record<string, TableDetailsState>;
   nodeRegions: Record<string, string>;
   isTenant: boolean;
@@ -150,7 +150,10 @@ export const deriveTableDetailsMemoized = createSelector(
   ): DatabaseDetailsPageDataTable[] => {
     tables = tables || [];
     return tables.map(table => {
-      const tableID = generateTableID(dbName, table);
+      const tableID = generateTableID(
+        dbName,
+        table.qualifiedNameWithSchemaAndTable,
+      );
       const details = tableDetails[tableID];
       return deriveDatabaseTableDetails(
         table,
@@ -164,7 +167,7 @@ export const deriveTableDetailsMemoized = createSelector(
 );
 
 const deriveDatabaseTableDetails = (
-  table: string,
+  table: TableNameParts,
   details: TableDetailsState,
   nodeRegions: Record<string, string>,
   isTenant: boolean,
@@ -183,6 +186,7 @@ const deriveDatabaseTableDetails = (
   const nodes: Nodes = getNodeIdsFromStoreIds(stores, nodeStatuses);
   return {
     name: table,
+    qualifiedDisplayName: `${table.schema}.${table.table}`,
     loading: !!details?.inFlight,
     loaded: !!details?.valid,
     requestError: details?.lastError,

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
@@ -63,7 +63,25 @@ describe("DatabaseDetails sagas", () => {
           },
         ],
       },
-      tablesResp: { tables: ["yet", "another", "table"] },
+      tablesResp: {
+        tables: [
+          {
+            schema: "schema",
+            table: "table",
+            qualifiedNameWithSchemaAndTable: `"schema"."table"`,
+          },
+          {
+            schema: "schema2",
+            table: "table2",
+            qualifiedNameWithSchemaAndTable: `"schema"."table"`,
+          },
+          {
+            table: "tabble",
+            schema: "schema",
+            qualifiedNameWithSchemaAndTable: `"schema2j"."table2"`,
+          },
+        ],
+      },
       zoneConfigResp: {
         zone_config: new ZoneConfig({
           inherited_constraints: true,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import { createMemoryHistory } from "history";
-import find from "lodash/find";
 import { RouteComponentProps } from "react-router-dom";
 import { bindActionCreators, Store } from "redux";
 import {
@@ -55,7 +54,10 @@ class TestDriver {
   private readonly actions: DatabaseDetailsPageActions;
   private readonly properties: () => DatabaseDetailsPageData;
 
-  constructor(store: Store<AdminUIState>, private readonly database: string) {
+  constructor(
+    store: Store<AdminUIState>,
+    private readonly database: string,
+  ) {
     this.actions = bindActionCreators(
       mapDispatchToProps,
       store.dispatch.bind(store),
@@ -131,7 +133,9 @@ class TestDriver {
   }
 
   private findTable(name: string) {
-    return find(this.properties().tables, { name });
+    return this.properties().tables.find(
+      t => t.name.qualifiedNameWithSchemaAndTable === name,
+    );
   }
 }
 
@@ -210,7 +214,12 @@ describe("Database Details Page", function () {
       sortSettingGrants: { ascending: true, columnTitle: "name" },
       tables: [
         {
-          name: `"public"."foo"`,
+          name: {
+            schema: "public",
+            table: "foo",
+            qualifiedNameWithSchemaAndTable: `"public"."foo"`,
+          },
+          qualifiedDisplayName: `public.foo`,
           loading: false,
           loaded: false,
           requestError: undefined,
@@ -230,7 +239,12 @@ describe("Database Details Page", function () {
           },
         },
         {
-          name: `"public"."bar"`,
+          name: {
+            schema: "public",
+            table: "bar",
+            qualifiedNameWithSchemaAndTable: `"public"."bar"`,
+          },
+          qualifiedDisplayName: `public.bar`,
           loading: false,
           loaded: false,
           requestError: undefined,
@@ -405,7 +419,12 @@ describe("Database Details Page", function () {
     await driver.refreshNodes();
 
     driver.assertTableDetails(`"public"."foo"`, {
-      name: `"public"."foo"`,
+      name: {
+        schema: "public",
+        table: "foo",
+        qualifiedNameWithSchemaAndTable: `"public"."foo"`,
+      },
+      qualifiedDisplayName: `public.foo`,
       loading: false,
       loaded: true,
       requestError: null,
@@ -437,7 +456,12 @@ describe("Database Details Page", function () {
     });
 
     driver.assertTableDetails(`"public"."bar"`, {
-      name: `"public"."bar"`,
+      name: {
+        schema: "public",
+        table: "bar",
+        qualifiedNameWithSchemaAndTable: `"public"."bar"`,
+      },
+      qualifiedDisplayName: `public.bar`,
       loading: false,
       loaded: true,
       requestError: null,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -304,7 +304,18 @@ describe("Databases Page", function () {
       nodes: [1, 2, 3],
       spanStats: undefined,
       tables: {
-        tables: [`"public"."foo"`, `"public"."bar"`],
+        tables: [
+          {
+            schema: "public",
+            table: "foo",
+            qualifiedNameWithSchemaAndTable: `"public"."foo"`,
+          },
+          {
+            schema: "public",
+            table: "bar",
+            qualifiedNameWithSchemaAndTable: `"public"."bar"`,
+          },
+        ],
       },
       nodesByRegionString: "gcp-europe-west1(n3), gcp-us-east1(n1,n2)",
       numIndexRecommendations: 1,


### PR DESCRIPTION
Backport 1/1 commits from #127085.

/cc @cockroachdb/release

Release justification: low-risk ui fix

---

This is a follow-up to #126961 which attempted to address remove quotes around the schema and table names if they did not contain periods or spaces. However, that PR was transforming the escaped version of the string.  Ideally we want the db pages to show user-friendly display names without any escape chars, like in `SHOW TABLES`.

The DB pages currently stores the table name as a qualified name by quoting and escaping the schema and table name parts from the server response in order to make it easier to make sql requests using the encoded name. In order to provide a user-friendly display name, this commit stores the raw schema and table names in addition to the encoded name. In order to differentiate schema and table names in the UI, we simply highlight the schema name when it is displayed as part of a qualifed name in the db details page. In the future we may want to split up the schema name into its own column.

This commit does _not_ fix this display issue for the table details page. Currently that page does not use any table name from the server, instead using the URL part as the table display name, which the page expects to be in the qualified encoded `<schema>.<table>` form. Ideally in the future we should change this route so that either:
* the path is changed to separate the schema and table parts in route params, e.g. `/db/schemaName/tableName`
* the route param is changed to use the table id instead of table the name and the raw table name will be fetched.

Fixes: #126823

Release note (ui change): In the DB details page, the table name will no longer appear with quotes around the schema and table name.


<img width="337" alt="image" src="https://github.com/user-attachments/assets/6bb1b257-e88e-49a3-a03d-e464e3806f2b">
<img width="374" alt="image" src="https://github.com/user-attachments/assets/10623ba1-747e-47e6-8058-b2da59c61b35">

