### PR TITLE
release-23.1: sql: block set default on computed col

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -936,6 +936,25 @@ func applyColumnMutation(
 		return AlterColumnType(ctx, tableDesc, col, t, params, cmds, tn)
 
 	case *tree.AlterTableSetDefault:
+		// If our column is computed, block mixing defaults in entirely.
+		// This check exists here instead of later on during validation because
+		// adding a null default to a computed column should also be blocked, but
+		// is undetectable later on since SET DEFAULT NUL means a nil default
+		// expression.
+		if col.IsComputed() {
+			// Block dropping a computed column "default" as well.
+			if t.Default == nil {
+				return pgerror.Newf(
+					pgcode.Syntax,
+					"column %q of relation %q is a computed column",
+					col.GetName(),
+					tn.ObjectName)
+			}
+			return pgerror.Newf(
+				pgcode.Syntax,
+				"computed column %q cannot also have a DEFAULT expression",
+				col.GetName())
+		}
 		if err := updateNonComputedColExpr(
 			params,
 			tableDesc,

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1028,7 +1028,7 @@ func (desc *wrapper) validateColumns() error {
 
 		if column.IsComputed() {
 			if column.HasDefault() {
-				return pgerror.Newf(pgcode.InvalidTableDefinition,
+				return pgerror.Newf(pgcode.Syntax,
 					"computed column %q cannot also have a DEFAULT expression",
 					column.GetName(),
 				)

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1070,7 +1070,7 @@ SELECT * FROM t69327
 f  f
 
 # Regression test for #72881. Computed columns can't have a DEFAULT expr.
-statement error pgcode 42P16 computed column "v" cannot also have a DEFAULT expression
+statement error pgcode 42601 computed column "v" cannot also have a DEFAULT expression
 ALTER TABLE t69327 ALTER COLUMN v SET DEFAULT 'foo'
 
 # Regression test for #69665.Computed columns should be evaluated after
@@ -1117,3 +1117,26 @@ FROM t88128
 ----
 b1    expected_b1  b2    expected_b2
 true  true         true  true
+
+# Regression test for #127522 where we do not properly block adding a default
+# value to a computed column.
+subtest computed_column_with_default
+
+statement ok
+CREATE TABLE foooooo (
+    id INT PRIMARY KEY,
+    x INT NOT NULL,
+    y INT NOT NULL,
+    gen INT AS (x + y) STORED
+);
+
+statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT expression
+ALTER TABLE foooooo ALTER COLUMN gen SET DEFAULT 1;
+
+statement error pgcode 42601 computed column "gen" cannot also have a DEFAULT expression
+ALTER TABLE foooooo ALTER COLUMN gen SET DEFAULT NULL;
+
+statement error pgcode 42601 column "gen" of relation "foooooo" is a computed column
+ALTER TABLE foooooo ALTER COLUMN gen DROP DEFAULT;
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #127545.

/cc @cockroachdb/release

---

This patch blocks setting a default (even a
null default) on a computed column in the
LSC.

Fixes: https://github.com/cockroachdb/cockroach/issues/127522

Release note (bug fix): Setting or dropping a default value
on a computed column is now blocked -- even for null
defaults. Previously, setting or dropping a default value on a
computed column was a no-op.

---

Release justification: low-risk fix (just going from no-op to an error message in special cases)