### PR TITLE
crosscluster/logical: add failure cause to DLQ'ed row

### DIFF
--- a/pkg/ccl/crosscluster/logical/dead_letter_queue.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue.go
@@ -229,10 +229,23 @@ func (dlq *deadLetterQueueClient) Log(
 func InitDeadLetterQueueClient(
 	ie isql.Executor, tableIDToName map[int32]fullyQualifiedTableName,
 ) DeadLetterQueueClient {
+	if testingDLQ != nil {
+		return testingDLQ
+	}
 	return &deadLetterQueueClient{
 		ie:            ie,
 		tableIDToName: tableIDToName,
 	}
+}
+
+var testingDLQ DeadLetterQueueClient
+
+// TestingSetDLQ sets the DLQ to the passed implementation, globally, until the
+// returned reversion function is called.
+func TestingSetDLQ(d DeadLetterQueueClient) func() {
+	v := testingDLQ
+	testingDLQ = d
+	return func() { testingDLQ = v }
 }
 
 func InitLoggingDeadLetterQueueClient() DeadLetterQueueClient {

--- a/pkg/ccl/crosscluster/logical/dead_letter_queue.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue.go
@@ -87,7 +87,8 @@ type DeadLetterQueueClient interface {
 		ingestionJobID int64,
 		kv streampb.StreamEvent_KV,
 		cdcEventRow cdcevent.Row,
-		dlqReason retryEligibility,
+		reason error,
+		stoppedRetryReason retryEligibility,
 	) error
 }
 
@@ -103,7 +104,8 @@ func (dlq *loggingDeadLetterQueueClient) Log(
 	ingestionJobID int64,
 	kv streampb.StreamEvent_KV,
 	cdcEventRow cdcevent.Row,
-	dlqReason retryEligibility,
+	reason error,
+	stoppedRetryReason retryEligibility,
 ) error {
 	if !cdcEventRow.IsInitialized() {
 		return errors.New("cdc event row not initialized")
@@ -124,11 +126,11 @@ func (dlq *loggingDeadLetterQueueClient) Log(
 
 	log.Infof(ctx, `ingestion_job_id: %d,  
 		table_id: %d, 
-		dlq_reason: %s, 
+		dlq_reason: (%s) %s,
 		mutation_type: %s,  
 		key_value_bytes: %v, 
 		incoming_row: %s`,
-		ingestionJobID, tableID, dlqReason.String(), mutationType.String(), bytes, cdcEventRow.DebugString())
+		ingestionJobID, tableID, reason.Error(), stoppedRetryReason.String(), mutationType.String(), bytes, cdcEventRow.DebugString())
 	return nil
 }
 
@@ -164,7 +166,8 @@ func (dlq *deadLetterQueueClient) Log(
 	ingestionJobID int64,
 	kv streampb.StreamEvent_KV,
 	cdcEventRow cdcevent.Row,
-	dlqReason retryEligibility,
+	reason error,
+	stoppedRetyingReason retryEligibility,
 ) error {
 	if !cdcEventRow.IsInitialized() {
 		return errors.New("cdc event row not initialized")
@@ -200,7 +203,7 @@ func (dlq *deadLetterQueueClient) Log(
 			fmt.Sprintf(insertRowStmtFallBack, dlqTableName),
 			ingestionJobID,
 			tableID,
-			dlqReason.String(),
+			fmt.Sprintf("%s (%s)", reason, stoppedRetyingReason),
 			mutationType.String(),
 			bytes,
 		); err != nil {
@@ -216,7 +219,7 @@ func (dlq *deadLetterQueueClient) Log(
 		fmt.Sprintf(insertBaseStmt, dlqTableName),
 		ingestionJobID,
 		tableID,
-		dlqReason.String(),
+		fmt.Sprintf("%s (%s)", reason, stoppedRetyingReason),
 		mutationType.String(),
 		bytes,
 		jsonRow,

--- a/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
@@ -95,7 +95,7 @@ func TestLoggingDLQClient(t *testing.T) {
 			if tc.applyError == nil {
 				tc.applyError = errors.New("some error")
 			}
-			err := dlqClient.Log(ctx, tc.jobID, tc.kv, tc.cdcEventRow, tc.dlqReason)
+			err := dlqClient.Log(ctx, tc.jobID, tc.kv, tc.cdcEventRow, tc.applyError, tc.dlqReason)
 			if tc.expectedErrMsg == "" {
 				require.NoError(t, err)
 			} else {
@@ -296,7 +296,7 @@ func TestDLQClient(t *testing.T) {
 				cdcEventRow = cdcevent.Row{EventDescriptor: ed}
 			}
 
-			err := dlqClient.Log(ctx, tc.jobID, tc.kv, cdcEventRow, tc.dlqReason)
+			err := dlqClient.Log(ctx, tc.jobID, tc.kv, cdcEventRow, tc.applyError, tc.dlqReason)
 			if tc.expectedErrMsg == "" {
 				require.NoError(t, err)
 
@@ -327,7 +327,7 @@ func TestDLQClient(t *testing.T) {
 				expectedRow := dlqRow{
 					jobID:        tc.jobID,
 					tableID:      tableID,
-					dlqReason:    tc.dlqReason.String(),
+					dlqReason:    fmt.Sprintf("%s (%s)", tc.applyError.Error(), tc.dlqReason),
 					mutationType: tc.mutationType.String(),
 					kv:           bytes,
 				}
@@ -396,7 +396,7 @@ func TestDLQJSONQuery(t *testing.T) {
 		ctx, kv, cdcevent.CurrentRow, row.Timestamp(), false)
 
 	require.NoError(t, err)
-	require.NoError(t, dlqClient.Log(ctx, 1, streampb.StreamEvent_KV{KeyValue: kv}, updatedRow, noSpace))
+	require.NoError(t, dlqClient.Log(ctx, 1, streampb.StreamEvent_KV{KeyValue: kv}, updatedRow, errInjected, noSpace))
 
 	dlqtableName := tableName.toDLQTableName(tableID)
 

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -165,9 +165,26 @@ func TestLogicalStreamIngestionJobNameResolution(t *testing.T) {
 	}
 }
 
+type fatalDLQ struct{ *testing.T }
+
+func (fatalDLQ) Create(ctx context.Context) error { return nil }
+
+func (t fatalDLQ) Log(
+	_ context.Context,
+	_ int64,
+	_ streampb.StreamEvent_KV,
+	cdcEventRow cdcevent.Row,
+	_ retryEligibility,
+) error {
+	t.Fatalf("failed to apply row update: %s", cdcEventRow.DebugString())
+	return nil
+}
+
 func TestLogicalStreamIngestionJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	defer TestingSetDLQ(fatalDLQ{t})()
 
 	ctx := context.Background()
 	// keyPrefix will be set later, but before countPuts is set.

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -221,6 +221,8 @@ func TestLogicalStreamIngestionJob(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, clusterArgs)
 	defer server.Stopper().Stop(ctx)
 
+	retryQueueSizeLimit.Override(ctx, &s.ClusterSettings().SV, 0)
+
 	desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "a", "tab")
 	keyPrefix = rowenc.MakeIndexKeyPrefix(s.Codec(), desc.GetID(), desc.GetPrimaryIndexID())
 	countPuts.Store(true)
@@ -894,8 +896,8 @@ func TestFlushErrorHandling(t *testing.T) {
 
 	lrw.bh = []BatchHandler{(mockBatchHandler(true))}
 
-	lrw.purgatory.byteLimit = func() int64 { return 0 }
-	// One failure immediately means a zero-byte purgatory is full.
+	lrw.purgatory.byteLimit = func() int64 { return 1 }
+	// One failure immediately means a 1-byte purgatory is full.
 	require.NoError(t, lrw.handleStreamBuffer(ctx, []streampb.StreamEvent_KV{skv("a")}))
 	require.Equal(t, int64(1), lrw.metrics.RetryQueueEvents.Value())
 	require.True(t, lrw.purgatory.full())

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -174,9 +174,10 @@ func (t fatalDLQ) Log(
 	_ int64,
 	_ streampb.StreamEvent_KV,
 	cdcEventRow cdcevent.Row,
+	reason error,
 	_ retryEligibility,
 ) error {
-	t.Fatalf("failed to apply row update: %s", cdcEventRow.DebugString())
+	t.Fatal(errors.Wrapf(reason, "failed to apply row update: %s", cdcEventRow.DebugString()))
 	return nil
 }
 
@@ -890,7 +891,12 @@ func (m *mockDLQ) Create(_ context.Context) error {
 }
 
 func (m *mockDLQ) Log(
-	_ context.Context, _ int64, _ streampb.StreamEvent_KV, _ cdcevent.Row, _ retryEligibility,
+	_ context.Context,
+	_ int64,
+	_ streampb.StreamEvent_KV,
+	_ cdcevent.Row,
+	_ error,
+	_ retryEligibility,
 ) error {
 	*m++
 	return nil

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -841,7 +841,7 @@ func (lrw *logicalReplicationWriterProcessor) dlq(
 	case errType:
 		lrw.metrics.DLQedDueToErrType.Inc(1)
 	}
-	return lrw.dlqClient.Log(ctx, lrw.spec.JobID, event, row, eligibility)
+	return lrw.dlqClient.Log(ctx, lrw.spec.JobID, event, row, applyErr, eligibility)
 }
 
 type batchStats struct {

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -515,7 +515,7 @@ func (lrw *logicalReplicationWriterProcessor) handleStreamBuffer(
 	ctx context.Context, kvs []streampb.StreamEvent_KV,
 ) error {
 	const notRetry = false
-	unapplied, unappliedBytes, err := lrw.flushBuffer(ctx, kvs, notRetry, retryAllowed)
+	unapplied, unappliedBytes, err := lrw.flushBuffer(ctx, kvs, notRetry, lrw.purgatory.Enabled())
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/crosscluster/logical/purgatory.go
+++ b/pkg/ccl/crosscluster/logical/purgatory.go
@@ -162,3 +162,10 @@ func (p *purgatory) full() bool {
 	}
 	return p.bytesGauge.Value() >= p.byteLimit()
 }
+
+func (p *purgatory) Enabled() retryEligibility {
+	if p != nil && p.byteLimit != nil && p.byteLimit() != 0 {
+		return retryAllowed
+	}
+	return noSpace
+}


### PR DESCRIPTION
While I'm here: add option to disable retry queue in tests and make DLQ fatal to make test failures quicker/easier to debug.