### PR TITLE
sql: restart rangefeed on descriptor table on error

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3911,11 +3911,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 
 	const numAccounts = 10
 	ctx := context.Background()
-	args := base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(118625),
-		},
-	}
+	args := base.TestClusterArgs{}
 	tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, args)
 	defer cleanupFn()
 	const dir = "nodelocal://1/"


### PR DESCRIPTION
Previously, if the rangefeed encountered a terminal error, it would remain offline. In at least one test, this led in our version check on drop to hang forever since it is the rangefeed that is responsible for driving the purging of leases on drop.

Now, we restart the feed.

Fixes #118625.

Release note: None