### PR TITLE
tests: update cdc metamorphic roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1453,13 +1453,13 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/initial-scan-only/parquet/metamorphic",
-		Owner:           registry.OwnerCDC,
-		Benchmark:       true,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
-		RequiresLicense: true,
-		// TODO(#127940): Reenable GCE once GCS permissions issue is resolved.
-		CompatibleClouds: registry.Clouds(spec.Azure, spec.Local),
+		Name:             "cdc/initial-scan-only/parquet/metamorphic",
+		Skip:             "#119295",
+		Owner:            registry.OwnerCDC,
+		Benchmark:        true,
+		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		RequiresLicense:  true,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)


### PR DESCRIPTION
Roachtest cdc/initial-scan-only/parquet/metamorphic uses cloud storage sink, which is currently only supported by GCE. This PR changes the supported cloud to GCE only instead of excluding GCE. However, there still remain permissions issues with GCE, so this PR also re-skips the roachtest until it can be tested or resolved.

Epic: none
Fixes: #128058
Informs: #119295

Release note: None