### PR TITLE
spanconfig: remove dryrun field

### DIFF
--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -74,7 +74,6 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	require.NoError(t, err)
 	deleted, added := spanConfigStore.Apply(
 		ctx,
-		false, /* dryrun */
 		add,
 	)
 	require.Empty(t, deleted)

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -246,9 +246,9 @@ type Store interface {
 
 // StoreWriter is the write-only portion of the Store interface.
 type StoreWriter interface {
-	// Apply applies a batch of non-overlapping updates atomically[1] and
-	// returns (i) the existing spans that were deleted, and (ii) the entries
-	// that were newly added to make room for the batch.
+	// Apply applies a batch of non-overlapping updates atomically and returns (i)
+	// the existing spans that were deleted, and (ii) the entries that were newly
+	// added to make room for the batch.
 	//
 	// Span configs are stored in non-overlapping fashion. When an update
 	// overlaps with existing configs, the existing configs are deleted. If the
@@ -274,11 +274,7 @@ type StoreWriter interface {
 	//  Deleted  |             [------------- B -----------)[---------- C -----)
 	//  Added    |             [--- D ----)[-- B --)         [-- C -)[--- E ---)
 	//  Store*   | [--- A ----)[--- D ----)[-- B --)         [-- C -)[--- E ---)
-	//
-	// [1]: Unless dryrun is true. We'll still generate the same {deleted,added}
-	//      lists.
-	// TODO(arul): Get rid of dryrun; we don't make use of it anywhere.
-	Apply(ctx context.Context, dryrun bool, updates ...Update) (
+	Apply(ctx context.Context, updates ...Update) (
 		deleted []Target, added []Record,
 	)
 }

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -414,7 +414,7 @@ func (s *KVSubscriber) handleCompleteUpdate(
 ) {
 	freshStore := spanconfigstore.New(s.fallback, s.settings, s.boundsReader, s.knobs)
 	for _, ev := range events {
-		freshStore.Apply(ctx, false /* dryrun */, ev.Update)
+		freshStore.Apply(ctx, ev.Update)
 	}
 	handlers := func() []handler {
 		s.mu.Lock()
@@ -468,7 +468,7 @@ func (s *KVSubscriber) handlePartialUpdate(
 			// atomically, the updates need to be non-overlapping. That's not the case
 			// here because we can have deletion events followed by additions for
 			// overlapping spans.
-			s.mu.internal.Apply(ctx, false /* dryrun */, ev.Update)
+			s.mu.internal.Apply(ctx, ev.Update)
 		}
 		s.setLastUpdatedLocked(ts)
 		return s.mu.handlers

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -211,7 +211,7 @@ type manualStore struct {
 
 // Apply implements the spanconfig.Store interface.
 func (m *manualStore) Apply(
-	context.Context, bool, ...spanconfig.Update,
+	context.Context, ...spanconfig.Update,
 ) (deleted []spanconfig.Target, added []spanconfig.Record) {
 	panic("unimplemented")
 }

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -252,7 +252,7 @@ func (f *fullReconciler) reconcile(
 		updates[i] = spanconfig.Update(record)
 	}
 
-	toDelete, toUpsert := storeWithExistingSpanConfigs.Apply(ctx, false /* dryrun */, updates...)
+	toDelete, toUpsert := storeWithExistingSpanConfigs.Apply(ctx, updates...)
 	if len(toDelete) != 0 || len(toUpsert) != 0 {
 		if err := updateSpanConfigRecords(
 			ctx, f.kvAccessor, toDelete, toUpsert, f.session,
@@ -281,7 +281,7 @@ func (f *fullReconciler) reconcile(
 			if err != nil {
 				return nil, hlc.Timestamp{}, err
 			}
-			storeWithExistingSpanConfigs.Apply(ctx, false /* dryrun */, del)
+			storeWithExistingSpanConfigs.Apply(ctx, del)
 		}
 		storeWithExtraneousSpanConfigs = storeWithExistingSpanConfigs
 	}
@@ -299,7 +299,7 @@ func (f *fullReconciler) reconcile(
 		if err != nil {
 			return nil, hlc.Timestamp{}, err
 		}
-		storeWithLatestSpanConfigs.Apply(ctx, false /* dryrun */, del)
+		storeWithLatestSpanConfigs.Apply(ctx, del)
 	}
 
 	if !f.codec.ForSystemTenant() {
@@ -401,7 +401,7 @@ func (f *fullReconciler) fetchExistingSpanConfigs(
 		}
 
 		for _, record := range records {
-			store.Apply(ctx, false /* dryrun */, spanconfig.Update(record))
+			store.Apply(ctx, spanconfig.Update(record))
 		}
 	}
 	return store, nil
@@ -572,7 +572,7 @@ func (r *incrementalReconciler) reconcile(
 				updates = append(updates, del)
 			}
 
-			toDelete, toUpsert := r.storeWithKVContents.Apply(ctx, false /* dryrun */, updates...)
+			toDelete, toUpsert := r.storeWithKVContents.Apply(ctx, updates...)
 			if len(toDelete) != 0 || len(toUpsert) != 0 {
 				if err := updateSpanConfigRecords(
 					ctx, r.kvAccessor, toDelete, toUpsert, r.session,

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -325,5 +325,5 @@ func (s *mockCluster) getRangeDescriptor(id roachpb.RangeID) roachpb.RangeDescri
 func (s *mockCluster) applyConfig(ctx context.Context, span roachpb.Span, conf roachpb.SpanConfig) {
 	update, err := spanconfig.Addition(spanconfig.MakeTargetFromSpan(span), conf)
 	require.NoError(s.t, err)
-	s.store.Apply(ctx, false, update)
+	s.store.Apply(ctx, update)
 }

--- a/pkg/spanconfig/spanconfigstore/span_store_test.go
+++ b/pkg/spanconfig/spanconfigstore/span_store_test.go
@@ -118,7 +118,7 @@ func TestRandomized(t *testing.T) {
 	})
 	for i := 0; i < numOps; i++ {
 		updates := getRandomUpdates()
-		_, _, err := store.apply(ctx, false /* dryrun */, updates...)
+		_, _, err := store.apply(ctx, updates...)
 		require.NoError(t, err)
 		for _, update := range updates {
 			if testSpan.Overlaps(update.GetTarget().GetSpan()) {

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -183,21 +183,19 @@ func (s *Store) getFallbackConfig() roachpb.SpanConfig {
 
 // Apply is part of the spanconfig.StoreWriter interface.
 func (s *Store) Apply(
-	ctx context.Context, dryrun bool, updates ...spanconfig.Update,
+	ctx context.Context, updates ...spanconfig.Update,
 ) (deleted []spanconfig.Target, added []spanconfig.Record) {
 
 	// Log the potential span config changes.
-	if !dryrun {
-		for _, update := range updates {
-			err := s.maybeLogUpdate(ctx, &update)
-			if err != nil {
-				log.KvDistribution.Warningf(ctx, "attempted to log a spanconfig update to "+
-					"target:%+v, but got the following error:%+v", update.GetTarget(), err)
-			}
+	for _, update := range updates {
+		err := s.maybeLogUpdate(ctx, &update)
+		if err != nil {
+			log.KvDistribution.Warningf(ctx, "attempted to log a spanconfig update to "+
+				"target:%+v, but got the following error:%+v", update.GetTarget(), err)
 		}
 	}
 
-	deleted, added, err := s.applyInternal(ctx, dryrun, updates...)
+	deleted, added, err := s.applyInternal(ctx, updates...)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
@@ -255,7 +253,7 @@ func (s *Store) Clone() *Store {
 }
 
 func (s *Store) applyInternal(
-	ctx context.Context, dryrun bool, updates ...spanconfig.Update,
+	ctx context.Context, updates ...spanconfig.Update,
 ) (deleted []spanconfig.Target, added []spanconfig.Record, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -275,7 +273,7 @@ func (s *Store) applyInternal(
 			return nil, nil, errors.AssertionFailedf("unknown target type")
 		}
 	}
-	deletedSpans, addedEntries, err := s.mu.spanConfigStore.apply(ctx, dryrun, spanStoreUpdates...)
+	deletedSpans, addedEntries, err := s.mu.spanConfigStore.apply(ctx, spanStoreUpdates...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -30,9 +30,9 @@ import (
 
 // TestingApplyInternal exports an internal method for testing purposes.
 func (s *Store) TestingApplyInternal(
-	ctx context.Context, dryrun bool, updates ...spanconfig.Update,
+	ctx context.Context, updates ...spanconfig.Update,
 ) (deleted []spanconfig.Target, added []spanconfig.Record, err error) {
-	return s.applyInternal(ctx, dryrun, updates...)
+	return s.applyInternal(ctx, updates...)
 }
 
 // TestingSplitKeys returns the computed list of range split points between
@@ -114,6 +114,12 @@ func (s *spanConfigStore) TestingSplitKeys(
 // delete /Tenant/10
 // ----
 //
+// checkpoint
+// ----
+//
+// restore-checkpoint
+// ----
+//
 // Text of the form [a,b), {entire-keyspace}, {source=1,target=20}, and [a,b):C
 // correspond to targets {spans, system targets} and span config records; see
 // spanconfigtestutils.Parse{Target,Config,SpanConfigRecord} for more details.
@@ -129,16 +135,16 @@ func TestDataDriven(t *testing.T) {
 			boundsReader,
 			&spanconfig.TestingKnobs{
 				StoreIgnoreCoalesceAdjacentExceptions: true,
-				StoreInternConfigsInDryRuns:           true,
 			},
 		)
+
+		var checkpointedStore *Store
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			var spanStr, keyStr string
 			switch d.Cmd {
 			case "apply":
 				updates := spanconfigtestutils.ParseStoreApplyArguments(t, d.Input)
-				dryrun := d.HasArg("dryrun")
-				deleted, added, err := store.TestingApplyInternal(ctx, dryrun, updates...)
+				deleted, added, err := store.TestingApplyInternal(ctx, updates...)
 				if err != nil {
 					return fmt.Sprintf("err: %v", err)
 				}
@@ -156,6 +162,15 @@ func TestDataDriven(t *testing.T) {
 					b.WriteString(fmt.Sprintf("added %s\n", spanconfigtestutils.PrintSpanConfigRecord(t, ent)))
 				}
 				return b.String()
+
+			case "checkpoint":
+				checkpointedStore = store.Clone()
+
+			case "restore-checkpoint":
+				if checkpointedStore == nil {
+					t.Error("error trying to restore a non-existent checkpoint")
+				}
+				store = checkpointedStore.Clone()
 
 			case "get":
 				d.ScanArgs(t, "key", &keyStr)
@@ -309,7 +324,7 @@ func TestStoreClone(t *testing.T) {
 		NewEmptyBoundsReader(),
 		nil,
 	)
-	original.Apply(ctx, false, updates...)
+	original.Apply(ctx, updates...)
 	clone := original.Clone()
 
 	var originalRecords, clonedRecords []spanconfig.Record
@@ -354,7 +369,7 @@ func BenchmarkStoreComputeSplitKey(b *testing.B) {
 				updates = append(updates, spanconfigtestutils.ParseStoreApplyArguments(b,
 					fmt.Sprintf("set [%08d,%08d):X", i, i+1))...)
 			}
-			deleted, added := store.Apply(ctx, false, updates...)
+			deleted, added := store.Apply(ctx, updates...)
 			require.Len(b, deleted, 0)
 			require.Len(b, added, numEntries)
 

--- a/pkg/spanconfig/spanconfigstore/system_store.go
+++ b/pkg/spanconfig/spanconfigstore/system_store.go
@@ -34,10 +34,6 @@ func newSystemSpanConfigStore() *systemSpanConfigStore {
 
 // apply takes an incremental set of system span config updates and applies them
 // to the underlying store. It returns a list of targets deleted/records added.
-//
-// TODO(arul): Even though this is called from spanconfig.Store.Apply, which
-// accepts a dryrun field, we don't accept a a dry run option here because it's
-// unused; instead, we plan on removing it entirely.
 func (s *systemSpanConfigStore) apply(
 	updates ...spanconfig.Update,
 ) (deleted []spanconfig.SystemTarget, added []spanconfig.Record, _ error) {

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/basic
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/basic
@@ -1,23 +1,6 @@
 # Test semantics of batched updates (multiple sets or deletes applied on a snapshot).
 
-# Test that dryruns don't actually mutate anything.
-apply dryrun
-set [b,d):A
-set [f,h):B
-----
-added [b,d):A
-added [f,h):B
-
-get key=b
-----
-conf=FALLBACK
-
-get key=g
-----
-conf=FALLBACK
-
-
-# Add span configs for real.
+# Add span configs.
 apply
 set [b,d):A
 set [f,h):B
@@ -45,21 +28,7 @@ set [f,h):B
 ----
 
 
-# Check that a delete dryrun does nothing, though emitting the right operations.
-apply dryrun
-delete [f,h)
-delete [c,d)
-----
-deleted [b,d)
-deleted [f,h)
-added [b,c):A
-
-get key=f
-----
-conf=B
-
-
-# Delete a span for real.
+# Delete a span.
 apply
 delete [f,h)
 delete [c,d)

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/encompass
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/encompass
@@ -17,12 +17,16 @@ added [d,e):B
 added [e,f):C
 added [g,i):D
 
+# We will need to get back to the current state in this test.
+checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-A)  [-B|-C)  [--D--)
 # set     [--------X--------)
 # ====================================
 # result  [--------X--------|--D--)
-apply dryrun
+apply
 set [a,g):X
 ----
 deleted [b,c)
@@ -30,12 +34,15 @@ deleted [d,e)
 deleted [e,f)
 added [a,g):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-A)  [-B|-C)  [--D--)
 # set     [--------X--|----Y---)
 # ====================================
 # result  [--------X--|----Y---|-D)
-apply dryrun
+apply
 set [a,e):X
 set [e,h):Y
 ----
@@ -47,12 +54,15 @@ added [a,e):X
 added [e,h):Y
 added [h,i):D
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-A)  [-B|-C)  [--D--)
 # set     [--------X-----------)
 # ====================================
 # result  [--------X-----------|-D)
-apply dryrun
+apply
 set [a,h):X
 ----
 deleted [b,c)
@@ -62,12 +72,15 @@ deleted [g,i)
 added [a,h):X
 added [h,i):D
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-A)  [-B|-C)  [--D--)
 # set     [--------X-----|xxxxx)
 # ====================================
 # result  [--------X-----)     [-D)
-apply dryrun
+apply
 set [a,f):X
 delete [f,h)
 ----

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/overlapping
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/overlapping
@@ -15,24 +15,31 @@ overlapping span=[a,z)
 ----
 [b,g):X
 
+# We will need to get back to the current state in this test.
+checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)
 # ====================================
 # result  [--A--)[-----X----)
-apply dryrun
+apply
 set [a,c):A
 ----
 deleted [b,g)
 added [a,c):A
 added [c,g):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)              [--B--)
 # ====================================
 # result  [--A--)[-----X----)  [--B--)
-apply dryrun
+apply
 set [a,c):A
 set [h,j):B
 ----
@@ -41,12 +48,15 @@ added [a,c):A
 added [c,g):X
 added [h,j):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)        [--B--)
 # ====================================
 # result  [--A--)[-X-----|--B--)
-apply dryrun
+apply
 set [a,c):A
 set [f,h):B
 ----
@@ -55,12 +65,15 @@ added [a,c):A
 added [c,f):X
 added [f,h):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)     [--B--)
 # ====================================
 # result  [--A--)[-X--|--B--)
-apply dryrun
+apply
 set [a,c):A
 set [e,g):B
 ----
@@ -69,12 +82,15 @@ added [a,c):A
 added [c,e):X
 added [e,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)  [--B--)
 # ====================================
 # result  [--A--)[X|--B--|-X)
-apply dryrun
+apply
 set [a,c):A
 set [d,f):B
 ----
@@ -84,12 +100,15 @@ added [c,d):X
 added [d,f):B
 added [f,g):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set           [--A--|--B--)
 # ====================================
 # result     [-X|--A--|--B--)
-apply dryrun
+apply
 set [c,e):A
 set [e,g):B
 ----
@@ -98,12 +117,15 @@ added [b,c):X
 added [c,e):A
 added [e,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)  [-B)  [--D--)
 # ====================================
 # set     [--A--|-X|-B|-X|--D--)
-apply dryrun
+apply
 set [a,c):A
 set [d,e):B
 set [f,h):D
@@ -115,12 +137,15 @@ added [d,e):B
 added [e,f):X
 added [f,h):D
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)  [-B)  [-D)
 # ====================================
 # set     [--A--|-X|-B|-X|-D)
-apply dryrun
+apply
 set [a,c):A
 set [d,e):B
 set [f,g):D
@@ -132,12 +157,15 @@ added [d,e):B
 added [e,f):X
 added [f,g):D
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)  [-B|-C|--D--)
 # ====================================
 # set     [--A--|-X|-B|-C|--D--)
-apply dryrun
+apply
 set [a,c):A
 set [d,e):B
 set [e,f):C
@@ -150,12 +178,15 @@ added [d,e):B
 added [e,f):C
 added [f,h):D
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)              [xxxxx)
 # ====================================
 # result  [--A--)[-----X----)
-apply dryrun
+apply
 set [a,c):A
 delete [h,j)
 ----
@@ -163,12 +194,15 @@ deleted [b,g)
 added [a,c):A
 added [c,g):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)        [xxxxx)
 # ====================================
 # result  [--A--)[-X-----)
-apply dryrun
+apply
 set [a,c):A
 delete [f,h)
 ----
@@ -176,12 +210,15 @@ deleted [b,g)
 added [a,c):A
 added [c,f):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [xxxxx)     [--B--)
 # ====================================
 # result         [-X--|--B--)
-apply dryrun
+apply
 delete [a,c)
 set [e,g):B
 ----
@@ -189,12 +226,15 @@ deleted [b,g)
 added [c,e):X
 added [e,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [-----X--------)
 # set     [--A--)  [xx)  [--D--)
 # ====================================
 # set     [--A--|-X)  [-X|--D--)
-apply dryrun
+apply
 set [a,c):A
 delete [d,e)
 set [f,h):D

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/straddle
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/straddle
@@ -13,12 +13,16 @@ set [e,g):B
 added [b,d):A
 added [e,g):B
 
+# We will need to get back to the current state in this test.
+checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set           [---X----)
 # ====================================
 # result     [-A|----X---|-B)
-apply dryrun
+apply
 set [c,f):X
 ----
 deleted [b,d)
@@ -27,12 +31,15 @@ added [b,c):A
 added [c,f):X
 added [f,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set           [---X-------)
 # ====================================
 # result     [-A|----X------)
-apply dryrun
+apply
 set [c,g):X
 ----
 deleted [b,d)
@@ -40,12 +47,15 @@ deleted [e,g)
 added [b,c):A
 added [c,g):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set           [---X----|xx)
 # ====================================
 # result     [-A|----X---)
-apply dryrun
+apply
 set [c,f):X
 delete [f,g)
 ----
@@ -54,12 +64,15 @@ deleted [e,g)
 added [b,c):A
 added [c,f):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set           [---X----------)
 # ====================================
 # result     [-A|----X---------)
-apply dryrun
+apply
 set [c,h):X
 ----
 deleted [b,d)
@@ -67,12 +80,15 @@ deleted [e,g)
 added [b,c):A
 added [c,h):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set        [---X-------)
 # ====================================
 # result     [-------X---|-B)
-apply dryrun
+apply
 set [b,f):X
 ----
 deleted [b,d)
@@ -80,12 +96,15 @@ deleted [e,g)
 added [b,f):X
 added [f,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set     [------X-------)
 # ====================================
 # result  [----------X---|-B)
-apply dryrun
+apply
 set [a,f):X
 ----
 deleted [b,d)
@@ -93,12 +112,15 @@ deleted [e,g)
 added [a,f):X
 added [f,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set           [xxxxxxxx)
 # ====================================
 # result     [-A)        [-B)
-apply dryrun
+apply
 delete [c,f)
 ----
 deleted [b,d)
@@ -106,12 +128,15 @@ deleted [e,g)
 added [b,c):A
 added [f,g):B
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set     [xxxxx|---X----------)
 # ====================================
 # result        [----X---------)
-apply dryrun
+apply
 delete [a,c)
 set [c,h):X
 ----
@@ -119,12 +144,15 @@ deleted [b,d)
 deleted [e,g)
 added [c,h):X
 
+restore-checkpoint
+----
+
 # keys    a  b  c  d  e  f  g  h  i  j
 # state      [--A--)  [--B--)
 # set        [--X--|xxxxx|-Y)
 # ====================================
 # result     [--X--)     [-Y)
-apply dryrun
+apply
 set [b,d):X
 delete [d,f)
 set [f,g):Y

--- a/pkg/spanconfig/spanconfigstore/testdata/single/basic
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/basic
@@ -8,18 +8,7 @@ get key=b
 conf=FALLBACK
 
 
-# Test that dryruns don't actually mutate anything.
-apply dryrun
-set [b,d):A
-----
-added [b,d):A
-
-get key=b
-----
-conf=FALLBACK
-
-
-# Add span configs for real.
+# Add span configs.
 apply
 set [b,d):A
 ----
@@ -59,18 +48,7 @@ get key=h
 conf=FALLBACK
 
 
-# Check that a delete dryrun does nothing.
-apply dryrun
-delete [f,h)
-----
-deleted [f,h)
-
-get key=f
-----
-conf=B
-
-
-# Delete a span for real.
+# Delete a span.
 apply
 delete [f,h)
 ----

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -128,10 +128,6 @@ type TestingKnobs struct {
 	// coalescing system database ranges for the host tenant.
 	StoreIgnoreCoalesceAdjacentExceptions bool
 
-	// StoreInternConfigsInDryRuns, if set, will intern span configs even when
-	// applying mutations in dry run mode.
-	StoreInternConfigsInDryRuns bool
-
 	// OverrideFallbackConf, if set, allows tests to override fields in the
 	// fallback config that will be applied to the span.
 	OverrideFallbackConf func(roachpb.SpanConfig) roachpb.SpanConfig


### PR DESCRIPTION
This commit addresses the TODO of removing the unused dryrun field from store's apply() function, and all of the calls up and down of the stack.

Release note: None