### PR TITLE
roachtest: reduce max node count and metamorphic cloud

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -90,6 +90,7 @@ type variations struct {
 	perturbation         perturbation
 	workload             workloadType
 	acceptableChange     float64
+	cloud                registry.CloudSet
 
 	// These fields are set up at the start of the test run
 	cluster       cluster.Cluster
@@ -102,9 +103,10 @@ const NUM_REGIONS = 3
 var durationOptions = []time.Duration{10 * time.Second, 10 * time.Minute, 30 * time.Minute}
 var splitOptions = []int{1, 100, 10000}
 var maxBlockBytes = []int{1, 1024, 4096}
-var numNodes = []int{5, 12, 36}
+var numNodes = []int{5, 12, 30}
 var numVCPUs = []int{4, 8, 16, 32}
 var numDisks = []int{1, 2}
+var cloudSets = []registry.CloudSet{registry.OnlyAWS, registry.OnlyGCE, registry.OnlyAzure}
 
 var leases = []registry.LeaseType{
 	registry.EpochLeases,
@@ -114,9 +116,10 @@ var leases = []registry.LeaseType{
 func (v variations) String() string {
 	return fmt.Sprintf("seed: %d, fillDuration: %s, maxBlockBytes: %d, perturbationDuration: %s, "+
 		"validationDuration: %s, ratioOfMax: %f, splits: %d, numNodes: %d, numWorkloadNodes: %d, "+
-		"partitionSite: %t, vcpu: %d, disks: %d, leaseType: %s", v.seed, v.fillDuration, v.maxBlockBytes,
+		"partitionSite: %t, vcpu: %d, disks: %d, leaseType: %s, cloud: %v",
+		v.seed, v.fillDuration, v.maxBlockBytes,
 		v.perturbationDuration, v.validationDuration, v.ratioOfMax, v.splits, v.numNodes, v.numWorkloadNodes,
-		v.partitionSite, v.vcpu, v.disks, v.leaseType)
+		v.partitionSite, v.vcpu, v.disks, v.leaseType, v.cloud)
 }
 
 // Normally a single worker can handle 20-40 nodes. If we find this is
@@ -145,6 +148,7 @@ func setupMetamorphic(p perturbation) variations {
 	v.disks = numDisks[rng.Intn(len(numDisks))]
 	v.partitionSite = rng.Intn(2) == 0
 	v.cleanRestart = rng.Intn(2) == 0
+	v.cloud = cloudSets[rng.Intn(len(cloudSets))]
 	v.perturbation = p
 	return v
 }
@@ -166,6 +170,7 @@ func setupFull(p perturbation) variations {
 	v.perturbationDuration = 10 * time.Minute
 	v.ratioOfMax = 0.5
 	v.cleanRestart = true
+	v.cloud = registry.OnlyGCE
 	v.perturbation = p
 	return v
 }
@@ -187,6 +192,7 @@ func setupDev(p perturbation) variations {
 	v.perturbationDuration = 30 * time.Second
 	v.ratioOfMax = 0.5
 	v.cleanRestart = true
+	v.cloud = registry.AllClouds
 	v.perturbation = p
 	return v
 }
@@ -245,11 +251,12 @@ func addMetamorphic(r registry.Registry, p perturbation, acceptableChange float6
 	// a given seed.
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("perturbation/metamorphic/%s", reflect.TypeOf(p).Name()),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: v.cloud,
 		Suites:           registry.Suites(registry.Nightly),
 		Owner:            registry.OwnerKV,
 		Cluster:          v.makeClusterSpec(),
 		Leases:           v.leaseType,
+		Randomized:       true,
 		Run:              v.runTest,
 	})
 }
@@ -259,7 +266,7 @@ func addFull(r registry.Registry, p perturbation, acceptableChange float64) {
 	v.acceptableChange = acceptableChange
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("perturbation/full/%s", reflect.TypeOf(p).Name()),
-		CompatibleClouds: registry.OnlyGCE,
+		CompatibleClouds: v.cloud,
 		Suites:           registry.Suites(registry.Nightly),
 		Owner:            registry.OwnerKV,
 		Cluster:          v.makeClusterSpec(),
@@ -273,7 +280,7 @@ func addDev(r registry.Registry, p perturbation, acceptableChange float64) {
 	v.acceptableChange = acceptableChange
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("perturbation/dev/%s", reflect.TypeOf(p).Name()),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: v.cloud,
 		Suites:           registry.ManualOnly,
 		Owner:            registry.OwnerKV,
 		Cluster:          v.makeClusterSpec(),


### PR DESCRIPTION
Previously the max node count was (36 + 2) * 32 = 1216 which is more than the quota of 1024 that is allowed. This commit reduces the max count to 1024 and additionally changes the metamorphic tests to on average only run once per night (rather than once per cloud per night). The on average part is important since it might run multiple times in some nights and no times on other nights.

Epic: none

Release note: None