### PR TITLE
roachtest: fix sysbench regression when using smaller workload node

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -231,7 +231,7 @@ func registerSysbench(r registry.Registry) {
 				Name:             fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
 				Benchmark:        true,
 				Owner:            registry.OwnerTestEng,
-				Cluster:          r.MakeClusterSpec(n+1, spec.CPU(cpus), spec.WorkloadNode()),
+				Cluster:          r.MakeClusterSpec(n+1, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(16)),
 				CompatibleClouds: registry.OnlyGCE,
 				Suites:           registry.Suites(registry.Nightly),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -247,7 +247,7 @@ func registerSysbench(r registry.Registry) {
 					Name:             fmt.Sprintf("sysbench/%s/postgres/cpu=%d/conc=%d", w, cpus, conc),
 					Benchmark:        true,
 					Owner:            registry.OwnerTestEng,
-					Cluster:          r.MakeClusterSpec(n+1, spec.CPU(cpus), spec.WorkloadNode()),
+					Cluster:          r.MakeClusterSpec(n+1, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(16)),
 					CompatibleClouds: registry.OnlyGCE,
 					Suites:           registry.ManualOnly,
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
In #126506 we made tests use a default workload node of 4 CPUs to save money. For sysbench, this was too aggressive and a few tests saw regressions in QPS.

This change gives sysbench workload nodes 16 CPUs instead. Testing showed that 8 CPUs is sufficient, but to play it safe, 16 CPUs was chosen.

Fixes: none
Release note: none
Epic: none