### PR TITLE
roachtest: mixedversion updates to support multiple clusters

### DIFF
--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -81,10 +81,15 @@ func StartVirtualClusterOpts(name string, nodes NodeListOption, opts ...StartSto
 
 // DefaultStartSharedVirtualClusterOpts returns StartOpts for starting a shared
 // process virtual cluster with the given name.
-func StartSharedVirtualClusterOpts(name string) StartOpts {
+func StartSharedVirtualClusterOpts(name string, opts ...StartStopOption) StartOpts {
 	startOpts := DefaultStartOpts()
 	startOpts.RoachprodOpts.Target = install.StartSharedProcessForVirtualCluster
 	startOpts.RoachprodOpts.VirtualClusterName = name
+
+	for _, opt := range opts {
+		opt(&startOpts)
+	}
+
 	return startOpts
 }
 
@@ -154,6 +159,19 @@ func SkipInit(opts interface{}) {
 	switch opts := opts.(type) {
 	case *StartOpts:
 		opts.RoachprodOpts.SkipInit = true
+	}
+}
+
+// WithInitTarget allows the caller to configure which node is used as
+// `InitTarget` when starting cockroach. Specially useful when
+// starting clusters in a subset of VMs in the cluster that doesn't
+// include the default init target (node 1).
+func WithInitTarget(node int) StartStopOption {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StartOpts:
+			opts.RoachprodOpts.InitTarget = node
+		}
 	}
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -287,10 +287,10 @@ func InstallFixtures(
 	name := CheckpointName(
 		roachpb.Version{Major: int32(v.Major()), Minor: int32(v.Minor())}.String(),
 	)
-	for _, n := range nodes {
+	for n := 1; n <= len(nodes); n++ {
 		if err := c.PutE(ctx, l,
 			"pkg/cmd/roachtest/fixtures/"+strconv.Itoa(n)+"/"+name+".tgz",
-			"{store-dir}/fixture.tgz", c.Node(n),
+			"{store-dir}/fixture.tgz", c.Node(nodes[n-1]),
 		); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
@@ -12,6 +12,7 @@ package mixedversion
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
@@ -171,6 +172,7 @@ func newContext(
 	tenant *ServiceDescriptor,
 ) *Context {
 	makeContext := func(name string, nodes option.NodeListOption) *ServiceContext {
+		sort.Ints(nodes)
 		return &ServiceContext{
 			Descriptor: &ServiceDescriptor{
 				Name:  name,

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -471,9 +471,10 @@ func (p *testPlanner) systemSetupSteps() []testStep {
 	setupContext := p.nonUpgradeContext(initialVersion, SystemSetupStage)
 	return append(steps,
 		p.newSingleStepWithContext(setupContext, startStep{
-			version:  initialVersion,
-			rt:       p.rt,
-			settings: p.clusterSettingsForSystem(),
+			version:    initialVersion,
+			rt:         p.rt,
+			initTarget: p.currentContext.System.Descriptor.Nodes[0],
+			settings:   p.clusterSettingsForSystem(),
 		}),
 		p.newSingleStepWithContext(setupContext, waitForStableClusterVersionStep{
 			nodes:              p.currentContext.System.Descriptor.Nodes,
@@ -498,8 +499,9 @@ func (p *testPlanner) tenantSetupSteps(v *clusterupgrade.Version) []testStep {
 	// necessary.
 	steps := []testStep{
 		p.newSingleStepWithContext(setupContext, startSharedProcessVirtualClusterStep{
-			name:     p.tenantName(),
-			settings: p.clusterSettingsForTenant(),
+			name:       p.tenantName(),
+			initTarget: p.currentContext.Tenant.Descriptor.Nodes[0],
+			settings:   p.clusterSettingsForTenant(),
 		}),
 		p.newSingleStepWithContext(setupContext, waitForStableClusterVersionStep{
 			nodes:              p.currentContext.Tenant.Descriptor.Nodes,
@@ -646,8 +648,12 @@ func (p *testPlanner) changeVersionSteps(
 	for j, node := range previousVersionNodes {
 		steps = append(steps, p.newSingleStep(
 			restartWithNewBinaryStep{
-				version: to, node: node, rt: p.rt, settings: p.clusterSettingsForSystem(),
+				version:              to,
+				node:                 node,
+				rt:                   p.rt,
+				settings:             p.clusterSettingsForSystem(),
 				sharedProcessStarted: virtualClusterSetup,
+				initTarget:           p.currentContext.System.Descriptor.Nodes[0],
 			},
 		))
 		for _, s := range p.services() {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -16,7 +16,6 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
@@ -100,7 +99,7 @@ type (
 
 		connCache struct {
 			mu    syncutil.Mutex
-			cache []*gosql.DB
+			cache map[int]*gosql.DB
 		}
 	}
 
@@ -108,6 +107,7 @@ type (
 		ctx           context.Context
 		cancel        context.CancelFunc
 		plan          *TestPlan
+		tag           string
 		cluster       cluster.Cluster
 		systemService *serviceRuntime
 		tenantService *serviceRuntime
@@ -153,6 +153,7 @@ func newTestRunner(
 	ctx context.Context,
 	cancel context.CancelFunc,
 	plan *TestPlan,
+	tag string,
 	l *logger.Logger,
 	c cluster.Cluster,
 ) *testRunner {
@@ -177,6 +178,7 @@ func newTestRunner(
 		ctx:           ctx,
 		cancel:        cancel,
 		plan:          plan,
+		tag:           tag,
 		logger:        l,
 		systemService: systemService,
 		tenantService: tenantService,
@@ -499,7 +501,7 @@ func (tr *testRunner) logVersions(l *logger.Logger, testContext Context) {
 		return
 	}
 
-	tw := newTableWriter(len(releasedVersions))
+	tw := newTableWriter(testContext.System.Descriptor.Nodes)
 	tw.AddRow("released versions", toString(releasedVersions)...)
 	tw.AddRow("logical binary versions", toString(binaryVersions)...)
 
@@ -521,9 +523,11 @@ func (tr *testRunner) logVersions(l *logger.Logger, testContext Context) {
 func (tr *testRunner) loggerFor(step *singleStep) (*logger.Logger, error) {
 	name := invalidChars.ReplaceAllString(strings.ToLower(step.impl.Description()), "")
 	name = fmt.Sprintf("%d_%s", step.ID, name)
+	prefix := filepath.Join(tr.tag, logPrefix, name)
 
-	prefix := path.Join(logPrefix, name)
-	return prefixedLogger(tr.logger, prefix)
+	// Use the root logger here as the `prefix` passed will already
+	// include the full path from the root, including the tag.
+	return prefixedLogger(tr.logger.RootLogger(), prefix)
 }
 
 // refreshBinaryVersions updates the `binaryVersions` field for every
@@ -602,7 +606,7 @@ func (tr *testRunner) maybeInitConnections(service *serviceRuntime) error {
 		return nil
 	}
 
-	cc := make([]*gosql.DB, len(service.descriptor.Nodes))
+	cc := map[int]*gosql.DB{}
 	for _, node := range service.descriptor.Nodes {
 		conn, err := tr.cluster.ConnE(
 			tr.ctx, tr.logger, node, option.VirtualClusterName(service.descriptor.Name),
@@ -611,7 +615,7 @@ func (tr *testRunner) maybeInitConnections(service *serviceRuntime) error {
 			return fmt.Errorf("failed to connect to node %d: %w", node, err)
 		}
 
-		cc[node-1] = conn
+		cc[node] = conn
 	}
 
 	service.connCache.cache = cc
@@ -677,7 +681,7 @@ func (tr *testRunner) conn(node int, virtualClusterName string) *gosql.DB {
 
 	service.connCache.mu.Lock()
 	defer service.connCache.mu.Unlock()
-	return service.connCache.cache[node-1]
+	return service.connCache.cache[node]
 }
 
 func (tr *testRunner) closeConnections() {
@@ -829,8 +833,7 @@ func (tfd *testFailureDetails) Format() string {
 		fmt.Sprintf("test random seed: %d\n", tfd.seed),
 	}
 
-	numNodes := len(tfd.systemService.descriptor.Nodes)
-	tw := newTableWriter(numNodes)
+	tw := newTableWriter(tfd.systemService.descriptor.Nodes)
 	if tfd.testContext != nil {
 		releasedVersions := make([]*clusterupgrade.Version, 0, len(tfd.testContext.System.Descriptor.Nodes))
 		for _, node := range tfd.testContext.System.Descriptor.Nodes {
@@ -873,8 +876,8 @@ type tableWriter struct {
 }
 
 // newTableWriter creates a tableWriter to display tabular data for
-// the given number of nodes.
-func newTableWriter(numNodes int) *tableWriter {
+// the nodes passed as parameter.
+func newTableWriter(nodes option.NodeListOption) *tableWriter {
 	var buffer bytes.Buffer
 	const (
 		minWidth = 3
@@ -888,8 +891,8 @@ func newTableWriter(numNodes int) *tableWriter {
 	writer := &tableWriter{buffer: &buffer, w: tw}
 
 	var nodeValues []string
-	for j := 1; j <= numNodes; j++ {
-		nodeValues = append(nodeValues, fmt.Sprintf("n%d", j))
+	for _, n := range nodes {
+		nodeValues = append(nodeValues, fmt.Sprintf("n%d", n))
 	}
 
 	writer.AddRow("", nodeValues...)
@@ -914,7 +917,7 @@ func renameFailedLogger(l *logger.Logger) error {
 	}
 
 	currentFileName := l.File.Name()
-	newLogName := path.Join(
+	newLogName := filepath.Join(
 		filepath.Dir(currentFileName),
 		"FAILED_"+filepath.Base(currentFileName),
 	)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -51,9 +51,10 @@ func (s installFixturesStep) Run(
 // startStep is the step that starts the cluster from a specific
 // `version`.
 type startStep struct {
-	rt       test.Test
-	version  *clusterupgrade.Version
-	settings []install.ClusterSettingOption
+	rt         test.Test
+	version    *clusterupgrade.Version
+	initTarget int
+	settings   []install.ClusterSettingOption
 }
 
 func (s startStep) Background() shouldStop { return nil }
@@ -77,8 +78,10 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, _ *rand.Rand, h *H
 		append([]install.ClusterSettingOption{}, s.settings...),
 		install.BinaryOption(binaryPath),
 	)
+
+	opts := startOpts(option.WithInitTarget(s.initTarget))
 	return clusterupgrade.StartWithSettings(
-		ctx, l, h.runner.cluster, systemNodes, startOpts(), clusterSettings...,
+		ctx, l, h.runner.cluster, systemNodes, opts, clusterSettings...,
 	)
 }
 
@@ -86,8 +89,9 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, _ *rand.Rand, h *H
 // virtual cluster with the given name, and starts it. At the end of
 // this step, the virtual cluster should be ready to receive requests.
 type startSharedProcessVirtualClusterStep struct {
-	name     string
-	settings []install.ClusterSettingOption
+	name       string
+	initTarget int
+	settings   []install.ClusterSettingOption
 }
 
 func (s startSharedProcessVirtualClusterStep) Background() shouldStop { return nil }
@@ -100,7 +104,7 @@ func (s startSharedProcessVirtualClusterStep) Run(
 	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
 ) error {
 	l.Printf("starting shared process virtual cluster %s", s.name)
-	startOpts := option.StartSharedVirtualClusterOpts(s.name)
+	startOpts := option.StartSharedVirtualClusterOpts(s.name, option.WithInitTarget(s.initTarget))
 
 	if err := h.runner.cluster.StartServiceForVirtualClusterE(
 		ctx, l, startOpts, install.MakeClusterSettings(s.settings...),
@@ -181,6 +185,7 @@ type restartWithNewBinaryStep struct {
 	rt                   test.Test
 	node                 int
 	settings             []install.ClusterSettingOption
+	initTarget           int
 	sharedProcessStarted bool
 }
 
@@ -200,7 +205,7 @@ func (s restartWithNewBinaryStep) Run(
 		l,
 		h.runner.cluster,
 		h.runner.cluster.Node(s.node),
-		startOpts(),
+		startOpts(option.WithInitTarget(s.initTarget)),
 		s.version,
 		s.settings...,
 	); err != nil {
@@ -507,6 +512,8 @@ func quoteVersionForPresentation(v string) string {
 // scheduled backup may make things non-deterministic. In the future,
 // we should change the default and add an API for tests to opt-out of
 // the default scheduled backup if necessary.
-func startOpts() option.StartOpts {
-	return option.NewStartOpts(option.NoBackupSchedule)
+func startOpts(opts ...option.StartStopOption) option.StartOpts {
+	return option.NewStartOpts(
+		append([]option.StartStopOption{option.NoBackupSchedule}, opts...)...,
+	)
 }


### PR DESCRIPTION
In this commit, we make a few changes to the `mixedversion` framework in order to support:

* running a mixedversion test for a cluster deployed in an arbitrary subset of nodes
* running multiple mixedversion tests concurrently.

For the first point, we fix a few locations where we assumed node 1 was part of the cluster. For the second point, we add support for adding tags to a test instance, making it easier to distinguish and isolate the output of two concurrent upgrades in a test.

This is in support of features that involve multiple clusters, such as PCR and LDR.

Epic: none

Release note: None