### PR TITLE
release-24.2: upgradecluster: introduce backoff in until cluster stable retries

### DIFF
--- a/pkg/upgrade/BUILD.bazel
+++ b/pkg/upgrade/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/sqlstats",
         "//pkg/upgrade/upgradebase",
         "//pkg/util/log",
+        "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/upgrade/system_upgrade.go
+++ b/pkg/upgrade/system_upgrade.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/logtags"
 )
@@ -95,7 +96,9 @@ type Cluster interface {
 	// ensures that the old data has vanished from the system. This is similar in
 	// spirit to how schema changes are split up into multiple smaller steps that
 	// are carried out sequentially.
-	UntilClusterStable(ctx context.Context, fn func() error) error
+	//
+	// UntilClusterStable will retry according to the provided retry options.
+	UntilClusterStable(ctx context.Context, retryOpts retry.Options, fn func() error) error
 
 	// IterateRangeDescriptors provides a handle on every range descriptor in the
 	// system, which callers can then use to send out arbitrary KV requests to in

--- a/pkg/upgrade/upgradecluster/BUILD.bazel
+++ b/pkg/upgrade/upgradecluster/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
+        "//pkg/util/retry",
         "//pkg/util/syncutil",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/pkg/upgrade/upgradecluster/helper_test.go
+++ b/pkg/upgrade/upgradecluster/helper_test.go
@@ -12,8 +12,8 @@ package upgradecluster
 
 import (
 	"context"
-	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"google.golang.org/grpc"
 )
@@ -51,7 +52,13 @@ func TestHelperEveryNode(t *testing.T) {
 			Dialer:       NoopDialer{},
 		})
 		opCount := 0
-		err := h.UntilClusterStable(ctx, func() error {
+		err := h.UntilClusterStable(ctx, retry.Options{
+			// Speed up testing, run for at most 10 retries over a second.
+			InitialBackoff: 100 * time.Millisecond,
+			MaxBackoff:     100 * time.Millisecond,
+			Multiplier:     1.0,
+			MaxRetries:     10,
+		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
 				context.Context, serverpb.MigrationClient,
 			) error {
@@ -84,7 +91,13 @@ func TestHelperEveryNode(t *testing.T) {
 			Dialer:       NoopDialer{},
 		})
 		opCount := 0
-		err := h.UntilClusterStable(ctx, func() error {
+		err := h.UntilClusterStable(ctx, retry.Options{
+			// Speed up testing, run for at most 10 retries over a second.
+			InitialBackoff: 100 * time.Millisecond,
+			MaxBackoff:     100 * time.Millisecond,
+			Multiplier:     1.0,
+			MaxRetries:     10,
+		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
 				context.Context, serverpb.MigrationClient,
 			) error {
@@ -117,9 +130,16 @@ func TestHelperEveryNode(t *testing.T) {
 			NodeLiveness: tc,
 			Dialer:       NoopDialer{},
 		})
-		expRe := fmt.Sprintf("nodes n\\{%d\\} required, but unavailable", downedNode)
+		expRe := "cluster not stable, nodes: n\\{1,2,3\\}, unavailable: n\\{2\\}"
 		opCount := 0
-		if err := h.UntilClusterStable(ctx, func() error {
+
+		if err := h.UntilClusterStable(ctx, retry.Options{
+			// Speed up testing, run for at most 10 retries over a second.
+			InitialBackoff: 100 * time.Millisecond,
+			MaxBackoff:     100 * time.Millisecond,
+			Multiplier:     1.0,
+			MaxRetries:     10,
+		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
 				context.Context, serverpb.MigrationClient,
 			) error {
@@ -137,7 +157,13 @@ func TestHelperEveryNode(t *testing.T) {
 		}
 
 		tc.RestartNode(downedNode)
-		if err := h.UntilClusterStable(ctx, func() error {
+		if err := h.UntilClusterStable(ctx, retry.Options{
+			// Speed up testing, run for at most 10 retries over a second.
+			InitialBackoff: 100 * time.Millisecond,
+			MaxBackoff:     100 * time.Millisecond,
+			Multiplier:     1.0,
+			MaxRetries:     10,
+		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
 				context.Context, serverpb.MigrationClient,
 			) error {

--- a/pkg/upgrade/upgradecluster/tenant_cluster.go
+++ b/pkg/upgrade/upgradecluster/tenant_cluster.go
@@ -277,14 +277,9 @@ func annotateDialError(err error) error {
 // tenant upgrade interlock which prevent those new SQL servers from starting if
 // they're at an incompatible binary version (at the time of writing, in
 // SQLServer.preStart).
-func (t *TenantCluster) UntilClusterStable(ctx context.Context, fn func() error) error {
-	retryOpts := retry.Options{
-		InitialBackoff: 1 * time.Second,
-		MaxBackoff:     1 * time.Second,
-		Multiplier:     1.0,
-		MaxRetries:     60, // retry for 60 seconds
-	}
-
+func (t *TenantCluster) UntilClusterStable(
+	ctx context.Context, retryOpts retry.Options, fn func() error,
+) error {
 	instances, err := t.InstanceReader.GetAllInstancesNoCache(ctx)
 	if err != nil {
 		return err

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/upgrade/upgrades",
         "//pkg/util/buildutil",
         "//pkg/util/log",
+        "//pkg/util/retry",
         "//pkg/util/startup",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -41,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -609,7 +611,12 @@ func forEveryNodeUntilClusterStable(
 	f func(ctx context.Context, client serverpb.MigrationClient) error,
 ) error {
 	log.Infof(ctx, "executing operation %s", redact.Safe(op))
-	return c.UntilClusterStable(ctx, func() error {
+	return c.UntilClusterStable(ctx, retry.Options{
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     1 * time.Second,
+		Multiplier:     1.0,
+		MaxRetries:     60, // retry for 60 seconds
+	}, func() error {
 		return c.ForEveryNodeOrServer(ctx, op, f)
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #127346

/cc @cockroachdb/release

---

Previously, `UntilClusterStable`, which is used when upgrading the cluster version, would retry immediately when there was an unavailable node or changing set of nodes in the cluster.

The retries all occurred in short succession, without any backoff, leading to the retry rarely succeeding on subsequent iterations when there were unavailable nodes.

Backoff the retries by a second and allow checking for no unavailable nodes up to 60 times before returning an error. Note that when the cluster has a changing set of nodes, we still allow retrying an unlimited number of times, identical to existing behavior.

Fixes: #125820
Release note: None

---

Release justification: Fixes noisy tests.