### PR TITLE
builtins: remove deprecated args from update_tenant_resource_limits

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
@@ -32,7 +32,7 @@ statement ok
 CREATE TENANT 'apptenant'
 
 statement ok
-SELECT crdb_internal.update_tenant_resource_limits('apptenant', 1000, 100, 0, now(), 0)
+SELECT crdb_internal.update_tenant_resource_limits('apptenant', 1000, 100, 0)
 
 user testuser
 

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -186,7 +186,7 @@ func runMultiTenantFairness(
 
 		t.L().Printf("virtual cluster %q started on n%d", name, node[0])
 		_, err := systemConn.ExecContext(
-			ctx, fmt.Sprintf("SELECT crdb_internal.update_tenant_resource_limits('%s', 1000000000, 10000, 1000000, now(), 0)", name),
+			ctx, fmt.Sprintf("SELECT crdb_internal.update_tenant_resource_limits('%s', 1000000000, 10000, 1000000)", name),
 		)
 		require.NoError(t, err)
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -255,7 +255,7 @@ query error tenant resource limits require a CCL binary
 SELECT crdb_internal.update_tenant_resource_limits(10, 1000, 100, 0, now(), 0)
 
 query error tenant resource limits require a CCL binary
-SELECT crdb_internal.update_tenant_resource_limits('tenant-number-ten', 1000, 100, 0, now(), 0)
+SELECT crdb_internal.update_tenant_resource_limits('tenant-number-ten', 1000, 100, 0)
 
 user testuser
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6967,15 +6967,11 @@ Parameters:` + randgencfg.ConfigDoc,
 			Volatility: volatility.Volatile,
 		},
 		tree.Overload{
-			// NOTE: as_of and as_of_consumed_tokens are not used and can be
-			// deprecated.
 			Types: tree.ParamTypes{
 				{Name: "tenant_name", Typ: types.String},
 				{Name: "available_tokens", Typ: types.Float},
 				{Name: "refill_rate", Typ: types.Float},
 				{Name: "max_burst_tokens", Typ: types.Float},
-				{Name: "as_of", Typ: types.Timestamp},
-				{Name: "as_of_consumed_tokens", Typ: types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2364,7 +2364,7 @@ var builtinOidsArray = []string{
 	2394: `array_cat_agg(arg1: varbit[]) -> varbit[]`,
 	2395: `array_cat_agg(arg1: anyenum[]) -> anyenum[]`,
 	2396: `array_cat_agg(arg1: tuple[]) -> tuple[]`,
-	2397: `crdb_internal.update_tenant_resource_limits(tenant_name: string, available_tokens: float, refill_rate: float, max_burst_tokens: float, as_of: timestamp, as_of_consumed_tokens: float) -> int`,
+	2397: `crdb_internal.update_tenant_resource_limits(tenant_name: string, available_tokens: float, refill_rate: float, max_burst_tokens: float) -> int`,
 	2398: `to_tsquery(text: string) -> tsquery`,
 	2399: `to_tsvector(text: string) -> tsvector`,
 	2400: `phraseto_tsquery(text: string) -> tsquery`,


### PR DESCRIPTION
The "as_of" and "as_of_consumed_tokens" arguments are not used by crdb_internal.update_tenant_resource_limits. While removing them from the "tenant_id" overload would break backwards-compatibility, they can be safely removed from the "tenant_name" overload, since that's not yet used (but eventually will be).

Epic: none

Release note: None