### PR TITLE
release-24.1: roachtest: use cockroach workload in kv tests

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -173,7 +173,7 @@ func registerKV(r registry.Registry) {
 				url = fmt.Sprintf(" {pgurl:1-%d:%s}", nodes, appTenantName)
 			}
 			cmd := fmt.Sprintf(
-				"./workload run kv --tolerate-errors --init --user=%s --password=%s", install.DefaultUser, install.DefaultPassword,
+				"./cockroach workload run kv --tolerate-errors --init --user=%s --password=%s", install.DefaultUser, install.DefaultPassword,
 			) +
 				histograms + concurrency + splits + duration + readPercent +
 				batchSize + blockSize + sequential + envFlags + url


### PR DESCRIPTION
In #126506 we refactored tests to stop using the
deprecated workload. This change was backported
but one occurence of the deprecated workload was
missed.

Release note: none
Fixes: #128167
Epic: none

Release Justification: test-only change