### PR TITLE
sql: move AfterBackupChunk and AfterBackupCheckpoint

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -313,8 +313,9 @@ func backup(
 			// Signal that an ExportRequest finished to update job progress.
 			for i := int32(0); i < progDetails.CompletedSpans; i++ {
 				requestFinishedCh <- struct{}{}
-				if execCtx.ExecCfg().TestingKnobs.AfterBackupChunk != nil {
-					execCtx.ExecCfg().TestingKnobs.AfterBackupChunk()
+				if execCtx.ExecCfg().BackupRestoreTestingKnobs != nil &&
+					execCtx.ExecCfg().BackupRestoreTestingKnobs.AfterBackupChunk != nil {
+					execCtx.ExecCfg().BackupRestoreTestingKnobs.AfterBackupChunk()
 				}
 			}
 
@@ -353,8 +354,9 @@ func backup(
 					log.Errorf(ctx, "unable to checkpoint backup descriptor: %+v", err)
 				}
 				lastCheckpoint = timeutil.Now()
-				if execCtx.ExecCfg().TestingKnobs.AfterBackupCheckpoint != nil {
-					execCtx.ExecCfg().TestingKnobs.AfterBackupCheckpoint()
+				if execCtx.ExecCfg().BackupRestoreTestingKnobs != nil &&
+					execCtx.ExecCfg().BackupRestoreTestingKnobs.AfterBackupCheckpoint != nil {
+					execCtx.ExecCfg().BackupRestoreTestingKnobs.AfterBackupCheckpoint()
 				}
 			}
 		}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -183,7 +183,7 @@ func TestBackupRestoreSingleNodeLocal(t *testing.T) {
 	// Set the testing knob so we count each time we write a checkpoint.
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{
-		SQLExecutor: &sql.ExecutorTestingKnobs{
+		BackupRestore: &sql.BackupRestoreTestingKnobs{
 			AfterBackupChunk: func() {
 				chunks++
 			},
@@ -10209,7 +10209,7 @@ func TestBackupNoOverwriteCheckpoint(t *testing.T) {
 	// Set the testing knob so we count each time we write a checkpoint.
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{
-		SQLExecutor: &sql.ExecutorTestingKnobs{
+		BackupRestore: &sql.BackupRestoreTestingKnobs{
 			AfterBackupCheckpoint: func() {
 				numCheckpointsWritten++
 			},

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1633,13 +1633,6 @@ type ExecutorTestingKnobs struct {
 		txErr error,
 	)
 
-	// AfterBackupChunk is called after each chunk of a backup is completed.
-	AfterBackupChunk func()
-
-	// AfterBackupCheckpoint if set will be called after a BACKUP-CHECKPOINT
-	// is written.
-	AfterBackupCheckpoint func()
-
 	// OnRecordTxnFinish, if set, will be called as we record a transaction
 	// finishing.
 	OnRecordTxnFinish func(isInternal bool, phaseTimes *sessionphase.Times, stmt string, txnStats sqlstats.RecordedTxnStats)
@@ -1759,6 +1752,13 @@ func (*SchemaTelemetryTestingKnobs) ModuleTestingKnobs() {}
 //
 // TODO (msbutler): move these to backupccl
 type BackupRestoreTestingKnobs struct {
+	// AfterBackupChunk is called after each chunk of a backup is completed.
+	AfterBackupChunk func()
+
+	// AfterBackupCheckpoint if set will be called after a BACKUP-CHECKPOINT
+	// is written.
+	AfterBackupCheckpoint func()
+
 	// CaptureResolvedTableDescSpans allows for intercepting the spans which are
 	// resolved during backup planning, and will eventually be backed up during
 	// execution.


### PR DESCRIPTION
This commit moves `AfterBackupChunk` and `AfterBackupCheckpoint`
from `ExecutorTestingKnobs` to `BackupRestoreTestingKnobs`.

Epic: None

Release note: None
