### PR TITLE
workload/schemachange: enable RENAME TABLE operation

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -110,9 +110,13 @@ func (og *operationGenerator) fnExists(
 }
 
 func (og *operationGenerator) tableHasDependencies(
-	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, includeFKs bool,
 ) (bool, error) {
-	return og.scanBool(ctx, tx, `
+	fkFilter := ""
+	if !includeFKs {
+		fkFilter = "AND fd.dependedonby_type != 'fk'"
+	}
+	q := fmt.Sprintf(`
 	SELECT EXISTS(
         SELECT fd.descriptor_name
           FROM crdb_internal.forward_dependencies AS fd
@@ -126,8 +130,10 @@ func (og *operationGenerator) tableHasDependencies(
                 )
            AND fd.descriptor_id != fd.dependedonby_id
            AND fd.dependedonby_type != 'sequence'
+           %s
        )
-	`, tableName.Object(), tableName.Schema())
+	`, fkFilter)
+	return og.scanBool(ctx, tx, q, tableName.Object(), tableName.Schema())
 }
 
 func (og *operationGenerator) columnIsDependedOn(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1921,7 +1921,7 @@ func (og *operationGenerator) dropTable(ctx context.Context, tx pgx.Tx) (*opStmt
 	if err != nil {
 		return nil, err
 	}
-	tableHasDependencies, err := og.tableHasDependencies(ctx, tx, tableName)
+	tableHasDependencies, err := og.tableHasDependencies(ctx, tx, tableName, true /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}
@@ -1953,7 +1953,7 @@ func (og *operationGenerator) dropView(ctx context.Context, tx pgx.Tx) (*opStmt,
 	if err != nil {
 		return nil, err
 	}
-	viewHasDependencies, err := og.tableHasDependencies(ctx, tx, viewName)
+	viewHasDependencies, err := og.tableHasDependencies(ctx, tx, viewName, true /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}
@@ -2220,7 +2220,7 @@ func (og *operationGenerator) renameTable(ctx context.Context, tx pgx.Tx) (*opSt
 		return nil, err
 	}
 
-	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcTableName)
+	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcTableName, false /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}
@@ -2270,7 +2270,7 @@ func (og *operationGenerator) renameView(ctx context.Context, tx pgx.Tx) (*opStm
 		return nil, err
 	}
 
-	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcViewName)
+	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcViewName, true /* includeFKs */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -299,7 +299,7 @@ var opWeights = []int{
 	dropView:                          1,
 	renameIndex:                       1,
 	renameSequence:                    1,
-	renameTable:                       0, // Disabled and tracked with #127980.
+	renameTable:                       1,
 	renameView:                        1,
 }
 


### PR DESCRIPTION
Enabling it requires an additional filter when checking table dependencies - we support renaming a table that has foreign keys, so those dependencies should be ignored.

Fixes: #127980
Release note: None