### PR TITLE
dev: refactor prompts for autofix permission

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=97
+DEV_VERSION=98
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
This code is duplicated in many places, so this refactor saves us some
LOC.

Epic: none
Release note: None
Release justification: Build-only code changes