### PR TITLE
backupccl: remove bulkio.backup.split_keys_on_timestamps setting

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -78,14 +78,6 @@ var (
 		128<<20,
 		settings.WithPublic)
 
-	splitKeysOnTimestamps = settings.RegisterBoolSetting(
-		settings.ApplicationLevel,
-		"bulkio.backup.split_keys_on_timestamps",
-		"split backup data on timestamps when writing revision history",
-		true,
-		settings.WithName("bulkio.backup.split_keys_on_timestamps.enabled"),
-	)
-
 	preSplitExports = settings.RegisterBoolSetting(
 		settings.ApplicationLevel,
 		"bulkio.backup.presplit_request_spans.enabled",
@@ -507,19 +499,13 @@ func runBackupProcessor(
 				for _, span := range spans {
 					resumed := false
 					for len(span.span.Key) != 0 {
-						splitMidKey := splitKeysOnTimestamps.Get(&clusterSettings.SV)
-						// If we started splitting already, we must continue until we reach the end
-						// of split span.
-						if !span.firstKeyTS.IsEmpty() {
-							splitMidKey = true
-						}
 						req := &kvpb.ExportRequest{
 							RequestHeader:          kvpb.RequestHeaderFromSpan(span.span),
 							ResumeKeyTS:            span.firstKeyTS,
 							StartTime:              span.start,
 							MVCCFilter:             spec.MVCCFilter,
 							TargetFileSize:         batcheval.ExportRequestTargetFileSize.Get(&clusterSettings.SV),
-							SplitMidKey:            splitMidKey,
+							SplitMidKey:            true,
 							IncludeMVCCValueHeader: spec.IncludeMVCCValueHeader,
 						}
 

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -174,10 +173,7 @@ func evalExport(
 	}
 
 	// Only use resume timestamp if splitting mid key is enabled.
-	resumeKeyTS := hlc.Timestamp{}
-	if args.SplitMidKey {
-		resumeKeyTS = args.ResumeKeyTS
-	}
+	resumeKeyTS := args.ResumeKeyTS
 
 	maybeAnnotateExceedMaxSizeError := func(err error) error {
 		if errors.HasType(err, (*storage.ExceedMaxSizeError)(nil)) {

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -245,6 +245,9 @@ var retiredSettings = map[InternalKey]struct{}{
 	"storage.value_blocks.enabled":       {},
 	"kv.gc.sticky_hint.enabled":          {},
 	"kv.rangefeed.range_stuck_threshold": {},
+
+	// removed as of 24.3
+	"bulkio.backup.split_keys_on_timestamps": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
Release note: none.
Epic: none.