### PR TITLE
crosscluster/logical: add job ID to application name

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -154,6 +154,7 @@ func newLogicalReplicationWriterProcessor(
 		} else {
 			rp, err = makeSQLProcessor(
 				ctx, flowCtx.Cfg.Settings, tableConfigs,
+				jobspb.JobID(spec.JobID),
 				// Initialize the executor with a fresh session data - this will
 				// avoid creating a new copy on each executor usage.
 				flowCtx.Cfg.DB.Executor(isql.WithSessionData(sql.NewInternalSessionData(ctx, flowCtx.Cfg.Settings, "" /* opName */))),

--- a/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationtestutils"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -84,7 +85,7 @@ func TestLWWInsertQueryGeneration(t *testing.T) {
 			dstDesc.GetID(): {
 				srcDesc: srcDesc,
 			},
-		}, s.InternalExecutor().(isql.Executor))
+		}, jobspb.JobID(1), s.InternalExecutor().(isql.Executor))
 		require.NoError(t, err)
 		return rp, func(datums ...interface{}) roachpb.KeyValue {
 			kv := replicationtestutils.EncodeKV(t, s.Codec(), srcDesc, datums...)
@@ -153,7 +154,7 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 		desc.GetID(): {
 			srcDesc: desc,
 		},
-	}, s.InternalDB().(isql.DB).Executor(isql.WithSessionData(sd)))
+	}, jobspb.JobID(1), s.InternalDB().(isql.DB).Executor(isql.WithSessionData(sd)))
 	require.NoError(b, err)
 
 	// In some configs, we'll be simulating processing the same INSERT over and


### PR DESCRIPTION
The goal of this change is to make it a bit easier to identify the queries for a particular job on the SQL activity page.

Fixes #127746

Release note: None