### PR TITLE
roachprod: fix the issue with test starvation in test selection

### DIFF
--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultForPastDays = 30
 	defaultFirstRunOn  = 20
-	defaultLastRunOn   = 4
+	defaultLastRunOn   = 7
 
 	account   = "lt53838.us-central1.gcp"
 	database  = "DATAMART_PROD"
@@ -50,7 +50,6 @@ type TestDetails struct {
 	Name                 string // test name
 	Selected             bool   // whether a test is Selected or not
 	AvgDurationInMillis  int64  // average duration of the test
-	TotalRuns            int    // total number of times the test has run successfully
 	LastFailureIsPreempt bool   // last failure is due to a VM preemption
 }
 
@@ -135,14 +134,12 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 		// 0. test name
 		// 1. whether a test is Selected or not
 		// 2. average duration of the test
-		// 3. total number of times the test has run successfully
-		// 4. last failure is due to an infra flake
+		// 3. last failure is due to an infra flake
 		testDetails := &TestDetails{
 			Name:                 testInfos[0],
 			Selected:             testInfos[1] != "no",
 			AvgDurationInMillis:  getDuration(testInfos[2]),
-			TotalRuns:            getTotalRuns(testInfos[3]),
-			LastFailureIsPreempt: testInfos[4] == "yes",
+			LastFailureIsPreempt: testInfos[3] == "yes",
 		}
 		if testDetails.Selected {
 			// selected for running
@@ -169,12 +166,6 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 func getDuration(durationStr string) int64 {
 	duration, _ := strconv.ParseInt(durationStr, 10, 64)
 	return duration
-}
-
-// getTotalRuns extracts the total runs from the snowflake query total_runs field
-func getTotalRuns(totalRunsStr string) int {
-	totalRuns, _ := strconv.ParseInt(totalRunsStr, 10, 64)
-	return int(totalRuns)
 }
 
 // getConnect makes connection to snowflake and returns the connection.

--- a/pkg/cmd/roachtest/testselector/snowflake_query.sql
+++ b/pkg/cmd/roachtest/testselector/snowflake_query.sql
@@ -1,12 +1,14 @@
-with builds as (
+with ts as (
+  select current_date() as t -- this returns the current date
+), builds as (
   -- select all the build IDs in the last "forPastDays" days
   select
     ID as run_id,
     min(start_date) as first_run, -- get the first time the test was run
     max(start_date) as last_run, -- -- get the last time the test was run
-  from DATAMART_PROD.TEAMCITY.BUILDS
+  from DATAMART_PROD.TEAMCITY.BUILDS, ts
   where
-    start_date > dateadd(DAY, ?, current_date()) -- last "forPastDays" days
+    start_date > dateadd(DAY, ?, ts.t) -- last "forPastDays" days
     and lower(status) = 'success' -- consider only successful builds
     and branch_name = ? -- consider the builds from target branch
     and lower(name) like ? -- name is based on the suite and cloud e.g. '%roachtest nightly - gce%'
@@ -20,6 +22,8 @@ with builds as (
          -- record the latest details of the test. this is useful for identifying if the latest failure of
          -- the test is due to infra failure
          MAX_BY(details, b.last_run) as recent_details,
+         MAX_BY(ignore_details, b.last_run) as recent_ignore_details,
+         MAX_BY(status, b.last_run) as last_status,
          -- get the first_run and last_run only if the status is not UNKNOWN. This returns nil for runs that have never run
          min(case when status!='UNKNOWN' then b.first_run end) as first_run,
          max(case when status!='UNKNOWN' then b.last_run end) as last_run,
@@ -36,14 +40,21 @@ select
   case when
          -- mark as selected if
          failure_count > 0 or -- the test has failed at least once in the past "forPastDays" days
-         first_run > dateadd(DAY, ?, current_date()) or -- recently added test - test has not run for more than "firstRunOn" days
-         last_run < dateadd(DAY, ?, current_date()) or -- the test has not been run for last "lastRunOn" days
-         last_run is null -- the test is always ignored till now or have never been run
+         first_run > dateadd(DAY, ?, ts.t) or -- recently added test - test has not run for more than "firstRunOn" days
+         last_run < dateadd(DAY, ?, ts.t) or -- the test has not been run for last "lastRunOn" days
+          -- last_status='UNKNOWN' can be for the following scenarios:
+           -- test is run in the past, but added to skip by the test writer
+            -- In this scenario, we want to select the test as we do not know when user may mark it to not skipped
+           -- test is not run due to incompatibility
+            -- here also, user can make it compatible at any point. So, we always select.
+           -- test is never run - we always select
+           -- test is not run by test selector in the last run
+            -- The test should not be selected by default in this case and should be selected based on the sorted unselected list
+         (last_status='UNKNOWN' and recent_ignore_details!='test selector')
          then 'yes' else 'no' end as selected,
   -- average duration - this is set to 0 if the test is never run (total_successful_runs=0)
   case when total_successful_runs > 0 then total_duration/total_successful_runs else 0 end as avg_duration,
-  total_successful_runs,
   -- indicates the last failure was due to infra flake
   case when recent_details like '%VMs preempted during the test run%' then 'yes' else 'no' end as last_failure_is_preeempt,
-from test_stats
-order by selected desc, total_successful_runs
+from test_stats, ts
+order by selected desc, last_run -- selected="yes" appears first. Rest of the tests are sorted by the last run.


### PR DESCRIPTION
In the selective test run, there is a possibility of test starvation in certain scenarios:
1. Decommissioned tests overshadow - If we have a number of tests that have stopped running, the run count for these tests will keep going down. So, these tests will keep getting selected by test selector, but, will not run. This overshadows all other test run counts.
2. Any failed test that ran successfully for the next 30 days - A test that has failed once is run everyday for the next 30 days. Now, when this 30 days period is over, the count for number of runs is way higher than other tests run in intervals (14 vs 30).

The solution that is done here are:
1. sort the tests by the last run date instead of the number if times the test has run.
2. add an extra check on the tests and consider only the tests that have been ignored by test selector. This way we are dealing with tests that are previously considered under test selector to be ignored. Any other test not ignored by test selector are selected by default. If those tests are decommissioned, those tests will anyways not run.

There is one more change added to extract the way the current date is used. This is done to ensure consistency in the query.

Also, changing the fallback time back to 7 days as this change should fix the starvation.

Fixes: #127791
Epic: None