### PR TITLE
release-24.1: roachtest/acceptance: remove schemachange workload

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -26,19 +26,18 @@ func registerAcceptance(r registry.Registry) {
 	cloudsWithoutServiceRegistration := registry.AllClouds.Remove(registry.CloudsWithServiceRegistration)
 
 	testCases := map[registry.Owner][]struct {
-		name                       string
-		fn                         func(ctx context.Context, t test.Test, c cluster.Cluster)
-		skip                       string
-		numNodes                   int
-		nodeRegions                []string
-		timeout                    time.Duration
-		encryptionSupport          registry.EncryptionSupport
-		defaultLeases              bool
-		requiresLicense            bool
-		nativeLibs                 []string
-		workloadNode               bool
-		incompatibleClouds         registry.CloudSet
-		requiresDeprecatedWorkload bool
+		name               string
+		fn                 func(ctx context.Context, t test.Test, c cluster.Cluster)
+		skip               string
+		numNodes           int
+		nodeRegions        []string
+		timeout            time.Duration
+		encryptionSupport  registry.EncryptionSupport
+		defaultLeases      bool
+		requiresLicense    bool
+		nativeLibs         []string
+		workloadNode       bool
+		incompatibleClouds registry.CloudSet
 	}{
 		// NOTE: acceptance tests are lightweight tests that run as part
 		// of CI. As such, they must:
@@ -77,12 +76,11 @@ func registerAcceptance(r registry.Registry) {
 		},
 		registry.OwnerTestEng: {
 			{
-				name:                       "version-upgrade",
-				fn:                         runVersionUpgrade,
-				timeout:                    2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
-				defaultLeases:              true,
-				nativeLibs:                 registry.LibGEOS,
-				requiresDeprecatedWorkload: true, // uses schemachange
+				name:          "version-upgrade",
+				fn:            runVersionUpgrade,
+				timeout:       2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
+				defaultLeases: true,
+				nativeLibs:    registry.LibGEOS,
 			},
 		},
 		registry.OwnerDisasterRecovery: {
@@ -145,16 +143,15 @@ func registerAcceptance(r registry.Registry) {
 			}
 
 			testSpec := registry.TestSpec{
-				Name:                       "acceptance/" + tc.name,
-				Owner:                      owner,
-				Cluster:                    r.MakeClusterSpec(numNodes, extraOptions...),
-				Skip:                       tc.skip,
-				EncryptionSupport:          tc.encryptionSupport,
-				Timeout:                    10 * time.Minute,
-				CompatibleClouds:           registry.AllClouds.Remove(tc.incompatibleClouds),
-				Suites:                     registry.Suites(registry.Nightly, registry.Quick, registry.Acceptance),
-				RequiresLicense:            tc.requiresLicense,
-				RequiresDeprecatedWorkload: tc.requiresDeprecatedWorkload,
+				Name:              "acceptance/" + tc.name,
+				Owner:             owner,
+				Cluster:           r.MakeClusterSpec(numNodes, extraOptions...),
+				Skip:              tc.skip,
+				EncryptionSupport: tc.encryptionSupport,
+				Timeout:           10 * time.Minute,
+				CompatibleClouds:  registry.AllClouds.Remove(tc.incompatibleClouds),
+				Suites:            registry.Suites(registry.Nightly, registry.Quick, registry.Acceptance),
+				RequiresLicense:   tc.requiresLicense,
 			}
 
 			if tc.timeout != 0 {


### PR DESCRIPTION
Backport 1/1 commits from #128491.

/cc @cockroachdb/release

---

This test has a tendency to flake in CI. Additionally, we have schemachange/mixed-versions that will already provide us with more coverage, but will actually generate a fail state that our team can easily detect.

Epic: none

Release note: None

---

Release justification: test-only change
