### PR TITLE
backupccl: replan restore on lagging processors

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1543,6 +1543,61 @@ func TestRestoreRetryProcErr(t *testing.T) {
 	})
 }
 
+func TestRestoreReplanOnLag(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "slow test under stress race")
+
+	retryErrorChan := make(chan error)
+	defer close(retryErrorChan)
+	//Shorten replan frequency setting to reduce test runtime.
+	replanFreq := time.Second
+
+	params := base.TestClusterArgs{}
+	knobs := base.TestingKnobs{
+		BackupRestore: &sql.BackupRestoreTestingKnobs{
+			RunAfterRetryIteration: func(err error) error {
+				retryErrorChan <- err
+				return jobs.MarkAsPermanentJobError(err)
+			},
+			RunAfterRestoreProcDrains: func() {
+				var timer timeutil.Timer
+				defer timer.Stop()
+				// Lag processors with double the duration of replan
+				// frequency such that the timer will be up before
+				// procCompleteCh receives a ping.
+				timer.Reset(replanFreq * 2)
+				for range timer.C {
+					timer.Read = true
+					break
+				}
+			},
+		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+	params.ServerArgs = base.TestServerArgs{Knobs: knobs}
+	c, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, multiNode, 1, InitManualReplication, params)
+	defer cleanupFn()
+	serverutils.SetClusterSetting(t, c, "bulkio.restore.replan_flow_frequency", replanFreq)
+
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `USE d`)
+	sqlDB.Exec(t, `CREATE TABLE t (a INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO t (a) SELECT * FROM generate_series(1, 100)`)
+
+	// Create BACKUP and RESTORE jobs.
+	sqlDB.Exec(t, `BACKUP DATABASE d INTO $1`, localFoo)
+	sqlDB.Exec(t, `DROP DATABASE d`)
+	var restoreJobID jobspb.JobID
+	sqlDB.QueryRow(t, `RESTORE DATABASE d FROM LATEST IN $1 WITH DETACHED`, localFoo).Scan(&restoreJobID)
+
+	require.ErrorContains(t, <-retryErrorChan, laggingRestoreProcErr.Error())
+
+	sqlDB.Exec(t, `USE system`)
+	jobutils.WaitForJobToFail(t, sqlDB, restoreJobID)
+}
+
 // TestBackupJobRetryReset tests that the job level retry counter
 // resets after the backup progresses. To do so, the test does the following:
 // 1. Intercept the backup job before the flow begins and send a retryable error.

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -158,12 +158,13 @@ func newRestoreDataProcessor(
 			InputsToDrain: []execinfra.RowSource{input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				rd.ConsumerClosed()
+				meta := &execinfrapb.ProducerMetadata{}
 				if rd.agg != nil {
-					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
+					meta = bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
 						rd.FlowCtx.NodeID.SQLInstanceID(), rd.FlowCtx.ID, rd.agg)
-					return []execinfrapb.ProducerMetadata{*meta}
 				}
-				return nil
+				meta.BulkProcessorProgress = &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{Drained: true}
+				return []execinfrapb.ProducerMetadata{*meta}
 			},
 		}); err != nil {
 		return nil, err

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -93,6 +93,16 @@ var restoreStatsInsertionConcurrency = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
+var replanFrequency = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"bulkio.restore.replan_flow_frequency",
+	"frequency at which RESTORE checks the number of lagging nodes to see if the job should be replanned",
+	time.Minute*10,
+	settings.PositiveDuration,
+)
+
+var laggingRestoreProcErr = errors.New("try re-planning due to lagging restore processors")
+
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of
 // splitting up the target key-space to send out the actual work of restoring.
 //
@@ -218,6 +228,13 @@ func restoreWithRetry(
 			log.Infof(restoreCtx, "restored frontier has advanced since last retry, resetting retry counter")
 		}
 		previousPersistedSpans = currentPersistedSpans
+
+		testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
+		if testingKnobs != nil && testingKnobs.RunAfterRetryIteration != nil {
+			if err := testingKnobs.RunAfterRetryIteration(err); err != nil {
+				return roachpb.RowCount{}, err
+			}
+		}
 	}
 
 	// We have exhausted retries, but we have not seen a "PermanentBulkJobError" so
@@ -448,6 +465,33 @@ func restore(
 		tasks = append(tasks, generativeCheckpointLoop)
 	}
 
+	procCompleteCh := make(chan struct{})
+	// countCompletedProcLoop is responsible for counting the number of completed
+	// processors. The goroutine returns a retryable error such that the job can
+	// replan if there are too many lagging nodes.
+	countCompletedProcLoop := func(ctx context.Context) error {
+		var timer timeutil.Timer
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case _, ok := <-procCompleteCh:
+				if !ok {
+					return nil
+				}
+				timer.Reset(replanFrequency.Get(&execCtx.ExecCfg().Settings.SV))
+			case <-timer.C:
+				timer.Read = true
+				// Replan the restore job if it has been 10 minutes since the last
+				// processor completed working.
+				return errors.Mark(laggingRestoreProcErr, retryableRestoreProcError)
+			}
+		}
+	}
+	tasks = append(tasks, countCompletedProcLoop)
+
 	// tracingAggLoop is responsible for draining the channel on which processors
 	// in the DistSQL flow will send back their tracing aggregator stats. These
 	// stats will be persisted to the job_info table whenever the job is told to
@@ -472,6 +516,9 @@ func restore(
 
 	runRestore := func(ctx context.Context) error {
 		if details.ExperimentalOnline {
+			// Let countCompletedProcLoop exit immediately such that online restore
+			// does not replan on lagging nodes.
+			close(procCompleteCh)
 			log.Warningf(ctx, "EXPERIMENTAL ONLINE RESTORE being used")
 			approxRows, approxDataSize, err := sendAddRemoteSSTs(
 				ctx,
@@ -512,6 +559,7 @@ func restore(
 			md,
 			progCh,
 			tracingAggCh,
+			procCompleteCh,
 		), "running distributed restore")
 	}
 	tasks = append(tasks, runRestore)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1792,6 +1792,10 @@ type BackupRestoreTestingKnobs struct {
 	RunBeforeBackupFlow func() error
 
 	RunAfterBackupFlow func() error
+
+	RunAfterRetryIteration func(err error) error
+
+	RunAfterRestoreProcDrains func()
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -333,6 +333,7 @@ message RemoteProducerMetadata {
     optional bytes flow_id = 8 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "FlowID",
       (gogoproto.customtype) = "FlowID"];
+    optional bool drained = 9 [(gogoproto.nullable) = false];
   }
   // Metrics are unconditionally emitted by table readers.
   message Metrics {


### PR DESCRIPTION
Replan a RESTORE job when a single processor completes early than all other processors. The job periodically checks the number of drained processors with frequency specified by cluster setting `bulkio.restore.replan_flow_frequency`, which is set to 10 minutes.

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/127676
Release note: none