### PR TITLE
testutils: extend succeeds soon duration under deadlock mode

### DIFF
--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -82,7 +83,7 @@ func SucceedsWithinError(fn func() error, duration time.Duration) error {
 }
 
 func SucceedsSoonDuration() time.Duration {
-	if util.RaceEnabled {
+	if util.RaceEnabled || syncutil.DeadlockEnabled {
 		return RaceSucceedsSoonDuration
 	}
 	return DefaultSucceedsSoonDuration


### PR DESCRIPTION
We've observed that the deadlock detector can have a large performance impact. As a result, it makes sense to wait longer for async conditions under deadlock.

Fixes #128452

Release note: None