### PR TITLE
roachprod-microbench: cache baseline results

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -311,3 +311,10 @@ check_workspace_clean() {
   fi
   echo "##teamcity[testFinished name='CheckGeneratedCode/$1']"
 }
+
+# Check if a given GCS path exists
+function check_gcs_path_exists() {
+  local path=$1
+  gsutil ls "$path" &>/dev/null
+  return
+}

--- a/build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh
@@ -9,19 +9,11 @@ source "$dir/teamcity-support.sh"
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
 
-# Check if a given GCS path exists
-function check_gcs_path_exists() {
-  local path=$1
-  gsutil ls "$path" &>/dev/null
-  return
-}
-
 # Build and copy binaries, for the given SHA, to GCS bucket
 function build_and_upload_binaries() {
   local sha=$1
-  archive_name=${BENCH_PACKAGE//\//-}
-  archive_name="$sha-${archive_name/.../all}.tar.gz"
-  if check_gcs_path_exists "gs://$BUILDS_BUCKET/builds/$archive_name"; then
+  archive_name="$sha-${SANITIZED_BENCH_PACKAGE}.tar.gz"
+  if check_gcs_path_exists "gs://$BENCH_BUCKET/builds/$archive_name"; then
     echo "Build for $sha already exists. Skipping..."
     return
   fi
@@ -57,7 +49,7 @@ EOF
   out_dir=$(mktemp -d)
   tar -chf - -C "$stage_dir" . | ./bin/roachprod-microbench compress > "$out_dir/$archive_name"
   rm -rf "$stage_dir"
-  gsutil -q -m cp "$out_dir/$archive_name" "gs://$BUILDS_BUCKET/builds/$archive_name"
+  gsutil -q -m cp "$out_dir/$archive_name" "gs://$BENCH_BUCKET/builds/$archive_name"
   rm -rf "$out_dir"
 }
 

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -128,6 +128,10 @@ if [[ ${#build_sha_arr[@]} -gt 1 ]]; then
   gsutil -mq cp -r "$output_dir/baseline" "$baseline_cache_path"
 fi
 
+# Push experiment results to cache
+experiment_cache_path="gs://$BENCH_BUCKET/cache/$GCE_MACHINE_TYPE/$SANITIZED_BENCH_PACKAGE/${sha_arr[0]}"
+gsutil -mq cp -r "$output_dir/experiment" "$experiment_cache_path"
+
 # Compare the results, if both sets of benchmarks were run.
 # These should exist if the benchmarks were run successfully.
 if [ -d "$output_dir/experiment" ] && [ "$(ls -A "$output_dir/experiment")" ] \

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 #
 # This script runs microbenchmarks across a roachprod cluster. It will build microbenchmark binaries
-# for the given revisions if they do not already exist in the BUILDS_BUCKET. It will then create a
+# for the given revisions if they do not already exist in the BENCH_BUCKET. It will then create a
 # roachprod cluster, stage the binaries on the cluster, and run the microbenchmarks.
 # Parameters (and suggested defaults):
 #   BENCH_REVISION: revision to build and run benchmarks against (default: master)
 #   BENCH_COMPARE_REVISION: revision to compare against (default: latest release branch)
-#   BUILDS_BUCKET: GCS bucket to store the built binaries
+#   BENCH_BUCKET: GCS bucket to store the built binaries and compare cache (default: cockroach-microbench)
 #   BENCH_PACKAGE: package to build and run benchmarks against (default: ./pkg/...)
 #   BENCH_ITERATIONS: number of iterations to run each microbenchmark (default: 10)
 #   GCE_NODE_COUNT: number of nodes to use in the roachprod cluster (default: 12)
@@ -27,6 +27,18 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 output_dir="./artifacts/microbench"
 exit_status=0
+
+# Set up credentials
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+log_into_gcloud
+export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
+export ROACHPROD_USER=teamcity
+export ROACHPROD_CLUSTER=teamcity-microbench-${TC_BUILD_ID}
+generate_ssh_key
+
+# Sanatize the package name for use in paths
+SANITIZED_BENCH_PACKAGE=${BENCH_PACKAGE//\//-}
+export SANITIZED_BENCH_PACKAGE=${SANITIZED_BENCH_PACKAGE/.../all}
 
 # Build rochprod and roachprod-microbench
 run_bazel <<'EOF'
@@ -61,17 +73,24 @@ for rev in "${revisions[@]}"; do
   sha_arr+=("$sha")
 done
 
-# Builds binaries for the given SHAs.
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GOOGLE_EPHEMERAL_CREDENTIALS -e BENCH_PACKAGE -e BUILDS_BUCKET" \
-  run_bazel build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh "${sha_arr[@]}"
+# Check if the baseline cache exists and copy it to the output directory.
+baseline_cache_path="gs://$BENCH_BUCKET/cache/$GCE_MACHINE_TYPE/$SANITIZED_BENCH_PACKAGE/${sha_arr[1]}"
+declare -a build_sha_arr
+build_sha_arr+=("${sha_arr[0]}")
+if check_gcs_path_exists "$baseline_cache_path"; then
+  mkdir -p "$output_dir/baseline"
+  gsutil -mq cp -r "$baseline_cache_path/*" "$output_dir/baseline"
+  echo "Baseline cache found for ${name_arr[1]}. Using it for comparison."
+else
+  build_sha_arr+=("${sha_arr[1]}")
+fi
 
-# Set up credentials (needs to be done after the build phase)
-google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+# Builds binaries for the given SHAs.
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GOOGLE_EPHEMERAL_CREDENTIALS -e SANITIZED_BENCH_PACKAGE -e BENCH_PACKAGE -e BENCH_BUCKET" \
+  run_bazel build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh "${build_sha_arr[@]}"
+
+# Log into gcloud again (credentials are removed by teamcity-support in the build script)
 log_into_gcloud
-export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
-export ROACHPROD_USER=teamcity
-export ROACHPROD_CLUSTER=teamcity-microbench-${TC_BUILD_ID}
-generate_ssh_key
 
 # Create roachprod cluster
 ./bin/roachprod create "$ROACHPROD_CLUSTER" -n "$GCE_NODE_COUNT" \
@@ -84,16 +103,16 @@ generate_ssh_key
   --os-volume-size=384
 
 # Stage binaries on the cluster
-for sha in "${sha_arr[@]}"; do
+for sha in "${build_sha_arr[@]}"; do
   archive_name=${BENCH_PACKAGE//\//-}
   archive_name="$sha-${archive_name/.../all}.tar.gz"
-  ./bin/roachprod-microbench stage --quiet "$ROACHPROD_CLUSTER" "gs://$BUILDS_BUCKET/builds/$archive_name" "$sha"
+  ./bin/roachprod-microbench stage --quiet "$ROACHPROD_CLUSTER" "gs://$BENCH_BUCKET/builds/$archive_name" "$sha"
 done
 
 # Execute microbenchmarks
 ./bin/roachprod-microbench run "$ROACHPROD_CLUSTER" \
-  --binaries experiment="${sha_arr[0]}" \
-  --binaries baseline="${sha_arr[1]}" \
+  --binaries experiment="${build_sha_arr[0]}" \
+  ${build_sha_arr[1]:+--binaries baseline="${build_sha_arr[1]}"} \
   --output-dir="$output_dir" \
   --iterations "$BENCH_ITERATIONS" \
   --shell="$BENCH_SHELL" \
@@ -104,10 +123,15 @@ done
   -- "$TEST_ARGS" \
   || exit_status=$?
 
+# Push baseline to cache if we ran both benchmarks
+if [[ ${#build_sha_arr[@]} -gt 1 ]]; then
+  gsutil -mq cp -r "$output_dir/baseline" "$baseline_cache_path"
+fi
 
-# Compare the results, if both sets of benchmarks were run
-if [ -d "$output_dir/0" ] && [ "$(ls -A "$output_dir/0")" ] \
-&& [ -d "$output_dir/1" ] && [ "$(ls -A "$output_dir/1")" ]; then
+# Compare the results, if both sets of benchmarks were run.
+# These should exist if the benchmarks were run successfully.
+if [ -d "$output_dir/experiment" ] && [ "$(ls -A "$output_dir/experiment")" ] \
+&& [ -d "$output_dir/baseline" ] && [ "$(ls -A "$output_dir/baseline")" ]; then
   # Set up slack token only if the build was triggered by TeamCity (not a manual run)
   if [ -n "${TRIGGERED_BUILD:-}" ]; then
     slack_token="${MICROBENCH_SLACK_TOKEN}"


### PR DESCRIPTION
Previously, we would run microbenchmarks for both sets of binaries (the baseline
and experiment revision). Although this was beneficial to eliminate variance to
some degree, we could rather reuse cached results from the baseline revision and
possibly spend the extra compute on an extra run mid-week.

This change writes the results of the baseline revision to GCS. If the revision
exists in storage it will pull and compare against those results, and only run
the `experiment` revision.

Resolves: #128883

Epic: None
Release note: None