### PR TITLE
tpcc/large-schema-benchmark: avoid AWS cloud for this test

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -75,7 +75,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 			10,
 			clusterSpec...,
 		),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Timeout:          testTimeout,
 		RequiresLicense:  true,


### PR DESCRIPTION
Previously, this test was specifying regions that were GCE only which would lead to failures on AWS. To address, this patch modifies tpcc/large-schema-benchmark to be GCE cloud only.

Fixes: #128252, #128246
Release note: None