### PR TITLE
release-24.1: roachtest: skip clearrange/zfs/checks=true

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -59,6 +59,8 @@ func registerClearRange(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runClearRange(ctx, t, c, true /* checks */)
 		},
+		Skip:        "#127723",
+		SkipDetails: "Issue setting up ZFS filesystem.",
 	})
 }
 


### PR DESCRIPTION
Epic: none
Informs: #127723
Release note: none
Release justification: test-only change