### PR TITLE
server: enable `data_distribution` API for secondary tenants.

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -7128,7 +7128,6 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | replica_count_by_node_id | [DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry](#cockroach.server.serverpb.DataDistributionResponse-cockroach.server.serverpb.DataDistributionResponse.TableInfo.ReplicaCountByNodeIdEntry) | repeated |  | [reserved](#support-status) |
-| zone_config_id | [int64](#cockroach.server.serverpb.DataDistributionResponse-int64) |  |  | [reserved](#support-status) |
 | dropped_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.DataDistributionResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 
 

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -52,14 +52,7 @@ func TestAdminAPIDataDistributionPartitioning(t *testing.T) {
 	// TODO(clust-obs): This test should work with just a single node,
 	// i.e. using serverutils.StartServer` instead of
 	// `StartCluster`.
-	testCluster := serverutils.StartCluster(t, 3,
-		base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				// The code below ought to work when this is omitted. This
-				// needs to be investigated further.
-				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(106897),
-			},
-		})
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	defer testCluster.Stopper().Stop(context.Background())
 
 	firstServer := testCluster.Server(0)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -2911,14 +2910,7 @@ func (s *systemAdminServer) Decommission(
 }
 
 // DataDistribution returns a count of replicas on each node for each table.
-//
-// TODO(kv): Now that we have coalesced ranges, this endpoint no longer reports
-// accurate replica counts. Furthermore, since it doesn't take coalesced ranges
-// into account, this endpoint doesn't work for secondary tenants whose ranges are
-// *always* coalesced. Update this endpoint to handle coalesced ranges and
-// implement tenant filtering, after which it can be moved back into the
-// adminServer instead of the systemAdminServer.
-func (s *systemAdminServer) DataDistribution(
+func (s *adminServer) DataDistribution(
 	ctx context.Context, req *serverpb.DataDistributionRequest,
 ) (_ *serverpb.DataDistributionResponse, retErr error) {
 	if err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
@@ -2949,19 +2941,42 @@ func (s *adminServer) dataDistributionHelper(
 		ZoneConfigs:  make(map[string]serverpb.DataDistributionResponse_ZoneConfig),
 	}
 
-	// Get ids and names for databases and tables.
-	// Set up this structure in the response.
-
-	// This relies on crdb_internal.tables returning data even for newly added tables
-	// and deleted tables (as opposed to e.g. information_schema) because we are interested
-	// in the data for all ranges, not just ranges for visible tables.
+	// We use crdb_internal.tables as it also returns data for deleted tables
+	// which are not garbage collected yet, as opposed to information_schema,
+	// because we are interested in the data for all ranges, not just ranges for
+	// visible tables.
 	//
-	// Don't include tables with a NULL database_name, which in this case means
-	// excluding virtual tables (like crdb_internal.tables itself, for example).
-	tablesQuery := `SELECT name, schema_name, table_id, database_name, drop_time FROM
-									"".crdb_internal.tables WHERE database_name IS NOT NULL`
+	// The query is structured as follows:
+	//
+	// 1. The tables CTE selects table details from crdb_internal.tables and
+	//    joins it with crdb_internal.table_spans to get the start and end keys for
+	//    each table. We exclude tables with a NULL database_name to avoid virtual
+	//    tables (like crdb_internal.tables itself).
+	//
+	// 2. The main SELECT joins the tables CTE with crdb_internal.ranges_no_leases to
+	//    get the ranges the current table overlaps with. A single table can
+	//    overlap with multiple ranges, and if range coalescing is enabled, a single
+	//    range may overlap with multiple tables too.
+	tablesQuery := `
+    WITH tables AS (
+        SELECT
+            t.schema_name, t.name AS table_name, t.database_name,
+            t.table_id, t.drop_time, s.start_key, s.end_key
+        FROM
+            "".crdb_internal.tables t
+            JOIN "".crdb_internal.table_spans s ON t.table_id = s.descriptor_id
+        WHERE
+            t.database_name IS NOT NULL
+    )
+    SELECT
+        t.table_id, t.table_name, t.schema_name, t.database_name, t.drop_time, r.replicas
+    FROM
+        tables t
+        JOIN "".crdb_internal.ranges_no_leases r ON t.start_key < r.end_key
+            AND t.end_key > r.start_key;`
+
 	it, err := s.internalExecutor.QueryIteratorEx(
-		ctx, "admin-replica-matrix", nil, /* txn */
+		ctx, "data-distribution", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: userName},
 		tablesQuery,
 	)
@@ -2978,122 +2993,71 @@ func (s *adminServer) dataDistributionHelper(
 	var hasNext bool
 	for hasNext, err = it.Next(ctx); hasNext; hasNext, err = it.Next(ctx) {
 		row := it.Cur()
-		tableName := (*string)(row[0].(*tree.DString))
-		schemaName := (*string)(row[1].(*tree.DString))
-		fqTableName := fmt.Sprintf("%s.%s",
-			tree.NameStringP(schemaName), tree.NameStringP(tableName))
-		tableID := uint32(tree.MustBeDInt(row[2]))
-		dbName := (*string)(row[3].(*tree.DString))
+		tableID := uint32(*row[0].(*tree.DInt))
+		tableInfo, ok := tableInfosByTableID[tableID]
 
-		// Look at whether it was dropped.
-		var droppedAtTime *time.Time
-		droppedAtDatum, ok := row[4].(*tree.DTimestamp)
-		if ok {
-			droppedAtTime = &droppedAtDatum.Time
-		}
-
-		// Insert database if it doesn't exist.
-		dbInfo, ok := resp.DatabaseInfo[*dbName]
 		if !ok {
-			dbInfo = serverpb.DataDistributionResponse_DatabaseInfo{
-				TableInfo: make(map[string]serverpb.DataDistributionResponse_TableInfo),
-			}
-			resp.DatabaseInfo[*dbName] = dbInfo
-		}
+			tableName := (*string)(row[1].(*tree.DString))
+			schemaName := (*string)(row[2].(*tree.DString))
+			fqTableName := fmt.Sprintf("%s.%s", tree.NameStringP(schemaName), tree.NameStringP(tableName))
+			dbName := (*string)(row[3].(*tree.DString))
 
-		// Get zone config for table.
-		zcID := int64(0)
-
-		if droppedAtTime == nil {
-			// TODO(vilterp): figure out a way to get zone configs for tables that are dropped
-			zoneConfigQuery := fmt.Sprintf(
-				`SELECT zone_id FROM [SHOW ZONE CONFIGURATION FOR TABLE %s.%s.%s]`,
-				(*tree.Name)(dbName), (*tree.Name)(schemaName), (*tree.Name)(tableName),
-			)
-			row, err := s.internalExecutor.QueryRowEx(
-				ctx, "admin-replica-matrix", nil, /* txn */
-				sessiondata.InternalExecutorOverride{User: userName},
-				zoneConfigQuery,
-			)
-			if err != nil {
-				return nil, err
+			// Look at whether it was dropped.
+			var droppedAtTime *time.Time
+			droppedAtDatum, ok := row[4].(*tree.DTimestamp)
+			if ok {
+				droppedAtTime = &droppedAtDatum.Time
 			}
-			if row == nil {
-				return nil, errors.Errorf(
-					"could not get zone config for table %s; 0 rows returned", *tableName,
+
+			// Insert database if it doesn't exist.
+			dbInfo, ok := resp.DatabaseInfo[*dbName]
+			if !ok {
+				dbInfo = serverpb.DataDistributionResponse_DatabaseInfo{
+					TableInfo: make(map[string]serverpb.DataDistributionResponse_TableInfo),
+				}
+				resp.DatabaseInfo[*dbName] = dbInfo
+			}
+
+			// Get zone config for table.
+			zcID := int64(0)
+
+			if droppedAtTime == nil {
+				// TODO(vilterp): figure out a way to get zone configs for tables that are dropped
+				zoneConfigQuery := fmt.Sprintf(
+					`SELECT zone_id FROM [SHOW ZONE CONFIGURATION FOR TABLE %s.%s.%s]`,
+					(*tree.Name)(dbName), (*tree.Name)(schemaName), (*tree.Name)(tableName),
 				)
+				row2, err := s.internalExecutor.QueryRowEx(
+					ctx, "data-distribution", nil, /* txn */
+					sessiondata.InternalExecutorOverride{User: userName},
+					zoneConfigQuery,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if row2 == nil {
+					return nil, errors.Errorf(
+						"could not get zone config for table %s; 0 rows returned", *tableName,
+					)
+				}
+
+				zcID = int64(tree.MustBeDInt(row2[0]))
 			}
 
-			zcID = int64(tree.MustBeDInt(row[0]))
+			// Insert table.
+			tableInfo = serverpb.DataDistributionResponse_TableInfo{
+				ReplicaCountByNodeId: make(map[roachpb.NodeID]int64),
+				ZoneConfigId:         zcID,
+				DroppedAt:            droppedAtTime,
+			}
+			dbInfo.TableInfo[fqTableName] = tableInfo
+			tableInfosByTableID[tableID] = tableInfo
 		}
-
-		// Insert table.
-		tableInfo := serverpb.DataDistributionResponse_TableInfo{
-			ReplicaCountByNodeId: make(map[roachpb.NodeID]int64),
-			ZoneConfigId:         zcID,
-			DroppedAt:            droppedAtTime,
+		for _, n := range row[5].(*tree.DArray).Array {
+			tableInfo.ReplicaCountByNodeId[roachpb.NodeID(*n.(*tree.DInt))]++
 		}
-		dbInfo.TableInfo[fqTableName] = tableInfo
-		tableInfosByTableID[tableID] = tableInfo
 	}
 	if err != nil {
-		return nil, err
-	}
-
-	// Get replica counts.
-	if err := s.db.Txn(ctx, func(txnCtx context.Context, txn *kv.Txn) error {
-		acct := s.memMonitor.MakeBoundAccount()
-		defer acct.Close(txnCtx)
-
-		kvs, err := kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
-			Key:    keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID + 1),
-			EndKey: keys.MaxKey,
-		})
-		if err != nil {
-			return err
-		}
-
-		// Group replicas by table and node, accumulate counts.
-		var rangeDesc roachpb.RangeDescriptor
-		for _, kv := range kvs {
-			if err := acct.Grow(txnCtx, int64(len(kv.Key)+len(kv.Value.RawBytes))); err != nil {
-				return err
-			}
-			if err := kv.ValueProto(&rangeDesc); err != nil {
-				return err
-			}
-			// TODO(embrown): Tables can use one codec since they
-			// seem to all share the same id.
-			_, tenID, err := keys.DecodeTenantPrefix(rangeDesc.StartKey.AsRawKey())
-			if err != nil {
-				return err
-			}
-
-			// A range descriptor for a secondary tenant may not contain
-			// a table prefix. Often, the start key for a tenant will be just
-			// the tenant prefix itself, e.g. `/Tenant/2`. Once the tenant prefix
-			// is stripped inside `DecodeTablePrefix`, nothing (aka `/Min`) is left.
-			keySansPrefix, _ := keys.MakeSQLCodec(tenID).StripTenantPrefix(rangeDesc.StartKey.AsRawKey())
-			if keys.MinKey.Equal(keySansPrefix) {
-				// There's no table prefix to be decoded.
-				// Try the next descriptor.
-				continue
-			}
-			_, tableID, err := keys.MakeSQLCodec(tenID).DecodeTablePrefix(rangeDesc.StartKey.AsRawKey())
-			if err != nil {
-				return err
-			}
-			for _, replicaDesc := range rangeDesc.Replicas().Descriptors() {
-				tableInfo, found := tableInfosByTableID[tableID]
-				if !found {
-					// This is a database, skip.
-					continue
-				}
-				tableInfo.ReplicaCountByNodeId[replicaDesc.NodeID]++
-			}
-		}
-		return nil
-	}); err != nil {
 		return nil, err
 	}
 
@@ -3105,7 +3069,7 @@ func (s *adminServer) dataDistributionHelper(
 		WHERE target IS NOT NULL
 	`
 	it, err = s.internalExecutor.QueryIteratorEx(
-		ctx, "admin-replica-matrix", nil, /* txn */
+		ctx, "data-distribution", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: userName},
 		zoneConfigsQuery)
 	if err != nil {

--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -197,11 +197,7 @@ func TestAdminAPIDataDistribution(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109501),
-		},
-	})
+	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(context.Background())
 
 	firstServer := tc.Server(0).ApplicationLayer()

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -825,7 +825,8 @@ message DataDistributionResponse {
   message TableInfo {
     map<int32, int64> replica_count_by_node_id = 1 [(gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
 
-    int64 zone_config_id = 2;
+    reserved 2;
+
     google.protobuf.Timestamp dropped_at = 3 [(gogoproto.stdtime) = true];
   }
 


### PR DESCRIPTION
Previously, this endpoint scanned over meta KVs and used their startKey to
determine the table they belong to. However, this approach does not work
for coalesced ranges.

The fix, inspired by the `SHOW CLUSTER RANGES` query, uses the
`crdb_internal.table_spans` table and joins it with the
`crdb_internal.ranges_no_leases` table.

There is still some work left that can be addressed in follow-up PR:

- We might want to add a summation of ranges at various levels because the
  sum of replicas of all tables in a database can be more than the actual
  number of ranges that belong to that database due to coalescing.

Overall, this PR also fixes the broken behavior to a large extent of this
endpoint since range coalescing is enabled.

Informs: #97942
Fixes: #109501, #106897
Epic: CRDB-12100
Release note: None
