### PR TITLE
bazel: never strip output binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,7 +47,7 @@ build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
-build:dev --strip=never
+build --strip=never
 common --experimental_allow_tags_propagation
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build --ui_event_filters=-DEBUG


### PR DESCRIPTION
To date, binaries are stripped by default when building with Bazel. We skip stripping for release binaries (via `-c opt`) and if you're building with the `dev` configuration (many developers use this configuration as `dev doctor` guides you to). This has led to some confusion as these mechanisms are non-obvious, leading some to wonder why their binaries are (or are not) stripped. We simplify this by *never* stripping. Since release binaries are not stripped, they are unaffected by this change. Only developers building without the `dev` config and CI jobs that don't set `-c opt` would be affected.

Epic: CRDB-17171

Release note: None