### PR TITLE
kvserver: rename stepRaftGroup to reflect raftMu is held

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2893,7 +2893,7 @@ func (r *Replica) getSenderReplicas(
 // there is either an initialized[2] replica or a `ReplicaPlaceholder`[3] to
 // accept the snapshot by creating a placeholder if necessary. Finally, a *Raft
 // snapshot* message is manually handed to the replica's Raft node (by calling
-// `stepRaftGroup` + `handleRaftReadyRaftMuLocked`). During the application
+// `stepRaftGroupRaftMuLocked` + `handleRaftReadyRaftMuLocked`). During the application
 // process, several other SSTs may be created for direct ingestion. An SST for
 // the unreplicated range-ID local keys is created for the Raft entries, hard
 // state, and truncated state. An SST is created for deleting each subsumed

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -577,10 +577,11 @@ func (r *Replica) isRaftLeaderRLocked() bool {
 
 var errRemoved = errors.New("replica removed")
 
-// stepRaftGroup calls Step on the replica's RawNode with the provided request's
-// message. Before doing so, it assures that the replica is unquiesced and ready
-// to handle the request.
-func (r *Replica) stepRaftGroup(req *kvserverpb.RaftMessageRequest) error {
+// stepRaftGroupRaftMuLocked calls Step on the replica's RawNode with the
+// provided request's message. Before doing so, it assures that the replica is
+// unquiesced and ready to handle the request.
+func (r *Replica) stepRaftGroupRaftMuLocked(req *kvserverpb.RaftMessageRequest) error {
+	r.raftMu.AssertHeld()
 	return r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
 		// We're processing an incoming raft message (from a batch that may
 		// include MsgVotes), so don't campaign if we wake up our raft

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -408,7 +408,7 @@ func (s *Store) processRaftRequestWithReplica(
 
 	drop := maybeDropMsgApp(ctx, (*replicaMsgAppDropper)(r), &req.Message, req.RangeStartKey)
 	if !drop {
-		if err := r.stepRaftGroup(req); err != nil {
+		if err := r.stepRaftGroupRaftMuLocked(req); err != nil {
 			return kvpb.NewError(err)
 		}
 	}
@@ -475,7 +475,7 @@ func (s *Store) processRaftSnapshotRequest(
 		// NB: we cannot get errRemoved here because we're promised by
 		// withReplicaForRequest that this replica is not currently being removed
 		// and we've been holding the raftMu the entire time.
-		if err := r.stepRaftGroup(&snapHeader.RaftMessageRequest); err != nil {
+		if err := r.stepRaftGroupRaftMuLocked(&snapHeader.RaftMessageRequest); err != nil {
 			return kvpb.NewError(err)
 		}
 

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -210,7 +210,7 @@ type StoreTestingKnobs struct {
 	// constructed and received, the follower will silently drop the snapshot
 	// without signaling an error to the sender, i.e. the leader. (To work around
 	// that, once could adjust the term for the message in that case in
-	// `(*Replica).stepRaftGroup` to prevent the message from getting dropped).
+	// `(*Replica).stepRaftGroupRaftMuLocked` to prevent the message from getting dropped).
 	//
 	// Another problem is that the snapshot may apply but fail to inform the
 	// leader of this fact. Once a Raft leader has determined that a follower


### PR DESCRIPTION
Informs #128308

Epic: CRDB-37515

Release note: None