### PR TITLE
parser,tree: fix handling of duplicate table names in LDR options

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4729,7 +4729,7 @@ logical_replication_options:
   } 
 | FUNCTION db_object_name FOR TABLE db_object_name
   {
-     $$.val = &tree.LogicalReplicationOptions{UserFunctions: map[*tree.UnresolvedName]tree.RoutineName{$5.unresolvedObjectName().ToUnresolvedName():$2.unresolvedObjectName().ToRoutineName()}}
+     $$.val = &tree.LogicalReplicationOptions{UserFunctions: map[tree.UnresolvedName]tree.RoutineName{*$5.unresolvedObjectName().ToUnresolvedName():$2.unresolvedObjectName().ToRoutineName()}}
   }
 
 // %Help: CREATE VIRTUAL CLUSTER - create a new virtual cluster

--- a/pkg/sql/parser/testdata/create_logical_replication
+++ b/pkg/sql/parser/testdata/create_logical_replication
@@ -62,3 +62,11 @@ DETAIL: source SQL:
 CREATE LOGICAL REPLICATION STREAM FROM TABLE foo, bar ON 'uri' INTO TABLE foo, bar
                                                 ^
 HINT: try \h CREATE LOGICAL REPLICATION STREAM
+
+error
+CREATE LOGICAL REPLICATION STREAM FROM TABLES (t1, t2, t3) ON 'uri' INTO TABLES (s.t4, t5) WITH OPTIONS (FUNCTION f1 FOR TABLE d.s.t5 , FUNCTION f2 FOR TABLE s.t4, FUNCTION f3 FOR TABLE s.t4, MODE = 'immediate')
+----
+at or near ",": syntax error: multiple user functions specified for table s.t4
+DETAIL: source SQL:
+CREATE LOGICAL REPLICATION STREAM FROM TABLES (t1, t2, t3) ON 'uri' INTO TABLES (s.t4, t5) WITH OPTIONS (FUNCTION f1 FOR TABLE d.s.t5 , FUNCTION f2 FOR TABLE s.t4, FUNCTION f3 FOR TABLE s.t4, MODE = 'immediate')
+                                                                                                                                                                                              ^

--- a/pkg/sql/sem/tree/create_logical_replication.go
+++ b/pkg/sql/sem/tree/create_logical_replication.go
@@ -30,7 +30,7 @@ type LogicalReplicationResources struct {
 
 type LogicalReplicationOptions struct {
 	// Mapping of table name to UDF name
-	UserFunctions   map[*UnresolvedName]RoutineName
+	UserFunctions   map[UnresolvedName]RoutineName
 	Cursor          Expr
 	Mode            Expr
 	DefaultFunction Expr
@@ -107,7 +107,7 @@ func (lro *LogicalReplicationOptions) Format(ctx *FmtCtx) {
 
 		// In order to make tests deterministic, the ordering of map keys
 		// needs to be the same each time.
-		keys := make([]*UnresolvedName, 0, len(lro.UserFunctions))
+		keys := make([]UnresolvedName, 0, len(lro.UserFunctions))
 		for k := range lro.UserFunctions {
 			keys = append(keys, k)
 		}
@@ -121,7 +121,7 @@ func (lro *LogicalReplicationOptions) Format(ctx *FmtCtx) {
 			r := lro.UserFunctions[k]
 			ctx.FormatNode(&r)
 			ctx.WriteString(" FOR TABLE ")
-			ctx.FormatNode(k)
+			ctx.FormatNode(&k)
 		}
 	}
 }
@@ -154,10 +154,10 @@ func (o *LogicalReplicationOptions) CombineWith(other *LogicalReplicationOptions
 	if other.UserFunctions != nil {
 		for tbl := range other.UserFunctions {
 			if _, ok := o.UserFunctions[tbl]; ok {
-				return errors.Newf("multiple user functions specified for table %q", tbl)
+				return errors.Newf("multiple user functions specified for table %s", tbl.String())
 			}
 			if o.UserFunctions == nil {
-				o.UserFunctions = make(map[*UnresolvedName]RoutineName)
+				o.UserFunctions = make(map[UnresolvedName]RoutineName)
 			}
 			o.UserFunctions[tbl] = other.UserFunctions[tbl]
 		}


### PR DESCRIPTION
The logic for detecting duplicate table names in the options clause was broken since it was based on pointer comparison. This switches to value comparison in order to fix it, and a test is added.

fixes https://github.com/cockroachdb/cockroach/issues/127808
Release note: None