### PR TITLE
kvflowcontrol: introduce v2 flow control core interfaces

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1443,6 +1443,7 @@ GO_TARGETS = [
     "//pkg/kv/kvserver/kvflowcontrol/kvflowsimulator:kvflowsimulator_test",
     "//pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker:kvflowtokentracker",
     "//pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker:kvflowtokentracker_test",
+    "//pkg/kv/kvserver/kvflowcontrol/rac2:rac2",
     "//pkg/kv/kvserver/kvflowcontrol:kvflowcontrol",
     "//pkg/kv/kvserver/kvserverbase:kvserverbase",
     "//pkg/kv/kvserver/kvserverpb:kvserverpb",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "rac2",
-    srcs = ["token_counter.go"],
+    srcs = [
+        "store_stream.go",
+        "token_counter.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "rac2",
+    srcs = ["token_counter.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv/kvserver/kvflowcontrol",
+        "//pkg/util/admission/admissionpb",
+    ],
+)

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "rac2",
     srcs = [
+        "range_controller.go",
         "store_stream.go",
         "token_counter.go",
     ],
@@ -10,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvserver/kvflowcontrol",
+        "//pkg/roachpb",
         "//pkg/util/admission/admissionpb",
     ],
 )

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+)
+
+// RangeController provides flow control for replication traffic in KV, for a
+// range at the leader.
+type RangeController interface {
+	// WaitForEval seeks admission to evaluate a request at the given priority.
+	// This blocks until there are positive tokens available for the request to
+	// be admitted for evaluation. Note the number of tokens required by the
+	// request is not considered, only the priority of the request, as the number
+	// of tokens is not known until eval.
+	//
+	// No mutexes should be held.
+	WaitForEval(ctx context.Context, pri admissionpb.WorkPriority) error
+	// HandleRaftEventRaftMuLocked handles the provided raft event for the range.
+	//
+	// Requires replica.raftMu to be held.
+	HandleRaftEventRaftMuLocked(ctx context.Context, e RaftEvent) error
+	// HandleSchedulerEventRaftMuLocked processes an event scheduled by the
+	// controller.
+	//
+	// Requires replica.raftMu to be held.
+	HandleSchedulerEventRaftMuLocked(ctx context.Context) error
+	// SetReplicasLocked sets the replicas of the range.
+	//
+	// Requires replica.raftMu and replica.mu to be held.
+	SetReplicasLocked(ctx context.Context, replicas roachpb.ReplicaSet) error
+	// SetLeaseholderRaftMuLocked sets the leaseholder of the range.
+	//
+	// Requires raftMu to be held.
+	SetLeaseholderRaftMuLocked(ctx context.Context, replica roachpb.ReplicaID)
+	// CloseRaftMuLocked closes the range controller.
+	//
+	// Requires replica.raftMu to be held.
+	CloseRaftMuLocked(ctx context.Context)
+}
+
+// TODO(pav-kv): This struct is a placeholder for the interface or struct
+// containing raft entries. Replace this as part of #128019.
+type RaftEvent struct{}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -1,0 +1,24 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
+
+// StreamTokenCounterProvider is the interface for retrieving token counters
+// for a given stream.
+//
+// TODO(kvoli): Consider de-interfacing if not necessary for testing.
+type StreamTokenCounterProvider interface {
+	// Eval returns the evaluation token counter for the given stream.
+	Eval(kvflowcontrol.Stream) TokenCounter
+	// Send returns the send token counter for the given stream.
+	Send(kvflowcontrol.Stream) TokenCounter
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -10,7 +10,11 @@
 
 package rac2
 
-import "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
+)
 
 // StreamTokenCounterProvider is the interface for retrieving token counters
 // for a given stream.
@@ -21,4 +25,37 @@ type StreamTokenCounterProvider interface {
 	Eval(kvflowcontrol.Stream) TokenCounter
 	// Send returns the send token counter for the given stream.
 	Send(kvflowcontrol.Stream) TokenCounter
+}
+
+// SendTokenWatcherHandleID is a unique identifier for a handle that is
+// watching for available elastic send tokens on a stream.
+type SendTokenWatcherHandleID int64
+
+// SendTokenWatcher is the interface for watching and waiting on available
+// elastic send tokens. The watcher registers a notification, which will be
+// called when elastic tokens are available for the stream this watcher is
+// monitoring. Note only elastic tokens are watched as this is intended to be
+// used when a send queue exists.
+//
+// TODO(kvoli): Consider de-interfacing if not necessary for testing.
+type SendTokenWatcher interface {
+	// NotifyWhenAvailable queues up for elastic tokens for the given send token
+	// counter. When elastic tokens are available, the provided
+	// TokenGrantNotification is called. It is the caller's responsibility to
+	// call CancelHandle when tokens are no longer needed, or when the caller is
+	// done.
+	NotifyWhenAvailable(
+		TokenCounter,
+		TokenGrantNotification,
+	) SendTokenWatcherHandleID
+	// CancelHandle cancels the given handle, stopping it from being notified
+	// when tokens are available. CancelHandle should be called at most once.
+	CancelHandle(SendTokenWatcherHandleID)
+}
+
+// TokenGrantNotification is an interface that is called when tokens are
+// available.
+type TokenGrantNotification interface {
+	// Notify is called when tokens are available to be granted.
+	Notify(context.Context)
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+)
+
+// TokenCounter is the interface for a token counter that can be used to deduct
+// and return flow control tokens. Additionally, it can be used to wait for
+// tokens to become available, and to check if tokens are available without
+// blocking.
+//
+// TODO(kvoli): Consider de-interfacing if not necessary for testing.
+type TokenCounter interface {
+	// TokensAvailable returns true if tokens are available. If false, it returns
+	// a handle that may be used for waiting for tokens to become available.
+	TokensAvailable(admissionpb.WorkClass) (available bool, tokenWaitingHandle TokenWaitingHandle)
+	// TryDeduct attempts to deduct flow tokens for the given work class. If
+	// there are no tokens available, 0 tokens are returned. When less than the
+	// requested token count is available, partial tokens are returned
+	// corresponding to this partial amount.
+	TryDeduct(
+		context.Context, admissionpb.WorkClass, kvflowcontrol.Tokens) kvflowcontrol.Tokens
+	// Deduct deducts (without blocking) flow tokens for the given work class. If
+	// there are not enough available tokens, the token counter will go into debt
+	// (negative available count) and still issue the requested number of tokens.
+	Deduct(context.Context, admissionpb.WorkClass, kvflowcontrol.Tokens)
+	// Return returns flow tokens for the given work class.
+	Return(context.Context, admissionpb.WorkClass, kvflowcontrol.Tokens)
+}
+
+// TokenWaitingHandle is the interface for waiting for positive tokens from a
+// token counter.
+type TokenWaitingHandle interface {
+	// WaitChannel is the channel that will be signaled if tokens are possibly
+	// available. If signaled, the caller must call
+	// ConfirmHaveTokensAndUnblockNextWaiter. There is no guarantee of tokens
+	// being available after this channel is signaled, just that tokens were
+	// available recently. A typical usage pattern is:
+	//
+	//   for {
+	//     select {
+	//     case <-handle.WaitChannel():
+	//       if handle.ConfirmHaveTokensAndUnblockNextWaiter() {
+	//         break
+	//       }
+	//     }
+	//   }
+	//   tokenCounter.Deduct(...)
+	//
+	// There is a possibility for races, where multiple goroutines may be
+	// signaled and deduct tokens, sending the counter into debt. These cases are
+	// acceptable, as in aggregate the counter provides pacing over time.
+	WaitChannel() <-chan struct{}
+	// ConfirmHaveTokensAndUnblockNextWaiter is called to confirm tokens are
+	// available. True is returned if tokens are available, false otherwise. If
+	// no tokens are available, the caller can resume waiting using WaitChannel.
+	ConfirmHaveTokensAndUnblockNextWaiter() bool
+}


### PR DESCRIPTION
Introduce the `TokenCounter` interface, underneath a new package, `rac2`.
The `TokenCounter` will be used by replication flow control v2 in a
similar, but distinct manner from the token buckets in v1. Notably, the
`TokenCounter` supports returning an encapsulated handle that may be
used in waiting for available tokens, `TokenWaitingHandle`.

Resolves: https://github.com/cockroachdb/cockroach/issues/128014
Release note: None

---

Introduce the `StreamTokenCounterProvider` interface, which will be used
by replication flow control v2 to access the `TokenCounter` for a given
tenant, store stream.

Note the original interface in the v2 prototype included two additional
methods for metrics gathering which are omitted here.

Resolves: https://github.com/cockroachdb/cockroach/issues/128010
Release note: None

---

Introduce the `StreamTokenWatcher` interface, which will be used to
watch and be notified when there are tokens available.

Resolves: https://github.com/cockroachdb/cockroach/issues/128011
Release note: None

---

Introduce the `RangeController` interface, which provides flow control
for replication traffic in KV, for a range.

Resolves: https://github.com/cockroachdb/cockroach/issues/128021
Release note: None