### PR TITLE
sql: refactor to combine `forEachTableDesc*` functions.

### DIFF
--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -41,12 +41,10 @@ func postgisColumnsTablePopulator(
 	matchingFamily types.Family,
 ) func(context.Context, *planner, catalog.DatabaseDescriptor, func(...tree.Datum) error) error {
 	return func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return forEachTableDesc(
-			ctx,
-			p,
-			dbContext,
-			hideVirtual,
-			func(ctx context.Context, db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor) error {
+		opts := forEachTableDescOptions{virtualOpts: hideVirtual}
+		return forEachTableDesc(ctx, p, dbContext, opts,
+			func(ctx context.Context, descCtx tableDescContext) error {
+				db, sc, table := descCtx.database, descCtx.schema, descCtx.table
 				if !table.IsPhysicalTable() {
 					return nil
 				}


### PR DESCRIPTION
Background:

I wanted to include deleted tables in `crdb_internal.table_spans` and add a
new column `is_deleted`. However, to achieve this, I needed to add a
boolean to `forEachTableDesc` and all the invoked functions so that
`forEachTableDescWithTableLookupInternalFromDescriptors` doesn't skip them.
The argument count for these functions was already excessive, so I made the
following changes to improve readability and maintainability.

Details:

Previously, there were around four different overloads of functions:
- forEachTableDesc
- forEachTableDescAll
- forEachTableDescWithTableLookup
- forEachTableDescAllWithTableLookup
- forEachTableDescWithTableLookupInternal

This added excessive nesting and reduced readability. In many cases,
functions with the prefix `TableLookup` were used even though they no
longer utilized `tableLookupFn`.

In these proposed changes:
- I aim to improve readability by merging these functions.
- To avoid repeatedly declaring the same definition, I moved all arguments
  to a new struct. This way, we only define what we need.

```diff
- func(ctx context.Context, db catalog.DatabaseDescriptor,
- 		 sc catalog.SchemaDescriptor, table catalog.TableDescriptor) error {
+ func(ctx context.Context, descCtx tableDescContext) error {
+     sc, table := descCtx.schema, descCtx.table
```

Now, we only have `forEachTableDesc` to iterate over table descriptors.

Informs: #128578, #97942
Epic: CRDB-12100
Release note: None
