### PR TITLE
changefeedccl: increase timeout for changefeed errors case

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5470,7 +5470,7 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='experimental_avro', confluent_schema_registry=$2`,
 		`kafka://nope`, `https://schemareg-nope/?ca_cert=!`,
 	)
-	sqlDB.ExpectErrWithTimeout(
+	longTimeoutSQLDB.ExpectErrWithTimeout(
 		t, `failed to parse certificate data`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='experimental_avro', confluent_schema_registry=$2`,
 		`kafka://nope`, `https://schemareg-nope/?ca_cert=Zm9v`,


### PR DESCRIPTION
The test for bad certificate data for schema registry flakes every month or so since April, but there are no clues as to what may have changed since then. For now, increase the timeout of this test to see if it still hangs.

Epic: none
Fixes: #123079
Fixes: #127055

Release note: None