### PR TITLE
logictestccl: deflake select_for_update_read_committed more

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
@@ -579,6 +579,9 @@ statement ok
 SET optimizer_use_lock_op_for_serializable = true
 
 statement ok
+SET enable_durable_locking_for_serializable = true
+
+statement ok
 BEGIN ISOLATION LEVEL SERIALIZABLE
 
 # Lock the first row.
@@ -606,6 +609,9 @@ COMMIT;
 statement ok
 SET optimizer_use_lock_op_for_serializable = true
 
+statement ok
+SET enable_durable_locking_for_serializable = true
+
 query III
 SELECT * FROM xyz WHERE z = 100 ORDER BY x FOR UPDATE SKIP LOCKED
 ----
@@ -619,7 +625,13 @@ COMMIT
 statement ok
 RESET optimizer_use_lock_op_for_serializable
 
+statement ok
+RESET enable_durable_locking_for_serializable
+
 user root
 
 statement ok
 RESET optimizer_use_lock_op_for_serializable
+
+statement ok
+RESET enable_durable_locking_for_serializable


### PR DESCRIPTION
The fix in #128203 was insufficient. We also need to set enable_durable_locking_for_serializable to be sure that the KV layer doesn't drop the locks we're testing.

Fixes: #128281

Release note: None