### PR TITLE
sqlstats/insights: fix mem leaks on session close

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -59,4 +59,5 @@ type TestingKnobs struct {
 	KeyVisualizer                  ModuleTestingKnobs
 	TenantCapabilitiesTestingKnobs ModuleTestingKnobs
 	TableStatsKnobs                ModuleTestingKnobs
+	Insights                       ModuleTestingKnobs
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -108,6 +108,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slprovider"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilegecache"
@@ -1135,6 +1136,11 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	}
 	if externalConnKnobs := cfg.TestingKnobs.ExternalConnection; externalConnKnobs != nil {
 		execCfg.ExternalConnectionTestingKnobs = externalConnKnobs.(*externalconn.TestingKnobs)
+	}
+
+	if insightsKnobs := cfg.TestingKnobs.Insights; insightsKnobs != nil {
+		execCfg.InsightsTestingKnobs = insightsKnobs.(*insights.TestingKnobs)
+
 	}
 	var tableStatsTestingKnobs *stats.TableStatsTestingKnobs
 	if tableStatsKnobs := cfg.TestingKnobs.TableStatsKnobs; tableStatsKnobs != nil {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -645,7 +645,7 @@ func (s *Server) GetIndexUsageStatsController() *idxusage.Controller {
 	return s.indexUsageStatsController
 }
 
-// GetInsightsReader returns the insights.Reader for the current sql.Server's
+// GetInsightsReader returns the insights store for the current sql.Server's
 // detected execution insights.
 func (s *Server) GetInsightsReader() *insights.LockingStore {
 	return s.insights.Store()
@@ -1267,7 +1267,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	}
 
 	// Free any memory used by the stats collector.
-	ex.statsCollector.Free(ctx)
+	ex.statsCollector.Close(ctx, ex.planner.extendedEvalCtx.SessionID)
 
 	var payloadErr error
 	if closeType == normalClose {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -415,7 +415,7 @@ type ServerMetrics struct {
 func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	metrics := makeMetrics(false /* internal */)
 	serverMetrics := makeServerMetrics(cfg)
-	insightsProvider := insights.New(cfg.Settings, serverMetrics.InsightsMetrics)
+	insightsProvider := insights.New(cfg.Settings, serverMetrics.InsightsMetrics, cfg.InsightsTestingKnobs)
 	// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
 	sqlstats.TxnStatsEnable.SetOnChange(&cfg.Settings.SV, func(_ context.Context) {
 		if !sqlstats.TxnStatsEnable.Get(&cfg.Settings.SV) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -103,6 +103,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilegecache"
@@ -1302,6 +1303,7 @@ type ExecutorConfig struct {
 	UnusedIndexRecommendationsKnobs      *idxusage.UnusedIndexRecommendationTestingKnobs
 	ExternalConnectionTestingKnobs       *externalconn.TestingKnobs
 	EventLogTestingKnobs                 *EventLogTestingKnobs
+	InsightsTestingKnobs                 *insights.TestingKnobs
 
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
 	HistogramWindowInterval time.Duration

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/sql/execstats",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sqlstats/insights",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "provider.go",
         "registry.go",
         "store.go",
+        "test_utils.go",
     ],
     embed = [":insights_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights",

--- a/pkg/sql/sqlstats/insights/ingester_test.go
+++ b/pkg/sql/sqlstats/insights/ingester_test.go
@@ -79,7 +79,7 @@ func TestIngester(t *testing.T) {
 				newRegistry(st, &fakeDetector{
 					stubEnabled: true,
 					stubIsSlow:  true,
-				}, store),
+				}, store, nil),
 			)
 
 			ingester.Start(ctx, stopper)
@@ -134,7 +134,7 @@ func TestIngester_Clear(t *testing.T) {
 		newRegistry(settings, &fakeDetector{
 			stubEnabled: true,
 			stubIsSlow:  true,
-		}, store))
+		}, store, nil))
 
 	// Fill the ingester's buffer with some data. This sets us up to
 	// call Clear() with guaranteed data in the buffer, so we can assert
@@ -181,7 +181,7 @@ func TestIngester_Disabled(t *testing.T) {
 	// the underlying registry is currently disabled.
 	st := cluster.MakeTestingClusterSettings()
 
-	ingester := newConcurrentBufferIngester(newRegistry(st, &fakeDetector{}, newStore(st)))
+	ingester := newConcurrentBufferIngester(newRegistry(st, &fakeDetector{}, newStore(st), nil))
 	ingester.ObserveStatement(clusterunique.ID{}, &Statement{})
 	ingester.ObserveTransaction(clusterunique.ID{}, &Transaction{})
 	require.Equal(t, event{}, ingester.guard.eventBuffer[0])
@@ -200,7 +200,7 @@ func TestIngester_DoesNotBlockWhenReceivingManyObservationsAfterShutdown(t *test
 	defer stopper.Stop(ctx)
 
 	st := cluster.MakeTestingClusterSettings()
-	registry := newRegistry(st, &fakeDetector{stubEnabled: true}, newStore(st))
+	registry := newRegistry(st, &fakeDetector{stubEnabled: true}, newStore(st), nil)
 	ingester := newConcurrentBufferIngester(registry)
 	ingester.Start(ctx, stopper)
 
@@ -259,7 +259,7 @@ func TestIngesterBlockedForceSync(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	st := cluster.MakeTestingClusterSettings()
-	registry := newRegistry(st, &fakeDetector{stubEnabled: true}, newStore(st))
+	registry := newRegistry(st, &fakeDetector{stubEnabled: true}, newStore(st), nil)
 	ingester := newConcurrentBufferIngester(registry)
 
 	// We queue up a bunch of sync operations because it's unclear how

--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -138,7 +138,7 @@ type PercentileValues struct {
 }
 
 // New builds a new Provider.
-func New(st *cluster.Settings, metrics Metrics) *Provider {
+func New(st *cluster.Settings, metrics Metrics, knobs *TestingKnobs) *Provider {
 	store := newStore(st)
 	anomalyDetector := newAnomalyDetector(st, metrics)
 
@@ -148,7 +148,7 @@ func New(st *cluster.Settings, metrics Metrics) *Provider {
 			newRegistry(st, &compositeDetector{detectors: []detector{
 				&latencyThresholdDetector{st: st},
 				anomalyDetector,
-			}}, store),
+			}}, store, knobs),
 		),
 		anomalyDetector: anomalyDetector,
 	}

--- a/pkg/sql/sqlstats/insights/insights_test.go
+++ b/pkg/sql/sqlstats/insights/insights_test.go
@@ -45,7 +45,7 @@ func BenchmarkInsights(b *testing.B) {
 	// down, guiding us as we tune buffer sizes, etc.
 	for _, numSessions := range []int{1, 10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("numSessions=%d", numSessions), func(b *testing.B) {
-			provider := insights.New(settings, insights.NewMetrics())
+			provider := insights.New(settings, insights.NewMetrics(), nil)
 			provider.Start(ctx, stopper)
 
 			// Spread the b.N work across the simulated SQL sessions, so that we

--- a/pkg/sql/sqlstats/insights/integration/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/integration/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/clusterunique",
         "//pkg/sql/contention",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats/insights",

--- a/pkg/sql/sqlstats/insights/pool.go
+++ b/pkg/sql/sqlstats/insights/pool.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 )
 
+// TODO (xinhaoz): Remove this pool (#128199). The insights object
+// can use the existing statementBuf pool for the statements slice.
 var insightPool = sync.Pool{
 	New: func() interface{} {
 		return new(Insight)
@@ -32,6 +34,9 @@ func makeInsight(sessionID clusterunique.ID, transaction *Transaction) *Insight 
 }
 
 func releaseInsight(insight *Insight) {
+	for i := range insight.Statements {
+		insight.Statements[i] = nil
+	}
 	insight.Statements = insight.Statements[:0]
 	*insight = Insight{Statements: insight.Statements}
 	insightPool.Put(insight)

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -23,10 +23,11 @@ import (
 // statement execution to determine which statements are outliers and
 // writes insights into the provided sink.
 type lockingRegistry struct {
-	statements map[clusterunique.ID]*statementBuf
-	detector   detector
-	causes     *causes
-	store      *LockingStore
+	statements   map[clusterunique.ID]*statementBuf
+	detector     detector
+	causes       *causes
+	store        *LockingStore
+	testingKnobs *TestingKnobs
 }
 
 func (r *lockingRegistry) Clear() {
@@ -195,11 +196,14 @@ func (r *lockingRegistry) enabled() bool {
 	return r.detector.enabled()
 }
 
-func newRegistry(st *cluster.Settings, detector detector, store *LockingStore) *lockingRegistry {
+func newRegistry(
+	st *cluster.Settings, detector detector, store *LockingStore, knobs *TestingKnobs,
+) *lockingRegistry {
 	return &lockingRegistry{
-		statements: make(map[clusterunique.ID]*statementBuf),
-		detector:   detector,
-		causes:     &causes{st: st},
-		store:      store,
+		statements:   make(map[clusterunique.ID]*statementBuf),
+		detector:     detector,
+		causes:       &causes{st: st},
+		store:        store,
+		testingKnobs: knobs,
 	}
 }

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -186,6 +186,18 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 	r.store.addInsight(insight)
 }
 
+// clearSession removes the session from the registry and releases the
+// associated statement buffer.
+func (r *lockingRegistry) clearSession(sessionID clusterunique.ID) {
+	if b, ok := r.statements[sessionID]; ok {
+		delete(r.statements, sessionID)
+		b.release()
+		if r.testingKnobs != nil && r.testingKnobs.OnSessionClear != nil {
+			r.testingKnobs.OnSessionClear(sessionID)
+		}
+	}
+}
+
 // TODO(todd):
 //
 //	Once we can handle sufficient throughput to live on the hot

--- a/pkg/sql/sqlstats/insights/test_utils.go
+++ b/pkg/sql/sqlstats/insights/test_utils.go
@@ -10,8 +10,13 @@
 
 package insights
 
+import "github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
+
 // TestingKnobs provides hooks and testingKnobs for unit tests.
 type TestingKnobs struct {
+	// OnSessionClear is a callback that is triggered when the locking
+	// registry clears a session entry.
+	OnSessionClear func(sessionID clusterunique.ID)
 }
 
 // ModuleTestingKnobs implements base.ModuleTestingKnobs interface.

--- a/pkg/sql/sqlstats/insights/test_utils.go
+++ b/pkg/sql/sqlstats/insights/test_utils.go
@@ -1,0 +1,18 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package insights
+
+// TestingKnobs provides hooks and testingKnobs for unit tests.
+type TestingKnobs struct {
+}
+
+// ModuleTestingKnobs implements base.ModuleTestingKnobs interface.
+func (*TestingKnobs) ModuleTestingKnobs() {}

--- a/pkg/sql/sqlstats/insights/test_utils.go
+++ b/pkg/sql/sqlstats/insights/test_utils.go
@@ -17,6 +17,15 @@ type TestingKnobs struct {
 	// OnSessionClear is a callback that is triggered when the locking
 	// registry clears a session entry.
 	OnSessionClear func(sessionID clusterunique.ID)
+
+	// InsightsWriterTxnInterceptor is a callback that's triggered when a txn insight
+	// is observed by the ingester. The callback is called instead of writing the
+	// insight to the buffer.
+	InsightsWriterTxnInterceptor func(sessionID clusterunique.ID, transaction *Transaction)
+
+	// InsightsWriterStmtInterceptor is a callback that's triggered when a stmt insight
+	// is observed. The callback is called instead of writing the insight to the buffer.
+	InsightsWriterStmtInterceptor func(sessionID clusterunique.ID, statement *Statement)
 }
 
 // ModuleTestingKnobs implements base.ModuleTestingKnobs interface.

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/clusterunique",
         "//pkg/sql/execstats",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sessionphase",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -448,7 +448,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		Settings: st,
 	})
 
-	insightsProvider := insights.New(st, insights.NewMetrics())
+	insightsProvider := insights.New(st, insights.NewMetrics(), nil)
 	sqlStats := sslocal.New(
 		st,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
@@ -576,7 +576,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 		require.NoError(t, err)
 
 		// Construct the SQL Stats machinery.
-		insightsProvider := insights.New(st, insights.NewMetrics())
+		insightsProvider := insights.New(st, insights.NewMetrics(), nil)
 		sqlStats := sslocal.New(
 			st,
 			sqlstats.MaxMemSQLStatsStmtFingerprints,
@@ -1725,7 +1725,7 @@ func TestSQLStats_ConsumeStats(t *testing.T) {
 		Name:     "test",
 		Settings: st,
 	})
-	insightsProvider := insights.New(st, insights.NewMetrics())
+	insightsProvider := insights.New(st, insights.NewMetrics(), nil)
 
 	sqlStats := sslocal.New(
 		st,

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -279,9 +279,7 @@ func (s *StatsCollector) ObserveStatement(
 		ErrorCode:            errorCode,
 		ErrorMsg:             errorMsg,
 	}
-	if s.knobs != nil && s.knobs.InsightsWriterStmtInterceptor != nil {
-		s.knobs.InsightsWriterStmtInterceptor(value.SessionID, &insight)
-	} else if s.insightsWriter != nil {
+	if s.insightsWriter != nil {
 		s.insightsWriter.ObserveStatement(value.SessionID, &insight)
 	}
 }
@@ -338,9 +336,7 @@ func (s *StatsCollector) ObserveTransaction(
 		LastErrorMsg:    errorMsg,
 		Status:          status,
 	}
-	if s.knobs != nil && s.knobs.InsightsWriterTxnInterceptor != nil {
-		s.knobs.InsightsWriterTxnInterceptor(ctx, value.SessionID, &insight)
-	} else if s.insightsWriter != nil {
+	if s.insightsWriter != nil {
 		s.insightsWriter.ObserveTransaction(value.SessionID, &insight)
 	}
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -38,7 +38,7 @@ func TestRecordStatement(t *testing.T) {
 		sqlstats.TxnStatsEnable.Override(ctx, &settings.SV, false)
 		// Initialize knobs & mem container.
 		numStmtInsights := 0
-		knobs := &sqlstats.TestingKnobs{
+		knobs := &insights.TestingKnobs{
 			InsightsWriterStmtInterceptor: func(sessionID clusterunique.ID, statement *insights.Statement) {
 				numStmtInsights++
 			},
@@ -47,8 +47,8 @@ func TestRecordStatement(t *testing.T) {
 			nil, /* uniqueServerCount */
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
-			knobs,
-			insights.New(settings, insights.NewMetrics(), nil).Anomalies(),
+			nil,
+			insights.New(settings, insights.NewMetrics(), knobs).Anomalies(),
 		)
 		// Record a statement, ensure no insights are generated.
 		statsKey := appstatspb.StatementStatisticsKey{
@@ -72,8 +72,8 @@ func TestRecordTransaction(t *testing.T) {
 		sqlstats.TxnStatsEnable.Override(ctx, &settings.SV, false)
 		// Initialize knobs & mem container.
 		numTxnInsights := 0
-		knobs := &sqlstats.TestingKnobs{
-			InsightsWriterTxnInterceptor: func(ctx context.Context, sessionID clusterunique.ID, transaction *insights.Transaction) {
+		knobs := &insights.TestingKnobs{
+			InsightsWriterTxnInterceptor: func(sessionID clusterunique.ID, transaction *insights.Transaction) {
 				numTxnInsights++
 			},
 		}
@@ -81,8 +81,8 @@ func TestRecordTransaction(t *testing.T) {
 			nil, /* uniqueServerCount */
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
-			knobs,
-			insights.New(settings, insights.NewMetrics(), nil).Anomalies(),
+			nil,
+			insights.New(settings, insights.NewMetrics(), knobs).Anomalies(),
 		)
 		// Record a transaction, ensure no insights are generated.
 		require.NoError(t, memContainer.RecordTransaction(ctx, appstatspb.TransactionFingerprintID(123), sqlstats.RecordedTxnStats{}))

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -48,7 +48,7 @@ func TestRecordStatement(t *testing.T) {
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			knobs,
-			insights.New(settings, insights.NewMetrics()).Anomalies(),
+			insights.New(settings, insights.NewMetrics(), nil).Anomalies(),
 		)
 		// Record a statement, ensure no insights are generated.
 		statsKey := appstatspb.StatementStatisticsKey{
@@ -82,7 +82,7 @@ func TestRecordTransaction(t *testing.T) {
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			knobs,
-			insights.New(settings, insights.NewMetrics()).Anomalies(),
+			insights.New(settings, insights.NewMetrics(), nil).Anomalies(),
 		)
 		// Record a transaction, ensure no insights are generated.
 		require.NoError(t, memContainer.RecordTransaction(ctx, appstatspb.TransactionFingerprintID(123), sqlstats.RecordedTxnStats{}))

--- a/pkg/sql/sqlstats/test_utils.go
+++ b/pkg/sql/sqlstats/test_utils.go
@@ -10,13 +10,7 @@
 
 package sqlstats
 
-import (
-	"context"
-	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
-)
+import "time"
 
 // TestingKnobs provides hooks and knobs for unit tests.
 type TestingKnobs struct {
@@ -27,16 +21,6 @@ type TestingKnobs struct {
 	// OnTxnStatsFlushFinished is a callback that is triggered when txn stats
 	// finishes flushing.
 	OnTxnStatsFlushFinished func()
-
-	// InsightsWriterTxnInterceptor is a callback that's triggered when a txn insight
-	// is observed when recording txn stats. The callback is called instead of the legitimate
-	// insights.Writer.
-	InsightsWriterTxnInterceptor func(ctx context.Context, sessionID clusterunique.ID, transaction *insights.Transaction)
-
-	// InsightsWriterStmtInterceptor is a callback that's triggered when a stmt insight
-	// is observed when recording stmt stats. The callback is called instead of the legitimate
-	// insights.Writer.
-	InsightsWriterStmtInterceptor func(sessionID clusterunique.ID, statement *insights.Statement)
 
 	// OnCleanupStartForShard is a callback that is triggered when background
 	// cleanup job starts to delete data from a shard from the system table.


### PR DESCRIPTION
insights: ensure releasing to Insight pool clears slice

Ensure that when we return objects into the Insight pool
that we release the statmeents in the slice. This fixes
an issue in the logic that returned this object to the pool
which did not nil the `Statements` slice, making it possible
for these slices to grow in capacity in the node's lifetime,
holding onto garbage Statement objects.

This is a lead up to https://github.com/cockroachdb/cockroach/issues/128199 which will likely remove
this pool and reuse the existing statmentBuf pool.

Epic: none
Release note: None

insights: add testing knobs

Add insights specific testing knobs. We'll add some
knobs in later commts.

Epic: none
Release note: None

sqlstats/insights: free memory allocated per session on session close

The insights locking registry buffers statement insight objects
by session id until receiving a transaction insight, when the
buffer is emptied. These buffers can leak if the session is closed
midway through a transaction since the registry will never
receive a transaction event for the session. This commit ensures
we clear any memory allocated in insights for a session by
sending an event to clear the container's session entry, if it
exists, on session close.

A testing knob was added, OnCloseSession, which is called
when the locking registry clears a session.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/128213

Release note (bug fix): Fixes a memory leak where statement
insight objects may leak if the session is closed without
the transaction finishing.

insights: move insights testing knobs from sqlstats

Move some insights testing knobs that were on the
sqlstats testing knobs to insights pkg.

Epic: none

Release note: None