### PR TITLE
dev: refactor and augment cache check logic

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=98
+DEV_VERSION=99
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -150,16 +150,6 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	cross := mustGetFlagString(cmd, crossFlag)
 	dockerArgs := mustGetFlagStringArray(cmd, dockerArgsFlag)
 
-	// Set up dev cache unless it's disabled via the environment variable or the
-	// testing knob.
-	skipCacheCheck := buildutil.CrdbTestBuild || d.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
-	if !skipCacheCheck {
-		_, err := d.setUpCache(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
 	args, buildTargets, err := d.getBasicBuildArgs(ctx, targets)
 	if err != nil {
 		return err

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/exec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/os"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/spf13/cobra"
 )
 
@@ -140,8 +141,8 @@ Typical usage:
 		skipDoctorCheckCommands := []string{
 			"builder",
 			"doctor",
+			"go",
 			"help",
-			"merge-test-xmls",
 		}
 		var skipDoctorCheck bool
 		for _, skipDoctorCheckCommand := range skipDoctorCheckCommands {
@@ -152,6 +153,34 @@ Typical usage:
 				return err
 			}
 		}
+
+		ctx := cmd.Context()
+		skipCacheCheckCommands := []string{
+			"cache",
+		}
+		skipCacheCheckCommands = append(skipCacheCheckCommands, skipDoctorCheckCommands...)
+		skipCacheCheck := buildutil.CrdbTestBuild || ret.os.Getenv("DEV_NO_REMOTE_CACHE") != ""
+		for _, skipCacheCheckCommand := range skipCacheCheckCommands {
+			skipCacheCheck = skipCacheCheck || cmd.Name() == skipCacheCheckCommand
+		}
+		// Check if we're running in remote mode: we don't want to setup
+		// the cache in this case.
+		if !skipCacheCheck {
+			workspace, err := ret.getWorkspace(ctx)
+			if err != nil {
+				return err
+			}
+			if ret.checkUsingConfig(workspace, "engflow") {
+				skipCacheCheck = true
+			}
+		}
+		if !skipCacheCheck {
+			_, err := ret.setUpCache(ctx)
+			if err != nil {
+				return err
+			}
+		}
+
 		if ret.debug {
 			ret.log.SetOutput(stdos.Stderr)
 		}


### PR DESCRIPTION
Always check if the cache is up before most `dev` commands. Also, check
if we're using remote builds, and if so, don't check if the cache is up.

Epic: CRDB-34137
Release note: None
Release justification: Build-only code changes