### PR TITLE
roachtest: improvements in connection to mixedversion services

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -125,10 +125,10 @@ func MustParseVersion(v string) *Version {
 // associated with the given database connection.
 // NB: version means major.minor[-internal]; the patch level isn't
 // returned. For example, a binary of version 19.2.4 will return 19.2.
-func BinaryVersion(db *gosql.DB) (roachpb.Version, error) {
+func BinaryVersion(ctx context.Context, db *gosql.DB) (roachpb.Version, error) {
 	zero := roachpb.Version{}
 	var sv string
-	if err := db.QueryRow(`SELECT crdb_internal.node_executable_version();`).Scan(&sv); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT crdb_internal.node_executable_version();`).Scan(&sv); err != nil {
 		return zero, err
 	}
 
@@ -428,7 +428,7 @@ func WaitForClusterUpgrade(
 	timeout time.Duration,
 ) error {
 	firstNode := nodes[0]
-	newVersion, err := BinaryVersion(dbFunc(firstNode))
+	newVersion, err := BinaryVersion(ctx, dbFunc(firstNode))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/intsets",
         "//pkg/util/randutil",
+        "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -236,7 +236,7 @@ func (h *Helper) Background(
 			}
 
 			err := errors.Wrapf(err, "error in background function %s", name)
-			return h.runner.testFailure(err, bgLogger, nil)
+			return h.runner.testFailure(ctx, err, bgLogger, nil)
 		}
 
 		return nil

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -261,12 +261,18 @@ func (p *testPlanner) Plan() *TestPlan {
 		upgrade.Add(p.initUpgradeSteps(virtualClusterSetup))
 		if p.shouldRollback(upgrade.to) {
 			// previous -> next
-			upgrade.Add(p.upgradeSteps(TemporaryUpgradeStage, upgrade.from, upgrade.to, scheduleHooks))
+			upgrade.Add(p.upgradeSteps(
+				TemporaryUpgradeStage, upgrade.from, upgrade.to, scheduleHooks, virtualClusterSetup,
+			))
 			// next -> previous (rollback)
-			upgrade.Add(p.downgradeSteps(upgrade.to, upgrade.from, scheduleHooks))
+			upgrade.Add(p.downgradeSteps(
+				upgrade.to, upgrade.from, scheduleHooks, virtualClusterSetup,
+			))
 		}
 		// previous -> next
-		upgrade.Add(p.upgradeSteps(LastUpgradeStage, upgrade.from, upgrade.to, scheduleHooks))
+		upgrade.Add(p.upgradeSteps(
+			LastUpgradeStage, upgrade.from, upgrade.to, scheduleHooks, virtualClusterSetup,
+		))
 
 		// finalize -- i.e., run upgrade migrations.
 		upgrade.Add(p.finalizeUpgradeSteps(upgrade.from, upgrade.to, scheduleHooks, virtualClusterSetup))
@@ -592,21 +598,21 @@ func (p *testPlanner) afterUpgradeSteps(
 }
 
 func (p *testPlanner) upgradeSteps(
-	stage UpgradeStage, from, to *clusterupgrade.Version, scheduleHooks bool,
+	stage UpgradeStage, from, to *clusterupgrade.Version, scheduleHooks, virtualClusterSetup bool,
 ) []testStep {
 	p.currentContext.SetStage(stage)
 	nodes := p.currentContext.System.Descriptor.Nodes
 	msg := fmt.Sprintf("upgrade nodes %v from %q to %q", nodes, from.String(), to.String())
-	return p.changeVersionSteps(from, to, msg, scheduleHooks)
+	return p.changeVersionSteps(from, to, msg, scheduleHooks, virtualClusterSetup)
 }
 
 func (p *testPlanner) downgradeSteps(
-	from, to *clusterupgrade.Version, scheduleHooks bool,
+	from, to *clusterupgrade.Version, scheduleHooks, virtualClusterSetup bool,
 ) []testStep {
 	p.currentContext.SetStage(RollbackUpgradeStage)
 	nodes := p.currentContext.System.Descriptor.Nodes
 	msg := fmt.Sprintf("downgrade nodes %v from %q to %q", nodes, from.String(), to.String())
-	return p.changeVersionSteps(from, to, msg, scheduleHooks)
+	return p.changeVersionSteps(from, to, msg, scheduleHooks, virtualClusterSetup)
 }
 
 // changeVersionSteps returns the sequence of steps to be performed
@@ -616,7 +622,7 @@ func (p *testPlanner) downgradeSteps(
 // mixed-version hooks will be scheduled randomly during the
 // upgrade/downgrade process.
 func (p *testPlanner) changeVersionSteps(
-	from, to *clusterupgrade.Version, label string, scheduleHooks bool,
+	from, to *clusterupgrade.Version, label string, scheduleHooks, virtualClusterSetup bool,
 ) []testStep {
 	nodes := p.currentContext.System.Descriptor.Nodes
 	// copy system `Nodes` here so that shuffling won't mutate that array
@@ -641,6 +647,7 @@ func (p *testPlanner) changeVersionSteps(
 		steps = append(steps, p.newSingleStep(
 			restartWithNewBinaryStep{
 				version: to, node: node, rt: p.rt, settings: p.clusterSettingsForSystem(),
+				sharedProcessStarted: virtualClusterSetup,
 			},
 		))
 		for _, s := range p.services() {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -130,6 +130,12 @@ type (
 var (
 	// everything that is not an alphanum or a few special characters
 	invalidChars = regexp.MustCompile(`[^a-zA-Z0-9 \-_\.]`)
+
+	// internalQueryTimeout is the maximum amount of time we will wait
+	// for an internal query (i.e., performed by the framework) to
+	// complete. These queries are typically associated with gathering
+	// upgrade state data to be displayed during execution.
+	internalQueryTimeout = 10 * time.Second
 )
 
 func newServiceRuntime(desc *ServiceDescriptor) *serviceRuntime {
@@ -221,7 +227,7 @@ func (tr *testRunner) run() (retErr error) {
 			return fmt.Errorf("background step `%s` returned error: %w", event.Name, event.Err)
 
 		case err := <-tr.monitor.Err():
-			return tr.testFailure(err, tr.logger, nil)
+			return tr.testFailure(tr.ctx, err, tr.logger, nil)
 		}
 	}
 }
@@ -231,13 +237,13 @@ func (tr *testRunner) run() (retErr error) {
 func (tr *testRunner) runStep(ctx context.Context, step testStep) error {
 	if ss, ok := step.(*singleStep); ok {
 		if ss.ID > tr.plan.startSystemID {
-			if err := tr.refreshServiceData(tr.systemService); err != nil {
+			if err := tr.refreshServiceData(ctx, tr.systemService); err != nil {
 				return err
 			}
 		}
 
 		if ss.ID > tr.plan.startTenantID && tr.tenantService != nil {
-			if err := tr.refreshServiceData(tr.tenantService); err != nil {
+			if err := tr.refreshServiceData(ctx, tr.tenantService); err != nil {
 				return err
 			}
 		}
@@ -321,7 +327,7 @@ func (tr *testRunner) runSingleStep(ctx context.Context, ss *singleStep, l *logg
 			// queries would be wasteful.
 			return err
 		}
-		return tr.stepError(err, ss, l)
+		return tr.stepError(ctx, err, ss, l)
 	}
 
 	return nil
@@ -352,21 +358,25 @@ func (tr *testRunner) startBackgroundStep(ss *singleStep, l *logger.Logger, stop
 // binary version on each node when the error occurred, and the
 // cluster version before and after the step (in case the failure
 // happened *while* the cluster version was updating).
-func (tr *testRunner) stepError(err error, step *singleStep, l *logger.Logger) error {
+func (tr *testRunner) stepError(
+	ctx context.Context, err error, step *singleStep, l *logger.Logger,
+) error {
 	stepErr := errors.Wrapf(
 		err,
 		"mixed-version test failure while running step %d (%s)",
 		step.ID, step.impl.Description(),
 	)
 
-	return tr.testFailure(stepErr, l, &step.context)
+	return tr.testFailure(ctx, stepErr, l, &step.context)
 }
 
 // testFailure generates a `testFailure` for failures that happened
 // due to the given error.  It logs the error to the logger passed,
 // and renames the underlying file to include the "FAILED" prefix to
 // help in debugging.
-func (tr *testRunner) testFailure(err error, l *logger.Logger, testContext *Context) error {
+func (tr *testRunner) testFailure(
+	ctx context.Context, err error, l *logger.Logger, testContext *Context,
+) error {
 	detailsForService := func(service *serviceRuntime) *serviceFailureDetails {
 		return &serviceFailureDetails{
 			descriptor:            service.descriptor,
@@ -388,7 +398,7 @@ func (tr *testRunner) testFailure(err error, l *logger.Logger, testContext *Cont
 
 	currentClusterVersions := func(service *serviceRuntime) []roachpb.Version {
 		if tr.connCacheInitialized(service) {
-			if err := tr.refreshClusterVersions(service); err == nil {
+			if err := tr.refreshClusterVersions(ctx, service); err == nil {
 				return loadAtomicVersions(service.clusterVersions)
 			} else {
 				tr.logger.Printf(
@@ -521,10 +531,13 @@ func (tr *testRunner) loggerFor(step *singleStep) (*logger.Logger, error) {
 // service with the binary version running on each node of the
 // cluster. We use the `atomic` package here as this function may be
 // called by two steps that are running concurrently.
-func (tr *testRunner) refreshBinaryVersions(service *serviceRuntime) error {
+func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *serviceRuntime) error {
 	newBinaryVersions := make([]roachpb.Version, 0, len(tr.systemService.descriptor.Nodes))
 	for _, node := range service.descriptor.Nodes {
-		bv, err := clusterupgrade.BinaryVersion(tr.conn(node, service.descriptor.Name))
+		connectionCtx, cancel := context.WithTimeout(ctx, internalQueryTimeout)
+		defer cancel()
+
+		bv, err := clusterupgrade.BinaryVersion(connectionCtx, tr.conn(node, service.descriptor.Name))
 		if err != nil {
 			return fmt.Errorf("failed to get binary version for node %d: %w", node, err)
 		}
@@ -538,10 +551,13 @@ func (tr *testRunner) refreshBinaryVersions(service *serviceRuntime) error {
 // refreshClusterVersions updates the internal `clusterVersions` field
 // with the current view of the cluster version in each of the nodes
 // of the cluster.
-func (tr *testRunner) refreshClusterVersions(service *serviceRuntime) error {
+func (tr *testRunner) refreshClusterVersions(ctx context.Context, service *serviceRuntime) error {
 	newClusterVersions := make([]roachpb.Version, 0, len(service.descriptor.Nodes))
 	for _, node := range service.descriptor.Nodes {
-		cv, err := clusterupgrade.ClusterVersion(tr.ctx, tr.conn(node, service.descriptor.Name))
+		connectionCtx, cancel := context.WithTimeout(ctx, internalQueryTimeout)
+		defer cancel()
+
+		cv, err := clusterupgrade.ClusterVersion(connectionCtx, tr.conn(node, service.descriptor.Name))
 		if err != nil {
 			return err
 		}
@@ -553,7 +569,7 @@ func (tr *testRunner) refreshClusterVersions(service *serviceRuntime) error {
 	return nil
 }
 
-func (tr *testRunner) refreshServiceData(service *serviceRuntime) error {
+func (tr *testRunner) refreshServiceData(ctx context.Context, service *serviceRuntime) error {
 	// Update the runner's view of the cluster's binary and cluster
 	// versions for given service before every non-initialization
 	// `singleStep` is executed.
@@ -562,12 +578,12 @@ func (tr *testRunner) refreshServiceData(service *serviceRuntime) error {
 	}
 
 	if service == tr.systemService {
-		if err := tr.refreshBinaryVersions(service); err != nil {
+		if err := tr.refreshBinaryVersions(ctx, service); err != nil {
 			return err
 		}
 	}
 
-	if err := tr.refreshClusterVersions(service); err != nil {
+	if err := tr.refreshClusterVersions(ctx, service); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -261,7 +261,6 @@ func (tr *testRunner) runStep(ctx context.Context, step testStep) error {
 	case concurrentRunStep:
 		group := ctxgroup.WithContext(tr.ctx)
 		for _, cs := range s.delayedSteps {
-			cs := cs
 			group.GoCtx(func(concurrentCtx context.Context) error {
 				return tr.runStep(concurrentCtx, cs)
 			})

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -153,7 +153,7 @@ func (s preserveDowngradeOptionStep) Run(
 	service := serviceByName(h, s.virtualClusterName)
 	node, db := service.RandomDB(rng)
 	l.Printf("checking binary version (via node %d)", node)
-	bv, err := clusterupgrade.BinaryVersion(db)
+	bv, err := clusterupgrade.BinaryVersion(ctx, db)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (s setTenantClusterVersionStep) Run(
 	targetVersion := s.targetVersion
 	if s.targetVersion == clusterupgrade.CurrentVersionString {
 		l.Printf("querying binary version on node %d", node)
-		bv, err := clusterupgrade.BinaryVersion(db)
+		bv, err := clusterupgrade.BinaryVersion(ctx, db)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -21,6 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors"
 )
 
 // installFixturesStep is the step that copies the fixtures from
@@ -98,9 +102,16 @@ func (s startSharedProcessVirtualClusterStep) Run(
 	l.Printf("starting shared process virtual cluster %s", s.name)
 	startOpts := option.StartSharedVirtualClusterOpts(s.name)
 
-	return h.runner.cluster.StartServiceForVirtualClusterE(
+	if err := h.runner.cluster.StartServiceForVirtualClusterE(
 		ctx, l, startOpts, install.MakeClusterSettings(s.settings...),
-	)
+	); err != nil {
+		return err
+	}
+
+	// When we first start the shared-process on the cluster, we wait
+	// until we are able to connect to the tenant on every node before
+	// moving on. The test runner infrastructure relies on that ability.
+	return waitForSharedProcess(ctx, l, h, h.Tenant.Descriptor.Nodes)
 }
 
 // waitForStableClusterVersionStep implements the process of waiting
@@ -166,10 +177,11 @@ func (s preserveDowngradeOptionStep) Run(
 // then the new binary will be uploaded and the `cockroach` process
 // will restart using the new binary.
 type restartWithNewBinaryStep struct {
-	version  *clusterupgrade.Version
-	rt       test.Test
-	node     int
-	settings []install.ClusterSettingOption
+	version              *clusterupgrade.Version
+	rt                   test.Test
+	node                 int
+	settings             []install.ClusterSettingOption
+	sharedProcessStarted bool
 }
 
 func (s restartWithNewBinaryStep) Background() shouldStop { return nil }
@@ -182,7 +194,7 @@ func (s restartWithNewBinaryStep) Run(
 	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
 ) error {
 	h.ExpectDeath()
-	return clusterupgrade.RestartNodesWithNewBinary(
+	if err := clusterupgrade.RestartNodesWithNewBinary(
 		ctx,
 		s.rt,
 		l,
@@ -191,7 +203,18 @@ func (s restartWithNewBinaryStep) Run(
 		startOpts(),
 		s.version,
 		s.settings...,
-	)
+	); err != nil {
+		return err
+	}
+
+	if s.sharedProcessStarted {
+		// If we are in shared-process mode and the tenant is already
+		// running at this point, we wait for the server on the restarted
+		// node to be up before moving on.
+		return waitForSharedProcess(ctx, l, h, h.runner.cluster.Node(s.node))
+	}
+
+	return nil
 }
 
 // allowUpgradeStep resets the `preserve_downgrade_option` cluster
@@ -423,6 +446,50 @@ func serviceByName(h *Helper, virtualClusterName string) *Service {
 	}
 
 	return h.Tenant
+}
+
+// waitForSharedProcess waits for the shared-process created for this
+// test to be ready to accept connections on the `nodes` provided.
+func waitForSharedProcess(
+	ctx context.Context, l *logger.Logger, h *Helper, nodes option.NodeListOption,
+) error {
+	group := ctxgroup.WithContext(ctx)
+	for _, n := range nodes {
+		group.GoCtx(func(ctx context.Context) error {
+			// We use a new connection pool in this function as the runner's
+			// connection pool might not be initialized.
+			db, err := h.runner.cluster.ConnE(
+				ctx, l, n, option.VirtualClusterName(h.Tenant.Descriptor.Name),
+			)
+			if err != nil {
+				return errors.Wrap(err, "waitForSharedProcess: failed to connect to tenant")
+			}
+			defer db.Close()
+
+			retryOpts := retry.Options{MaxRetries: 5}
+			var nonRetryableErr error
+
+			// Retry the dummy `SELECT 1` statement if we keep getting the
+			// service unavailable error. However, any other error is
+			// unexpected and should cause the test to fail.
+			err = retryOpts.Do(ctx, func(ctx context.Context) error {
+				_, err := db.ExecContext(ctx, "SELECT 1")
+				err = errors.Wrapf(err, "waiting for shared-process tenant on n%d", n)
+
+				if err != nil && strings.Contains(err.Error(), "service unavailable for target tenant") {
+					l.Printf("failed to connect to shared-process tenant, retrying: %v", err)
+					return err
+				}
+
+				nonRetryableErr = err
+				return nil
+			})
+
+			return errors.CombineErrors(err, nonRetryableErr)
+		})
+	}
+
+	return group.Wait()
 }
 
 func quoteVersionForPresentation(v string) string {

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -267,7 +267,7 @@ func (u *versionUpgradeTest) binaryVersion(
 	ctx context.Context, t test.Test, i int,
 ) roachpb.Version {
 	db := u.conn(ctx, t, i)
-	v, err := clusterupgrade.BinaryVersion(db)
+	v, err := clusterupgrade.BinaryVersion(ctx, db)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**roachtest/mixedversion: limit max time spent in internal queries**
In this commit, we change the `BinaryVersion` and `ClusterVersion` functions accept a `context` parameter. In addition, we change the mixedversion calls to these functions to pass a context with a fixed timeout. This effectively limits the maximum amount of time we will spend trying to gather this debug information.

In some failure scenarios, nodes may become unresponsive, which may make the test seem "stuck." With this change, tests should fail if, for whatever reason, we can't determine a node's binary or cluster version within 10s.

**roachtest: make sure tenant is ready after restart in mixedversion**
This updates the start and restart steps in the mixedversion framework
to wait for the shared-process tenant (if any) to be able to handle
incoming requests before moving on, as the test plan generated by the
framework assumes that the tenant is able to handle connections after
the `start` step.

In rare occasions, it is possible for the tenant to have started but, by
the time the framework attempts to query internal debug information
from the tenant, the tenant is not ready to accept requests yet.

We retry for a short period of time until we are sure the tenant
server is up.

Epic: none

Release note: None