### PR TITLE
build: VersionForURLs should return vMM.d for production releases

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -114,7 +114,12 @@ func BinaryVersion() string {
 // N.B. new public-facing doc URLs are expected to be up beginning with the "alpha.1" prerelease. Otherwise, "dev" will
 // cause the url mapper to redirect to the latest stable release.
 func VersionForURLs() string {
+	// Prerelease versions >= "alpha.1"
 	if parsedVersionTxt.PreRelease() >= "alpha.1" {
+		return fmt.Sprintf("v%d.%d", parsedVersionTxt.Major(), parsedVersionTxt.Minor())
+	}
+	// Production release versions
+	if parsedVersionTxt.PreRelease() == "" {
 		return fmt.Sprintf("v%d.%d", parsedVersionTxt.Major(), parsedVersionTxt.Minor())
 	}
 	return "dev"


### PR DESCRIPTION
This PR fixes VersionForURLs() to return vMM.d for production release versions.

See also:
- https://github.com/cockroachdb/cockroach/pull/128482
- https://github.com/cockroachdb/cockroach/pull/128481

Epic: None
Release note: None