### PR TITLE
sql: SHOW CLUSTER SETTING FOR TENANT returns NULL for renamed cluster setting

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -166,7 +166,7 @@ SHOW CLUSTER SETTING diagnostics.reporting.enabled
 ----
 true
 
-user root 
+user root
 
 statement ok
 REVOKE SYSTEM MODIFYSQLCLUSTERSETTING FROM testuser
@@ -435,3 +435,16 @@ query T noticetrace
 ALTER TENANT ALL RESET CLUSTER SETTING sql.trace.log_statement_execute
 ----
 NOTICE: "sql.trace.log_statement_execute" is now an alias for "sql.log.all_statements.enabled", the preferred setting name
+
+
+subtest show_renamed_setting_for_tenant
+
+skipif config 3node-tenant-default-configs
+statement ok
+ALTER TENANT "cluster-10" SET CLUSTER SETTING sql.explain_analyze.include_ru_estimation.enabled=false;
+
+skipif config 3node-tenant-default-configs
+query B
+SHOW CLUSTER SETTING sql.explain_analyze.include_ru_estimation.enabled FOR TENANT "cluster-10"
+----
+false

--- a/pkg/sql/tenant_settings.go
+++ b/pkg/sql/tenant_settings.go
@@ -251,7 +251,7 @@ FROM
 				ctx, "get-tenant-setting-value", p.txn,
 				sessiondata.NoSessionDataOverride,
 				lookupEncodedTenantSetting,
-				setting.Name(), rec.ID)
+				setting.InternalKey(), rec.ID)
 			if err != nil {
 				return false, "", err
 			}


### PR DESCRIPTION
If a cluster setting has been renamed, the internal key used in the settings tables is different from the name. The lookup code was using the user-facing Name rather than the InternalKey, resulting in SHOW CLUSTER SETTING FOR TENANT returning NULL for settings that had been renamed.

Epic: none
Release note (bug fix): Fix a bug in which SHOW CLUSTER SETTING FOR VIRTUAL CLUSTER would erroneously return NULL for some settings.