### PR TITLE
sql,server: avoid conn routing memory leak with invalid virtual cluster name

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2357,6 +2357,7 @@ func (s *topLevelServer) AcceptInternalClients(ctx context.Context) error {
 					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 					return
 				}
+				defer status.ReleaseMemory(ctx)
 
 				if err := s.serverController.sqlMux(connCtx, conn, status); err != nil {
 					log.Ops.Errorf(connCtx, "serving internal SQL client conn: %s", err)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1914,6 +1914,7 @@ func startServeSQL(
 					}
 					return
 				}
+				defer status.ReleaseMemory(ctx)
 
 				if err := serveConn(connCtx, conn, status); err != nil {
 					if logEvery.ShouldLog() {
@@ -1973,6 +1974,7 @@ func startServeSQL(
 						log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 						return
 					}
+					defer status.ReleaseMemory(ctx)
 
 					if err := serveConn(connCtx, conn, status); err != nil {
 						log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1024,6 +1024,7 @@ func (s *SQLServerWrapper) AcceptInternalClients(ctx context.Context) error {
 					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 					return
 				}
+				defer status.ReleaseMemory(ctx)
 
 				if err := s.serveConn(connCtx, conn, status); err != nil {
 					log.Ops.Errorf(connCtx, "serving internal SQL client conn: %s", err)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -951,11 +951,11 @@ func (h ConnectionHandler) GetQueryCancelKey() pgwirecancel.BackendKeyData {
 func (s *Server) ServeConn(
 	ctx context.Context, h ConnectionHandler, reserved *mon.BoundAccount, cancel context.CancelFunc,
 ) error {
-	// Make sure to close the reserved account even if closeWrapper below
+	// Make sure to clear the reserved account even if closeWrapper below
 	// panics: so we do it in a defer that is guaranteed to execute. We also
-	// cannot close it before closeWrapper since we need to close the internal
+	// cannot clear it before closeWrapper since we need to close the internal
 	// monitors of the connExecutor first.
-	defer reserved.Close(ctx)
+	defer reserved.Clear(ctx)
 	defer func(ctx context.Context, h ConnectionHandler) {
 		r := recover()
 		h.ex.closeWrapper(ctx, r)

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -166,7 +166,7 @@ func (c *conn) processCommands(
 	defer func() {
 		// Release resources, if we still own them.
 		if reservedOwned {
-			reserved.Close(ctx)
+			reserved.Clear(ctx)
 		}
 		// Notify the connection's goroutine that we're terminating. The
 		// connection might know already, as it might have triggered this

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -283,7 +283,7 @@ type PreServeStatus struct {
 
 	// Reserved is a memory account of the memory overhead for the
 	// connection. Defined only if State == PreServeReady.
-	Reserved mon.BoundAccount
+	Reserved *mon.BoundAccount
 
 	// clientParameters is the set of client-provided status parameters.
 	clientParameters tenantIndependentClientParameters
@@ -292,6 +292,14 @@ type PreServeStatus struct {
 // GetTenantName retrieves the selected tenant name.
 func (st PreServeStatus) GetTenantName() string {
 	return st.clientParameters.tenantName
+}
+
+// ReleaseMemory releases memory reserved for the "pre-serve" phase of a
+// connection.
+func (st PreServeStatus) ReleaseMemory(ctx context.Context) {
+	if st.State == PreServeReady {
+		st.Reserved.Clear(ctx)
+	}
 }
 
 // PreServe serves a single connection, up to and including the
@@ -395,7 +403,8 @@ func (s *PreServeConnHandler) PreServe(
 	// reduces pressure on the shared pool because the server monitor allocates in
 	// chunks from the shared pool and these chunks should be larger than
 	// baseSQLMemoryBudget.
-	st.Reserved = s.tenantIndependentConnMonitor.MakeBoundAccount()
+	connBoundAccount := s.tenantIndependentConnMonitor.MakeBoundAccount()
+	st.Reserved = &connBoundAccount
 	if err := st.Reserved.Grow(ctx, baseSQLMemoryBudget); err != nil {
 		return conn, st, errors.Wrapf(err, "unable to pre-allocate %d bytes for this connection",
 			baseSQLMemoryBudget)
@@ -405,7 +414,7 @@ func (s *PreServeConnHandler) PreServe(
 	st.clientParameters, err = parseClientProvidedSessionParameters(
 		ctx, &buf, conn.RemoteAddr(), s.trustClientProvidedRemoteAddr.Load(), s.acceptTenantName, s.acceptSystemIdentityOption.Load())
 	if err != nil {
-		st.Reserved.Close(ctx)
+		st.Reserved.Clear(ctx)
 		return conn, st, s.sendErr(ctx, s.st, conn, err)
 	}
 	st.clientParameters.IsSSL = st.ConnType == hba.ConnHostSSL

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -790,14 +790,12 @@ func (s *Server) ServeConn(
 
 	sArgs, err := finalizeClientParameters(ctx, preServeStatus.clientParameters, &st.SV)
 	if err != nil {
-		preServeStatus.Reserved.Close(ctx)
 		return s.sendErr(ctx, st, conn, err)
 	}
 
 	// Transfer the memory account into this tenant.
-	tenantReserved, err := s.tenantSpecificConnMonitor.TransferAccount(ctx, &preServeStatus.Reserved)
+	tenantReserved, err := s.tenantSpecificConnMonitor.TransferAccount(ctx, preServeStatus.Reserved)
 	if err != nil {
-		preServeStatus.Reserved.Close(ctx)
 		return s.sendErr(ctx, st, conn, err)
 	}
 
@@ -1046,7 +1044,7 @@ func (s *Server) serveImpl(
 	} else {
 		// sqlServer == nil means we are in a local test. In this case
 		// we only need the minimum to make pgx happy.
-		defer reserved.Close(ctx)
+		defer reserved.Clear(ctx)
 		var err error
 		for param, value := range testingStatusReportParams {
 			err = c.bufferParamStatus(param, value)

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -951,7 +951,7 @@ func (mm *BytesMonitor) TransferAccount(
 	if err = b.Grow(ctx, origAccount.used); err != nil {
 		return newAccount, err
 	}
-	origAccount.Close(ctx)
+	origAccount.Clear(ctx)
 	return b, nil
 }
 


### PR DESCRIPTION
This patch addresses a memory leak by using `defer` to unconditionally free the memory of the pre-conn bound account. Previously, extreme care was needed to release the memory in every possible error condition that could arise in between creating the pre-conn account and transfering the memory to the tenant-specific account.

In this case, the area of the code that did not release the memory upon error is the code that handles the case where there is no virtual cluster with the specified name: https://github.com/cockroachdb/cockroach/blob/25232a68fd77bb6f517b39864a8605205864ee99/pkg/server/server_controller_sql.go#L78-L94

Now, the memory will always be freed. Since it is an error to call Close twice on the same memory account, these calls were changed to use Clear instead. (Clear will be called when the memory is successfully transferred to the new account, and also when the connection serving goroutine ends.)

fixes CRDB-40449
Epic: None
Release note (bug fix): Fixed a memory leak that could occur when specifying a non-existent virtual cluster name in the connection string.