### PR TITLE
cdcevent: prevent misleading log when ErrUnwatchedFamily is encountered

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -533,6 +533,11 @@ func (d *eventDecoder) DecodeKV(
 	if err == nil {
 		return r, nil
 	}
+	// Unwatched family errors aren't terminal so return early and let caller
+	// decide what to do with it.
+	if errors.Is(err, ErrUnwatchedFamily) {
+		return Row{}, err
+	}
 
 	// Failure to decode roachpb.KeyValue we received from rangefeed is pretty bad.
 	// At this point, we only have guesses why this happened (schema change? data corruption?).


### PR DESCRIPTION
Currently, we log a message saying "terminal error decoding KV" in
`*eventDecoder.DecodeKV` when we attempt to decode a KV belonging to an
unwatched family but then at all changefeed code call sites, we do not
in fact treat it as terminal. This patch ensures that we no longer emit
this misleading message.

Informs #126096

Release note: None