### PR TITLE
workload/schemachange: enable drop column support

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -142,6 +142,9 @@ func (og *operationGenerator) columnIsDependedOn(
 	// stored as a list of numbers in a string, so SQL functions are used to parse these values
 	// into arrays. unnest is used to flatten rows with this column of array type into multiple rows,
 	// so performing unions and joins is easier.
+	//
+	// To check if any foreign key references exist to this table, we use pg_constraint
+	// and check if any columns are dependent.
 	return og.scanBool(ctx, tx, `SELECT EXISTS(
 		SELECT source.column_id
 			FROM (
@@ -178,7 +181,51 @@ func (og *operationGenerator) columnIsDependedOn(
 			      AND table_name = $3
 			      AND column_name = $4
 			  ) AS source ON source.column_id = cons.column_id
-)`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
+)
+OR EXISTS(
+	-- Check for foreign key references
+	SELECT
+		(
+			SELECT
+				r.relname
+			FROM
+				pg_class AS r
+			WHERE
+				r.oid = c.confrelid
+		)
+			AS base_table,
+		a.attname AS base_col,
+		(
+			SELECT
+				r.relname
+			FROM
+				pg_class AS r
+			WHERE
+				r.oid = c.conrelid
+		)
+			AS referencing_table,
+		unnest(
+			(
+				SELECT
+					array_agg(attname)
+				FROM
+					pg_attribute
+				WHERE
+					attrelid = c.conrelid
+					AND ARRAY[attnum] <@ c.conkey
+			)
+		)
+			AS referencing_col
+	FROM
+		pg_constraint AS c
+		JOIN pg_attribute AS a ON
+				c.confrelid = a.attrelid
+				AND a.attnum = ANY (confkey)
+	WHERE
+		c.confrelid = $1::REGCLASS::OID
+		AND c.confrelid != c.conrelid
+)
+`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
 }
 
 // colIsRefByComputed determines if a column is referenced by a computed column.

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -271,7 +271,7 @@ var opWeights = []int{
 	alterTableAddConstraintUnique:     0,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
 	alterTableAlterPrimaryKey:         1,
-	alterTableDropColumn:              0, // Disabled and tracked with #127286.
+	alterTableDropColumn:              1, // Disabled and tracked with #127286.
 	alterTableDropColumnDefault:       1,
 	alterTableDropConstraint:          0, // Disabled and tracked with #127273.
 	alterTableDropNotNull:             1,


### PR DESCRIPTION
Previously, drop column support was disabled because we did not properly detect if a column was referenced by foreign keys. This patch adds logic to detect if a column is in use by a foreign key.

Fixes: #127286

Release note: None