### PR TITLE
roachtest/cdc: fix cdc/mixed-versions deadlock

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -178,7 +178,7 @@ func (cmvt *cdcMixedVersionTester) waitAndValidate(
 		cmvt.timestampsResolved.Lock()
 		defer cmvt.timestampsResolved.Unlock()
 
-		cmvt.timestampsResolved.C = make(chan hlc.Timestamp)
+		cmvt.timestampsResolved.C = make(chan hlc.Timestamp, resolvedTimestampsPerState)
 	}()
 
 	var numResolved int
@@ -333,8 +333,10 @@ func (cmvt *cdcMixedVersionTester) timestampResolved(resolved hlc.Timestamp) {
 	cmvt.timestampsResolved.Lock()
 	defer cmvt.timestampsResolved.Unlock()
 
-	if cmvt.timestampsResolved.C != nil {
-		cmvt.timestampsResolved.C <- resolved
+	select {
+	case cmvt.timestampsResolved.C <- resolved:
+	default:
+		// If the channel is full or nil, we drop the resolved timestamp.
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -262,7 +262,7 @@ func (cmvt *cdcMixedVersionTester) runKafkaConsumer(
 			if err != nil {
 				return errors.Wrap(err, "failed to parse timestamps from message")
 			}
-			cmvt.timestampResolved(resolved)
+			cmvt.timestampResolved(l, resolved)
 
 			if everyN.ShouldLog() {
 				l.Printf("latest resolved timestamp %s behind realtime", timeutil.Since(resolved.GoTime()).String())
@@ -329,12 +329,13 @@ func (cmvt *cdcMixedVersionTester) validate(
 
 // timestampsResolved updates the underlying channel if set (i.e., if
 // we are waiting for resolved timestamps events)
-func (cmvt *cdcMixedVersionTester) timestampResolved(resolved hlc.Timestamp) {
+func (cmvt *cdcMixedVersionTester) timestampResolved(l *logger.Logger, resolved hlc.Timestamp) {
 	cmvt.timestampsResolved.Lock()
 	defer cmvt.timestampsResolved.Unlock()
 
 	select {
 	case cmvt.timestampsResolved.C <- resolved:
+		l.Printf("sent resolved timestamp %s", resolved)
 	default:
 		// If the channel is full or nil, we drop the resolved timestamp.
 	}


### PR DESCRIPTION
**roachtest/cdc: fix cdc/mixed-versions deadlock**

Previously, cmvt.timestampsResolved.C could deadlock if it receives more
timestamps after waitAndValidate have received all of resolved timestamps they
are waiting for. This patch changes it to be a buffered channel with a size of
resolvedTimestampsPerState and is now unblocking.

Fixes: https://github.com/cockroachdb/cockroach/issues/128173
Release note: none

----

**roachtest/cdc: add more debugging lines to cdcMixedVersionTester**

This patch adds more debugging lines to cdcMixedVersionTester for
cmvt.timestampsResolved.C.

Epic: none
Release note: none