### PR TITLE
raft: fix logging around leader election, warn on hung election

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -993,7 +993,6 @@ func (r *raft) hup(t CampaignType) {
 		return
 	}
 
-	r.logger.Infof("%x is starting a new election at term %d", r.id, r.Term)
 	r.campaign(t)
 }
 
@@ -1036,18 +1035,21 @@ func (r *raft) campaign(t CampaignType) {
 		// better safe than sorry.
 		r.logger.Warningf("%x is unpromotable; campaign() should have been called", r.id)
 	}
+	var pre string
 	var term uint64
 	var voteMsg pb.MessageType
 	if t == campaignPreElection {
+		pre = "pre-"
 		r.becomePreCandidate()
-		voteMsg = pb.MsgPreVote
 		// PreVote RPCs are sent for the next term before we've incremented r.Term.
 		term = r.Term + 1
+		voteMsg = pb.MsgPreVote
 	} else {
 		r.becomeCandidate()
-		voteMsg = pb.MsgVote
 		term = r.Term
+		voteMsg = pb.MsgVote
 	}
+	r.logger.Infof("%x is starting a new %selection at term %d", r.id, pre, term)
 	var ids []pb.PeerID
 	{
 		idMap := r.config.Voters.IDs()

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -15,8 +15,8 @@ INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10,
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
 INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
 

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -73,8 +73,8 @@ Messages:
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
 INFO 3 became candidate at term 2
+INFO 3 is starting a new election at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgVote request to 4 at term 2
@@ -247,8 +247,8 @@ Messages:
 
 campaign 4
 ----
-INFO 4 is starting a new election at term 2
 INFO 4 became candidate at term 3
+INFO 4 is starting a new election at term 3
 INFO 4 [logterm: 1, index: 11] sent MsgVote request to 1 at term 3
 INFO 4 [logterm: 1, index: 11] sent MsgVote request to 2 at term 3
 INFO 4 [logterm: 1, index: 11] sent MsgVote request to 3 at term 3

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -16,8 +16,8 @@ INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 2, applied: 2, lastindex: 2, la
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 INFO 1 [logterm: 1, index: 2] sent MsgVote request to 2 at term 1
 INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
 

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -52,8 +52,8 @@ ok
 
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
+INFO 2 is starting a new election at term 2
 INFO 2 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
 INFO 2 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
 

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -27,8 +27,8 @@ ok
 # Campaigning will fail when there is an active leader.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
+INFO 2 is starting a new election at term 2
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
 
@@ -134,8 +134,8 @@ stabilize
 # it won't grant votes.
 campaign 2
 ----
-INFO 2 is starting a new election at term 2
 INFO 2 became candidate at term 3
+INFO 2 is starting a new election at term 3
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 3
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 3
 

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -135,7 +135,7 @@ stabilize
 campaign 2
 ----
 INFO 2 became candidate at term 3
-INFO 2 is starting a new election at term 3
+WARN 2 is restarting a hung election at term 3
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 3
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 3
 

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -15,8 +15,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 stabilize log-level=none
 ----

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -11,8 +11,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 stabilize log-level=none
 ----

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -9,8 +9,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 process-ready 1
 ----

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -11,8 +11,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 process-ready 1
 ----

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -13,8 +13,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 process-ready 1
 ----

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -11,8 +11,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 process-ready 1
 ----

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -11,8 +11,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 process-ready 1
 ----

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -168,8 +168,8 @@ stabilize
 > 4 receiving messages
   1->4 MsgTimeoutNow Term:1 Log:0/0
   INFO 4 [term 1] received MsgTimeoutNow from 1 and starts an election to get leadership.
-  INFO 4 is starting a new election at term 1
   INFO 4 became candidate at term 2
+  INFO 4 is starting a new election at term 2
   INFO 4 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2
   INFO 4 [logterm: 1, index: 4] sent MsgVote request to 2 at term 2
   INFO 4 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2

--- a/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -175,8 +175,8 @@ WARN 1 is unpromotable and can not campaign
 # Campaign the dedicated voter n2 to become the new leader.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
+INFO 2 is starting a new election at term 2
 INFO 2 [logterm: 1, index: 5] sent MsgVote request to 3 at term 2
 INFO 2 [logterm: 1, index: 5] sent MsgVote request to 4 at term 2
 

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -120,8 +120,8 @@ raft-state
 # ForgetLeader is a noop on candidates.
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
 INFO 3 became candidate at term 2
+INFO 3 is starting a new election at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 
@@ -175,8 +175,8 @@ INFO 2 forgetting leader 3 at term 2
 
 tick-heartbeat 2
 ----
-INFO 2 is starting a new election at term 2
 INFO 2 became candidate at term 3
+INFO 2 is starting a new election at term 3
 INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
 INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
 

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -26,8 +26,8 @@ ok
 # If 3 attempts to campaign, 2 rejects it because it has a leader.
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
+INFO 3 is starting a new pre-election at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 
@@ -101,8 +101,8 @@ raft-state
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
+INFO 3 is starting a new pre-election at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 
@@ -138,6 +138,7 @@ stabilize 3
   INFO 3 received MsgPreVoteResp from 2 at term 1
   INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 3 became candidate at term 2
+  INFO 3 is starting a new election at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 > 3 handling Ready
@@ -199,8 +200,8 @@ raft-log 1
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 2
 INFO 1 became pre-candidate at term 2
+INFO 1 is starting a new pre-election at term 3
 INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 2 at term 2
 INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -138,7 +138,7 @@ stabilize 3
   INFO 3 received MsgPreVoteResp from 2 at term 1
   INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 3 became candidate at term 2
-  INFO 3 is starting a new election at term 2
+  WARN 3 is restarting a hung election at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 > 3 handling Ready

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -167,7 +167,7 @@ stabilize
   INFO 2 received MsgPreVoteResp from 1 at term 1
   INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 2 became candidate at term 2
-  INFO 2 is starting a new election at term 2
+  WARN 2 is restarting a hung election at term 2
   INFO 2 [logterm: 1, index: 12] sent MsgVote request to 1 at term 2
   INFO 2 [logterm: 1, index: 12] sent MsgVote request to 3 at term 2
   3->2 MsgPreVoteResp Term:2 Log:0/0

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -58,8 +58,8 @@ raft-log 3
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
+INFO 3 is starting a new pre-election at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 
@@ -132,8 +132,8 @@ stabilize
 # Let 2 campaign. It should succeed, since it's up-to-date on the log.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
 INFO 2 became pre-candidate at term 1
+INFO 2 is starting a new pre-election at term 2
 INFO 2 [logterm: 1, index: 12] sent MsgPreVote request to 1 at term 1
 INFO 2 [logterm: 1, index: 12] sent MsgPreVote request to 3 at term 1
 
@@ -167,6 +167,7 @@ stabilize
   INFO 2 received MsgPreVoteResp from 1 at term 1
   INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 2 became candidate at term 2
+  INFO 2 is starting a new election at term 2
   INFO 2 [logterm: 1, index: 12] sent MsgVote request to 1 at term 2
   INFO 2 [logterm: 1, index: 12] sent MsgVote request to 3 at term 2
   3->2 MsgPreVoteResp Term:2 Log:0/0

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -98,7 +98,7 @@ stabilize
   INFO 3 received MsgPreVoteResp from 2 at term 1
   INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 3 became candidate at term 2
-  INFO 3 is starting a new election at term 2
+  WARN 3 is restarting a hung election at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 > 3 handling Ready
@@ -266,7 +266,7 @@ stabilize
   INFO 2 received MsgPreVoteResp from 1 at term 2
   INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 2 became candidate at term 3
-  INFO 2 is starting a new election at term 3
+  WARN 2 is restarting a hung election at term 3
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
 > 2 handling Ready

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -26,8 +26,8 @@ ok
 # 2 should fail to campaign, leaving 1's leadership alone.
 campaign 2
 ----
-INFO 2 is starting a new election at term 1
 INFO 2 became pre-candidate at term 1
+INFO 2 is starting a new pre-election at term 2
 INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
 INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
 
@@ -61,8 +61,8 @@ ok
 
 campaign 3
 ----
-INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
+INFO 3 is starting a new pre-election at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 
@@ -98,6 +98,7 @@ stabilize
   INFO 3 received MsgPreVoteResp from 2 at term 1
   INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 3 became candidate at term 2
+  INFO 3 is starting a new election at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 > 3 handling Ready
@@ -209,8 +210,8 @@ stabilize
 # We first let 1 lose an election, as we'd otherwise get a tie.
 campaign 1
 ----
-INFO 1 is starting a new election at term 2
 INFO 1 became pre-candidate at term 2
+INFO 1 is starting a new pre-election at term 3
 INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 2 at term 2
 INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 
@@ -234,8 +235,8 @@ stabilize
 
 campaign 2
 ----
-INFO 2 is starting a new election at term 2
 INFO 2 became pre-candidate at term 2
+INFO 2 is starting a new pre-election at term 3
 INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2
 INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 
@@ -265,6 +266,7 @@ stabilize
   INFO 2 received MsgPreVoteResp from 1 at term 2
   INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 2 became candidate at term 3
+  INFO 2 is starting a new election at term 3
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
 > 2 handling Ready

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -355,8 +355,8 @@ raft-log 7
 # Elect node 1 as leader and stabilize.
 campaign 1
 ----
-INFO 1 is starting a new election at term 7
 INFO 1 became candidate at term 8
+INFO 1 is starting a new election at term 8
 INFO 1 [logterm: 6, index: 20] sent MsgVote request to 2 at term 8
 INFO 1 [logterm: 6, index: 20] sent MsgVote request to 3 at term 8
 INFO 1 [logterm: 6, index: 20] sent MsgVote request to 4 at term 8

--- a/pkg/raft/testdata/single_node.txt
+++ b/pkg/raft/testdata/single_node.txt
@@ -10,8 +10,8 @@ INFO newRaft 1 [peers: [1], term: 0, commit: 3, applied: 3, lastindex: 3, lastte
 
 campaign 1
 ----
-INFO 1 is starting a new election at term 0
 INFO 1 became candidate at term 1
+INFO 1 is starting a new election at term 1
 
 stabilize
 ----


### PR DESCRIPTION
The first commit updates the leader election log line to use the correct term and distinguish between pre-elections and normal elections.

The second commit updates the leader election log line to call out cases where the previous leader election hung and a new election is being called.

Epic: None
Release note: None