### PR TITLE
crosscluster/logical: retry for longer

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -597,8 +597,12 @@ func getRetryPolicy(knobs *sql.StreamingTestingKnobs) retry.Options {
 	// This feature is potentially running over WAN network links / the public
 	// internet, so we want to recover on our own from hiccups that could last a
 	// few seconds or even minutes. Thus we allow a relatively long MaxBackoff and
-	// number of retries that should cause us to retry for a few minutes.
-	return retry.Options{MaxBackoff: 15 * time.Second, MaxRetries: 20} // 205.5s.
+	// number of retries that should cause us to retry for several minutes.
+	return retry.Options{
+		InitialBackoff: 250 * time.Millisecond,
+		MaxBackoff:     1 * time.Minute,
+		MaxRetries:     30,
+	}
 }
 
 func init() {


### PR DESCRIPTION
This retry configuration was very aggressive, exhausting all retries in under 5 minutes. This feature is intended for use in situations where there may be prolonged network disruption.

Here, we adjust the config so that we retry for closer to 20 minutes before pausing the job. We should consider pushing this even further.

Fixes #128659
Release note: None