### PR TITLE
dev: remove unnecessary testing knobs

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -152,7 +152,7 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 
 	// Set up dev cache unless it's disabled via the environment variable or the
 	// testing knob.
-	skipCacheCheck := d.knobs.skipCacheCheckDuringBuild || d.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
+	skipCacheCheck := buildutil.CrdbTestBuild || d.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
 	if !skipCacheCheck {
 		_, err := d.setUpCache(ctx)
 		if err != nil {

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -83,8 +83,6 @@ func TestDataDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			dev := makeDevCmd()
 			dev.exec, dev.os = devExec, devOS
-			dev.knobs.skipDoctorCheck = true
-			dev.knobs.skipCacheCheckDuringBuild = true
 			dev.knobs.devBinOverride = "dev"
 			dev.log = log.New(logger, "", 0)
 

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -29,9 +29,7 @@ type dev struct {
 	debug bool
 
 	knobs struct { // testing knobs
-		skipDoctorCheck           bool
-		skipCacheCheckDuringBuild bool
-		devBinOverride            string
+		devBinOverride string
 	}
 }
 

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/exec"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/spf13/cobra"
 )
 
@@ -598,7 +599,7 @@ func (d *dev) getDoctorStatus(ctx context.Context) (int, error) {
 // checkDoctorStatus returns an error iff the current doctor status is not the
 // latest.
 func (d *dev) checkDoctorStatus(ctx context.Context) error {
-	if d.knobs.skipDoctorCheck {
+	if buildutil.CrdbTestBuild {
 		return nil
 	}
 

--- a/pkg/cmd/dev/recorderdriven_test.go
+++ b/pkg/cmd/dev/recorderdriven_test.go
@@ -123,8 +123,6 @@ func TestRecorderDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			dev := makeDevCmd()
 			dev.exec, dev.os = devExec, devOS
-			dev.knobs.skipDoctorCheck = true
-			dev.knobs.skipCacheCheckDuringBuild = true
 			dev.knobs.devBinOverride = "dev"
 
 			if !verbose {


### PR DESCRIPTION
These were never necessary as we can just check `CrdbTestBuild`.

Epic: none
Release note: None
Release justification: Non-production code changes