### PR TITLE
release-24.1: changefeedccl: don't fetch all kafka topics on connection check in the v2 sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -48,6 +48,8 @@ type kafkaSinkClientV2 struct {
 	canTryResizing bool
 	recordResize   func(numRecords int64)
 
+	topicsForConnectionCheck []string
+
 	// we need to fetch and keep track of this ourselves since kgo doesnt expose metadata to us
 	metadataMu struct {
 		syncutil.Mutex
@@ -67,6 +69,7 @@ func newKafkaSinkClientV2(
 	settings *cluster.Settings,
 	knobs kafkaSinkV2Knobs,
 	mb metricsRecorderBuilder,
+	topicsForConnectionCheck []string,
 ) (*kafkaSinkClientV2, error) {
 
 	baseOpts := []kgo.Opt{
@@ -118,12 +121,13 @@ func newKafkaSinkClientV2(
 	}
 
 	c := &kafkaSinkClientV2{
-		client:         client,
-		adminClient:    adminClient,
-		knobs:          knobs,
-		batchCfg:       batchCfg,
-		canTryResizing: changefeedbase.BatchReductionRetryEnabled.Get(&settings.SV),
-		recordResize:   recordResize,
+		client:                   client,
+		adminClient:              adminClient,
+		knobs:                    knobs,
+		batchCfg:                 batchCfg,
+		canTryResizing:           changefeedbase.BatchReductionRetryEnabled.Get(&settings.SV),
+		recordResize:             recordResize,
+		topicsForConnectionCheck: topicsForConnectionCheck,
 	}
 	c.metadataMu.allTopicPartitions = make(map[string][]int32)
 
@@ -212,6 +216,11 @@ func (k *kafkaSinkClientV2) FlushResolvedPayload(
 
 func (k *kafkaSinkClientV2) CheckConnection(ctx context.Context) error {
 	return k.maybeUpdateTopicPartitions(ctx, func(cb func(topic string) error) error {
+		for _, topic := range k.topicsForConnectionCheck {
+			if err := cb(topic); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 }
@@ -236,6 +245,8 @@ func (k *kafkaSinkClientV2) maybeUpdateTopicPartitions(
 	if len(topics) == len(k.metadataMu.allTopicPartitions) && timeutil.Since(k.metadataMu.lastMetadataRefresh) < metadataRefreshMinDuration {
 		return nil
 	}
+
+	log.Infof(ctx, `updating kafka metadata for topics: %+v`, topics)
 
 	topicDetails, err := k.adminClient.ListTopics(ctx, topics...)
 	if err != nil {
@@ -363,7 +374,8 @@ func makeKafkaSinkV2(
 			`unknown kafka sink query parameters: %s`, strings.Join(unknownParams, ", "))
 	}
 
-	client, err := newKafkaSinkClientV2(ctx, clientOpts, batchCfg, u.Host, settings, knobs, mb)
+	topicsForConnectionCheck := topicNamer.DisplayNamesSlice()
+	client, err := newKafkaSinkClientV2(ctx, clientOpts, batchCfg, u.Host, settings, knobs, mb, topicsForConnectionCheck)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -553,7 +553,7 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 	}
 
 	var err error
-	fx.sink, err = newKafkaSinkClientV2(ctx, fx.additionalKOpts, fx.batchConfig, "no addrs", settings, knobs, nilMetricsRecorderBuilder)
+	fx.sink, err = newKafkaSinkClientV2(ctx, fx.additionalKOpts, fx.batchConfig, "no addrs", settings, knobs, nilMetricsRecorderBuilder, nil)
 	require.NoError(t, err)
 
 	targets := makeChangefeedTargets(fx.targetNames...)

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1682,9 +1682,14 @@ func registerCDC(r registry.Registry) {
 				// https://github.com/IBM/sarama/blob/fd84c2b0f0185100dbaec28ca4074289b35cc1b1/client.go#L1023-L1027
 				// which tells us what topics are being fetched for metadata. We expect
 				// to see logs for tpcc tables but not for random topics.
+				//
+				// We now also check for similar logs from the kafka v2 sink &
+				// kgo. There isn't a direct equivalent, however, so check a few
+				// things.
+				logSearchStr := `(client/metadata fetching metadata for|updating kafka metadata for topics|fetching metadata to learn its partitions|waiting for metadata for new topic)`
 				results, checkLogsErr := ct.cluster.RunWithDetails(ct.ctx, t.L(),
 					option.WithNodes(ct.cluster.Range(1, c.Spec().NodeCount-1)),
-					"grep \"client/metadata fetching metadata for\" logs/cockroach.log")
+					fmt.Sprintf(`grep -E "%s" logs/cockroach.log`, logSearchStr))
 				if checkLogsErr != nil {
 					t.Fatal(checkLogsErr)
 				}
@@ -1697,7 +1702,7 @@ func registerCDC(r registry.Registry) {
 					}
 
 					// We do not expect to see fetching metadata for all topics.
-					if strings.Contains(str, "all topics") {
+					if strings.Contains(str, "all topics") || strings.Contains(str, "updating kafka metadata for topics: []") {
 						return errors.New("did not expect to fetch metadata for all topics")
 					}
 					return nil


### PR DESCRIPTION
Backport 1/1 commits from #128390.

Release justification: Fix an issue in the new kafka sink v2 which was also backported.

/cc @cockroachdb/release

---

Prevously the kafka v2 sink would fetch metadata for all topics on initial dial. Now it will not, bringing it in line with the v1 sink.

Fixes: #127946

Release note: None
