### PR TITLE
schemachanger: Add notice for inbound FKs with row level TTL

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -2221,8 +2221,24 @@ func handleTTLStorageParamChange(
 			&descpb.ModifyRowLevelTTL{RowLevelTTL: after},
 			direction,
 		)
+		// Also, check if the table has inbound foreign keys (i.e. this table is being
+		// referenced  by other tables). In such a case, flag a notice to the user
+		// advising them to update the ttl_delete_batch_size to avoid generating
+		// TTL deletion jobs with a high cardinality of rows being deleted.
+		// See https://github.com/cockroachdb/cockroach/issues/125103 for more details.
+		for _, fk := range tableDesc.InboundFKs {
+			// Use foreign key actions to determine upstream impact and flag a notice if the
+			// actions for delete involve cascading deletes for any one of the inbound foreign keys.
+			if fk.OnDelete != semenumpb.ForeignKeyAction_NO_ACTION && fk.OnDelete != semenumpb.ForeignKeyAction_RESTRICT {
+				params.p.BufferClientNotice(
+					params.ctx,
+					pgnotice.Newf("Columns within table %s are referenced as foreign keys."+
+						" This will make TTL deletion jobs more expensive as dependent rows"+
+						" in other tables will need to be updated as well. To improve performance"+
+						" of the TTL job, consider reducing the value of ttl_delete_batch_size.", tableDesc.GetName()))
+			}
+		}
 	}
-
 	// Validate the type and volatility of ttl_expiration_expression.
 	if after != nil {
 		if err := schemaexpr.ValidateTTLExpirationExpression(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1053,6 +1053,25 @@ func ResolveFK(
 		}
 	}
 
+	// Adding a foreign key dependency on a table with row-level TTL enabled can
+	// cause a slowdown in the TTL deletion job as the number of rows to be updated per
+	// deletion can go up. In such a case, flag a notice to the user advising them to
+	// update the ttl_delete_batch_size to avoid generating TTL deletion jobs with a high
+	// cardinality of rows being deleted.
+	// See https://github.com/cockroachdb/cockroach/issues/125103 for more details.
+	if target.HasRowLevelTTL() {
+		// Use foreign key actions to determine upstream impact and flag a notice if the
+		// actions for delete involve cascading deletes.
+		if d.Actions.Delete != tree.NoAction && d.Actions.Delete != tree.Restrict {
+			evalCtx.ClientNoticeSender.BufferClientNotice(
+				ctx,
+				pgnotice.Newf("Table %s has row level TTL enabled. This will make TTL deletion jobs"+
+					" more expensive as dependent rows will need to be updated as well. To improve performance"+
+					" of the TTL job, consider reducing the value of ttl_delete_batch_size.",
+					target.GetName()))
+		}
+	}
+
 	ref := descpb.ForeignKeyConstraint{
 		OriginTableID:       tbl.ID,
 		OriginColumnIDs:     originColumnIDs,

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1325,3 +1325,105 @@ WHERE label = 'row-level-ttl: $label_suffix'
 ACTIVE  @daily  root
 
 subtest end
+
+# Subtest set_fk_on_table_with_ttl creates inbound foreign key dependency
+# on table with TTL enabled and confirms that a notice regarding implications
+# on performance of TTL job deletions is raised as appropriate.
+# Weak isolation levels emit extra notices, so skip them for the purpose
+# of this subtest.
+subtest set_fk_on_table_with_ttl
+statement ok
+CREATE TABLE tbl_with_ttl (
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMPTZ,
+  FAMILY (id, expire_at)
+) WITH (
+  ttl_expiration_expression = 'expire_at'
+)
+
+skipif config weak-iso-level-configs
+query T noticetrace
+CREATE TABLE tbl_with_dep(
+  id1 INT PRIMARY KEY,
+  id INT REFERENCES tbl_with_ttl(id) ON DELETE CASCADE
+)
+----
+NOTICE: Table tbl_with_ttl has row level TTL enabled. This will make TTL deletion jobs more expensive as dependent rows will need to be updated as well. To improve performance of the TTL job, consider reducing the value of ttl_delete_batch_size.
+
+# Create a table with a dependency on tbl_with_ttl but with the default action of no update on delete
+# and confirm no notice is raised.
+skipif config weak-iso-level-configs
+query T noticetrace
+CREATE TABLE tbl_with_dep_2(
+  id1 INT PRIMARY KEY,
+  id INT REFERENCES tbl_with_ttl(id)
+)
+----
+
+# Alter a table with dependency on tbl_with_ttl and confirm notice is raised.
+statement ok
+CREATE TABLE tbl_to_alter (
+    t_id SERIAL PRIMARY KEY,
+    f_id INT NOT NULL,
+    name STRING NOT NULL
+);
+
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE tbl_to_alter ADD CONSTRAINT fk_tbl_with_ttl FOREIGN KEY(f_id) REFERENCES tbl_with_ttl(id) ON DELETE CASCADE
+----
+NOTICE: Table tbl_with_ttl has row level TTL enabled. This will make TTL deletion jobs more expensive as dependent rows will need to be updated as well. To improve performance of the TTL job, consider reducing the value of ttl_delete_batch_size.
+
+# Alter a table with dependency on tbl_with_ttl with the default action of
+# no updates on deletes and confirm no notice is raised.
+statement ok
+CREATE TABLE tbl_to_alter_2 (
+    t_id SERIAL PRIMARY KEY,
+    f_id INT NOT NULL,
+    name STRING NOT NULL
+);
+
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE tbl_to_alter_2 ADD CONSTRAINT fk_tbl_with_ttl FOREIGN KEY(f_id) REFERENCES tbl_with_ttl(id)
+----
+
+# Alter a table with inbound foreign keys to enable row level TTL and confirm
+# notice is raised.
+statement ok
+CREATE TABLE tbl_to_add_ttl(
+  id INT PRIMARY KEY,
+  expire_at TIMESTAMPTZ NOT NULL DEFAULT now() + '30 days'
+)
+
+statement ok
+CREATE TABLE tbl_with_fk_default_action(
+  id1 INT PRIMARY KEY,
+  name STRING,
+  id INT REFERENCES tbl_to_add_ttl(id)
+)
+
+# Confirm no notice is raised.
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE tbl_to_add_ttl SET (ttl_expiration_expression = 'expire_at')
+----
+
+statement ok
+ALTER TABLE tbl_to_add_ttl RESET (ttl);
+
+statement ok
+CREATE TABLE tbl_with_fk(
+  id1 INT PRIMARY KEY,
+  name STRING,
+  id INT REFERENCES tbl_to_add_ttl(id) ON DELETE CASCADE
+)
+
+# Confirm notice is raised.
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE tbl_to_add_ttl SET (ttl_expiration_expression = 'expire_at')
+----
+NOTICE: Columns within table tbl_to_add_ttl are referenced as foreign keys. This will make TTL deletion jobs more expensive as dependent rows in other tables will need to be updated as well. To improve performance of the TTL job, consider reducing the value of ttl_delete_batch_size.
+
+subtest end


### PR DESCRIPTION
This PR adds a notice when a user attempts to add a foreign key on a table with row level TTL enabled. Additionally, it also adds a notice when we enable row level TTL on a table which has inbound foreign keys. The notice alerts the user that adding FKs on referencing a table with row level TTL can lead to inefficiencies in the TTL deletion job due to the extra work needed to also drop dependent rows.

Informs: https://github.com/cockroachdb/cockroach/issues/125103
Epic: none
Release note (sql change): Attempting to add foreign keys referencing a table with row level TTL enabled will generate a notice informing the user about potential impact on the row level TTL deletion job. Similarly, a notice is generated while attempting to enable row level TTL on a table that has inbound foreign key references.