### PR TITLE
release-24.2: log: update crdbV2 log decoder

### DIFF
--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -460,15 +460,12 @@ func (zc *debugZipContext) collectPerNodeData(
 			// Log the list of errors that occurred during log entries request.
 			if len(entries.ParseErrors) > 0 {
 				sf.shout("%d parsing errors occurred:", len(entries.ParseErrors))
-				for _, err := range entries.ParseErrors {
-					sf.shout("%s", err)
-				}
 				parseErr := fmt.Errorf("%d errors occurred:\n%s", len(entries.ParseErrors), strings.Join(entries.ParseErrors, "\n"))
 				if err := zc.z.createError(sf, name, parseErr); err != nil {
 					return err
 				}
 			}
-			sf.progress("writing output: %s", name)
+			sf = logPrinter.start("writing output")
 			warnRedactLeak := false
 			if err := func() error {
 				// Use a closure so that the zipper is only locked once per

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1367,6 +1367,8 @@ func (s *statusServer) LogFile(
 			}
 			if errors.Is(err, log.ErrMalformedLogEntry) {
 				resp.ParseErrors = append(resp.ParseErrors, err.Error())
+				//Append log generated from malformed line.
+				resp.Entries = append(resp.Entries, entry)
 				// Proceed decoding next entry, as we want to retrieve as much logs
 				// as possible.
 				continue

--- a/pkg/server/storage_api/logfiles_test.go
+++ b/pkg/server/storage_api/logfiles_test.go
@@ -513,5 +513,5 @@ func TestStatusLogCorruptedEntry(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, wrapper.Entries)
 	require.NotEmpty(t, wrapper.ParseErrors)
-	require.Equal(t, len(wrapper.ParseErrors), 1)
+	require.Equal(t, 2, len(wrapper.ParseErrors))
 }

--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -460,6 +460,7 @@ func (buf *buffer) maybeMultiLine(
 var startRedactionMarker = string(redact.StartMarker())
 var endRedactionMarker = string(redact.EndMarker())
 var markersStartWithMultiByteRune = startRedactionMarker[0] >= utf8.RuneSelf && endRedactionMarker[0] >= utf8.RuneSelf
+var defaultCrdbV2Format = "I000101 00:00:00.000000 0  :0 ⋮ [-] 0  %s"
 
 var (
 	entryREV2 = regexp.MustCompile(
@@ -495,13 +496,16 @@ var (
 const tenantDetailsTags = string(tenantIDLogTagKey) + string(tenantNameLogTagKey)
 
 type entryDecoderV2 struct {
-	lines           int // number of lines read from reader
-	reader          *bufio.Reader
-	nextFragment    entryDecoderV2Fragment
-	sensitiveEditor redactEditor
+	lines               int // number of lines read from reader
+	reader              *bufio.Reader
+	nextFragment        entryDecoderV2Fragment
+	sensitiveEditor     redactEditor
+	isMalformedFragment bool
 }
 
 // Decode decodes the next log entry into the provided protobuf message.
+// If we encounter any malformed line then we are updating log entry along with
+// MalformedLogEntry error
 func (d *entryDecoderV2) Decode(entry *logpb.Entry) (err error) {
 	defer func() {
 		if err != nil && !errors.Is(err, io.EOF) {
@@ -509,13 +513,22 @@ func (d *entryDecoderV2) Decode(entry *logpb.Entry) (err error) {
 		}
 	}()
 	frag, err := d.peekNextFragment()
+
 	if err != nil {
 		return err
 	}
-	d.popFragment()
-	if err = d.initEntryFromFirstLine(entry, frag); err != nil {
-		return err
+
+	// construct the log entry from malformed fragment and return it along
+	// with malformed log entry error
+	if d.isMalformedFragment {
+		d.popFragment()
+		d.initEntryFromFirstLine(entry, frag)
+		entry.Message = string(frag.getMsg())
+		return ErrMalformedLogEntry
 	}
+
+	d.popFragment()
+	d.initEntryFromFirstLine(entry, frag)
 
 	// Process the message.
 	var entryMsg bytes.Buffer
@@ -524,8 +537,8 @@ func (d *entryDecoderV2) Decode(entry *logpb.Entry) (err error) {
 	// While the entry has additional lines, collect the full message.
 	for {
 		frag, err = d.peekNextFragment()
-		if err != nil || !frag.isContinuation() {
-			// Ignore this error as it is relevant to the next line and we don't
+		if err != nil || d.isMalformedFragment || !frag.isContinuation() {
+			// Ignore the error or malformed fragment as it is relevant to the next line and we don't
 			// know if it is continuation line or not.
 			break
 		}
@@ -595,7 +608,10 @@ func (d *entryDecoderV2) peekNextFragment() (entryDecoderV2Fragment, error) {
 			if d.lines == 1 { // allow non-matching lines if we've never seen a line
 				continue
 			}
-			return nil, ErrMalformedLogEntry
+			// construct fragment based on malformed line in crdbV2 format with default values
+			d.nextFragment = entryREV2.FindSubmatch([]byte((fmt.Sprintf(defaultCrdbV2Format, nextLine))))
+			d.isMalformedFragment = true
+			return d.nextFragment, nil
 		}
 		d.nextFragment = m
 	}
@@ -607,11 +623,10 @@ func (d *entryDecoderV2) popFragment() {
 		panic(errors.AssertionFailedf("cannot pop unpopulated fragment"))
 	}
 	d.nextFragment = nil
+	d.isMalformedFragment = false
 }
 
-func (d *entryDecoderV2) initEntryFromFirstLine(
-	entry *logpb.Entry, m entryDecoderV2Fragment,
-) (err error) {
+func (d *entryDecoderV2) initEntryFromFirstLine(entry *logpb.Entry, m entryDecoderV2Fragment) {
 	// Erase all the fields, to be sure.
 	tenantID, tenantName := m.getTenantDetails()
 	*entry = logpb.Entry{
@@ -631,7 +646,6 @@ func (d *entryDecoderV2) initEntryFromFirstLine(
 		entry.StructuredStart = 0
 		entry.StructuredEnd = uint32(len(m.getMsg()))
 	}
-	return nil
 }
 
 // entryDecoderV2Fragment is a line which is part of a v2 log entry.

--- a/pkg/util/log/format_crdb_v2_test.go
+++ b/pkg/util/log/format_crdb_v2_test.go
@@ -268,6 +268,7 @@ func TestCrdbV2Decode(t *testing.T) {
 							break
 						}
 						if errors.Is(err, ErrMalformedLogEntry) {
+							fmt.Fprintf(&out, "malformed entry:%# v\n", pretty.Formatter(e))
 							continue
 						}
 						td.Fatalf(t, "error while decoding: %v", err)

--- a/pkg/util/log/testdata/parse
+++ b/pkg/util/log/testdata/parse
@@ -279,14 +279,48 @@ subtest corrupted_log
 
 # Check that entries after corrupted line is parsed.
 log
-.
 I210116 17:49:17.073282-020000 14 server/node.go:464 ⋮ [-] 23  started with engine type ‹2›
-.
-.
-.
+panic: invalid tenant ID 0
+
+goroutine 6603729 [running]:
 I210116 19:49:17.073282 14 server/node.go:464 ⋮ [-] 23  last line
 ----
 logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"panic: invalid tenant ID 0", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"goroutine 6603729 [running]:", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"last line", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+
+
+subtest end
+
+subtest corrupted_log_at_end
+
+# Check that entries after corrupted at end are getting parsed
+log
+I210116 17:49:17.073282-020000 14 server/node.go:464 ⋮ [-] 23  started with engine type ‹2›
+panic: invalid tenant ID 0
+
+goroutine 6603729 [running]:
+----
+logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"started with engine type ‹2›", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"panic: invalid tenant ID 0", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"goroutine 6603729 [running]:", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
+
+
+subtest end
+
+
+subtest corrupted_log_at_start
+
+# Check that entries after corrupted at start are getting parsed
+log
+goroutine 6603729 [running]:
+panic: invalid tenant ID 0
+I210116 19:49:17.073282 14 server/node.go:464 ⋮ [-] 23  last line
+----
+malformed entry:logpb.Entry{Severity:1, Time:946684800000000000, Goroutine:0, File:" ", Line:0, Message:"panic: invalid tenant ID 0", Tags:"", Counter:0x0, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 logpb.Entry{Severity:1, Time:1610826557073282000, Goroutine:14, File:"server/node.go", Line:464, Message:"last line", Tags:"", Counter:0x17, Redactable:true, Channel:0, StructuredEnd:0x0, StructuredStart:0x0, StackTraceStart:0x0, TenantID:"1", TenantName:""}
 
 


### PR DESCRIPTION
Backport 1/1 commits from #127057.

/cc @cockroachdb/release

---

Previously, we were returning an error during decode when there is a malformed log entry. We were ignoring unstructured log line & returning  error. This was causing issues during debug zip generation. To address this, we have updated the crdbV2 log decoder so that it would return malformed/unstructured line as log entry along with error. LogFile RPC would append such logs along with error.

Fixes: #104210
Release note (bug fix): This patch fixes the bug where debug zip is giving error while fetching unstructured/malformed logs.

---

Release justification: debug zip bug fix