### PR TITLE
crosscluster: fix retained time test flake

### DIFF
--- a/pkg/ccl/crosscluster/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/crosscluster/replicationtestutils/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/testutils.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
 
@@ -284,12 +285,13 @@ func (c *TenantStreamingClusters) Cutover(
 	require.LessOrEqual(c.T, protectedTimestamp.GoTime(), cutoverOutput.GoTime())
 
 	// PTS should be less than or equal to retained time as a result of heartbeats.
-	var retainedTime time.Time
+	var retainedTime pq.NullTime
 	c.DestSysSQL.QueryRow(c.T,
 		`SELECT retained_time FROM [SHOW TENANT $1 WITH REPLICATION STATUS]`,
 		c.Args.DestTenantName).Scan(&retainedTime)
-
-	require.LessOrEqual(c.T, protectedTimestamp.GoTime(), retainedTime)
+	if retainedTime.Valid {
+		require.LessOrEqual(c.T, protectedTimestamp.GoTime(), retainedTime.Time)
+	}
 
 	if !async {
 		jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))


### PR DESCRIPTION
This PR deflakes unit tests that use `Cutover()` in
`replicationtestutils` by catching potential nil
pointer to `retained_time` when a job completes.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/127291, https://github.com/cockroachdb/cockroach/issues/127233, https://github.com/cockroachdb/cockroach/issues/127732, https://github.com/cockroachdb/cockroach/issues/127731, https://github.com/cockroachdb/cockroach/issues/127406
Release note: none