### PR TITLE
dev: in `doctor`, add `--sandbox_add_mount_pair` if relevant

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=97
+DEV_VERSION=98
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
This was apparently broken with the Bazel 7 upgrade and bazelbuild/bazel#22001 specifically. If `--test_tmpdir` is set to some directory under `/tmp`, we need to add `/tmp` as a mount pair as well. This cannot be done in remote mode so `doctor` needs to be aware of this.

Closes: #128204
Epic: None
Release note: None
Release justification: Build-only code changes