### PR TITLE
ldr: send frontier updates to heartbeater

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -102,6 +102,7 @@ go_test(
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/crosscluster/replicationtestutils",
+        "//pkg/ccl/crosscluster/replicationutils",
         "//pkg/ccl/storageccl",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -516,6 +516,11 @@ func (rh *rowHandler) handleRow(ctx context.Context, row tree.Datums) error {
 		}); err != nil {
 		return err
 	}
+	select {
+	case rh.frontierUpdates <- replicatedTime:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
 	rh.metrics.ReplicatedTimeSeconds.Update(replicatedTime.GoTime().Unix())
 	return nil

--- a/pkg/ccl/crosscluster/replicationutils/BUILD.bazel
+++ b/pkg/ccl/crosscluster/replicationutils/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
         "//pkg/storage",
+        "//pkg/testutils",
         "//pkg/testutils/fingerprintutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
Previously, the logical replication stream ingestion job failed to send frontier updates to the heartbeat sender, which meant the pts on the source side would never update.

This patch fixes this bug.

Fixes #128191

Epic: none