### PR TITLE
Revert "pkg/cli: debugzip - decode some system tables before dumping them"

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -1134,14 +1134,13 @@ var zipSystemTables = DebugZipTableRegistry{
 		},
 	},
 	"system.descriptor": {
-		// For readability, we unmarsal the descriptor into JSON format.
 		customQueryUnredacted: `SELECT
 				id,
-        crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false) AS descriptor
+				descriptor
 			FROM system.descriptor`,
 		customQueryRedacted: `SELECT
 				id,
-        crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', crdb_internal.redact_descriptor(descriptor), false) AS descriptor
+				crdb_internal.redact_descriptor(descriptor) AS descriptor
 			FROM system.descriptor`,
 	},
 	"system.eventlog": {
@@ -1352,26 +1351,17 @@ var zipSystemTables = DebugZipTableRegistry{
     	)`,
 	},
 	"system.span_configurations": {
-		// For readability, we decode the config into JSON format and pretty print the start and end keys.
 		nonSensitiveCols: NonSensitiveColumns{
-			"crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config) as config",
+			"config",
 			// Boundary keys for span configs, which are derived from zone configs, are typically on
 			// metadata object boundaries (database, table, or index), and not arbitrary range boundaries
 			// and therefore do not contain sensitive information. Therefore they can remain unredacted.
-			"crdb_internal.pretty_key(start_key, 0) as start_key",
+			"start_key",
 			// Boundary keys for span configs, which are derived from zone configs, are typically on
 			// metadata object boundaries (database, table, or index), and not arbitrary range boundaries
 			// and therefore do not contain sensitive information. Therefore they can remain unredacted.
-			"crdb_internal.pretty_key(end_key, 0) as end_key",
+			"end_key",
 		},
-		// Since we are decoding the columns while selecting them, we also need to
-		// provide a custom unredacted query to make sure it doesn't default to
-		// "TABLE system.span_configurations" when `--redact` flag is not set.
-		customQueryUnredacted: `SELECT
-    crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config) as config,
-    crdb_internal.pretty_key(start_key, 0) as start_key,
-    crdb_internal.pretty_key(end_key, 0) as end_key
-		FROM system.span_configurations`,
 	},
 	"system.sql_instances": {
 		// Some fields are marked as `<redacted>` because we want to redact hostname, ip address and other sensitive fields

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -998,8 +999,8 @@ func TestToHex(t *testing.T) {
 	// fields is not always precise as there can be spaces in the fields but the
 	// hex fields are always in the end of the row and they don't contain spaces.
 	hexFiles := map[string][]hexField{
-		"debug/system.scheduled_jobs.txt": {
-			{idx: -3, msg: &jobspb.ScheduleDetails{}},
+		"debug/system.descriptor.txt": {
+			{idx: 1, msg: &descpb.Descriptor{}},
 		},
 	}
 


### PR DESCRIPTION
This commit reverts #123865. #123865 originally made some of the system table dumps human readable when written to the debug zip. This becomes a problem with tools like `debug doctor recreate zipdir` which expect the encoded data.

This commit reverts that change. It's ok to dump the data as it is to debug zip. The responsibility of transforming the data to a desirable format should be of the clients using them.

Since we are anyway going to upload the contents of a debug zip on Datadog, we can take care of making things human readable during the upload process.

Fixes: #127909
Part of: CRDB-40666
Release note: None