### PR TITLE
release-23.1: backupccl: distribute restore validation work

### DIFF
--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/logtags"
@@ -83,7 +84,8 @@ func newGenerativeSplitAndScatterProcessor(
 	post *execinfrapb.PostProcessSpec,
 ) (execinfra.Processor, error) {
 	db := flowCtx.Cfg.DB
-	numChunkSplitAndScatterWorkers := int(spec.NumNodes)
+	numNodes := int(spec.NumNodes)
+	numChunkSplitAndScatterWorkers := numNodes
 	// numEntrySplitWorkers is set to be 2 * numChunkSplitAndScatterWorkers in
 	// order to keep up with the rate at which chunks are split and scattered.
 	// TODO(rui): This tries to cover for a bad scatter by having 2 * the number
@@ -92,8 +94,8 @@ func newGenerativeSplitAndScatterProcessor(
 
 	mkSplitAndScatterer := func() (splitAndScatterer, error) {
 		if spec.ValidateOnly {
-			nodeID, _ := flowCtx.NodeID.OptionalNodeID()
-			return noopSplitAndScatterer{nodeID}, nil
+			rng, _ := randutil.NewPseudoRand()
+			return noopSplitAndScatterer{rng, spec.SQLInstanceIDs}, nil
 		}
 		kr, err := MakeKeyRewriterFromRekeys(flowCtx.Codec(), spec.TableRekeys, spec.TenantRekeys,
 			false /* restoreTenantFromStream */)
@@ -130,7 +132,7 @@ func newGenerativeSplitAndScatterProcessor(
 		// other than it's the max number of entries that can be processed
 		// in parallel downstream. It has been verified ad-hoc that this
 		// sizing does not bottleneck restore.
-		doneScatterCh:     make(chan entryNode, int(spec.NumNodes)*maxConcurrentRestoreWorkers),
+		doneScatterCh:     make(chan entryNode, numNodes*maxConcurrentRestoreWorkers),
 		routingDatumCache: newRoutingDatumCache(),
 	}
 	if err := ssp.Init(ctx, ssp, post, generativeSplitAndScatterOutputTypes, flowCtx, processorID, nil, /* memMonitor */

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -260,5 +260,6 @@ func makeTestingGenerativeSplitAndScatterSpec(
 		NumNodes:             1,
 		JobID:                0,
 		UseSimpleImportSpans: false,
+		SQLInstanceIDs:       []int32{1},
 	}
 }

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -114,6 +114,11 @@ func distRestore(
 			return nil, nil, err
 		}
 
+		numNodes := len(sqlInstanceIDs)
+		instanceIDs := make([]int32, numNodes)
+		for i, instanceID := range sqlInstanceIDs {
+			instanceIDs[i] = int32(instanceID)
+		}
 		p := planCtx.NewPhysicalPlan()
 
 		restoreDataSpec := execinfrapb.RestoreDataSpec{
@@ -191,6 +196,7 @@ func distRestore(
 			UseSimpleImportSpans:     useSimpleImportSpans,
 			UseFrontierCheckpointing: spanFilter.useFrontierCheckpointing,
 			JobID:                    int64(jobID),
+			SQLInstanceIDs:           instanceIDs,
 		}
 		if spanFilter.useFrontierCheckpointing {
 			spec.CheckpointedSpans = persistFrontier(spanFilter.checkpointFrontier, 0)

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -427,6 +427,9 @@ message GenerativeSplitAndScatterSpec {
   optional bool use_simple_import_spans = 19 [(gogoproto.nullable) = false];
   optional bool use_frontier_checkpointing = 20 [(gogoproto.nullable) = false];
   repeated jobs.jobspb.RestoreProgress.FrontierEntry checkpointed_spans = 21 [(gogoproto.nullable) = false];
+  // SQLInstanceIDs is a slice of SQL instance IDs available for dist restore.
+  // Set field ID to 24 to be forward compatible with future versions.
+  repeated int32 sql_instance_ids = 24[(gogoproto.nullable) = false, (gogoproto.customname) = "SQLInstanceIDs"];
 }
 
 


### PR DESCRIPTION
Backport 1/1 commits from #127925.

/cc @cockroachdb/release

---

Currently, when `verify_backup_table_data` flag is used in a restore statement, the node that is currently running gets selected for reading with the noop split and scatterer. In this PR, we randomly select a node from the list of nodes available for dist restore for reading, this ensures that we don't put all the reading workload on a single node.

Work loads between nodes are uniformly distributed when running restore validation for tpcc fixture (~400GB) with a 3-node cluster on roachprod. See screenshots for metrics below.

CPU usage per node:
![image (1)](https://github.com/user-attachments/assets/0fcda673-4b40-47ee-9d16-7ab60b0c36f0)

Time series of `cloud.read_bytes` per node:
![image](https://github.com/user-attachments/assets/ec5aa125-d818-48e3-a92c-7abd413a8bc0)

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/127677
Release note: none

----

Release justification: RESTORE bug fix