### PR TITLE
drtprod: print post-configuration information for datadog

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -286,6 +286,13 @@ EOF"
       --datadog-service drt-cockroachdb \
       --datadog-tags 'service:drt-cockroachdb,team:drt'
 
+    echo
+    echo "Updated ${cluster} configuration to send telemetry data to Datadog."
+    echo
+    echo "If this was the first time this script was run against ${cluster} then"
+    echo "CockroachDB must be restarted to reload its logging configuration."
+    echo
+
     exit 0
     ;;
   "ua-failover")


### PR DESCRIPTION
When configuring a `drtprod` cluster to send its telemetry data to Datadog there exists a chicken and egg problem for logs where the TCP receiver for logs (e.g., Fluent Bit) must exist before the CockroachDB logging configuration can be updated to send its logs over TCP.

If the CockroachDB logging configuration is updated to send logs over TCP without a TCP receiver listening then CockroachDB will log `logging error from *log.fluentSink: dial tcp ‹[::1]:5170›: connect: connection refused` errors and emit the logs it would have sent over TCP to standard error instead. This is not okay for two reasons. One, clusters that do not wish to send logs to Datadog would consistently see the above error in their logs which creates excess noise for engineers. Two, `drtprod` clusters do not have log rotation configured for the standard error log file which leads to filling up the small disk that's provisioned.

In the interest of time, this patch takes a half-measure approach to inform the operator to restart CockroachDB after they have configured their cluster to send telemetry data to Datadog.

Epic: CC-28321

Release note: None
