### PR TITLE
logictest: deflake select_for_update

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1712,6 +1712,13 @@ func TestTenantLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestTenantLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestTenantLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -202,10 +202,6 @@ func (t *testdir) dump() error {
 		for _, configPaths := range t.logicTestsConfigPaths {
 			paths := configPaths.configPaths[configIdx]
 			for _, file := range paths {
-				if filepath.Base(file) == "select_for_update" {
-					// TODO(#124197): unskip this.
-					continue
-				}
 				dumpTestForFile(f, configPaths.testPrefix, filepath.Base(file), "runLogicTest")
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -539,9 +539,15 @@ CREATE TABLE t3 (
   u INT,
   INDEX (u),
   FAMILY (k, v, u)
-);
-INSERT INTO t3 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 2);
-GRANT SELECT ON t3 TO testuser;
+)
+
+statement ok
+INSERT INTO t3 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 2)
+
+statement ok
+GRANT SELECT ON t3 TO testuser
+
+statement ok
 GRANT UPDATE ON t3 TO testuser
 
 statement ok

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1688,6 +1688,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1688,6 +1688,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1702,6 +1702,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1674,6 +1674,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.1/generated_test.go
@@ -1688,6 +1688,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1702,6 +1702,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1877,6 +1877,13 @@ func TestLogic_select_for_share(
 	runLogicTest(t, "select_for_share")
 }
 
+func TestLogic_select_for_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "select_for_update")
+}
+
 func TestLogic_select_index(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Performing the INSERT INTO t3 in the same batch as CREATE TABLE t3 somehow makes it possible for the SELECT FOR UPDATE SKIP LOCKED statement to skip over the inserted rows. I'm not sure why this is, or whether it is actually a problem, but performing the INSERT into a separate batch seems to prevent it.

Fixes: #124197

Release note: None