### PR TITLE
kvserver: deflake TestGossipHandlesReplacedNode

### DIFF
--- a/pkg/kv/kvserver/gossip_test.go
+++ b/pkg/kv/kvserver/gossip_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGossipFirstRange(t *testing.T) {
@@ -188,8 +189,11 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	// beginning of the test, and to make sure they aren't closed on server
 	// shutdown. Then we can pass the listeners to the second invocation. Alas,
 	// this requires some refactoring that remains out of scope for now.
-	if err := tc.AddAndStartServerE(newServerArgs); err != nil && !testutils.IsError(err, `address already in use`) {
-		t.Fatal(err)
+	err := tc.AddAndStartServerE(newServerArgs)
+	if testutils.IsError(err, `address already in use`) {
+		skip.WithIssue(t, 114036, "could not start server due to port reuse:", err)
+	} else {
+		require.NoError(t, err)
 	}
 
 	tc.WaitForNStores(t, tc.NumServers(), tc.Server(1).GossipI().(*gossip.Gossip))


### PR DESCRIPTION
The test attempts to start a new server after shutting down another server at the same address. It can flake if the address is taken between the shutdown and start.

The test skips itself if such an error is encountered. However, there was a bug in the skipping logic, which this commit fixes.

A proper fix is to reuse the port/listener acquired exclusively for the duration of the test, but it requires some refactor. Tracked in #114036.

Fixes #128595, #127576
Epic: none
Release note: none