### PR TITLE
roachtest: fix ycsb regression by giving workload node more cpu

### DIFF
--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -119,7 +119,7 @@ func registerYCSB(r registry.Registry) {
 				Name:      name,
 				Owner:     registry.OwnerTestEng,
 				Benchmark: true,
-				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
+				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, ycsbOptions{})
 				},

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -587,6 +587,8 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 				}
 				continue
 			}
+			// Log the error so we get the stack trace.
+			log.Errorf(ctx, "%v", err)
 			return err
 
 		case <-ticker.C:


### PR DESCRIPTION
Previously, we gave the workload node only 4 CPUs but this
showed perf regressions and ocassional flakes on workload E
which is read heavy.

This change reverts that and gives ycsb workload nodes the
full CPUs as the rest of the cluster. Some of the more write
heavy tests seemed fine with just 4 CPUs, but for consistency
we revert it for all workloads.

Fixes: #128145
Release note: none
Epic: none