### PR TITLE
workload/schemachange: re-enable DROP SCHEMA

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1285,31 +1285,18 @@ func (og *operationGenerator) schemaContainsHasReferredFunctions(
 	return len(result) > 0, err
 }
 
-func (og *operationGenerator) schemaContainsTypesWithCrossSchemaReferences(
+func (og *operationGenerator) schemaContainsTypes(
 	ctx context.Context, tx pgx.Tx, schemaName string,
 ) (bool, error) {
 	ctes := []CTE{
 		{"descriptors", descJSONQuery},
-		{"functions", functionDescsQuery},
 		{"types", enumDescsQuery},
-		{"referenced_descriptor_ids", `
-				SELECT json_array_elements(descriptor->'referencingDescriptorIds')::INT8 AS id FROM types WHERE schema_id = $1::REGNAMESPACE::INT8
-			UNION ALL
-				SELECT (ref->'id')::INT8 AS id FROM (SELECT json_array_elements(descriptor->'dependedOnBy') AS ref from functions WHERE schema_id = $1::REGNAMESPACE::INT8)
-		`},
 	}
 
-	_, err := Collect(ctx, og, tx, pgx.RowToMap, With(ctes, `SELECT * FROM types WHERE schema_id = $1::REGNAMESPACE::INT8`), schemaName)
+	result, err := Collect(ctx, og, tx, pgx.RowToMap, With(ctes, `SELECT * FROM types WHERE schema_id = $1::REGNAMESPACE::INT8`), schemaName)
 	if err != nil {
 		return false, err
 	}
-
-	result, err := Collect(ctx, og, tx, pgx.RowToMap, With(ctes, `
-		SELECT $1::REGNAMESPACE::INT8 AS this_schema_id, * FROM descriptors d
-		WHERE schema_id != $1::REGNAMESPACE::INT8
-		AND EXISTS(SELECT * FROM referenced_descriptor_ids WHERE id = d.id)
-		AND (NOT descriptor ? 'table')
-	`), schemaName)
 	return len(result) > 0, err
 }
 

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -297,7 +297,7 @@ var opWeights = []int{
 	createView:                        1,
 	dropFunction:                      1,
 	dropIndex:                         1,
-	dropSchema:                        0, // Disabled and tracked with #127977.
+	dropSchema:                        1,
 	dropSequence:                      1,
 	dropTable:                         1,
 	dropView:                          1,


### PR DESCRIPTION
The schemachange workload aims to predict errors when dropping schemas. However, the query in `schemaContainsTypesWithCrossSchemaReferences` missed handling two specific cases:

1. Cross-Schema Table Reference: If a table in another schema references a type within the schema being dropped, the query failed to identify the table. As a result, the system incorrectly assumed that the drop would succeed, even though it would actually be blocked.

2. Cross-Schema UDF Reference: On the other hand, if a UDF in another schema depends on a type in the schema being dropped, the function is correctly dropped during cascade. The test didn’t handle this situation properly as it thought that the drop should be blocked.

Instead of fixing the error-prediction logic for DROP SCHEMA, I’ve removed the query altogether. I will now flag a potential error when dropping a type that is referenced in another schema to cover the first scenario. This also re-enables the DROP SCHEMA operation in the workload.

Closes: #128345
Closes: #127977
Release note: None