### PR TITLE
crosscluster/streamclient: Set statement_timeout in stream_partition

### DIFF
--- a/pkg/ccl/crosscluster/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/crosscluster/streamclient/partitioned_stream_client.go
@@ -445,6 +445,14 @@ func (p *partitionedStreamSubscription) Subscribe(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Set statement_timeout to 0s for no statement timeout. We
+	// expect crdb_internal.stream_partition to run forevever.
+	_, err = srcConn.Exec(ctx, `SET statement_timeout = '0s'`)
+	if err != nil {
+		return err
+	}
+
 	rows, err := srcConn.Query(ctx, `SELECT * FROM crdb_internal.stream_partition($1, $2)`,
 		p.streamID, p.specBytes)
 	if err != nil {


### PR DESCRIPTION
We expect this statement to run forever so any non-zero timeout doesn't make sense for this call.

Epic: none
Release note: None