### PR TITLE
colexec: fix projections with constant NULL values

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1039,4 +1039,18 @@ LEFT JOIN LATERAL (
 row-1  row-1  {row-1}  1
 row-2  row-2  {row-2}  1
 
-subtest end
+# Regression test for #127814. The vectorized engine should correctly project
+# expressions operating on NULL.
+statement ok
+CREATE TABLE t127814_empty (i INT)
+
+statement ok
+CREATE TABLE t127814 (o OID)
+
+statement ok
+INSERT INTO t127814 VALUES (0)
+
+query B
+SELECT o NOT IN ((SELECT NULL FROM t127814_empty),) FROM t127814
+----
+NULL


### PR DESCRIPTION
This commit fixes a bug in the vectorized engine that caused incorrect
results when projections operated on constant NULL values. The
`proj_const_right_ops` operators do not correctly handle NULL inputs.
So, we avoid these code paths when operator does not operate on NULL
values and the RHS of an operator is NULL by simply projecting NULLs.

Fixes #127814

Release note (bug fix): A bug has been fixed that could cause incorrect
evaluation of scalar expressions involving `NULL` values in rare cases.
