### PR TITLE
roachtest: cdc/mixed-versions support for shared-process deployments

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -560,7 +560,7 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 		args.sinkType, args.targets, feedOptions,
 	))
 	db := ct.DB()
-	jobID, err := newChangefeedCreator(db, ct.logger, globalRand, targetsStr, sinkURI, makeDefaultFeatureFlags()).
+	jobID, err := newChangefeedCreator(db, db, ct.logger, globalRand, targetsStr, sinkURI, makeDefaultFeatureFlags()).
 		With(feedOptions).Create()
 	if err != nil {
 		ct.t.Fatalf("failed to create changefeed: %s", err.Error())
@@ -795,7 +795,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"min_checkpoint_frequency": "'2s'",
 		"diff":                     "",
 	}
-	_, err := newChangefeedCreator(db, t.L(), globalRand, "bank.bank", kafka.sinkURL(ctx), makeDefaultFeatureFlags()).
+	_, err := newChangefeedCreator(db, db, t.L(), globalRand, "bank.bank", kafka.sinkURL(ctx), makeDefaultFeatureFlags()).
 		With(options).
 		Create()
 	if err != nil {
@@ -1158,7 +1158,7 @@ func runCDCSchemaRegistry(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"diff":                      "",
 	}
 
-	_, err := newChangefeedCreator(db, t.L(), globalRand, "foo", kafka.sinkURL(ctx), makeDefaultFeatureFlags()).
+	_, err := newChangefeedCreator(db, db, t.L(), globalRand, "foo", kafka.sinkURL(ctx), makeDefaultFeatureFlags()).
 		With(options).
 		Args(kafka.schemaRegistryURL(ctx)).
 		Create()
@@ -1300,7 +1300,7 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	for _, f := range feeds {
 		t.Status(fmt.Sprintf("running:%s, query:%s", f.desc, f.queryArg))
-		_, err := newChangefeedCreator(db, t.L(), globalRand, "auth_test_table", f.queryArg, makeDefaultFeatureFlags()).Create()
+		_, err := newChangefeedCreator(db, db, t.L(), globalRand, "auth_test_table", f.queryArg, makeDefaultFeatureFlags()).Create()
 		if err != nil {
 			t.Fatalf("%s: %s", f.desc, err.Error())
 		}
@@ -3303,6 +3303,7 @@ func (lw *ledgerWorkload) run(ctx context.Context, c cluster.Cluster, workloadDu
 // different options and sinks
 type changefeedCreator struct {
 	db              *gosql.DB
+	systemDB        *gosql.DB
 	logger          *logger.Logger
 	targets         string
 	sinkURL         string
@@ -3314,16 +3315,21 @@ type changefeedCreator struct {
 }
 
 func newChangefeedCreator(
-	db *gosql.DB, logger *logger.Logger, r *rand.Rand, targets, sinkURL string, flags cdcFeatureFlags,
+	db, systemDB *gosql.DB,
+	logger *logger.Logger,
+	r *rand.Rand,
+	targets, sinkURL string,
+	flags cdcFeatureFlags,
 ) *changefeedCreator {
 	return &changefeedCreator{
-		db:      db,
-		logger:  logger,
-		targets: targets,
-		sinkURL: sinkURL,
-		options: make(map[string]string),
-		flags:   flags,
-		rng:     enthropy{Rand: r},
+		db:       db,
+		systemDB: systemDB,
+		logger:   logger,
+		targets:  targets,
+		sinkURL:  sinkURL,
+		options:  make(map[string]string),
+		flags:    flags,
+		rng:      enthropy{Rand: r},
 	}
 }
 
@@ -3358,14 +3364,14 @@ func (cfc *changefeedCreator) applySettings() error {
 		return nil
 	}
 	// kv.rangefeed.enabled is required for changefeeds to run
-	if _, err := cfc.db.Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
+	if _, err := cfc.systemDB.Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
 		return err
 	}
 
 	schedEnabled := cfc.flags.RangeFeedScheduler.enabled(cfc.rng)
 	if schedEnabled != featureUnset {
 		cfc.logger.Printf("Setting kv.rangefeed.scheduler.enabled to %t", schedEnabled == featureEnabled)
-		if _, err := cfc.db.Exec(
+		if _, err := cfc.systemDB.Exec(
 			"SET CLUSTER SETTING kv.rangefeed.scheduler.enabled = $1", schedEnabled == featureEnabled,
 		); err != nil {
 			return err

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -314,7 +314,7 @@ func (ct *cdcTester) runTPCCWorkload(args tpccArgs) {
 	if !ct.t.SkipInit() {
 		ct.t.Status("installing TPCC workload")
 		tpcc.install(ct.ctx, ct.cluster)
-		if args.SchemaLockTables.enabled(globalEnthropy) == featureEnabled {
+		if args.SchemaLockTables.enabled(globalEntropy) == featureEnabled {
 			ct.t.Status(fmt.Sprintf("Setting schema_locked for %s", allTpccTargets))
 			ct.lockSchema(allTpccTargets)
 		}
@@ -433,18 +433,18 @@ var (
 	featureEnabled  featureState = 2
 )
 
-type enthropy struct {
+type entropy struct {
 	*rand.Rand
 }
 
-func (r *enthropy) Bool() bool {
+func (r *entropy) Bool() bool {
 	if r.Rand == nil {
 		return rand.Int()%2 == 0
 	}
 	return r.Rand.Int()%2 == 0
 }
 
-func (r *enthropy) Intn(n int) int {
+func (r *entropy) Intn(n int) int {
 	if r.Rand == nil {
 		return rand.Intn(n)
 	}
@@ -452,9 +452,9 @@ func (r *enthropy) Intn(n int) int {
 }
 
 var globalRand *rand.Rand
-var globalEnthropy enthropy
+var globalEntropy entropy
 
-func (f *featureFlag) enabled(r enthropy) featureState {
+func (f *featureFlag) enabled(r entropy) featureState {
 	if f.v != nil {
 		return *f.v
 	}
@@ -473,7 +473,7 @@ type enumFeatureFlag struct {
 }
 
 // enabled returns a valid string if the returned featureState is featureEnabled.
-func (f *enumFeatureFlag) enabled(r enthropy, choose func(enthropy) string) (string, featureState) {
+func (f *enumFeatureFlag) enabled(r entropy, choose func(entropy) string) (string, featureState) {
 	if f.v != nil {
 		return f.state, *f.v
 	}
@@ -3310,7 +3310,7 @@ type changefeedCreator struct {
 	options         map[string]string
 	extraArgs       []interface{}
 	flags           cdcFeatureFlags
-	rng             enthropy
+	rng             entropy
 	settingsApplied bool
 }
 
@@ -3329,7 +3329,7 @@ func newChangefeedCreator(
 		sinkURL:  sinkURL,
 		options:  make(map[string]string),
 		flags:    flags,
-		rng:      enthropy{Rand: r},
+		rng:      entropy{Rand: r},
 	}
 }
 
@@ -3352,7 +3352,7 @@ func (cfc *changefeedCreator) Args(args ...interface{}) *changefeedCreator {
 	return cfc
 }
 
-func chooseDistributionStrategy(r enthropy) string {
+func chooseDistributionStrategy(r entropy) string {
 	vals := changefeedccl.RangeDistributionStrategy.GetAvailableValues()
 	return vals[r.Intn(len(vals))]
 }


### PR DESCRIPTION
This commit updates the `cdc/mixed-versions` test so that it is able to run on a shared-process deployment. Specifically, it updates the changefeed creator to take two connections: one to the tenant being tested (which could be the system tenant as well), and one to the system tenant. The latter is used to set cluster settings that are only visible to the system tenant and control how changefeeds work.

Informs: #127378

Release note: None