### PR TITLE
interval: rename `cmp` function to `compare`

### DIFF
--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
@@ -29,7 +29,7 @@ const (
 	minItems = degree - 1
 )
 
-// cmp returns a value indicating the sort order relationship between
+// compare returns a value indicating the sort order relationship between
 // a and b. The comparison is performed lexicographically on
 //
 //	(a.Key(), a.EndKey(), a.ID())
@@ -40,12 +40,12 @@ const (
 //
 // tuples.
 //
-// Given c = cmp(a, b):
+// Given c = compare(a, b):
 //
 //	c == -1  if (a.Key(), a.EndKey(), a.ID()) <  (b.Key(), b.EndKey(), b.ID())
 //	c ==  0  if (a.Key(), a.EndKey(), a.ID()) == (b.Key(), b.EndKey(), b.ID())
 //	c ==  1  if (a.Key(), a.EndKey(), a.ID()) >  (b.Key(), b.EndKey(), b.ID())
-func cmp(a, b *keyLocks) int {
+func compare(a, b *keyLocks) int {
 	c := bytes.Compare(a.Key(), b.Key())
 	if c != 0 {
 		return c
@@ -331,7 +331,7 @@ func (n *node) find(item *keyLocks) (index int, found bool) {
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		v := cmp(item, n.items[h])
+		v := compare(item, n.items[h])
 		if v == 0 {
 			return h, true
 		} else if v > 0 {
@@ -415,10 +415,10 @@ func (n *node) insert(item *keyLocks) (replaced, newBound bool) {
 		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
 		n.insertAt(i, splitLa, splitNode)
 
-		switch cmp := cmp(item, n.items[i]); {
-		case cmp < 0:
+		switch v := compare(item, n.items[i]); {
+		case v < 0:
 			// no change, we want first split node
-		case cmp > 0:
+		case v > 0:
 			i++ // we want second split node
 		default:
 			n.items[i] = item

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
@@ -103,15 +103,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+		require.LessOrEqual(t, compare(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
-			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+			require.LessOrEqual(t, compare(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, compare(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -412,8 +412,8 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
+// TestBTreeCompare tests the btree item comparison.
+func TestBTreeCompare(t *testing.T) {
 	// NB: go_generics doesn't do well with anonymous types, so name this type.
 	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
 	// anonymous constructors with.
@@ -482,13 +482,13 @@ func TestBTreeCmp(t *testing.T) {
 		},
 	)
 	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		name := fmt.Sprintf("compare(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
 		t.Run(name, func(t *testing.T) {
 			laA := newItem(tc.spanA)
 			laA.SetID(tc.idA)
 			laB := newItem(tc.spanB)
 			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
+			require.Equal(t, tc.exp, compare(laA, laB))
 		})
 	}
 }

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -29,7 +29,7 @@ const (
 	minItems = degree - 1
 )
 
-// cmp returns a value indicating the sort order relationship between
+// compare returns a value indicating the sort order relationship between
 // a and b. The comparison is performed lexicographically on
 //
 //	(a.Key(), a.EndKey(), a.ID())
@@ -40,12 +40,12 @@ const (
 //
 // tuples.
 //
-// Given c = cmp(a, b):
+// Given c = compare(a, b):
 //
 //	c == -1  if (a.Key(), a.EndKey(), a.ID()) <  (b.Key(), b.EndKey(), b.ID())
 //	c ==  0  if (a.Key(), a.EndKey(), a.ID()) == (b.Key(), b.EndKey(), b.ID())
 //	c ==  1  if (a.Key(), a.EndKey(), a.ID()) >  (b.Key(), b.EndKey(), b.ID())
-func cmp(a, b *latch) int {
+func compare(a, b *latch) int {
 	c := bytes.Compare(a.Key(), b.Key())
 	if c != 0 {
 		return c
@@ -331,7 +331,7 @@ func (n *node) find(item *latch) (index int, found bool) {
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		v := cmp(item, n.items[h])
+		v := compare(item, n.items[h])
 		if v == 0 {
 			return h, true
 		} else if v > 0 {
@@ -415,10 +415,10 @@ func (n *node) insert(item *latch) (replaced, newBound bool) {
 		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
 		n.insertAt(i, splitLa, splitNode)
 
-		switch cmp := cmp(item, n.items[i]); {
-		case cmp < 0:
+		switch v := compare(item, n.items[i]); {
+		case v < 0:
 			// no change, we want first split node
-		case cmp > 0:
+		case v > 0:
 			i++ // we want second split node
 		default:
 			n.items[i] = item

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -103,15 +103,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+		require.LessOrEqual(t, compare(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
-			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+			require.LessOrEqual(t, compare(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, compare(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -412,8 +412,8 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
+// TestBTreeCompare tests the btree item comparison.
+func TestBTreeCompare(t *testing.T) {
 	// NB: go_generics doesn't do well with anonymous types, so name this type.
 	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
 	// anonymous constructors with.
@@ -482,13 +482,13 @@ func TestBTreeCmp(t *testing.T) {
 		},
 	)
 	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		name := fmt.Sprintf("compare(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
 		t.Run(name, func(t *testing.T) {
 			laA := newItem(tc.spanA)
 			laA.SetID(tc.idA)
 			laB := newItem(tc.spanB)
 			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
+			require.Equal(t, tc.exp, compare(laA, laB))
 		})
 	}
 }

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
@@ -29,7 +29,7 @@ const (
 	minItems = degree - 1
 )
 
-// cmp returns a value indicating the sort order relationship between
+// compare returns a value indicating the sort order relationship between
 // a and b. The comparison is performed lexicographically on
 //
 //	(a.Key(), a.EndKey(), a.ID())
@@ -40,12 +40,12 @@ const (
 //
 // tuples.
 //
-// Given c = cmp(a, b):
+// Given c = compare(a, b):
 //
 //	c == -1  if (a.Key(), a.EndKey(), a.ID()) <  (b.Key(), b.EndKey(), b.ID())
 //	c ==  0  if (a.Key(), a.EndKey(), a.ID()) == (b.Key(), b.EndKey(), b.ID())
 //	c ==  1  if (a.Key(), a.EndKey(), a.ID()) >  (b.Key(), b.EndKey(), b.ID())
-func cmp(a, b *entry) int {
+func compare(a, b *entry) int {
 	c := bytes.Compare(a.Key(), b.Key())
 	if c != 0 {
 		return c
@@ -331,7 +331,7 @@ func (n *node) find(item *entry) (index int, found bool) {
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		v := cmp(item, n.items[h])
+		v := compare(item, n.items[h])
 		if v == 0 {
 			return h, true
 		} else if v > 0 {
@@ -415,10 +415,10 @@ func (n *node) insert(item *entry) (replaced, newBound bool) {
 		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
 		n.insertAt(i, splitLa, splitNode)
 
-		switch cmp := cmp(item, n.items[i]); {
-		case cmp < 0:
+		switch v := compare(item, n.items[i]); {
+		case v < 0:
 			// no change, we want first split node
-		case cmp > 0:
+		case v > 0:
 			i++ // we want second split node
 		default:
 			n.items[i] = item

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
@@ -103,15 +103,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+		require.LessOrEqual(t, compare(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
-			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+			require.LessOrEqual(t, compare(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, compare(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -412,8 +412,8 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
+// TestBTreeCompare tests the btree item comparison.
+func TestBTreeCompare(t *testing.T) {
 	// NB: go_generics doesn't do well with anonymous types, so name this type.
 	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
 	// anonymous constructors with.
@@ -482,13 +482,13 @@ func TestBTreeCmp(t *testing.T) {
 		},
 	)
 	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		name := fmt.Sprintf("compare(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
 		t.Run(name, func(t *testing.T) {
 			laA := newItem(tc.spanA)
 			laA.SetID(tc.idA)
 			laB := newItem(tc.spanB)
 			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
+			require.Equal(t, tc.exp, compare(laA, laB))
 		})
 	}
 }

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -29,7 +29,7 @@ const (
 	minItems = degree - 1
 )
 
-// cmp returns a value indicating the sort order relationship between
+// compare returns a value indicating the sort order relationship between
 // a and b. The comparison is performed lexicographically on
 //
 //	(a.Key(), a.EndKey(), a.ID())
@@ -40,12 +40,12 @@ const (
 //
 // tuples.
 //
-// Given c = cmp(a, b):
+// Given c = compare(a, b):
 //
 //	c == -1  if (a.Key(), a.EndKey(), a.ID()) <  (b.Key(), b.EndKey(), b.ID())
 //	c ==  0  if (a.Key(), a.EndKey(), a.ID()) == (b.Key(), b.EndKey(), b.ID())
 //	c ==  1  if (a.Key(), a.EndKey(), a.ID()) >  (b.Key(), b.EndKey(), b.ID())
-func cmp(a, b *example) int {
+func compare(a, b *example) int {
 	c := bytes.Compare(a.Key(), b.Key())
 	if c != 0 {
 		return c
@@ -331,7 +331,7 @@ func (n *node) find(item *example) (index int, found bool) {
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		v := cmp(item, n.items[h])
+		v := compare(item, n.items[h])
 		if v == 0 {
 			return h, true
 		} else if v > 0 {
@@ -415,10 +415,10 @@ func (n *node) insert(item *example) (replaced, newBound bool) {
 		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
 		n.insertAt(i, splitLa, splitNode)
 
-		switch cmp := cmp(item, n.items[i]); {
-		case cmp < 0:
+		switch v := compare(item, n.items[i]); {
+		case v < 0:
 			// no change, we want first split node
-		case cmp > 0:
+		case v > 0:
 			i++ // we want second split node
 		default:
 			n.items[i] = item

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -103,15 +103,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+		require.LessOrEqual(t, compare(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
-			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+			require.LessOrEqual(t, compare(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, compare(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -412,8 +412,8 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
+// TestBTreeCompare tests the btree item comparison.
+func TestBTreeCompare(t *testing.T) {
 	// NB: go_generics doesn't do well with anonymous types, so name this type.
 	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
 	// anonymous constructors with.
@@ -482,13 +482,13 @@ func TestBTreeCmp(t *testing.T) {
 		},
 	)
 	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		name := fmt.Sprintf("compare(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
 		t.Run(name, func(t *testing.T) {
 			laA := newItem(tc.spanA)
 			laA.SetID(tc.idA)
 			laB := newItem(tc.spanB)
 			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
+			require.Equal(t, tc.exp, compare(laA, laB))
 		})
 	}
 }

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -30,7 +30,7 @@ const (
 	minItems = degree - 1
 )
 
-// cmp returns a value indicating the sort order relationship between
+// compare returns a value indicating the sort order relationship between
 // a and b. The comparison is performed lexicographically on
 //
 //	(a.Key(), a.EndKey(), a.ID())
@@ -41,12 +41,12 @@ const (
 //
 // tuples.
 //
-// Given c = cmp(a, b):
+// Given c = compare(a, b):
 //
 //	c == -1  if (a.Key(), a.EndKey(), a.ID()) <  (b.Key(), b.EndKey(), b.ID())
 //	c ==  0  if (a.Key(), a.EndKey(), a.ID()) == (b.Key(), b.EndKey(), b.ID())
 //	c ==  1  if (a.Key(), a.EndKey(), a.ID()) >  (b.Key(), b.EndKey(), b.ID())
-func cmp(a, b T) int {
+func compare(a, b T) int {
 	c := bytes.Compare(a.Key(), b.Key())
 	if c != 0 {
 		return c
@@ -332,7 +332,7 @@ func (n *node) find(item T) (index int, found bool) {
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		v := cmp(item, n.items[h])
+		v := compare(item, n.items[h])
 		if v == 0 {
 			return h, true
 		} else if v > 0 {
@@ -416,10 +416,10 @@ func (n *node) insert(item T) (replaced, newBound bool) {
 		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
 		n.insertAt(i, splitLa, splitNode)
 
-		switch cmp := cmp(item, n.items[i]); {
-		case cmp < 0:
+		switch v := compare(item, n.items[i]); {
+		case v < 0:
 			// no change, we want first split node
-		case cmp > 0:
+		case v > 0:
 			i++ // we want second split node
 		default:
 			n.items[i] = item

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -104,15 +104,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+		require.LessOrEqual(t, compare(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
-			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+			require.LessOrEqual(t, compare(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, compare(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -413,8 +413,8 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
+// TestBTreeCompare tests the btree item comparison.
+func TestBTreeCompare(t *testing.T) {
 	// NB: go_generics doesn't do well with anonymous types, so name this type.
 	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
 	// anonymous constructors with.
@@ -483,13 +483,13 @@ func TestBTreeCmp(t *testing.T) {
 		},
 	)
 	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		name := fmt.Sprintf("compare(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
 		t.Run(name, func(t *testing.T) {
 			laA := newItem(tc.spanA)
 			laA.SetID(tc.idA)
 			laB := newItem(tc.spanB)
 			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
+			require.Equal(t, tc.exp, compare(laA, laB))
 		})
 	}
 }

--- a/pkg/util/span/btreefrontierentry_interval_btree.go
+++ b/pkg/util/span/btreefrontierentry_interval_btree.go
@@ -29,7 +29,7 @@ const (
 	minItems = degree - 1
 )
 
-// cmp returns a value indicating the sort order relationship between
+// compare returns a value indicating the sort order relationship between
 // a and b. The comparison is performed lexicographically on
 //
 //	(a.Key(), a.EndKey(), a.ID())
@@ -40,12 +40,12 @@ const (
 //
 // tuples.
 //
-// Given c = cmp(a, b):
+// Given c = compare(a, b):
 //
 //	c == -1  if (a.Key(), a.EndKey(), a.ID()) <  (b.Key(), b.EndKey(), b.ID())
 //	c ==  0  if (a.Key(), a.EndKey(), a.ID()) == (b.Key(), b.EndKey(), b.ID())
 //	c ==  1  if (a.Key(), a.EndKey(), a.ID()) >  (b.Key(), b.EndKey(), b.ID())
-func cmp(a, b *btreeFrontierEntry) int {
+func compare(a, b *btreeFrontierEntry) int {
 	c := bytes.Compare(a.Key(), b.Key())
 	if c != 0 {
 		return c
@@ -331,7 +331,7 @@ func (n *node) find(item *btreeFrontierEntry) (index int, found bool) {
 	for i < j {
 		h := int(uint(i+j) >> 1) // avoid overflow when computing h
 		// i ≤ h < j
-		v := cmp(item, n.items[h])
+		v := compare(item, n.items[h])
 		if v == 0 {
 			return h, true
 		} else if v > 0 {
@@ -415,10 +415,10 @@ func (n *node) insert(item *btreeFrontierEntry) (replaced, newBound bool) {
 		splitLa, splitNode := mut(&n.children[i]).split(maxItems / 2)
 		n.insertAt(i, splitLa, splitNode)
 
-		switch cmp := cmp(item, n.items[i]); {
-		case cmp < 0:
+		switch v := compare(item, n.items[i]); {
+		case v < 0:
 			// no change, we want first split node
-		case cmp > 0:
+		case v > 0:
 			i++ // we want second split node
 		default:
 			n.items[i] = item

--- a/pkg/util/span/btreefrontierentry_interval_btree_test.go
+++ b/pkg/util/span/btreefrontierentry_interval_btree_test.go
@@ -103,15 +103,15 @@ func (t *btree) isSorted(tt *testing.T) {
 
 func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
+		require.LessOrEqual(t, compare(n.items[i-1], n.items[i]), 0)
 	}
 	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
 
-			require.LessOrEqual(t, cmp(prev.items[prev.count-1], n.items[i]), 0)
-			require.LessOrEqual(t, cmp(n.items[i], next.items[0]), 0)
+			require.LessOrEqual(t, compare(prev.items[prev.count-1], n.items[i]), 0)
+			require.LessOrEqual(t, compare(n.items[i], next.items[0]), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -412,8 +412,8 @@ func TestBTreeSeekOverlap(t *testing.T) {
 	}
 }
 
-// TestBTreeCmp tests the btree item comparison.
-func TestBTreeCmp(t *testing.T) {
+// TestBTreeCompare tests the btree item comparison.
+func TestBTreeCompare(t *testing.T) {
 	// NB: go_generics doesn't do well with anonymous types, so name this type.
 	// Avoid the slice literal syntax, which GofmtSimplify mandates the use of
 	// anonymous constructors with.
@@ -482,13 +482,13 @@ func TestBTreeCmp(t *testing.T) {
 		},
 	)
 	for _, tc := range testCases {
-		name := fmt.Sprintf("cmp(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
+		name := fmt.Sprintf("compare(%s:%d,%s:%d)", tc.spanA, tc.idA, tc.spanB, tc.idB)
 		t.Run(name, func(t *testing.T) {
 			laA := newItem(tc.spanA)
 			laA.SetID(tc.idA)
 			laB := newItem(tc.spanB)
 			laB.SetID(tc.idB)
-			require.Equal(t, tc.exp, cmp(laA, laB))
+			require.Equal(t, tc.exp, compare(laA, laB))
 		})
 	}
 }


### PR DESCRIPTION
Avoid a collision with the `cmp` package.

Epic: None
Release note: None