### PR TITLE
pkg/server: add tenant_id to Sentry context for tenants

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -896,6 +896,9 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			"cluster":   clusterID.String(),
 			"instance":  instanceID.String(),
 			"server_id": fmt.Sprintf("%s-%s", clusterID.Short(), instanceID.String()),
+			// TODO(jaylim-crl): Consider using tenant names here in the future
+			// as well. See discussions in https://github.com/cockroachdb/cockroach/pull/128602.
+			"tenant_id": s.rpcContext.TenantID.String(),
 		})
 	})
 


### PR DESCRIPTION
Previously, Sentry context for tenants included the logical cluster ID and
instance ID, but those information are insufficient to locate the tenant right
away. This commit ensures that Sentry context for tenants includes the
tenant_id field as part of Sentry reports. Note that one could already figure
out the tenant_id from the existing information, but they would need to compute
the tenant_id manually using a combination of the host's cluster ID and the
tenant's cluster ID, which can be cumbersome.

Release note: None

Epic: none