### PR TITLE
ui: add hovering focus behavior to metric graphs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -331,6 +331,7 @@ export function nodeCapacityStats(n: INodeStatus): CapacityStats {
 export function getDisplayName(
   node: INodeStatus | NoConnection,
   livenessStatus = LivenessStatus.NODE_STATUS_LIVE,
+  includeAddress = true,
 ) {
   const decommissionedString =
     livenessStatus === LivenessStatus.NODE_STATUS_DECOMMISSIONED
@@ -341,7 +342,11 @@ export function getDisplayName(
     return `${decommissionedString}(n${node.from.nodeID})`;
   }
   // as the only other type possible right now is INodeStatus we don't have a type guard for that
-  return `${decommissionedString}(n${node.desc.node_id}) ${node.desc.address.address_field}`;
+  if (includeAddress) {
+    return `${decommissionedString}(n${node.desc.node_id}) ${node.desc.address.address_field}`;
+  } else {
+    return `${decommissionedString}n${node.desc.node_id}`;
+  }
 }
 
 function isNoConnection(
@@ -368,6 +373,25 @@ export const nodeDisplayNameByIDSelector = createSelector(
         result[ns.desc.node_id] = getDisplayName(
           ns,
           livenessStatusByNodeID[ns.desc.node_id],
+          true,
+        );
+      });
+    }
+    return result;
+  },
+);
+
+export const nodeDisplayNameByIDSelectorWithoutAddress = createSelector(
+  partialNodeStatusesSelector,
+  livenessStatusByNodeIDSelector,
+  (nodeStatuses, livenessStatusByNodeID) => {
+    const result: { [key: string]: string } = {};
+    if (!isEmpty(nodeStatuses)) {
+      nodeStatuses.forEach(ns => {
+        result[ns.desc.node_id] = getDisplayName(
+          ns,
+          livenessStatusByNodeID[ns.desc.node_id],
+          false,
         );
       });
     }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -67,7 +67,6 @@ export interface OwnProps extends MetricsDataComponentProps {
   hoverOff?: typeof hoverOff;
   hoverState?: HoverState;
   preCalcGraphSize?: boolean;
-  legendAsTooltip?: boolean;
   showMetricsInTooltip?: boolean;
 }
 
@@ -359,7 +358,6 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
         this.setNewTimeRange,
         () => this.xAxisDomain,
         () => this.yAxisDomain,
-        this.props.legendAsTooltip,
       );
 
       if (this.u) {
@@ -384,7 +382,6 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
       data,
       tenantSource,
       preCalcGraphSize,
-      legendAsTooltip,
       showMetricsInTooltip,
     } = this.props;
     let tt = tooltip;
@@ -439,7 +436,6 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
         </div>
       );
     }
-    const legendClassName = legendAsTooltip ? "linegraph-tooltip" : "linegraph";
     return (
       <Visualization
         title={title}
@@ -448,7 +444,7 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
         loading={!data}
         preCalcGraphSize={preCalcGraphSize}
       >
-        <div className={legendClassName}>
+        <div className="linegraph">
           <div ref={this.el} />
         </div>
       </Visualization>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
@@ -164,7 +164,6 @@ describe("<LineGraph>", function () {
           util.NanoToMilli(mockProps.timeInfo.start.toNumber()),
           util.NanoToMilli(mockProps.timeInfo.end.toNumber()),
         ),
-      false,
     );
     instance.u = new uPlot(mockOptions);
     const setDataSpy = jest.spyOn(instance.u, "setData");

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
@@ -22,49 +22,50 @@ $viz-sides = 62px
     color gray
     text-decoration underline
 
-.linegraph-tooltip
-  height 100%
-  .uplot
+.u-legend
+  max-height: 300px
+  display flex
+  flex-wrap wrap
+  flex-direction row
+  align-items flex-start
+  align-content flex-start
+  overflow auto
+  > tr
     display flex
-    flex-direction column
-    > .u-legend
+    flex-direction row
+    align-items flex-end
+  > tr:first-child
+    flex-basis 100%
+    text-align left
+    color gray
+    .u-marker
       display none
-      position absolute
-      left 0
-      top 0
-      font-size 10px
-      background-color white
-      text-align left
-      margin-top 20px
-      z-index 100
-      pointer-events: none;
-      width: max-content;
-      border-radius: 5px
-      padding: 10px;
-      border 1px solid rgba(0,0,0,0.1)
 
-    // stick the legend to the char's bottom.
-    // Chart height is hardcoded to 300px (pkg/ui/src/views/cluster/util/graphs.ts)
-    > .u-legend.u-legend--place-bottom
-      position relative
-      top 0!important // Necessary because uPlot adds top/left on hover to make legend appear near mouse pointer
-      left 0!important // Necessary because uPlot adds top/left on hover to make legend appear near mouse pointer
-      width auto
-      margin-left -1px
-      margin-right -1px
-      padding-left 50px
-      // the first line in the legend represents Y-axis and it occupies an entire line
-      // to stand out from the rest of x-axis values
-      > tr:first-child
-        width 100%
-        font-size $font-size--small
-
-      > tr
-        min-width 30%
-
-  .u-legend:not(.u-legend--place-bottom)
-    .u-series
-      display block
+.u-tooltip
+  font-size 10pt
+  position absolute
+  background #fff
+  display none
+  border 1px solid black
+  padding 0 0.5em 0 0.5em
+  pointer-events none
+  z-index 100
+  white-space pre
+  .u-time
+    color gray
+    margin-top: 4px
+  .u-series
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+  .u-label
+    font-weight 600
+  .u-marker
+    height 1em
+    width 1em
+    display inline-block
+    vertical-align middle
 
 .no-data
   width 100%

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -43,7 +43,7 @@ import {
   livenessStatusByNodeIDSelector,
   nodeIDsSelector,
   nodeIDsStringifiedSelector,
-  selectStoreIDsByNodeID,
+  selectStoreIDsByNodeID, nodeDisplayNameByIDSelectorWithoutAddress,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import {
@@ -521,7 +521,7 @@ export class NodeGraphs extends React.Component<
  */
 const nodeDropdownOptionsSelector = createSelector(
   nodeIDsSelector,
-  nodeDisplayNameByIDSelector,
+    (state) => nodeDisplayNameByIDSelector(state),
   livenessStatusByNodeIDSelector,
   (nodeIds, nodeDisplayNameByID, livenessStatusByNodeID): DropdownOption[] => {
     const base = [{ value: "", label: "Cluster" }];
@@ -547,7 +547,7 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   nodeIds: nodeIDsStringifiedSelector(state),
   storeIDsByNodeID: selectStoreIDsByNodeID(state),
   nodeDropdownOptions: nodeDropdownOptionsSelector(state),
-  nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
+  nodeDisplayNameByID: nodeDisplayNameByIDSelectorWithoutAddress(state),
   tenantOptions: tenantDropdownOptions(state),
   currentTenant: getCookieValue("tenant"),
 });

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -90,6 +90,118 @@ export function formatMetricData(
   return formattedData;
 }
 
+function hoverTooltipPlugin(xFormatter: (v: number) => string, yFormatter: (v: number) => string) {
+  const shiftX = 10;
+  const shiftY = 10;
+  let tooltipLeftOffset = 0;
+  let tooltipTopOffset = 0;
+
+  const tooltip = document.createElement("div");
+  tooltip.className = "u-tooltip";
+
+  let timeNode = document.createElement("div")
+  timeNode.className = "u-time"
+  tooltip.appendChild(timeNode)
+
+  let seriesNode = document.createElement("div")
+  seriesNode.className = "u-series"
+
+  let markerNode = document.createElement("div")
+  markerNode.className = "u-marker"
+
+  let labelNode = document.createElement("div")
+  labelNode.className = "u-label"
+
+  let dataNode = document.createTextNode(`--`)
+
+  seriesNode.appendChild(markerNode)
+  seriesNode.appendChild(labelNode)
+  seriesNode.appendChild(dataNode)
+  tooltip.appendChild(seriesNode)
+
+  let seriesIdx: number= null;
+  let dataIdx: number = null;
+  let over: HTMLDivElement;
+  let tooltipVisible = false;
+
+  function showTooltip() {
+    if (!tooltipVisible) {
+      tooltip.style.display = "block";
+      over.style.cursor = "pointer";
+      tooltipVisible = true;
+    }
+  }
+
+  function hideTooltip() {
+    if (tooltipVisible) {
+      tooltip.style.display = "none";
+      over.style.cursor = null;
+      tooltipVisible = false;
+    }
+  }
+
+  function setTooltip(u: uPlot) {
+    showTooltip();
+
+    // `yAxis` is used instead of `y` here because that's below in the
+    // `uPlot` config as the custom scale that we define.n
+    let top = u.valToPos(u.data[seriesIdx][dataIdx], 'yAxis');
+    let lft = u.valToPos(u.data[        0][dataIdx], 'x');
+
+    tooltip.style.top  = (tooltipTopOffset  + top + shiftX) + "px";
+    tooltip.style.left = (tooltipLeftOffset + lft + shiftY) + "px";
+
+    timeNode.textContent = `Time: ${xFormatter(u.data[0][dataIdx])}`
+    labelNode.textContent = `${u.series[seriesIdx].label}:`
+    dataNode.textContent = ` ${yFormatter(u.data[seriesIdx][dataIdx])}`
+
+    let stroke = u.series[seriesIdx].stroke;
+    if (typeof stroke === 'function' && stroke.length === 0) {
+      markerNode.style.background = stroke(u, seriesIdx) as string;
+    } else if (typeof stroke === 'string') {
+      markerNode.style.borderColor = stroke;
+    }
+  }
+
+  return {
+    hooks: {
+      ready: [
+        (u: uPlot) => {
+          over = u.over;
+          tooltipLeftOffset = parseFloat(over.style.left);
+          tooltipTopOffset = parseFloat(over.style.top);
+          u.root.querySelector(".u-wrap").appendChild(tooltip);
+        }
+      ],
+      setCursor: [
+        (u: uPlot) => {
+          let c = u.cursor;
+
+          if (dataIdx !== c.idx) {
+            dataIdx = c.idx;
+
+            if (seriesIdx != null)
+              setTooltip(u);
+          }
+        }
+      ],
+      setSeries: [
+        (u: uPlot, sidx: number) => {
+          if (seriesIdx !== sidx) {
+            seriesIdx = sidx;
+
+            if (sidx == null)
+              hideTooltip();
+            else if (dataIdx !== null)
+              setTooltip(u);
+          }
+        }
+      ],
+    }
+  };
+}
+
+
 // configureUPlotLineChart constructs the uplot Options object based on
 // information about the metrics, axis, and data that we'd like to plot.
 // Most of the settings are defined as functions instead of static values
@@ -103,7 +215,6 @@ export function configureUPlotLineChart(
   setMetricsFixedWindow: (startMillis: number, endMillis: number) => void,
   getLatestXAxisDomain: () => AxisDomain,
   getLatestYAxisDomain: () => AxisDomain,
-  legendAsTooltip: boolean,
 ): uPlot.Options {
   const formattedRaw = formatMetricData(metrics, data);
   // Copy palette over since we mutate it in the `series` function
@@ -116,67 +227,16 @@ export function configureUPlotLineChart(
     ...formattedRaw.filter(r => !!r.color).map(r => r.color),
   );
 
-  const tooltipPlugin = () => {
-    return {
-      hooks: {
-        init: (self: uPlot) => {
-          const over: HTMLElement = self.root.querySelector(".u-over");
-          const legend: HTMLElement = self.root.querySelector(".u-legend");
-
-          // apply class to stick a legend to the bottom of a chart if it has more than 10 series
-          if (self.series.length > 10) {
-            legend.classList.add("u-legend--place-bottom");
-          }
-
-          // Show/hide legend when we enter/exit the bounds of the graph
-          over.onmouseenter = () => {
-            legend.style.display = "block";
-          };
-
-          // persistLegend determines if legend should continue showing even when mouse
-          // hovers away.
-          let persistLegend = false;
-
-          over.addEventListener("click", () => {
-            persistLegend = !persistLegend;
-          });
-
-          over.onmouseleave = () => {
-            if (!persistLegend) {
-              legend.style.display = "none";
-            }
-          };
-        },
-        setCursor: (self: uPlot) => {
-          // Place legend to the right of the mouse pointer
-          const legend: HTMLElement = self.root.querySelector(".u-legend");
-          if (self.cursor.left > 0 && self.cursor.top > 0) {
-            // TODO(davidh): This placement is not aware of the viewport edges
-            legend.style.left = self.cursor.left + 100 + "px";
-            legend.style.top = self.cursor.top - 10 + "px";
-          }
-        },
-      },
-    };
-  };
-
   // Please see https://github.com/leeoniya/uPlot/tree/master/docs for
   // information on how to construct this object.
   return {
     width: 947,
     height: 300,
-    // TODO(davidh): Enable sync-ed guidelines once legend is redesigned
-    // currently, if you enable this with a hovering legend, the FPS
-    // gets quite choppy on large clusters.
-    // cursor: {
-    //   sync: {
-    //     // graphs with matching keys will get their guidelines
-    //     // sync-ed so we just use the same key for the page
-    //     key: "sync-everything",
-    //   },
-    // },
     cursor: {
       lock: true,
+      focus: {
+        prox: 5,
+      },
     },
     legend: {
       show: true,
@@ -184,6 +244,19 @@ export function configureUPlotLineChart(
       // This setting sets the default legend behavior to isolate
       // a series when it's clicked in the legend.
       isolate: true,
+      markers: {
+        stroke: () => {
+          return null
+        },
+        fill: (u: uPlot, i: number) => {
+          let stroke = u.series[i].stroke;
+          if (typeof stroke === 'function' && stroke.length === 0) {
+            return stroke(u, i) as string;
+          } else if (typeof stroke === 'string') {
+            return stroke;
+          }
+        },
+      }
     },
     // By default, uPlot expects unix seconds in the x axis.
     // This setting defaults it to milliseconds which our
@@ -243,6 +316,7 @@ export function configureUPlotLineChart(
           return [domain.extent[0], ...domain.ticks, domain.extent[1]];
         },
         scale: "yAxis",
+        labelGap: 5,
       },
     ],
     scales: {
@@ -253,7 +327,7 @@ export function configureUPlotLineChart(
         range: () => getLatestYAxisDomain().extent,
       },
     },
-    plugins: legendAsTooltip ? [tooltipPlugin()] : null,
+    plugins: [hoverTooltipPlugin(getLatestXAxisDomain().guideFormat, getLatestYAxisDomain().guideFormat)],
     hooks: {
       // setSelect is a hook that fires when a selection is made on the graph
       // by dragging a range to zoom.

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
@@ -19,7 +19,9 @@ import {
   refreshNodes,
   refreshSessions,
 } from "src/redux/apiReducers";
-import { nodeDisplayNameByIDSelector } from "src/redux/nodes";
+import {
+  nodeDisplayNameByIDSelectorWithoutAddress
+} from "src/redux/nodes";
 import {
   terminateQueryAction,
   terminateSessionAction,
@@ -54,7 +56,7 @@ export const selectSession = createSelector(
 const SessionDetailsPageConnected = withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
-      nodeNames: nodeDisplayNameByIDSelector(state),
+      nodeNames: nodeDisplayNameByIDSelectorWithoutAddress(state),
       session: selectSession(state, props),
       sessionError: state.cachedData.sessions.lastError,
     }),


### PR DESCRIPTION
This PR enables a few new behaviors on the metrics graphs in DB
Console:
* Show individual lines on hover
* Show closest point to mouse pointer
* Revamped legend that takes up static amount of space and
scrolls
* Node series names no longer include the IP address for brevity

Additionally there are some minor visual tweaks in the legend like a
gray colored timestamp, and circle series markers instead of squares.

Resolves: CRDB-37094
Resolves: https://github.com/cockroachdb/cockroach/issues/118645
Epic: CRDB-37557

Release note (ui change): the user experience for metrics charges in
DB Console now has hover behavior that focuses on individual lines and
shows values under the mouse pointer.