### PR TITLE
roachtest: use errors.Join in the monitor

### DIFF
--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -234,11 +234,5 @@ func (m *monitorImpl) wait() error {
 	// goroutines after wait() returns.
 	monitorErr := m.WaitForNodeDeath()
 
-	// For better error messages in roachtest failures, we make the
-	// "context canceled" error secondary.
-	if errors.Is(userErr, context.Canceled) {
-		return errors.CombineErrors(monitorErr, userErr)
-	}
-
-	return errors.CombineErrors(userErr, monitorErr)
+	return errors.Join(userErr, monitorErr)
 }

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -139,6 +139,22 @@ func Test_failuresMatchingError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "an error contains the expected error type, as part of a multi-error",
+			args: args{
+				failures: []failure{
+					createFailure(
+						// Errors that use the `Join` API are recognizable by the
+						// flake detection logic. This test fails if we use
+						// `CombineErrors`.
+						errors.Join(errors.New("oops"), targetError{errors.New("expected-error")}),
+						nil,
+					),
+				},
+				refError: targetError{errors.New("some error")},
+			},
+			want: true,
+		},
+		{
 			name: "single failure - none of errors or squashedErr contains expected error",
 			args: args{
 				failures: []failure{


### PR DESCRIPTION
This changes roachtest's monitor wrapper to use the `errors.Join` API instead of `errors.CombineErrors` as previously.

The main relevant distinction in this case is that `Join` is the API to use in a multi-error use-case, as is the case here. `CombineErrors`, on the other hand, is used when the secondary error is only relevant during display, for debugging purposes. In other words, it is not possible to reference the secondary error from an opaque `error` reference, making it impossible to detect flakes if the transient error is in a secondary error.

Fixes: #127633

Release note: None