### PR TITLE
kv: propose lease acquisition if raft leader is unknown, by default

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -530,8 +530,13 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	v.perturbation.startTargetNode(ctx, t.L(), v)
 
 	func() {
+		// TODO(baptist): Remove this block once #120073 is fixed.
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
+		if _, err := db.Exec(
+			`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true`); err != nil {
+			t.Fatal(err)
+		}
 		// This isn't strictly necessary, but it would be nice if this test passed at 10s (or lower).
 		if _, err := db.Exec(
 			`SET CLUSTER SETTING server.time_after_store_suspect = '10s'`); err != nil {

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1793,12 +1793,14 @@ func getStreamIngestionJobInfo(db *gosql.DB, jobID int) (jobInfo, error) {
 func srcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
+		`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true;`,
 	)
 }
 
 func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration time.Duration) {
 	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
+		`SET CLUSTER SETTING kv.lease.reject_on_leader_unknown.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
 	)
 

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -188,7 +188,7 @@ func defaultSettings() Settings {
 		UseExpirationLeases:               false,
 		TransferExpirationLeases:          true,
 		PreferLeaderLeasesOverEpochLeases: false,
-		RejectLeaseOnLeaderUnknown:        true,
+		RejectLeaseOnLeaderUnknown:        false,
 		ExpToEpochEquiv:                   true,
 		MinExpirationSupported:            true,
 		RangeLeaseDuration:                20,

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -159,7 +159,7 @@ var RejectLeaseOnLeaderUnknown = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lease.reject_on_leader_unknown.enabled",
 	"reject lease requests on a replica that does not know the raft leader",
-	true,
+	false,
 )
 
 // leaseRequestHandle is a handle to an asynchronous lease request.


### PR DESCRIPTION
Closes #128642.
Reopens #118435.
Reopens #120073.

This commit is a partial revert of #127082. It switches the default value for the `kv.lease.reject_on_leader_unknown.enabled` cluster setting back to `false`. This avoids the regression we see in #128642 and may also help stabilize #127724.

When manually testing range failover with epoch-based leases, we see that the cluster setting is causing hung raft elections. As hypothesized in #128642, by redirecting immediately after unquiescing a range, finding a dead leader, and campaigning (`shouldCampaignOnWake`), instead of just sitting tight and waiting for a raft leader election to complete, we trigger multiple replicas to campaign for leadership in quick succession. This leads to a hung election and requires a new election to be called after an additional (jittered) election timeout. We don't see this behavior with the setting disabled.

Release note: None