### PR TITLE
release-23.2: scbuild: handle names with special characters in hash-sharded constraint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1941,3 +1941,25 @@ statement ok
 ALTER TABLE t_view_func_ref_123017 ALTER PRIMARY KEY USING COLUMNS (a);
 
 subtest end
+
+subtest special_characters
+
+statement ok
+CREATE TABLE table_w0_66 ( "Abc" INT4 PRIMARY KEY, "ab\f" INT2 NOT NULL, FAMILY ("Abc", "ab\f"));
+
+statement ok
+ALTER TABLE public.table_w0_66 ALTER PRIMARY KEY USING COLUMNS ("Abc", "ab\f") USING HASH;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE public.table_w0_66]
+----
+CREATE TABLE public.table_w0_66 (
+  "Abc" INT4 NOT NULL,
+  "ab\f" INT2 NOT NULL,
+  "crdb_internal_Abc_ab\f_shard_16" INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes("Abc", "ab\f"))), 16:::INT8)) VIRTUAL,
+  CONSTRAINT table_w0_66_pkey PRIMARY KEY ("Abc" ASC, "ab\f" ASC) USING HASH WITH (bucket_count=16),
+  UNIQUE INDEX "table_w0_66_Abc_key" ("Abc" ASC),
+  FAMILY "fam_0_Abc_ab\f" ("Abc", "ab\f")
+)
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -12,7 +12,6 @@ package scbuildstmt
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -758,7 +757,8 @@ func maybeCreateAndAddShardCol(
 	backing := addColumn(b, spec, n)
 	// Create a new check constraint for the hash sharded index column.
 	checkConstraintBucketValues := strings.Builder{}
-	checkConstraintBucketValues.WriteString(fmt.Sprintf("%q IN (", shardColName))
+	checkConstraintBucketValues.WriteString(tree.NameString(shardColName))
+	checkConstraintBucketValues.WriteString(" IN (")
 	for bucket := 0; bucket < shardBuckets; bucket++ {
 		checkConstraintBucketValues.WriteString(strconv.Itoa(bucket))
 		if bucket != shardBuckets-1 {

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -113,7 +113,7 @@ CREATE INDEX id4
 - [[ColumnNotNull:{DescID: 104, ColumnID: 4, IndexID: 1}, PUBLIC], ABSENT]
   {columnId: 4, indexIdForValidation: 1, tableId: 104}
 - [[CheckConstraint:{DescID: 104, IndexID: 1, ConstraintID: 2, ReferencedColumnIDs: [4]}, PUBLIC], ABSENT]
-  {constraintId: 2, expr: '"crdb_internal_id_name_shard_8" IN (0,1,2,3,4,5,6,7)', fromHashShardedColumn: true, indexIdForValidation: 1, referencedColumnIds: [4], tableId: 104}
+  {constraintId: 2, expr: 'crdb_internal_id_name_shard_8 IN (0,1,2,3,4,5,6,7)', fromHashShardedColumn: true, indexIdForValidation: 1, referencedColumnIds: [4], tableId: 104}
 - [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_id_name_shard_8, ConstraintID: 2}, PUBLIC], ABSENT]
   {constraintId: 2, name: check_crdb_internal_id_name_shard_8, tableId: 104}
 - [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC], ABSENT]

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_index
@@ -94,7 +94,7 @@ DROP INDEX idx3 CASCADE
 - [[IndexData:{DescID: 104, IndexID: 6}, ABSENT], PUBLIC]
   {indexId: 6, tableId: 104}
 - [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedColumnIDs: [5]}, ABSENT], PUBLIC]
-  {columnIds: [5], constraintId: 2, expr: '"crdb_internal_i_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)', fromHashShardedColumn: true, referencedColumnIds: [5], tableId: 104}
+  {columnIds: [5], constraintId: 2, expr: 'crdb_internal_i_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)', fromHashShardedColumn: true, referencedColumnIds: [5], tableId: 104}
 - [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC]
   {constraintId: 2, name: check_crdb_internal_i_shard_16, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
@@ -253,7 +253,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── AddCheckConstraint {"CheckExpr":"\"crdb_internal_j...","ConstraintID":2,"FromHashShardedColumn":true,"TableID":104,"Validity":2}
+      │         ├── AddCheckConstraint {"CheckExpr":"crdb_internal_j_...","ConstraintID":2,"FromHashShardedColumn":true,"TableID":104,"Validity":2}
       │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_crdb_inter...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
@@ -792,7 +792,7 @@ upsert descriptor #104
   -  checks: []
   +  checks:
   +  - constraintId: 2
-  +    expr: '"crdb_internal_j_shard_3" IN (0,1,2)'
+  +    expr: crdb_internal_j_shard_3 IN (0,1,2)
   +    fromHashShardedColumn: true
   +    name: check_crdb_internal_j_shard_3
   +    validity: Validating
@@ -879,7 +879,7 @@ upsert descriptor #104
   +  - constraint:
   +      check:
   +        constraintId: 2
-  +        expr: '"crdb_internal_j_shard_3" IN (0,1,2)'
+  +        expr: crdb_internal_j_shard_3 IN (0,1,2)
   +        fromHashShardedColumn: true
   +        name: crdb_internal_constraint_2_name_placeholder
   +        validity: Validating
@@ -999,7 +999,7 @@ upsert descriptor #104
   -  - constraint:
   -      check:
   -        constraintId: 2
-  -        expr: '"crdb_internal_j_shard_3" IN (0,1,2)'
+  -        expr: crdb_internal_j_shard_3 IN (0,1,2)
   -        fromHashShardedColumn: true
   -        name: crdb_internal_constraint_2_name_placeholder
   -        validity: Validating

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index/drop_index_hash_sharded_index.side_effects
@@ -30,7 +30,7 @@ upsert descriptor #104
   ...
        - 3
        constraintId: 2
-  -    expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
+  -    expr: crdb_internal_j_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
   +    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
        fromHashShardedColumn: true
   -    name: check_crdb_internal_j_shard_16
@@ -183,7 +183,7 @@ upsert descriptor #104
   ...
        - 3
        constraintId: 2
-  -    expr: '"crdb_internal_j_shard_16" IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'
+  -    expr: crdb_internal_j_shard_16 IN (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)
   +    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
        fromHashShardedColumn: true
   -    name: check_crdb_internal_j_shard_16


### PR DESCRIPTION
Backport 1/1 commits from #128496.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/128397
Release note (bug fix): Fixed a bug where a hash sharded constraint could not be created if it referred to columns that had a backslash in the name.
