### PR TITLE
raft: proactively break dependency cycle

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -445,7 +445,6 @@ go_test(
         "//pkg/raft/confchange",
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
-        "//pkg/raft/raftstoreliveness",
         "//pkg/raft/tracker",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/kv/kvserver/below_raft_protos_test.go
+++ b/pkg/kv/kvserver/below_raft_protos_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
-	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -56,7 +55,7 @@ func TestBelowRaftProtosDontChange(t *testing.T) {
 				Vote      raftpb.PeerID
 				Commit    uint64
 				Lead      raftpb.PeerID
-				LeadEpoch raftstoreliveness.Epoch
+				LeadEpoch raftpb.Epoch
 			}
 			// Conversion fails if new fields are added to `HardState`, in which case this method
 			// and the expected sums should be updated.
@@ -68,7 +67,7 @@ func TestBelowRaftProtosDontChange(t *testing.T) {
 				Vote:      raftpb.PeerID(n % 7),
 				Commit:    n % 11,
 				Lead:      raftpb.PeerID(n % 13),
-				LeadEpoch: raftstoreliveness.Epoch(n % 17),
+				LeadEpoch: raftpb.Epoch(n % 17),
 			}
 		},
 		func(r *rand.Rand) protoutil.Message {

--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
     deps = [
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
-        "//pkg/raft/raftstoreliveness",
         "//pkg/raft/rafttest",
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -354,7 +354,7 @@ type raft struct {
 	// the leader id
 	lead pb.PeerID
 	// TODO(arul): This should be populated when responding to a MsgFortify.
-	leadEpoch raftstoreliveness.Epoch
+	leadEpoch pb.Epoch
 	// leadTransferee is id of the leader transfer target when its value is not zero.
 	// Follow the procedure defined in raft thesis 3.10.
 	leadTransferee pb.PeerID

--- a/pkg/raft/raftpb/BUILD.bazel
+++ b/pkg/raft/raftpb/BUILD.bazel
@@ -17,7 +17,6 @@ go_proto_library(
     proto = ":raftpb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/raft/raftstoreliveness",  #keep
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )

--- a/pkg/raft/raftpb/raft.go
+++ b/pkg/raft/raftpb/raft.go
@@ -15,3 +15,10 @@ type PeerID uint64
 
 // SafeValue implements the redact.SafeValue interface.
 func (p PeerID) SafeValue() {}
+
+// Epoch is an epoch in the Store Liveness fabric, referencing an uninterrupted
+// period of support from one store to another.
+type Epoch int64
+
+// SafeValue implements the redact.SafeValue interface.
+func (e Epoch) SafeValue() {}

--- a/pkg/raft/raftpb/raft.proto
+++ b/pkg/raft/raftpb/raft.proto
@@ -89,8 +89,7 @@ message Message {
   repeated Entry       entries     = 7  [(gogoproto.nullable) = false];
   optional uint64      commit      = 8  [(gogoproto.nullable) = false];
   optional uint64      lead        = 16 [(gogoproto.nullable) = false, (gogoproto.casttype) = "PeerID"];
-  optional uint64      leadEpoch   = 17 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness.Epoch"];
+  optional uint64      leadEpoch   = 17 [(gogoproto.nullable) = false, (gogoproto.casttype) = "Epoch"];
   // (type=MsgStorageAppend,vote=5,term=10) means the local node is voting for
   // peer 5 in term 10. For MsgStorageAppends, the term, vote, lead, leadEpoch,
   // and commit fields will either all be set (to facilitate the construction of
@@ -131,8 +130,7 @@ message HardState {
   optional uint64 vote         = 2 [(gogoproto.nullable) = false, (gogoproto.casttype) = "PeerID"];
   optional uint64 commit       = 3 [(gogoproto.nullable) = false];
   optional uint64 lead         = 4 [(gogoproto.nullable) = false, (gogoproto.casttype) = "PeerID"];
-  optional uint64 lead_epoch   = 5 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness.Epoch"];
+  optional uint64 lead_epoch   = 5 [(gogoproto.nullable) = false, (gogoproto.casttype) = "Epoch"];
 }
 
 // ConfChangeTransition specifies the behavior of a configuration change with

--- a/pkg/raft/raftstoreliveness/BUILD.bazel
+++ b/pkg/raft/raftstoreliveness/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["store_liveness.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util/hlc"],
+    deps = [
+        "//pkg/raft/raftpb",
+        "//pkg/util/hlc",
+    ],
 )

--- a/pkg/raft/raftstoreliveness/store_liveness.go
+++ b/pkg/raft/raftstoreliveness/store_liveness.go
@@ -10,16 +10,14 @@
 
 package raftstoreliveness
 
-import "github.com/cockroachdb/cockroach/pkg/util/hlc"
-
-// Epoch is an epoch in the Store Liveness fabric, referencing an uninterrupted
-// period of support from one store to another.
-type Epoch int64
+import (
+	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
 
 // StoreLiveness is a representation of the Store Liveness fabric. It provides
 // information about uninterrupted periods of "support" between stores.
 type StoreLiveness interface {
-
 	// SupportFor returns the epoch of the current uninterrupted period of Store
 	// Liveness support for the specified replica's remote store (S_remote) from
 	// the local replica's store (S_local), and a boolean indicating whether
@@ -36,7 +34,7 @@ type StoreLiveness interface {
 	// If S_local cannot map the replica ID to a store ID, false will be returned.
 	// It is therefore important to ensure that the replica ID to store ID mapping
 	// is not lost during periods of support.
-	SupportFor(id uint64) (Epoch, bool)
+	SupportFor(id pb.PeerID) (pb.Epoch, bool)
 
 	// SupportFrom returns the epoch of the current uninterrupted period of Store
 	// Liveness support from the specified replica's remote store (S_remote) for
@@ -53,7 +51,7 @@ type StoreLiveness interface {
 	// providing.
 	//
 	// If S_local cannot map the replica ID to a store ID, false will be returned.
-	SupportFrom(id uint64) (Epoch, hlc.Timestamp, bool)
+	SupportFrom(id pb.PeerID) (pb.Epoch, hlc.Timestamp, bool)
 
 	// SupportFromEnabled returns whether StoreLiveness is currently active, and
 	// callers can rely on getting support from peers by calling SupportFrom.

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
-	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -634,7 +633,7 @@ func TestRawNodeRestart(t *testing.T) {
 	assert.Equal(t, uint64(1), rawNode.raft.raftLog.committed)
 	assert.Equal(t, pb.PeerID(1), rawNode.raft.lead)
 	assert.True(t, rawNode.raft.state == StateFollower)
-	assert.Equal(t, raftstoreliveness.Epoch(1), rawNode.raft.leadEpoch)
+	assert.Equal(t, pb.Epoch(1), rawNode.raft.leadEpoch)
 
 	// Ensure we campaign after the election timeout has elapsed.
 	for i := 0; i < rawNode.raft.randomizedElectionTimeout; i++ {

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -141,6 +141,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					},
 					"github.com/cockroachdb/cockroach/pkg/raft/raftpb": {
 						"PeerID": {},
+						"Epoch":  {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/repstream/streampb": {
 						"StreamID": {},


### PR DESCRIPTION
Once StoreLiveness started accepting raftpb.PeerIDs instead of raw uint64s, we would've created a dependency cycle, because raftpb needed storeliveness.Epochs. Proactively break this by moving Epoch into raftpb.

Epic: none

Release note: None