### PR TITLE
workload/schemachange: fix expected error for set default

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2304,7 +2304,7 @@ func (og *operationGenerator) setColumnDefault(ctx context.Context, tx pgx.Tx) (
 			return nil, err
 		}
 		if newTyp == nil {
-			errCode := pgcode.UndefinedColumn
+			errCode := pgcode.UndefinedObject // Error: type 'IrrelevantType'::<newTypeName> does not exist.
 			// Setting default on generated column short-circuits and returns a syntax
 			// error.
 			if columnForDefault.generated {


### PR DESCRIPTION
This fix is related to the schemachanger workload. When setting the default of a column to a non-existent type, it was looking for the wrong SQLCODE. It should be 42704, as shown below:

```
demo@127.0.0.1:26257/demoapp/movr> create table t(i int);
CREATE TABLE

Time: 9ms total (execution 7ms / network 1ms)

-- unknown type
demo@127.0.0.1:26257/demoapp/movr> alter table t alter
                                -> column i set default
                                -> 'irr':::enum;
ERROR: type "enum" does not exist
SQLSTATE: 42704
```

Closes: #128206
Release note: None