### PR TITLE
backupccl: distribute restore validation work

### DIFF
--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -97,7 +99,8 @@ type splitAndScatterer interface {
 }
 
 type noopSplitAndScatterer struct {
-	scatterNode roachpb.NodeID
+	rng            *rand.Rand
+	sqlInstanceIDs []int32
 }
 
 var _ splitAndScatterer = noopSplitAndScatterer{}
@@ -111,7 +114,13 @@ func (n noopSplitAndScatterer) split(_ context.Context, _ keys.SQLCodec, _ roach
 func (n noopSplitAndScatterer) scatter(
 	_ context.Context, _ keys.SQLCodec, _ roachpb.Key,
 ) (roachpb.NodeID, error) {
-	return n.scatterNode, nil
+	numInstances := len(n.sqlInstanceIDs)
+	if numInstances == 0 {
+		return 0, nil
+	}
+	idx := n.rng.Intn(numInstances)
+	sqlInstanceID := n.sqlInstanceIDs[idx]
+	return roachpb.NodeID(sqlInstanceID), nil
 }
 
 // dbSplitAndScatter is the production implementation of this processor's
@@ -251,7 +260,8 @@ func newGenerativeSplitAndScatterProcessor(
 	post *execinfrapb.PostProcessSpec,
 ) (execinfra.Processor, error) {
 	db := flowCtx.Cfg.DB
-	numChunkSplitAndScatterWorkers := int(spec.NumNodes)
+	numNodes := int(spec.NumNodes)
+	numChunkSplitAndScatterWorkers := numNodes
 	// numEntrySplitWorkers is set to be 2 * numChunkSplitAndScatterWorkers in
 	// order to keep up with the rate at which chunks are split and scattered.
 	// TODO(rui): This tries to cover for a bad scatter by having 2 * the number
@@ -260,8 +270,8 @@ func newGenerativeSplitAndScatterProcessor(
 
 	mkSplitAndScatterer := func() (splitAndScatterer, error) {
 		if spec.ValidateOnly {
-			nodeID, _ := flowCtx.NodeID.OptionalNodeID()
-			return noopSplitAndScatterer{nodeID}, nil
+			rng, _ := randutil.NewPseudoRand()
+			return noopSplitAndScatterer{rng, spec.SQLInstanceIDs}, nil
 		}
 		kr, err := MakeKeyRewriterFromRekeys(flowCtx.Codec(), spec.TableRekeys, spec.TenantRekeys,
 			false /* restoreTenantFromStream */)
@@ -297,7 +307,7 @@ func newGenerativeSplitAndScatterProcessor(
 		// other than it's the max number of entries that can be processed
 		// in parallel downstream. It has been verified ad-hoc that this
 		// sizing does not bottleneck restore.
-		doneScatterCh:     make(chan entryNode, int(spec.NumNodes)*maxConcurrentRestoreWorkers),
+		doneScatterCh:     make(chan entryNode, numNodes*maxConcurrentRestoreWorkers),
 		routingDatumCache: newRoutingDatumCache(),
 	}
 	if err := ssp.Init(ctx, ssp, post, generativeSplitAndScatterOutputTypes, flowCtx, processorID, nil, /* memMonitor */

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -265,5 +265,6 @@ func makeTestingGenerativeSplitAndScatterSpec(
 		NumEntries:         1,
 		NumNodes:           1,
 		JobID:              0,
+		SQLInstanceIDs:     []int32{1},
 	}
 }

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -103,6 +103,10 @@ func distRestore(
 		}
 
 		numNodes := len(sqlInstanceIDs)
+		instanceIDs := make([]int32, numNodes)
+		for i, instanceID := range sqlInstanceIDs {
+			instanceIDs[i] = int32(instanceID)
+		}
 		p := planCtx.NewPhysicalPlan()
 
 		restoreDataSpec := execinfrapb.RestoreDataSpec{
@@ -177,9 +181,10 @@ func distRestore(
 			MaxFileCount:                int64(md.spanFilter.maxFileCount),
 			ChunkSize:                   int64(chunkSize),
 			NumEntries:                  int64(md.numImportSpans),
-			NumNodes:                    int64(numNodes),
 			UseFrontierCheckpointing:    md.spanFilter.useFrontierCheckpointing,
+			NumNodes:                    int64(numNodes),
 			JobID:                       int64(md.jobID),
+			SQLInstanceIDs:              instanceIDs,
 			ExclusiveFileSpanComparison: md.exclusiveEndKeys,
 		}
 		if md.spanFilter.useFrontierCheckpointing {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -459,6 +459,8 @@ message GenerativeSplitAndScatterSpec {
   optional bool exclusive_file_span_comparison = 22 [(gogoproto.nullable) = false];
   // MaxFileCount is the max number of files in an extending restore span entry.
   optional int64 max_file_count = 23[(gogoproto.nullable) = false];
+  // SQLInstanceIDs is a slice of SQL instance IDs available for dist restore.
+  repeated int32 sql_instance_ids = 24[(gogoproto.nullable) = false, (gogoproto.customname) = "SQLInstanceIDs"];
   reserved 19;
 }
 


### PR DESCRIPTION
Currently, when `verify_backup_table_data` flag is used in a restore statement, the node that is currently running gets selected for reading with the noop split and scatterer. In this PR, we randomly select a node from the list of nodes available for dist restore for reading, this ensures that we don't put all the reading workload on a single node.

Work loads between nodes are uniformly distributed when running restore validation for tpcc fixture (~400GB) with a 3-node cluster on roachprod. See screenshots for metrics below.

CPU usage per node:
![image (1)](https://github.com/user-attachments/assets/0fcda673-4b40-47ee-9d16-7ab60b0c36f0)

Time series of `cloud.read_bytes` per node:
![image](https://github.com/user-attachments/assets/ec5aa125-d818-48e3-a92c-7abd413a8bc0)

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/127677
Release note: none