### PR TITLE
server: fix use of context in onStoreDiskSlow

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -870,7 +870,7 @@ func (n *Node) addStore(ctx context.Context, store *kvserver.Store) {
 		log.Fatal(ctx, "attempting to add a store without a version")
 	}
 	store.TODOEngine().RegisterDiskSlowCallback(func(info pebble.DiskSlowInfo) {
-		n.onStoreDiskSlow(ctx, store.StoreID(), info)
+		n.onStoreDiskSlow(n.AnnotateCtx(context.Background()), store.StoreID(), info)
 	})
 	n.stores.AddStore(store)
 	n.recorder.AddStore(store)


### PR DESCRIPTION
Previously, we were using the node's start-time
context throughout the life of a store, if the store were to see any disk-slow events. This was problematic as tracing spans in the context would get closed, throwing errors around misuse of tracing spans. This change updates the context used to be a newly-minted one off of the node itself.

Fixes #127729.

Epic: none

Release note: None