### PR TITLE
roachtest: test selector causes test starvation due to decommissioned tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -94,6 +94,12 @@ var (
 		Usage: `Use selective tests to run based on previous test execution. this is considered only if the select-probability is 1.0`,
 	})
 
+	SuccessfulTestsSelectPct = 0.35
+	_                        = registerRunFlag(&SuccessfulTestsSelectPct, FlagInfo{
+		Name:  "successful-test-select-pct",
+		Usage: `The percent of test that should be selected from the tests that have been running successfully as per test selection. Default is 0.35`,
+	})
+
 	Username string = os.Getenv("ROACHPROD_USER")
 	_               = registerRunFlag(&Username, FlagInfo{
 		Name:      "user",


### PR DESCRIPTION
As a part of the test selection is explained in https://cockroachlabs.atlassian.net/wiki/spaces/TE/pages/3596091522/Test+Selection+for+roachtest+nightlies, we currently sort all tests by the last run and create 2 groups as selected and unselected. Out of the unselected tests, we select 35% of tests.

But, if tests are decommissioned, the test selector does not know about that as test selector data is from snowflake and has no information of whether a test is decommissioned or temporarily removed. But, if decommissioned tests are considered, they can cause starvation for other tests as they always appear in the top of the list for selection as their last run date will never change as they never run and the tests are sorted by last run date.

To fix this, this PR creates an intersection of the tests that are selected by test selector and the tests are part of the run. From that 35% of the tests are selected.

Fixes: #128780
Epic: none