### PR TITLE
release-24.1: schemachanger: assorted fixes to CREATE INDEX

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -487,3 +487,22 @@ CREATE INDEX tab1_i1 ON tab1 (c3) STORING (c2);
 
 statement ok
 DROP TABLE tab1;
+
+# Make sure the IF NOT EXISTS clause short-circuits if the index already exists.
+subtest create_index_if_not_exists_short_circuits
+
+statement ok
+CREATE TABLE tbl_ifne (a INT PRIMARY KEY, b INT)
+
+statement ok
+CREATE INDEX idx ON tbl_ifne (b)
+
+statement error index "invalid_idx" already contains column "a".*
+CREATE INDEX invalid_idx ON tbl_ifne (b) STORING (a)
+
+# With IF NOT EXISTS, the statement never runs, so this succeeds.
+statement ok
+CREATE INDEX IF NOT EXISTS idx ON tbl_ifne (b) STORING (a)
+
+statement ok
+DROP TABLE tbl_ifne CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -430,6 +430,16 @@ CREATE INDEX ON opclasses(c blah_ops)
 statement error pgcode 42704 operator class "blah_ops" does not exist
 CREATE INVERTED INDEX ON opclasses(c blah_ops)
 
+# Make sure that we don't permit a descending column for the last column of an
+# inverted index.
+statement error pgcode 0A000 the last column in an inverted index cannot have the DESC option
+CREATE INVERTED INDEX ON opclasses(c DESC)
+
+# Make sure that we don't permit a descending column for the last column of an
+# inverted index.
+statement ok
+CREATE INVERTED INDEX ON opclasses(a DESC, c)
+
 subtest create_index_on_materialized_view
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -462,26 +462,31 @@ CREATE INDEX ON v ((b>0));
 # Repro of issue found in #124511 when using the declarative schema changer.
 # Using utf8 character in column name that is included in STORED() clause is not
 # being seen as a duplicate of an existing index.
+# This also tests to make sure mixed-case names are handled correctly.
 subtest create_index_with_utf8_col_names
 
 statement ok
 CREATE TABLE tab_w0_7 (
    "col\u000b7ͪ%q_w0_10" UUID,
    c2 STRING,
-   PRIMARY KEY(c2, "col\u000b7ͪ%q_w0_10")
+   "MixedCase" INT,
+   PRIMARY KEY(c2, "col\u000b7ͪ%q_w0_10", "MixedCase")
 );
 
-statement error index ".*" already contains column ".*".*
+statement error index ".*" already contains column ".*q_w0_10".*
 CREATE INDEX tab_w0_7_i1 on tab_w0_7 (c2) STORING ("col\u000b7ͪ%q_w0_10");
 
-statement error index ".*" already contains column ".*".*
+statement error index ".*" already contains column ".*q_w0_10".*
 CREATE INDEX tab_w0_7_i1 on tab_w0_7 ("col\u000b7ͪ%q_w0_10") STORING ("col\u000b7ͪ%q_w0_10");
+
+statement error index ".*" already contains column "MixedCase".*
+CREATE INDEX tab_w0_7_i1 on tab_w0_7 (c2) STORING ("MixedCase");
 
 statement ok
 DROP TABLE tab_w0_7;
 
 # Repro of issue found in #124511 when using the declarative schema changer. We
-# need to block when attempting to include a virtual column in a STORED()
+# need to block when attempting to include a virtual column in a STORING()
 # clause.
 subtest create_index_with_stored_virtual_col
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -550,7 +550,7 @@ func addColumnsForSecondaryIndex(
 		// 1) CREATE INDEX idx ON t(i, i)
 		// 2) CREATE INDEX idx ON t(lower(i), j, lower(i)).
 		if columnNode.Expr == nil {
-			colName := columnNode.Column.Normalize()
+			colName := string(columnNode.Column)
 			if _, found := columnRefs[colName]; found {
 				panic(pgerror.Newf(pgcode.InvalidObjectDefinition,
 					"index %q contains duplicate column %q", n.Name, colName))
@@ -566,7 +566,7 @@ func addColumnsForSecondaryIndex(
 		}
 	}
 	for _, storingNode := range n.Storing {
-		colName := storingNode.Normalize()
+		colName := string(storingNode)
 		if _, found := columnRefs[colName]; found {
 			panic(sqlerrors.NewColumnAlreadyExistsInIndexError(string(n.Name), colName))
 		}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -48,48 +48,17 @@ import (
 
 // CreateIndex implements CREATE INDEX.
 func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
+	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(b)
+	if !activeVersion.IsActive(clusterversion.V23_2) &&
+		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
+		panic(unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported"))
+	}
 	b.IncrementSchemaChangeCreateCounter("index")
 	// Resolve the table name and start building the new index element.
 	relationElements := b.ResolveRelation(n.Table.ToUnresolvedObjectName(), ResolveParams{
 		IsExistenceOptional: false,
 		RequiredPrivilege:   privilege.CREATE,
 	})
-	// We don't support handling zone config related properties for tables required
-	// for regional by row tables.
-	if _, _, tbl := scpb.FindTable(relationElements); tbl != nil {
-		fallBackIfRegionalByRowTable(b, n, tbl.TableID)
-	}
-	_, _, partitioning := scpb.FindTablePartitioning(relationElements)
-	if partitioning != nil && n.PartitionByIndex != nil &&
-		n.PartitionByIndex.ContainsPartitions() {
-		panic(pgerror.New(
-			pgcode.FeatureNotSupported,
-			"cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition",
-		))
-	}
-	panicIfSchemaIsLocked(relationElements)
-
-	// Inverted indexes do not support hash sharding or unique.
-	if n.Inverted {
-		if n.Sharded != nil {
-			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes don't support hash sharding"))
-		}
-		if len(n.Storing) > 0 {
-			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes don't support stored columns"))
-		}
-		if n.Unique {
-			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique"))
-		}
-		b.IncrementSchemaChangeIndexCounter("inverted")
-		if len(n.Columns) > 1 {
-			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
-		}
-	}
-	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(b)
-	if !activeVersion.IsActive(clusterversion.V23_2) &&
-		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
-		panic(unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported"))
-	}
 	var idxSpec indexSpec
 	idxSpec.secondary = &scpb.SecondaryIndex{
 		Index: scpb.Index{
@@ -123,23 +92,6 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			}
 			idxSpec.secondary.TableID = t.ViewID
 			relation = e
-
-		case *scpb.TableLocalityGlobal, *scpb.TableLocalityPrimaryRegion, *scpb.TableLocalitySecondaryRegion:
-			if n.PartitionByIndex != nil {
-				panic(pgerror.New(pgcode.FeatureNotSupported,
-					"cannot define PARTITION BY on a new INDEX in a multi-region database",
-				))
-			}
-
-		case *scpb.TableLocalityRegionalByRow:
-			if n.PartitionByIndex != nil {
-				panic(pgerror.New(pgcode.FeatureNotSupported,
-					"cannot define PARTITION BY on a new INDEX in a multi-region database",
-				))
-			}
-			if n.Sharded != nil {
-				panic(pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes are not compatible with REGIONAL BY ROW tables"))
-			}
 
 		case *scpb.PrimaryIndex:
 			// TODO(ajwerner): This is too simplistic. We should build a better
@@ -178,6 +130,57 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			panic(pgerror.Newf(pgcode.DuplicateRelation, "index with name %q already exists", n.Name))
 		}
 	}
+	// We don't support handling zone config related properties for tables required
+	// for regional by row tables.
+	if _, _, tbl := scpb.FindTable(relationElements); tbl != nil {
+		fallBackIfRegionalByRowTable(b, n, tbl.TableID)
+	}
+	_, _, partitioning := scpb.FindTablePartitioning(relationElements)
+	if partitioning != nil && n.PartitionByIndex != nil &&
+		n.PartitionByIndex.ContainsPartitions() {
+		panic(pgerror.New(
+			pgcode.FeatureNotSupported,
+			"cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition",
+		))
+	}
+	panicIfSchemaIsLocked(relationElements)
+
+	// Inverted indexes do not support hash sharding or unique.
+	if n.Inverted {
+		if n.Sharded != nil {
+			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes don't support hash sharding"))
+		}
+		if len(n.Storing) > 0 {
+			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes don't support stored columns"))
+		}
+		if n.Unique {
+			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique"))
+		}
+		b.IncrementSchemaChangeIndexCounter("inverted")
+		if len(n.Columns) > 1 {
+			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
+		}
+	}
+	relationElements.ForEach(func(_ scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		switch e.(type) {
+		case *scpb.TableLocalityGlobal, *scpb.TableLocalityPrimaryRegion, *scpb.TableLocalitySecondaryRegion:
+			if n.PartitionByIndex != nil {
+				panic(pgerror.New(pgcode.FeatureNotSupported,
+					"cannot define PARTITION BY on a new INDEX in a multi-region database",
+				))
+			}
+
+		case *scpb.TableLocalityRegionalByRow:
+			if n.PartitionByIndex != nil {
+				panic(pgerror.New(pgcode.FeatureNotSupported,
+					"cannot define PARTITION BY on a new INDEX in a multi-region database",
+				))
+			}
+			if n.Sharded != nil {
+				panic(pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes are not compatible with REGIONAL BY ROW tables"))
+			}
+		}
+	})
 	// Assign the ID here, since we may have added columns
 	// and made a new primary key above.
 	idxSpec.secondary.SourceIndexID = sourceIndex.IndexID

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -321,7 +321,7 @@ func processColNodeType(
 			"operator classes are only allowed for the last column of an inverted index"))
 	}
 	// Disallow descending last columns in inverted indexes.
-	if n.Inverted && columnNode.Direction == tree.Descending {
+	if n.Inverted && columnNode.Direction == tree.Descending && lastColIdx {
 		panic(pgerror.New(pgcode.FeatureNotSupported,
 			"the last column in an inverted index cannot have the DESC option"))
 	}


### PR DESCRIPTION
Backport 3/3 commits from #128215.

/cc @cockroachdb/release

Release justification: bug fix

---

This is broken up into separate commits.

### scbuild: short circuit CREATE INDEX IF NOT EXISTS

Release note (bug fix): Fixed a bug where CREATE INDEX IF NOT EXISTS
would not correctly short-circuit if the given index already existed.

### scbuild: only disallow descending columns for last col of inverted index

Release note (bug fix): Fixed a bug in overly eager syntax validation,
in which the DESCENDING clause was not allowed for non-terminal columns
of an inverted index. Only the last column of an inverted index should
be prevented from being DESCENDING, and this is properly checked now.

### scbuild: properly check mixed-case names when creating index

This bug was introduced in e638cb6e09c6fee145206aa83fe835d28427aba9.

Release note (bug fix): Fixed a bug where an index could store a column
in the primary index if that column had a mixed-case name.

Epic: None
