### PR TITLE
tenantcostmodel: update cost model to reflect batching changes

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -1822,7 +1822,10 @@ func TestCPUModelSettingsChanged(t *testing.T) {
 	newModel := `
 	{
 	  "ReadBatchCost": 1,
-	  "ReadRequestCost": 2,
+	  "ReadRequestCost": {
+		"BatchSize": [1, 2, 3],
+		"CPUPerRequest": [0.1, 0.2, 0.3]
+	  },
 	  "ReadBytesCost": {
 		"PayloadSize": [1, 2, 3],
 		"CPUPerByte": [0.5, 1, 1.5]

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/estimated-cpu
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/estimated-cpu
@@ -18,10 +18,10 @@ token-bucket
 write repeat=35 count=6 bytes=2048 localities=same-zone
 ----
 
-# Expect ~283 tokens to be consumed.
+# Expect ~235 tokens to be consumed.
 token-bucket
 ----
-4717.33 tokens filling @ 0.00 tokens/s
+4764.99 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -38,8 +38,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 0.28
-tenant.sql_usage.estimated_cpu_seconds: 0.28
+tenant.sql_usage.estimated_kv_cpu_seconds: 0.24
+tenant.sql_usage.estimated_cpu_seconds: 0.24
 tenant.sql_usage.estimated_replication_bytes: 145460
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 145460
 
@@ -56,10 +56,10 @@ advance wait=true
 ----
 00:00:01.000
 
-# ~31 tokens removed from bucket to account for background CPU.
+# ~25 tokens removed from bucket to account for background CPU.
 token-bucket
 ----
-4686.71 tokens filling @ 0.00 tokens/s
+4739.54 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -76,8 +76,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 0.28
-tenant.sql_usage.estimated_cpu_seconds: 0.31
+tenant.sql_usage.estimated_kv_cpu_seconds: 0.24
+tenant.sql_usage.estimated_cpu_seconds: 0.26
 tenant.sql_usage.estimated_replication_bytes: 145460
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 145460
 
@@ -109,10 +109,10 @@ advance wait=true
 ----
 00:00:42.000
 
-# Expect ~254 tokens to be removed, as compared to ~314 above (283 + 31).
+# Expect ~208 tokens to be removed, as compared to ~260 above (235 + 25).
 token-bucket
 ----
-4432.93 tokens filling @ 0.00 tokens/s
+4531.69 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -129,8 +129,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 0.51
-tenant.sql_usage.estimated_cpu_seconds: 0.57
+tenant.sql_usage.estimated_kv_cpu_seconds: 0.42
+tenant.sql_usage.estimated_cpu_seconds: 0.47
 tenant.sql_usage.estimated_replication_bytes: 290920
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 218190
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 72730
@@ -163,10 +163,10 @@ advance wait=true
 ----
 00:00:53.000
 
-# Expect ~254 tokens to be consumed, like above.
+# Expect ~206 tokens to be consumed, like above.
 token-bucket
 ----
-4179.15 tokens filling @ 0.00 tokens/s
+4323.84 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -183,8 +183,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 0.74
-tenant.sql_usage.estimated_cpu_seconds: 0.82
+tenant.sql_usage.estimated_kv_cpu_seconds: 0.61
+tenant.sql_usage.estimated_cpu_seconds: 0.68
 tenant.sql_usage.estimated_replication_bytes: 436380
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
@@ -201,7 +201,7 @@ advance wait=true
 
 token-bucket
 ----
-2787.54 tokens filling @ 0.00 tokens/s
+2466.99 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -218,8 +218,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.00
-tenant.sql_usage.estimated_cpu_seconds: 2.21
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.29
+tenant.sql_usage.estimated_cpu_seconds: 2.53
 tenant.sql_usage.estimated_replication_bytes: 436380
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
@@ -237,7 +237,7 @@ advance wait=true
 
 token-bucket
 ----
-1690.29 tokens filling @ 0.00 tokens/s
+1369.74 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -254,8 +254,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.00
-tenant.sql_usage.estimated_cpu_seconds: 3.31
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.29
+tenant.sql_usage.estimated_cpu_seconds: 3.63
 tenant.sql_usage.estimated_replication_bytes: 436380
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
@@ -274,7 +274,7 @@ advance wait=true
 
 token-bucket
 ----
-1690.29 tokens filling @ 0.00 tokens/s
+1369.74 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -291,8 +291,8 @@ tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 1024000
 tenant.sql_usage.external_io_egress_bytes: 1024000
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.00
-tenant.sql_usage.estimated_cpu_seconds: 3.31
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.29
+tenant.sql_usage.estimated_cpu_seconds: 3.63
 tenant.sql_usage.estimated_replication_bytes: 436380
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
@@ -309,7 +309,7 @@ advance wait=true
 
 token-bucket
 ----
-1690.29 tokens filling @ 0.00 tokens/s
+1369.74 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -326,8 +326,8 @@ tenant.sql_usage.pgwire_egress_bytes: 12345
 tenant.sql_usage.external_io_ingress_bytes: 1024000
 tenant.sql_usage.external_io_egress_bytes: 1024000
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.00
-tenant.sql_usage.estimated_cpu_seconds: 3.31
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.29
+tenant.sql_usage.estimated_cpu_seconds: 3.63
 tenant.sql_usage.estimated_replication_bytes: 436380
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
@@ -345,7 +345,7 @@ token-bucket-response
 
 token-bucket
 ----
-1690.29 tokens filling @ 0.00 tokens/s
+1369.74 tokens filling @ 0.00 tokens/s
 
 # Perform cross-region write request.
 write count=100 bytes=1000 localities=cross-region
@@ -359,7 +359,7 @@ advance wait=true
 
 token-bucket
 ----
-1652.30 tokens filling @ 0.00 tokens/s
+1335.90 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -376,8 +376,8 @@ tenant.sql_usage.pgwire_egress_bytes: 12345
 tenant.sql_usage.external_io_ingress_bytes: 1024000
 tenant.sql_usage.external_io_egress_bytes: 1024000
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.03
-tenant.sql_usage.estimated_cpu_seconds: 3.35
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.32
+tenant.sql_usage.estimated_cpu_seconds: 3.66
 tenant.sql_usage.estimated_replication_bytes: 441980
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="",to_region="europe-west1",to_zone=""}: 2800
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 292320
@@ -397,4 +397,4 @@ advance wait=true
 
 token-bucket
 ----
-1652.30 tokens filling @ 0.00 tokens/s
+1335.90 tokens filling @ 0.00 tokens/s

--- a/pkg/multitenant/tenantcostmodel/ecpu_model_test.go
+++ b/pkg/multitenant/tenantcostmodel/ecpu_model_test.go
@@ -139,8 +139,14 @@ func TestEstimatedCPUBatchInfo(t *testing.T) {
 
 func TestEstimatedCPUBatchCost(t *testing.T) {
 	model := EstimatedCPUModel{
-		ReadBatchCost:   1,
-		ReadRequestCost: 2,
+		ReadBatchCost: 1,
+		ReadRequestCost: struct {
+			BatchSize     []float64
+			CPUPerRequest []EstimatedCPU
+		}{
+			BatchSize:     []float64{8, 16, 32, 64},
+			CPUPerRequest: []EstimatedCPU{0.5, 1.5, 2.5, 3.5},
+		},
 		ReadBytesCost: struct {
 			PayloadSize []float64
 			CPUPerByte  []EstimatedCPU
@@ -160,7 +166,7 @@ func TestEstimatedCPUBatchCost(t *testing.T) {
 			BatchSize     []float64
 			CPUPerRequest []EstimatedCPU
 		}{
-			BatchSize:     []float64{3, 6, 12, 25},
+			BatchSize:     []float64{4, 8, 16, 32},
 			CPUPerRequest: []EstimatedCPU{2, 3, 4, 5},
 		},
 		WriteBytesCost: struct {
@@ -222,50 +228,50 @@ func TestEstimatedCPUBatchCost(t *testing.T) {
 		{
 			name: "metrics are smaller than min lookup values",
 			info: BatchInfo{
-				ReadCount:  10,
+				ReadCount:  3,
 				ReadBytes:  100,
-				WriteCount: 2,
+				WriteCount: 3,
 				WriteBytes: 1,
 			},
 			ratePerNode: 50,
 			replicas:    3,
-			cost:        119 + 13.5,
+			cost:        102 + 13.5,
 		},
 		{
 			name: "metrics are equal to min lookup values",
 			info: BatchInfo{
-				ReadCount:  10,
+				ReadCount:  8,
 				ReadBytes:  256,
-				WriteCount: 3,
+				WriteCount: 4,
 				WriteBytes: 256,
 			},
 			ratePerNode: 100,
 			replicas:    3,
-			cost:        275 + 1549.5,
+			cost:        260.5 + 1549.5,
 		},
 		{
 			name: "metrics between lookup values",
 			info: BatchInfo{
-				ReadCount:  50,
+				ReadCount:  48,
 				ReadBytes:  2560,
-				WriteCount: 9,
+				WriteCount: 12,
 				WriteBytes: 640,
 			},
 			ratePerNode: 150,
 			replicas:    5,
-			cost:        6499 + 9743.75,
+			cost:        6542 + 9778.75,
 		},
 		{
 			name: "metrics are equal to max lookup values",
 			info: BatchInfo{
-				ReadCount:  100,
+				ReadCount:  64,
 				ReadBytes:  4096,
-				WriteCount: 25,
+				WriteCount: 32,
 				WriteBytes: 4096,
 			},
 			ratePerNode: 800,
 			replicas:    3,
-			cost:        12_487 + 98_670,
+			cost:        12_509.5 + 98_760,
 		},
 		{
 			name: "metrics are larger than max lookup values",
@@ -277,7 +283,7 @@ func TestEstimatedCPUBatchCost(t *testing.T) {
 			},
 			ratePerNode: 1000,
 			replicas:    5,
-			cost:        31_999 + 402_485,
+			cost:        33_497.5 + 402_460,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/multitenant/tenantcostmodel/settings.go
+++ b/pkg/multitenant/tenantcostmodel/settings.go
@@ -151,7 +151,8 @@ func validateEstimatedCPUSetting(values *settings.Values, jsonStr string) error 
 		return errors.Wrapf(err, "validating estimated_cpu model: %s", jsonStr)
 	}
 
-	if len(model.ReadBytesCost.PayloadSize) != len(model.ReadBytesCost.CPUPerByte) ||
+	if len(model.ReadRequestCost.BatchSize) != len(model.ReadRequestCost.CPUPerRequest) ||
+		len(model.ReadBytesCost.PayloadSize) != len(model.ReadBytesCost.CPUPerByte) ||
 		len(model.WriteBatchCost.RatePerNode) != len(model.WriteBatchCost.CPUPerBatch) ||
 		len(model.WriteRequestCost.BatchSize) != len(model.WriteRequestCost.CPUPerRequest) ||
 		len(model.WriteBytesCost.PayloadSize) != len(model.WriteBytesCost.CPUPerByte) {

--- a/pkg/multitenant/tenantcostmodel/settings_test.go
+++ b/pkg/multitenant/tenantcostmodel/settings_test.go
@@ -152,13 +152,18 @@ func TestEstimatedCPUSetting(t *testing.T) {
 			}(),
 		},
 		{
+			name:    "mismatched ReadRequestCost field lengths",
+			jsonStr: `{"ReadRequestCost": {"BatchSize": [], "CPUPerRequest": [1]}}`,
+			err:     "estimated_cpu model lookup arrays cannot have different lengths",
+		},
+		{
 			name:    "mismatched ReadBytesCost field lengths",
 			jsonStr: `{"ReadBytesCost": {"PayloadSize": [1], "CPUPerByte": [1, 2]}}`,
 			err:     "estimated_cpu model lookup arrays cannot have different lengths",
 		},
 		{
 			name:    "mismatched WriteBatchCost field lengths",
-			jsonStr: `{"WriteBatchCost": {"RatePerNode": [1, 2], "CPUPerBatch": [1]}}`,
+			jsonStr: `{"WriteBatchCost": {"RatePerNode": [1, 2], "CPUPerRequest": [1]}}`,
 			err:     "estimated_cpu model lookup arrays cannot have different lengths",
 		},
 		{


### PR DESCRIPTION
A previous change updated the eCPU model to count all requests in read/write batches, rather than a subset of requests. This PR updates the cost of each request to reflect that change, based on a suite of tests. Changing the cost of requests has a ripple effect across other costs, so they changed as well. The resulting cost model has fewer outliers in testing and should be more resilient to future changes to KV batches/requests (e.g. adding a new request type).

Epic: https://cockroachlabs.atlassian.net/browse/CC-28471

Release note: None