### PR TITLE
github: update CODEOWNERS for product-security team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,7 +87,7 @@
 
 /pkg/sql/crdb_internal.go    @cockroachdb/sql-foundations
 /pkg/sql/pg_catalog.go       @cockroachdb/sql-foundations
-/pkg/sql/pgwire/             @cockroachdb/sql-foundations @cockroachdb/server-prs
+/pkg/sql/pgwire/             @cockroachdb/sql-foundations @cockroachdb/server-prs @cockroachdb/product-security
 /pkg/sql/pgwire/auth.go      @cockroachdb/sql-foundations @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/sql/sem/builtins/       @cockroachdb/sql-foundations
 /pkg/sql/vtable/             @cockroachdb/sql-foundations
@@ -125,8 +125,8 @@
 # functionality into sub-packages assigned to their respective teams.
 #
 #!/pkg/cli/                  @cockroachdb/unowned
-/pkg/cli/auth.go             @cockroachdb/prodsec @cockroachdb/cli-prs
-/pkg/cli/cert*.go            @cockroachdb/prodsec @cockroachdb/cli-prs
+/pkg/cli/auth.go             @cockroachdb/prodsec @cockroachdb/cli-prs @cockroachdb/product-security
+/pkg/cli/cert*.go            @cockroachdb/prodsec @cockroachdb/cli-prs @cockroachdb/product-security
 /pkg/cli/cli.go              @cockroachdb/cli-prs
 /pkg/cli/cli_debug*.go       @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/cli_test.go         @cockroachdb/cli-prs
@@ -152,7 +152,7 @@
 /pkg/cli/inflight_trace_dump/ @cockroachdb/obs-prs @cockroachdb/cli-prs @cockroachdb/obs-india-prs
 /pkg/cli/init.go             @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/log*.go             @cockroachdb/obs-prs    @cockroachdb/cli-prs @cockroachdb/obs-india-prs
-/pkg/cli/mt_cert*            @cockroachdb/prodsec
+/pkg/cli/mt_cert*            @cockroachdb/prodsec @cockroachdb/product-security
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_test_directory.go @cockroachdb/sqlproxy-prs  @cockroachdb/server-prs
@@ -177,8 +177,8 @@
 #!/pkg/server/                           @cockroachdb/unowned
 /pkg/server/admin*.go                    @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/api_v2*.go                   @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/api_v2_auth*.go              @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/server/authentication*.go           @cockroachdb/prodsec     @cockroachdb/server-prs
+/pkg/server/api_v2_auth*.go              @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec @cockroachdb/product-security
+/pkg/server/authentication*.go           @cockroachdb/prodsec     @cockroachdb/server-prs @cockroachdb/product-security
 /pkg/server/clock_monotonicity.go        @cockroachdb/kv-prs
 /pkg/server/combined_statement_stats*.go @cockroachdb/obs-prs
 /pkg/server/critical_nodes*.go           @cockroachdb/obs-prs
@@ -217,7 +217,7 @@
 /pkg/server/server_obs*                  @cockroachdb/obs-prs
 /pkg/server/server_systemlog*            @cockroachdb/obs-prs
 /pkg/server/serverpb/                    @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/serverpb/authentication*     @cockroachdb/obs-prs @cockroachdb/prodsec @cockroachdb/server-prs
+/pkg/server/serverpb/authentication*     @cockroachdb/obs-prs @cockroachdb/prodsec @cockroachdb/server-prs @cockroachdb/product-security
 /pkg/server/serverpb/index_reco*         @cockroachdb/obs-prs
 /pkg/server/serverrules/                 @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/settings_cache*.go           @cockroachdb/server-prs
@@ -236,7 +236,7 @@
 /pkg/server/tenantsettingswatcher/       @cockroachdb/server-prs
 /pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
 /pkg/server/tracedumper/                 @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/user*.go                     @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/server/user*.go                     @cockroachdb/obs-prs @cockroachdb/server-prs @cockroachdb/prodsec @cockroachdb/product-security
 /pkg/server/version_cluster*.go          @cockroachdb/dev-inf
 
 
@@ -378,11 +378,11 @@
 /pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
 /pkg/ccl/cmdccl/clusterrepl/ @cockroachdb/disaster-recovery
 /pkg/ccl/gqpccl/             @cockroachdb/sql-queries-prs
-#!/pkg/ccl/gssapiccl/        @cockroachdb/unowned
-/pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
+/pkg/ccl/gssapiccl/          @cockroachdb/product-security
+/pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity @cockroachdb/product-security
 #!/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/server-prs
-/pkg/ccl/ldapccl/            @cockroachdb/prodsec
+/pkg/ccl/ldapccl/            @cockroachdb/prodsec @cockroachdb/product-security
 #!/pkg/ccl/upgradeccl/       @cockroachdb/release-eng-prs @cockroachdb/upgrade-prs
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
@@ -390,11 +390,11 @@
 /pkg/ccl/multitenantccl/     @cockroachdb/server-prs
 /pkg/ccl/multitenant/tenantcostclient/ @cockroachdb/sqlproxy-prs
 /pkg/ccl/multitenant/tenantcostserver/ @cockroachdb/sqlproxy-prs
-/pkg/ccl/oidcccl/            @cockroachdb/obs-prs
+/pkg/ccl/oidcccl/            @cockroachdb/product-security
 /pkg/ccl/partitionccl/       @cockroachdb/sql-foundations
 /pkg/ccl/pgcryptoccl/        @cockroachdb/sql-foundations
 /pkg/ccl/plpgsqlccl/         @cockroachdb/sql-queries-prs
-
+/pkg/ccl/securityccl/        @cockroachdb/prodsec @cockroachdb/product-security
 #!/pkg/ccl/serverccl/        @cockroachdb/unowned
 /pkg/ccl/serverccl/diagnosticsccl/ @cockroachdb/obs-prs
 /pkg/ccl/serverccl/server_sql* @cockroachdb/server-prs
@@ -407,7 +407,7 @@
 
 /pkg/ccl/telemetryccl/       @cockroachdb/obs-prs
 
-/pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity @cockroachdb/prodsec
+/pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity @cockroachdb/prodsec @cockroachdb/product-security
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries-prs
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-foundations
 #!/pkg/ccl/testutilsccl/     @cockroachdb/test-eng-noreview
@@ -459,7 +459,6 @@
 /pkg/cmd/release/            @cockroachdb/dev-inf
 /pkg/cmd/returncheck/        @cockroachdb/dev-inf
 /pkg/cmd/roachprod/          @cockroachdb/test-eng
-/pkg/cmd/roachprod/vm/azure/auth.go @cockroachdb/test-eng @cockroachdb/prodsec
 /pkg/cmd/roachprod-microbench/ @cockroachdb/test-eng
 /pkg/cmd/roachprod-stress/   @cockroachdb/test-eng
 /pkg/cmd/roachtest/          @cockroachdb/test-eng
@@ -540,12 +539,11 @@
 #!/pkg/roachpb/version*      @cockroachdb/unowned
 /pkg/roachprod/              @cockroachdb/test-eng
 /pkg/rpc/                    @cockroachdb/kv-prs
-/pkg/rpc/auth.go             @cockroachdb/kv-prs @cockroachdb/prodsec
-/pkg/rpc/auth_tenant.go      @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/rpc/auth.go             @cockroachdb/kv-prs @cockroachdb/prodsec @cockroachdb/product-security
+/pkg/rpc/auth_tenant.go      @cockroachdb/server-prs @cockroachdb/prodsec @cockroachdb/product-security
 /pkg/scheduledjobs/          @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
-/pkg/security/               @cockroachdb/prodsec @cockroachdb/server-prs
-/pkg/security/clientsecopts/ @cockroachdb/sql-foundations @cockroachdb/prodsec
-/pkg/ccl/securityccl/        @cockroachdb/prodsec
+/pkg/security/               @cockroachdb/prodsec @cockroachdb/server-prs @cockroachdb/product-security
+/pkg/security/clientsecopts/ @cockroachdb/sql-foundations @cockroachdb/prodsec @cockroachdb/product-security
 #!/pkg/settings/             @cockroachdb/unowned
 /pkg/spanconfig/                         @cockroachdb/kv-prs @cockroachdb/sql-foundations
 /pkg/spanconfig/spanconfigbounds/        @cockroachdb/sql-foundations

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -72,6 +72,8 @@ cockroachdb/security:
   label: T-cross-product-security
 cockroachdb/prodsec:
   label: T-cross-product-security
+cockroachdb/product-security:
+  label: T-product-security
 cockroachdb/disaster-recovery:
   triage_column_id: 3097123
   label: T-disaster-recovery

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -34,6 +34,7 @@ const (
 	OwnerServer             Owner = `server` // not currently staffed
 	OwnerSQLFoundations     Owner = `sql-foundations`
 	OwnerMigrations         Owner = `migrations`
+	OwnerProductSecurity    Owner = `product-security`
 	OwnerReleaseEng         Owner = `release-eng`
 	OwnerSQLQueries         Owner = `sql-queries`
 	OwnerStorage            Owner = `storage`

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -72,6 +72,8 @@ cockroachdb/security:
   label: T-cross-product-security
 cockroachdb/prodsec:
   label: T-cross-product-security
+cockroachdb/product-security:
+  label: T-product-security
 cockroachdb/disaster-recovery:
   triage_column_id: 3097123
   label: T-disaster-recovery


### PR DESCRIPTION
This PR updates code ownership for the `product-security` team. This team is responsible for all the customer-facing security features (AuthN, AuthZ, Network Security, etc.).

Release note: None