### PR TITLE
workload/schemachange: enable drop column support

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -134,6 +134,150 @@ func (og *operationGenerator) tableHasDependencies(
 	return og.scanBool(ctx, tx, q, tableName.Object(), tableName.Schema())
 }
 
+// columnRemovalWillDropFKBackingIndexes determines if dropping this column
+// will lead to no indexes backing a foreign key.
+func (og *operationGenerator) columnRemovalWillDropFKBackingIndexes(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columName tree.Name,
+) (bool, error) {
+	return og.scanBool(ctx, tx, fmt.Sprintf(`
+WITH
+	fk
+		AS (
+			SELECT
+				oid,
+				(
+					SELECT
+						r.relname
+					FROM
+						pg_class AS r
+					WHERE
+						r.oid = c.confrelid
+				)
+					AS base_table,
+				a.attname AS base_col,
+				array_position(c.confkey, a.attnum)
+					AS base_ordinal,
+				(
+					SELECT
+						r.relname
+					FROM
+						pg_class AS r
+					WHERE
+						r.oid = c.conrelid
+				)
+					AS referencing_table,
+				unnest(
+					(
+						SELECT
+							array_agg(attname)
+						FROM
+							pg_attribute
+						WHERE
+							attrelid = c.conrelid
+							AND ARRAY[attnum] <@ c.conkey
+							AND array_position(
+									c.confkey,
+									a.attnum
+								)
+								= array_position(
+										c.conkey,
+										attnum
+									)
+					)
+				)
+					AS referencing_col
+			FROM
+				pg_constraint AS c
+				JOIN pg_attribute AS a ON
+						c.confrelid = a.attrelid
+						AND ARRAY[attnum] <@ c.confkey
+			WHERE
+				c.confrelid = $1::REGCLASS::OID
+		),
+	valid_indexes
+		AS (
+			SELECT
+				*
+			FROM
+				[SHOW INDEXES FROM %s]
+			WHERE
+				index_name
+				NOT IN (
+						SELECT
+							DISTINCT index_name
+						FROM
+							[SHOW INDEXES FROM %s]
+						WHERE
+							column_name = $2
+							AND index_name
+								!= table_name || '_pkey'
+					)
+		),
+	matching_indexes
+		AS (
+			SELECT
+				oid,
+				index_name,
+				count(base_ordinal) AS count_base_ordinal,
+				count(seq_in_index) AS count_seq_in_index
+			FROM
+				fk, valid_indexes
+			WHERE
+				storing = 'f'
+				AND non_unique = 'f'
+				AND base_col = column_name
+			GROUP BY
+				(oid, index_name)
+		),
+	valid_index_attrib_count
+		AS (
+			SELECT
+				index_name,
+				max(seq_in_index) AS max_seq_in_index
+			FROM
+				valid_indexes
+			WHERE
+				storing = 'f'
+			GROUP BY
+				index_name
+		),
+	valid_fk_count
+		AS (
+			SELECT
+				oid, max(base_ordinal) AS max_base_ordinal
+			FROM
+				fk
+			GROUP BY
+				fk
+		),
+	matching_fks
+		AS (
+			SELECT
+				DISTINCT f.oid
+			FROM
+				valid_index_attrib_count AS i,
+				valid_fk_count AS f,
+				matching_indexes AS m
+			WHERE
+				f.oid = m.oid
+				AND i.index_name = m.index_name
+				AND i.max_seq_in_index
+					= m.count_seq_in_index
+				AND f.max_base_ordinal
+					= m.count_base_ordinal
+		)
+SELECT
+	EXISTS(
+		SELECT
+			*
+		FROM
+			fk
+		WHERE
+			oid NOT IN (SELECT oid FROM matching_fks)
+	);
+`, tableName.String(), tableName.String()), tableName.String(), columName)
+}
+
 func (og *operationGenerator) columnIsDependedOn(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name,
 ) (bool, error) {
@@ -146,6 +290,9 @@ func (og *operationGenerator) columnIsDependedOn(
 	// stored as a list of numbers in a string, so SQL functions are used to parse these values
 	// into arrays. unnest is used to flatten rows with this column of array type into multiple rows,
 	// so performing unions and joins is easier.
+	//
+	// To check if any foreign key references exist to this table, we use pg_constraint
+	// and check if any columns are dependent.
 	return og.scanBool(ctx, tx, `SELECT EXISTS(
 		SELECT source.column_id
 			FROM (
@@ -182,7 +329,8 @@ func (og *operationGenerator) columnIsDependedOn(
 			      AND table_name = $3
 			      AND column_name = $4
 			  ) AS source ON source.column_id = cons.column_id
-)`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
+)
+`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
 }
 
 // colIsRefByComputed determines if a column is referenced by a computed column.
@@ -1038,7 +1186,7 @@ func (og *operationGenerator) violatesFkConstraintsHelper(
 	return og.scanBool(ctx, tx, q)
 }
 
-func (og *operationGenerator) columnIsInDroppingIndex(
+func (og *operationGenerator) columnIsInAddingOrDroppingIndex(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name,
 ) (bool, error) {
 	return og.scanBool(ctx, tx, `
@@ -1053,7 +1201,6 @@ SELECT EXISTS(
                                                      = indexes.index_id
                                                  AND table_id = $1::REGCLASS
                                                  AND type = 'INDEX'
-                                                 AND direction = 'DROP'
        );
 `, tableName.String(), columnName)
 }

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -275,7 +275,7 @@ var opWeights = []int{
 	alterTableAddConstraintUnique:     1,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
 	alterTableAlterPrimaryKey:         1,
-	alterTableDropColumn:              0, // Disabled and tracked with #127286.
+	alterTableDropColumn:              1,
 	alterTableDropColumnDefault:       1,
 	alterTableDropConstraint:          1,
 	alterTableDropNotNull:             1,


### PR DESCRIPTION
Previously, drop column support was disabled because we did not properly
detect if a column was referenced by foreign keys. We also did not
properly detect if removing a column would remove indexes needed to
enforce other foreign keys. This patch adds logic if a column or any
indexes referencing this column are used by foreign keys.

Fixes: #127286

Release note: None