### PR TITLE
backupccl: always close SSTWriter

### DIFF
--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -100,6 +100,7 @@ func (s *fileSSTSink) Close() error {
 	if s.out != nil {
 		return s.out.Close()
 	}
+	s.sst.Close()
 	return nil
 }
 


### PR DESCRIPTION
Since e839e603b60aae5260782181ad5f196e52ced09a it is possible that in certain error conditions we exit (*fileSSTSink).flushFile with an error before closing the SSTWriter.  While we always conditionally call (*fileSSTSink).Close, close did not close the SSTWriter.

Now, we always close the SSTWriter. This is a speculative fix for

Fixes #127813
Epic: none