### PR TITLE
sqlstats: don't redact informational log message

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_robfig_cron_v3//:cron",
     ],

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // MaybeFlush flushes in-memory sql stats into a system table, returning true if the flush
@@ -172,7 +173,9 @@ func (s *PersistedSQLStats) StmtsLimitSizeReached(ctx context.Context) (bool, er
 	return isSizeLimitReached, nil
 }
 
-func (s *PersistedSQLStats) doFlush(ctx context.Context, workFn func() error, errMsg string) {
+func (s *PersistedSQLStats) doFlush(
+	ctx context.Context, workFn func() error, errMsg redact.RedactableString,
+) {
 	var err error
 
 	defer func() {


### PR DESCRIPTION
Due to how the format string is used, a message that contains no sensitive info was being redacted. This fixes it.

Epic: None
Release note: None