### PR TITLE
release-24.2: add provisioned_vcpus setting and metric

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -1635,6 +1635,7 @@
 <tr><td>APPLICATION</td><td>tenant.sql_usage.external_io_ingress_bytes</td><td>Total number of bytes read from external services such as cloud storage providers</td><td>Bytes</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>tenant.sql_usage.kv_request_units</td><td>RU consumption attributable to KV</td><td>Request Units</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>tenant.sql_usage.pgwire_egress_bytes</td><td>Total number of bytes transferred from a SQL pod to the client</td><td>Bytes</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>APPLICATION</td><td>tenant.sql_usage.provisioned_vcpus</td><td>Number of vcpus available to the virtual cluster</td><td>Count</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>tenant.sql_usage.read_batches</td><td>Total number of KV read batches</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>tenant.sql_usage.read_bytes</td><td>Total number of bytes read from KV</td><td>Bytes</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>tenant.sql_usage.read_requests</td><td>Total number of KV read requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
@@ -32,7 +32,7 @@ statement ok
 CREATE TENANT 'apptenant'
 
 statement ok
-SELECT crdb_internal.update_tenant_resource_limits('apptenant', 1000, 100, 0, now(), 0)
+SELECT crdb_internal.update_tenant_resource_limits('apptenant', 1000, 100, 0)
 
 user testuser
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
@@ -125,6 +125,12 @@ var (
 		Measurement: "Bytes",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaProvisionedVcpus = metric.Metadata{
+		Name:        "tenant.sql_usage.provisioned_vcpus",
+		Help:        "Number of vcpus available to the virtual cluster",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // metrics manage the metrics used by the tenant cost client.
@@ -146,6 +152,7 @@ type metrics struct {
 	TotalEstimatedKVCPUSeconds  *metric.CounterFloat64
 	TotalEstimatedCPUSeconds    *metric.CounterFloat64
 	EstimatedReplicationBytes   *aggmetric.AggCounter
+	ProvisionedVcpus            *metric.Gauge
 
 	// cachedPathMetrics stores a cache of network paths to the metrics which
 	// have been initialized. Having this layer of caching prevents us from
@@ -198,6 +205,7 @@ func (m *metrics) Init(locality roachpb.Locality) {
 	m.TotalCrossRegionNetworkRU = metric.NewCounterFloat64(metaTotalCrossRegionNetworkRU)
 	m.TotalEstimatedKVCPUSeconds = metric.NewCounterFloat64(metaTotalEstimatedKVCPUSeconds)
 	m.TotalEstimatedCPUSeconds = metric.NewCounterFloat64(metaTotalEstimatedCPUSeconds)
+	m.ProvisionedVcpus = metric.NewGauge(metaProvisionedVcpus)
 
 	// Metric labels for KV replication traffic will be derived from the SQL
 	// server's locality. e.g. {"from_region", "from_az", "to_region", "to_az"}.

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -29,6 +29,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # With no usage, consumption gets reported only every 40s. Advance by 30s here
 # since we're at the 10s mark.
@@ -87,6 +88,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 usage
 ----
@@ -142,6 +144,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test write operation consumption.
 write bytes=1024
@@ -188,6 +191,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test CPU consumption.
 advance wait=true
@@ -243,6 +247,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test multiple operations together.
 write bytes=4096
@@ -281,6 +286,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 advance
 30s
@@ -322,6 +328,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test larger amount of CPU usage that exceeds 100 RUs. The consumption report
 # should be sent after only 10s. In addition, the CPU usage should only be
@@ -370,6 +377,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test egress.
 pgwire-egress
@@ -416,6 +424,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test multiple requests in the same batch.
 write count=2 bytes=1024
@@ -464,6 +473,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test a small amount of CPU usage in a tick that has no read/write operations.
 # Anything under 30ms (3% of one CPU) should be ignored.
@@ -523,6 +533,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Now ensure that 30ms meets the threshold and is reported.
 cpu
@@ -575,6 +586,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Ensure RUs are updated for egress and ingress.
 external-egress bytes=1024000
@@ -624,6 +636,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Read the same amount of bytes as the first subtest. Should have an increase
 # of ~21 RUs compared to the first test.
@@ -670,6 +683,7 @@ tenant.sql_usage.cross_region_network_ru: 20.97
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # This write is expected to consume an extra ~20.5 RUs from network cost usage,
 # due to 2 cross-region replicas.
@@ -716,6 +730,7 @@ tenant.sql_usage.cross_region_network_ru: 41.55
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test multiple requests in the same batch.
 write count=2 bytes=1024 localities=cross-region
@@ -764,6 +779,7 @@ tenant.sql_usage.cross_region_network_ru: 63.54
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0
 
 # Test write batch across zones in same region (replicas=3).
 write count=1 bytes=1024 localities=cross-zone
@@ -809,3 +825,4 @@ tenant.sql_usage.cross_region_network_ru: 63.54
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.00
 tenant.sql_usage.estimated_cpu_seconds: 0.00
 tenant.sql_usage.estimated_replication_bytes: 0
+tenant.sql_usage.provisioned_vcpus: 0

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/estimated-cpu
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/estimated-cpu
@@ -1,7 +1,7 @@
 # Test that estimated CPU metrics and tokens are recorded and reported.
 
 # Switch to use the estimated CPU model rather than the RU model.
-estimated-nodes count=3
+provisioned-vcpus count=12
 ----
 
 # When throttle = -1, the provider will refuse to grant any tokens, either
@@ -41,6 +41,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.24
 tenant.sql_usage.estimated_cpu_seconds: 0.24
 tenant.sql_usage.estimated_replication_bytes: 145460
+tenant.sql_usage.provisioned_vcpus: 12
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 145460
 
 # Wait for the token bucket response triggered by low tokens. Not doing this
@@ -79,6 +80,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.24
 tenant.sql_usage.estimated_cpu_seconds: 0.31
 tenant.sql_usage.estimated_replication_bytes: 145460
+tenant.sql_usage.provisioned_vcpus: 12
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 145460
 
 # Do same writes, but with a different write batch rate. This time, the
@@ -132,6 +134,7 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.42
 tenant.sql_usage.estimated_cpu_seconds: 0.56
 tenant.sql_usage.estimated_replication_bytes: 290920
+tenant.sql_usage.provisioned_vcpus: 12
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 218190
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 72730
 
@@ -186,7 +189,46 @@ tenant.sql_usage.cross_region_network_ru: 0.00
 tenant.sql_usage.estimated_kv_cpu_seconds: 0.61
 tenant.sql_usage.estimated_cpu_seconds: 0.81
 tenant.sql_usage.estimated_replication_bytes: 436380
+tenant.sql_usage.provisioned_vcpus: 12
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
+
+# Update provisioned vCPUs.
+provisioned-vcpus count=48
+----
+
+write count=10 bytes=10000 localities=same-zone
+----
+
+advance wait=true
+1s
+----
+00:00:54.000
+
+token-bucket
+----
+4180.53 tokens filling @ 0.00 tokens/s
+
+metrics
+----
+tenant.sql_usage.request_units: 0.00
+tenant.sql_usage.kv_request_units: 0.00
+tenant.sql_usage.read_batches: 0
+tenant.sql_usage.read_requests: 0
+tenant.sql_usage.read_bytes: 0
+tenant.sql_usage.write_batches: 318
+tenant.sql_usage.write_requests: 1920
+tenant.sql_usage.write_bytes: 684720
+tenant.sql_usage.sql_pods_cpu_seconds: 0.00
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+tenant.sql_usage.estimated_kv_cpu_seconds: 0.62
+tenant.sql_usage.estimated_cpu_seconds: 0.82
+tenant.sql_usage.estimated_replication_bytes: 456480
+tenant.sql_usage.provisioned_vcpus: 48
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 311020
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
 
 # Now perform some read operations.
@@ -197,11 +239,11 @@ read repeat=1000 count=20 bytes=10000 localities=cross-zone
 advance wait=true
 1s
 ----
-00:00:54.000
+00:00:55.000
 
 token-bucket
 ----
-2045.34 tokens filling @ 0.00 tokens/s
+2034.21 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -210,18 +252,19 @@ tenant.sql_usage.kv_request_units: 0.00
 tenant.sql_usage.read_batches: 1000
 tenant.sql_usage.read_requests: 20000
 tenant.sql_usage.read_bytes: 10000000
-tenant.sql_usage.write_batches: 315
-tenant.sql_usage.write_requests: 1890
-tenant.sql_usage.write_bytes: 654570
+tenant.sql_usage.write_batches: 318
+tenant.sql_usage.write_requests: 1920
+tenant.sql_usage.write_bytes: 684720
 tenant.sql_usage.sql_pods_cpu_seconds: 0.00
 tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.23
-tenant.sql_usage.estimated_cpu_seconds: 2.95
-tenant.sql_usage.estimated_replication_bytes: 436380
-tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.24
+tenant.sql_usage.estimated_cpu_seconds: 2.97
+tenant.sql_usage.estimated_replication_bytes: 456480
+tenant.sql_usage.provisioned_vcpus: 48
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 311020
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
 
 # KV CPU seconds should not change, only total CPU seconds. Background CPU usage
@@ -233,11 +276,11 @@ cpu
 advance wait=true
 1s
 ----
-00:00:55.000
+00:00:56.000
 
 token-bucket
 ----
-733.59 tokens filling @ 0.00 tokens/s
+722.46 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -246,18 +289,19 @@ tenant.sql_usage.kv_request_units: 0.00
 tenant.sql_usage.read_batches: 1000
 tenant.sql_usage.read_requests: 20000
 tenant.sql_usage.read_bytes: 10000000
-tenant.sql_usage.write_batches: 315
-tenant.sql_usage.write_requests: 1890
-tenant.sql_usage.write_bytes: 654570
+tenant.sql_usage.write_batches: 318
+tenant.sql_usage.write_requests: 1920
+tenant.sql_usage.write_bytes: 684720
 tenant.sql_usage.sql_pods_cpu_seconds: 0.99
 tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 0
 tenant.sql_usage.external_io_egress_bytes: 0
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.23
-tenant.sql_usage.estimated_cpu_seconds: 4.27
-tenant.sql_usage.estimated_replication_bytes: 436380
-tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.24
+tenant.sql_usage.estimated_cpu_seconds: 4.28
+tenant.sql_usage.estimated_replication_bytes: 456480
+tenant.sql_usage.provisioned_vcpus: 48
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 311020
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
 
 # External I/O should not block or consume tokens.
@@ -270,11 +314,11 @@ external-ingress bytes=1024000
 advance wait=true
 1s
 ----
-00:00:56.000
+00:00:57.000
 
 token-bucket
 ----
-733.59 tokens filling @ 0.00 tokens/s
+722.46 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -283,18 +327,19 @@ tenant.sql_usage.kv_request_units: 0.00
 tenant.sql_usage.read_batches: 1000
 tenant.sql_usage.read_requests: 20000
 tenant.sql_usage.read_bytes: 10000000
-tenant.sql_usage.write_batches: 315
-tenant.sql_usage.write_requests: 1890
-tenant.sql_usage.write_bytes: 654570
+tenant.sql_usage.write_batches: 318
+tenant.sql_usage.write_requests: 1920
+tenant.sql_usage.write_bytes: 684720
 tenant.sql_usage.sql_pods_cpu_seconds: 0.99
 tenant.sql_usage.pgwire_egress_bytes: 0
 tenant.sql_usage.external_io_ingress_bytes: 1024000
 tenant.sql_usage.external_io_egress_bytes: 1024000
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.23
-tenant.sql_usage.estimated_cpu_seconds: 4.27
-tenant.sql_usage.estimated_replication_bytes: 436380
-tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.24
+tenant.sql_usage.estimated_cpu_seconds: 4.28
+tenant.sql_usage.estimated_replication_bytes: 456480
+tenant.sql_usage.provisioned_vcpus: 48
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 311020
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
 
 # PGWire egress should not block or consume tokens.
@@ -305,11 +350,11 @@ pgwire-egress
 advance wait=true
 1s
 ----
-00:00:57.000
+00:00:58.000
 
 token-bucket
 ----
-733.59 tokens filling @ 0.00 tokens/s
+722.46 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -318,18 +363,19 @@ tenant.sql_usage.kv_request_units: 0.00
 tenant.sql_usage.read_batches: 1000
 tenant.sql_usage.read_requests: 20000
 tenant.sql_usage.read_bytes: 10000000
-tenant.sql_usage.write_batches: 315
-tenant.sql_usage.write_requests: 1890
-tenant.sql_usage.write_bytes: 654570
+tenant.sql_usage.write_batches: 318
+tenant.sql_usage.write_requests: 1920
+tenant.sql_usage.write_bytes: 684720
 tenant.sql_usage.sql_pods_cpu_seconds: 0.99
 tenant.sql_usage.pgwire_egress_bytes: 12345
 tenant.sql_usage.external_io_ingress_bytes: 1024000
 tenant.sql_usage.external_io_egress_bytes: 1024000
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.23
-tenant.sql_usage.estimated_cpu_seconds: 4.27
-tenant.sql_usage.estimated_replication_bytes: 436380
-tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 290920
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.24
+tenant.sql_usage.estimated_cpu_seconds: 4.28
+tenant.sql_usage.estimated_replication_bytes: 456480
+tenant.sql_usage.provisioned_vcpus: 48
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 311020
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 145460
 
 # Ensure that token bucket request is made after 10 seconds (though it returns
@@ -337,7 +383,7 @@ tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone
 advance
 10s
 ----
-00:01:07.000
+00:01:08.000
 
 wait-for-event
 token-bucket-response
@@ -345,7 +391,7 @@ token-bucket-response
 
 token-bucket
 ----
-733.59 tokens filling @ 0.00 tokens/s
+722.46 tokens filling @ 0.00 tokens/s
 
 # Perform cross-region write request.
 write count=100 bytes=1000 localities=cross-region
@@ -355,11 +401,11 @@ write count=100 bytes=1000 localities=cross-region
 advance wait=true
 1s
 ----
-00:01:08.000
+00:01:09.000
 
 token-bucket
 ----
-693.13 tokens filling @ 0.00 tokens/s
+680.41 tokens filling @ 0.00 tokens/s
 
 metrics
 ----
@@ -368,19 +414,20 @@ tenant.sql_usage.kv_request_units: 0.00
 tenant.sql_usage.read_batches: 1000
 tenant.sql_usage.read_requests: 20000
 tenant.sql_usage.read_bytes: 10000000
-tenant.sql_usage.write_batches: 320
-tenant.sql_usage.write_requests: 2390
-tenant.sql_usage.write_bytes: 661570
+tenant.sql_usage.write_batches: 323
+tenant.sql_usage.write_requests: 2420
+tenant.sql_usage.write_bytes: 691720
 tenant.sql_usage.sql_pods_cpu_seconds: 0.99
 tenant.sql_usage.pgwire_egress_bytes: 12345
 tenant.sql_usage.external_io_ingress_bytes: 1024000
 tenant.sql_usage.external_io_egress_bytes: 1024000
 tenant.sql_usage.cross_region_network_ru: 0.00
-tenant.sql_usage.estimated_kv_cpu_seconds: 2.26
-tenant.sql_usage.estimated_cpu_seconds: 4.31
-tenant.sql_usage.estimated_replication_bytes: 441980
+tenant.sql_usage.estimated_kv_cpu_seconds: 2.27
+tenant.sql_usage.estimated_cpu_seconds: 4.32
+tenant.sql_usage.estimated_replication_bytes: 462080
+tenant.sql_usage.provisioned_vcpus: 48
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="",to_region="europe-west1",to_zone=""}: 2800
-tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 292320
+tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az1"}: 312420
 tenant.sql_usage.estimated_replication_bytes{from_region="us-central1",from_zone="az1",to_region="us-central1",to_zone="az2"}: 146860
 
 # Allow the provider to grant tokens again.
@@ -393,8 +440,8 @@ throttle: 0
 advance wait=true
 10s
 ----
-00:01:18.000
+00:01:19.000
 
 token-bucket
 ----
-693.13 tokens filling @ 0.00 tokens/s
+680.41 tokens filling @ 0.00 tokens/s

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -186,7 +186,7 @@ func runMultiTenantFairness(
 
 		t.L().Printf("virtual cluster %q started on n%d", name, node[0])
 		_, err := systemConn.ExecContext(
-			ctx, fmt.Sprintf("SELECT crdb_internal.update_tenant_resource_limits('%s', 1000000000, 10000, 1000000, now(), 0)", name),
+			ctx, fmt.Sprintf("SELECT crdb_internal.update_tenant_resource_limits('%s', 1000000000, 10000, 1000000)", name),
 		)
 		require.NoError(t, err)
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -255,7 +255,7 @@ query error tenant resource limits require a CCL binary
 SELECT crdb_internal.update_tenant_resource_limits(10, 1000, 100, 0, now(), 0)
 
 query error tenant resource limits require a CCL binary
-SELECT crdb_internal.update_tenant_resource_limits('tenant-number-ten', 1000, 100, 0, now(), 0)
+SELECT crdb_internal.update_tenant_resource_limits('tenant-number-ten', 1000, 100, 0)
 
 user testuser
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6964,15 +6964,11 @@ Parameters:` + randgencfg.ConfigDoc,
 			Volatility: volatility.Volatile,
 		},
 		tree.Overload{
-			// NOTE: as_of and as_of_consumed_tokens are not used and can be
-			// deprecated.
 			Types: tree.ParamTypes{
 				{Name: "tenant_name", Typ: types.String},
 				{Name: "available_tokens", Typ: types.Float},
 				{Name: "refill_rate", Typ: types.Float},
 				{Name: "max_burst_tokens", Typ: types.Float},
-				{Name: "as_of", Typ: types.Timestamp},
-				{Name: "as_of_consumed_tokens", Typ: types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2364,7 +2364,7 @@ var builtinOidsArray = []string{
 	2394: `array_cat_agg(arg1: varbit[]) -> varbit[]`,
 	2395: `array_cat_agg(arg1: anyenum[]) -> anyenum[]`,
 	2396: `array_cat_agg(arg1: tuple[]) -> tuple[]`,
-	2397: `crdb_internal.update_tenant_resource_limits(tenant_name: string, available_tokens: float, refill_rate: float, max_burst_tokens: float, as_of: timestamp, as_of_consumed_tokens: float) -> int`,
+	2397: `crdb_internal.update_tenant_resource_limits(tenant_name: string, available_tokens: float, refill_rate: float, max_burst_tokens: float) -> int`,
 	2398: `to_tsquery(text: string) -> tsquery`,
 	2399: `to_tsvector(text: string) -> tsvector`,
 	2400: `phraseto_tsquery(text: string) -> tsquery`,


### PR DESCRIPTION
These commits will be used by Cloud 2.0 to show the percentage of CPU in use and to switch over to tenant names from tenant ids.

Backport:
  * 1/1 commits from "tenantcostclient: add provisioned_vcpus setting and metric" (#128367)
  * 1/1 commits from "builtins: remove deprecated args from update_tenant_resource_limits" (#128433)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: This PR contains updates to functionality needed for the business-critical Cloud 2.0 release. In addition, these changes shouldn't have any impact on non-Serverless clusters.