### PR TITLE
release-23.1: sql,server: avoid conn routing memory leak with invalid virtual cluster name

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2114,6 +2114,7 @@ func (s *Server) AcceptInternalClients(ctx context.Context) error {
 					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 					return
 				}
+				defer status.ReleaseMemory(ctx)
 
 				if err := s.serverController.sqlMux(connCtx, conn, status); err != nil {
 					log.Ops.Errorf(connCtx, "serving internal SQL client conn: %s", err)

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -15,9 +15,11 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +71,7 @@ func TestSQLErrorUponInvalidTenant(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		DisableDefaultTestTenant: true,
 	})
 	defer s.Stopper().Stop(ctx)
@@ -82,4 +84,17 @@ func TestSQLErrorUponInvalidTenant(t *testing.T) {
 
 	err = db.Ping()
 	require.Regexp(t, `service unavailable for target tenant \(nonexistent\)`, err.Error())
+
+	// Regression test for CRDB-40449; make sure pre-conn memory is freed.
+	testutils.SucceedsSoon(t, func() error {
+		var usedPreConnMemory int
+		err = sqlDB.QueryRow("select used from crdb_internal.node_memory_monitors where name='pre-conn'").Scan(&usedPreConnMemory)
+		if err != nil {
+			return err
+		}
+		if usedPreConnMemory != 0 {
+			return errors.Errorf("expected 0 bytes used, got %d", usedPreConnMemory)
+		}
+		return nil
+	})
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1776,6 +1776,7 @@ func startServeSQL(
 					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 					return
 				}
+				defer status.ReleaseMemory(ctx)
 
 				if err := serveConn(connCtx, conn, status); err != nil {
 					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
@@ -1833,6 +1834,7 @@ func startServeSQL(
 						log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 						return
 					}
+					defer status.ReleaseMemory(ctx)
 
 					if err := serveConn(connCtx, conn, status); err != nil {
 						log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -900,6 +900,7 @@ func (s *SQLServerWrapper) AcceptInternalClients(ctx context.Context) error {
 					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
 					return
 				}
+				defer status.ReleaseMemory(ctx)
 
 				if err := s.serveConn(connCtx, conn, status); err != nil {
 					log.Ops.Errorf(connCtx, "serving internal SQL client conn: %s", err)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -899,11 +899,11 @@ func (h ConnectionHandler) GetQueryCancelKey() pgwirecancel.BackendKeyData {
 func (s *Server) ServeConn(
 	ctx context.Context, h ConnectionHandler, reserved *mon.BoundAccount, cancel context.CancelFunc,
 ) error {
-	// Make sure to close the reserved account even if closeWrapper below
+	// Make sure to clear the reserved account even if closeWrapper below
 	// panics: so we do it in a defer that is guaranteed to execute. We also
-	// cannot close it before closeWrapper since we need to close the internal
+	// cannot clear it before closeWrapper since we need to close the internal
 	// monitors of the connExecutor first.
-	defer reserved.Close(ctx)
+	defer reserved.Clear(ctx)
 	defer func(ctx context.Context, h ConnectionHandler) {
 		r := recover()
 		h.ex.closeWrapper(ctx, r)

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -224,7 +224,7 @@ func (c *conn) processCommandsAsync(
 		defer func() {
 			// Release resources, if we still own them.
 			if reservedOwned {
-				reserved.Close(ctx)
+				reserved.Clear(ctx)
 			}
 			// Notify the connection's goroutine that we're terminating. The
 			// connection might know already, as it might have triggered this

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -798,14 +798,12 @@ func (s *Server) ServeConn(
 
 	sArgs, err := finalizeClientParameters(ctx, preServeStatus.clientParameters, &st.SV)
 	if err != nil {
-		preServeStatus.Reserved.Close(ctx)
 		return s.sendErr(ctx, st, conn, err)
 	}
 
 	// Transfer the memory account into this tenant.
-	tenantReserved, err := s.tenantSpecificConnMonitor.TransferAccount(ctx, &preServeStatus.Reserved)
+	tenantReserved, err := s.tenantSpecificConnMonitor.TransferAccount(ctx, preServeStatus.Reserved)
 	if err != nil {
-		preServeStatus.Reserved.Close(ctx)
 		return s.sendErr(ctx, st, conn, err)
 	}
 
@@ -1035,7 +1033,7 @@ func (s *Server) serveImpl(
 	} else {
 		// sqlServer == nil means we are in a local test. In this case
 		// we only need the minimum to make pgx happy.
-		defer reserved.Close(ctx)
+		defer reserved.Clear(ctx)
 		var err error
 		for param, value := range testingStatusReportParams {
 			err = c.bufferParamStatus(param, value)

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -774,7 +774,7 @@ func (mm *BytesMonitor) TransferAccount(
 	if err = b.Grow(ctx, origAccount.used); err != nil {
 		return newAccount, err
 	}
-	origAccount.Close(ctx)
+	origAccount.Clear(ctx)
 	return b, nil
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #127846.

/cc @cockroachdb/release

Release justification: bug fix

---

This patch addresses a memory leak by using `defer` to unconditionally free the memory of the pre-conn bound account. Previously, extreme care was needed to release the memory in every possible error condition that could arise in between creating the pre-conn account and transfering the memory to the tenant-specific account.

In this case, the area of the code that did not release the memory upon error is the code that handles the case where there is no virtual cluster with the specified name: https://github.com/cockroachdb/cockroach/blob/25232a68fd77bb6f517b39864a8605205864ee99/pkg/server/server_controller_sql.go#L78-L94

Now, the memory will always be freed. Since it is an error to call Close twice on the same memory account, these calls were changed to use Clear instead. (Clear will be called when the memory is successfully transferred to the new account, and also when the connection serving goroutine ends.)

fixes CRDB-40449
Epic: None
Release note (bug fix): Fixed a memory leak that could occur when specifying a non-existent virtual cluster name in the connection string.
