### PR TITLE
drtprod: fix unbound variable error

### DIFF
--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -92,6 +92,14 @@ case $1 in
     shift
     cluster="${1}"
 
+    dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+    if [ -z "${dd_api_key}" ]; then
+      echo "Missing Datadog API key!"
+      exit 1
+    fi
+
+    dd_site="us5.datadoghq.com"
+
     case $cluster in
       "drt-chaos")
         roachprod ssh ${cluster} -- "sudo mkdir -p /etc/fluent-bit && sudo tee /etc/fluent-bit/config-override.yaml > /dev/null << EOF
@@ -245,16 +253,10 @@ EOF"
         ;;
     esac
 
-    dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
-    if [ -z "${dd_api_key}" ]; then
-      echo "Missing Datadog API key!"
-      exit 1
-    fi
-
     # TODO: Move this into roachtest_ops.sh per
     # https://github.com/cockroachdb/cockroach/pull/126530#discussion_r1668760594
     roachprod ssh ${cluster} -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
-export DD_SITE=us5.datadoghq.com
+export DD_SITE=${dd_site}
 export DD_API_KEY=${dd_api_key}
 export DD_TAGS=env:development,cluster${cluster%:*},team:drt,service:drt-cockroachdb
 EOF"


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/126530 the `dd_api_key` and `dd_site` variable declarations were moved down the file. However, this cause an unbound variable error when run against the `drt-chaos` cluster. This patch fixes this unbound variable error by moving `dd_api_key` and `dd_site` back up to before they are used.

Epic: CC-28323

Release note: None
