### PR TITLE
pgwire,eventpb: add structured logging for connection breakage during shutdown

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -176,6 +176,54 @@ after being offline.
 | `StartedAt` | The time when this node was last started. | no |
 | `LastUp` | The approximate last time the node was up before the last restart. | no |
 
+### `node_shutdown_connection_timeout`
+
+An event of type `node_shutdown_connection_timeout` is recorded when SQL connections remain open
+during shutdown, after waiting for the server.shutdown.connections.timeout
+to transpire.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Detail` | The detailed message, meant to be a human-understandable explanation. | no |
+| `ConnectionsRemaining` | The number of connections still open after waiting for the client to close them. | no |
+| `TimeoutMillis` | The amount of time the server waited for the client to close the connections, defined by server.shutdown.connections.timeout. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `NodeID` | The node ID where the event was originated. | no |
+| `StartedAt` | The time when this node was last started. | no |
+| `LastUp` | The approximate last time the node was up before the last restart. | no |
+
+### `node_shutdown_transaction_timeout`
+
+An event of type `node_shutdown_transaction_timeout` is recorded when SQL transactions remain open
+during shutdown, after waiting for the server.shutdown.transactions.timeout
+to transpire.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Detail` | The detailed message, meant to be a human-understandable explanation. | no |
+| `ConnectionsRemaining` | The number of connections still running SQL transactions after waiting for the client to end them. | no |
+| `TimeoutMillis` | The amount of time the server waited for the client to close the connections, defined by server.shutdown.transactions.timeout. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `NodeID` | The node ID where the event was originated. | no |
+| `StartedAt` | The time when this node was last started. | no |
+| `LastUp` | The approximate last time the node was up before the last restart. | no |
+
 ### `tenant_shared_service_start`
 
 An event of type `tenant_shared_service_start` is recorded when a tenant server

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -523,11 +523,24 @@ func (s *Server) WaitForSQLConnsToClose(
 	s.setRejectNewConnectionsLocked(true)
 	s.mu.Unlock()
 
+	connectionTimeoutEvent := &eventpb.NodeShutdownConnectionTimeout{
+		CommonNodeEventDetails: eventpb.CommonNodeEventDetails{
+			NodeID: int32(s.execCfg.NodeInfo.NodeID.SQLInstanceID()),
+		},
+		Detail:        redact.SafeString("draining SQL queries after waiting for server.shutdown.connections.timeout"),
+		TimeoutMillis: uint32(connectionWait.Milliseconds()),
+	}
+
 	if connectionWait == 0 {
+		numOpenConns := s.GetConnCancelMapLen()
+		if numOpenConns > 0 {
+			connectionTimeoutEvent.ConnectionsRemaining = uint32(numOpenConns)
+			log.StructuredEvent(ctx, severity.WARNING, connectionTimeoutEvent)
+		}
 		return nil
 	}
 
-	log.Ops.Info(ctx, "waiting for clients to close existing SQL connections")
+	log.Ops.Infof(ctx, "waiting for clients to close %d existing SQL connections", s.GetConnCancelMapLen())
 
 	timer := time.NewTimer(connectionWait)
 	defer timer.Stop()
@@ -538,11 +551,8 @@ func (s *Server) WaitForSQLConnsToClose(
 	select {
 	// Connection wait times out.
 	case <-time.After(connectionWait):
-		log.Ops.Warningf(ctx,
-			"%d connections remain after waiting %s; proceeding to drain SQL connections",
-			s.GetConnCancelMapLen(),
-			connectionWait,
-		)
+		connectionTimeoutEvent.ConnectionsRemaining = uint32(s.GetConnCancelMapLen())
+		log.StructuredEvent(ctx, severity.WARNING, connectionTimeoutEvent)
 	case <-allConnsDone:
 	case <-ctx.Done():
 		return ctx.Err()
@@ -643,7 +653,15 @@ func (s *Server) drainImpl(
 	// Wait for connections to finish up their queries for the duration of queryWait.
 	select {
 	case <-time.After(queryWait):
-		log.Ops.Warningf(ctx, "canceling all sessions after waiting %s", queryWait)
+		transactionTimeoutEvent := &eventpb.NodeShutdownTransactionTimeout{
+			CommonNodeEventDetails: eventpb.CommonNodeEventDetails{
+				NodeID: int32(s.execCfg.NodeInfo.NodeID.SQLInstanceID()),
+			},
+			Detail:               redact.SafeString("forcibly closing SQL connections after waiting for server.shutdown.transactions.timeout"),
+			ConnectionsRemaining: uint32(s.GetConnCancelMapLen()),
+			TimeoutMillis:        uint32(queryWait.Milliseconds()),
+		}
+		log.StructuredEvent(ctx, severity.WARNING, transactionTimeoutEvent)
 	case <-allConnsDone:
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/util/log/eventpb/cluster_events.proto
+++ b/pkg/util/log/eventpb/cluster_events.proto
@@ -57,6 +57,34 @@ message NodeRestart {
   CommonNodeEventDetails node = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
 }
 
+// NodeShutdownConnectionTimeout is recorded when SQL connections remain open
+// during shutdown, after waiting for the server.shutdown.connections.timeout
+// to transpire.
+message NodeShutdownConnectionTimeout {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonNodeEventDetails node = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The detailed message, meant to be a human-understandable explanation.
+  string detail = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.SafeString", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The number of connections still open after waiting for the client to close them.
+  uint32 connections_remaining = 4 [(gogoproto.jsontag) = ",includeempty"];
+  // The amount of time the server waited for the client to close the connections, defined by server.shutdown.connections.timeout.
+  uint32 timeout_millis = 5 [(gogoproto.jsontag) = ",includeempty"];
+}
+
+// NodeShutdownTransactionTimeout is recorded when SQL transactions remain open
+// during shutdown, after waiting for the server.shutdown.transactions.timeout
+// to transpire.
+message NodeShutdownTransactionTimeout {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonNodeEventDetails node = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The detailed message, meant to be a human-understandable explanation.
+  string detail = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.SafeString", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The number of connections still running SQL transactions after waiting for the client to end them.
+  uint32 connections_remaining = 4 [(gogoproto.jsontag) = ",includeempty"];
+  // The amount of time the server waited for the client to close the connections, defined by server.shutdown.transactions.timeout.
+  uint32 timeout_millis = 5 [(gogoproto.jsontag) = ",includeempty"];
+}
+
 
 // CommonNodeDecommissionDetails contains the fields common to all
 // node-level decommission/recommission events.

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -29,6 +29,12 @@ func (m *NodeRecommissioned) LoggingChannel() logpb.Channel { return logpb.Chann
 func (m *NodeRestart) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *NodeShutdownConnectionTimeout) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *NodeShutdownTransactionTimeout) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *TenantSharedServiceStart) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3600,6 +3600,74 @@ func (m *NodeRestart) AppendJSONFields(printComma bool, b redact.RedactableBytes
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *NodeShutdownConnectionTimeout) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonNodeEventDetails.AppendJSONFields(printComma, b)
+
+	if m.Detail != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Detail\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Detail)))
+		b = append(b, '"')
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"ConnectionsRemaining\":"...)
+	b = strconv.AppendUint(b, uint64(m.ConnectionsRemaining), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"TimeoutMillis\":"...)
+	b = strconv.AppendUint(b, uint64(m.TimeoutMillis), 10)
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *NodeShutdownTransactionTimeout) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonNodeEventDetails.AppendJSONFields(printComma, b)
+
+	if m.Detail != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Detail\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Detail)))
+		b = append(b, '"')
+	}
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"ConnectionsRemaining\":"...)
+	b = strconv.AppendUint(b, uint64(m.ConnectionsRemaining), 10)
+
+	if printComma {
+		b = append(b, ',')
+	}
+	printComma = true
+	b = append(b, "\"TimeoutMillis\":"...)
+	b = strconv.AppendUint(b, uint64(m.TimeoutMillis), 10)
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *PasswordHashConverted) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)


### PR DESCRIPTION
Making these into structured logs will make this more easily consumable by operators, and will allow us to add monitoring for these events occurring in CC clusters.

fixes https://github.com/cockroachdb/cockroach/issues/128635

Release note (ops change): There are now structured logging events that report connection breakage during node shutdown. Previously, these logs existed but were unstructured. These logs appear in the OPS logging channel. There are two new events:
- The node_shutdown_connection_timeout event is logged after the timeout defined by server.shutdown.connections.timeout transpires, if there are still open SQL connections.
- The node_shutdown_transaction_timeout event is logged after the timeout defined by server.shutdown.transactions.timeout transpires, if there are still open transactions on those SQL connections.