### PR TITLE
take2

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2064,9 +2064,14 @@ func registerCDC(r registry.Registry) {
 				// https://github.com/IBM/sarama/blob/fd84c2b0f0185100dbaec28ca4074289b35cc1b1/client.go#L1023-L1027
 				// which tells us what topics are being fetched for metadata. We expect
 				// to see logs for tpcc tables but not for random topics.
+				//
+				// We now also check for similar logs from the kafka v2 sink &
+				// kgo. There isn't a direct equivalent, however, so check a few
+				// things.
+				logSearchStr := `(client/metadata fetching metadata for|updating kafka metadata for topics|fetching metadata to learn its partitions|waiting for metadata for new topic)`
 				results, checkLogsErr := ct.cluster.RunWithDetails(ct.ctx, t.L(),
 					option.WithNodes(ct.cluster.Range(1, c.Spec().NodeCount-1)),
-					"grep \"client/metadata fetching metadata for\" logs/cockroach.log")
+					fmt.Sprintf(`grep -E "%s" logs/cockroach.log`, logSearchStr))
 				if checkLogsErr != nil {
 					t.Fatal(checkLogsErr)
 				}
@@ -2079,7 +2084,7 @@ func registerCDC(r registry.Registry) {
 					}
 
 					// We do not expect to see fetching metadata for all topics.
-					if strings.Contains(str, "all topics") {
+					if strings.Contains(str, "all topics") || strings.Contains(str, "updating kafka metadata for topics: []") {
 						return errors.New("did not expect to fetch metadata for all topics")
 					}
 					return nil


### PR DESCRIPTION
- **kvserver: Optimize MaybeGossipNodeLivenessRaftMuLocked**
- **kvserver: Take gossip mutex less in MaybeGossipNodeLivenessRaftMuLocked**
- **changefeedccl: add CompressionLevel option to kafka_sink_config**
- **workload: split reads from follower reads**
- **workload: add histogram latency protobuf**
- **roachtest/ldr: run workload on both nodes**
- **scripts: fix a couple of nits in ldr**
- **sql: reduce allocations when planning aggregators**
- **streamingccl: skip TestStreamingAutoReplan under deadlock**
- **authors: add gourav.kumar to authors**
- **dev: add a shorthand for cloudupload Observability team needs to upload artifacts to GCS. We would like to use existing cloudupload command. This patch adds a `dev` shorthand for the `cloudupload` CLI tool.**
- **cli: add --shutdown flag to `node drain`**
- **sqlstats: fix discarded stats metric**
- **set roachprod vm LoginGraceTime to 0**
- **logictest: parse error/notice conditions for async statements & queries**
- **sql: allow fast path insert on RBR tables with unique keys under R-C**
- **drtprod: emit audit logs for drt-chaos**
- **pkg/cli: add new sub-command 'upload' to 'debug zip'**
- **kv: add support for Lease.MinExpiration**
- **ui: resolve transient JS dependencies**
- **roachprod: implement "Reset" for aws and azure.**
- **crosscluster/logical: rename error to reason, remove writeTS**
- **crosscluster/logical: pass row to DLQ**
- **crosscluster/logical: pass failed rows to the DLQ client**
- **sql/telemetry: include TCL statements in sampling**
- **sql: create_as logic test can fail when txn retries happen**
- **timeutil: don't redact operation name in TimeoutError**
- **storage: add trace statement for lock table scans**
- **roachprod gc: enable cluster cleanup for multiple AWS accounts**
- **kvadmission: use log.Warning for grunning time assertion**
- **cli: bump default worker pool to heavy**
- **oidcccl: Add configurable timeout to HTTP client**
- **roachtest: add `MaxUpgrades` option back to `validate-system-schema`**
- **raft: move maybeCommit to the right layer**
- **ui: fix expand row icons on Nodes Overview page**
- **raft: introduce logMark type**
- **roachtest: skip loading `version` key from `system.tenant_settings`**
- **build: add script to build fuzzers in oss-fuzz**
- **roachprod: lock dns records by name**
- **workload/schemachange: fix unique constraint validation on inserts**
- **crosscluster/logical: fix metrics buckets**
- **crosscluster/logical: fix missing not-processed counter**
- **crosscluster/logical: fix total events applied metric**
- **crosscluster/logical: move drain and flush funcs to fields**
- **crosscluster/logical: add metrics for retries, DLQs**
- **opt: eliminate unnecessary NULL reordering of NOT NULL columns**
- **sql: fix pg_catalog formatting of BYTES expressions**
- **sqlsmith: unskip TestGenerateParse**
- **kv-obs: annotate consistency queue graph with explanation**
- **drt: replace northamerica-northeast1 with us-central1 for drt and workload-large**
- **distsql: improve unhealthy node detection in SQL instances-based planning.**
- **raft: add type-safe snapshot tied to leader term**
- **raft: pass snapshot to raft.restore method**
- **raft: pass snapshot to raftLog.restore method**
- **raft: pass snapshot to unstable.restore method**
- **raft: use logMark in maybeCommit and commitTo**
- **crosscluster/purgatory: limit size of purgatory on bytes**
- **crosscluster/logical: add gauges for retry queue size**
- **crosscluster/logical: clarify logical bytes metric is recv not applied**
- **sql: fix casts for TSVector and TSQuery**
- **crosscluster/logical: add ability to inject synthetic application failures**
- **crosscluster/logical: fix error handling in lrw**
- **crosscluster/logical: unit test lrw error handling**
- **roachtest: add backup-restore roundtrip operation**
- **roachtest: use `CompatibleClouds` to define clouds where a test can run**
- **sql: implement pgvector datatype and evaluation**
- **cli: fix duplicate scheme in encode-uri**
- **cli: add --user option to encode-uri**
- **cli: add --certs-dir support to encode-uri**
- **server: rename BinaryVersionOverride to ClusterVersionOverride**
- **crosscluster/logical: add metrics for reason event sent to DLQ**
- **Release note (general change): Fixed typo in array_functions description**
- **logical: Add ReplanCount to logical metrics**
- **crosscluster: Refactor measurePlanChange to be reusable**
- **scbuild: add ResolvePhysicalTable**
- **scop: remove unused SeqNum from AddDatabaseZoneConfig**
- **scpb: modify TableZoneConfig element**
- **schemachanger: add table zone config opgen rule**
- **schemachanger: support tbl zone config**
- **ui: fix query fetching store ids for db/tables**
- **sql: override StmtTimeout to 0 for background jobs**
- **roachprod: update docker image for cron roachprod-gc.yaml.**
- **sql: rename PreparedStatement.Memo to BaseMemo**
- **sql: refactor plan_opt.go**
- **crosscluster/logical: fix retry queue guage drift on unclean proc exit**
- **crosscluster/logical: avoid age limit for unclosed levels**
- **crosscluster/logical: add cluster settings for retry queue**
- **roachprod-microbench: add clean command**
- **github: update codeowners**
- **metric: add prev, next values in counter update panic**
- **sql: ignore outer buckets when merging partial and full statistics**
- **logical: Add replanning logic to LDR**
- **kvserver: add mutex to prevent store metrics race**
- **storage: remove unnecessarily strict RangeBounds assertion**
- **build: update go to 1.22.5 * [x] Update `build/teamcity/internal/release/build-and-publish-patched-go/impl.sh` with the new version and adjust SHA256 sums as necessary. * [x] Adjust `GO_VERSION` and `GO_FIPS_COMMIT` for the FIPS Go toolchain ([source](./teamcity/internal/release/build-and-publish-patched-go/impl-fips.sh)). * [x] Run the `Internal / Cockroach / Build / Toolchains / Publish Patched Go for Mac` build configuration in TeamCity with your latest version of the script above. Note the job depends on another job `Build and Publish Patched Go`. That job prints out the SHA256 of all tarballs, which you will need to copy-paste into `WORKSPACE` (see below). `Publish Patched Go for Mac` is an extra step that publishes the *signed* `go` binaries for macOS. That job also prints out the SHA256 of the Mac tarballs in particular. * [x] Adjust `--@io_bazel_rules_go//go/toolchain:sdk_version` in [.bazelrc](../.bazelrc). * [x] Bump the version in `WORKSPACE` under `go_download_sdk`. You may need to bump [rules_go](https://github.com/bazelbuild/rules_go/releases). Also edit the filenames listed in `sdks` and update all the hashes to match what you built in the step above. * [x] Bump the version in `WORKSPACE` under `go_download_sdk` for the FIPS version of Go (`go_sdk_fips`). * [x] Run `./dev generate bazel` to refresh `distdir_files.bzl`, then `bazel fetch @distdir//:archives` to ensure you've updated all hashes to the correct value. * [x] Bump the go version in `go.mod`. * [x] Bump the default installed version of Go in `bootstrap-debian.sh` ([source](./bootstrap/bootstrap-debian.sh)). * [x] Replace other mentions of the older version of go (grep for `golang:<old_version>` and `go<old_version>`).**
- **roachtest: clean up acceptance tests**
- **tree: avoid race on Overload.PreferredOverload**
- **kv: consolidate range lease validation**
- **log: add new parameter to log.StructuredEvent**
- **log,job: log status change on update via updater**
- **orchestration: released CockroachDB version 24.1.2. Next version: 24.1.3**
- **storage: make pebbleLogger.Eventf also log**
- **ui/dashboards: add retry queue size, dlq reasons**
- **ui/dashboards: reorder LDR dash**
- **sql: fix and improve the computation of merged statistic counts**
- **sql: implement plan_cache_mode=force_generic_plan**
- **kvserver: skip TestGossipHandlesReplacedNode under race**
- **raft: unify table-driven test pattern in log_unstable_test.go**
- **raft: use logSlice in log_unstable_test.go**
- **raft: propagate logSlice to truncateAndAppend**
- **raft: straighten up maybeAppend and append semantics**
- **raft: make unstable a logSlice**
- **raft: add safety checks in truncateAndAppend**
- **raft: add safety checks to snapshot restore**
- **raft: add unstable.append with stricter semantics**
- **raft: rm "offset" from log_unstable_test.go**
- **raft: take accTerm from unstable**
- **sql: add pgvector in a couple of missing places**
- **master: Update pkg/testutils/release/cockroach_releases.yaml**
- **sql: improve bundle with plan-gist matching**
- **roachtest: add manual compaction operation**
- **roachprod-microbench: address review comments in clean command**
- **catalog/lease: address TestDescriptorRefreshOnRetry flake**
- **sql: statement_timeout should also cancel synchronous rollback**
- **workload: add sending stats to histogram**
- **roachtest: add download to http util**
- **roachtest: add utility methods for gathering profiles**
- **roachtest: add utility method to get local ip**
- **roachtest: add perturbation tests**
- **go.mod: bump Pebble to 7920d968a3d5**
- **changefeedccl: add support for IAM role-based authentication to Kafka sink**
- **multitenant: allow auto-upgrades to internal versions**
- **kv: delete unused Store.spanConfigUpdateQueueRateLimiter**
- **syncutil: make IntMap generic**
- **syncutil: rename int_mapXXX.go files to mapXXX.go**
- **syncutil: rename IntMap to Map**
- **sql: ensure truncate preserves pkey zone configs**
- **logical: Refactor tests to use some common logic**
- **logical: Periodically send heartbeats to logical replication streams and retry ingestion on errors**
- **colexec: fix IS NOT NULL filter for tuples with NULLs**
- **kvcoord: use generic syncutil.Map in DistSenderCircuitBreakers**
- **tenantcostmodel: skip first read/write request when calc'ing eCPU**
- **drt: update drtprod start for drt-large**
- **cli: update TestZipSpecialNames test execution conditions**
- **raft/testdata: log leader status after Ready**
- **tests: for kv0 overload test, make jemalloc release memory to OS more aggressively**
- **raft: presize progress maps**
- **sql: add cluster setting to determine if owner has implicit GRANT OPTION**
- **roachtest: commandbuilder equals syntax mode**
- **raft: update leader's Next when appending entries**
- **crosscluster: implement dlq logic**
- **sqlsmith: unconditionally log multi-region setup statements**
- **sql: fix column formatting in inverted index backfill**
- **backupccl: deflake TestOnlineRestoreBasic**
- **go.mod: bump Pebble to e727ab747b2f**
- **perf: fix ycsb for chaos testing**
- **sql/opt: add session setting to disable merged partial stats use in opt**
- **workload: check for pgvector type in mixed version state**
- **server: change nodeMetrics methods to pointer receivers**
- **kvserver/rangefeed: introduce stream muxer**
- **kvserver/rangefeed: handle StreamMuxer.run errors**
- **cluster-ui: remove quotes in table name in db details**
- **kvserver/rangefeed: move active streams to stream muxer**
- **kvserver/rangefeed: move metrics updates to stream muxer**
- **execbuilder: limit internal function search to builtins**
- **sql: implement plan_cache_mode=auto**
- **rfc: minor edits to generic query plans RFC**
- **tenantcostclient: add tenant.sql_usage.estimated_replication_bytes metric**
- **crosscluster/logical: a couple optimizations for ingestion**
- **drt: fix drt start command**
- **build: fix seed corpus for oss-fuzz**
- **crosscluster/logical: limit bytes per server, not proc**
- **crosscluster/logical: mark levels closed even without checkpoints**
- **backupccl: deflake backup/assume-role roachtest**
- **kvserver/rangefeed: remove unused cancel**
- **roachtest: add support for Side-Eye**
- **kvserver/rangefeed: wrap muxer inside setRangeIDEventSink**
- **kvserver/rangefeed: rename setRangeIDEventSink to perRangeEventSink**
- **status: change monotonic counter metrics to Counters**
- **kvserver: change monotonic counter metrics to Counters**
- **sql: skip populating some fields in SetupFlowRequest in local plans**
- **crosscluster/logical: don't ingest events with future origin ts**
- **workload/schemachange: version gate pgvector in more places**
- **sql/schemachanger: infra to move ALTER COLUMN .. SET TYPE to DSC**
- **upgrademanager: possibly run each upgrade multiple times in test builds**
- **rowexec: properly exclude some things in stats job from EXPLAIN ANALYZE**
- **distsql: Fix flaky TestDistSQLUnavailableHosts.**
- **jwtauthccl: use RedactableString for detailed error**
- **crosscluster/logical: move replication writes to UserLow QoS**
- **execinfra: clean up some helpers a bit**
- **bazel,ui: compress assets (bundle.js) using zstd**
- **roachtest: fix multi-store-remove**
- **execinfra: ensure all processors are properly cleaned up on shutdown**
- **scripts/drtprod: add drt-ldr{1,2} and workload-ldr clusters**
- **logical/crosscluster: save checkpoint during initial scan**
- **logical: add eval replication options**
- **logical: add ability to use cursor**
- **kvserver/rangefeed: skip TestRangeFeedIntentResolutionRace under stress**
- **changefeedccl: fix sink leaks in a few places**
- **mixedversion: run skip-version upgrades when supported**
- **logical: parse udfs/default function options**
- **roachtest: add cdcbench variant with a kafka sink**
- **sql: stop propagating DistSQL version via gossip**
- **sqlliveness: detect and handle invalid SessionIDs**
- **roachtest/cdc: bump cdc/mixed-versions timeout to 2h**
- **delegate: show privleges inherited through public role**
- **changefeedccl: add support for multiple sinks in cdc roachtests**
- **crosscluster/logical: add failed row insert as json object to DLQ**
- **server: emit disk slowness detected/cleared events in eventlog**
- **backupccl: skip backup/assume-role on aws**
- **pgwire, ccl: add support for LDAP server authentication**
- **kv: don't propose lease acquisition if raft leader is unknown, by default**
- **ui/dashboards: swap lag and latency metrics on ldr dash**
- **kvserver: prefer BasicStatus over Status**
- **admission: use syncutil.Map in WorkQueueMetrics**
- **kvserver: use syncutil.Map in pebbleCategoryIterMetricsContainer**
- **kvserver: use syncutil.Map in pebbleCategoryDiskWriteMetricsContainer**
- **kvflowcontroller: use syncutil.Map in Controller**
- **tenantcostclient: use syncutil.Map in metrics**
- **jobs: use syncutil.Map in Registry**
- **kvcoord: use syncutil.Map in DistSender**
- **rangefeed: use syncutil.Map in StreamMuxer**
- **server: use syncutil.Map in HotRangesV2**
- **settings/cluster: use syncutil.Map in Settings**
- **stopper: use syncutil.Map in Stopper**
- ***: use syncutil.Map in tests**
- ***: remove mention of sync.Map from comments**
- **lint: forbid use of sync.Map**
- **sql: skip flaky TestStatementCancelRollback**
- **colexec: fix incorrect eager cancellation in parallel unordered sync**
- **opttester: allow no-stable-folds for opt directive**
- **opt: optimize generic query plans with stable expressions**
- **multiregionccl: split up TestRegionAddDropWithConcurrentBackupOps**
- **multiregionccl: split up TestMultiRegionDataDriven**
- **workload/tpcc-multi-db: support multi-region with large schemas**
- **workload: optimize creating a large number of tables**
- **roachtest/tpcc/large-schema-benchmark: publish a histogram for the test**
- **jwtauthccl: Rename and hide `server.jwt_authentication.issuer_custom_ca`**
- **sql: add logging for copyfrom roachtest**
- **roachprod: remove LB destroy ref checks**
- **roachprod: reword create health check spinner msg**
- **roachprod: resize support for local clusters**
- **raochtest/tpcc/large-schema-benchmark: add support for multiregion**
- **storeliveness: add Transport**
- **github: fix check-pebble-dep action**
- **sql: SHOW CREATE now uses two-part names for composite types**
- **roachtest: use enum for cloud value**
- **roachtest: fix broken failover test naming**
- **crosscluster/logical: add heuristic for choosing implicit vs explicit**
- **mixedversion: pass in cluster settings when restarting binary**
- **crosscluster: heartbeat retained time to source cluster**
- **roachtest: bump mixed_version_sql_stats timeout**
- **sql: fix out-of-bounds exception in insert fast path**
- **crosscluster/logical: allow replication between different table names**
- **mixedversion: bump datadriven test build version**
- **raft: export LeadSupportStatus method**
- **kv: fix check in WaitForLeaseUpgrade for leader leases**
- **loqrecovery: make make-plan CLI print updates**
- **kv: add "leases.leader" metric**
- **kv: fix logging around leader lease promotion**
- **cast: only allow vector to array cast for float arrays**
- **roachtest: fix stdout logging when parallelism=1**
- **workload/schemachange: create composite type in RSW**
- **docs: mark rate limit cluster settings as public**
- **DEPS.bzl: update `rules_go` and enable assembly routines for zstd**
- **workload/tpcc: fix hang on error or when the workload gets interrupted**
- **syntheticprivilegecache: use correct context when reading the table**
- **schematelemetry: don't redact object ID or validation error in logs**
- **roachprod: test selector for aws**
- **sql: alter type drop value can crash formatting out dependent rows**
- **kvcoord: move NodeDescScore to kvclient**
- **sql: require an enterprise license to use generic query plans**
- **pkg/cli: Include both resolutions (10s and 30min) in tsdump**
- **sql: unskip TestSqlActivityUpdateTopLimitJob**
- **roachtest: update pg_regress diff**
- **sql: skip TestShowFingerprintsDuringSchemaChange under deadlock**
- **drt: fix ldr related commands**
- **gossip: only communicate HighWaterStamps deltas**
- **bulitins: rewrite concat() to accept any datum type**
- **workload: stop skipping split/scatter on tenants**
- **crosscluster/logical: small refactor in SQL row processor**
- **sql: add QueryRowExParsed to InternalExecutor**
- **sql/randgen: add RequirePrimaryIndex option**
- **crosscluster: rework how the change in plan is measured**
- **crosscluster/logical: initial UDF-applier implementation**
- **crosscluster/logical: add previous value to custom UDF API**
- **crosscluster/logical: cleanup a few comments**
- **crosscluster/logical: add existing MVCC timestamp**
- **crosscluster/logical: add remote cluster timestamps to function arguments**
- **sql: add crdb_internal.log builtin**
- **crosscluster/logical: add UDF-fallback for LWW querier**
- **sql/stats: fix inject/restore of partial stats not creating merged stats**
- **crosscluster/logical: skip TestUDFWithRandomTables**
- **build: add `init` time and heap allocs verification to `bincheck`**
- **tree: add FormatURI and FormatURIs**
- **tree, parser, backupccl: use FormatURI in BACKUP and RESTORE**
- **tree, parser, backupccl: use FormatURI in ALTER BACKUP**
- **tree, parser, backupccl: use FormatURI in SHOW BACKUP**
- **tree, parser, changefeedccl: use FormatURI in CREATE CHANGEFEED**
- **tree, parser, importer: use FormatURI in IMPORT**
- **tree, parser: use FormatURI in EXPORT**
- **tree, parser, externalconn: use FormatURI in CREATE EXTERNAL CONNECTION**
- **tree, parser: use FormatURI in COPY**
- **syncutil: panic on store with nil value**
- **syncutil: add concurrent Set type**
- ***: use syncutil.Set**
- **crosscluster/logical: adjust observability of ingestion queries**
- **master: Update pkg/testutils/release/cockroach_releases.yaml**
- **tenantcostclient: move code from kvcoord to tenantcostclient**
- **go.mod: bump Pebble to cbd534e661cc**
- **crosscluster/logical: move settings to application level**
- **crosscluter/logical: fix source-side table name parsing**
- **crosscluster/producer: release leases in crdb_internal.stream_partition**
- **crosscluster: name querier params to be self-documenting**
- **raft: persist Lead into the HardState**
- **kvserver: gate new manual split rangefeed cancellation reason on 24.1**
- **crosscluster/logical: fix backoff setting default**
- **sql/schemachanger: Add DSC support for trivial data type changes**
- **sql: allow DISCARD in read-only transactions**
- **kvclient: don't drop ambiguous errors on incompatible transport**
- **tenantcostclient: include all requests in eCPU model**
- **crosscluster/physical: check for multistatement transactions**
- **ui: change 'Physcial Replication Producer' category to 'Replication Producer'**
- **ui: add Logical Replication Ingestion Category**
- **mixedversion: don't find all predecessors if skip version is not avaiable**
- **crosscluster: make a redaction-safe processorType enum**
- **kv: deflake TestStoreRangeMergeWithData**
- **kvserver/rangefeed: remove future package**
- **schematelemetry: test that logs are redacted correctly**
- **ui: add Leader lease observability**
- **roachtest: register single-node sysbench benchmarks**
- **roachtest: support running sysbench against PostgreSQL**
- **cli: reset `securityassets` `Loader` after test completion**
- **sql: cannot drop enum values if referenced in index expressions**
- **crosscluster: add dlq tests and refactor**
- **pkg/cli: add --locality-file to server start commands**
- **colexecagg: remove redundant NewAggregatorArgs.MemAccount field**
- **raft: persist LeadEpoch in HardState**
- **raft: convert indents in raft.proto to spaces**
- **crosscluster/logical: don't log raw spec**
- **sql: clean up `TestLargeDynamicRows`**
- **changefeedccl: fix kafka-azure roachtest**
- **bootstrap: create an explicit zoneconfig for timeseries data**
- **opt: do not construct unnecessary index-join for inverted index scans**
- **ui: add "Lease Types" graph to Replication dashboard**
- **roachtest: avoid pooling in DSC job compat test**
- **roachtest: rename DSC job compat test for 24.3**
- **colexec: release in-memory resources after spilling to disk**
- **ui: only show LDR badge on jobs page**
- **go.mod: bump Pebble to 9e150e60e12c**
- **roachtest: update pgjdbc version under test**
- **sql/schemachanger: add TTL dependency checking for ALTER TYPE in DSC**
- **crosscluster/logical: set UDF function name from SQL input**
- **crosscluster/logical: remove upsert_specified applier action**
- **crosscluster/logical: move and relax validation logic**
- **catalog/lease: monitor rangefeed and recover from failures**
- **crosscluster: consolidate mutation type enum**
- **roachtest: bump up warehouse count in disagg-rebalance**
- **rpc: deflake TestRemoteOffsetUnhealthy**
- **rpc: deflake TestRemoteOffsetUnhealthy**
- **ui: add loading skeletons to databases and tables pages**
- **sql: fix typo of "Immutable" from previous refactoring**
- **master: Update pkg/testutils/release/cockroach_releases.yaml**
- **crosscluster/logical: call function by OID**
- **kvprober: add leaseholder information for ranges in kvprober logs**
- **log: crdbV2 decoder handles malformed lines**
- **roachprod: add unimplemented error**
- **roachprod-microbench: add threshold flag to compare command**
- **workflows: run `update_releases` on release-24.2**
- **rpc: deflake TestRemoteOffsetUnhealthy, further**
- **crosscluster: escape dlq table name**
- **rpc: clarify relationship between AdvancingClock and ManualTime**
- **changefeedccl: add log messages for when a core changefeed retries/fails**
- **add suggested changes**
- **crosscluster/logical: handle single-element tables in UDF**
- **concurrency: delete LockPromotionError**
- **roachtest: fix warehouse count increase in disagg-rebalance**
- **changefeedccl: implement new Kafka sink to sidestep reordering issue**
- **roachtest: cleanup job-compat cleanup**
- **raft: move Config from tracker to quorum**
- **raft: move Config onto the raft struct**
- **raft: use ProgressMap instead of ProgressTracker for config changes**
- **raft: move ProgressTracker construction into switchToConfig**
- **storage: bump Pebble and update interval collector implementation**
- **sql: support external row data spans for tables**
- **roachtest: export tpce perf data to roachperf**
- **sql/parser: display line number for unexpected parser error**
- **sql/parser: add support for parsing CREATE TRIGGER statements**
- **sql/parser: add support for parsing DROP TRIGGER statements**
- **sql: add TRIGGER datatype**
- **sql: include MaxTimestampAge info for TableReader in DistSQL diagrams**
- **changefeedccl: fix data race in kafka sink v2 partitioner**
- **changefeedccl: add some debug logging to the test sinkless feed**
- **stmtdiagnostics: skip TestDiagnosticsRequest under duress**
- **roachprod: implement spot vm preemption detection for AWS.**
- **sql: fix incorrect context capture for the internal executor**
- **roachprod: small command-line cleanups**
- **roachprod: remove `StartRoutingProxy` start option**
- **roachprod: encapsulate start options validation**
- **roachtest: direct mixedversion planning errors to test-eng**
- **sql: make datum compare safe to use with nil eval contexts**
- **roachtests: fix 5x upreplication with timeseries zonecfg range**
- **codeowners: add obs-india-prs**
- **roachtest: add operation name as a datadog tag**
- **cluster-ui: db details page should show user-friendly table names**
- **sql: remove io conversion functions for TRIGGER**
- **workload/tpccmultidb: add support for invoking the web console APIs**
- **roachtest/large-schema-benchmark: invoke console REST APIs**
- **sql: add cache invalidation builtin functions**
- **authors: add chandra.thumuluru to authors**
- **raft: pull out an ElectionTracker**
- **raft: make config private on the ProgressTacker**
- **sql/sessiondatapb: fix parsing/formatting of sql_sequence_cached_node**
- **changefeedccl: fix cdc/kafka-chaos-single-row roachtest**
- **logictest: retry relocate stmt in a couple of places**
- **master: Update pkg/testutils/release/cockroach_releases.yaml**
- **sql/stats: fix some flaky partial stats tests**
- **ui: alphabetize imports**
- **githooks: clarify commit message reminder about bug fixes and GitHub issues**
- **authors: add noam.hacker to authors**
- **storage: add OriginTimestamp to MVCCValueHeader**
- **internal/sqlsmith: don't generate abs on FLOAT4**
- **logictest: add a new file for testing blathers, to be deleted soon**
- **execinfra: fix up recent improvement**
- **roachtest: use aws spot vm for running roachtest nightlies.**
- **sql/schemachanger: copy ALTER TABLE .. SET TYPE pre-checks from legacy to DSC**
- **Revert "logictest: add a new file for testing blathers, to be deleted soon"**
- **sql/parser: fix memory leak of scanned comments**
- **opt: fix comment for GenerateLocalityOptimizedScan**
- **opt: refactor GenerateLocalityOptimizedScan**
- **changefeedccl: add support for MSK IAM authentication in the v2 kafka sink**
- **sql/schemachange: Fix drop database degradation**
- **opt: reformat benchmark slow-queries.sql**
- **opt: set all session settings to their global default**
- **opt: enable implicit SELECT FOR UPDATE locking in opt tests**
- **roachtest: use WorkloadNode spec and cockroach workload**
- **Console: fix sources for network ui graphs**
- **roachtest: remove the datadog agent from drt clusters**
- **backupccl: remove old syntax from some tests**
- **[roachtest] Opt-out of test selection for DR tests**
- **sql: block set default on computed col**
- **kv: parallelize raft log sync callback handling**
- **drtprod: print post-configuration information for datadog**
- **drtprod: fix unbound variable error**
- **roachtest: mark tests that use runTPCC as using workload node**
- **roachprod: fix prom service update issue**
- **gitignore workload binary**
- **perf: add deletes to ycsb CUSTOM workload**
- **perf: handle float inaccuracies in yscb workload custom**
- **perf: use insert starting point when reading in ycsb**
- **perf: remove dead code**
- **roachprod: add secure flag to grow**
- **roachprod: fix provider check for grow and shrink**
- **roachtest: add drain and decommission util for operations**
- **roachprod: add managed check to grow command**
- **roachprod: move cert signal to redist certs**
- **roachtest: dynamic cluster interface**
- **roachtest: add operation config**
- **roachtest: add resize operation**
- **drt: remove prometheus & grafana configurations**
- **roachprod: reduce the test rerun time**
- **roachtest: readd erroneously deleted workload run in alterpk-bank**
- **kvserver/rangefeed: add rangeID as part of activeStreams map**
- **roachtest/large-schema-benchmark: fix regression with the setup phase**
- **upgradecluster: introduce backoff in until cluster stable retries**
- **changefeedccl: support specifying compression levels in the v2 kafka sink**
- **kvserver/rangefeed: change registration to be a pointer everywhere**
- **kvserver/rangefeed: rename registration to buffered registration**
- **kvserver/rangefeed: separate out buffered registration into its own file**
- **kvserver/rangefeed: abstract registration in interface**
- **raft: make ProgressMap private**
- **changefeedccl: fix kafka sink v2 flush frequency**
- **sql: allow creating partial stats at extremes by default**
- **crosscluster: fix retained time test flake**
- **Revert "bootstrap: create an explicit zoneconfig for timeseries data"**
- **sql: fix TestStatementCancelRollback flake**
- **Revert "roachtests: fix 5x upreplication with timeseries zonecfg range"**
- **changefeedccl: enable the new Kafka v2 sink by default**
- **storage: stop setting IterOptions.TableFilter**
- **master: Update pkg/testutils/release/cockroach_releases.yaml**
- **raft: use last accepted term for log writes**
- **raft: remove unused Term from MsgStorageAppendResp**
- **raft: rm offset from TestStableToWithSnap**
- **raft: put accepted term to MsgStorageAppend**
- **changefeedccl: don't fetch all kafka topics on initial connection check in the v2 sink**
