### PR TITLE
optbuilder: remove outdated hint

### DIFF
--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -65,15 +65,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		case nil:
 			// No error.
 		case error:
-			if errors.Is(recErr, tree.ErrRoutineUndefined) {
-				panic(
-					errors.WithHint(
-						recErr,
-						"There is probably a typo in function name. Or the intention was to use a user-defined "+
-							"function in the function body, which is currently not supported.",
-					),
-				)
-			}
 			panic(recErr)
 		default:
 			panic(recErr)


### PR DESCRIPTION
The hint said that we do not support using a UDF in the body of another UDF, which is no longer true as v24.1.

Epic: None
Release note: None