### PR TITLE
release-23.1: roachtest: use errors.Join in the monitor

### DIFF
--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -204,11 +204,5 @@ func (m *monitorImpl) wait() error {
 	// goroutines after wait() returns.
 	monitorErr := m.WaitForNodeDeath()
 
-	// For better error messages in roachtest failures, we make the
-	// "context canceled" error secondary.
-	if errors.Is(userErr, context.Canceled) {
-		return errors.CombineErrors(monitorErr, userErr)
-	}
-
-	return errors.CombineErrors(userErr, monitorErr)
+	return errors.Join(userErr, monitorErr)
 }


### PR DESCRIPTION
Backport 1/1 commits from #127926.

/cc @cockroachdb/release

---

This changes roachtest's monitor wrapper to use the `errors.Join` API instead of `errors.CombineErrors` as previously.

The main relevant distinction in this case is that `Join` is the API to use in a multi-error use-case, as is the case here. `CombineErrors`, on the other hand, is used when the secondary error is only relevant during display, for debugging purposes. In other words, it is not possible to reference the secondary error from an opaque `error` reference, making it impossible to detect flakes if the transient error is in a secondary error.

Fixes: #127633

Release note: None

Release justification: test only changes.