### PR TITLE
flowinfra: remove SendIsThreadSafe from delayedErrorServerStream

### DIFF
--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -717,8 +717,6 @@ type delayedErrorServerStream struct {
 	err         error
 }
 
-func (s *delayedErrorServerStream) SendIsThreadSafe() {}
-
 func (s *delayedErrorServerStream) Send(*execinfrapb.ConsumerSignal) error {
 	s.rpcCalledCh <- struct{}{}
 	<-s.delayCh


### PR DESCRIPTION
Previously, we added `SendIsThreadSafe` to the `delayedErrorServerStream` struct
by mistakes, which is unrelated to `RangeFeedEventSink`. This patch removes it.

Related: https://github.com/cockroachdb/cockroach/pull/126486
Release note: none
Epic: none