### PR TITLE
roachtest: improve pebble/ycsb debuggability

### DIFF
--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -109,7 +109,7 @@ func runPebbleYCSB(
 	// larger value sizes, so we do this once and reuse the same DB state on
 	// all of the workloads.
 	runPebbleCmd(ctx, t, c, fmt.Sprintf(
-		"(./pebble bench ycsb %s"+
+		"./pebble bench ycsb %s"+
 			" --wipe "+
 			" --workload=read=100"+
 			" --concurrency=1"+
@@ -117,7 +117,7 @@ func runPebbleYCSB(
 			" --initial-keys=%d"+
 			" --cache=%d"+
 			" --num-ops=1 && "+
-			"rm -f %s && tar cvPf %s %s) > init.log 2>&1",
+			"rm -f %s && tar cvPf %s %s",
 		benchDir, size, initialKeys, cache, dataTar, dataTar, benchDir))
 
 	for _, workload := range workloads {


### PR DESCRIPTION
Previously the pebble nightly benchmarks redirected stdout and stderr of the command to init the database to an init.log file. If this command failed and exited with a non-zero exit code, the test would fail without collecting the init.log file.

We don't need to redirect to a log file when run with roachtest — both stdout and stderr of the command will be collected and included with the test's artifacts.

Informs cockroachdb/pebble#3837.
Epic: none
Release note: none