### PR TITLE
logictestccl: deflake select_for_update_read_committed yet again 🤦

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
@@ -571,7 +571,7 @@ statement ok
 GRANT ALL ON xyz TO testuser
 
 statement ok
-INSERT INTO xyz VALUES (1, 10, 100), (2, 10, 100)
+INSERT INTO xyz VALUES (1, 10, 100), (2, 10, 200), (3, 30, 100)
 
 user testuser
 
@@ -601,7 +601,7 @@ BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM xyz@xyz_y_idx WHERE y = 10 ORDER BY y, x LIMIT 1 FOR UPDATE SKIP LOCKED;
 COMMIT;
 ----
-2  10  100
+2  10  200
 
 # The unlocked reads in SKIP LOCKED should not block on locks, either, even
 # under serializable isolation.
@@ -615,7 +615,7 @@ SET enable_durable_locking_for_serializable = true
 query III
 SELECT * FROM xyz WHERE z = 100 ORDER BY x FOR UPDATE SKIP LOCKED
 ----
-2  10  100
+3  30  100
 
 user testuser
 


### PR DESCRIPTION
The fixes in #128203 and #128341 were both insufficient. There's yet another way in which the results of the test can differ, which is when the lock from the second SELECT FOR UPDATE on x=2 lingers after the COMMIT, causing the third SELECT FOR UPDATE to skip both x=1 and x=2. I believe this laziness in releasing locks is expected, so the test needs to either retry the third SELECT FOR UPDATE or lock a different row. I think it's clearer to lock a different row, which also decouples the second and third SELECT FOR UPDATE statements.

This passed 10k runs successfully, so hopefully is the last fix.

Fixes: #128375

Release note: None