### PR TITLE
changefeedccl: enable the new Kafka v2 sink by default

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -194,7 +194,7 @@ var KafkaV2Enabled = settings.RegisterBoolSetting(
 	"changefeed.new_kafka_sink_enabled",
 	"if enabled, this setting enables a new implementation of the kafka sink with improved reliability",
 	// TODO(#126991): delete the original kafka sink code
-	metamorphic.ConstantWithTestBool("changefeed.new_kafka_sink.enabled", false),
+	metamorphic.ConstantWithTestBool("changefeed.new_kafka_sink.enabled", true),
 	settings.WithName("changefeed.new_kafka_sink.enabled"),
 )
 


### PR DESCRIPTION
Enable the new Kafka v2 sink by default.

Fixes: #127860

Release note (enterprise change): The new Kafka v2
sink is now enabled by default.
