### PR TITLE
roachtest/large-schema-benchmark: fix regression with the setup phase

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -154,8 +154,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 						settings := install.MakeClusterSettings()
 						startOpts := option.DefaultStartOpts()
 						startOpts.RoachprodOpts.ScheduleBackups = false
-						crdbNodes := c.Range(1, c.Spec().NodeCount-1)
-						c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
+						c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 						conn := c.Conn(ctx, t.L(), 1)
 						defer conn.Close()
 						// Since we will be making a large number of databases / tables
@@ -174,6 +173,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 				}
 				err := c.PutString(ctx, strings.Join(dbList, "\n"), populateFileName, 0755, c.WorkloadNode())
 				require.NoError(t, err)
+				setupTPCC(ctx, t, t.L(), c, options)
 			}
 			// Upload a file containing the ORM queries.
 			require.NoError(t, c.PutString(ctx, LargeSchemaOrmQueries, "ormQueries.sql", 0755, c.WorkloadNode()))


### PR DESCRIPTION
Previously, the large schema benchmark was regressed because a call to setupTPCC was incorrectly removed via #62302. To address this, this patch restores the missing call back, which should allow this test to function nighties again.

Fixes: #127800
Fixes: #127799
Fixes: #127797
Fixes: #127796
Fixes: #127795,
Fixes: #127794
Fixes: #127793
Fixes: #127792

Release note: None