### PR TITLE
roachprod: reduce the test rerun time

### DIFF
--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultForPastDays = 30
 	defaultFirstRunOn  = 20
-	defaultLastRunOn   = 7
+	defaultLastRunOn   = 4
 
 	account   = "lt53838.us-central1.gcp"
 	database  = "DATAMART_PROD"


### PR DESCRIPTION
In the selective test run, there is a possibility of test starvation in certain scenarios:
1. Decommissioned tests overshadow - If we have a number of tests that have stopped running, the run count for these tests will keep going down. So, these tests will keep getting selected by test selector, but, will not run. This overshadows all other test run counts.
2. Any failed test that ran successfully for the next 30 days - A test that has failed once is run everyday for the next 30 days. Now, when this 30 days period is over, the count for number of runs is way higher than other tests run in intervals (14 vs 30).

So, number of run based sorting may not work well for successful test selection. As a quick fix, this PR reduces the check for the number of days a test is not run from 7 days to 4 days.   So, the test will definitely run on the 4th day.

Informs: #127791
Epic: None