### PR TITLE
sql: allow creating partial stats at extremes by default

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -219,9 +219,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 	}
 
 	if n.Options.UsingExtremes && !n.p.SessionData().EnableCreateStatsUsingExtremes {
-		return nil, pgerror.New(pgcode.FeatureNotSupported,
-			"creating partial statistics at extremes is not yet supported",
-		)
+		return nil, errors.Errorf(`creating partial statistics at extremes is disabled`)
 	}
 
 	// TODO(93998): Add support for WHERE.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2292,12 +2292,6 @@ INSERT INTO xy VALUES (-1, 9), (-2, 8), (5, 15), (6, 16)
 statement error pgcode 0A000 creating partial statistics with a WHERE clause is not yet supported
 CREATE STATISTICS abcd_a_partial ON a FROM abcd WHERE a > 1;
 
-statement error pgcode 0A000 creating partial statistics at extremes is not yet supported
-CREATE STATISTICS abcd_a_partial ON a FROM abcd USING EXTREMES;
-
-statement ok
-SET enable_create_stats_using_extremes = on
-
 statement ok
 CREATE STATISTICS abcd_a_partial ON a FROM abcd USING EXTREMES;
 
@@ -2518,6 +2512,15 @@ sdn              NULL                                               8          2
 sdnp             (a IS NULL) OR ((a < 0:::INT8) OR (a > 5:::INT8))  2          2
 
 # Verify errors.
+statement ok
+SET enable_create_stats_using_extremes = off
+
+statement error creating partial statistics at extremes is disabled
+CREATE STATISTICS abcd_defaults ON a FROM abcd USING EXTREMES;
+
+statement ok
+RESET enable_create_stats_using_extremes
+
 statement error pq: cannot process multiple partial statistics at once
 CREATE STATISTICS abcd_defaults FROM abcd USING EXTREMES;
 
@@ -2622,9 +2625,6 @@ CREATE INDEX ON xy (y) WHERE y > 5;
 
 statement error pq: table xy does not contain a non-partial forward index with y as a prefix column
 CREATE STATISTICS xy_partial_idx ON y FROM xy USING EXTREMES;
-
-statement ok
-RESET enable_create_stats_using_extremes
 
 # Regression test for #100909. Ensure enum is hydrated in SHOW HISTOGRAM.
 statement ok
@@ -2904,9 +2904,6 @@ upper_bound            range_rows  distinct_range_rows  equal_rows
 
 # Test partial stats using extremes on indexed virtual computed columns.
 statement ok
-SET enable_create_stats_using_extremes = on
-
-statement ok
 INSERT INTO t68254 (a, b, c) VALUES (5, '5', '{"foo": {"bar": {"baz": 5}}}')
 
 statement ok
@@ -3154,9 +3151,6 @@ CREATE STATISTICS enum_table_partial ON a FROM bool_table USING EXTREMES
 
 statement ok
 RESET enable_create_stats_using_extremes_bool_enum
-
-statement ok
-RESET enable_create_stats_using_extremes
 
 # Regression test for #118537. Do not create stats on non-public mutation
 # columns.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6110,7 +6110,7 @@ disable_plan_gists                                         off
 disallow_full_table_scans                                  off
 distsql_plan_gateway_bias                                  2
 enable_auto_rehoming                                       off
-enable_create_stats_using_extremes                         off
+enable_create_stats_using_extremes                         on
 enable_create_stats_using_extremes_bool_enum               off
 enable_durable_locking_for_serializable                    off
 enable_experimental_alter_column_type_general              off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2845,7 +2845,7 @@ disallow_full_table_scans                                  off                 N
 distsql                                                    off                 NULL      NULL        NULL        string
 distsql_plan_gateway_bias                                  2                   NULL      NULL        NULL        string
 enable_auto_rehoming                                       off                 NULL      NULL        NULL        string
-enable_create_stats_using_extremes                         off                 NULL      NULL        NULL        string
+enable_create_stats_using_extremes                         on                  NULL      NULL        NULL        string
 enable_create_stats_using_extremes_bool_enum               off                 NULL      NULL        NULL        string
 enable_durable_locking_for_serializable                    off                 NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general              off                 NULL      NULL        NULL        string
@@ -3034,7 +3034,7 @@ disallow_full_table_scans                                  off                 N
 distsql                                                    off                 NULL  user     NULL      off                 off
 distsql_plan_gateway_bias                                  2                   NULL  user     NULL      2                   2
 enable_auto_rehoming                                       off                 NULL  user     NULL      off                 off
-enable_create_stats_using_extremes                         off                 NULL  user     NULL      off                 off
+enable_create_stats_using_extremes                         on                  NULL  user     NULL      on                  on
 enable_create_stats_using_extremes_bool_enum               off                 NULL  user     NULL      off                 off
 enable_durable_locking_for_serializable                    off                 NULL  user     NULL      off                 off
 enable_experimental_alter_column_type_general              off                 NULL  user     NULL      off                 off

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -67,7 +67,7 @@ disallow_full_table_scans                                  off
 distsql                                                    off
 distsql_plan_gateway_bias                                  2
 enable_auto_rehoming                                       off
-enable_create_stats_using_extremes                         off
+enable_create_stats_using_extremes                         on
 enable_create_stats_using_extremes_bool_enum               off
 enable_durable_locking_for_serializable                    off
 enable_experimental_alter_column_type_general              off

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1241,9 +1241,6 @@ SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev
 # Verify that we can merge partial stats with full stats that have outer
 # buckets.
 statement ok
-SET enable_create_stats_using_extremes = on
-
-statement ok
 CREATE TABLE ka (k INT PRIMARY KEY, a INT, INDEX(a))
 
 statement ok

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2853,7 +2853,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableCreateStatsUsingExtremes), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 
 	// CockroachDB extension.


### PR DESCRIPTION
This commit makes the `enable_create_stats_using_extremes` session setting true by default, enabling the collection of partial statistics at extremes.

See also: #125950, #93983

Release note (sql): The `enable_create_stats_using_extremes` session setting is now true by default. Partial statistics at extremes can be collected using the `CREATE STATISTICS <stat_name> ON <column_name> FROM <table_name> USING EXTREMES` syntax.