### PR TITLE
jobs: ignore schemachange gc during validation

### DIFF
--- a/pkg/jobs/validate.go
+++ b/pkg/jobs/validate.go
@@ -11,6 +11,8 @@
 package jobs
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -56,9 +58,13 @@ func ValidateJobReferencesInDescriptor(
 
 // ValidateDescriptorReferencesInJob checks a job for inconsistencies relative
 // to system.descriptor and passes any validation failures in the form of errors
-// to an accumulator function.
+// to an accumulator function. We also have a second accumulator function for
+// keeping track of INFO level details that do not need to fail validation.
 func ValidateDescriptorReferencesInJob(
-	j JobMetadata, descLookupFn func(id descpb.ID) catalog.Descriptor, errorAccFn func(error),
+	j JobMetadata,
+	descLookupFn func(id descpb.ID) catalog.Descriptor,
+	errorAccFn func(error),
+	infoAccFn func(string),
 ) {
 	switch j.Status {
 	case StatusRunning, StatusPaused, StatusPauseRequested:
@@ -84,9 +90,9 @@ func ValidateDescriptorReferencesInJob(
 			j.Status, missing.Ordered()))
 	case jobspb.TypeSchemaChangeGC:
 		isSafeToDelete := existing.Len() == 0 && len(j.Progress.GetSchemaChangeGC().Indexes) == 0
-		errorAccFn(errors.AssertionFailedf("%s schema change GC refers to missing table descriptor(s) %+v; "+
-			"existing descriptors that still need to be dropped %+v; job safe to delete: %v",
-			j.Status, missing.Ordered(), existing.Ordered(), isSafeToDelete))
+		infoAccFn(fmt.Sprintf("%s schema change GC refers to missing table "+
+			"descriptor(s) %+v; existing descriptors that still need to be dropped %+v; job safe to "+
+			"delete: %v", j.Status, missing.Ordered(), existing.Ordered(), isSafeToDelete))
 	case jobspb.TypeTypeSchemaChange:
 		errorAccFn(errors.AssertionFailedf("%s type schema change refers to missing type descriptor %v",
 			j.Status, missing.Ordered()))

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -244,6 +244,8 @@ func ExamineJobs(
 		jobs.ValidateDescriptorReferencesInJob(j, descLookupFn, func(err error) {
 			problemsFound = true
 			fmt.Fprintf(stdout, "job %d: %s.\n", j.ID, err)
+		}, func(s string) {
+			fmt.Fprintf(stdout, "job %d: %s.\n", j.ID, s)
 		})
 	}
 	return !problemsFound, nil

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -573,6 +573,7 @@ func TestExamineJobs(t *testing.T) {
 					Status: jobs.StatusPaused,
 				},
 			},
+			valid: true,
 			expected: `Examining 3 jobs...
 job 100: running schema change GC refers to missing table descriptor(s) [3]; existing descriptors that still need to be dropped [2]; job safe to delete: false.
 job 200: pause-requested schema change GC refers to missing table descriptor(s) [3]; existing descriptors that still need to be dropped []; job safe to delete: true.


### PR DESCRIPTION
During our validation of jobs, we do not need to consider
SchemaChangeGC jobs as a cause of failing validation.
If these GC jobs are running, we can assume
that the descriptor will eventually get gc'ed.
In a pause or pause requested state, once the job is
allowed to run again, descriptors will eventually get gc'ed.
SchemaChangeGC jobs with invalid descriptor references
likely means that the GC job has already progressed.

Since this information is still useful, we continue logging
these messages to stdout.

Epic: none

Fixes: #126374
Release note: None