### PR TITLE
changefeedccl: fix kafka sink v2 flush frequency

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -369,7 +369,7 @@ func makeKafkaSinkV2(
 		return nil, err
 	}
 
-	return makeBatchingSink(ctx, sinkTypeKafka, client, time.Second, retryOpts,
+	return makeBatchingSink(ctx, sinkTypeKafka, client, time.Duration(batchCfg.Frequency), retryOpts,
 		parallelism, topicNamer, pacerFactory, timeSource, mb(true), settings), nil
 }
 

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -281,8 +281,9 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 		name       string
 		jsonConfig map[string]any
 		// Both expectedOpts and expectedBatchCfg will be merged with their respective base* before comparison.
-		expectedOpts        map[string]any
-		expectedBatchConfig sinkBatchConfig
+		expectedOpts                map[string]any
+		expectedBatchConfig         sinkBatchConfig
+		expectedBatchingSinkMinFreq time.Duration
 	}{
 		{
 			name: "default",
@@ -337,7 +338,7 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 				"Flush": map[string]any{
 					"Messages":    100,
 					"Bytes":       1000,
-					"Frequency":   "1s",
+					"Frequency":   "2s",
 					"MaxMessages": 2000,
 				},
 			},
@@ -349,10 +350,11 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 				"MaxBufferedRecords":       int64(2000),
 			},
 			expectedBatchConfig: sinkBatchConfig{
-				Frequency: jsonDuration(1 * time.Second),
+				Frequency: jsonDuration(2 * time.Second),
 				Messages:  100,
 				Bytes:     1000,
 			},
+			expectedBatchingSinkMinFreq: 2 * time.Second,
 		},
 	}
 
@@ -374,6 +376,9 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 				assert.Equal(t, v, val, "opt %q has value %+#v, expected %+#v", k, val, v)
 			}
 			assert.Equal(t, expectedBatchCfg, batchCfg)
+			if c.expectedBatchingSinkMinFreq != 0 {
+				assert.Equal(t, c.expectedBatchingSinkMinFreq, fx.bs.minFlushFrequency)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Previously, the flush frequency for the Kafka sink
v2 was hardcoded to 1 second. This correctly sets
it to the value specifed in the sink config.

Release note: None
