### PR TITLE
changefeedccl: example changefeed logic test and cdc queries logging

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -88,6 +88,7 @@ func NewEvaluator(
 	statementTS hlc.Timestamp,
 	withDiff bool,
 ) *Evaluator {
+	log.Infof(context.Background(), "NewEvaluator statementTS: %v", statementTS)
 	return &Evaluator{
 		sc:          sc,
 		execCfg:     execCfg,
@@ -167,6 +168,9 @@ func (e *Evaluator) Eval(
 func (e *familyEvaluator) eval(
 	ctx context.Context, updatedRow cdcevent.Row, prevRow cdcevent.Row,
 ) (projection cdcevent.Row, evalErr error) {
+	log.Infof(ctx, "eval: updatedRow: %v mvcc@%v schema@%v,\n      prevRow: %v mvcc@%v schema@%v",
+		updatedRow.DebugString(), updatedRow.MvccTimestamp, updatedRow.SchemaTS,
+		prevRow.DebugString(), prevRow.MvccTimestamp, prevRow.SchemaTS)
 	if updatedRow.FamilyID != e.targetFamilyID {
 		return cdcevent.Row{}, errors.AssertionFailedf(
 			"row family id (%d) differs from target id (%d)", updatedRow.FamilyID, e.targetFamilyID)
@@ -286,6 +290,7 @@ func (e *familyEvaluator) preparePlan(
 	// Perform cleanup of the previous plan if there is one.
 	e.performCleanup()
 
+	log.Infof(ctx, "preparePlan: statementTS: %v, schemaTS: %v, prevTS: %v", e.statementTS, e.currDesc.SchemaTS, e.prevDesc.SchemaTS)
 	err = withPlanner(ctx, e.execCfg, e.statementTS, e.user, e.currDesc.SchemaTS, e.sessionData,
 		func(ctx context.Context, execCtx sql.JobExecContext, cleanup func()) error {
 			e.cleanup = cleanup

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -279,6 +279,7 @@ func NewEventDescriptor(
 	keyOnly bool,
 	schemaTS hlc.Timestamp,
 ) (*EventDescriptor, error) {
+	log.Infof(context.Background(), "NewEventDescriptor schemaTS: %v, descV: %v", schemaTS, desc.GetVersion())
 	sd := EventDescriptor{
 		Metadata: Metadata{
 			TableID:          desc.GetID(),
@@ -462,11 +463,13 @@ func getEventDescriptorCached(
 	if v, ok := cache.Get(idVer); ok {
 		ed := v.(*EventDescriptor)
 		if catalog.UserDefinedTypeColsHaveSameVersion(ed.td, desc) {
+			log.Infof(context.Background(), "getEventDescriptorCached: cached event desc schemaTS: %v, descV: %v", ed.SchemaTS, ed.Version)
 			return ed, nil
 		}
 	}
 
 	ed, err := NewEventDescriptor(desc, family, includeVirtual, keyOnly, schemaTS)
+	log.Infof(context.Background(), "getEventDescriptorCached: new event desc schemaTS: %v, descV: %v", ed.SchemaTS, ed.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -223,6 +223,8 @@ func newKVEventToRowConsumer(
 ) (_ *kvEventToRowConsumer, err error) {
 	includeVirtual := details.Opts.IncludeVirtual()
 	keyOnly := details.Opts.KeyOnly()
+
+	log.Infof(context.Background(), "NewKVEventToRowConsumer cursor: %v", cursor)
 	decoder, err := cdcevent.NewEventDecoder(ctx, cfg, details.Targets, includeVirtual, keyOnly)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/logictestccl/testdata/logic_test/cdc_eval
+++ b/pkg/ccl/logictestccl/testdata/logic_test/cdc_eval
@@ -1,0 +1,51 @@
+statement ok
+SET CLUSTER SETTING kv.rangefeed.enabled = true
+
+statement ok
+alter range default configure zone using gc.ttlseconds = 1;
+
+statement ok
+alter database system configure zone using gc.ttlseconds = 1;
+
+statement ok
+create table s (k int primary key, v int, family (k,v));
+
+statement ok
+create table t (k int primary key, v int, family (k,v));
+
+statement ok
+INSERT INTO t values (1,1);
+
+statement ok
+INSERT INTO s values (1,1);
+
+statement ok
+CREATE CHANGEFEED INTO 'null:///50ms' WITH OPTIONS (initial_scan = 'no', schema_change_policy = 'nobackfill') AS SELECT (cdc_prev).v, v FROM t WHERE v != (cdc_prev).v
+
+query T
+select status from [show changefeed jobs]
+----
+running
+
+statement ok
+UPDATE t SET v = 4 WHERE k = 1;
+
+statement ok
+alter table s add constraint fkey foreign key (v) references t (k) on delete set null on update cascade;
+
+statement ok
+select pg_sleep(3);
+
+statement ok
+UPDATE t SET v = 4 WHERE k = 1;
+
+statement ok
+UPDATE t SET v = 6 WHERE k = 1;
+
+statement ok
+select pg_sleep(10);
+
+query T
+select status from [show changefeed jobs]
+----
+running

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -368,6 +368,13 @@ func TestTenantLogic_cast(
 	runLogicTest(t, "cast")
 }
 
+func TestTenantLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestTenantLogic_check_constraints(
 	t *testing.T,
 ) {
@@ -2592,6 +2599,13 @@ func TestTenantLogic_zone_config(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "zone_config")
+}
+
+func TestTenantLogicCCL_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
 }
 
 func TestTenantLogicCCL_cluster_locks_tenant(

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-23.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 26,
+    shard_count = 27,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-23.2/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 37,
+    shard_count = 38,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -105,6 +105,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestReadCommittedLogicCCL_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestReadCommittedLogicCCL_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 47,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -106,6 +106,13 @@ func TestCCLLogic_case_sensitive_names(
 	runCCLLogicTest(t, "case_sensitive_names")
 }
 
+func TestCCLLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cdc_eval")
+}
+
 func TestCCLLogic_changefeed(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -389,6 +389,7 @@ func getDescriptorsFromStoreForInterval(
 		}
 
 		// Export request returns descriptors in decreasing modification time.
+		log.Infof(ctx, "lease desc bounds [%v, %v)", lowerBound, upperBound)
 		res, pErr := kv.SendWrappedWith(ctx, db.NonTransactionalSender(), batchRequestHeader, req)
 		if pErr != nil {
 			return nil, errors.Wrapf(pErr.GoError(), "error in retrieving descs between %s, %s",

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -337,6 +337,13 @@ func TestLogic_ccl(
 	runLogicTest(t, "ccl")
 }
 
+func TestLogic_cdc_eval(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cdc_eval")
+}
+
 func TestLogic_check_constraints(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -203,6 +203,11 @@ func TestSchemaChangeComparator_ccl(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/ccl"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_cdc_eval(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/cdc_eval"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_check_constraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/check_constraints"


### PR DESCRIPTION
The draft PR has a ccl logic test with a changefeed to a null sink. This was useful to quickly iterate on logging and using a debugger. It also adds some logging about schema timestamps and versions to the cdc queries planning code path.

DO NOT MERGE