### PR TITLE
workflows: use github ref name in microbench ci

### DIFF
--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -53,7 +53,7 @@ $roachprod_microbench_dir/roachprod-microbench clean "$log_output_file_path" "$c
 
 # Push artifact if this is a base merge and skip comparison
 if $PUSH_STEP; then
-  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_REF/$GITHUB_SHA.log"
+  gcloud storage cp "$cleaned_current_dir/$benchmark_file_name" "$storage_bucket_url/$GITHUB_REF_NAME/$GITHUB_SHA.log"
   echo "Skipping comparison since this is a push step into the target branch"
   exit $success_exit_status
 fi


### PR DESCRIPTION
`GITHUB_REF` gives the full reference of the branch `ref/head/master`. However we only require `master` for the use case, therefore using `GITHUB_REF_NAME`

Epic: none

Release note: None