### PR TITLE
roachtest: minor fix when logging error in `FetchDebugZip`

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1221,7 +1221,7 @@ func (c *clusterImpl) FetchLogs(ctx context.Context, l *logger.Logger) error {
 		return nil
 	}
 
-	l.Printf("fetching logs\n")
+	l.Printf("fetching logs")
 	c.status("fetching logs")
 
 	// Don't hang forever if we can't fetch the logs.
@@ -1313,7 +1313,7 @@ func (c *clusterImpl) CopyRoachprodState(ctx context.Context) error {
 //
 // `COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob ./cockroach start-single-node --insecure --store=$(mktemp -d)`
 func (c *clusterImpl) FetchTimeseriesData(ctx context.Context, l *logger.Logger) error {
-	l.Printf("fetching timeseries data\n")
+	l.Printf("fetching timeseries data")
 	return timeutil.RunWithTimeout(ctx, "fetch tsdata", 5*time.Minute, func(ctx context.Context) error {
 		node := 1
 		for ; node <= c.spec.NodeCount; node++ {
@@ -1399,7 +1399,7 @@ func (c *clusterImpl) FetchDebugZip(
 		return nil
 	}
 
-	l.Printf("fetching debug zip\n")
+	l.Printf("fetching debug zip")
 	c.status("fetching debug zip")
 
 	var nodes option.NodeListOption
@@ -1426,7 +1426,7 @@ func (c *clusterImpl) FetchDebugZip(
 			// `cockroach debug zip` does not support non root authentication.
 			nodePgUrl, err := c.InternalPGUrl(ctx, l, c.Node(node), roachprod.PGURLOptions{Auth: install.AuthRootCert})
 			if err != nil {
-				l.Printf("cluster.FetchDebugZip failed to retrieve PGUrl on node %d: %v", test.DefaultCockroachPath, node, err)
+				l.Printf("cluster.FetchDebugZip failed to retrieve PGUrl on node %d: %v", node, err)
 				continue
 			}
 
@@ -1492,7 +1492,7 @@ func (c *clusterImpl) FetchVMSpecs(ctx context.Context, l *logger.Logger) error 
 
 				err = os.WriteFile(dest, specJSON, 0644)
 				if err != nil {
-					l.Printf("Failed to write spec to file for %s\n", name)
+					l.Printf("Failed to write spec to file for %s", name)
 					continue
 				}
 			}
@@ -1620,7 +1620,7 @@ func (c *clusterImpl) FetchDmesg(ctx context.Context, l *logger.Logger) error {
 		return nil
 	}
 
-	l.Printf("fetching dmesg\n")
+	l.Printf("fetching dmesg")
 	c.status("fetching dmesg")
 
 	// Don't hang forever.
@@ -1671,7 +1671,7 @@ func (c *clusterImpl) FetchJournalctl(ctx context.Context, l *logger.Logger) err
 		return nil
 	}
 
-	l.Printf("fetching journalctl\n")
+	l.Printf("fetching journalctl")
 	c.status("fetching journalctl")
 
 	// Don't hang forever.
@@ -1726,11 +1726,11 @@ func (c *clusterImpl) FetchCores(ctx context.Context, l *logger.Logger) error {
 		// from having the cores, but we should push them straight into a temp
 		// bucket on S3 instead. OTOH, the ROI of this may be low; I don't know
 		// of a recent example where we've wanted the Core dumps.
-		l.Printf("skipped fetching cores\n")
+		l.Printf("skipped fetching cores")
 		return nil
 	}
 
-	l.Printf("fetching cores\n")
+	l.Printf("fetching cores")
 	c.status("fetching cores")
 
 	// Don't hang forever. The core files can be large, so we give a generous
@@ -1874,7 +1874,7 @@ func (c *clusterImpl) doDestroy(ctx context.Context, l *logger.Logger) <-chan st
 			}
 		}
 	} else {
-		l.Printf("skipping cluster wipe\n")
+		l.Printf("skipping cluster wipe")
 	}
 	c.r.unregisterCluster(c)
 	c.destroyState.mu.Lock()


### PR DESCRIPTION
The call to `Printf` had an extra argument.

Epic: none

Release note: None