### PR TITLE
roachprod-microbench: fix threshold log

### DIFF
--- a/pkg/cmd/roachprod-microbench/compare.go
+++ b/pkg/cmd/roachprod-microbench/compare.go
@@ -312,7 +312,7 @@ func (c *compare) compareUsingThreshold(comparisonResultsMap model.ComparisonRes
 	if len(reportStrings) > 0 {
 		reportString := strings.Join(reportStrings, "\n\n")
 		return errors.Errorf("there are benchmark regressions of > %.2f%% in the following packages:\n\n%s",
-			c.threshold*100, reportString)
+			c.threshold, reportString)
 	}
 
 	return nil


### PR DESCRIPTION
When there's a threshold error in compare command, the log line multiplies the threshold value with 100. This is wrong since we pass percentage value in the threshold itself

Epic: none

Release note: None