### PR TITLE
changefeedccl: deflake TestChangefeedSchemaChangeBackfillCheckpoint

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2216,7 +2216,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 		}
 
 		// Setup changefeed job details, avoid relying on initial scan functionality
-		baseFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved='100ms', no_initial_scan`)
+		baseFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved='100ms', min_checkpoint_frequency='100ms', no_initial_scan`)
 		jobFeed := baseFeed.(cdctest.EnterpriseTestFeed)
 		jobRegistry := s.Server.JobRegistry().(*jobs.Registry)
 
@@ -2247,6 +2247,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			prog := loadProgress()
 			if p := prog.GetHighWater(); p != nil && !p.IsEmpty() {
+				t.Logf("highwater: %s", p)
 				return nil
 			}
 			return errors.New("waiting for highwater")


### PR DESCRIPTION
This test deflakes `TestChangefeedSchemaChangeBackfillCheckpoint` by
setting `min_checkpoint_frequency` to be the same lower value that
the `resolved` option is set to in the test.

Fixes #127053

Release note: None