### PR TITLE
logictestccl: deflake select_for_update_read_committed

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
@@ -576,6 +576,9 @@ INSERT INTO xyz VALUES (1, 10, 100), (2, 10, 100)
 user testuser
 
 statement ok
+SET optimizer_use_lock_op_for_serializable = true
+
+statement ok
 BEGIN ISOLATION LEVEL SERIALIZABLE
 
 # Lock the first row.
@@ -613,4 +616,10 @@ user testuser
 statement ok
 COMMIT
 
+statement ok
+RESET optimizer_use_lock_op_for_serializable
+
 user root
+
+statement ok
+RESET optimizer_use_lock_op_for_serializable

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -273,7 +273,7 @@ func constructVirtualScan(
 	if params.NeededCols.Contains(0) {
 		return nil, errors.Errorf("use of %s column not allowed.", table.Column(0).ColName())
 	}
-	if params.Locking.IsNonZeroLocking() {
+	if !params.Locking.IsNoOp() {
 		// We shouldn't have allowed SELECT FOR UPDATE for a virtual table.
 		return nil, errors.AssertionFailedf("locking cannot be used with virtual table")
 	}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1227,7 +1227,7 @@ func (b *Builder) buildLock(lock *memo.LockExpr) (_ execPlan, outputCols colOrdM
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	if !locking.IsNonZeroLocking() {
+	if locking.IsNoOp() {
 		return b.buildRelational(lock.Input)
 	}
 

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -82,17 +82,18 @@ func (l Locking) Max(l2 Locking) Locking {
 	}
 }
 
-// IsLocking returns whether the receiver is configured to use a row-level
-// locking mode.
+// IsLocking returns whether the receiver is configured to use row-level
+// locking.
 func (l Locking) IsLocking() bool {
 	return l.Strength != tree.ForNone
 }
 
-// IsNonZeroLocking returns true if the locking properties somehow differ from
-// the zero value locking properties. This can mean a row-level locking mode is
-// set (i.e. l.Strength != tree.ForNone) or the SKIP LOCKED wait policy is in
-// use even if no locking mode is set (i.e. l.WaitPolicy ==
-// tree.LockWaitSkipLocked).
-func (l Locking) IsNonZeroLocking() bool {
-	return l != Locking{}
+// IsNoOp returns true if none of the locking properties are set. It differs
+// from IsLocking in that it considers all of the locking properties, instead of
+// only Strength. Currently, the only locking property that can be set when
+// Strength=ForNone is WaitPolicy=LockWaitSkipLocked. So we can say: IsNoOp
+// returns false if IsLocking returns true OR the SKIP LOCKED wait policy is in
+// effect.
+func (l Locking) IsNoOp() bool {
+	return l == Locking{}
 }

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1629,7 +1629,7 @@ func (f *ExprFmtCtx) formatLocking(tp treeprinter.Node, locking opt.Locking) {
 func (f *ExprFmtCtx) formatLockingWithPrefix(
 	tp treeprinter.Node, labelPrefix string, locking opt.Locking,
 ) {
-	if !locking.IsNonZeroLocking() {
+	if locking.IsNoOp() {
 		return
 	}
 	strength := ""

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -81,7 +81,7 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 	// Side Effects
 	// ------------
 	// A Locking option is a side-effect (we don't want to elide this scan).
-	if scan.Locking.IsNonZeroLocking() {
+	if !scan.Locking.IsNoOp() {
 		rel.VolatilitySet.AddVolatile()
 	}
 


### PR DESCRIPTION
This commit fixes an oversight in the original testcase added for #127718. The initial `SELECT * FROM xyz WHERE x = 1 FOR UPDATE` run under serializable isolation was sometimes using a different plan that caused it to lock more than one row. I needed to turn on `optimizer_use_lock_op_for_serializable` for the testuser connection, too, to ensure the first SELECT only locks a single row.

Also change `opt.Locking.IsNonZeroLocking` to `opt.Locking.IsNoOp` which is more meaningful.

Fixes: #128177

Release note: None