### PR TITLE
sql/schemachanger: automatically adjust the batch size of the merge

### DIFF
--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -75,7 +75,6 @@ func registerAlterPK(r registry.Registry) {
 			db := c.Conn(ctx, t.L(), c.CRDBNodes()[0])
 			defer db.Close()
 			cmds := []string{
-				`SET CLUSTER SETTING kv.transaction.internal.max_auto_retries = 10000`,
 				`USE bank;`,
 				`ALTER TABLE bank ALTER COLUMN balance SET NOT NULL;`,
 				`ALTER TABLE bank ALTER PRIMARY KEY USING COLUMNS (id, balance)`,

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -63,6 +63,14 @@ var MaxInternalTxnAutoRetries = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
+var ErrAutoRetryLimitExhausted = errors.New("retry limit exhausted")
+
+// IsAutoRetryLimitExhaustedError checks if the given error indicates
+// that the maximum number of transaction auto-retries has been reached.
+func IsAutoRetryLimitExhaustedError(err error) bool {
+	return errors.Is(err, ErrAutoRetryLimitExhausted)
+}
+
 // Txn is an in-progress distributed database transaction. A Txn is safe for
 // concurrent use by multiple goroutines.
 type Txn struct {
@@ -1116,10 +1124,13 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 			// If the retries limit has been exceeded, rollback and return an error.
 			rollbackErr := txn.Rollback(ctx)
 			// NOTE: we don't errors.Wrap the most recent retry error because we want
-			// to terminate it here. Instead, we just include it in the error text.
-			err = errors.Errorf("have retried transaction: %s %d times, most recently because of the "+
+			// to terminate it here. Instead, we mark the error to allow callers to
+			// detect this condition and avoid automatic retries. We also include the
+			// original error in the error message.
+			err = errors.Mark(errors.Errorf("have retried transaction: %s %d times, most recently because of the "+
 				"retryable error: %s. Terminating retry loop and returning error due to cluster setting %s (%d). "+
-				"Rollback error: %v.", txn.DebugName(), attempt, err, MaxInternalTxnAutoRetries.Name(), maxRetries, rollbackErr)
+				"Rollback error: %v.", txn.DebugName(), attempt, err, MaxInternalTxnAutoRetries.Name(), maxRetries, rollbackErr),
+				ErrAutoRetryLimitExhausted)
 			log.Warningf(ctx, "%v", err)
 			break
 		}

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -51,14 +51,20 @@ go_library(
 
 go_test(
     name = "backfill_test",
-    srcs = ["index_backfiller_cols_test.go"],
+    srcs = [
+        "index_backfiller_cols_test.go",
+        "mvcc_index_merger_test.go",
+    ],
     embed = [":backfill"],
     deps = [
+        "//pkg/kv",
+        "//pkg/roachpb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/sem/catid",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/backfill/mvcc_index_merger_test.go
+++ b/pkg/sql/backfill/mvcc_index_merger_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backfill
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReduceBatchSizeWhenAutoRetryLimitExhausted(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		kvErrs                 []error
+		expectedFinalErr       error
+		batch                  keyBatch
+		expectedFinalBatchSize int
+	}{
+		{
+			name:                   "no errors",
+			kvErrs:                 []error{nil},
+			expectedFinalErr:       nil,
+			batch:                  keyBatch{sourceKeys: make([]roachpb.Key, 1000)},
+			expectedFinalBatchSize: 1000,
+		},
+		{
+			name:                   "retry once",
+			kvErrs:                 []error{errors.Mark(errors.New("retry"), kv.ErrAutoRetryLimitExhausted), nil},
+			expectedFinalErr:       nil,
+			batch:                  keyBatch{sourceKeys: make([]roachpb.Key, 1000)},
+			expectedFinalBatchSize: 500,
+		},
+		{
+			name:                   "retry max times",
+			kvErrs:                 []error{errors.Mark(errors.New("retry"), kv.ErrAutoRetryLimitExhausted)},
+			expectedFinalErr:       errors.Mark(errors.New("retry"), kv.ErrAutoRetryLimitExhausted),
+			batch:                  keyBatch{sourceKeys: make([]roachpb.Key, 1000)},
+			expectedFinalBatchSize: 1,
+		},
+		{
+			name: "don't retry if not a auto retry limit exhausted error",
+			kvErrs: []error{
+				errors.Mark(errors.New("retry"), kv.ErrAutoRetryLimitExhausted),
+				errors.Mark(errors.New("retry"), kv.ErrAutoRetryLimitExhausted),
+				errors.New("not a retry"),
+			},
+			expectedFinalErr:       errors.New("not a retry"),
+			batch:                  keyBatch{sourceKeys: make([]roachpb.Key, 1000)},
+			expectedFinalBatchSize: 250,
+		},
+	} {
+		ctx := context.Background()
+		t.Run(tc.name, func(t *testing.T) {
+			i := 0
+			batch := tc.batch
+			err := retryWithReducedBatchWhenAutoRetryLimitExceeded(ctx, &batch, func(context.Context, []roachpb.Key) error {
+				// Return the next error in the list, or the last one if we run out.
+				if i >= len(tc.kvErrs) {
+					i = len(tc.kvErrs) - 1
+				}
+				err := tc.kvErrs[i]
+				i++
+				return err
+			})
+			if tc.expectedFinalErr == nil {
+				require.NoError(t, err)
+				require.Equal(t, batch.processedKeys, len(batch.sourceKeys))
+			} else {
+				require.True(t, kv.IsAutoRetryLimitExhaustedError(tc.expectedFinalErr) == kv.IsAutoRetryLimitExhaustedError(err))
+				require.Equal(t, batch.processedKeys, 0)
+			}
+			require.Equal(t, tc.expectedFinalBatchSize, batch.batchSize)
+		})
+	}
+}


### PR DESCRIPTION
We have observed contention issues with the schema changer's merge process, usually manifesting as a WriteTooOldErrors in the kv. KV retries the transaction up to 100 times before failing. Although various settings can be adjusted to control this behaviour and allow the schema change to succeed, this approach requires manual intervention.

This update makes the schema changer aware of such contention and enables it to automatically adjust the batch size. Specifically, it will detect when the KV error hits the auto-retry limit, allowing the schema changer to respond to this error by reducing its batch size for the next merge attempt.

Previously, a roachtest (alterpk-bank) was modified to retry more often by tuning the `kv.transaction.internal.max_auto_retries` setting. This has been removed from the test now, as the new code automatically reduces the batch size, providing a reliable solution to the issue.

Closes: #126197
Release note (bug fix): Changed the schema changer’s merge process so that it can detect contention errors and automatically retry with a smaller batch size. This makes the merge process more likely to succeed without needing any manual tuning of settings.