### PR TITLE
workflows: fix cockroach-microbench-ci step failing

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -369,6 +369,7 @@ jobs:
           
           # Set the latest commit hash as an output variable
           echo "::set-output name=latest_commit::$LATEST_COMMIT"
+        if: ${{ github.event_name != 'push' }}
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
@@ -380,11 +381,11 @@ jobs:
         run: ./build/github/cockroach-microbench-ci.sh
         env:
           COMPARE_THRESHOLD: "5.00"
-          PUSH_STEP: ${{ github.event_name == 'push' }}
+          PUSH_STEP: ${{ github.event_name == 'push' && env.GITHUB_ACTIONS_BRANCH != 'staging' }}
           BASE_SHA: ${{ steps.get_latest_commit_target_branch.outputs.latest_commit }}
 
           # TODO(sambhav-jain-16): add Performance note check and use this flag. Currently set to false (https://github.com/cockroachdb/cockroach/issues/106661)
-          SKIP_COMPARISON: false
+          SKIP_COMPARISON: ${{ env.GITHUB_ACTIONS_BRANCH == 'staging' }}
       - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -53,8 +53,8 @@ $roachprod_microbench_dir/roachprod-microbench clean "$log_output_file_path" "$c
 
 # Push artifact if this is a base merge and skip comparison
 if $PUSH_STEP; then
-  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_HEAD_REF/$GITHUB_SHA.log"
-  echo "Skipping comparison since this is a base merge."
+  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_REF/$GITHUB_SHA.log"
+  echo "Skipping comparison since this is a push step into the target branch"
   exit $success_exit_status
 fi
 
@@ -64,7 +64,7 @@ if ! gcloud storage cp "$storage_bucket_url/$GITHUB_BASE_REF/$BASE_SHA.log" "$cl
   exit $success_exit_status
 fi
 
-if ! $roachprod_microbench_dir/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold "$threshold"; then
+if ! $roachprod_microbench_dir/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold="$threshold" --publish-sheets=false; then
   echo "There is an error during comparison. If it's a perf regression, please try to fix it. This won't block your change for merging currently."
   exit $error_exit_status
 fi


### PR DESCRIPTION
There were errors during the push step of staging and master github
actions branch. Since both are push step, the jobs are trying to upload
the results in both cases which is duplicated data. Also
`GITHUB_HEAD_REF` doesn't work in cases of push step.

Fixes in this change:
1. Add `staging` branch into the skip comparison part.
2. Use `GITHUB_REF` rather than `GITHUB_HEAD_REF`.
3. Add `--publish-sheets=false` to roachprod-microbench compare command

Epic: none

Release note: None