### PR TITLE
roachtest, reduce: reduce multi-region sqlsmith-based roachtests

### DIFF
--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -303,6 +303,7 @@ SELECT '%[1]s';
 		if multiRegion {
 			cmd = exec.CommandContext(ctx, binary,
 				"demo",
+				"--insecure",
 				"--empty",
 				"--nodes=9",
 				"--multitenant=false",
@@ -312,6 +313,7 @@ SELECT '%[1]s';
 		} else {
 			cmd = exec.CommandContext(ctx, binary,
 				"demo",
+				"--insecure",
 				"--empty",
 				"--set=errexit=false",
 				"--format=tsv",
@@ -402,9 +404,9 @@ func findPreviousQuery(lines []string, lineIdx int) (string, int) {
 		lineIdx--
 	}
 	// lineIdx right now points at an empty line before the query.
-	query := strings.Join(lines[lineIdx+1:lastQueryLineIdx+1], " ")
+	query := strings.Join(lines[lineIdx+1:lastQueryLineIdx+1], "\n")
 	// Remove the semicolon.
-	return query[:len(query)-1], lineIdx
+	return strings.TrimSuffix(query, ";"), lineIdx
 }
 
 // findPreviousSetStatements returns any SET or RESET statements preceding
@@ -431,7 +433,7 @@ func findPreviousSetStatements(lines []string, lineIdx int) (string, int) {
 		}
 	}
 	// firstQueryLineIdx right now points at an empty line before the statement.
-	query := strings.Join(lines[firstQueryLineIdx+1:lastQueryLineIdx+1], " ")
+	query := strings.Join(lines[firstQueryLineIdx+1:lastQueryLineIdx+1], "\n")
 	return query, firstQueryLineIdx
 }
 

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -172,7 +172,7 @@ func runOneTLP(
 		// for a fraction of iterations after that to continually change the
 		// state of the database.
 		if i < 1000 || i%10 == 0 {
-			runMutationStatement(conn, mutSmither, logStmt)
+			runMutationStatement(conn, "", mutSmither, logStmt)
 			continue
 		}
 
@@ -184,7 +184,9 @@ func runOneTLP(
 
 // runMutationsStatement runs a random INSERT, UPDATE, or DELETE statement that
 // potentially modifies the state of the database.
-func runMutationStatement(conn *gosql.DB, smither *sqlsmith.Smither, logStmt func(string)) {
+func runMutationStatement(
+	conn *gosql.DB, connInfo string, smither *sqlsmith.Smither, logStmt func(string),
+) {
 	// Ignore panics from Generate.
 	defer func() {
 		if r := recover(); r != nil {
@@ -199,7 +201,7 @@ func runMutationStatement(conn *gosql.DB, smither *sqlsmith.Smither, logStmt fun
 	_ = runWithTimeout(func() error {
 		// Ignore errors. Log successful statements.
 		if _, err = conn.Exec(stmt); err == nil {
-			logStmt(stmt)
+			logStmt(connInfo + stmt)
 		}
 		return nil
 	})


### PR DESCRIPTION
Change the connection info string used by multi-region sqlsmith-based roachtests from a comment to a `\connect` command. This should allow us to replay multi-region randomized test logs correctly, assuming a demo cluster something like:

```
cockroach demo --insecure --nodes=9 --multitenant=false
```

Also make a few small changes to `reduce` to work with this format. After this we should be able to reduce multi-region randomized test logs.

Epic: CRDB-37838

Release note: None