### PR TITLE
workload/schemachange: fix constraintIsPrimary name escaping

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1791,15 +1791,16 @@ func (og *operationGenerator) dropConstraint(ctx context.Context, tx pgx.Tx) (*o
 		stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
 	}
 
-	constraintBeingDropped, err := og.constraintInDroppingState(ctx, tx, tableName, constraintName)
+	constraintAddingOrDropping, err := og.constraintInAddOrDropState(ctx, tx, tableName, constraintName)
 	if err != nil {
 		return nil, err
 	}
-	if constraintBeingDropped {
+	if constraintAddingOrDropping {
 		stmt.expectedExecErrors.add(pgcode.FeatureNotSupported)
+		stmt.potentialExecErrors.add(pgcode.UndefinedObject)
 	}
 
-	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP CONSTRAINT "%s"`, tableName, constraintName)
+	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP CONSTRAINT %s`, tableName.String(), lexbase.EscapeSQLIdent(constraintName))
 	return stmt, nil
 }
 

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -273,7 +273,7 @@ var opWeights = []int{
 	alterTableAlterPrimaryKey:         1,
 	alterTableDropColumn:              0, // Disabled and tracked with #127286.
 	alterTableDropColumnDefault:       1,
-	alterTableDropConstraint:          0, // Disabled and tracked with #127273.
+	alterTableDropConstraint:          1,
 	alterTableDropNotNull:             1,
 	alterTableDropStored:              1,
 	alterTableLocality:                1,


### PR DESCRIPTION
Using a placeholder argument for the SQL string makes it so any escaping
that is needed is automatically handled in the database when the
argument is parsed, rather than needing to do it in the workload code.

This also fixes the constraintIsDropping check to also check if the
constraint is being added. Dropping the constraint in either states
is not fully supported, as per:
https://github.com/cockroachdb/cockroach/blob/a3b0aa3902155b01470c4c512d23f201c8b18f7c/pkg/sql/catalog/tabledesc/structured.go#L1271-L1278

Finally, when creaing the DROP CONSTRAINT command itself, the constraint
name needs to be treated as an identifier so it gets double-quoted.

fixes https://github.com/cockroachdb/cockroach/issues/127273
Release note: None