### PR TITLE
workflows: fix cockroach-microbench-ci step failing

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -348,43 +348,44 @@ jobs:
     runs-on: [ self-hosted, basic_runner_group ]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1  # Fetch only the latest commit
-
-      - name: Get the latest commit of the target branch
-        id: get_latest_commit_target_branch
-        run: |
-          # Get the target branch name
-          TARGET_BRANCH=${{ github.event.pull_request.base.ref }}
-          
-          # Fetch the latest commit of the target branch
-          git fetch origin $TARGET_BRANCH --depth=1
-          
-          # Get the latest commit hash of the target branch
-          LATEST_COMMIT=$(git rev-parse FETCH_HEAD)
-          
-          # Output the latest commit hash
-          echo "Latest commit on target branch ($TARGET_BRANCH): $LATEST_COMMIT"
-          
-          # Set the latest commit hash as an output variable
-          echo "::set-output name=latest_commit::$LATEST_COMMIT"
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 1  # Fetch only the latest commit
+#
+#      - name: Get the latest commit of the target branch
+#        id: get_latest_commit_target_branch
+#        run: |
+#          # Get the target branch name
+#          TARGET_BRANCH=${{ github.event.pull_request.base.ref }}
+#
+#          # Fetch the latest commit of the target branch
+#          git fetch origin $TARGET_BRANCH --depth=1
+#
+#          # Get the latest commit hash of the target branch
+#          LATEST_COMMIT=$(git rev-parse FETCH_HEAD)
+#
+#          # Output the latest commit hash
+#          echo "Latest commit on target branch ($TARGET_BRANCH): $LATEST_COMMIT"
+#
+#          # Set the latest commit hash as an output variable
+#          echo "::set-output name=latest_commit::$LATEST_COMMIT"
+#        if: ${{ github.event_name != 'push' }}
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: compute metadata
-        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
-      - run: ./build/github/get-engflow-keys.sh
-      - run: ./build/github/prepare-summarize-build.sh
+#      - name: compute metadata
+#        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
+#      - run: ./build/github/get-engflow-keys.sh
+#      - run: ./build/github/prepare-summarize-build.sh
       - name: run scripts
         run: ./build/github/cockroach-microbench-ci.sh
         env:
           COMPARE_THRESHOLD: "5.00"
-          PUSH_STEP: ${{ github.event_name == 'push' }}
+          PUSH_STEP: ${{ github.event_name == 'push' && env.GITHUB_ACTIONS_BRANCH != 'staging' }}
           BASE_SHA: ${{ steps.get_latest_commit_target_branch.outputs.latest_commit }}
 
           # TODO(sambhav-jain-16): add Performance note check and use this flag. Currently set to false (https://github.com/cockroachdb/cockroach/issues/106661)
-          SKIP_COMPARISON: false
+          SKIP_COMPARISON: ${{ env.GITHUB_ACTIONS_BRANCH == 'staging' }}
       - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -17,7 +17,7 @@ threshold=${COMPARE_THRESHOLD:-0}
 success_exit_status=0
 error_exit_status=1
 
-gsutil mv gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://cockroach-microbench-ci/master/
+gsutil cp gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://cockroach-microbench-ci/master/2558f3f3a1dab0907db3dafd510ec5bc2464073f.log
 # Exit early if SKIP_COMPARISON is true and not a push step
 #if $SKIP_COMPARISON && ! $PUSH_STEP; then
 #  echo "Exiting since skip comparison is enabled and this is not a push step."

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -17,57 +17,58 @@ threshold=${COMPARE_THRESHOLD:-0}
 success_exit_status=0
 error_exit_status=1
 
+gsutil mv gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://cockroach-microbench-ci/master/
 # Exit early if SKIP_COMPARISON is true and not a push step
-if $SKIP_COMPARISON && ! $PUSH_STEP; then
-  echo "Exiting since skip comparison is enabled and this is not a push step."
-  exit $success_exit_status
-fi
-
-# Build binary with Bazel
-bazel build --config crosslinux $(./build/github/engflow-args.sh) --jobs 100 //pkg/cmd/roachprod-microbench
-
-roachprod_microbench_dir="_bazel/bin/pkg/cmd/roachprod-microbench/roachprod-microbench_"
-
-mkdir -p "$output_dir"
-
-# Run benchmarks and clean output
-# running count=4 here because that's the minimum required for a comparison
-bazel test //pkg/sql/tests:tests_test \
-  --config=use_ci_timeouts \
-  --strategy=TestRunner=sandboxed \
-  --jobs 100 \
-  --config=crosslinux \
-  --remote_download_minimal \
-  $(./build/github/engflow-args.sh) \
-  --test_arg=-test.run=- \
-  --test_arg='-test.bench=^BenchmarkKV$' \
-  --test_sharding_strategy=disabled \
-  --test_arg=-test.cpu --test_arg=1 \
-  --test_arg=-test.v \
-  --test_arg=-test.count=4 \
-  --test_arg=-test.benchmem \
-  --crdb_test_off \
-  --test_output=all > "$log_output_file_path"
-
-$roachprod_microbench_dir/roachprod-microbench clean "$log_output_file_path" "$cleaned_current_dir/$benchmark_file_name"
-
-# Push artifact if this is a base merge and skip comparison
-if $PUSH_STEP; then
-  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_HEAD_REF/$GITHUB_SHA.log"
-  echo "Skipping comparison since this is a base merge."
-  exit $success_exit_status
-fi
-
-# Compare benchmarks
-if ! gcloud storage cp "$storage_bucket_url/$GITHUB_BASE_REF/$BASE_SHA.log" "$cleaned_base_dir/$benchmark_file_name"; then
-  echo "Couldn't download base bench file, exiting."
-  exit $success_exit_status
-fi
-
-if ! $roachprod_microbench_dir/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold "$threshold"; then
-  echo "There is an error during comparison. If it's a perf regression, please try to fix it. This won't block your change for merging currently."
-  exit $error_exit_status
-fi
-
-rm -rf "$output_dir"
-exit $success_exit_status
+#if $SKIP_COMPARISON && ! $PUSH_STEP; then
+#  echo "Exiting since skip comparison is enabled and this is not a push step."
+#  exit $success_exit_status
+#fi
+#
+## Build binary with Bazel
+#bazel build --config crosslinux $(./build/github/engflow-args.sh) --jobs 100 //pkg/cmd/roachprod-microbench
+#
+#roachprod_microbench_dir="_bazel/bin/pkg/cmd/roachprod-microbench/roachprod-microbench_"
+#
+#mkdir -p "$output_dir"
+#
+## Run benchmarks and clean output
+## running count=4 here because that's the minimum required for a comparison
+#bazel test //pkg/sql/tests:tests_test \
+#  --config=use_ci_timeouts \
+#  --strategy=TestRunner=sandboxed \
+#  --jobs 100 \
+#  --config=crosslinux \
+#  --remote_download_minimal \
+#  $(./build/github/engflow-args.sh) \
+#  --test_arg=-test.run=- \
+#  --test_arg='-test.bench=^BenchmarkKV$' \
+#  --test_sharding_strategy=disabled \
+#  --test_arg=-test.cpu --test_arg=1 \
+#  --test_arg=-test.v \
+#  --test_arg=-test.count=4 \
+#  --test_arg=-test.benchmem \
+#  --crdb_test_off \
+#  --test_output=all > "$log_output_file_path"
+#
+#$roachprod_microbench_dir/roachprod-microbench clean "$log_output_file_path" "$cleaned_current_dir/$benchmark_file_name"
+#
+## Push artifact if this is a base merge and skip comparison
+#if $PUSH_STEP; then
+#  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_REF/$GITHUB_SHA.log"
+#  echo "Skipping comparison since this is a push step into the target branch"
+#  exit $success_exit_status
+#fi
+#
+## Compare benchmarks
+#if ! gcloud storage cp "$storage_bucket_url/$GITHUB_BASE_REF/$BASE_SHA.log" "$cleaned_base_dir/$benchmark_file_name"; then
+#  echo "Couldn't download base bench file, exiting."
+#  exit $success_exit_status
+#fi
+#
+#if ! $roachprod_microbench_dir/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold "$threshold"; then
+#  echo "There is an error during comparison. If it's a perf regression, please try to fix it. This won't block your change for merging currently."
+#  exit $error_exit_status
+#fi
+#
+#rm -rf "$output_dir"
+#exit $success_exit_status

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -17,7 +17,7 @@ threshold=${COMPARE_THRESHOLD:-0}
 success_exit_status=0
 error_exit_status=1
 
-gsutil cp gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://cockroach-microbench-ci/master/2558f3f3a1dab0907db3dafd510ec5bc2464073f.log
+gsutil cp gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://"cockroach-microbench-ci/master/2558f3f3a1dab0907db3dafd510ec5bc2464073f.log"
 # Exit early if SKIP_COMPARISON is true and not a push step
 #if $SKIP_COMPARISON && ! $PUSH_STEP; then
 #  echo "Exiting since skip comparison is enabled and this is not a push step."

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -17,44 +17,44 @@ threshold=${COMPARE_THRESHOLD:-0}
 success_exit_status=0
 error_exit_status=1
 
-gsutil cp gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://"cockroach-microbench-ci/master/2558f3f3a1dab0907db3dafd510ec5bc2464073f.log"
+# gsutil cp gs://cockroach-microbench-ci//2558f3f3a1dab0907db3dafd510ec5bc2464073f.log gs://"cockroach-microbench-ci/master/2558f3f3a1dab0907db3dafd510ec5bc2464073f.log"
 # Exit early if SKIP_COMPARISON is true and not a push step
 #if $SKIP_COMPARISON && ! $PUSH_STEP; then
 #  echo "Exiting since skip comparison is enabled and this is not a push step."
 #  exit $success_exit_status
 #fi
 #
-## Build binary with Bazel
-#bazel build --config crosslinux $(./build/github/engflow-args.sh) --jobs 100 //pkg/cmd/roachprod-microbench
+# Build binary with Bazel
+bazel build --config crosslinux $(./build/github/engflow-args.sh) --jobs 100 //pkg/cmd/roachprod-microbench
+
+roachprod_microbench_dir="_bazel/bin/pkg/cmd/roachprod-microbench/roachprod-microbench_"
+
+mkdir -p "$output_dir"
+
+# Run benchmarks and clean output
+# running count=4 here because that's the minimum required for a comparison
+bazel test //pkg/sql/tests:tests_test \
+ --config=use_ci_timeouts \
+ --strategy=TestRunner=sandboxed \
+ --jobs 100 \
+ --config=crosslinux \
+ --remote_download_minimal \
+ $(./build/github/engflow-args.sh) \
+ --test_arg=-test.run=- \
+ --test_arg='-test.bench=^BenchmarkKV$' \
+ --test_sharding_strategy=disabled \
+ --test_arg=-test.cpu --test_arg=1 \
+ --test_arg=-test.v \
+ --test_arg=-test.count=4 \
+ --test_arg=-test.benchmem \
+ --crdb_test_off \
+ --test_output=all > "$log_output_file_path"
 #
-#roachprod_microbench_dir="_bazel/bin/pkg/cmd/roachprod-microbench/roachprod-microbench_"
-#
-#mkdir -p "$output_dir"
-#
-## Run benchmarks and clean output
-## running count=4 here because that's the minimum required for a comparison
-#bazel test //pkg/sql/tests:tests_test \
-#  --config=use_ci_timeouts \
-#  --strategy=TestRunner=sandboxed \
-#  --jobs 100 \
-#  --config=crosslinux \
-#  --remote_download_minimal \
-#  $(./build/github/engflow-args.sh) \
-#  --test_arg=-test.run=- \
-#  --test_arg='-test.bench=^BenchmarkKV$' \
-#  --test_sharding_strategy=disabled \
-#  --test_arg=-test.cpu --test_arg=1 \
-#  --test_arg=-test.v \
-#  --test_arg=-test.count=4 \
-#  --test_arg=-test.benchmem \
-#  --crdb_test_off \
-#  --test_output=all > "$log_output_file_path"
-#
-#$roachprod_microbench_dir/roachprod-microbench clean "$log_output_file_path" "$cleaned_current_dir/$benchmark_file_name"
+$roachprod_microbench_dir/roachprod-microbench clean "$log_output_file_path" "$cleaned_current_dir/$benchmark_file_name"
 #
 ## Push artifact if this is a base merge and skip comparison
 #if $PUSH_STEP; then
-#  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_REF/$GITHUB_SHA.log"
+ gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/master/2558f3f3a1dab0907db3dafd510ec5bc2464073f.log"
 #  echo "Skipping comparison since this is a push step into the target branch"
 #  exit $success_exit_status
 #fi


### PR DESCRIPTION
There were errors during the push step of staging and master github actions branch. Since both are push step, the jobs are trying to upload the results in both cases which is duplicated data. Also `GITHUB_HEAD_REF` doesn't work in cases of push step.

Fixes in this change:
1. Add `staging` branch into the skip comparison part.
2. Use `GITHUB_REF` rather than `GITHUB_HEAD_REF`.

Epic: none

Release note: None