### PR TITLE
ccl, sql: add authZ handler for ldap groups retrieval

### DIFF
--- a/pkg/ccl/ldapccl/BUILD.bazel
+++ b/pkg/ccl/ldapccl/BUILD.bazel
@@ -4,6 +4,9 @@ go_library(
     name = "ldapccl",
     srcs = [
         "authentication_ldap.go",
+        "authorization_ldap.go",
+        "ldap_manager.go",
+        "ldap_test_util.go",
         "ldap_util.go",
         "settings.go",
     ],
@@ -13,6 +16,7 @@ go_library(
         "//pkg/ccl/utilccl",
         "//pkg/clusterversion",
         "//pkg/security",
+        "//pkg/security/distinguishedname",
         "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings",
@@ -36,6 +40,7 @@ go_test(
     size = "small",
     srcs = [
         "authentication_ldap_test.go",
+        "authorization_ldap_test.go",
         "main_test.go",
         "settings_test.go",
     ],
@@ -49,7 +54,6 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/security/username",
         "//pkg/server",
-        "//pkg/sql/pgwire/hba",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",
@@ -58,7 +62,6 @@ go_test(
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
-        "@com_github_go_ldap_ldap_v3//:ldap",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/ldapccl/authentication_ldap.go
+++ b/pkg/ccl/ldapccl/authentication_ldap.go
@@ -13,157 +13,36 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/go-ldap/ldap/v3"
 )
 
 const (
-	counterPrefix           = "auth.ldap."
-	beginAuthCounterName    = counterPrefix + "begin_auth"
+	beginAuthNCounterName   = counterPrefix + "begin_authentication"
 	loginSuccessCounterName = counterPrefix + "login_success"
-	enableCounterName       = counterPrefix + "enable"
 )
 
 var (
-	beginAuthUseCounter    = telemetry.GetCounterOnce(beginAuthCounterName)
+	beginAuthNUseCounter   = telemetry.GetCounterOnce(beginAuthNCounterName)
 	loginSuccessUseCounter = telemetry.GetCounterOnce(loginSuccessCounterName)
-	enableUseCounter       = telemetry.GetCounterOnce(enableCounterName)
 )
 
-// ldapAuthenticator is an object that is used to enable ldap connection
-// validation that are used as part of the CRDB client auth flow.
-//
-// The implementation uses the `go-ldap/ldap/` client package and is supported
-// through a number of cluster settings defined in `ldapccl/settings.go`. These
-// settings specify how the ldap auth attempt should be executed and if this
-// feature is enabled.
-type ldapAuthenticator struct {
-	mu struct {
-		syncutil.RWMutex
-		// conf contains all the values that come from cluster settings.
-		conf ldapAuthenticatorConf
-		// util contains connection object required for interfacing with ldap server.
-		util ILDAPUtil
-		// enabled represents the present state of if this feature is enabled. It
-		// is set to true once ldap util is initialized.
-		enabled bool
-	}
-	// clusterUUID is used to check the validity of the enterprise license. It is
-	// set once at initialization.
-	clusterUUID uuid.UUID
-}
-
-// ldapAuthenticatorConf contains all the values to configure LDAP
-// authentication. These values are copied from the matching cluster settings or
-// from hba conf options for LDAP entry.
-type ldapAuthenticatorConf struct {
-	domainCACert        string
-	clientTLSCert       string
-	clientTLSKey        string
-	ldapServer          string
-	ldapPort            string
-	ldapBaseDN          string
-	ldapBindDN          string
-	ldapBindPassword    string
-	ldapSearchFilter    string
-	ldapSearchAttribute string
-}
-
-// reloadConfig locks mutex and then refreshes the values in conf from the cluster settings.
-func (authenticator *ldapAuthenticator) reloadConfig(ctx context.Context, st *cluster.Settings) {
-	authenticator.mu.Lock()
-	defer authenticator.mu.Unlock()
-	authenticator.reloadConfigLocked(ctx, st)
-}
-
-// reloadConfig refreshes the values in conf from the cluster settings without locking the mutex.
-func (authenticator *ldapAuthenticator) reloadConfigLocked(
-	ctx context.Context, st *cluster.Settings,
-) {
-	conf := ldapAuthenticatorConf{
-		domainCACert:  LDAPDomainCACertificate.Get(&st.SV),
-		clientTLSCert: LDAPClientTLSCertSetting.Get(&st.SV),
-		clientTLSKey:  LDAPClientTLSKeySetting.Get(&st.SV),
-	}
-	authenticator.mu.conf = conf
-
-	var err error
-	authenticator.mu.util, err = NewLDAPUtil(ctx, authenticator.mu.conf)
-	if err != nil {
-		log.Warningf(ctx, "LDAP authentication: unable to initialize LDAP connection: %v", err)
-		return
-	}
-
-	if !authenticator.mu.enabled {
-		telemetry.Inc(enableUseCounter)
-	}
-	authenticator.mu.enabled = true
-	log.Infof(ctx, "initialized LDAP authenticator")
-}
-
-// setLDAPConfigOptions extracts hba conf parameters required for connecting and
-// querying LDAP server from hba conf entry and sets them for LDAP authenticator.
-func (authenticator *ldapAuthenticator) setLDAPConfigOptions(entry *hba.Entry) error {
-	conf := ldapAuthenticatorConf{
-		domainCACert: authenticator.mu.conf.domainCACert,
-	}
-	for _, opt := range entry.Options {
-		switch opt[0] {
-		case "ldapserver":
-			conf.ldapServer = opt[1]
-		case "ldapport":
-			conf.ldapPort = opt[1]
-		case "ldapbasedn":
-			conf.ldapBaseDN = opt[1]
-		case "ldapbinddn":
-			conf.ldapBindDN = opt[1]
-		case "ldapbindpasswd":
-			conf.ldapBindPassword = opt[1]
-		case "ldapsearchfilter":
-			conf.ldapSearchFilter = opt[1]
-		case "ldapsearchattribute":
-			conf.ldapSearchAttribute = opt[1]
-		default:
-			return errors.Newf("invalid LDAP option provided in hba conf: %s", opt[0])
-		}
-	}
-	authenticator.mu.conf = conf
-	return nil
-}
-
-// validateLDAPOptions checks the ldap authenticator config values for validity.
-func (authenticator *ldapAuthenticator) validateLDAPOptions() error {
-	const ldapOptionsErrorMsg = "ldap params in HBA conf missing"
-	if authenticator.mu.conf.ldapServer == "" {
-		return errors.New(ldapOptionsErrorMsg + " ldap server")
-	}
-	if authenticator.mu.conf.ldapPort == "" {
-		return errors.New(ldapOptionsErrorMsg + " ldap port")
-	}
-	if authenticator.mu.conf.ldapBaseDN == "" {
-		return errors.New(ldapOptionsErrorMsg + " base DN")
-	}
-	if authenticator.mu.conf.ldapBindDN == "" {
-		return errors.New(ldapOptionsErrorMsg + " bind DN")
-	}
-	if authenticator.mu.conf.ldapBindPassword == "" {
-		return errors.New(ldapOptionsErrorMsg + " bind password")
-	}
-	if authenticator.mu.conf.ldapSearchFilter == "" {
+// validateLDAPAuthNOptions checks the ldap authentication config values.
+func (authManager *ldapAuthManager) validateLDAPAuthNOptions() error {
+	const ldapOptionsErrorMsg = "ldap authentication params in HBA conf missing"
+	if authManager.mu.conf.ldapSearchFilter == "" {
 		return errors.New(ldapOptionsErrorMsg + " search filter")
 	}
-	if authenticator.mu.conf.ldapSearchAttribute == "" {
+	if authManager.mu.conf.ldapSearchAttribute == "" {
 		return errors.New(ldapOptionsErrorMsg + " search attribute")
 	}
 	return nil
@@ -173,78 +52,92 @@ func (authenticator *ldapAuthenticator) validateLDAPOptions() error {
 // In particular, it checks that:
 // * The cluster has an enterprise license.
 // * The active cluster version is 24.2 for this feature.
-// * LDAP authentication is enabled after settings were reloaded.
+// * LDAP authManager is enabled after settings were reloaded.
 // * The auth attempt is not for a reserved user.
 // * The hba conf entry options could be parsed to obtain ldap server params.
 // * All ldap server params are valid.
 // * LDAPs connection can be established with configured server.
 // * Configured bind DN and password can be used to search for the sql user DN on ldap server.
 // * The obtained user DN could be used to bind with the password from sql connection string.
-// It returns authError (which is the error sql clients will see in case of
+// It returns the retrievedUserDN which is the DN associated with the user in
+// LDAP server, authError (which is the error sql clients will see in case of
 // failures) and detailedError (which is the internal error from ldap clients
 // that might contain sensitive information we do not want to send to sql
 // clients but still want to log it). We do not want to send any information
 // back to client which was not provided by the client.
-func (authenticator *ldapAuthenticator) ValidateLDAPLogin(
+func (authManager *ldapAuthManager) ValidateLDAPLogin(
 	ctx context.Context,
 	st *cluster.Settings,
 	user username.SQLUsername,
 	ldapPwd string,
 	entry *hba.Entry,
 	_ *identmap.Conf,
-) (detailedErrorMsg redact.RedactableString, authError error) {
+) (retrievedUserDN *ldap.DN, detailedErrorMsg redact.RedactableString, authError error) {
 	if err := utilccl.CheckEnterpriseEnabled(st, "LDAP authentication"); err != nil {
-		return "", err
+		return nil, "", err
 	}
 	if !st.Version.IsActive(ctx, clusterversion.V24_2) {
-		return "", pgerror.Newf(pgcode.FeatureNotSupported, "LDAP authentication is only supported after v24.2 upgrade is finalized")
+		return nil, "", pgerror.Newf(pgcode.FeatureNotSupported, "LDAP authentication is only supported after v24.2 upgrade is finalized")
 	}
 
-	authenticator.mu.Lock()
-	defer authenticator.mu.Unlock()
+	authManager.mu.Lock()
+	defer authManager.mu.Unlock()
 
-	if !authenticator.mu.enabled {
-		return "", errors.Newf("LDAP authentication: not enabled")
+	if !authManager.mu.enabled {
+		return nil, "", errors.Newf("LDAP authentication: not enabled")
 	}
-	telemetry.Inc(beginAuthUseCounter)
+	telemetry.Inc(beginAuthNUseCounter)
 
 	if user.IsRootUser() || user.IsReserved() {
-		return "", errors.WithDetailf(
+		return nil, "", errors.WithDetailf(
 			errors.Newf("LDAP authentication: invalid identity"),
 			"cannot use LDAP auth to login to a reserved user %s", user.Normalized())
 	}
 
-	if err := authenticator.setLDAPConfigOptions(entry); err != nil {
-		return redact.Sprintf("error parsing hba conf options for LDAP: %v", err),
+	if err := authManager.setLDAPConfigOptions(entry); err != nil {
+		return nil, redact.Sprintf("error parsing hba conf options for LDAP: %v", err),
 			errors.Newf("LDAP authentication: unable to parse hba conf options")
 	}
 
-	if err := authenticator.validateLDAPOptions(); err != nil {
-		return redact.Sprintf("error validating hba conf options for LDAP: %v", err),
-			errors.Newf("LDAP authentication: unable to validate authenticator options")
+	if err := authManager.validateLDAPBaseOptions(); err != nil {
+		return nil, redact.Sprintf("error validating base hba conf options for LDAP: %v", err),
+			errors.Newf("LDAP authentication: unable to validate authManager base options")
+	}
+
+	if err := authManager.validateLDAPAuthNOptions(); err != nil {
+		return nil, redact.Sprintf("error validating authentication hba conf options for LDAP: %v", err),
+			errors.Newf("LDAP authentication: unable to validate authManager authentication options")
 	}
 
 	// Establish a LDAPs connection with the set LDAP server and port
-	err := authenticator.mu.util.InitLDAPsConn(ctx, authenticator.mu.conf)
+	err := authManager.mu.util.MaybeInitLDAPsConn(ctx, authManager.mu.conf)
 	if err != nil {
-		return redact.Sprintf("error when trying to create LDAP connection: %v", err),
+		return nil, redact.Sprintf("error when trying to create LDAP connection: %v", err),
 			errors.Newf("LDAP authentication: unable to establish LDAP connection")
 	}
 
 	// Fetch the ldap server Distinguished Name using sql username as search value
 	// for  ldap search attribute
-	userDN, err := authenticator.mu.util.Search(ctx, authenticator.mu.conf, user.Normalized())
+	userDN, err := authManager.mu.util.Search(ctx, authManager.mu.conf, user.Normalized())
 	if err != nil {
-		return redact.Sprintf("error when searching for user in LDAP server: %v", err),
+		return nil, redact.Sprintf("error when searching for user in LDAP server: %v", err),
 			errors.WithDetailf(
 				errors.Newf("LDAP authentication: unable to find LDAP user distinguished name"),
 				"cannot find provided user %s on LDAP server", user.Normalized())
 	}
 
-	// Bind as the user to verify their password
-	err = authenticator.mu.util.Bind(ctx, userDN, ldapPwd)
+	retrievedUserDN, err = distinguishedname.ParseDN(userDN)
 	if err != nil {
-		return redact.Sprintf("error when binding as user %s with DN(%s) in LDAP server: %v",
+		return nil, redact.Sprintf("error parsing user DN %s obtained from LDAP server: %v", userDN, err),
+			errors.WithDetailf(
+				errors.Newf("LDAP authentication: unable to parse LDAP user distinguished name"),
+				"cannot find provided user %s on LDAP server", user.Normalized())
+	}
+
+	// Bind as the user to verify their password
+	err = authManager.mu.util.Bind(ctx, userDN, ldapPwd)
+	if err != nil {
+		return retrievedUserDN, redact.Sprintf("error when binding as user %s with DN(%s) in LDAP server: %v",
 				user.Normalized(), userDN, err,
 			),
 			errors.WithDetailf(
@@ -253,26 +146,5 @@ func (authenticator *ldapAuthenticator) ValidateLDAPLogin(
 	}
 
 	telemetry.Inc(loginSuccessUseCounter)
-	return "", nil
-}
-
-// ConfigureLDAPAuth initializes and returns a ldapAuthenticator. It also sets up listeners so
-// that the ldapAuthenticator's config is updated when the cluster settings values change.
-var ConfigureLDAPAuth = func(
-	serverCtx context.Context,
-	ambientCtx log.AmbientContext,
-	st *cluster.Settings,
-	clusterUUID uuid.UUID,
-) pgwire.LDAPVerifier {
-	authenticator := ldapAuthenticator{}
-	authenticator.clusterUUID = clusterUUID
-	authenticator.reloadConfig(serverCtx, st)
-	LDAPDomainCACertificate.SetOnChange(&st.SV, func(ctx context.Context) {
-		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
-	})
-	return &authenticator
-}
-
-func init() {
-	pgwire.ConfigureLDAPAuth = ConfigureLDAPAuth
+	return retrievedUserDN, "", nil
 }

--- a/pkg/ccl/ldapccl/authentication_ldap_test.go
+++ b/pkg/ccl/ldapccl/authentication_ldap_test.go
@@ -12,117 +12,18 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-	"github.com/go-ldap/ldap/v3"
 	"github.com/stretchr/testify/require"
 )
-
-const (
-	emptyParam   = "empty"
-	invalidParam = "invalid"
-)
-
-type mockLDAPUtil struct {
-	conn      *ldap.Conn
-	tlsConfig *tls.Config
-}
-
-// InitLDAPsConn implements the ILDAPUtil interface.
-func (lu *mockLDAPUtil) InitLDAPsConn(ctx context.Context, conf ldapAuthenticatorConf) error {
-	if strings.Contains(conf.ldapServer, invalidParam) {
-		return errors.Newf(ldapsFailureMessage + ": invalid ldap server provided")
-	} else if strings.Contains(conf.ldapPort, invalidParam) {
-		return errors.Newf(ldapsFailureMessage + ": invalid ldap port provided")
-	}
-	lu.conn = &ldap.Conn{}
-	return nil
-}
-
-// Bind implements the ILDAPUtil interface.
-func (lu *mockLDAPUtil) Bind(ctx context.Context, userDN string, ldapPwd string) error {
-	if strings.Contains(userDN, invalidParam) {
-		return errors.Newf(bindFailureMessage + ": invalid username provided")
-	} else if strings.Contains(ldapPwd, invalidParam) {
-		return errors.Newf(bindFailureMessage + ": invalid password provided")
-	}
-
-	return nil
-}
-
-// Search implements the ILDAPUtil interface.
-func (lu *mockLDAPUtil) Search(
-	ctx context.Context, conf ldapAuthenticatorConf, username string,
-) (userDN string, err error) {
-	if err := lu.Bind(ctx, conf.ldapBindDN, conf.ldapBindPassword); err != nil {
-		return "", errors.Wrap(err, searchFailureMessage)
-	}
-	if strings.Contains(conf.ldapBaseDN, invalidParam) {
-		return "", errors.Newf(searchFailureMessage+": invalid base DN %q provided", conf.ldapBaseDN)
-	}
-	if strings.Contains(conf.ldapSearchFilter, invalidParam) {
-		return "", errors.Newf(searchFailureMessage+": invalid search filter %q provided", conf.ldapSearchFilter)
-	}
-	if strings.Contains(conf.ldapSearchAttribute, invalidParam) {
-		return "", errors.Newf(searchFailureMessage+": invalid search attribute %q provided", conf.ldapSearchAttribute)
-	}
-	if strings.Contains(username, invalidParam) {
-		return "", errors.Newf(searchFailureMessage+": invalid search value %q provided", username)
-	}
-	distinguishedNames := strings.Split(username, ",")
-	switch {
-	case len(username) == 0:
-		return "", errors.Newf(searchFailureMessage+": user %q does not exist", username)
-	case len(distinguishedNames) > 1:
-		return "", errors.Newf(searchFailureMessage+": too many matching entries returned for user %q", username)
-	}
-	return distinguishedNames[0], nil
-}
-
-var _ ILDAPUtil = &mockLDAPUtil{}
-
-func constructHBAEntry(
-	t *testing.T,
-	hbaEntryBase string,
-	hbaConfLDAPDefaultOpts map[string]string,
-	hbaConfLDAPOpts map[string]string,
-) hba.Entry {
-	hbaEntryLDAP := hbaEntryBase
-	// add options from default and override default options when provided with one
-	for opt, value := range hbaConfLDAPDefaultOpts {
-		setValue := value
-		if hbaConfLDAPOpts[opt] == emptyParam {
-			continue
-		} else if hbaConfLDAPOpts[opt] != "" {
-			setValue = hbaConfLDAPOpts[opt]
-		}
-		hbaEntryLDAP += fmt.Sprintf("\"%s=%s\" ", opt, setValue)
-	}
-	// add non default options
-	for additionalOpt, additionalOptValue := range hbaConfLDAPOpts {
-		if _, ok := hbaConfLDAPDefaultOpts[additionalOpt]; !ok {
-			hbaEntryLDAP += fmt.Sprintf("\"%s=%s\" ", additionalOpt, additionalOptValue)
-		}
-	}
-	hbaConf, err := hba.ParseAndNormalize(hbaEntryLDAP)
-	if err != nil {
-		t.Fatalf("error parsing hba conf: %v", err)
-	}
-	if len(hbaConf.Entries) != 1 {
-		t.Fatalf("hba conf value invalid: should contain only 1 entry")
-	}
-	return hbaConf.Entries[0]
-}
 
 func TestLDAPAuthentication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -130,13 +31,13 @@ func TestLDAPAuthentication(t *testing.T) {
 	// Intercept the call to NewLDAPUtil and return the mocked NewLDAPUtil function
 	defer testutils.TestingHook(
 		&NewLDAPUtil,
-		func(ctx context.Context, conf ldapAuthenticatorConf) (ILDAPUtil, error) {
+		func(ctx context.Context, conf ldapConfig) (ILDAPUtil, error) {
 			return &mockLDAPUtil{tlsConfig: &tls.Config{}}, nil
 		})()
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	verifier := ConfigureLDAPAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
+	manager := ConfigureLDAPAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
 	hbaEntryBase := "host all all all ldap "
 	hbaConfLDAPDefaultOpts := map[string]string{
 		"ldapserver": "localhost", "ldapport": "636", "ldapbasedn": "dc=localhost", "ldapbinddn": "cn=readonly,dc=localhost",
@@ -167,24 +68,24 @@ func TestLDAPAuthentication(t *testing.T) {
 			expectedDetailedErrMsg: `error parsing hba conf options for LDAP: invalid LDAP option provided in hba conf: ‹invalidOpt›`},
 		{testName: "empty server",
 			hbaConfLDAPOpts: map[string]string{"ldapserver": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing ldap server"},
+			expectedErr:            "LDAP authentication: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing ldap server"},
 		{testName: "invalid server",
 			hbaConfLDAPOpts: map[string]string{"ldapserver": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to establish LDAP connection",
 			expectedDetailedErrMsg: "error when trying to create LDAP connection: LDAPs connection failed: invalid ldap server provided"},
 		{testName: "empty port",
 			hbaConfLDAPOpts: map[string]string{"ldapport": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing ldap port"},
+			expectedErr:            "LDAP authentication: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing ldap port"},
 		{testName: "invalid port",
 			hbaConfLDAPOpts: map[string]string{"ldapport": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to establish LDAP connection",
 			expectedDetailedErrMsg: "error when trying to create LDAP connection: LDAPs connection failed: invalid ldap port provided"},
 		{testName: "empty base dn",
 			hbaConfLDAPOpts: map[string]string{"ldapbasedn": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing base DN"},
+			expectedErr:            "LDAP authentication: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing base DN"},
 		{testName: "invalid base dn",
 			hbaConfLDAPOpts: map[string]string{"ldapbasedn": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to find LDAP user distinguished name",
@@ -192,8 +93,8 @@ func TestLDAPAuthentication(t *testing.T) {
 			expectedDetailedErrMsg: `error when searching for user in LDAP server: LDAP search failed: invalid base DN ‹"invalid"› provided`},
 		{testName: "empty bind dn",
 			hbaConfLDAPOpts: map[string]string{"ldapbinddn": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing bind DN"},
+			expectedErr:            "LDAP authentication: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing bind DN"},
 		{testName: "invalid bind dn",
 			hbaConfLDAPOpts: map[string]string{"ldapbinddn": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to find LDAP user distinguished name",
@@ -201,8 +102,8 @@ func TestLDAPAuthentication(t *testing.T) {
 			expectedDetailedErrMsg: "error when searching for user in LDAP server: LDAP search failed: LDAP bind failed: invalid username provided"},
 		{testName: "empty bind pwd",
 			hbaConfLDAPOpts: map[string]string{"ldapbindpasswd": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing bind password"},
+			expectedErr:            "LDAP authentication: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing bind password"},
 		{testName: "invalid bind pwd",
 			hbaConfLDAPOpts: map[string]string{"ldapbindpasswd": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to find LDAP user distinguished name",
@@ -210,8 +111,8 @@ func TestLDAPAuthentication(t *testing.T) {
 			expectedDetailedErrMsg: "error when searching for user in LDAP server: LDAP search failed: LDAP bind failed: invalid password provided"},
 		{testName: "empty search attribute",
 			hbaConfLDAPOpts: map[string]string{"ldapsearchattribute": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing search attribute"},
+			expectedErr:            "LDAP authentication: unable to validate authManager authentication options",
+			expectedDetailedErrMsg: "error validating authentication hba conf options for LDAP: ldap authentication params in HBA conf missing search attribute"},
 		{testName: "invalid search attribute",
 			hbaConfLDAPOpts: map[string]string{"ldapsearchattribute": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to find LDAP user distinguished name",
@@ -219,8 +120,8 @@ func TestLDAPAuthentication(t *testing.T) {
 			expectedDetailedErrMsg: `error when searching for user in LDAP server: LDAP search failed: invalid search attribute ‹"invalid"› provided`},
 		{testName: "empty search filter",
 			hbaConfLDAPOpts: map[string]string{"ldapsearchfilter": emptyParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
-			expectedErr:            "LDAP authentication: unable to validate authenticator options",
-			expectedDetailedErrMsg: "error validating hba conf options for LDAP: ldap params in HBA conf missing search filter"},
+			expectedErr:            "LDAP authentication: unable to validate authManager authentication options",
+			expectedDetailedErrMsg: "error validating authentication hba conf options for LDAP: ldap authentication params in HBA conf missing search filter"},
 		{testName: "invalid search filter",
 			hbaConfLDAPOpts: map[string]string{"ldapsearchfilter": invalidParam}, user: "foo", pwd: "bar", ldapAuthSuccess: false,
 			expectedErr:            "LDAP authentication: unable to find LDAP user distinguished name",
@@ -241,12 +142,12 @@ func TestLDAPAuthentication(t *testing.T) {
 		{testName: "invalid ldap password",
 			user: "foo", pwd: invalidParam, ldapAuthSuccess: false, expectedErr: "LDAP authentication: unable to bind as LDAP user",
 			expectedErrDetails:     "credentials invalid for LDAP server user foo",
-			expectedDetailedErrMsg: `error when binding as user ‹foo› with DN(‹foo›) in LDAP server: LDAP bind failed: invalid password provided`},
+			expectedDetailedErrMsg: `error when binding as user ‹foo› with DN(‹CN=foo›) in LDAP server: LDAP bind failed: invalid password provided`},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d: testName:%v hbConfOpts:%v user:%v password:%v", i, tc.testName, tc.hbaConfLDAPOpts, tc.user, tc.pwd), func(t *testing.T) {
 			hbaEntry := constructHBAEntry(t, hbaEntryBase, hbaConfLDAPDefaultOpts, tc.hbaConfLDAPOpts)
-			detailedErrorMsg, err := verifier.ValidateLDAPLogin(
+			_, detailedErrorMsg, err := manager.ValidateLDAPLogin(
 				ctx, s.ClusterSettings(), username.MakeSQLUsernameFromPreNormalizedString(tc.user), tc.pwd, &hbaEntry, nil)
 
 			if (err == nil) != tc.ldapAuthSuccess {

--- a/pkg/ccl/ldapccl/authorization_ldap.go
+++ b/pkg/ccl/ldapccl/authorization_ldap.go
@@ -1,0 +1,136 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package ldapccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/security/distinguishedname"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+const (
+	beginAuthZCounterName   = counterPrefix + "begin_authorization"
+	authZSuccessCounterName = counterPrefix + "authorization_success"
+)
+
+var (
+	beginAuthZUseCounter = telemetry.GetCounterOnce(beginAuthZCounterName)
+	authZSuccessCounter  = telemetry.GetCounterOnce(authZSuccessCounterName)
+)
+
+// validateLDAPAuthZOptions checks the ldap authorization config values.
+func (authManager *ldapAuthManager) validateLDAPAuthZOptions() error {
+	const ldapOptionsErrorMsg = "ldap authorization params in HBA conf missing"
+	if authManager.mu.conf.ldapGroupListFilter == "" {
+		return errors.New(ldapOptionsErrorMsg + " group list attribute")
+	}
+	return nil
+}
+
+// FetchLDAPGroups retrieves ldap groups for supplied ldap user DN.
+// In particular, it checks that:
+// * The cluster has an enterprise license.
+// * The active cluster version is 24.3 for this feature.
+// * The provided LDAP user distinguished name is a valid DN.
+// * LDAP authManager is enabled after settings were reloaded.
+// * The hba conf entry options could be parsed to obtain ldap server params.
+// * All ldap server params are valid.
+// * LDAPs connection can be established with configured server.
+// * Configured bind DN and password can be used to fetch ldap groups for provided user DN.
+// It returns the ldap groups DN list for which  the user is a member, authError
+// (which is the error sql clients will see in case of failures) and
+// detailedError (which is the internal error from ldap clients that might
+// contain sensitive information we do not want to send to sql clients but still
+// want to log it). We do not want to send any information back to client which
+// was not provided by the client.
+//
+//	 Example authorization example for obtaining LDAP groups for LDAP user:
+//	 if ldapGroups, detailedErrors, authError := ldapManager.m.FetchLDAPGroups(ctx, execCfg.Settings, externalUserDN, entry, identMap); authError != nil {
+//		errForLog := authError
+//		if detailedErrors != "" {
+//			errForLog = errors.Join(errForLog, errors.Newf("%s", detailedErrors))
+//		}
+//		  log.Warningf(ctx, "error retrieving ldap groups for authZ: %+v", errForLog)
+//	 } else {
+//		  log.Infof(ctx, "LDAP authorization: retrieved ldap groups are %+v", ldapGroups)
+//	 }
+func (authManager *ldapAuthManager) FetchLDAPGroups(
+	ctx context.Context,
+	st *cluster.Settings,
+	userDN username.SQLUsername,
+	entry *hba.Entry,
+	_ *identmap.Conf,
+) (ldapGroups []string, detailedErrorMsg redact.RedactableString, authError error) {
+	if err := utilccl.CheckEnterpriseEnabled(st, "LDAP authorization"); err != nil {
+		return nil, "", err
+	}
+	if !st.Version.IsActive(ctx, clusterversion.V24_3) {
+		return nil, "", pgerror.Newf(pgcode.FeatureNotSupported, "LDAP authorization is only supported after v24.3 upgrade is finalized")
+	}
+
+	authManager.mu.Lock()
+	defer authManager.mu.Unlock()
+
+	if !authManager.mu.enabled {
+		return nil, "", errors.Newf("LDAP authentication: not enabled")
+	}
+	telemetry.Inc(beginAuthZUseCounter)
+
+	if err := distinguishedname.ValidateDN(userDN.Normalized()); err != nil {
+		return nil,
+			redact.Sprintf("error validating provided ldap DN %q for LDAP: %v", userDN.Normalized(), err),
+			errors.Newf("LDAP authorization: unable to validate provided ldap DN")
+	}
+
+	if err := authManager.setLDAPConfigOptions(entry); err != nil {
+		return nil, redact.Sprintf("error parsing hba conf options for LDAP: %v", err),
+			errors.Newf("LDAP authorization: unable to parse hba conf options")
+	}
+
+	if err := authManager.validateLDAPBaseOptions(); err != nil {
+		return nil, redact.Sprintf("error validating base hba conf options for LDAP: %v", err),
+			errors.Newf("LDAP authorization: unable to validate authManager base options")
+	}
+
+	if err := authManager.validateLDAPAuthZOptions(); err != nil {
+		return nil, redact.Sprintf("error validating authorization hba conf options for LDAP: %v", err),
+			errors.Newf("LDAP authorization: unable to validate authManager authorization options")
+	}
+
+	// Establish a LDAPs connection with the set LDAP server and port
+	err := authManager.mu.util.MaybeInitLDAPsConn(ctx, authManager.mu.conf)
+	if err != nil {
+		return nil, redact.Sprintf("error when trying to create LDAP connection: %v", err),
+			errors.Newf("LDAP authorization: unable to establish LDAP connection")
+	}
+
+	// Fetch the ldap server Distinguished Name using sql username as search value
+	// for  ldap search attribute
+	ldapGroups, err = authManager.mu.util.ListGroups(ctx, authManager.mu.conf, userDN.Normalized())
+	if err != nil {
+		return nil, redact.Sprintf("error when searching for user dn %q in LDAP server: %v", userDN.Normalized(), err),
+			errors.WithDetailf(
+				errors.Newf("LDAP authorization: unable to fetch groups for user"),
+				"cannot find groups for which user is a member")
+	}
+
+	telemetry.Inc(authZSuccessCounter)
+	return ldapGroups, "", nil
+}

--- a/pkg/ccl/ldapccl/authorization_ldap_test.go
+++ b/pkg/ccl/ldapccl/authorization_ldap_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package ldapccl
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLDAPAuthorization(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	// Intercept the call to NewLDAPUtil and return the mocked NewLDAPUtil function
+	defer testutils.TestingHook(
+		&NewLDAPUtil,
+		func(ctx context.Context, conf ldapConfig) (ILDAPUtil, error) {
+			return &mockLDAPUtil{tlsConfig: &tls.Config{}}, nil
+		})()
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	manager := ConfigureLDAPAuth(ctx, s.AmbientCtx(), s.ClusterSettings(), s.StorageClusterID())
+	hbaEntryBase := "host all all all ldap "
+	hbaConfLDAPDefaultOpts := map[string]string{
+		"ldapserver": "localhost", "ldapport": "636", "ldapbasedn": "dc=localhost", "ldapbinddn": "cn=readonly,dc=localhost",
+		"ldapbindpasswd": "readonly_pwd", "ldapgrouplistfilter": "(objectCategory=CN=Group,CN=Schema,CN=Configuration,DC=crlcloud,DC=dev)",
+	}
+	testCases := []struct {
+		testName               string
+		hbaConfLDAPOpts        map[string]string
+		userDN                 string
+		authZSuccess           bool
+		ldapGroups             []string
+		expectedErr            string
+		expectedErrDetails     string
+		expectedDetailedErrMsg string
+	}{
+		{testName: "proper hba conf and valid user cred",
+			userDN: "CN=foo", authZSuccess: true, ldapGroups: []string{"CN=foo"}},
+		{testName: "proper hba conf and invalid distinguished name",
+			userDN: "root", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate provided ldap DN",
+			expectedDetailedErrMsg: "error validating provided ldap DN ‹\"root\"› for LDAP: failed to parse distinguished name ‹root›: ‹DN ended with incomplete type, value pair›"},
+		{testName: "invalid ldap option",
+			hbaConfLDAPOpts: map[string]string{"invalidOpt": "invalidVal"}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to parse hba conf options",
+			expectedDetailedErrMsg: `error parsing hba conf options for LDAP: invalid LDAP option provided in hba conf: ‹invalidOpt›`},
+		{testName: "empty server",
+			hbaConfLDAPOpts: map[string]string{"ldapserver": emptyParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing ldap server"},
+		{testName: "invalid server",
+			hbaConfLDAPOpts: map[string]string{"ldapserver": invalidParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to establish LDAP connection",
+			expectedDetailedErrMsg: "error when trying to create LDAP connection: LDAPs connection failed: invalid ldap server provided"},
+		{testName: "empty port",
+			hbaConfLDAPOpts: map[string]string{"ldapport": emptyParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing ldap port"},
+		{testName: "invalid port",
+			hbaConfLDAPOpts: map[string]string{"ldapport": invalidParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to establish LDAP connection",
+			expectedDetailedErrMsg: "error when trying to create LDAP connection: LDAPs connection failed: invalid ldap port provided"},
+		{testName: "empty base dn",
+			hbaConfLDAPOpts: map[string]string{"ldapbasedn": emptyParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing base DN"},
+		{testName: "invalid base dn",
+			hbaConfLDAPOpts: map[string]string{"ldapbasedn": invalidParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to fetch groups for user",
+			expectedErrDetails:     "cannot find groups for which user is a member",
+			expectedDetailedErrMsg: `error when searching for user dn ‹"CN=foo"› in LDAP server: LDAP groups list failed: invalid base DN ‹"invalid"› provided`},
+		{testName: "empty bind dn",
+			hbaConfLDAPOpts: map[string]string{"ldapbinddn": emptyParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing bind DN"},
+		{testName: "invalid bind dn",
+			hbaConfLDAPOpts: map[string]string{"ldapbinddn": invalidParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to fetch groups for user",
+			expectedErrDetails:     "cannot find groups for which user is a member",
+			expectedDetailedErrMsg: `error when searching for user dn ‹"CN=foo"› in LDAP server: LDAP groups list failed: LDAP bind failed: invalid username provided`},
+		{testName: "empty bind pwd",
+			hbaConfLDAPOpts: map[string]string{"ldapbindpasswd": emptyParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate authManager base options",
+			expectedDetailedErrMsg: "error validating base hba conf options for LDAP: ldap params in HBA conf missing bind password"},
+		{testName: "invalid bind pwd",
+			hbaConfLDAPOpts: map[string]string{"ldapbindpasswd": invalidParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to fetch groups for user",
+			expectedErrDetails:     "cannot find groups for which user is a member",
+			expectedDetailedErrMsg: `error when searching for user dn ‹"CN=foo"› in LDAP server: LDAP groups list failed: LDAP bind failed: invalid password provided`},
+		{testName: "empty group list filter",
+			hbaConfLDAPOpts: map[string]string{"ldapgrouplistfilter": emptyParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to validate authManager authorization options",
+			expectedDetailedErrMsg: "error validating authorization hba conf options for LDAP: ldap authorization params in HBA conf missing group list attribute"},
+		{testName: "invalid group list filter",
+			hbaConfLDAPOpts: map[string]string{"ldapgrouplistfilter": invalidParam}, userDN: "CN=foo", authZSuccess: false,
+			expectedErr:            "LDAP authorization: unable to fetch groups for user",
+			expectedErrDetails:     "cannot find groups for which user is a member",
+			expectedDetailedErrMsg: `error when searching for user dn ‹"CN=foo"› in LDAP server: LDAP groups list failed: invalid group list filter ‹"invalid"› provided`},
+		{testName: "no matching ldap groups",
+			userDN: "", authZSuccess: false, expectedErr: "LDAP authorization: unable to fetch groups for user",
+			expectedErrDetails:     "cannot find groups for which user is a member",
+			expectedDetailedErrMsg: `error when searching for user dn ‹""› in LDAP server: LDAP groups list failed: user dn ‹""› does not belong to any groups`},
+		{testName: "more than 1 matching ldap groups",
+			userDN: "CN=foo,CN=foo2,CN=foo3", authZSuccess: true, ldapGroups: []string{"CN=foo", "CN=foo2", "CN=foo3"}},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d: testName:%v hbConfOpts:%v userDN:%v", i, tc.testName, tc.hbaConfLDAPOpts, tc.userDN), func(t *testing.T) {
+			hbaEntry := constructHBAEntry(t, hbaEntryBase, hbaConfLDAPDefaultOpts, tc.hbaConfLDAPOpts)
+			retrievedLDAPGroups, detailedErrorMsg, err := manager.FetchLDAPGroups(
+				ctx, s.ClusterSettings(), username.MakeSQLUsernameFromPreNormalizedString(tc.userDN), &hbaEntry, nil)
+
+			if (err == nil) != tc.authZSuccess {
+				t.Fatalf("expected success=%t, got err=%v", tc.authZSuccess, err)
+			}
+			if err != nil {
+				require.Equal(t, tc.expectedErr, err.Error())
+				require.Equal(t, tc.expectedErrDetails, errors.FlattenDetails(err))
+				require.Equal(t, redact.RedactableString(tc.expectedDetailedErrMsg), detailedErrorMsg)
+			} else {
+				require.Equal(t, tc.ldapGroups, retrievedLDAPGroups)
+			}
+		})
+	}
+}

--- a/pkg/ccl/ldapccl/ldap_manager.go
+++ b/pkg/ccl/ldapccl/ldap_manager.go
@@ -1,0 +1,178 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package ldapccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	counterPrefix     = "auth.ldap."
+	enableCounterName = counterPrefix + "enable"
+)
+
+var enableUseCounter = telemetry.GetCounterOnce(enableCounterName)
+
+// ldapAuthManager is an object that is used for both:
+// 1. enabling ldap connection validation that are used as part of the CRDB
+// client auth flow.
+// 2. facilitating authorization to fetch parent groups as part of CRDB role
+// privilege resolution.
+//
+// The implementation uses the `go-ldap/ldap/` client package and is supported
+// through a number of cluster settings defined in `ldapccl/settings.go`. These
+// settings specify how the ldap auth attempt should be executed and if this
+// feature is enabled. A common ldapAuthManager object is used for both authN
+// and authZ to reduce redundancy of cluster settings listeners and auth
+// parameter configurations.
+type ldapAuthManager struct {
+	mu struct {
+		syncutil.RWMutex
+		// conf contains all the values that come from cluster settings.
+		conf ldapConfig
+		// util contains connection object required for interfacing with ldap server.
+		util ILDAPUtil
+		// enabled represents the present state of if this feature is enabled. It
+		// is set to true once ldap util is initialized.
+		enabled bool
+	}
+	// clusterUUID is used to check the validity of the enterprise license. It is
+	// set once at initialization.
+	clusterUUID uuid.UUID
+}
+
+// ldapConfig contains all the values to configure LDAP authN and authZ. These
+// values are set using matching cluster settings or from hba conf options for
+// LDAP entry.
+type ldapConfig struct {
+	domainCACert        string
+	clientTLSCert       string
+	clientTLSKey        string
+	ldapServer          string
+	ldapPort            string
+	ldapBaseDN          string
+	ldapBindDN          string
+	ldapBindPassword    string
+	ldapSearchFilter    string
+	ldapSearchAttribute string
+	ldapGroupListFilter string
+}
+
+// reloadConfig locks mutex and then refreshes the values in conf from the cluster settings.
+func (authManager *ldapAuthManager) reloadConfig(ctx context.Context, st *cluster.Settings) {
+	authManager.mu.Lock()
+	defer authManager.mu.Unlock()
+	authManager.reloadConfigLocked(ctx, st)
+}
+
+// reloadConfig refreshes the values in conf from the cluster settings without locking the mutex.
+func (authManager *ldapAuthManager) reloadConfigLocked(ctx context.Context, st *cluster.Settings) {
+	conf := ldapConfig{
+		domainCACert:  LDAPDomainCACertificate.Get(&st.SV),
+		clientTLSCert: LDAPClientTLSCertSetting.Get(&st.SV),
+		clientTLSKey:  LDAPClientTLSKeySetting.Get(&st.SV),
+	}
+	authManager.mu.conf = conf
+
+	var err error
+	authManager.mu.util, err = NewLDAPUtil(ctx, authManager.mu.conf)
+	if err != nil {
+		log.Warningf(ctx, "LDAP auth manager: unable to initialize LDAP connection: %v", err)
+		return
+	}
+
+	if !authManager.mu.enabled {
+		telemetry.Inc(enableUseCounter)
+	}
+	authManager.mu.enabled = true
+	log.Infof(ctx, "initialized LDAP authManager")
+}
+
+// setLDAPConfigOptions extracts hba conf parameters required for connecting and
+// querying LDAP server from hba conf entry and sets them for LDAP auth.
+func (authManager *ldapAuthManager) setLDAPConfigOptions(entry *hba.Entry) error {
+	conf := ldapConfig{
+		domainCACert: authManager.mu.conf.domainCACert,
+	}
+	for _, opt := range entry.Options {
+		switch opt[0] {
+		case "ldapserver":
+			conf.ldapServer = opt[1]
+		case "ldapport":
+			conf.ldapPort = opt[1]
+		case "ldapbasedn":
+			conf.ldapBaseDN = opt[1]
+		case "ldapbinddn":
+			conf.ldapBindDN = opt[1]
+		case "ldapbindpasswd":
+			conf.ldapBindPassword = opt[1]
+		case "ldapsearchfilter":
+			conf.ldapSearchFilter = opt[1]
+		case "ldapsearchattribute":
+			conf.ldapSearchAttribute = opt[1]
+		case "ldapgrouplistfilter":
+			conf.ldapGroupListFilter = opt[1]
+		default:
+			return errors.Newf("invalid LDAP option provided in hba conf: %s", opt[0])
+		}
+	}
+	authManager.mu.conf = conf
+	return nil
+}
+
+// validateLDAPBaseOptions checks the mandatory ldap auth config values for validity.
+func (authManager *ldapAuthManager) validateLDAPBaseOptions() error {
+	const ldapOptionsErrorMsg = "ldap params in HBA conf missing"
+	if authManager.mu.conf.ldapServer == "" {
+		return errors.New(ldapOptionsErrorMsg + " ldap server")
+	}
+	if authManager.mu.conf.ldapPort == "" {
+		return errors.New(ldapOptionsErrorMsg + " ldap port")
+	}
+	if authManager.mu.conf.ldapBaseDN == "" {
+		return errors.New(ldapOptionsErrorMsg + " base DN")
+	}
+	if authManager.mu.conf.ldapBindDN == "" {
+		return errors.New(ldapOptionsErrorMsg + " bind DN")
+	}
+	if authManager.mu.conf.ldapBindPassword == "" {
+		return errors.New(ldapOptionsErrorMsg + " bind password")
+	}
+	return nil
+}
+
+// ConfigureLDAPAuth initializes and returns a ldapAuthManager. It also sets up listeners so
+// that the ldapAuthManager's config is updated when the cluster settings values change.
+var ConfigureLDAPAuth = func(
+	serverCtx context.Context,
+	ambientCtx log.AmbientContext,
+	st *cluster.Settings,
+	clusterUUID uuid.UUID,
+) pgwire.LDAPManager {
+	authManager := ldapAuthManager{}
+	authManager.clusterUUID = clusterUUID
+	authManager.reloadConfig(serverCtx, st)
+	LDAPDomainCACertificate.SetOnChange(&st.SV, func(ctx context.Context) {
+		authManager.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
+	})
+	return &authManager
+}
+
+func init() {
+	pgwire.ConfigureLDAPAuth = ConfigureLDAPAuth
+}

--- a/pkg/ccl/ldapccl/ldap_test_util.go
+++ b/pkg/ccl/ldapccl/ldap_test_util.go
@@ -1,0 +1,143 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package ldapccl
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
+	"github.com/cockroachdb/errors"
+	"github.com/go-ldap/ldap/v3"
+)
+
+const (
+	emptyParam   = "empty"
+	invalidParam = "invalid"
+)
+
+type mockLDAPUtil struct {
+	conn      *ldap.Conn
+	tlsConfig *tls.Config
+}
+
+// MaybeInitLDAPsConn implements the ILDAPUtil interface.
+func (lu *mockLDAPUtil) MaybeInitLDAPsConn(ctx context.Context, conf ldapConfig) error {
+	if strings.Contains(conf.ldapServer, invalidParam) {
+		return errors.Newf(ldapsFailureMessage + ": invalid ldap server provided")
+	} else if strings.Contains(conf.ldapPort, invalidParam) {
+		return errors.Newf(ldapsFailureMessage + ": invalid ldap port provided")
+	}
+	lu.conn = &ldap.Conn{}
+	return nil
+}
+
+// Bind implements the ILDAPUtil interface.
+func (lu *mockLDAPUtil) Bind(ctx context.Context, userDN string, ldapPwd string) error {
+	if strings.Contains(userDN, invalidParam) {
+		return errors.Newf(bindFailureMessage + ": invalid username provided")
+	} else if strings.Contains(ldapPwd, invalidParam) {
+		return errors.Newf(bindFailureMessage + ": invalid password provided")
+	}
+
+	return nil
+}
+
+// Search implements the ILDAPUtil interface.
+func (lu *mockLDAPUtil) Search(
+	ctx context.Context, conf ldapConfig, username string,
+) (userDN string, err error) {
+	if err := lu.Bind(ctx, conf.ldapBindDN, conf.ldapBindPassword); err != nil {
+		return "", errors.Wrap(err, searchFailureMessage)
+	}
+	if strings.Contains(conf.ldapBaseDN, invalidParam) {
+		return "", errors.Newf(searchFailureMessage+": invalid base DN %q provided", conf.ldapBaseDN)
+	}
+	if strings.Contains(conf.ldapSearchFilter, invalidParam) {
+		return "", errors.Newf(searchFailureMessage+": invalid search filter %q provided", conf.ldapSearchFilter)
+	}
+	if strings.Contains(conf.ldapSearchAttribute, invalidParam) {
+		return "", errors.Newf(searchFailureMessage+": invalid search attribute %q provided", conf.ldapSearchAttribute)
+	}
+	if strings.Contains(username, invalidParam) {
+		return "", errors.Newf(searchFailureMessage+": invalid search value %q provided", username)
+	}
+	commonNames := strings.Split(username, ",")
+	switch {
+	case len(username) == 0:
+		return "", errors.Newf(searchFailureMessage+": user %q does not exist", username)
+	case len(commonNames) > 1:
+		return "", errors.Newf(searchFailureMessage+": too many matching entries returned for user %q", username)
+	}
+
+	distinguishedName := "CN=" + commonNames[0]
+	return distinguishedName, nil
+}
+
+// ListGroups implements the ILDAPUtil interface.
+func (lu *mockLDAPUtil) ListGroups(
+	ctx context.Context, conf ldapConfig, userDN string,
+) (ldapGroupsDN []string, err error) {
+	if err := lu.Bind(ctx, conf.ldapBindDN, conf.ldapBindPassword); err != nil {
+		return nil, errors.Wrap(err, groupListFailureMessage)
+	}
+	if strings.Contains(conf.ldapBaseDN, invalidParam) {
+		return nil, errors.Newf(groupListFailureMessage+": invalid base DN %q provided", conf.ldapBaseDN)
+	}
+	if strings.Contains(conf.ldapSearchFilter, invalidParam) {
+		return nil, errors.Newf(groupListFailureMessage+": invalid search filter %q provided", conf.ldapSearchFilter)
+	}
+	if strings.Contains(conf.ldapGroupListFilter, invalidParam) {
+		return nil, errors.Newf(groupListFailureMessage+": invalid group list filter %q provided", conf.ldapGroupListFilter)
+	}
+	if len(userDN) == 0 {
+		return nil, errors.Newf(groupListFailureMessage+": user dn %q does not belong to any groups", userDN)
+	}
+
+	ldapGroupsDN = strings.Split(userDN, ",")
+	return ldapGroupsDN, nil
+}
+
+var _ ILDAPUtil = &mockLDAPUtil{}
+
+func constructHBAEntry(
+	t *testing.T,
+	hbaEntryBase string,
+	hbaConfLDAPDefaultOpts map[string]string,
+	hbaConfLDAPOpts map[string]string,
+) hba.Entry {
+	hbaEntryLDAP := hbaEntryBase
+	// add options from default and override default options when provided with one
+	for opt, value := range hbaConfLDAPDefaultOpts {
+		setValue := value
+		if hbaConfLDAPOpts[opt] == emptyParam {
+			continue
+		} else if hbaConfLDAPOpts[opt] != "" {
+			setValue = hbaConfLDAPOpts[opt]
+		}
+		hbaEntryLDAP += fmt.Sprintf("\"%s=%s\" ", opt, setValue)
+	}
+	// add non default options
+	for additionalOpt, additionalOptValue := range hbaConfLDAPOpts {
+		if _, ok := hbaConfLDAPDefaultOpts[additionalOpt]; !ok {
+			hbaEntryLDAP += fmt.Sprintf("\"%s=%s\" ", additionalOpt, additionalOptValue)
+		}
+	}
+	hbaConf, err := hba.ParseAndNormalize(hbaEntryLDAP)
+	if err != nil {
+		t.Fatalf("error parsing hba conf: %v", err)
+	}
+	if len(hbaConf.Entries) != 1 {
+		t.Fatalf("hba conf value invalid: should contain only 1 entry")
+	}
+	return hbaConf.Entries[0]
+}

--- a/pkg/ccl/ldapccl/ldap_util.go
+++ b/pkg/ccl/ldapccl/ldap_util.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	invalidLDAPConfMessage = "LDAP configuration invalid"
-	ldapsFailureMessage    = "LDAPs connection failed"
-	bindFailureMessage     = "LDAP bind failed"
-	searchFailureMessage   = "LDAP search failed"
+	invalidLDAPConfMessage  = "LDAP configuration invalid"
+	ldapsFailureMessage     = "LDAPs connection failed"
+	bindFailureMessage      = "LDAP bind failed"
+	searchFailureMessage    = "LDAP search failed"
+	groupListFailureMessage = "LDAP groups list failed"
 )
 
 type ldapUtil struct {
@@ -30,14 +31,14 @@ type ldapUtil struct {
 	tlsConfig *tls.Config
 }
 
-// InitLDAPsConn implements the ILDAPUtil interface.
-func (lu *ldapUtil) InitLDAPsConn(ctx context.Context, conf ldapAuthenticatorConf) (err error) {
+// MaybeInitLDAPsConn implements the ILDAPUtil interface.
+func (lu *ldapUtil) MaybeInitLDAPsConn(ctx context.Context, conf ldapConfig) (err error) {
 	// TODO(souravcrl): (Fix 1) DialTLS is slow if we do it for every authN
 	// attempt. We should look into ways for caching connections and avoiding
 	// connection timeouts in case LDAP server enforces that for idle connections.
 	// We still should be able to validate a large number of authN requests
 	// reusing the same connection(s).
-	// (Fix 2) Every authN attempt acquires a lock on ldapAuthenticator, so
+	// (Fix 2) Every authN attempt acquires a lock on ldapAuthManager, so
 	// only 1 authN attempt is possible at a given time(for entire flow of
 	// bind+search+bind). We should have a permanent bind connection to search for
 	// entries and short-lived bind attempts for requested sql authNs.
@@ -47,6 +48,10 @@ func (lu *ldapUtil) InitLDAPsConn(ctx context.Context, conf ldapAuthenticatorCon
 	// connections crdb nodes can take up(either in total or on a per node basis)
 	//
 	// ldapAddress := "ldap://ldap.example.com:636"
+	//
+	if lu.conn != nil {
+		return nil
+	}
 	ldapAddress := conf.ldapServer + ":" + conf.ldapPort
 	if lu.conn, err = ldap.DialTLS("tcp", ldapAddress, lu.tlsConfig); err != nil {
 		return errors.Wrap(err, ldapsFailureMessage)
@@ -64,7 +69,7 @@ func (lu *ldapUtil) Bind(ctx context.Context, userDN string, ldapPwd string) (er
 
 // Search implements the ILDAPUtil interface.
 func (lu *ldapUtil) Search(
-	ctx context.Context, conf ldapAuthenticatorConf, username string,
+	ctx context.Context, conf ldapConfig, username string,
 ) (userDN string, err error) {
 	if err := lu.Bind(ctx, conf.ldapBindDN, conf.ldapBindPassword); err != nil {
 		return "", errors.Wrap(err, searchFailureMessage)
@@ -94,19 +99,55 @@ func (lu *ldapUtil) Search(
 	return sr.Entries[0].DN, nil
 }
 
+// ListGroups implements the ILDAPUtil interface.
+func (lu *ldapUtil) ListGroups(
+	ctx context.Context, conf ldapConfig, userDN string,
+) (ldapGroupsDN []string, err error) {
+	if err := lu.Bind(ctx, conf.ldapBindDN, conf.ldapBindPassword); err != nil {
+		return nil, errors.Wrap(err, groupListFailureMessage)
+	}
+	// TODO(souravcrl): Currently list groups can only be performed at subtree
+	// level but this should be configurable through HBA conf using any of the
+	// scopes provided:
+	// https://github.com/go-ldap/ldap/blob/master/search.go#L17-L24
+	searchRequest := ldap.NewSearchRequest(
+		conf.ldapBaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		fmt.Sprintf("(&%s(member=%s))", conf.ldapGroupListFilter, ldap.EscapeFilter(userDN)),
+		[]string{},
+		nil,
+	)
+	sr, err := lu.conn.Search(searchRequest)
+	if err != nil {
+		return nil, errors.Wrap(err, groupListFailureMessage)
+	}
+
+	if len(sr.Entries) == 0 {
+		return nil, errors.Newf(groupListFailureMessage+": user dn %s does not belong to any groups", userDN)
+	}
+	for idx := range sr.Entries {
+		ldapGroupsDN = append(ldapGroupsDN, sr.Entries[idx].DN)
+	}
+	return ldapGroupsDN, nil
+}
+
 // ILDAPUtil is an interface for the `ldapauthccl` library to wrap various LDAP
 // functionalities exposed by `go-ldap` library as part of CRDB modules for
 // authN and authZ.
 type ILDAPUtil interface {
-	// InitLDAPsConn creates a mTLS connection with the LDAP server taking
-	// arguments for domain CA, ldap client key and cert, ldap server & port
-	InitLDAPsConn(ctx context.Context, conf ldapAuthenticatorConf) error
+	// MaybeInitLDAPsConn optionally creates a mTLS connection with the LDAP
+	// server if it does not already exist taking arguments for domain CA, ldap
+	// client key and cert, ldap server & port
+	MaybeInitLDAPsConn(ctx context.Context, conf ldapConfig) error
 	// Bind performs a bind given a valid DN and LDAP password
 	Bind(ctx context.Context, userDN string, ldapPwd string) error
 	// Search performs search on LDAP server binding with bindDN and bindpwd
 	// expecting search arguments from HBA conf and crdb database connection
 	// string and returns the ldap userDN.
-	Search(ctx context.Context, conf ldapAuthenticatorConf, username string) (userDN string, err error)
+	Search(ctx context.Context, conf ldapConfig, username string) (userDN string, err error)
+	// ListGroups performs search on AD subtree starting from baseDN filtered by
+	// groupListFilter and lists groups which have provided userDN as a member
+	ListGroups(ctx context.Context, conf ldapConfig, userDN string) (ldapGroupsDN []string, err error)
 }
 
 var _ ILDAPUtil = &ldapUtil{}
@@ -115,9 +156,9 @@ var _ ILDAPUtil = &ldapUtil{}
 // client interface provided by `go-ldap`. This is needed for testing (to
 // intercept the call to NewLDAPUtil and return the mocked NewLDAPUtil which has
 // mock implementations for ILDAPUtil interface).
-var NewLDAPUtil func(context.Context, ldapAuthenticatorConf) (ILDAPUtil, error) = func(
+var NewLDAPUtil func(context.Context, ldapConfig) (ILDAPUtil, error) = func(
 	ctx context.Context,
-	conf ldapAuthenticatorConf,
+	conf ldapConfig,
 ) (ILDAPUtil, error) {
 	util := ldapUtil{tlsConfig: &tls.Config{}}
 


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/125087
fixes CRDB-39227
Epic CRDB-33829

This PR adds support for fetching LDAP groups info for sql user which is trying
to gain authorization for cockroach cluster via LDAP. This change will enable us
to assign appropriate role privileges for user on CRDB.

Release note(enterprise, security): We add support for authorization to CRDB
cluster via LDAP retrieving AD groups membership information for LDAP user to
enable us to appropriately assign role privileges on CRDB.

Example hba conf entry to support LDAP authZ configuration:
```
 # TYPE    DATABASE      USER           ADDRESS             METHOD             OPTIONS
 # Allow all users to connect to using LDAP authentication with search and bind
   host    all           all            all                 ldap               ldapserver=ldap.example.com ldapport=636 "ldapbasedn=ou=users,dc=example,dc=com" "ldapbinddn=cn=readonly,dc=example,dc=com" ldapbindpasswd=readonly_password ldapsearchattribute=uid "ldapsearchfilter=(memberof=cn=cockroachdb_users,ou=groups,dc=example,dc=com)" "ldapgrouplistfilter=(objectClass=groupOfNames)"
 # Fallback to password authentication for the root user
   host    all           root           0.0.0.0/0          password
```
Example to use for azure AD server:
```
SET cluster setting server.host_based_authentication.configuration = 'host    all           all            all                 ldap ldapserver=azure.dev ldapport=636 "ldapbasedn=OU=AADDC Users,DC=azure,DC=dev" "ldapbinddn=CN=Some User,OU=AADDC Users,DC=azure,DC=dev" ldapbindpasswd=my_pwd ldapsearchattribute=sAMAccountName "ldapsearchfilter=(memberOf=CN=azure-dev-domain-sync-users,OU=AADDC Users,DC=crlcloud,DC=dev)" "ldapgrouplistfilter=(objectCategory=CN=Group,CN=Schema,CN=Configuration,DC=crlcloud,DC=dev)"
host    all           root           0.0.0.0/0          password';
```

Post configuration CRDB cluster should be able to authorize users via LDAP
server if:
1. Users LDAP authentication attempt is successful, and it has the user's DN for
LDAP server.
2. `ldapgrouplistfilter` is properly configured, and it successfully syncs
groups of the user.