### PR TITLE
buildutil: allow `disallowed_imports_test` to execute remotely

### DIFF
--- a/pkg/testutils/buildutil/buildutil.bzl
+++ b/pkg/testutils/buildutil/buildutil.bzl
@@ -152,5 +152,4 @@ def disallowed_imports_test(
         name = src.strip(":") + "_disallowed_imports_test",
         size = "small",
         srcs = [":" + script],
-        tags = ["local"],
     )


### PR DESCRIPTION
This has been tagged as `local` since it existed, apparently for no reason.

Epic: none
Release note: None
Release justification: Test-only code changes