### PR TITLE
roachtest: mark tests that use runTPCC as using workload node

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -59,6 +59,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 		Owner:   registry.OwnerTestEng,
 		Cluster: r.MakeClusterSpec(
 			len(regions)*nodesPerRegion+1, // add one workload node
+			spec.WorkloadNode(),
 			spec.Geo(),
 			spec.GCEZones(strings.Join(zones, ",")),
 		),

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -423,7 +423,7 @@ func makeSchemaChangeBulkIngestTest(
 }
 
 func registerSchemaChangeDuringTPCC800(r registry.Registry) {
-	r.Add(makeSchemaChangeDuringTPCC(r.MakeClusterSpec(5, spec.CPU(16)), 800, time.Hour*3))
+	r.Add(makeSchemaChangeDuringTPCC(r.MakeClusterSpec(5, spec.CPU(16), spec.WorkloadNode()), 800, time.Hour*3))
 }
 
 func makeSchemaChangeDuringTPCC(


### PR DESCRIPTION
runTPCC assumes that the last node is a workload node.

Fixes: #127802
Release note: none