### PR TITLE
changefeedccl: support specifying compression levels in the v2 kafka sink

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -171,6 +171,7 @@ go_library(
         "@com_github_gogo_protobuf//types",
         "@com_github_google_btree//:btree",
         "@com_github_ibm_sarama//:sarama",
+        "@com_github_klauspost_compress//gzip",
         "@com_github_klauspost_compress//zstd",
         "@com_github_klauspost_pgzip//:pgzip",
         "@com_github_linkedin_goavro_v2//:goavro",

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"hash/fnv"
+	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -27,6 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zstd"
 	"github.com/rcrowley/go-metrics"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -485,20 +488,29 @@ func buildKgoConfig(
 
 	// TODO(#126991): Remove this sarama dependency.
 	// NOTE: kgo lets you give multiple compression options in preference order, which is cool but the config json doesnt support that. Should we?
+	var comp kgo.CompressionCodec
 	switch sarama.CompressionCodec(sinkCfg.Compression) {
 	case sarama.CompressionNone:
-		opts = append(opts, kgo.ProducerBatchCompression(kgo.NoCompression()))
 	case sarama.CompressionGZIP:
-		opts = append(opts, kgo.ProducerBatchCompression(kgo.GzipCompression()))
+		comp = kgo.GzipCompression()
 	case sarama.CompressionSnappy:
-		opts = append(opts, kgo.ProducerBatchCompression(kgo.SnappyCompression()))
+		comp = kgo.SnappyCompression()
 	case sarama.CompressionLZ4:
-		opts = append(opts, kgo.ProducerBatchCompression(kgo.Lz4Compression()))
+		comp = kgo.Lz4Compression()
 	case sarama.CompressionZSTD:
-		opts = append(opts, kgo.ProducerBatchCompression(kgo.ZstdCompression()))
+		comp = kgo.ZstdCompression()
 	default:
 		return nil, errors.Errorf(`unknown compression codec: %v`, sinkCfg.Compression)
 	}
+
+	if level := sinkCfg.CompressionLevel; level != sarama.CompressionLevelDefault {
+		if err := validateCompressionLevel(sinkCfg.Compression, level); err != nil {
+			return nil, err
+		}
+		comp = comp.WithLevel(level)
+	}
+
+	opts = append(opts, kgo.ProducerBatchCompression(comp))
 
 	if version := sinkCfg.Version; version != "" {
 		if !strings.HasPrefix(version, `v`) {
@@ -515,6 +527,38 @@ func buildKgoConfig(
 	}
 
 	return opts, nil
+}
+
+// NOTE: kgo will ignore invalid compression levels, but the v1 sinks will fail validations. So we have to validate these ourselves.
+func validateCompressionLevel(compressionType compressionCodec, level int) error {
+	switch sarama.CompressionCodec(compressionType) {
+	case sarama.CompressionNone:
+		return nil
+	case sarama.CompressionGZIP:
+		if level < gzip.NoCompression || level > gzip.BestCompression {
+			return errors.Errorf(`invalid gzip compression level: %d`, level)
+		}
+	case sarama.CompressionSnappy:
+		return errors.Errorf(`snappy does not support compression levels`)
+	case sarama.CompressionLZ4:
+		// NOTE: it's not possible to define a valid non-default lz4 compression
+		// level before https://github.com/twmb/franz-go/pull/781 is released in
+		// the next kgo version.
+		//
+		// Additionally, the v1 sink ignores `level` for lz4 anyway. So let's do
+		// the best of both worlds and let the user specify valid levels and
+		// default to the default level.
+		return nil
+	case sarama.CompressionZSTD:
+		w, err := zstd.NewWriter(io.Discard, zstd.WithEncoderLevel(zstd.EncoderLevel(level)))
+		if err != nil {
+			return errors.Errorf(`invalid zstd compression level: %d`, level)
+		}
+		_ = w.Close()
+	default:
+		return errors.Errorf(`unknown compression codec: %v`, compressionType)
+	}
+	return nil
 }
 
 type kgoLogAdapter struct {

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -402,6 +402,117 @@ func mergeBatchConfig(a, b sinkBatchConfig) sinkBatchConfig {
 	return a
 }
 
+func TestKafkaSinkClientV2_CompressionOpts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cases := []struct {
+		name         string
+		codec, level string
+		expected     kgo.CompressionCodec
+		shouldErr    bool
+	}{
+		{
+			name:     "default",
+			expected: kgo.NoCompression(),
+		},
+		{
+			name:     "gzip no level",
+			codec:    "GZIP",
+			expected: kgo.GzipCompression(),
+		},
+		{
+			name:     "gzip level zero (not the default)",
+			codec:    "GZIP",
+			level:    "0",
+			expected: kgo.GzipCompression().WithLevel(0),
+		},
+		{
+			name:     "gzip level 9",
+			codec:    "GZIP",
+			level:    "9",
+			expected: kgo.GzipCompression().WithLevel(9),
+		},
+		{
+			name:     "snappy no level",
+			codec:    "SNAPPY",
+			expected: kgo.SnappyCompression(),
+		},
+		{
+			name:     "lz4 no level",
+			codec:    "LZ4",
+			expected: kgo.Lz4Compression(),
+		},
+		{
+			name:     "lz4 level 0", // This is the only level we're able to set currently. see https://github.com/twmb/franz-go/issues/778.
+			codec:    "LZ4",
+			level:    "0",
+			expected: kgo.Lz4Compression().WithLevel(0),
+		},
+		{
+			name:     "zstd no level",
+			codec:    "ZSTD",
+			expected: kgo.ZstdCompression(),
+		},
+		{
+			name:     "zstd level 4",
+			codec:    "ZSTD",
+			level:    "4",
+			expected: kgo.ZstdCompression().WithLevel(4),
+		},
+		{
+			name:      "invalid gzip level",
+			codec:     "GZIP",
+			level:     "100",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid snappy level",
+			codec:     "SNAPPY",
+			level:     "1", // Snappy doesn't have levels.
+			shouldErr: true,
+		},
+		{
+			name:      "invalid zstd level",
+			codec:     "ZSTD",
+			level:     "10", // ZSTD has a valid range of [1, 4].
+			shouldErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opt := map[string]any{}
+			if c.codec != "" {
+				opt["Compression"] = c.codec
+			}
+			if c.level != "" {
+				i, err := strconv.Atoi(c.level)
+				require.NoError(t, err)
+				opt["CompressionLevel"] = i
+			}
+			jbs, err := json.Marshal(opt)
+			require.NoError(t, err)
+
+			var createErr error
+			fx := newKafkaSinkV2Fx(t, withJSONConfig(string(jbs)), withRealClient(), withCreateClientErrorCb(func(err error) { createErr = err }))
+			defer fx.close()
+
+			if c.shouldErr {
+				require.Error(t, createErr)
+				return
+			} else {
+				require.NoError(t, createErr)
+			}
+
+			client := fx.bs.client.(*kafkaSinkClientV2).client.(*kgo.Client)
+			val := client.OptValue("ProducerBatchCompression").([]kgo.CompressionCodec)
+			assert.Equal(t, []kgo.CompressionCodec{c.expected}, val)
+		})
+	}
+
+}
+
 func TestKafkaSinkClientV2_ErrorsEventually(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -461,13 +572,14 @@ type kafkaSinkV2Fx struct {
 	mockCtrl *gomock.Controller
 
 	// set with fxOpts to modify the created sinks
-	targetNames     []string
-	topicOverride   string
-	topicPrefix     string
-	sinkJSONConfig  changefeedbase.SinkSpecificJSONConfig
-	batchConfig     sinkBatchConfig
-	realClient      bool
-	additionalKOpts []kgo.Opt
+	targetNames         []string
+	topicOverride       string
+	topicPrefix         string
+	sinkJSONConfig      changefeedbase.SinkSpecificJSONConfig
+	batchConfig         sinkBatchConfig
+	realClient          bool
+	additionalKOpts     []kgo.Opt
+	createClientErrorCb func(error)
 
 	sink *kafkaSinkClientV2
 	bs   *batchingSink
@@ -517,6 +629,12 @@ func withKOptsClient(kOpts []kgo.Opt) fxOpt {
 	}
 }
 
+func withCreateClientErrorCb(cb func(error)) fxOpt {
+	return func(fx *kafkaSinkV2Fx) {
+		fx.createClientErrorCb = cb
+	}
+}
+
 func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
@@ -549,6 +667,10 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 
 	var err error
 	fx.sink, err = newKafkaSinkClientV2(ctx, fx.additionalKOpts, fx.batchConfig, "no addrs", settings, knobs, nilMetricsRecorderBuilder)
+	if err != nil && fx.createClientErrorCb != nil {
+		fx.createClientErrorCb(err)
+		return fx
+	}
 	require.NoError(t, err)
 
 	targets := makeChangefeedTargets(fx.targetNames...)
@@ -566,6 +688,10 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 	u.RawQuery = q.Encode()
 
 	bs, err := makeKafkaSinkV2(ctx, sinkURL{URL: u}, targets, fx.sinkJSONConfig, 1, nilPacerFactory, timeutil.DefaultTimeSource{}, settings, nilMetricsRecorderBuilder, knobs)
+	if err != nil && fx.createClientErrorCb != nil {
+		fx.createClientErrorCb(err)
+		return fx
+	}
 	require.NoError(t, err)
 	fx.bs = bs.(*batchingSink)
 
@@ -573,11 +699,15 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 }
 
 func (fx *kafkaSinkV2Fx) close() {
-	if _, ok := fx.sink.client.(*mocks.MockKafkaClientV2); ok {
-		fx.kc.EXPECT().Close().AnyTimes()
+	if fx.sink != nil {
+		if _, ok := fx.sink.client.(*mocks.MockKafkaClientV2); ok {
+			fx.kc.EXPECT().Close().AnyTimes()
+		}
+		require.NoError(fx.t, fx.sink.Close())
 	}
-	require.NoError(fx.t, fx.sink.Close())
-	require.NoError(fx.t, fx.bs.Close())
+	if fx.bs != nil {
+		require.NoError(fx.t, fx.bs.Close())
+	}
 }
 
 type fnMatcher func(arg any) bool


### PR DESCRIPTION

Add support for specifying compression levels to the v2 kafka sink.

Fixes: #127256

Release note (enterprise change): The v2 kafka
sink now supports specifying compression levels.
