### PR TITLE
jobsprotectedtsccl: deflake TestJobsProtectedTimestamp

### DIFF
--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -68,48 +68,49 @@ func testJobsProtectedTimestamp(
 ) {
 	t.Helper()
 
-	mkJobRec := func() jobs.Record {
-		return jobs.Record{
-			Description: "testing",
-			Statements:  []string{"SELECT 1"},
-			Username:    username.RootUserName(),
-			Details: jobspb.SchemaChangeGCDetails{
-				Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
-					{
-						ID:       42,
-						DropTime: clock.PhysicalNow(),
-					},
-				},
-			},
-			Progress:      jobspb.SchemaChangeGCProgress{},
-			DescriptorIDs: []descpb.ID{42},
-		}
-	}
 	insqlDB := execCfg.InternalDB
-	mkJobAndRecord := func() (j *jobs.Job, rec *ptpb.Record) {
+	mkJobAndRecord := func(f func(context.Context, isql.Txn, *jobs.Job) error) (rec *ptpb.Record) {
 		ts := clock.Now()
 		jobID := jr.MakeJobID()
-		require.NoError(t, insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
-			if j, err = jr.CreateJobWithTxn(ctx, mkJobRec(), jobID, txn); err != nil {
+		require.NoError(t, insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			jobRec := jobs.Record{
+				Description: "testing",
+				Statements:  []string{"SELECT 1"},
+				Username:    username.RootUserName(),
+				Details: jobspb.SchemaChangeGCDetails{
+					Tables: []jobspb.SchemaChangeGCDetails_DroppedID{
+						{
+							ID:       42,
+							DropTime: clock.PhysicalNow(),
+						},
+					},
+				},
+				Progress:      jobspb.SchemaChangeGCProgress{},
+				DescriptorIDs: []descpb.ID{42},
+			}
+
+			j, err := jr.CreateJobWithTxn(ctx, jobRec, jobID, txn)
+			if err != nil {
 				return err
 			}
 			deprecatedSpansToProtect := roachpb.Spans{{Key: keys.MinKey, EndKey: keys.MaxKey}}
 			targetToProtect := ptpb.MakeClusterTarget()
 			rec = jobsprotectedts.MakeRecord(uuid.MakeV4(), int64(jobID), ts,
 				deprecatedSpansToProtect, jobsprotectedts.Jobs, targetToProtect)
-			return ptp.WithTxn(txn).Protect(ctx, rec)
+			if err := ptp.WithTxn(txn).Protect(ctx, rec); err != nil {
+				return err
+			}
+			return f(ctx, txn, j)
 		}))
-		return j, rec
+		return rec
 	}
-	jMovedToFailed, recMovedToFailed := mkJobAndRecord()
-	require.NoError(t, insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jr.UnsafeFailed(ctx, txn, jMovedToFailed.ID(), io.ErrUnexpectedEOF)
-	}))
-	jFinished, recFinished := mkJobAndRecord()
-	require.NoError(t, insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jr.Succeeded(ctx, txn, jFinished.ID())
-	}))
-	_, recRemains := mkJobAndRecord()
+	recMovedToFailed := mkJobAndRecord(func(ctx context.Context, txn isql.Txn, j *jobs.Job) error {
+		return jr.UnsafeFailed(ctx, txn, j.ID(), io.ErrUnexpectedEOF)
+	})
+	recFinished := mkJobAndRecord(func(ctx context.Context, txn isql.Txn, j *jobs.Job) error {
+		return jr.Succeeded(ctx, txn, j.ID())
+	})
+	recRemains := mkJobAndRecord(func(context.Context, isql.Txn, *jobs.Job) error { return nil })
 	ensureNotExists := func(ctx context.Context, txn isql.Txn, ptsID uuid.UUID) (err error) {
 		_, err = ptp.WithTxn(txn).GetRecord(ctx, ptsID)
 		if err == nil {
@@ -151,6 +152,13 @@ WHERE
 func TestJobsProtectedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	defer jobs.TestingRegisterConstructor(
+		jobspb.TypeSchemaChangeGC,
+		func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+			return fakeResumer{}
+		},
+		jobs.UsesTenantCostControl)()
 
 	ctx := context.Background()
 	s0, db, _ := serverutils.StartServer(t, base.TestServerArgs{


### PR DESCRIPTION
This test was attempting to test the job reconciliation by forcing jobs into a particular state and then making assertions about their associated PTS records.

However, it was doing this with real jobs which might be adopted and move states before the test was able to change the relevant job state or make the relevant assertions.

Here, we hopefully make the test less flaky by using a fakeResumer, ensuring the job won't change states automatically. Further, we push jobs into our desired end-state in the same transaction in which they are created so that jobs that are supposed to be in terminal states never even run their resumers.

Fixes #128377
Release note: None