### PR TITLE
memo: redact constants in EXPLAIN (OPT, REDACT) of various CREATE stmts

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_redact
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_redact
@@ -338,3 +338,68 @@ memo (optimized, ~7KB, required=[presentation: info:5] [distribution: test])
  └── G7: (const ‹×›)
 scan q
  └── constraint: /1: ‹×›
+
+# Regression test for #128282: check EXPLAIN (OPT, REDACT) of various CREATE
+# statements.
+
+statement ok
+CREATE TABLE t128282 (col STRING)
+
+query T
+EXPLAIN (OPT, REDACT) CREATE FUNCTION f() RETURNS STRING LANGUAGE SQL AS $$ SELECT * FROM t128282 WHERE col = 'secret' $$
+----
+create-function
+ ├── CREATE FUNCTION f()
+ │     RETURNS STRING
+ │     LANGUAGE SQL
+ │     AS $$SELECT t128282.col FROM test.public.t128282 WHERE col = ‹×›;$$
+ └── dependencies
+      └── t128282 [columns: col]
+
+query T
+EXPLAIN (OPT, VERBOSE, REDACT) CREATE FUNCTION f() RETURNS STRING LANGUAGE SQL AS $$ SELECT * FROM t128282 WHERE col = 'secret' $$
+----
+create-function
+ ├── CREATE FUNCTION f()
+ │     RETURNS STRING
+ │     LANGUAGE SQL
+ │     AS $$SELECT t128282.col FROM test.public.t128282 WHERE col = ‹×›;$$
+ ├── dependencies
+ │    └── t128282 [columns: col]
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── cost: 0.01
+ └── distribution: test
+
+query T
+EXPLAIN (OPT, MEMO, REDACT) CREATE FUNCTION f() RETURNS STRING LANGUAGE SQL AS $$ SELECT * FROM t128282 WHERE col = 'secret' $$
+----
+memo (optimized, ~8KB, required=[presentation: info:5] [distribution: test])
+ ├── G1: (explain G2 [distribution: test])
+ │    └── [presentation: info:5] [distribution: test]
+ │         ├── best: (explain G2="[distribution: test]" [distribution: test])
+ │         └── cost: 0.03
+ └── G2: (create-function &{‹×› ‹×›
+     ‹×›
+     ‹×›
+     ‹×› [{‹×› ‹×› map[‹×›:0 ‹×›:1 ‹×›:2 ‹×›:3] false 0}] ‹×› ‹×›})
+      ├── [distribution: test]
+      │    ├── best: (create-function &{‹×› ‹×›
+      │    │   ‹×›
+      │    │   ‹×›
+      │    │   ‹×› [{‹×› ‹×› map[‹×›:0 ‹×›:1 ‹×›:2 ‹×›:3] false 0}] ‹×› ‹×›})
+      │    └── cost: 0.01
+      └── []
+           ├── best: (create-function &{‹×› ‹×›
+           │   ‹×›
+           │   ‹×›
+           │   ‹×› [{‹×› ‹×› map[‹×›:0 ‹×›:1 ‹×›:2 ‹×›:3] false 0}] ‹×› ‹×›})
+           └── cost: 0.01
+create-function
+ ├── CREATE FUNCTION f()
+ │     RETURNS STRING
+ │     LANGUAGE SQL
+ │     AS $$SELECT t128282.col FROM test.public.t128282 WHERE col = ‹×›;$$
+ └── dependencies
+      └── t128282 [columns: col]

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -3860,3 +3860,96 @@ project
       └── windows
            └── min [frame="rows from unbounded to unbounded exclude current row"]
                 └── min_1_arg1
+
+# Regression test for #128282: check EXPLAIN (OPT, REDACT) of various CREATE
+# statements.
+
+statement ok
+CREATE TABLE t128282 (col STRING)
+
+query T
+EXPLAIN (OPT, REDACT) CREATE VIEW v AS SELECT * FROM t128282 WHERE col = 'secret'
+----
+create-view .v
+ ├── SELECT t128282.col FROM test.public.t128282 WHERE col = ‹×›
+ ├── columns: col
+ └── dependencies
+      └── t128282 [columns: col]
+
+query T
+EXPLAIN (OPT, VERBOSE, REDACT) CREATE VIEW v AS SELECT * FROM t128282 WHERE col = 'secret'
+----
+create-view .v
+ ├── SELECT t128282.col FROM test.public.t128282 WHERE col = ‹×›
+ ├── columns: col:1
+ ├── dependencies
+ │    └── t128282 [columns: col]
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── cost: 0.01
+ └── distribution: test
+
+query T
+EXPLAIN (OPT, MEMO, REDACT) CREATE VIEW v AS SELECT * FROM t128282 WHERE col = 'secret'
+----
+memo (optimized, ~8KB, required=[presentation: info:5] [distribution: test])
+ ├── G1: (explain G2 [distribution: test])
+ │    └── [presentation: info:5] [distribution: test]
+ │         ├── best: (explain G2="[distribution: test]" [distribution: test])
+ │         └── cost: 0.03
+ └── G2: (create-view .v)
+      ├── [distribution: test]
+      │    ├── best: (create-view .v)
+      │    └── cost: 0.01
+      └── []
+           ├── best: (create-view .v)
+           └── cost: 0.01
+create-view .v
+ ├── SELECT t128282.col FROM test.public.t128282 WHERE col = ‹×›
+ ├── columns: col
+ └── dependencies
+      └── t128282 [columns: col]
+
+query T
+EXPLAIN (OPT, REDACT) CREATE TABLE t (col STRING CHECK (col != 'secret'))
+----
+create-table
+ └── CREATE TABLE t (col STRING, CHECK (col != ‹×›))
+
+query T
+EXPLAIN (OPT, VERBOSE, REDACT) CREATE TABLE t (col STRING CHECK (col != 'secret'))
+----
+create-table
+ ├── CREATE TABLE t (col STRING, CHECK (col != ‹×›))
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── cost: 0.02
+ └── distribution: test
+
+query T
+EXPLAIN (OPT, MEMO, REDACT) CREATE TABLE t (col STRING CHECK (col != 'secret'))
+----
+memo (optimized, ~3KB, required=[presentation: info:1] [distribution: test])
+ ├── G1: (explain G2 [distribution: test])
+ │    └── [presentation: info:1] [distribution: test]
+ │         ├── best: (explain G2="[distribution: test]" [distribution: test])
+ │         └── cost: 0.04
+ ├── G2: (create-table G3 &{‹×›  ‹×›})
+ │    ├── [distribution: test]
+ │    │    ├── best: (create-table G3="[distribution: test]" &{‹×›  ‹×›})
+ │    │    └── cost: 0.02
+ │    └── []
+ │         ├── best: (create-table G3 &{‹×›  ‹×›})
+ │         └── cost: 0.02
+ ├── G3: (values G4 id=v1)
+ │    ├── [distribution: test]
+ │    │    ├── best: (values G4 id=v1)
+ │    │    └── cost: 0.01
+ │    └── []
+ │         ├── best: (values G4 id=v1)
+ │         └── cost: 0.01
+ └── G4: (scalar-list)
+create-table
+ └── CREATE TABLE t (col STRING, CHECK (col != ‹×›))

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -726,10 +726,19 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *CreateTableExpr:
-		tp.Child(t.Syntax.String())
+		fmtFlags := tree.FmtSimple
+		if f.RedactableValues {
+			fmtFlags = tree.FmtMarkRedactionNode | tree.FmtOmitNameRedaction
+		}
+		tp.Child(tree.AsStringWithFlags(t.Syntax, fmtFlags))
 
 	case *CreateViewExpr:
-		tp.Child(t.ViewQuery)
+		// Match the format flags used to create t.ViewQuery.
+		fmtFlags := tree.FmtParsable | tree.FmtAlwaysQualifyUserDefinedTypeNames
+		if f.RedactableValues {
+			fmtFlags |= tree.FmtMarkRedactionNode | tree.FmtOmitNameRedaction
+		}
+		tp.Child(tree.AsStringWithFlags(t.Syntax.AsSource, fmtFlags))
 
 		f.Buffer.Reset()
 		f.Buffer.WriteString("columns:")
@@ -741,7 +750,11 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		f.formatDependencies(tp, t.Deps, t.TypeDeps)
 
 	case *CreateFunctionExpr:
-		tp.Child(t.Syntax.String())
+		fmtFlags := tree.FmtSimple
+		if f.RedactableValues {
+			fmtFlags = tree.FmtMarkRedactionNode | tree.FmtOmitNameRedaction
+		}
+		tp.Child(tree.AsStringWithFlags(t.Syntax, fmtFlags))
 		f.formatDependencies(tp, t.Deps, t.TypeDeps)
 
 	case *CreateStatisticsExpr:


### PR DESCRIPTION
When producing EXPLAIN (OPT) output for various CREATE statements, we include the entire body of the statement. When the REDACT option is also used, we need to redact these statements in the output.

Fixes: #128282

Release note (bug fix): Fix a bug in which output of `EXPLAIN (OPT, REDACT)` of various CREATE statements was not redacted. This bug has existed since `EXPLAIN (REDACT)` was introduced in v23.1 and affects the following statements:
- `EXPLAIN (OPT, REDACT) CREATE TABLE`
- `EXPLAIN (OPT, REDACT) CREATE VIEW`
- `EXPLAIN (OPT, REDACT) CREATE FUNCTION`