### PR TITLE
workspaces: create actual dummy go modules

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/go.mod
+++ b/pkg/ui/workspaces/cluster-ui/go.mod
@@ -1,0 +1,1 @@
+module clusterui

--- a/pkg/ui/workspaces/crdb-api-client/go.mod
+++ b/pkg/ui/workspaces/crdb-api-client/go.mod
@@ -1,0 +1,1 @@
+module crdbapiclient

--- a/pkg/ui/workspaces/db-console/go.mod
+++ b/pkg/ui/workspaces/db-console/go.mod
@@ -1,0 +1,1 @@
+module dbconsole

--- a/pkg/ui/workspaces/e2e-tests/go.mod
+++ b/pkg/ui/workspaces/e2e-tests/go.mod
@@ -1,0 +1,1 @@
+module eetests

--- a/pkg/ui/workspaces/eslint-plugin-crdb/go.mod
+++ b/pkg/ui/workspaces/eslint-plugin-crdb/go.mod
@@ -1,0 +1,1 @@
+module eslintplugincrdb


### PR DESCRIPTION
`go list` (which is invoked occasionally GoLand) throws a "missing module
declaration" error on the empty `go.mod` files that were created in
https://github.com/cockroachdb/cockroach/pull/99775 (to prevent `go list` from
recursing into subdirectories to save IO).

Now we make actual empty named modules, which seems to work better.

```
for i in pkg/ui/workspaces/*/
  do echo "module $(basename $i | sed 's/[^a-z]//g')" > $i/go.mod
done
```

Epic: none
