### PR TITLE
release-23.2: cli: add fallback query support for debug zip

### DIFF
--- a/pkg/cli/testdata/zip/testzip_fallback
+++ b/pkg/cli/testdata/zip/testzip_fallback
@@ -1,0 +1,268 @@
+----
+debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+[cluster] discovering virtual clusters... done
+[cluster] creating output file /dev/null... done
+[cluster] establishing RPC connection to ...
+[cluster] using SQL address: ...
+[cluster] requesting data for debug/events... received response... writing JSON output: debug/events.json... done
+[cluster] requesting data for debug/rangelog... received response... writing JSON output: debug/rangelog.json... done
+[cluster] requesting data for debug/settings... received response... writing JSON output: debug/settings.json... done
+[cluster] requesting data for debug/reports/problemranges... received response... writing JSON output: debug/reports/problemranges.json... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_node_stream_checkpoints... writing output: debug/crdb_internal.cluster_replication_node_stream_checkpoints.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_node_stream_spans... writing output: debug/crdb_internal.cluster_replication_node_stream_spans.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_node_streams... writing output: debug/crdb_internal.cluster_replication_node_streams.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.cluster_replication_spans... writing output: debug/crdb_internal.cluster_replication_spans.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_function_statements... writing output: debug/crdb_internal.create_function_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_procedure_statements... writing output: debug/crdb_internal.create_procedure_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_schema_statements... writing output: debug/crdb_internal.create_schema_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_statements... writing output: debug/crdb_internal.create_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_type_statements... writing output: debug/crdb_internal.create_type_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.logical_replication_node_processors... writing output: debug/crdb_internal.logical_replication_node_processors.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_contention_events... writing output: debug/crdb_internal.cluster_contention_events.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_database_privileges... writing output: debug/crdb_internal.cluster_database_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_distsql_flows... writing output: debug/crdb_internal.cluster_distsql_flows.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_locks... writing output: debug/crdb_internal.cluster_locks.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_queries... writing output: debug/crdb_internal.cluster_queries.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_sessions... writing output: debug/crdb_internal.cluster_sessions.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_settings... writing output: debug/crdb_internal.cluster_settings.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_transactions... writing output: debug/crdb_internal.cluster_transactions.txt... done
+[cluster] retrieving SQL data for crdb_internal.default_privileges... writing output: debug/crdb_internal.default_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.index_usage_statistics... writing output: debug/crdb_internal.index_usage_statistics.txt... done
+[cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/crdb_internal.invalid_objects.txt... done
+[cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/crdb_internal.jobs.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/crdb_internal.kv_node_liveness.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/crdb_internal.kv_node_status.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_protected_ts_records... writing output: debug/crdb_internal.kv_protected_ts_records.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/crdb_internal.kv_store_status.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/crdb_internal.kv_system_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/crdb_internal.partitions.txt... done
+[cluster] retrieving SQL data for crdb_internal.probe_ranges_1s_read_limit_100... writing output: debug/crdb_internal.probe_ranges_1s_read_limit_100.txt... done
+[cluster] retrieving SQL data for crdb_internal.regions... writing output: debug/crdb_internal.regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.schema_changes... writing output: debug/crdb_internal.schema_changes.txt... done
+[cluster] retrieving SQL data for crdb_internal.super_regions... writing output: debug/crdb_internal.super_regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.system_jobs... writing output: debug/crdb_internal.system_jobs.txt... done
+[cluster] retrieving SQL data for crdb_internal.table_indexes... writing output: debug/crdb_internal.table_indexes.txt... done
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events... writing output: debug/crdb_internal.transaction_contention_events.txt...
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events: last request failed: ERROR: column "fail" does not exist (SQLSTATE 42703)
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events: creating error output: debug/crdb_internal.transaction_contention_events.txt.err.txt... done
+[cluster] retrieving SQL data for crdb_internal.zones... writing output: debug/crdb_internal.zones.txt... done
+[cluster] retrieving SQL data for system.database_role_settings... writing output: debug/system.database_role_settings.txt... done
+[cluster] retrieving SQL data for system.descriptor... writing output: debug/system.descriptor.txt... done
+[cluster] retrieving SQL data for system.eventlog... writing output: debug/system.eventlog.txt... done
+[cluster] retrieving SQL data for system.external_connections... writing output: debug/system.external_connections.txt... done
+[cluster] retrieving SQL data for system.job_info... writing output: debug/system.job_info.txt... done
+[cluster] retrieving SQL data for system.jobs... writing output: debug/system.jobs.txt... done
+[cluster] retrieving SQL data for system.lease... writing output: debug/system.lease.txt... done
+[cluster] retrieving SQL data for system.locations... writing output: debug/system.locations.txt... done
+[cluster] retrieving SQL data for system.migrations... writing output: debug/system.migrations.txt... done
+[cluster] retrieving SQL data for system.namespace... writing output: debug/system.namespace.txt... done
+[cluster] retrieving SQL data for system.privileges... writing output: debug/system.privileges.txt... done
+[cluster] retrieving SQL data for system.protected_ts_meta... writing output: debug/system.protected_ts_meta.txt... done
+[cluster] retrieving SQL data for system.protected_ts_records... writing output: debug/system.protected_ts_records.txt... done
+[cluster] retrieving SQL data for system.rangelog... writing output: debug/system.rangelog.txt... done
+[cluster] retrieving SQL data for system.replication_constraint_stats... writing output: debug/system.replication_constraint_stats.txt... done
+[cluster] retrieving SQL data for system.replication_critical_localities... writing output: debug/system.replication_critical_localities.txt... done
+[cluster] retrieving SQL data for system.replication_stats... writing output: debug/system.replication_stats.txt... done
+[cluster] retrieving SQL data for system.reports_meta... writing output: debug/system.reports_meta.txt... done
+[cluster] retrieving SQL data for system.role_id_seq... writing output: debug/system.role_id_seq.txt... done
+[cluster] retrieving SQL data for system.role_members... writing output: debug/system.role_members.txt... done
+[cluster] retrieving SQL data for system.role_options... writing output: debug/system.role_options.txt... done
+[cluster] retrieving SQL data for system.scheduled_jobs... writing output: debug/system.scheduled_jobs.txt... done
+[cluster] retrieving SQL data for system.settings... writing output: debug/system.settings.txt... done
+[cluster] retrieving SQL data for system.span_configurations... writing output: debug/system.span_configurations.txt... done
+[cluster] retrieving SQL data for system.sql_instances... writing output: debug/system.sql_instances.txt... done
+[cluster] retrieving SQL data for system.sql_stats_cardinality... writing output: debug/system.sql_stats_cardinality.txt... done
+[cluster] retrieving SQL data for system.sqlliveness... writing output: debug/system.sqlliveness.txt... done
+[cluster] retrieving SQL data for system.statement_diagnostics... writing output: debug/system.statement_diagnostics.txt... done
+[cluster] retrieving SQL data for system.statement_diagnostics_requests... writing output: debug/system.statement_diagnostics_requests.txt... done
+[cluster] retrieving SQL data for system.statement_statistics_limit_5000... writing output: debug/system.statement_statistics_limit_5000.txt... done
+[cluster] retrieving SQL data for system.table_statistics... writing output: debug/system.table_statistics.txt... done
+[cluster] retrieving SQL data for system.task_payloads... writing output: debug/system.task_payloads.txt... done
+[cluster] retrieving SQL data for system.tenant_settings... writing output: debug/system.tenant_settings.txt... done
+[cluster] retrieving SQL data for system.tenant_tasks... writing output: debug/system.tenant_tasks.txt... done
+[cluster] retrieving SQL data for system.tenant_usage... writing output: debug/system.tenant_usage.txt... done
+[cluster] retrieving SQL data for system.tenants... writing output: debug/system.tenants.txt... done
+[cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
+[cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
+[cluster] requesting tenant ranges... received response...
+[cluster] requesting tenant ranges: last request failed: rpc error: ...
+[cluster] requesting tenant ranges: creating error output: debug/tenant_ranges.err.txt... done
+[cluster] collecting the inflight traces for jobs... received response... done
+[cluster] requesting CPU profiles
+[cluster] profiles generated
+[cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
+[node 1] node status... writing JSON output: debug/nodes/1/status.json... done
+[node 1] using SQL connection URL: postgresql://...
+[node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/nodes/1/crdb_internal.active_range_feeds.txt... done
+[node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/nodes/1/crdb_internal.feature_usage.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/nodes/1/crdb_internal.gossip_alerts.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/nodes/1/crdb_internal.gossip_liveness.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/nodes/1/crdb_internal.gossip_nodes.txt... done
+[node 1] retrieving SQL data for crdb_internal.kv_session_based_leases... writing output: debug/nodes/1/crdb_internal.kv_session_based_leases.txt... done
+[node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/nodes/1/crdb_internal.leases.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/nodes/1/crdb_internal.node_build_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_contention_events... writing output: debug/nodes/1/crdb_internal.node_contention_events.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_distsql_flows... writing output: debug/nodes/1/crdb_internal.node_distsql_flows.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_execution_insights... writing output: debug/nodes/1/crdb_internal.node_execution_insights.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing output: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_memory_monitors... writing output: debug/nodes/1/crdb_internal.node_memory_monitors.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_metrics... writing output: debug/nodes/1/crdb_internal.node_metrics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_queries... writing output: debug/nodes/1/crdb_internal.node_queries.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_runtime_info... writing output: debug/nodes/1/crdb_internal.node_runtime_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_sessions... writing output: debug/nodes/1/crdb_internal.node_sessions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_statement_statistics... writing output: debug/nodes/1/crdb_internal.node_statement_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache... writing output: debug/nodes/1/crdb_internal.node_tenant_capabilities_cache.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transaction_statistics... writing output: debug/nodes/1/crdb_internal.node_transaction_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transactions... writing output: debug/nodes/1/crdb_internal.node_transactions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_execution_insights... writing output: debug/nodes/1/crdb_internal.node_txn_execution_insights.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_stats... writing output: debug/nodes/1/crdb_internal.node_txn_stats.txt... done
+[node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
+[node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
+[node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done
+[node 1] requesting stacks with labels... received response... writing binary output: debug/nodes/1/stacks_with_labels.txt... done
+[node 1] requesting heap profile... received response... writing binary output: debug/nodes/1/heap.pprof... done
+[node 1] requesting engine stats... received response... writing binary output: debug/nodes/1/lsm.txt... done
+[node 1] requesting heap profile list... received response... done
+[node ?] ? heap profiles found
+[node 1] requesting goroutine dump list... received response... done
+[node ?] ? goroutine dumps found
+[node 1] requesting cpu profile list... received response... done
+[node ?] ? cpu profiles found
+[node 1] requesting log files list... received response... done
+[node ?] ? log files found
+[node 1] requesting ranges... received response... done
+[node 1] writing ranges... writing JSON output: debug/nodes/1/ranges.json... done
+[cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
+[cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
+[cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
+----
+debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+[cluster] discovering virtual clusters... done
+[cluster] creating output file /dev/null... done
+[cluster] establishing RPC connection to ...
+[cluster] using SQL address: ...
+[cluster] requesting data for debug/events... received response... writing JSON output: debug/events.json... done
+[cluster] requesting data for debug/rangelog... received response... writing JSON output: debug/rangelog.json... done
+[cluster] requesting data for debug/settings... received response... writing JSON output: debug/settings.json... done
+[cluster] requesting data for debug/reports/problemranges... received response... writing JSON output: debug/reports/problemranges.json... done
+[cluster] retrieving SQL data for "".crdb_internal.create_function_statements... writing output: debug/crdb_internal.create_function_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_procedure_statements... writing output: debug/crdb_internal.create_procedure_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_schema_statements... writing output: debug/crdb_internal.create_schema_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_statements... writing output: debug/crdb_internal.create_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_type_statements... writing output: debug/crdb_internal.create_type_statements.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_contention_events... writing output: debug/crdb_internal.cluster_contention_events.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_database_privileges... writing output: debug/crdb_internal.cluster_database_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_distsql_flows... writing output: debug/crdb_internal.cluster_distsql_flows.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_locks... writing output: debug/crdb_internal.cluster_locks.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_queries... writing output: debug/crdb_internal.cluster_queries.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_sessions... writing output: debug/crdb_internal.cluster_sessions.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_settings... writing output: debug/crdb_internal.cluster_settings.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_transactions... writing output: debug/crdb_internal.cluster_transactions.txt... done
+[cluster] retrieving SQL data for crdb_internal.default_privileges... writing output: debug/crdb_internal.default_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.index_usage_statistics... writing output: debug/crdb_internal.index_usage_statistics.txt... done
+[cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/crdb_internal.invalid_objects.txt... done
+[cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/crdb_internal.jobs.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_liveness... writing output: debug/crdb_internal.kv_node_liveness.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_node_status... writing output: debug/crdb_internal.kv_node_status.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_protected_ts_records... writing output: debug/crdb_internal.kv_protected_ts_records.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_store_status... writing output: debug/crdb_internal.kv_store_status.txt... done
+[cluster] retrieving SQL data for crdb_internal.kv_system_privileges... writing output: debug/crdb_internal.kv_system_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/crdb_internal.partitions.txt... done
+[cluster] retrieving SQL data for crdb_internal.probe_ranges_1s_read_limit_100... writing output: debug/crdb_internal.probe_ranges_1s_read_limit_100.txt... done
+[cluster] retrieving SQL data for crdb_internal.regions... writing output: debug/crdb_internal.regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.schema_changes... writing output: debug/crdb_internal.schema_changes.txt... done
+[cluster] retrieving SQL data for crdb_internal.super_regions... writing output: debug/crdb_internal.super_regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.system_jobs... writing output: debug/crdb_internal.system_jobs.txt... done
+[cluster] retrieving SQL data for crdb_internal.table_indexes... writing output: debug/crdb_internal.table_indexes.txt... done
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events... writing output: debug/crdb_internal.transaction_contention_events.txt...
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events: last request failed: ERROR: column "fail" does not exist (SQLSTATE 42703)
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events: creating error output: debug/crdb_internal.transaction_contention_events.txt.err.txt... done
+[cluster] retrieving SQL data for crdb_internal.transaction_contention_events (fallback)... writing output: debug/crdb_internal.transaction_contention_events.fallback.txt... done
+[cluster] retrieving SQL data for crdb_internal.zones... writing output: debug/crdb_internal.zones.txt... done
+[cluster] retrieving SQL data for system.database_role_settings... writing output: debug/system.database_role_settings.txt... done
+[cluster] retrieving SQL data for system.descriptor... writing output: debug/system.descriptor.txt... done
+[cluster] retrieving SQL data for system.eventlog... writing output: debug/system.eventlog.txt... done
+[cluster] retrieving SQL data for system.external_connections... writing output: debug/system.external_connections.txt... done
+[cluster] retrieving SQL data for system.job_info... writing output: debug/system.job_info.txt... done
+[cluster] retrieving SQL data for system.jobs... writing output: debug/system.jobs.txt... done
+[cluster] retrieving SQL data for system.lease... writing output: debug/system.lease.txt... done
+[cluster] retrieving SQL data for system.locations... writing output: debug/system.locations.txt... done
+[cluster] retrieving SQL data for system.migrations... writing output: debug/system.migrations.txt... done
+[cluster] retrieving SQL data for system.namespace... writing output: debug/system.namespace.txt... done
+[cluster] retrieving SQL data for system.privileges... writing output: debug/system.privileges.txt... done
+[cluster] retrieving SQL data for system.protected_ts_meta... writing output: debug/system.protected_ts_meta.txt... done
+[cluster] retrieving SQL data for system.protected_ts_records... writing output: debug/system.protected_ts_records.txt... done
+[cluster] retrieving SQL data for system.rangelog... writing output: debug/system.rangelog.txt... done
+[cluster] retrieving SQL data for system.replication_constraint_stats... writing output: debug/system.replication_constraint_stats.txt... done
+[cluster] retrieving SQL data for system.replication_critical_localities... writing output: debug/system.replication_critical_localities.txt... done
+[cluster] retrieving SQL data for system.replication_stats... writing output: debug/system.replication_stats.txt... done
+[cluster] retrieving SQL data for system.reports_meta... writing output: debug/system.reports_meta.txt... done
+[cluster] retrieving SQL data for system.role_id_seq... writing output: debug/system.role_id_seq.txt... done
+[cluster] retrieving SQL data for system.role_members... writing output: debug/system.role_members.txt... done
+[cluster] retrieving SQL data for system.role_options... writing output: debug/system.role_options.txt... done
+[cluster] retrieving SQL data for system.scheduled_jobs... writing output: debug/system.scheduled_jobs.txt... done
+[cluster] retrieving SQL data for system.settings... writing output: debug/system.settings.txt... done
+[cluster] retrieving SQL data for system.span_configurations... writing output: debug/system.span_configurations.txt... done
+[cluster] retrieving SQL data for system.sql_instances... writing output: debug/system.sql_instances.txt... done
+[cluster] retrieving SQL data for system.sqlliveness... writing output: debug/system.sqlliveness.txt... done
+[cluster] retrieving SQL data for system.statement_diagnostics... writing output: debug/system.statement_diagnostics.txt... done
+[cluster] retrieving SQL data for system.statement_diagnostics_requests... writing output: debug/system.statement_diagnostics_requests.txt... done
+[cluster] retrieving SQL data for system.statement_statistics_limit_5000... writing output: debug/system.statement_statistics_limit_5000.txt... done
+[cluster] retrieving SQL data for system.table_statistics... writing output: debug/system.table_statistics.txt... done
+[cluster] retrieving SQL data for system.task_payloads... writing output: debug/system.task_payloads.txt... done
+[cluster] retrieving SQL data for system.tenant_settings... writing output: debug/system.tenant_settings.txt... done
+[cluster] retrieving SQL data for system.tenant_tasks... writing output: debug/system.tenant_tasks.txt... done
+[cluster] retrieving SQL data for system.tenant_usage... writing output: debug/system.tenant_usage.txt... done
+[cluster] retrieving SQL data for system.tenants... writing output: debug/system.tenants.txt... done
+[cluster] requesting nodes... received response... writing JSON output: debug/nodes.json... done
+[cluster] requesting liveness... received response... writing JSON output: debug/liveness.json... done
+[cluster] requesting tenant ranges... received response...
+[cluster] requesting tenant ranges: last request failed: rpc error: ...
+[cluster] requesting tenant ranges: creating error output: debug/tenant_ranges.err.txt... done
+[cluster] collecting the inflight traces for jobs... received response... done
+[cluster] requesting CPU profiles
+[cluster] profiles generated
+[cluster] profile for node 1... writing binary output: debug/nodes/1/cpu.pprof... done
+[node 1] node status... writing JSON output: debug/nodes/1/status.json... done
+[node 1] using SQL connection URL: postgresql://...
+[node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/nodes/1/crdb_internal.active_range_feeds.txt... done
+[node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/nodes/1/crdb_internal.feature_usage.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_alerts... writing output: debug/nodes/1/crdb_internal.gossip_alerts.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_liveness... writing output: debug/nodes/1/crdb_internal.gossip_liveness.txt... done
+[node 1] retrieving SQL data for crdb_internal.gossip_nodes... writing output: debug/nodes/1/crdb_internal.gossip_nodes.txt... done
+[node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/nodes/1/crdb_internal.leases.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/nodes/1/crdb_internal.node_build_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_contention_events... writing output: debug/nodes/1/crdb_internal.node_contention_events.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_distsql_flows... writing output: debug/nodes/1/crdb_internal.node_distsql_flows.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_execution_insights... writing output: debug/nodes/1/crdb_internal.node_execution_insights.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing output: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_memory_monitors... writing output: debug/nodes/1/crdb_internal.node_memory_monitors.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_metrics... writing output: debug/nodes/1/crdb_internal.node_metrics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_queries... writing output: debug/nodes/1/crdb_internal.node_queries.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_runtime_info... writing output: debug/nodes/1/crdb_internal.node_runtime_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_sessions... writing output: debug/nodes/1/crdb_internal.node_sessions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_statement_statistics... writing output: debug/nodes/1/crdb_internal.node_statement_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache... writing output: debug/nodes/1/crdb_internal.node_tenant_capabilities_cache.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transaction_statistics... writing output: debug/nodes/1/crdb_internal.node_transaction_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transactions... writing output: debug/nodes/1/crdb_internal.node_transactions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_execution_insights... writing output: debug/nodes/1/crdb_internal.node_txn_execution_insights.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_stats... writing output: debug/nodes/1/crdb_internal.node_txn_stats.txt... done
+[node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
+[node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
+[node 1] requesting data for debug/nodes/1/enginestats... received response... writing JSON output: debug/nodes/1/enginestats.json... done
+[node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done
+[node 1] requesting stacks with labels... received response... writing binary output: debug/nodes/1/stacks_with_labels.txt... done
+[node 1] requesting heap profile... received response... writing binary output: debug/nodes/1/heap.pprof... done
+[node 1] requesting heap profile list... received response... done
+[node ?] ? heap profiles found
+[node 1] requesting goroutine dump list... received response... done
+[node ?] ? goroutine dumps found
+[node 1] requesting cpu profile list... received response... done
+[node ?] ? cpu profiles found
+[node 1] requesting log files list... received response... done
+[node ?] ? log files found
+[node 1] requesting ranges... received response... done
+[node 1] writing ranges... writing JSON output: debug/nodes/1/ranges.json... done
+[cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
+[cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
+[cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -44,6 +44,15 @@ type TableRegistryConfig struct {
 	// table when redaction is required.
 	// NB: this field is optional, and takes precedence over nonSensitiveCols.
 	customQueryRedacted string
+
+	// customQueryUnredactedFallback is an alternative query that will be
+	// attempted if `customQueryUnredacted` does not return within the
+	// timeout or fails. If empty it will be ignored.
+	customQueryUnredactedFallback string
+	// customQueryRedactedFallback is an alternative query that will be
+	// attempted if `customQueryRedacted` does not return within the
+	// timeout or fails. If empty it will be ignored.
+	customQueryRedactedFallback string
 }
 
 // DebugZipTableRegistry is a registry of `crdb_internal` and `system` tables
@@ -60,26 +69,35 @@ type TableRegistryConfig struct {
 // may be a way to avoid having to completely omit entire columns.
 type DebugZipTableRegistry map[string]TableRegistryConfig
 
+// TableQuery holds two sql query strings together that are used to
+// dump tables when generating a debug zip. `query` is the primary
+// query to run, and `fallback` is one to try if the primary fails or
+// times out.
+type TableQuery struct {
+	query    string
+	fallback string
+}
+
 // QueryForTable produces the appropriate query for `debug zip` for the given
 // table to use, taking redaction into account. If the provided tableName does
 // not exist in the registry, or no redacted config exists in the registry for
 // the tableName, an error is returned.
-func (r DebugZipTableRegistry) QueryForTable(tableName string, redact bool) (string, error) {
+func (r DebugZipTableRegistry) QueryForTable(tableName string, redact bool) (TableQuery, error) {
 	tableConfig, ok := r[tableName]
 	if !ok {
-		return "", errors.Newf("no entry found in table registry for: %s", tableName)
+		return TableQuery{}, errors.Newf("no entry found in table registry for: %s", tableName)
 	}
 	if !redact {
 		if tableConfig.customQueryUnredacted != "" {
-			return tableConfig.customQueryUnredacted, nil
+			return TableQuery{tableConfig.customQueryUnredacted, tableConfig.customQueryUnredactedFallback}, nil
 		}
-		return fmt.Sprintf("TABLE %s", tableName), nil
+		return TableQuery{fmt.Sprintf("TABLE %s", tableName), ""}, nil
 	}
 	if tableConfig.customQueryRedacted != "" {
-		return tableConfig.customQueryRedacted, nil
+		return TableQuery{tableConfig.customQueryRedacted, tableConfig.customQueryRedactedFallback}, nil
 	}
 	if len(tableConfig.nonSensitiveCols) == 0 {
-		return "", errors.Newf("requested redacted query for table %s, but no non-sensitive columns defined", tableName)
+		return TableQuery{}, errors.Newf("requested redacted query for table %s, but no non-sensitive columns defined", tableName)
 	}
 	var colsString strings.Builder
 	for i, colName := range tableConfig.nonSensitiveCols {
@@ -89,7 +107,7 @@ func (r DebugZipTableRegistry) QueryForTable(tableName string, redact bool) (str
 			colsString.WriteString(", ")
 		}
 	}
-	return fmt.Sprintf("SELECT %s FROM %s", colsString.String(), tableName), nil
+	return TableQuery{fmt.Sprintf("SELECT %s FROM %s", colsString.String(), tableName), ""}, nil
 }
 
 // GetTables returns all the table names within the registry. Useful for
@@ -530,6 +548,20 @@ WHERE ss.transaction_fingerprint_id != '\x0000000000000000' AND s.fingerprint_id
 GROUP BY collection_ts, contention_duration, waiting_txn_id, waiting_txn_fingerprint_id, blocking_txn_id,
          blocking_txn_fingerprint_id, waiting_stmt_fingerprint_id, contending_pretty_key, s.metadata ->> 'query',
          index_name, table_name, database_name
+`,
+		customQueryUnredactedFallback: `
+SELECT collection_ts,
+       contention_duration,
+       waiting_txn_id,
+       waiting_txn_fingerprint_id,
+       waiting_stmt_fingerprint_id,
+       blocking_txn_id,
+       blocking_txn_fingerprint_id,
+       contending_pretty_key,
+       index_name,
+       table_name,
+       database_name
+FROM crdb_internal.transaction_contention_events
 `,
 		// `contending_key` column contains the contended key, which may
 		// contain sensitive row-level data. So, we will only fetch if the

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -178,6 +178,46 @@ func TestZip(t *testing.T) {
 	})
 }
 
+// This tests the operation of zip over secure clusters.
+func TestZipQueryFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "test too slow under race")
+
+	existing := zipInternalTablesPerCluster["crdb_internal.transaction_contention_events"]
+	zipInternalTablesPerCluster["crdb_internal.transaction_contention_events"] = TableRegistryConfig{
+		nonSensitiveCols: existing.nonSensitiveCols,
+		// We want this to fail to trigger the fallback.
+		customQueryUnredacted:         "SELECT FAIL;",
+		customQueryUnredactedFallback: existing.customQueryUnredactedFallback,
+	}
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	c := NewCLITest(TestCLIParams{
+		StoreSpecs: []base.StoreSpec{{
+			Path: dir,
+		}},
+	})
+	defer c.Cleanup()
+
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s " + os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Strip any non-deterministic messages.
+	out = eraseNonDeterministicZipOutput(out)
+
+	// We use datadriven simply to read the golden output file; we don't actually
+	// run any commands. Using datadriven allows TESTFLAGS=-rewrite.
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "zip", "testzip_fallback"), func(t *testing.T, td *datadriven.TestData) string {
+		return out
+	})
+}
+
 // This tests the operation of zip using --include-goroutine-stacks.
 func TestZipIncludeGoroutineStacks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -767,7 +807,7 @@ func TestZipRetries(t *testing.T) {
 			sqlConn,
 			"test",
 			`generate_series(1,15000) as t(x)`,
-			`select if(x<11000,x,crdb_internal.force_retry('1h')) from generate_series(1,15000) as t(x)`,
+			TableQuery{query: `select if(x<11000,x,crdb_internal.force_retry('1h')) from generate_series(1,15000) as t(x)`},
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -792,6 +832,95 @@ test/generate_series(1,15000) as t(x).3.json
 test/generate_series(1,15000) as t(x).3.json.err.txt
 test/generate_series(1,15000) as t(x).4.json
 test/generate_series(1,15000) as t(x).4.json.err.txt
+`
+	assert.Equal(t, expected, fileList.String())
+}
+
+// This checks that SQL retry errors are properly handled.
+func TestZipFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
+	defer s.Stopper().Stop(context.Background())
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	zipName := filepath.Join(dir, "test.zip")
+
+	func() {
+		out, err := os.Create(zipName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		z := newZipper(out)
+		defer func() {
+			if err := z.close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// Lower the buffer size so that an error is returned when running the
+		// generate_series query.
+		sqlURL := url.URL{
+			Scheme: "postgres",
+			User:   url.User(username.RootUser),
+			Host:   s.AdvSQLAddr(),
+		}
+		sqlConn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, sqlURL.String())
+		defer func() {
+			if err := sqlConn.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		zr := zipCtx.newZipReporter("test")
+		zr.sqlOutputFilenameExtension = "json"
+		zc := debugZipContext{
+			z:              z,
+			clusterPrinter: zr,
+			timeout:        3 * time.Second,
+		}
+		if err := zc.dumpTableDataForZip(
+			zr,
+			sqlConn,
+			"test",
+			`test_table_fail`,
+			TableQuery{
+				query: `SELECT blah`,
+			},
+		); err != nil {
+			t.Fatal(err)
+		}
+		if err := zc.dumpTableDataForZip(
+			zr,
+			sqlConn,
+			"test",
+			`test_table_succeed`,
+			TableQuery{
+				query:    `SELECT blah`,
+				fallback: `SELECT 1`,
+			},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	r, err := zip.OpenReader(zipName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	var fileList bytes.Buffer
+	for _, f := range r.File {
+		fmt.Fprintln(&fileList, f.Name)
+	}
+	const expected = `test/test_table_fail.json
+test/test_table_fail.json.err.txt
+test/test_table_succeed.json
+test/test_table_succeed.json.err.txt
+test/test_table_succeed.fallback.json
 `
 	assert.Equal(t, expected, fileList.String())
 }


### PR DESCRIPTION
Backport 1/1 commits from #126352.

/cc @cockroachdb/release

---

Previously, when SQL queries for dumping tables to debug zip would fail, we would have no follow-up. Engineers can now define "fallback" queries for tables in debug zip in order to make a second attempt with a simpler query. Often we want to run a more complex query to gather more debug data but these queries can fail when the cluster is experiencing problems. This change gives us a chance to define a simpler approach that can be attempted when necessary.

In order to define a fallback, there are two new optional fields in the `TableRegistryConfig` struct for redacted and unredacted queries respectively.

Debug zip output will still include the failed attempts at the original query along with the error message file as before. If a fallback query is defined, that query will produce its own output (and error) file with an additional `.fallback` suffix added to the base table name to identify it.

Resolves: #123964
Epic: CRDB-35278

Release note: None

---

Release justification: low-risk improvement to debug zip CLI tool

---
This PR was previously merged and reverted due to failed tests:

Merge: https://github.com/cockroachdb/cockroach/pull/127068
Revert: https://github.com/cockroachdb/cockroach/pull/127607
Failed tests: https://github.com/cockroachdb/cockroach/issues/127575, https://github.com/cockroachdb/cockroach/issues/127574, https://github.com/cockroachdb/cockroach/issues/127573, https://github.com/cockroachdb/cockroach/issues/127572, https://github.com/cockroachdb/cockroach/issues/127571