### PR TITLE
opt: use `Relational.SetAvailable` method in multiplicity builder

### DIFF
--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -81,7 +81,7 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 	if relational.IsAvailable(props.UnfilteredCols) {
 		return relational.Rule.UnfilteredCols
 	}
-	relational.Rule.Available |= props.UnfilteredCols
+	relational.SetAvailable(props.UnfilteredCols)
 	unfilteredCols := opt.ColSet{}
 
 	// Derive UnfilteredCols now.


### PR DESCRIPTION
In all but one case where `Relational.Rule` properties are set, the
`Relational.SetAvailable` method is used, rather than mutating
`Rule.Available` directly. This commit updates that one case to use the
method so that it is consistent with the others.

Epic: None

Release note: None
