### PR TITLE
telemetry: remove expectation of no force-custom counter

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/generic
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/generic
@@ -54,15 +54,6 @@ EXECUTE p_join(1)
 ----
 sql.plan.type.force-custom
 
-# Non-prepared statements do not increment plan type counters.
-feature-usage
-SELECT * FROM kv WHERE v = 100
-----
-
-feature-usage
-SELECT * FROM kv WHERE v = 100
-----
-
 feature-list
 sql.plan.type.force-generic
 ----


### PR DESCRIPTION
This test flakes in cases where we run a query and expect the `sql.plan.type.force-custom` to not get incremented. This can't be guaranteed as this is the default counter and it occasionally gets bumped by background operations.

There's no easy way to prevent these from happening so these cases are removed from this suite.

Resolves: #128523, #128640
Epic: None

Release note: None