### PR TITLE
release-23.2: backupccl: distribute restore validation work

### DIFF
--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -262,5 +262,6 @@ func makeTestingGenerativeSplitAndScatterSpec(
 		NumEntries:         1,
 		NumNodes:           1,
 		JobID:              0,
+		SQLInstanceIDs:     []int32{1},
 	}
 }

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -112,6 +112,10 @@ func distRestore(
 		}
 
 		numNodes := len(sqlInstanceIDs)
+		instanceIDs := make([]int32, numNodes)
+		for i, instanceID := range sqlInstanceIDs {
+			instanceIDs[i] = int32(instanceID)
+		}
 		p := planCtx.NewPhysicalPlan()
 
 		restoreDataSpec := execinfrapb.RestoreDataSpec{
@@ -190,6 +194,7 @@ func distRestore(
 			NumNodes:                 int64(numNodes),
 			UseFrontierCheckpointing: md.spanFilter.useFrontierCheckpointing,
 			JobID:                    int64(md.jobID),
+			SQLInstanceIDs:           instanceIDs,
 		}
 		if md.spanFilter.useFrontierCheckpointing {
 			spec.CheckpointedSpans = persistFrontier(md.spanFilter.checkpointFrontier, 0)

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -446,6 +446,9 @@ message GenerativeSplitAndScatterSpec {
   repeated jobs.jobspb.RestoreProgress.FrontierEntry checkpointed_spans = 21 [(gogoproto.nullable) = false];
   // MaxFileCount is the max number of files in an extending restore span entry.
   optional int64 max_file_count = 22 [(gogoproto.nullable) = false];
+  // SQLInstanceIDs is a slice of SQL instance IDs available for dist restore.
+  // Set field ID to 24 to be forward compatible with future versions.
+  repeated int32 sql_instance_ids = 24[(gogoproto.nullable) = false, (gogoproto.customname) = "SQLInstanceIDs"];
   reserved 19;
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #127925.

/cc @cockroachdb/release

---

Currently, when `verify_backup_table_data` flag is used in a restore statement, the node that is currently running gets selected for reading with the noop split and scatterer. In this PR, we randomly select a node from the list of nodes available for dist restore for reading, this ensures that we don't put all the reading workload on a single node.

Work loads between nodes are uniformly distributed when running restore validation for tpcc fixture (~400GB) with a 3-node cluster on roachprod. See screenshots for metrics below.

CPU usage per node:
![image (1)](https://github.com/user-attachments/assets/0fcda673-4b40-47ee-9d16-7ab60b0c36f0)

Time series of `cloud.read_bytes` per node:
![image](https://github.com/user-attachments/assets/ec5aa125-d818-48e3-a92c-7abd413a8bc0)

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/127677
Release note: none

----

Release justification: RESTORE bug fix