### PR TITLE
release-23.1: roachtest: direct mixedversion planning errors to test-eng

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -81,6 +81,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -613,7 +614,7 @@ func (t *Test) Workload(
 func (t *Test) Run() {
 	plan, err := t.plan()
 	if err != nil {
-		t.rt.Fatal(fmt.Errorf("error creating test plan: %w", err))
+		t.rt.Fatal(err)
 	}
 
 	t.logger.Printf("mixed-version test:\n%s", plan.PrettyPrint())
@@ -629,7 +630,18 @@ func (t *Test) run(plan *TestPlan) error {
 	).run()
 }
 
-func (t *Test) plan() (*TestPlan, error) {
+func (t *Test) plan() (plan *TestPlan, retErr error) {
+	defer func() {
+		if retErr != nil {
+			// Planning failures are always internal framework errors, so
+			// they should be sent to TestEng.
+			retErr = registry.ErrorWithOwner(
+				registry.OwnerTestEng,
+				fmt.Errorf("error creating test plan: %w", retErr),
+			)
+		}
+	}()
+
 	previousReleases, err := t.choosePreviousReleases()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -16,9 +16,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -152,6 +154,23 @@ func Test_choosePreviousReleases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTest_plan(t *testing.T) {
+	// Assert that planning failures are owned by test-eng. At the time
+	// of writing, planning can only return an error if we fail to find
+	// a required predecessor of a certain release.
+	mvt := newTest(NumUpgrades(100))
+	_, err := mvt.plan()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no known predecessor for")
+
+	var errWithOwnership registry.ErrorWithOwnership
+	require.True(t,
+		errors.As(err, &errWithOwnership),
+		"error %q (%T) is not ErrorWithOwnership", err.Error(), err,
+	)
+	require.Equal(t, registry.OwnerTestEng, errWithOwnership.Owner)
 }
 
 // withTestBuildVersion overwrites the `TestBuildVersion` variable in

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -366,6 +366,9 @@ func boolP(b bool) *bool {
 func testPredecessorFunc(
 	rng *rand.Rand, v *clusterupgrade.Version, n int,
 ) ([]*clusterupgrade.Version, error) {
+	if n > 5 { // arbitrary check, simulating errors in the predecessor function
+		return nil, fmt.Errorf("no known predecessor for %q", v)
+	}
 	return parseVersions([]string{predecessorVersion}), nil
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #127615.

/cc @cockroachdb/release

---

Mixedversion planning failures are always internal errors and therefore shouldn't lead to issues being assigned to the team that owns the test. We fix that in this commit.

Epic: none

Release note: None

Release justification: test-only changes.