### PR TITLE
sql: support partial stats at extremes without specifying columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_stats
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_stats
@@ -125,3 +125,38 @@ WHERE stat->>'columns' = '["region"]'
 # Make sure we can still use the histogram in statistics_builder.
 statement ok
 INSERT INTO t124181 (region, a) VALUES ('ca-central-1', 2)
+
+# Verify that we don't collect partial stats on LOCALITY REGIONAL BY ROW table
+# indexes when columns are unspecified since they are implicitly partitioned
+# by the region column.
+statement ok
+CREATE TABLE multiregion_pstats (a INT PRIMARY KEY, b INT) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO multiregion_pstats (a, b, crdb_region) VALUES (1, 1, 'ap-southeast-2'), (2, 2, 'ca-central-1'), (3, 3, 'us-east-1')
+
+statement ok
+CREATE STATISTICS multiregion_full FROM multiregion_pstats
+
+statement ok
+INSERT INTO multiregion_pstats (a, b, crdb_region) VALUES (4, 4, 'ap-southeast-2'), (5, 5, 'ca-central-1')
+
+statement ok
+CREATE STATISTICS multiregion_partial FROM multiregion_pstats USING EXTREMES
+
+query TTIII colnames
+SELECT
+	statistics_name,
+	column_names,
+	row_count,
+	distinct_count,
+	null_count
+FROM
+	[SHOW STATISTICS FOR TABLE multiregion_pstats]
+ORDER BY statistics_name, column_names::STRING
+----
+statistics_name   column_names     row_count  distinct_count  null_count
+multiregion_full  {a,crdb_region}  3          3               0
+multiregion_full  {a}              3          3               0
+multiregion_full  {b}              3          3               0
+multiregion_full  {crdb_region}    3          3               0

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -77,7 +78,7 @@ func StubTableStats(
 ) ([]*stats.TableStatisticProto, error) {
 	colStats, err := createStatsDefaultColumns(
 		context.Background(), desc, false /* virtColEnabled */, false, /* multiColEnabled */
-		nonIndexColHistogramBuckets, nil, /* evalCtx */
+		false /* partialStats */, nonIndexColHistogramBuckets, nil, /* evalCtx */
 	)
 	if err != nil {
 		return nil, err
@@ -247,7 +248,13 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		}
 		defaultHistogramBuckets := stats.GetDefaultHistogramBuckets(n.p.ExecCfg().SV(), tableDesc)
 		if colStats, err = createStatsDefaultColumns(
-			ctx, tableDesc, virtColEnabled, multiColEnabled, defaultHistogramBuckets, n.p.EvalContext(),
+			ctx,
+			tableDesc,
+			virtColEnabled,
+			multiColEnabled,
+			n.Options.UsingExtremes,
+			defaultHistogramBuckets,
+			n.p.EvalContext(),
 		); err != nil {
 			return nil, err
 		}
@@ -364,13 +371,18 @@ const maxNonIndexCols = 100
 // predicate expressions are also likely to appear in query filters, so stats
 // are collected for those columns as well.
 //
+// If partialStats is true, we only collect statistics on single columns that
+// are prefixes of forward indexes, and skip over partial, sharded, and
+// implicitly partitioned indexes. Partial statistic creation only supports
+// these columns.
+//
 // In addition to the index columns, we collect stats on up to maxNonIndexCols
 // other columns from the table. We only collect histograms for index columns,
 // plus any other boolean or enum columns (where the "histogram" is tiny).
 func createStatsDefaultColumns(
 	ctx context.Context,
 	desc catalog.TableDescriptor,
-	virtColEnabled, multiColEnabled bool,
+	virtColEnabled, multiColEnabled, partialStats bool,
 	defaultHistogramBuckets uint32,
 	evalCtx *eval.Context,
 ) ([]jobspb.CreateStatsDetails_ColStat, error) {
@@ -468,6 +480,27 @@ func createStatsDefaultColumns(
 		}
 
 		return nil
+	}
+
+	// Only collect statistics on single columns that are prefixes of forward
+	// indexes for partial statistics, and skip over partial, sharded, and
+	// implicitly partitioned indexes.
+	if partialStats {
+		for _, idx := range desc.ActiveIndexes() {
+			if idx.GetType() != descpb.IndexDescriptor_FORWARD ||
+				idx.IsPartial() ||
+				idx.IsSharded() ||
+				idx.ImplicitPartitioningColumnCount() > 0 {
+				continue
+			}
+			if idx.NumKeyColumns() != 0 {
+				colID := idx.GetKeyColumnID(0)
+				if err := addIndexColumnStatsIfNotExists(colID, false /* isInverted */); err != nil {
+					return nil, err
+				}
+			}
+		}
+		return colStats, nil
 	}
 
 	// Add column stats for the primary key.
@@ -688,13 +721,35 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 		}
 
 		dsp := innerP.DistSQLPlanner()
-		planCtx := dsp.NewPlanningCtx(ctx, innerEvalCtx, innerP, txn.KV(), FullDistribution)
 		// CREATE STATS flow doesn't produce any rows and only emits the
 		// metadata, so we can use a nil rowContainerHelper.
 		resultWriter := NewRowResultWriter(nil /* rowContainer */)
-		if err := dsp.planAndRunCreateStats(
-			ctx, innerEvalCtx, planCtx, innerP.SemaCtx(), txn.KV(), r.job, resultWriter,
-		); err != nil {
+
+		var err error
+		if details.UsingExtremes {
+			for i, colStat := range details.ColumnStats {
+				// Plan and run partial stats on multiple columns separately since each
+				// partial stat collection will use a different index and have different
+				// plans.
+				singleColDetails := protoutil.Clone(&details).(*jobspb.CreateStatsDetails)
+				singleColDetails.ColumnStats = []jobspb.CreateStatsDetails_ColStat{colStat}
+				planCtx := dsp.NewPlanningCtx(ctx, innerEvalCtx, innerP, txn.KV(), FullDistribution)
+				if err = dsp.planAndRunCreateStats(
+					ctx, innerEvalCtx, planCtx, innerP.SemaCtx(), txn.KV(), resultWriter, r.job.ID(), *singleColDetails,
+					len(details.ColumnStats), i,
+				); err != nil {
+					break
+				}
+			}
+		} else {
+			planCtx := dsp.NewPlanningCtx(ctx, innerEvalCtx, innerP, txn.KV(), FullDistribution)
+			err = dsp.planAndRunCreateStats(
+				ctx, innerEvalCtx, planCtx, innerP.SemaCtx(), txn.KV(), resultWriter, r.job.ID(), details,
+				1 /* numIndexes */, 0, /* curIndex */
+			)
+		}
+
+		if err != nil {
 			// Check if this was a context canceled error and restart if it was.
 			if grpcutil.IsContextCanceled(err) {
 				return jobs.MarkAsRetryJobError(err)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3792,8 +3792,16 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 			if err != nil {
 				return nil, err
 			}
+			details := record.Details.(jobspb.CreateStatsDetails)
+
+			numIndexes := 1
+			if details.UsingExtremes {
+				// Partial stats collections scan a different index for each column.
+				numIndexes = len(details.ColumnStats)
+			}
 			plan, err = dsp.createPlanForCreateStats(
-				ctx, planCtx, planCtx.planner.SemaCtx(), 0 /* jobID */, record.Details.(jobspb.CreateStatsDetails),
+				ctx, planCtx, planCtx.planner.SemaCtx(), 0 /* jobID */, details,
+				numIndexes, 0, /* curIndex */
 			)
 		}
 

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -194,4 +194,12 @@ message SampleAggregatorSpec {
   // If true, calculate partial table statistics on the extreme values of
   // the previous full table stat.
   optional bool using_extremes = 11 [(gogoproto.nullable) = false];
+
+  // The number of indexes expected to be scanned as part of this stats
+  // collection. Used for progress reporting.
+  optional uint64 num_indexes = 12 [(gogoproto.nullable) = false];
+
+  // The number of indexes that have been scanned so far. Used for progress
+  // reporting.
+  optional uint64 cur_index = 13 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2506,9 +2506,6 @@ CREATE STATISTICS abcd_defaults ON a FROM abcd USING EXTREMES;
 statement ok
 RESET enable_create_stats_using_extremes
 
-statement error pq: cannot process multiple partial statistics at once
-CREATE STATISTICS abcd_defaults FROM abcd USING EXTREMES;
-
 statement error pq: multi-column partial statistics are not currently supported
 CREATE STATISTICS abcd_a_b ON a, c FROM abcd USING EXTREMES;
 
@@ -3348,3 +3345,62 @@ upper_bound   range_rows  distinct_range_rows  equal_rows
 'paid'        0           0                    1
 'dispatched'  0           0                    1
 'delivered'   0           0                    1
+
+# Verify that partial stats are collected on single column prefixes of forward
+# indexes and skips over partial, sharded, and implicitly partitioned indexes
+# when columns are unspecified.
+statement ok
+CREATE TABLE pstat_allindex (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  f INT,
+  j JSONB,
+  PRIMARY KEY (a),
+  INDEX(b, c),
+  INDEX(b, c, d),
+  INDEX(d),
+  INVERTED INDEX (j),
+  INDEX (c) USING HASH,
+  INDEX (e) WHERE e > 2,
+  INDEX ((f + 1))
+);
+
+statement ok
+INSERT INTO pstat_allindex VALUES
+  (1, 1, 1, 1, 1, 1, '{"1": "1"}'),
+  (2, 2, 2, 2, 2, 2, '{"2": "2"}'),
+  (3, 3, 3, 3, 3, 3, '{"3": "3"}'),
+  (4, 4, 4, 4, 4, 4, '{"4": "4"}');
+
+statement ok
+CREATE STATISTICS pstat_allindex_full FROM pstat_allindex;
+
+statement ok
+INSERT INTO pstat_allindex VALUES
+  (5, 5, 5, 5, 5, 5,'{"5": "5"}'),
+  (6, 6, 6, 6, 6, 6, '{"6": "6"}'),
+  (7, 7, 7, 7, 7, 7, '{"7": "7"}');
+
+statement ok
+CREATE STATISTICS pstat_allindex_partial FROM pstat_allindex USING EXTREMES;
+
+query TTIII colnames
+SELECT
+	statistics_name,
+	column_names,
+	row_count,
+	distinct_count,
+	null_count
+FROM
+	[SHOW STATISTICS FOR TABLE pstat_allindex]
+WHERE statistics_name = 'pstat_allindex_partial'
+ORDER BY statistics_name, column_names::STRING
+----
+statistics_name         column_names              row_count  distinct_count  null_count
+pstat_allindex_partial  {a}                       3          3               0
+pstat_allindex_partial  {b}                       3          3               0
+pstat_allindex_partial  {crdb_internal_idx_expr}  3          3               0
+pstat_allindex_partial  {d}                       3          3               0

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -265,7 +265,16 @@ func (s *sampleAggregator) mainLoop(
 					// not been paused or canceled.
 					var fractionCompleted float32
 					if s.spec.RowsExpected > 0 {
-						fractionCompleted = float32(float64(rowsProcessed) / float64(s.spec.RowsExpected))
+						// Compute the fraction of rows processed so far for the current
+						// index.
+						fractionCompleted = min(float32(float64(rowsProcessed)/float64(s.spec.RowsExpected)), 1.0)
+
+						if s.spec.NumIndexes > 0 {
+							// Adjust the fraction to account for the indexes that have already
+							// been processed.
+							fractionCompleted = (float32(s.spec.CurIndex) + fractionCompleted) / float32(s.spec.NumIndexes)
+						}
+
 						const maxProgress = 0.99
 						if fractionCompleted > maxProgress {
 							// Since the total number of rows expected is just an estimate,
@@ -347,10 +356,12 @@ func (s *sampleAggregator) mainLoop(
 			return false, err
 		}
 	}
-	// Report progress one last time so we don't write results if the job was
-	// canceled.
-	if err = progFn(1.0); err != nil {
-		return false, err
+	// Report progress one last time if this is the last index being scanned, so
+	// we don't write results if the job was canceled.
+	if s.spec.CurIndex+1 == s.spec.NumIndexes || s.spec.NumIndexes == 0 {
+		if err = progFn(1.0); err != nil {
+			return false, err
+		}
 	}
 	return false, s.writeResults(ctx)
 }


### PR DESCRIPTION
This commit adds support to collect partial statistics at extremes without specifying a column, such as:

`CREATE STATISTICS my_stat FROM t USING EXTREMES`

This will collect partial stats on a default set of columns, which are all single columns that are prefixes of forward indexes, excluding partial, sharded, and implicitly partitioned indexes.

Modifies create stats job progress reporting to work when multiple indexes will be scanned as part of the stat collection. The i'th index scan will only report progress between `(i-1)/numIndexes`% and `i/numIndexes`%. For example, if we expect to scan 4 indexes, each index will report progress between 0%-25%, 25%-50%, 50%-75%, and 75%-100% respectively. Also changes the `rowsExpected` count used by the SampleAggregator and sample size computation to be the estimated number of stale rows computed as `estimated row count * fraction of stale rows` for partial stat collections.

Closes: #127832

Release note (sql): Partial stats at extremes can now be collected on all valid columns of a table using the `CREATE STATISTICS <stat_name> FROM <table_name> USING EXTREMES` syntax, without an `ON <col_name>` clause. Valid columns are all single column prefixes of a forward index excluding partial, sharded, and implicitly partitioned indexes.