### PR TITLE
roachtest: update version skipping logic in mixedversion

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -181,13 +181,14 @@ func Test_choosePreviousReleases(t *testing.T) {
 			numUpgrades:      6,
 			expectedReleases: []string{"22.2.14", "23.1.17", "23.2.4", "24.1.1", "24.2.2"},
 		},
-		{
-			name:              "skip-version upgrades",
-			arch:              vm.ArchAMD64,
-			numUpgrades:       3,
-			enableSkipVersion: true,
-			expectedReleases:  []string{"23.1.17", "23.2.4", "24.1.1"},
-		},
+		// TODO(radu): reenable when we actually support a skippable release.
+		//{
+		//	name:              "skip-version upgrades",
+		//	arch:              vm.ArchAMD64,
+		//	numUpgrades:       3,
+		//	enableSkipVersion: true,
+		//	expectedReleases:  []string{"23.1.17", "23.2.4", "24.1.1"},
+		//},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/skip_version_upgrades
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/skip_version_upgrades
@@ -1,106 +1,107 @@
-# Test that we are able to generate "skip-version" upgrades when
-# requested (default disabled if no custom option is passed).
-
-mixed-version-test predecessors=(22.2.3, 23.1.4, 23.2.0, 24.1.1, 24.2.0) num_upgrades=3 enable_skip_version
-----
-ok
-
-in-mixed-version name=(mixed-version 1)
-----
-ok
-
-in-mixed-version name=(mixed-version 2)
-----
-ok
-
-workload name=bank
-----
-ok
-
-background-command name=(csv server)
-----
-ok
-
-after-upgrade-finalized name=(validate upgrade)
-----
-ok
-
-plan
-----
-Seed:               12345
-Upgrades:           v23.1.4 → v23.2.0 → v24.1.1 → <current>
-Deployment mode:    system-only
-Plan:
-├── install fixtures for version "v23.1.4" (1)
-├── start cluster at version "v23.1.4" (2)
-├── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (3)
-├── run "initialize bank workload" (4)
-├── start background hooks concurrently
-│   ├── run "bank workload", after 3m0s delay (5)
-│   └── run "csv server", after 5s delay (6)
-├── upgrade cluster from "v23.1.4" to "v23.2.0"
-│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (7)
-│   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
-│   │   ├── restart node 4 with binary version v23.2.0 (8)
-│   │   ├── restart node 1 with binary version v23.2.0 (9)
-│   │   ├── run mixed-version hooks concurrently
-│   │   │   ├── run "mixed-version 1", after 500ms delay (10)
-│   │   │   └── run "mixed-version 2", after 5s delay (11)
-│   │   ├── restart node 2 with binary version v23.2.0 (12)
-│   │   └── restart node 3 with binary version v23.2.0 (13)
-│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (14)
-│   ├── run mixed-version hooks concurrently
-│   │   ├── run "mixed-version 1", after 100ms delay (15)
-│   │   └── run "mixed-version 2", after 500ms delay (16)
-│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (17)
-│   └── run "validate upgrade" (18)
-├── upgrade cluster from "v23.2.0" to "v24.1.1"
-│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (19)
-│   ├── upgrade nodes :1-4 from "v23.2.0" to "v24.1.1"
-│   │   ├── restart node 1 with binary version v24.1.1 (20)
-│   │   ├── restart node 3 with binary version v24.1.1 (21)
-│   │   ├── restart node 4 with binary version v24.1.1 (22)
-│   │   ├── run "mixed-version 1" (23)
-│   │   ├── restart node 2 with binary version v24.1.1 (24)
-│   │   └── run "mixed-version 2" (25)
-│   ├── downgrade nodes :1-4 from "v24.1.1" to "v23.2.0"
-│   │   ├── restart node 4 with binary version v23.2.0 (26)
-│   │   ├── restart node 3 with binary version v23.2.0 (27)
-│   │   ├── restart node 2 with binary version v23.2.0 (28)
-│   │   └── restart node 1 with binary version v23.2.0 (29)
-│   ├── upgrade nodes :1-4 from "v23.2.0" to "v24.1.1"
-│   │   ├── restart node 3 with binary version v24.1.1 (30)
-│   │   ├── run "mixed-version 1" (31)
-│   │   ├── restart node 2 with binary version v24.1.1 (32)
-│   │   ├── restart node 1 with binary version v24.1.1 (33)
-│   │   ├── run "mixed-version 2" (34)
-│   │   └── restart node 4 with binary version v24.1.1 (35)
-│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (36)
-│   ├── wait for system tenant on nodes :1-4 to reach cluster version '24.1' (37)
-│   └── run "validate upgrade" (38)
-└── upgrade cluster from "v24.1.1" to "<current>"
-   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (39)
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
-   │   ├── restart node 3 with binary version <current> (40)
-   │   ├── run "mixed-version 1" (41)
-   │   ├── restart node 2 with binary version <current> (42)
-   │   ├── run "mixed-version 2" (43)
-   │   ├── restart node 4 with binary version <current> (44)
-   │   └── restart node 1 with binary version <current> (45)
-   ├── downgrade nodes :1-4 from "<current>" to "v24.1.1"
-   │   ├── restart node 2 with binary version v24.1.1 (46)
-   │   ├── restart node 3 with binary version v24.1.1 (47)
-   │   ├── restart node 1 with binary version v24.1.1 (48)
-   │   ├── run "mixed-version 1" (49)
-   │   └── restart node 4 with binary version v24.1.1 (50)
-   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
-   │   ├── restart node 1 with binary version <current> (51)
-   │   ├── restart node 3 with binary version <current> (52)
-   │   ├── run "mixed-version 2" (53)
-   │   ├── restart node 2 with binary version <current> (54)
-   │   ├── run "mixed-version 1" (55)
-   │   └── restart node 4 with binary version <current> (56)
-   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (57)
-   ├── run "mixed-version 1" (58)
-   ├── wait for system tenant on nodes :1-4 to reach cluster version <current> (59)
-   └── run "validate upgrade" (60)
+# TODO(radu): reenable when we actually support a skippable release.
+## Test that we are able to generate "skip-version" upgrades when
+## requested (default disabled if no custom option is passed).
+#
+#mixed-version-test predecessors=(22.2.3, 23.1.4, 23.2.0, 24.1.1, 24.2.0) num_upgrades=3 enable_skip_version
+#----
+#ok
+#
+#in-mixed-version name=(mixed-version 1)
+#----
+#ok
+#
+#in-mixed-version name=(mixed-version 2)
+#----
+#ok
+#
+#workload name=bank
+#----
+#ok
+#
+#background-command name=(csv server)
+#----
+#ok
+#
+#after-upgrade-finalized name=(validate upgrade)
+#----
+#ok
+#
+#plan
+#----
+#Seed:               12345
+#Upgrades:           v23.1.4 → v23.2.0 → v24.1.1 → <current>
+#Deployment mode:    system-only
+#Plan:
+#├── install fixtures for version "v23.1.4" (1)
+#├── start cluster at version "v23.1.4" (2)
+#├── wait for system tenant on nodes :1-4 to reach cluster version '23.1' (3)
+#├── run "initialize bank workload" (4)
+#├── start background hooks concurrently
+#│   ├── run "bank workload", after 3m0s delay (5)
+#│   └── run "csv server", after 5s delay (6)
+#├── upgrade cluster from "v23.1.4" to "v23.2.0"
+#│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (7)
+#│   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
+#│   │   ├── restart node 4 with binary version v23.2.0 (8)
+#│   │   ├── restart node 1 with binary version v23.2.0 (9)
+#│   │   ├── run mixed-version hooks concurrently
+#│   │   │   ├── run "mixed-version 1", after 500ms delay (10)
+#│   │   │   └── run "mixed-version 2", after 5s delay (11)
+#│   │   ├── restart node 2 with binary version v23.2.0 (12)
+#│   │   └── restart node 3 with binary version v23.2.0 (13)
+#│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (14)
+#│   ├── run mixed-version hooks concurrently
+#│   │   ├── run "mixed-version 1", after 100ms delay (15)
+#│   │   └── run "mixed-version 2", after 500ms delay (16)
+#│   ├── wait for system tenant on nodes :1-4 to reach cluster version '23.2' (17)
+#│   └── run "validate upgrade" (18)
+#├── upgrade cluster from "v23.2.0" to "v24.1.1"
+#│   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (19)
+#│   ├── upgrade nodes :1-4 from "v23.2.0" to "v24.1.1"
+#│   │   ├── restart node 1 with binary version v24.1.1 (20)
+#│   │   ├── restart node 3 with binary version v24.1.1 (21)
+#│   │   ├── restart node 4 with binary version v24.1.1 (22)
+#│   │   ├── run "mixed-version 1" (23)
+#│   │   ├── restart node 2 with binary version v24.1.1 (24)
+#│   │   └── run "mixed-version 2" (25)
+#│   ├── downgrade nodes :1-4 from "v24.1.1" to "v23.2.0"
+#│   │   ├── restart node 4 with binary version v23.2.0 (26)
+#│   │   ├── restart node 3 with binary version v23.2.0 (27)
+#│   │   ├── restart node 2 with binary version v23.2.0 (28)
+#│   │   └── restart node 1 with binary version v23.2.0 (29)
+#│   ├── upgrade nodes :1-4 from "v23.2.0" to "v24.1.1"
+#│   │   ├── restart node 3 with binary version v24.1.1 (30)
+#│   │   ├── run "mixed-version 1" (31)
+#│   │   ├── restart node 2 with binary version v24.1.1 (32)
+#│   │   ├── restart node 1 with binary version v24.1.1 (33)
+#│   │   ├── run "mixed-version 2" (34)
+#│   │   └── restart node 4 with binary version v24.1.1 (35)
+#│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (36)
+#│   ├── wait for system tenant on nodes :1-4 to reach cluster version '24.1' (37)
+#│   └── run "validate upgrade" (38)
+#└── upgrade cluster from "v24.1.1" to "<current>"
+#   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (39)
+#   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+#   │   ├── restart node 3 with binary version <current> (40)
+#   │   ├── run "mixed-version 1" (41)
+#   │   ├── restart node 2 with binary version <current> (42)
+#   │   ├── run "mixed-version 2" (43)
+#   │   ├── restart node 4 with binary version <current> (44)
+#   │   └── restart node 1 with binary version <current> (45)
+#   ├── downgrade nodes :1-4 from "<current>" to "v24.1.1"
+#   │   ├── restart node 2 with binary version v24.1.1 (46)
+#   │   ├── restart node 3 with binary version v24.1.1 (47)
+#   │   ├── restart node 1 with binary version v24.1.1 (48)
+#   │   ├── run "mixed-version 1" (49)
+#   │   └── restart node 4 with binary version v24.1.1 (50)
+#   ├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+#   │   ├── restart node 1 with binary version <current> (51)
+#   │   ├── restart node 3 with binary version <current> (52)
+#   │   ├── run "mixed-version 2" (53)
+#   │   ├── restart node 2 with binary version <current> (54)
+#   │   ├── run "mixed-version 1" (55)
+#   │   └── restart node 4 with binary version <current> (56)
+#   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (57)
+#   ├── run "mixed-version 1" (58)
+#   ├── wait for system tenant on nodes :1-4 to reach cluster version <current> (59)
+#   └── run "validate upgrade" (60)


### PR DESCRIPTION
We update the infrastructure for deciding whether a version supports direct upgrade from older releases (without a special env flag). For now, we disable skipping for all versions so that we can add v24.3 without too many changes. We will enable 24.1->24.3 in a follow-up.

Epic: REL-1045
Release note: None