### PR TITLE
release-24.2: jwtauthccl: add mapper for issuer url to jwks URI

### DIFF
--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lestrrat_go_jwx//jwk",
         "@com_github_lestrrat_go_jwx//jwt",
+        "@org_golang_x_exp//maps",
     ],
 )
 

--- a/pkg/ccl/jwtauthccl/authentication_jwt.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt.go
@@ -67,7 +67,7 @@ type jwtAuthenticator struct {
 type jwtAuthenticatorConf struct {
 	audience             []string
 	enabled              bool
-	issuers              []string
+	issuersConf          issuerURLConf
 	issuerCA             string
 	jwks                 jwk.Set
 	claim                string
@@ -89,7 +89,7 @@ func (authenticator *jwtAuthenticator) reloadConfigLocked(
 	conf := jwtAuthenticatorConf{
 		audience:             mustParseValueOrArray(JWTAuthAudience.Get(&st.SV)),
 		enabled:              JWTAuthEnabled.Get(&st.SV),
-		issuers:              mustParseValueOrArray(JWTAuthIssuers.Get(&st.SV)),
+		issuersConf:          mustParseJWTIssuersConf(JWTAuthIssuersConfig.Get(&st.SV)),
 		issuerCA:             JWTAuthIssuerCustomCA.Get(&st.SV),
 		jwks:                 mustParseJWKS(JWTAuthJWKS.Get(&st.SV)),
 		claim:                JWTAuthClaim.Get(&st.SV),
@@ -165,25 +165,15 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 	}
 
 	// Check for issuer match against configured issuers.
-	issuerUrl := ""
-	issuerMatch := false
-	for _, issuer := range authenticator.mu.conf.issuers {
-		if issuer == unverifiedToken.Issuer() {
-			issuerMatch = true
-			issuerUrl = issuer
-			break
-		}
-	}
-	if !issuerMatch {
-		return "", errors.WithDetailf(
-			errors.Newf("JWT authentication: invalid issuer"),
-			"token issued by %s", unverifiedToken.Issuer())
+	tokenIssuer := unverifiedToken.Issuer()
+	if err = authenticator.mu.conf.issuersConf.checkIssuerConfigured(tokenIssuer); err != nil {
+		return "", errors.WithDetailf(err, "token issued by %s", tokenIssuer)
 	}
 
 	var jwkSet jwk.Set
-	// If auto-fetch is enabled, fetch the JWKS remotely from the issuer's well known jwks url.
+	// If auto-fetch is enabled, fetch the JWKS remotely from the issuer's well known jwks URI.
 	if authenticator.mu.conf.jwksAutoFetchEnabled {
-		jwkSet, err = authenticator.remoteFetchJWKS(ctx, issuerUrl)
+		jwkSet, err = authenticator.remoteFetchJWKS(ctx, tokenIssuer)
 		if err != nil {
 			return fmt.Sprintf("unable to fetch jwks: %v", err),
 				errors.Newf("JWT authentication: unable to validate token")
@@ -286,16 +276,27 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 	return "", nil
 }
 
-// remoteFetchJWKS fetches the JWKS from the provided URI.
+// remoteFetchJWKS fetches the JWKS URI from the provided issuer URL.
 func (authenticator *jwtAuthenticator) remoteFetchJWKS(
-	ctx context.Context, issuerUrl string,
+	ctx context.Context, issuerURL string,
 ) (jwk.Set, error) {
-	jwksUrl, err := authenticator.getJWKSUrl(ctx, issuerUrl)
+	var jwksURI string
+	// if JWKS URI is configured in JWTAuthIssuersConfig use that instead of URL
+	// from issuer's well-known endpoint
+	err := authenticator.mu.conf.issuersConf.checkJWKSConfigured()
 	if err != nil {
-		return nil, err
+		jwksURI, err = authenticator.getJWKSURI(ctx, issuerURL)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		jwksURI, err = authenticator.mu.conf.issuersConf.getJWKSURI(issuerURL)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	body, err := getHttpResponse(ctx, jwksUrl, authenticator)
+	body, err := getHttpResponse(ctx, jwksURI, authenticator)
 	if err != nil {
 		return nil, err
 	}
@@ -306,8 +307,8 @@ func (authenticator *jwtAuthenticator) remoteFetchJWKS(
 	return jwkSet, nil
 }
 
-// getJWKSUrl returns the JWKS URI from the OpenID configuration endpoint.
-func (authenticator *jwtAuthenticator) getJWKSUrl(
+// getJWKSURI returns the JWKS URI from the OpenID configuration endpoint.
+func (authenticator *jwtAuthenticator) getJWKSURI(
 	ctx context.Context, issuerUrl string,
 ) (string, error) {
 	type OIDCConfigResponse struct {
@@ -365,7 +366,7 @@ var ConfigureJWTAuth = func(
 	JWTAuthEnabled.SetOnChange(&st.SV, func(ctx context.Context) {
 		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
 	})
-	JWTAuthIssuers.SetOnChange(&st.SV, func(ctx context.Context) {
+	JWTAuthIssuersConfig.SetOnChange(&st.SV, func(ctx context.Context) {
 		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
 	})
 	JWTAuthIssuerCustomCA.SetOnChange(&st.SV, func(ctx context.Context) {

--- a/pkg/ccl/jwtauthccl/settings.go
+++ b/pkg/ccl/jwtauthccl/settings.go
@@ -12,10 +12,12 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/json"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/errors"
 	"github.com/lestrrat-go/jwx/jwk"
+	"golang.org/x/exp/maps"
 )
 
 // All cluster settings necessary for the JWT authentication feature.
@@ -28,6 +30,7 @@ const (
 	JWTAuthClaimSettingName          = baseJWTAuthSettingName + "claim"
 	JWKSAutoFetchEnabledSettingName  = baseJWTAuthSettingName + "jwks_auto_fetch.enabled"
 	jwtAuthIssuerCustomCASettingName = baseJWTAuthSettingName + "issuers.custom_ca"
+	jwtAuthIssuersConfigSettingName  = JWTAuthIssuersSettingName + ".configuration"
 )
 
 // JWTAuthClaim sets the JWT claim that is parsed to get the username.
@@ -66,14 +69,37 @@ var JWTAuthJWKS = settings.RegisterStringSetting(
 	settings.WithValidateString(validateJWTAuthJWKS),
 )
 
-// JWTAuthIssuers is the list of "issuer" values that are accepted for JWT logins over the SQL interface.
-var JWTAuthIssuers = settings.RegisterStringSetting(
+// JWTAuthIssuersConfig contains the configuration of all JWT issuers  whose
+// tokens are allowed for JWT logins over the SQL interface. This can be set to
+// one of the following values:
+// 1. Simple string that Go can parse as a valid issuer URL.
+// 2. String that can be parsed as valid JSON array of issuer URLs list.
+// 3. String that can be parsed as valid JSON and deserialized into a map of
+// issuer URLs to corresponding JWKS URIs.
+// In the third case we will be overriding the JWKS URI present in the issuer's
+// well-known endpoint.
+// Example valid values:
+//   - 'https://accounts.google.com'
+//   - ['example.com/adfs','https://accounts.google.com']
+//   - '{
+//     "issuer_jwks_map": {
+//     "https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs",
+//     "example.com/adfs": "https://example.com/adfs/discovery/keys"
+//     }
+//     }'
+//
+// When issuer_jwks_map is set, we directly use the JWKS URI to get the key set.
+// In all other cases where JWKSAutoFetchEnabled is set we obtain the JWKS URI
+// first from issuer's well-known endpoint and the use this endpoint.
+var JWTAuthIssuersConfig = settings.RegisterStringSetting(
 	settings.ApplicationLevel,
 	JWTAuthIssuersSettingName,
-	"sets accepted issuer values for JWT logins over the SQL interface either as a string or as a JSON "+
-		"string with an array of issuer strings in it",
+	"sets accepted issuer values for JWT logins over the SQL interface which can "+
+		"be a single issuer URL string or a JSON string containing an array of "+
+		"issuer URLs or a JSON object containing map of issuer URLS to JWKS URIs",
 	"",
-	settings.WithValidateString(validateJWTAuthIssuers),
+	settings.WithValidateString(validateJWTAuthIssuersConf),
+	settings.WithName(jwtAuthIssuersConfigSettingName),
 )
 
 // JWTAuthIssuerCustomCA is the custom root CA for verifying certificates while
@@ -88,30 +114,104 @@ var JWTAuthIssuerCustomCA = settings.RegisterStringSetting(
 	settings.WithValidateString(validateJWTAuthIssuerCACert),
 )
 
-// JWKSAutoFetchEnabled enables or disables automatic fetching of JWKs from the issuer's well-known endpoint.
+// JWKSAutoFetchEnabled enables or disables automatic fetching of JWKS either
+// from JWKS URI present in the issuer's well-known endpoint  or value set in
+// JWTAuthIssuersConfig for JWKS URI corresponding to the issuer from presented
+// JWT token for JWT login over SQL interface.
 var JWKSAutoFetchEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	JWKSAutoFetchEnabledSettingName,
-	"enables or disables automatic fetching of JWKs from the issuer's well-known endpoint. "+
-		"If this is enabled, the server.jwt_authentication.jwks will be ignored.",
+	"enables or disables automatic fetching of JWKS from the issuer's well-known "+
+		"endpoint or JWKS URI set in JWTAuthIssuersConfig. If this is enabled, the "+
+		"server.jwt_authentication.jwks will be ignored.",
 	false,
 	settings.WithReportable(true),
 )
 
-func validateJWTAuthIssuers(values *settings.Values, s string) error {
+// getJSONDecoder generates a new decoder from provided json string. This is
+// necessary as currently the offset for decoder can't be reset after Decode().
+func getJSONDecoder(s string) *json.Decoder {
+	decoder := json.NewDecoder(bytes.NewReader([]byte(s)))
+	decoder.DisallowUnknownFields()
+	return decoder
+}
+
+type issuerURLConf struct {
+	ijMap   *issuerJWKSMap
+	issuers []string
+}
+
+func (conf *issuerURLConf) checkIssuerConfigured(issuer string) error {
+	if !slices.Contains(conf.issuers, issuer) {
+		return errors.Newf("JWT authentication: invalid issuer")
+	}
+	return nil
+}
+
+func (conf *issuerURLConf) checkJWKSConfigured() error {
+	if conf.ijMap == nil || len(conf.ijMap.Mappings) == 0 {
+		return errors.Newf("JWT authentication: no jwks mappings configured")
+	}
+	return nil
+}
+
+func (conf *issuerURLConf) getJWKSURI(issuer string) (jwksURI string, err error) {
+	var ok bool
+	if jwksURI, ok = conf.ijMap.Mappings[issuer]; !ok {
+		return "", errors.Newf("JWT authentication: no jwks uri set for issuer")
+	}
+	return jwksURI, nil
+}
+
+// issuerJWKSMap is a struct that defines a valid JSON body for the
+// OIDCRedirectURL cluster setting in multi-region environments.
+type issuerJWKSMap struct {
+	Mappings map[string]string `json:"issuer_jwks_map"`
+}
+
+// mustParseJWTIssuersConf will read in a string that's from the
+// JWTAuthIssuersConfig setting. We know from the validation that runs on that
+// setting that any value that's not valid JSON that deserializes into the
+// issuerJWKSMap struct will be either a list of issuer URLs or a single issuer
+// URL which will populate and return issuerURLConf.
+func mustParseJWTIssuersConf(s string) issuerURLConf {
+	var ijMap = issuerJWKSMap{}
 	var issuers []string
+	decoder := getJSONDecoder(s)
+	err := decoder.Decode(&ijMap)
+	if err == nil {
+		issuers = append(issuers, maps.Keys(ijMap.Mappings)...)
+		return issuerURLConf{ijMap: &ijMap, issuers: issuers}
+	}
+
+	decoder = getJSONDecoder(s)
+	err = decoder.Decode(&issuers)
+	if err == nil {
+		return issuerURLConf{issuers: issuers}
+	}
+	return issuerURLConf{issuers: []string{s}}
+}
+
+func validateJWTAuthIssuersConf(values *settings.Values, s string) error {
+	var issuers []string
+	var ijMap = issuerJWKSMap{}
 
 	var jsonCheck json.RawMessage
 	if json.Unmarshal([]byte(s), &jsonCheck) != nil {
 		// If we know the string is *not* valid JSON, fall back to assuming basic
-		// string to use a single valid issuer
+		// string to use a single valid issuer.
 		return nil
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader([]byte(s)))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&issuers); err != nil {
-		return errors.Wrap(err, "JWT authentication issuers JSON not valid")
+	decoder := getJSONDecoder(s)
+	issuerListErr := decoder.Decode(&issuers)
+	decoder = getJSONDecoder(s)
+	issuerJWKSMapErr := decoder.Decode(&ijMap)
+	if issuerListErr != nil && issuerJWKSMapErr != nil {
+		return errors.Wrap(
+			errors.Join(issuerListErr, issuerJWKSMapErr),
+			"JWT authentication: issuers JSON not valid",
+		)
 	}
 	return nil
 }
@@ -147,7 +247,7 @@ func mustParseValueOrArray(rawString string) []string {
 	var jsonCheck json.RawMessage
 	if json.Unmarshal([]byte(rawString), &jsonCheck) != nil {
 		// If we know the string is *not* valid JSON, fall back to assuming basic
-		// string to use a single valid.
+		// string to use a single valid issuer.
 		return []string{rawString}
 	}
 

--- a/pkg/ccl/jwtauthccl/settings_test.go
+++ b/pkg/ccl/jwtauthccl/settings_test.go
@@ -18,41 +18,53 @@ import (
 func TestValidateAndParseJWTAuthIssuers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tests := []struct {
-		name            string
-		setting         string
-		wantErr         bool
-		expectedIssuers []string
+		name                  string
+		setting               string
+		wantErr               bool
+		expectedIssuers       []string
+		expectedIssuerJWKSMap map[string]string
 	}{
-		{"empty string",
-			"", false,
-			[]string{""}},
-		{"string constant",
-			"issuer1", false,
-			[]string{"issuer1"}},
-		{"odd string constant",
-			"issuer1{}`[]!@#%#^$&*", false,
-			[]string{"issuer1{}`[]!@#%#^$&*"}},
-		{"empty json",
-			"[]", false,
-			[]string{}},
-		{"single element json",
-			"[\"issuer 1\"]", false,
-			[]string{"issuer 1"}},
-		{"multiple element json",
-			"[\"issuer 1\", \"issuer 2\", \"issuer 3\", \"issuer 4\", \"issuer 5\"]", false,
-			[]string{"issuer 1", "issuer 2", "issuer 3", "issuer 4", "issuer 5"}},
-		{"json but invalid in this context",
-			"{\"redirect_urls\": {\"key\":\"http://example.com\"}}", true,
-			nil},
+		{name: "empty string",
+			expectedIssuers: []string{""}},
+		{name: "string constant",
+			setting:         "issuer1",
+			expectedIssuers: []string{"issuer1"}},
+		{name: "odd string constant",
+			setting:         "issuer1{}`[]!@#%#^$&*",
+			expectedIssuers: []string{"issuer1{}`[]!@#%#^$&*"}},
+		{name: "empty json",
+			setting:         "[]",
+			expectedIssuers: []string{}},
+		{name: "single element json",
+			setting:         "[\"issuer 1\"]",
+			expectedIssuers: []string{"issuer 1"}},
+		{name: "multiple element json",
+			setting:         "[\"issuer 1\", \"issuer 2\", \"issuer 3\", \"issuer 4\", \"issuer 5\"]",
+			expectedIssuers: []string{"issuer 1", "issuer 2", "issuer 3", "issuer 4", "issuer 5"}},
+		{name: "json but invalid in this context",
+			setting: "{\"redirect_urls\": {\"key\":\"http://example.com\"}}", wantErr: true},
+		{name: "json object valid in this context single mapping",
+			setting:               "{\"issuer_jwks_map\": {\"https://accounts.google.com\": \"https://www.googleapis.com/oauth2/v3/certs\"}}",
+			expectedIssuers:       []string{"https://accounts.google.com"},
+			expectedIssuerJWKSMap: map[string]string{"https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs"}},
+		{name: "json object valid in this context multiple mapping",
+			setting: "{\"issuer_jwks_map\": {\"https://accounts.google.com\": \"https://www.googleapis.com/oauth2/v3/certs\"" +
+				",\"example.com/adfs\": \"https://example.com/adfs/discovery/keys\"}}",
+			expectedIssuers: []string{"https://accounts.google.com", "example.com/adfs"},
+			expectedIssuerJWKSMap: map[string]string{"https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs",
+				"example.com/adfs": "https://example.com/adfs/discovery/keys"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateJWTAuthIssuers(nil, tt.setting); (err != nil) != tt.wantErr {
+			if err := validateJWTAuthIssuersConf(nil, tt.setting); (err != nil) != tt.wantErr {
 				t.Errorf("validateJWTAuthIssuers() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr {
-				parsedIssuers := mustParseValueOrArray(tt.setting)
-				require.Equal(t, parsedIssuers, tt.expectedIssuers)
+				parsedIssuersConf := mustParseJWTIssuersConf(tt.setting)
+				require.ElementsMatch(t, parsedIssuersConf.issuers, tt.expectedIssuers)
+				if parsedIssuersConf.ijMap != nil {
+					require.Equal(t, parsedIssuersConf.ijMap.Mappings, tt.expectedIssuerJWKSMap)
+				}
 			}
 		})
 	}

--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -532,7 +532,7 @@ func TestOIDCProviderInitialization(t *testing.T) {
 				Issuer      string   `json:"issuer"`
 				AuthURL     string   `json:"authorization_endpoint"`
 				TokenURL    string   `json:"token_endpoint"`
-				JWKSURL     string   `json:"jwks_uri"`
+				JWKSURI     string   `json:"jwks_uri"`
 				UserInfoURL string   `json:"userinfo_endpoint"`
 				Algorithms  []string `json:"id_token_signing_alg_values_supported"`
 			}

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -220,7 +220,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting issuers: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthIssuers.Override(context.Background(), sv, a.Vals[0])
+							jwtauthccl.JWTAuthIssuersConfig.Override(context.Background(), sv, a.Vals[0])
 						case "jwks":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting jwks: %d", len(a.Vals))


### PR DESCRIPTION
Backport 1/1 commits from #127508.

/cc @cockroachdb/release

---

For provisioning JWKS auto fetch feature we currently depend on issuer's well-known endpoint. This conflicts for some JWT issuers who either don't have a well-known endpoint or path of the well-known endpoint is non-standard. In such cases, operators require to manually set the JWKS URI mapping for each JWT issuer they are intending to allow JWT login. This is facilitated by this PR by allowing `server.jwt_authentication.issuers.configuration` to now take in json object mapping of issuer URL to JWKS URI.

informs https://github.com/cockroachlabs/support/issues/2956 
fixes https://github.com/cockroachdb/cockroach/issues/124976 
Epic CRDB-39178

Release note(security, ops): The cluster setting
`server.jwt_authentication.issuers` is now changed to client facing name `server.jwt_authentication.issuers.configuration` to be reflective of the value the setting can take. This can be set to one of the following values:
1. Simple string that Go can parse as a valid issuer URL.
2. String that can be parsed as valid JSON array of issuer URLs list.
3. String that can be parsed as valid JSON and deserialized into a map of issuer URLs to corresponding JWKS URIs.
In the third case we will be overriding the JWKS URI present in the issuer's well-known endpoint.

Example valid values:
- 'https://accounts.google.com'
- ['example.com/adfs','https://accounts.google.com']
- '{ "issuer_jwks_map": { "https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs", "example.com/adfs": "https://example.com/adfs/discovery/keys" } }' 

When `issuer_jwks_map` is set, we directly use the JWKS URI to get the key set. In all other cases where JWKSAutoFetchEnabled is set we obtain the JWKS URI first from issuer's well-known endpoint and then use this endpoint.

Release justification: this is needed as a fix for the AD FS specific issue