### PR TITLE
kvserver: add MsgBeat.Match into RaftHeartbeat

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -36,9 +36,11 @@ message RaftHeartbeat {
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID"];
   uint64 term = 4 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftTerm"];
   uint64 commit = 5 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftIndex"];
+  uint64 match = 11 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftIndex"];
   bool quiesce = 6;
   reserved 7;
   repeated kv.kvserver.liveness.livenesspb.Liveness lagging_followers_on_quiesce = 8 [(gogoproto.nullable) = false];
+  reserved 9;
   // This field helps migrate in the lagging_followers_on_quiesce field. For
   // messages sent by versions of Cockroach that do not know about the
   // lagging_followers_on_quiesce field (i.e. v20.1), we need to assume that all

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1583,6 +1583,7 @@ func (r *Replica) maybeCoalesceHeartbeat(
 		FromReplicaID:                     fromReplica.ReplicaID,
 		Term:                              kvpb.RaftTerm(msg.Term),
 		Commit:                            kvpb.RaftIndex(msg.Commit),
+		Match:                             kvpb.RaftIndex(msg.Match),
 		Quiesce:                           quiesce,
 		LaggingFollowersOnQuiesce:         lagging,
 		LaggingFollowersOnQuiesceAccurate: quiesce,

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -244,6 +244,7 @@ func (s *Store) uncoalesceBeats(
 			To:     raftpb.PeerID(beat.ToReplicaID),
 			Term:   uint64(beat.Term),
 			Commit: uint64(beat.Commit),
+			Match:  uint64(beat.Match),
 		}
 		beatReqs[i] = kvserverpb.RaftMessageRequest{
 			RangeID: beat.RangeID,


### PR DESCRIPTION
This PR puts the raft `MsgBeat.Match` index into `RaftHeartbeat`. Previously, it was not delivered to the recepient.

Related to #124225
Fixes #127350