### PR TITLE
raft: start sending MsgFortify requests on becoming leader

### DIFF
--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -11,6 +11,9 @@
 package kvserver
 
 import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
@@ -66,8 +69,17 @@ func (r *replicaRLockedStoreLiveness) SupportFrom(
 
 // SupportFromEnabled implements the raftstoreliveness.StoreLiveness interface.
 func (r *replicaRLockedStoreLiveness) SupportFromEnabled() bool {
-	// TODO(nvanbenschoten): hook this up to a version check and cluster setting.
-	return false
+	// TODO(mira): this version check is incorrect. For one, it doesn't belong
+	// here. Instead, the version should be checked when deciding to enable
+	// StoreLiveness or not. Then, the check here should only check whether store
+	// liveness is enabled. The other incorrect bit about this version check is
+	// that it re-uses clusterversion.V24_2_LeaseMinTimestamp; we should instead
+	// introduce a new version (V24_3_StoreLivenessEnabled); this can only happen
+	// once https://github.com/cockroachdb/cockroach/pull/128616 lands.
+	//
+	// TODO(nvanbenschoten): hook this up to a cluster setting to gradually roll
+	// out raft fortification.
+	return r.store.ClusterSettings().Version.IsActive(context.TODO(), clusterversion.V24_2_LeaseMinTimestamp)
 }
 
 // SupportExpired implements the raftstoreliveness.StoreLiveness interface.

--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
     deps = [
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
+        "//pkg/raft/raftstoreliveness",
         "//pkg/raft/rafttest",
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -472,6 +473,7 @@ func TestNodeStart(t *testing.T) {
 		Storage:         storage,
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
+		StoreLiveness:   raftstoreliveness.AlwaysLive{},
 	}
 	StartNode(c, []Peer{{ID: 1}})
 	ctx, cancel, n := newNodeTestHarness(context.Background(), t, c, Peer{ID: 1})
@@ -545,6 +547,7 @@ func TestNodeRestart(t *testing.T) {
 		Storage:         storage,
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
+		StoreLiveness:   raftstoreliveness.AlwaysLive{},
 	}
 	n := RestartNode(c)
 	defer n.Stop()
@@ -593,6 +596,7 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 		Storage:         s,
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
+		StoreLiveness:   raftstoreliveness.AlwaysLive{},
 	}
 	n := RestartNode(c)
 	defer n.Stop()
@@ -616,6 +620,7 @@ func TestNodeAdvance(t *testing.T) {
 		Storage:         storage,
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
+		StoreLiveness:   raftstoreliveness.AlwaysLive{},
 	}
 	ctx, cancel, n := newNodeTestHarness(context.Background(), t, c)
 	defer cancel()

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3892,6 +3893,7 @@ func newTestConfig(id pb.PeerID, election, heartbeat int, storage Storage) *Conf
 		Storage:         storage,
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
+		StoreLiveness:   raftstoreliveness.AlwaysLive{},
 	}
 }
 

--- a/pkg/raft/raftstoreliveness/store_liveness.go
+++ b/pkg/raft/raftstoreliveness/store_liveness.go
@@ -68,3 +68,29 @@ type StoreLiveness interface {
 	// point in time.
 	SupportExpired(ts hlc.Timestamp) bool
 }
+
+// AlwaysLive is a mock implementation of StoreLiveness that treats all store
+// to store connections as live.
+type AlwaysLive struct{}
+
+var _ StoreLiveness = AlwaysLive{}
+
+// SupportFor implements the StoreLiveness interface.
+func (AlwaysLive) SupportFor(pb.PeerID) (pb.Epoch, bool) {
+	return pb.Epoch(1), true
+}
+
+// SupportFrom implements the StoreLiveness interface.
+func (AlwaysLive) SupportFrom(pb.PeerID) (pb.Epoch, hlc.Timestamp, bool) {
+	return pb.Epoch(1), hlc.MaxTimestamp, true
+}
+
+// SupportFromEnabled implements the StoreLiveness interface.
+func (AlwaysLive) SupportFromEnabled() bool {
+	return true
+}
+
+// SupportExpired implements the StoreLiveness interface.
+func (AlwaysLive) SupportExpired(hlc.Timestamp) bool {
+	return false
+}

--- a/pkg/raft/rafttest/BUILD.bazel
+++ b/pkg/raft/rafttest/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
     deps = [
         "//pkg/raft",
         "//pkg/raft/raftpb",
+        "//pkg/raft/raftstoreliveness",
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",

--- a/pkg/raft/rafttest/interaction_env.go
+++ b/pkg/raft/rafttest/interaction_env.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 )
 
 // InteractionOpts groups the options for an InteractionEnv.
@@ -102,6 +103,7 @@ func raftConfigStub() raft.Config {
 		HeartbeatTick:   1,
 		MaxSizePerMsg:   math.MaxUint64,
 		MaxInflightMsgs: math.MaxInt32,
+		StoreLiveness:   raftstoreliveness.AlwaysLive{},
 	}
 }
 

--- a/pkg/raft/rafttest/node.go
+++ b/pkg/raft/rafttest/node.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 )
 
 type node struct {
@@ -52,6 +53,7 @@ func startNode(id raftpb.PeerID, peers []raft.Peer, iface iface) *node {
 		MaxSizePerMsg:             1024 * 1024,
 		MaxInflightMsgs:           256,
 		MaxUncommittedEntriesSize: 1 << 30,
+		StoreLiveness:             raftstoreliveness.AlwaysLive{},
 	}
 	rn := raft.StartNode(c, peers)
 	n := &node{
@@ -142,6 +144,7 @@ func (n *node) restart() {
 		MaxSizePerMsg:             1024 * 1024,
 		MaxInflightMsgs:           256,
 		MaxUncommittedEntriesSize: 1 << 30,
+		StoreLiveness:             raftstoreliveness.AlwaysLive{},
 	}
 	n.Node = raft.RestartNode(c)
 	n.start()

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -88,6 +88,8 @@ stabilize
   Entries:
   1/11 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""] Responses:[
@@ -95,8 +97,10 @@ stabilize
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 1 processing append thread
   Processing:
@@ -110,6 +114,7 @@ stabilize
   Entries:
   1/11 EntryNormal ""
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""] Responses:[
     2->1 MsgAppResp Term:1 Log:0/11
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
@@ -120,6 +125,7 @@ stabilize
   Entries:
   1/11 EntryNormal ""
   Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""] Responses:[
     3->1 MsgAppResp Term:1 Log:0/11
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
@@ -127,6 +133,8 @@ stabilize
 > 1 receiving messages
   1->1 MsgAppResp Term:1 Log:0/11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""]

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -189,6 +189,12 @@ HardState Term:2 Vote:3 Commit:11 Lead:3
 Entries:
 2/12 EntryNormal ""
 Messages:
+3->1 MsgFortifyLeader Term:2 Log:0/0
+3->2 MsgFortifyLeader Term:2 Log:0/0
+3->4 MsgFortifyLeader Term:2 Log:0/0
+3->5 MsgFortifyLeader Term:2 Log:0/0
+3->6 MsgFortifyLeader Term:2 Log:0/0
+3->7 MsgFortifyLeader Term:2 Log:0/0
 3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->4 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
@@ -206,15 +212,21 @@ deliver-msgs 1 drop=(2,4,5,6,7)
 INFO 1 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
 INFO 1 became follower at term 2
 INFO 1 [logterm: 1, index: 12, vote: 0] rejected MsgVote from 3 [logterm: 1, index: 11] at term 2
+3->1 MsgFortifyLeader Term:2 Log:0/0
 3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 INFO found conflict at index 12 [existing term: 1, conflicting term: 2]
 INFO replace the unstable entries from index 12
 dropped: 3->2 MsgVote Term:2 Log:1/11
+dropped: 3->2 MsgFortifyLeader Term:2 Log:0/0
 dropped: 3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+dropped: 3->4 MsgFortifyLeader Term:2 Log:0/0
 dropped: 3->4 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+dropped: 3->5 MsgFortifyLeader Term:2 Log:0/0
 dropped: 3->5 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+dropped: 3->6 MsgFortifyLeader Term:2 Log:0/0
 dropped: 3->6 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 dropped: 3->7 MsgVote Term:2 Log:1/11
+dropped: 3->7 MsgFortifyLeader Term:2 Log:0/0
 dropped: 3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 
 process-ready 1
@@ -224,6 +236,7 @@ HardState Term:2 Commit:11 Lead:3
 Entries:
 2/12 EntryNormal ""
 Messages:
+1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
 1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Lead:3 Entries:[2/12 EntryNormal ""] Responses:[
   1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->3 MsgAppResp Term:2 Log:0/12
@@ -345,6 +358,12 @@ HardState Term:3 Vote:4 Commit:11 Lead:4
 Entries:
 3/12 EntryNormal ""
 Messages:
+4->1 MsgFortifyLeader Term:3 Log:0/0
+4->2 MsgFortifyLeader Term:3 Log:0/0
+4->3 MsgFortifyLeader Term:3 Log:0/0
+4->5 MsgFortifyLeader Term:3 Log:0/0
+4->6 MsgFortifyLeader Term:3 Log:0/0
+4->7 MsgFortifyLeader Term:3 Log:0/0
 4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->2 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
@@ -365,6 +384,7 @@ Messages:
 deliver-msgs drop=1
 ----
 dropped: 4->1 MsgVote Term:3 Log:1/11
+dropped: 4->1 MsgFortifyLeader Term:3 Log:0/0
 dropped: 4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 
 tick-heartbeat 4

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -65,11 +65,15 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=true:
@@ -77,6 +81,7 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/3
 > 3 handling Ready
   Ready MustSync=true:
@@ -84,9 +89,12 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/3
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -100,17 +100,22 @@ stabilize 2 3
   Entries:
   2/5 EntryNormal ""
   Messages:
+  2->1 MsgFortifyLeader Term:2 Log:0/0
+  2->3 MsgFortifyLeader Term:2 Log:0/0
   2->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
 > 3 receiving messages
+  2->3 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:3 Lead:2
   Messages:
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
 > 2 receiving messages
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -180,20 +180,25 @@ stabilize
   Entries:
   3/12 EntryNormal ""
   Messages:
+  2->1 MsgFortifyLeader Term:3 Log:0/0
+  2->3 MsgFortifyLeader Term:3 Log:0/0
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
   2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 1 receiving messages
+  2->1 MsgFortifyLeader Term:3 Log:0/0
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-  INFO 3 [term: 1] received a MsgApp message with higher term from 2 [term: 3]
+  2->3 MsgFortifyLeader Term:3 Log:0/0
+  INFO 3 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3]
   INFO 3 became follower at term 3
+  2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:11 Lead:2
   Entries:
   3/12 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   1->2 MsgAppResp Term:3 Log:0/12
 > 3 handling Ready
   Ready MustSync=true:
@@ -201,9 +206,12 @@ stabilize
   Entries:
   3/12 EntryNormal ""
   Messages:
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:3 Log:0/12
 > 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   1->2 MsgAppResp Term:3 Log:0/12
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:3 Log:0/12
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -230,14 +230,20 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
+  4->1 MsgFortifyLeader Term:2 Log:0/0
+  4->2 MsgFortifyLeader Term:2 Log:0/0
+  4->3 MsgFortifyLeader Term:2 Log:0/0
   4->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   4->2 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   4->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
 > 1 receiving messages
+  4->1 MsgFortifyLeader Term:2 Log:0/0
   4->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
 > 2 receiving messages
+  4->2 MsgFortifyLeader Term:2 Log:0/0
   4->2 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
 > 3 receiving messages
+  4->3 MsgFortifyLeader Term:2 Log:0/0
   4->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
@@ -245,6 +251,7 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
+  1->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->4 MsgAppResp Term:2 Log:0/5
 > 2 handling Ready
   Ready MustSync=true:
@@ -252,6 +259,7 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
+  2->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   2->4 MsgAppResp Term:2 Log:0/5
 > 3 handling Ready
   Ready MustSync=true:
@@ -259,10 +267,14 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
+  3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->4 MsgAppResp Term:2 Log:0/5
 > 4 receiving messages
+  1->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->4 MsgAppResp Term:2 Log:0/5
+  2->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   2->4 MsgAppResp Term:2 Log:0/5
+  3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->4 MsgAppResp Term:2 Log:0/5
 > 4 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -213,11 +213,15 @@ stabilize
   Entries:
   2/13 EntryNormal ""
   Messages:
+  2->1 MsgFortifyLeader Term:2 Log:0/0
+  2->3 MsgFortifyLeader Term:2 Log:0/0
   2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
   2->3 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
 > 1 receiving messages
+  2->1 MsgFortifyLeader Term:2 Log:0/0
   2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
 > 3 receiving messages
+  2->3 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
@@ -225,6 +229,7 @@ stabilize
   Entries:
   2/13 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->2 MsgAppResp Term:2 Log:0/13
 > 3 handling Ready
   Ready MustSync=true:
@@ -232,9 +237,12 @@ stabilize
   Entries:
   2/13 EntryNormal ""
   Messages:
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:2 Log:0/13
 > 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->2 MsgAppResp Term:2 Log:0/13
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:2 Log:0/13
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -135,13 +135,17 @@ stabilize
   Entries:
   2/12 EntryNormal ""
   Messages:
+  3->1 MsgFortifyLeader Term:2 Log:0/0
+  3->2 MsgFortifyLeader Term:2 Log:0/0
   3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
-  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
-  INFO 1 [term: 1] received a MsgApp message with higher term from 3 [term: 2]
+  3->1 MsgFortifyLeader Term:2 Log:0/0
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 3 [term: 2]
   INFO 1 became follower at term 2
+  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 2 receiving messages
+  3->2 MsgFortifyLeader Term:2 Log:0/0
   3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
@@ -150,6 +154,7 @@ stabilize
   Entries:
   2/12 EntryNormal ""
   Messages:
+  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->3 MsgAppResp Term:2 Log:0/12
 > 2 handling Ready
   Ready MustSync=true:
@@ -157,9 +162,12 @@ stabilize
   Entries:
   2/12 EntryNormal ""
   Messages:
+  2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   2->3 MsgAppResp Term:2 Log:0/12
 > 3 receiving messages
+  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   1->3 MsgAppResp Term:2 Log:0/12
+  2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   2->3 MsgAppResp Term:2 Log:0/12
 > 3 handling Ready
   Ready MustSync=false:
@@ -294,20 +302,25 @@ stabilize
   Entries:
   3/13 EntryNormal ""
   Messages:
+  2->1 MsgFortifyLeader Term:3 Log:0/0
+  2->3 MsgFortifyLeader Term:3 Log:0/0
   2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 receiving messages
+  2->1 MsgFortifyLeader Term:3 Log:0/0
   2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
-  INFO 3 [term: 2] received a MsgApp message with higher term from 2 [term: 3]
+  2->3 MsgFortifyLeader Term:3 Log:0/0
+  INFO 3 [term: 2] received a MsgFortifyLeader message with higher term from 2 [term: 3]
   INFO 3 became follower at term 3
+  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12 Lead:2
   Entries:
   3/13 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   1->2 MsgAppResp Term:3 Log:0/13
 > 3 handling Ready
   Ready MustSync=true:
@@ -316,9 +329,12 @@ stabilize
   Entries:
   3/13 EntryNormal ""
   Messages:
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:3 Log:0/13
 > 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   1->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:3 Log:0/13
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -473,6 +473,12 @@ stabilize 1
   Entries:
   8/21 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeader Term:8 Log:0/0
+  1->3 MsgFortifyLeader Term:8 Log:0/0
+  1->4 MsgFortifyLeader Term:8 Log:0/0
+  1->5 MsgFortifyLeader Term:8 Log:0/0
+  1->6 MsgFortifyLeader Term:8 Log:0/0
+  1->7 MsgFortifyLeader Term:8 Log:0/0
   1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
@@ -484,13 +490,16 @@ stabilize 1
 stabilize 1 2
 ----
 > 2 receiving messages
+  1->2 MsgFortifyLeader Term:8 Log:0/0
   1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:18 Lead:1
   Messages:
+  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
 > 1 handling Ready
   Ready MustSync=false:
@@ -517,13 +526,16 @@ stabilize 1 2
 stabilize 1 3
 ----
 > 3 receiving messages
+  1->3 MsgFortifyLeader Term:8 Log:0/0
   1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:14 Lead:1
   Messages:
+  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
 > 1 receiving messages
+  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
 > 1 handling Ready
   Ready MustSync=false:
@@ -571,6 +583,7 @@ stabilize 1 3
 stabilize 1 4
 ----
 > 4 receiving messages
+  1->4 MsgFortifyLeader Term:8 Log:0/0
   1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   INFO found conflict at index 21 [existing term: 6, conflicting term: 8]
   INFO replace the unstable entries from index 21
@@ -580,8 +593,10 @@ stabilize 1 4
   Entries:
   8/21 EntryNormal ""
   Messages:
+  4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   4->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages
+  4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   4->1 MsgAppResp Term:8 Log:0/21
 > 1 handling Ready
   Ready MustSync=false:
@@ -611,13 +626,16 @@ stabilize 1 4
 stabilize 1 5
 ----
 > 5 receiving messages
+  1->5 MsgFortifyLeader Term:8 Log:0/0
   1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 5 handling Ready
   Ready MustSync=true:
   HardState Term:8 Commit:18 Lead:1
   Messages:
+  5->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
 > 1 receiving messages
+  5->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
 > 1 handling Ready
   Ready MustSync=false:
@@ -654,13 +672,16 @@ stabilize 1 5
 stabilize 1 6
 ----
 > 6 receiving messages
+  1->6 MsgFortifyLeader Term:8 Log:0/0
   1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 6 handling Ready
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:15 Lead:1
   Messages:
+  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
 > 1 receiving messages
+  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
 > 1 handling Ready
   Ready MustSync=false:
@@ -709,13 +730,16 @@ stabilize 1 6
 stabilize 1 7
 ----
 > 7 receiving messages
+  1->7 MsgFortifyLeader Term:8 Log:0/0
   1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 7 handling Ready
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:13 Lead:1
   Messages:
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
 > 1 receiving messages
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
 > 1 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -107,6 +107,7 @@ Messages:
 # 3 receives and applies the snapshot, but doesn't respond with MsgAppResp yet.
 deliver-msgs 3
 ----
+1->3 MsgFortifyLeader Term:1 Log:0/0
 1->3 MsgSnap Term:1 Log:0/0
   Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
@@ -146,11 +147,13 @@ stabilize 3
   HardState Term:1 Vote:1 Commit:11 Lead:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/11
 
 stabilize 1
 ----
 > 1 receiving messages
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 paused pendingSnap=12]
 > 1 handling Ready


### PR DESCRIPTION
With this patch, raft leaders broadcast a MsgFortifyLeader to all peers
after being successfully elected as leader. We added most of the
structure for this in
https://github.com/cockroachdb/cockroach/pull/128426. However, we never
actually sent messages to fortify leadership because doing so needed to
be predicated on a cluster version check. This patch simply adds the
cluster version check and updates tests.

We're not handling MsgFortifyLeader or MsgFortifyLeaderResp just yet.
That'll happen in a subsequent patch.

Informs https://github.com/cockroachdb/cockroach/issues/125261

Release note: None