### PR TITLE
raft: add the concept of quorum supported expiration

### DIFF
--- a/pkg/raft/quorum/BUILD.bazel
+++ b/pkg/raft/quorum/BUILD.bazel
@@ -12,7 +12,10 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/quorum",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/raft/raftpb"],
+    deps = [
+        "//pkg/raft/raftpb",
+        "//pkg/util/hlc",
+    ],
 )
 
 go_test(
@@ -21,12 +24,17 @@ go_test(
         "bench_test.go",
         "datadriven_test.go",
         "quick_test.go",
+        "quorum_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":quorum"],
     deps = [
         "//pkg/raft/raftpb",
+        "//pkg/util/hlc",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/raft/quorum/datadriven_test.go
+++ b/pkg/raft/quorum/datadriven_test.go
@@ -192,14 +192,14 @@ func TestDataDriven(t *testing.T) {
 						for iid := range c {
 							if iid == id {
 								ll[iid] = idx
-							} else if idx, ok := l.AckedIndex(iid); ok {
+							} else if idx, ok := l.Get(iid); ok {
 								ll[iid] = idx
 							}
 						}
 						return ll
 					}
 					for id := range c {
-						iidx, _ := l.AckedIndex(id)
+						iidx, _ := l.Get(id)
 						if idx > iidx && iidx > 0 {
 							// If the committed index was definitely above the currently
 							// inspected idx, the result shouldn't change if we lower it

--- a/pkg/raft/quorum/majority.go
+++ b/pkg/raft/quorum/majority.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // MajorityConfig is a set of IDs that uses majority quorums to make decisions.
@@ -50,7 +51,7 @@ func (c MajorityConfig) String() string {
 
 // Describe returns a (multi-line) representation of the commit indexes for the
 // given lookuper.
-func (c MajorityConfig) Describe(l AckedIndexer) string {
+func (c MajorityConfig) Describe(l ComparableMap[Index]) string {
 	if len(c) == 0 {
 		return "<empty majority quorum>"
 	}
@@ -68,7 +69,7 @@ func (c MajorityConfig) Describe(l AckedIndexer) string {
 	n := len(c)
 	info := make([]tup, 0, n)
 	for id := range c {
-		idx, ok := l.AckedIndex(id)
+		idx, ok := l.Get(id)
 		info = append(info, tup{id: id, idx: idx, ok: ok})
 	}
 
@@ -128,41 +129,10 @@ func (c MajorityConfig) CommittedIndex(l AckedIndexer) Index {
 		return math.MaxUint64
 	}
 
-	// Use an on-stack slice to collect the committed indexes when n <= 7
-	// (otherwise we alloc). The alternative is to stash a slice on
-	// MajorityConfig, but this impairs usability (as is, MajorityConfig is just
-	// a map, and that's nice). The assumption is that running with a
-	// replication factor of >7 is rare, and in cases in which it happens
-	// performance is a lesser concern (additionally the performance
-	// implications of an allocation here are far from drastic).
-	var stk [7]uint64
-	var srt []uint64
-	if len(stk) >= n {
-		srt = stk[:n]
-	} else {
-		srt = make([]uint64, n)
-	}
-
-	{
-		// Fill the slice with the indexes observed. Any unused slots will be
-		// left as zero; these correspond to voters that may report in, but
-		// haven't yet. We fill from the right (since the zeroes will end up on
-		// the left after sorting below anyway).
-		i := n - 1
-		for id := range c {
-			if idx, ok := l.AckedIndex(id); ok {
-				srt[i] = uint64(idx)
-				i--
-			}
-		}
-	}
-	slices.Sort(srt)
-
-	// The smallest index into the array for which the value is acked by a
-	// quorum. In other words, from the end of the slice, move n/2+1 to the
-	// left (accounting for zero-indexing).
-	pos := n - (n/2 + 1)
-	return Index(srt[pos])
+	// The commit index is the smallest index that's been acked by all replicas in
+	// a quorum. For the majority config, we want the largest such index across
+	// all quorums. quorumSupportedElement will give us that.
+	return computeElement(c, l)
 }
 
 // VoteResult takes a mapping of voters to yes/no (true/false) votes and returns
@@ -177,7 +147,9 @@ func (c MajorityConfig) VoteResult(votes map[pb.PeerID]bool) VoteResult {
 		return VoteWon
 	}
 
-	var votedCnt int //vote counts for yes.
+	// NB: We could use computeElement here instead. However, this logic is a bit
+	// more intuitive.
+	var votedCnt int // vote counts for yes.
 	var missing int
 	for id := range c {
 		v, ok := votes[id]
@@ -198,4 +170,94 @@ func (c MajorityConfig) VoteResult(votes map[pb.PeerID]bool) VoteResult {
 		return VotePending
 	}
 	return VoteLost
+}
+
+// supportMap allows looking up fortification support provided to the leader by
+// a given peer.
+type supportMap map[pb.PeerID]hlc.Timestamp
+
+// Get implements the ComparableMap interface.
+func (s supportMap) Get(id pb.PeerID) (hlc.Timestamp, bool) {
+	idx, ok := s[id]
+	return idx, ok
+}
+
+// LeadSupportExpiration takes a mapping of timestamps peers have promised a
+// fortified leader support until and returns the timestamp until which the
+// leader is guaranteed support until.
+func (c MajorityConfig) LeadSupportExpiration(supported supportMap) hlc.Timestamp {
+	if len(c) == 0 {
+		// There are no peers in the config, and therefore no leader, so we return
+		// MaxTimestamp as a sentinel value. This also plays well with joint quorums
+		// when one half is the zero MajorityConfig. In such cases, the joint config
+		// should behave like the other half.
+		return hlc.MaxTimestamp
+	}
+
+	// As per the definition of QSE above, quorumSupportedElement should give us
+	// what we need.
+	return computeElement(c, supported)
+}
+
+// Comparable is a thin interface that allows computeElement to compare
+// elements.
+type Comparable[T any] interface {
+	Compare(T) int
+}
+
+// ComparableMap is a thin interface that allows computeElement to map peer IDs
+// in a config to comparable elements.
+type ComparableMap[T Comparable[T]] interface {
+	Get(id pb.PeerID) (T, bool)
+}
+
+// computeElement returns the maximum element that's supported by a majority in
+// the provided configuration. We assume that if an element is supported by a
+// peer, then all elements with smaller values (as defined by the Comparable
+// ordering) are also supported by it.
+//
+// Elements must be comparable to each other. If an element does not exist for
+// a peer then it is treated as the zero value and sorts before all other
+// elements.
+func computeElement[E Comparable[E], M ComparableMap[E]](c MajorityConfig, elems M) E {
+	n := len(c)
+
+	// Use an on-stack slice whenever n <= 7 (otherwise we alloc). The assumption
+	// is that running with a replication factor of >7 is rare, and in cases in
+	// which it happens, performance is less of a concern (it's not like
+	// performance implications of an allocation here are drastic).
+	var stk [7]E
+	var srt []E
+	if len(stk) >= n {
+		srt = stk[:n]
+	} else {
+		srt = make([]E, n)
+	}
+
+	{
+		// Fill the slice with elements. Any unused slots will be left as zero/empty
+		// for our calculation. We fill from the right (since the zeros will end up
+		// on the left after sorting anyway).
+		i := n - 1
+		for id := range c {
+			if e, ok := elems.Get(id); ok {
+				srt[i] = e
+				i--
+			}
+		}
+	}
+
+	slices.SortFunc(srt, func(a, b E) int {
+		return a.Compare(b)
+	})
+
+	// We want the maximum element supported by the quorum, with the assumption
+	// that if an element is supported by a peer, so are all elements with smaller
+	// values (as defined by the Comparable ordering). For this, we can simply
+	// consider the quorum formed by picking the highest value elements and pick
+	// the minimum from this. In other words, from our sorted (in increasing
+	// order) array srt, we want to move n/2 + 1 to the left from the end
+	// (accounting for zero-indexing).
+	pos := n - (n/2 + 1)
+	return srt[pos]
 }

--- a/pkg/raft/quorum/quick_test.go
+++ b/pkg/raft/quorum/quick_test.go
@@ -94,7 +94,7 @@ func alternativeMajorityCommittedIndex(c MajorityConfig, l AckedIndexer) Index {
 
 	idToIdx := map[pb.PeerID]Index{}
 	for id := range c {
-		if idx, ok := l.AckedIndex(id); ok {
+		if idx, ok := l.Get(id); ok {
 			idToIdx[id] = idx
 		}
 	}

--- a/pkg/raft/quorum/quorum.go
+++ b/pkg/raft/quorum/quorum.go
@@ -18,6 +18,7 @@
 package quorum
 
 import (
+	"cmp"
 	"math"
 	"strconv"
 
@@ -34,16 +35,23 @@ func (i Index) String() string {
 	return strconv.FormatUint(uint64(i), 10)
 }
 
-// AckedIndexer allows looking up a commit index for a given ID of a voter
-// from a corresponding MajorityConfig.
-type AckedIndexer interface {
-	AckedIndex(voterID pb.PeerID) (idx Index, found bool)
+// Compare returns -1 if this Index is lesser than the one supplied, 1 if it is
+// greater, and 0 if they're equal.
+func (a Index) Compare(b Index) int {
+	return cmp.Compare(a, b)
 }
 
+// AckedIndexer is a specialization of ComparableMap that allows looking up
+// commit indexes for a given ID.
+type AckedIndexer ComparableMap[Index]
+
+// mapAckIndexer is a type of AckedIndexer. It's primarily used as a type to
+// mock commit index lookups in tests. See ProgressMap for the production
+// implementation.
 type mapAckIndexer map[pb.PeerID]Index
 
-// AckedIndex implements AckedIndexer interface.
-func (m mapAckIndexer) AckedIndex(id pb.PeerID) (Index, bool) {
+// Get implements the ComparableMap interface.
+func (m mapAckIndexer) Get(id pb.PeerID) (Index, bool) {
 	idx, ok := m[id]
 	return idx, ok
 }

--- a/pkg/raft/quorum/quorum_test.go
+++ b/pkg/raft/quorum/quorum_test.go
@@ -1,0 +1,141 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package quorum
+
+import (
+	"testing"
+
+	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeadSupportExpiration ensures that the leader's support expiration is
+// correctly calculated.
+func TestLeadSupportExpiration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts := func(ts int64) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: ts,
+		}
+	}
+
+	testCases := []struct {
+		ids     []pb.PeerID
+		support map[pb.PeerID]hlc.Timestamp
+		expQSE  hlc.Timestamp
+	}{
+		{
+			ids:     []pb.PeerID{1, 2, 3},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15)},
+			expQSE:  ts(15),
+		},
+		{
+			ids:     []pb.PeerID{1, 2, 3, 4},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15), 4: ts(20)},
+			expQSE:  ts(15),
+		},
+		{
+			ids:     []pb.PeerID{1, 2, 3, 4, 5},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15), 4: ts(20), 5: ts(20)},
+			expQSE:  ts(20),
+		},
+		{
+			ids:     []pb.PeerID{1, 2, 3},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20)},
+			expQSE:  ts(10),
+		},
+		{
+			ids:     []pb.PeerID{1, 2, 3},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10)},
+			expQSE:  hlc.Timestamp{},
+		},
+		{
+			ids:     []pb.PeerID{},
+			support: map[pb.PeerID]hlc.Timestamp{},
+			expQSE:  hlc.MaxTimestamp,
+		},
+	}
+
+	for _, tc := range testCases {
+		m := MajorityConfig{}
+		for _, id := range tc.ids {
+			m[id] = struct{}{}
+		}
+
+		require.Equal(t, tc.expQSE, m.LeadSupportExpiration(tc.support))
+	}
+}
+
+// TestComputeQSEJointConfig ensures that the QSE is calculated correctly for
+// joint configurations. In particular, it's the minimum of the two majority
+// configs.
+func TestComputeQSEJointConfig(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts := func(ts int64) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: ts,
+		}
+	}
+
+	testCases := []struct {
+		cfg1    []pb.PeerID
+		cfg2    []pb.PeerID
+		support map[pb.PeerID]hlc.Timestamp
+		expQSE  hlc.Timestamp
+	}{
+		{
+			cfg1:    []pb.PeerID{1, 2, 3},
+			cfg2:    []pb.PeerID{},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15)},
+			expQSE:  ts(15), // cfg2 is empty, should behave like the (cfg1) majority config case
+		},
+		{
+			cfg1:    []pb.PeerID{},
+			cfg2:    []pb.PeerID{1, 2, 3},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15)},
+			expQSE:  ts(15), // cfg1 is empty, should behave like the (cfg2) majority config case
+		},
+		{
+			cfg1:    []pb.PeerID{3, 4, 5},
+			cfg2:    []pb.PeerID{1, 2, 3},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15), 4: ts(20), 5: ts(25)},
+			expQSE:  ts(15), // lower of the two
+		},
+		{
+			cfg1:    []pb.PeerID{3, 4, 5},
+			cfg2:    []pb.PeerID{1, 2, 3},
+			support: map[pb.PeerID]hlc.Timestamp{1: ts(10), 2: ts(20), 3: ts(15), 4: ts(10), 5: ts(10)},
+			expQSE:  ts(10), // lower of the two; this time, cfg2 has the lower qse
+		},
+	}
+
+	for _, tc := range testCases {
+		j := JointConfig{
+			MajorityConfig{},
+			MajorityConfig{},
+		}
+		for _, id := range tc.cfg1 {
+			j[0][id] = struct{}{}
+		}
+		for _, id := range tc.cfg2 {
+			j[1][id] = struct{}{}
+		}
+
+		require.Equal(t, tc.expQSE, j.LeadSupportExpiration(tc.support))
+	}
+}

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 )
 
@@ -375,4 +376,13 @@ func (m ProgressMap) String() string {
 		fmt.Fprintf(&buf, "%d: %s\n", id, m[id])
 	}
 	return buf.String()
+}
+
+// Get implements the ComparableMap interface.
+func (m ProgressMap) Get(id pb.PeerID) (quorum.Index, bool) {
+	pr, ok := m[id]
+	if !ok {
+		return 0, false
+	}
+	return quorum.Index(pr.Match), true
 }

--- a/pkg/raft/tracker/progresstracker.go
+++ b/pkg/raft/tracker/progresstracker.go
@@ -65,23 +65,10 @@ func (p *ProgressTracker) TestingSetProgress(id pb.PeerID, progress *Progress) {
 	p.progress[id] = progress
 }
 
-type matchAckIndexer map[pb.PeerID]*Progress
-
-var _ quorum.AckedIndexer = matchAckIndexer(nil)
-
-// AckedIndex implements AckedIndexer interface.
-func (l matchAckIndexer) AckedIndex(id pb.PeerID) (quorum.Index, bool) {
-	pr, ok := l[id]
-	if !ok {
-		return 0, false
-	}
-	return quorum.Index(pr.Match), true
-}
-
 // Committed returns the largest log index known to be committed based on what
 // the voting members of the group have acknowledged.
 func (p *ProgressTracker) Committed() uint64 {
-	return uint64(p.config.Voters.CommittedIndex(matchAckIndexer(p.progress)))
+	return uint64(p.config.Voters.CommittedIndex(p.progress))
 }
 
 // Visit invokes the supplied closure for all tracked progresses in stable order.


### PR DESCRIPTION
This patch adds the concept of QSE to {Majority,Joint}Config. For a majority config, the QSE is defined as the leader's maximum supported store liveness expiration across all quorums, where the value for each quorum is the minimum across all replicas, from the perspective of an oracle. For joint configurations, the QSE is the minimum across both its LHS and RHS.

Closes https://github.com/cockroachdb/cockroach/issues/125263

Release note: None